### PR TITLE
Possible work-around for gherkin require issues

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -24,6 +24,7 @@
     "console": true,
     "define": true,
     "router": true,
-    "translator": true
+    "translator": true,
+    "gherkin": true
   }
 }

--- a/app/index.html
+++ b/app/index.html
@@ -27,6 +27,7 @@
 
         <!-- build:js scripts/main.js -->
         <script data-main="scripts/main" src="bower_components/requirejs/require.js"></script>
+        <script src="bower_components/fxa-js-client-old/web/bundle.js"></script>
         <!-- endbuild -->
     </body>
 </html>

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -12,7 +12,6 @@ require.config({
     hgn: '../bower_components/requirejs-hogan-plugin/hgn',
     text: '../bower_components/requirejs-hogan-plugin/text',
     hogan: '../bower_components/requirejs-hogan-plugin/hogan',
-    gherkin: '../bower_components/fxa-js-client-old/web/bundle',
     transit: '../bower_components/jquery.transit/jquery.transit',
     modernizr: '../bower_components/modernizr/modernizr'
   },

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -7,11 +7,10 @@
 define([
   'views/base',
   'hgn!templates/sign_in',
-  'gherkin',
   'lib/session',
   'processed/constants'
 ],
-function(BaseView, SignInTemplate, gherkin, Session, Constants) {
+function(BaseView, SignInTemplate, Session, Constants) {
   var SignInView = BaseView.extend({
     template: SignInTemplate,
     className: 'sign-in',

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -7,11 +7,10 @@
 define([
   'views/base',
   'hgn!templates/sign_up',
-  'gherkin',
   'lib/session',
   'processed/constants'
 ],
-function(BaseView, SignUpTemplate, gherkin, Session, Constants) {
+function(BaseView, SignUpTemplate, Session, Constants) {
   var SignUpView = BaseView.extend({
     template: SignUpTemplate,
     className: 'sign-up',


### PR DESCRIPTION
This is one possible solution for our `require` conflict in `fxa-js-client-old` or the library formerly known as gherkin. This removes `fxa-js-client-old` from the require.js dependency flow in `main.js` and makes it globally accessible. It is now being included in `index.html` and built into the distributed `main.js` file via the grunt build tools.

This is only necessary if we can't get a stand alone version of gherkin working, but since this works, I figured I'd submit it for consideration. This might also let us move on from worrying about old client and work on new client. Let me know what you guys think...
