### PR TITLE
Receive verification code in URL fragment, not querystring

### DIFF
--- a/server/views/verify_email.html
+++ b/server/views/verify_email.html
@@ -19,6 +19,10 @@ var code = "{{ code }}";
 var uid = "{{ uid }}";
 var fxaUrl = "{{ fxa }}";
 
+if (!code && window.location.hash) {
+  code = /code=(\w+)/.exec(window.location.hash)[1]
+}
+
 var Client = gherkin.Client;
 var client = new Client(fxaUrl);
 client.uid = uid;


### PR DESCRIPTION
The spec says that we will send the verification code in the fragment portion of the verification URL, presumably so that it will not be leaked in logs etc. We currently pull it from the querystring.
