### PR TITLE
Cleanup and force `grunt server:dist` to use production resources.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,12 +30,6 @@ module.exports = function (grunt) {
             app: 'app',
             dist: 'dist'
         },
-        watch: {
-            styles: {
-                files: ['<%= yeoman.app %>/styles/{,*/}*.css'],
-                tasks: ['copy:styles', 'autoprefixer']
-            }
-        },
         clean: {
             dist: {
                 files: [{
@@ -240,12 +234,9 @@ module.exports = function (grunt) {
 
     grunt.registerTask('serverproc', function (target) {
       if ( ! target) target = 'app';
-
-      var done = this.async();
-
       process.env.CONFIG_FILES = TARGET_TO_CONFIG[target];
 
-      runServer(done);
+      runServer(this.async());
     });
 
     grunt.registerTask('server', function (target) {
@@ -257,8 +248,7 @@ module.exports = function (grunt) {
             'clean:server',
             'concurrent:server',
             'autoprefixer',
-            'serverproc:app',
-            'watch'
+            'serverproc:app'
         ]);
     });
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Firefox Accounts Content Server",
   "scripts": {
-    "start": "node scripts/run_locally.js",
+    "start": "grunt server",
     "test": "node node_modules/intern/runner.js config=tests/intern suites=tests/tdd ",
     "test-functional": "node node_modules/intern/runner.js config=tests/intern_functional"
   },

--- a/server/config/production.json
+++ b/server/config/production.json
@@ -1,4 +1,4 @@
 {
   "env": "production",
-  "static_root": "dist"
+  "static_directory": "dist"
 }


### PR DESCRIPTION
- Remove the `watch` task, we weren't using it.
- Update production.json's `static_root` to be `static_directory` which forces `grunt server:dist` to use production files.
- Hook `npm start` to `grunt server`
