### PR TITLE
Removed link to preferences page in Jelly. 

### DIFF
--- a/server/views/accounts/desktop_flow.html
+++ b/server/views/accounts/desktop_flow.html
@@ -83,7 +83,6 @@ Firefox Sync stores your passwords, bookmarks, tabs and browsing history. Use it
           <p id="progress-message">Syncing your data...</p>
           <progress id="progress-meter"></progress>
         </div>
-        <p>You may close this tab and keep browsing or go to <a href="#" class="prefs">Preferences</a> to manage your account.</p>
   </div>
 
   <div class="notes-t2-get-password">


### PR DESCRIPTION
Removed link to preferences page in Jelly. That was for our user test and is no longer used. Fixes #72.
