### PR TITLE
Switch static directory to dist when deployed + cleaning

### DIFF
--- a/.awsbox.json
+++ b/.awsbox.json
@@ -1,7 +1,6 @@
 {
   "processes": [
-    "server/bin/firefox_account_bridge.js",
-    "server/bin/browserid-certifier.js"
+    "server/bin/fxa-content-server.js"
   ],
   "env": {
     "CONFIG_FILES": "$HOME/code/server/config/awsbox.json,$HOME/config.json",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,10 @@
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL 2.0",
   "dependencies": {
-    "client-sessions": "0.3.1",
     "connect-cachify": "0.0.15",
     "convict": "0.4.0",
     "express": "3.3.4",
     "i18n-abide": "0.0.14",
-    "nunjucks": "0.1.9",
-    "urlparse": "0.0.1",
     "jwcrypto": "0.4.3",
     "intel": "0.4.0",
     "helmet": "0.1.2"

--- a/server/config/awsbox.json
+++ b/server/config/awsbox.json
@@ -1,3 +1,4 @@
 {
-  "fxaccount_url": "https://api-accounts.dev.lcip.org"
+  "fxaccount_url": "https://api-accounts.dev.lcip.org",
+  "static_directory": "dist"
 }

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -86,6 +86,11 @@ var conf = module.exports = convict({
     format: "url",
     default: "http://127.0.0.1:9000",
     env: "FXA_URL"
+  },
+  static_directory: {
+    doc: "Directory that static files are served from.",
+    format: String,
+    default: "app"
   }
 });
 


### PR DESCRIPTION
This adds a configuration parameter for which directory will serve static assets and sets it to dist on awsbox.

Plus it cleans more unused modules on the server.
