### PR TITLE
client now handles timeskew and replaced const with var

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "backbone": "~1.1.0",
     "modernizr": "~2.6.2",
     "requirejs-hogan-plugin": "~0.3.1",
-    "fxa-js-client-old": "https://github.com/mozilla/fxa-js-client-old.git#ac05bdf012a7f141e7262618097499ac20a07d83",
+    "fxa-js-client-old": "https://github.com/mozilla/fxa-js-client-old.git#50114bad33712ec3e1f2a82df1836c2f10cd7519",
     "normalize-css": "~2.1.3",
     "jquery.transit": "~0.9.9"
   },


### PR DESCRIPTION
The client can now handle timeskew. It also no longer uses `const`. One thing that's not so easy to replace are instances of `function.bind`, since we are relying on browserified dependencies. I suggest we just go with a polyfill to fix `bind` for now, as the lesser evil. #108
