### PR TITLE
removed some refs to fxaccounts domains that don't exist, fixes #41

### DIFF
--- a/scripts/run_locally.js
+++ b/scripts/run_locally.js
@@ -7,24 +7,31 @@ const path = require('path'),
       spawn = require('child_process').spawn,
       config = require('../server/lib/configuration');
 
+
+// CK: 09/17/13 The role of the FxA Bridge going forward is unclear. We're not using
+// the certifier right now so I'm disabling it, but leaving the code in that supports
+// it for now.
 // TODO what if priv or pub key don't exist?
 
 // Certifier can't be run in the same process,
 // convict's schema mapping wil get messed up.
 // So we must run as a process
-var certifierPath = path.join(__dirname, '..', 'server', 'bin', 'browserid-certifier.js');
-var certifier = spawn('node', [certifierPath]);
-certifier.stdout.on('data', function(data) {
-  var msg = data.toString('utf8');
-  if (msg.indexOf('Certifier started') !== -1) {
-    console.log(msg);
-    startFAB();
-  }
-});
+// var certifierPath = path.join(__dirname, '..', 'server', 'bin', 'browserid-certifier.js');
+// var certifier = spawn('node', [certifierPath]);
+// certifier.stdout.on('data', function(data) {
+//   var msg = data.toString('utf8');
+//   if (msg.indexOf('Certifier started') !== -1) {
+//     console.log(msg);
+//     startFAB();
+//   }
+// });
 
-certifier.stderr.on('data', function(data) {
-  console.error('CERTIFIER ERR:', data.toString('utf8'));
-});
+// certifier.stderr.on('data', function(data) {
+//   console.error('CERTIFIER ERR:', data.toString('utf8'));
+// });
+
+// No certifier so just start the FAB server directly
+startFAB();
 
 function startFAB() {
   process.chdir(path.dirname(__dirname));

--- a/server/bin/firefox_account_bridge.js
+++ b/server/bin/firefox_account_bridge.js
@@ -100,7 +100,7 @@ function listen(theApp) {
     lstnUrl = util.format('http://%s:%s', config.get('issuer'), port);
   }
   if (isMain) { // -> log
-    console.log('Firefox Account Bridge listening at', lstnUrl);
+    console.log('Firefox Account Bridge listening on port', port);
   }
   return true; // used by test
 }

--- a/server/config/local.json-dist
+++ b/server/config/local.json-dist
@@ -11,8 +11,7 @@
   "env": "development",
   "issuer": "localhost",
   "use_https": false,
-  "translation_directory": "/home/ozten/bigtent/static/i18n",
   "pub_key_ttl": 120,
   "pub_key_path": "var/key.publickey",
-  "supported_languages": ["en-US", "it-CH", "db-LB"]
+  "supported_languages": ["en-US"]
 }


### PR DESCRIPTION
@jbonacci I made this better, but if you grep through the code, you'll still find some hits to the said non-existent domains. I've removed those references from the visible README (they're commented out) and the logs, and turned off the certifier for now. I could change the domains to PLEASECHANGEMELATER.com if that is any better, but I suggest we just leave it for now until we get more visibility.
