### PR TITLE
Wait for explicit elements when starting each test.

### DIFF
--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -1,4 +1,4 @@
-<h1>{{#t}}Firefox Accounts{{/t}}</h1>
+<h1 id="fxa-signin-header">{{#t}}Firefox Accounts{{/t}}</h1>
 
 <p class="error"></p>
 

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -1,4 +1,4 @@
-<h1>{{#t}}Firefox Accounts{{/t}}</h1>
+<h1 id="fxa-signup-header">{{#t}}Firefox Accounts{{/t}}</h1>
 
 <p class="error"></p>
 

--- a/tests/functional/signIn.js
+++ b/tests/functional/signIn.js
@@ -26,7 +26,7 @@ define([
 
       return this.get('remote')
         .get(require.toUrl(url))
-        .wait(2000)
+        .waitForElementById('fxa-signin-header')
 
         .elementByCssSelector('form input.email')
           .click()

--- a/tests/functional/signUp.js
+++ b/tests/functional/signUp.js
@@ -20,7 +20,7 @@ define([
 
       return this.get('remote')
         .get(require.toUrl(url))
-        .wait(2000)
+        .waitForElementById('fxa-signup-header')
 
         .elementByCssSelector('form input.email')
           .click()


### PR DESCRIPTION
@zaach or @nchapman - I was seeing a lot of timeouts when running remote Selenium tests, so now I am waiting until the header is shown before going any further in the tests.

r?
