### PR TITLE
Assume 'en' as the default language.

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -47,7 +47,9 @@ require([
 function (Backbone, Router, Translator) {
   // A few globals
   window.router = new Router();
-  window.translator = new Translator(window.navigator.language);
+
+  // IE8 does not support window.navigator.language. Set a default of English.
+  window.translator = new Translator(window.navigator.language || 'en');
 
   // Don't start backbone until we have our translations
   translator.fetch(function() {


### PR DESCRIPTION
- window.navigator.language is unsupported by IE8. This is a workaround until we do some server side work.

fixes #183.
