### PR TITLE
Replace Hogan.js with Mustache.js

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -9,10 +9,10 @@ require.config({
     jquery: '../bower_components/jquery/jquery',
     backbone: '../bower_components/backbone/backbone',
     underscore: '../bower_components/underscore/underscore',
-    hgn: '../bower_components/requirejs-hogan-plugin/hgn',
-    text: '../bower_components/requirejs-hogan-plugin/text',
-    hogan: '../bower_components/requirejs-hogan-plugin/hogan',
     gherkin: '../bower_components/fxa-js-client-old/web/bundle',
+    text: '../bower_components/requirejs-text/text',
+    mustache: '../bower_components/mustache/mustache',
+    stache: '../bower_components/requirejs-mustache/stache',
     transit: '../bower_components/jquery.transit/jquery.transit',
     modernizr: '../bower_components/modernizr/modernizr'
   },
@@ -33,6 +33,9 @@ require.config({
       ],
       exports: 'jQuery.fn.transition'
     }
+  },
+  stache: {
+    extension: '.mustache'
   }
 });
 

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -6,7 +6,7 @@
 
 define([
   'views/base',
-  'hgn!templates/confirm',
+  'stache!templates/confirm',
   'lib/session'
 ],
 function(BaseView, ConfirmTemplate, Session) {

--- a/app/scripts/views/intro.js
+++ b/app/scripts/views/intro.js
@@ -6,7 +6,7 @@
 
 define([
   'views/base',
-  'hgn!templates/intro'
+  'stache!templates/intro'
 ],
 function(BaseView, IntroTemplate) {
   var IntroView = BaseView.extend({

--- a/app/scripts/views/pp.js
+++ b/app/scripts/views/pp.js
@@ -6,7 +6,7 @@
 
 define([
   'views/base',
-  'hgn!templates/pp'
+  'stache!templates/pp'
 ],
 function (BaseView, PpTemplate) {
   var PpView = BaseView.extend({

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -6,7 +6,7 @@
 
 define([
   'views/base',
-  'hgn!templates/settings'
+  'stache!templates/settings'
 ],
 function(BaseView, SettingsTemplate) {
   var SettingsView = BaseView.extend({

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -6,7 +6,7 @@
 
 define([
   'views/base',
-  'hgn!templates/sign_in',
+  'stache!templates/sign_in',
   'lib/session',
   'processed/constants'
 ],

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -6,7 +6,7 @@
 
 define([
   'views/base',
-  'hgn!templates/sign_up',
+  'stache!templates/sign_up',
   'lib/session',
   'processed/constants'
 ],

--- a/app/scripts/views/tos.js
+++ b/app/scripts/views/tos.js
@@ -6,7 +6,7 @@
 
 define([
   'views/base',
-  'hgn!templates/tos'
+  'stache!templates/tos'
 ],
 function (BaseView, TosTemplate) {
   var TosView = BaseView.extend({

--- a/bower.json
+++ b/bower.json
@@ -7,10 +7,12 @@
     "underscore": "~1.5.2",
     "backbone": "~1.1.0",
     "modernizr": "~2.6.2",
-    "requirejs-hogan-plugin": "~0.3.1",
     "fxa-js-client-old": "https://github.com/mozilla/fxa-js-client-old.git#umd2",
     "normalize-css": "~2.1.3",
-    "jquery.transit": "~0.9.9"
+    "jquery.transit": "~0.9.9",
+    "requirejs-mustache": "*",
+    "mustache": "~0.7.3",
+    "requirejs-text": "~2.0.10"
   },
   "devDependencies": {}
 }

--- a/grunttasks/requirejs.js
+++ b/grunttasks/requirejs.js
@@ -14,10 +14,6 @@ module.exports = function (grunt) {
         // `name` and `out` are set by grunt-usemin
         baseUrl: '<%= yeoman.app %>/scripts',
         optimize: 'none',
-        // This path seems to interfere with hogan templates being built
-        // paths: {
-        //     'templates': '../../.tmp/scripts/templates'
-        // },
         // TODO: Figure out how to make sourcemaps work with grunt-usemin
         // https://github.com/yeoman/grunt-usemin/issues/30
         //generateSourceMaps: true,
@@ -26,7 +22,7 @@ module.exports = function (grunt) {
         preserveLicenseComments: false,
         useStrict: true,
         wrap: true,
-        stubModules: ['text', 'hgn']
+        stubModules: ['text', 'stache']
       }
     }
   });


### PR DESCRIPTION
This fixes the issue with translated strings (#154) by replacing Hogan.js with Mustache.js. Hogan performs better in production because the templates are completely precompiled, but that also prevents lambdas functions from working properly. Since we're using lambdas to look up translated strings, we don't have much choice but to abandon Hogan.js.

I configured `requirejs-mustache` to use `.mustache` rather than `.html` as the template file extension to minimize changes, but we might want to rename them to end in `.html` for convention's sake. The other change is that we'll now use `stache!` in the template path rather than `hgn!`.
