### PR TITLE
Use a restmail.net address for pre-baked test account.

### DIFF
--- a/tests/tdd/assertion_service.js
+++ b/tests/tdd/assertion_service.js
@@ -21,7 +21,7 @@ define([
 
         var Client = gherkin.Client;
         //var email = 'some' + new Date().getTime() + '@example.com';
-        var email = 'pbnqm@tagyourself.com';
+        var email = 'fxab-test@restmail.net';
         var password = '12345678';
 
         Client


### PR DESCRIPTION
No big deal, but using an @restmail.net address puts the setup of this account a bit more squarely under our control.
