### PR TITLE
Use https URLs now that we have a proper certificate.

### DIFF
--- a/server/config/awsbox.json
+++ b/server/config/awsbox.json
@@ -1,3 +1,3 @@
 {
-  "fxaccount_url": "http://idp.dev.lcip.org"
+  "fxaccount_url": "https://idp.dev.lcip.org"
 }

--- a/static/js/gherkin.js
+++ b/static/js/gherkin.js
@@ -1107,7 +1107,7 @@ function derive(email, password, saltHex) {
     .then(
       function(K1) {
         // request a hash from scrypt based on the first key
-        return scrypt.hash(K1, KW("scrypt"), 'http://scrypt.dev.lcip.org/')
+        return scrypt.hash(K1, KW("scrypt"), 'https://scrypt.dev.lcip.org/')
       }
     )
     .then(

--- a/tests/tdd/assertion_service.js
+++ b/tests/tdd/assertion_service.js
@@ -13,7 +13,7 @@ define([
       var client;
       var assertionService;
       //var serverUrl = 'http://localhost:9000';
-      var serverUrl = 'http://idp.dev.lcip.org';
+      var serverUrl = 'https://idp.dev.lcip.org';
 
       // before the suite starts
       before(function () {


### PR DESCRIPTION
Mixing HTTP, HTTPS and CORS seems to be producing an exciting array of
strange issues, let's standardize on secure connections across the board.
