### PR TITLE
Start certifier as a process, not a module

### DIFF
--- a/scripts/run_locally.js
+++ b/scripts/run_locally.js
@@ -14,21 +14,38 @@ process.env['PUB_KEY_PATH'] = path.join(process.cwd(), 'server', 'var', 'key.pub
 process.env['PRIV_KEY_PATH'] = path.join(process.cwd(), 'server', 'var', 'key.secretkey');
 process.env['VAR_PATH'] = path.join(process.cwd(), 'server', 'var');
 
+var original_config_files = process.env['CONFIG_FILES'];
+if (! original_config_files) {
+  original_config_files = '';
+}
+
 // TODO what if priv or pub key don't exist?
 
-var certifier = require('browserid-certifier');
-certifier.bin(function(err, port) {
-  if (err) {
-    console.error(err);
-    process.exit(1);
+// Certifier can't be run in the same process,
+// convict's schema mapping wil get messed up.
+// So we must run as a process
+var certifierPath = path.join(__dirname, '..', 'node_modules',
+			      'browserid-certifier', 'bin',
+			      'certifier');
+var certifier = spawn('node', [certifierPath]);
+var certifierPort;
+certifier.stdout.on('data', function(data) {
+  var msg = data.toString('utf8');
+  if (msg.indexOf('Certifier started, listening at') !== -1) {
+    var start = msg.indexOf(' on ');
+    certifierPort =
+      parseInt(msg.substring(start + (' on '.length)), 10);
+    startFAB(certifierPort);
   }
-  console.log('Started browserid-certifier on port', port);
-  startFAB(port);
+});
+certifier.stderr.on('data', function(data) {
+  console.error('CERTIFIER ERR:', data.toString('utf8'));
 });
 
 function startFAB(certifierPort) {
   process.chdir(path.dirname(__dirname));
   process.env['CERTIFIER_PORT'] = certifierPort;
+  process.env['CONFIG_FILES'] = original_config_files;
   // We'll get PORT via config/local.json
   delete process.env['PORT'];
 

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -123,9 +123,10 @@ if (! process.env.CONFIG_FILES &&
 // handle configuration files.  you can specify a CSV list of configuration
 // files to process, which will be overlayed in order, in the CONFIG_FILES
 // environment variable
-if (process.env.CONFIG_FILES) {
-  var files = process.env.CONFIG_FILES.split(',');
-  conf.loadFile(files);
+if (process.env.CONFIG_FILES &&
+    process.env.CONFIG_FILES != '') {
+      var files = process.env.CONFIG_FILES.split(',');
+      conf.loadFile(files);
 }
 
 if (! process.env.NODE_ENV) {

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const config = require('../lib/configuration'),
-      certifier = require('browserid-certifier').client;
+certifier = require('browserid-certifier')
+  .client(config.get('certifier_host'), config.get('certifier_port'));
 
 module.exports = function(app) {
   app.get('/.well-known/browserid', function(req, res) {


### PR DESCRIPTION
So it turns out... we can't load browserid-certifier as a module in the same process as FAB.
This would confuse convict.

Instead, we tweak [browserid-certifier](https://github.com/mozilla/firefox-account-bridge/branches) and we tweak run_locally.js.
