### PR TITLE
Web Fonts FTW!

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -10,6 +10,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+        <link rel="stylesheet" href="/latin/firasans-regular,firasans-medium,clearsans-regular/fonts.css">
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="bower_components/normalize-css/normalize.css">
         <link rel="stylesheet" href="styles/main.css">

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -7,8 +7,16 @@
 
 body {
   color: #333;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: "Clear Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 16px;
+}
+
+h1, h2 {
+  font-family: "Fira Sans", Helvetica, Arial, sans-serif;
+}
+
+h2 {
+  font-weight: 300;
 }
 
 p.center {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "i18n-abide": "0.0.14",
     "jwcrypto": "0.4.3",
     "intel": "0.4.0",
-    "helmet": "0.1.2"
+    "helmet": "0.1.2",
+    "connect-fonts": "0.0.12",
+    "connect-fonts-firasans": "0.0.2",
+    "connect-fonts-clearsans": "0.0.1"
   },
   "devDependencies": {
     "bower": "1.2.8",

--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -16,6 +16,9 @@ if (isMain) {
 const util = require('util');
 const helmet = require('helmet');
 const express = require('express');
+const connect_fonts = require('connect-fonts');
+const firasans = require('connect-fonts-firasans');
+const clearsans = require('connect-fonts-clearsans');
 
 const config = require('../lib/configuration');
 const routes = require('../lib/routes');
@@ -32,6 +35,13 @@ function makeApp() {
   app.use(helmet.xframe('deny'));
   app.use(helmet.iexss());
   app.disable('x-powered-by');
+
+  app.use(connect_fonts.setup({
+    fonts: [ firasans, clearsans ],
+    allow_origin: [ config.get('public_url') ],
+    max_age: config.get('font_max_age_ms'),
+    compress: true
+  }));
 
   app.use(routeLogging());
   app.use(express.cookieParser());

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -91,6 +91,11 @@ var conf = module.exports = convict({
     doc: "Directory that static files are served from.",
     format: String,
     default: "app"
+  },
+  font_max_age_ms: {
+    doc: "Cache fonts for this amount of time, in ms",
+    format: Number,
+    default: 180 * 24 * 60 * 60 * 1000      // 180 days
   }
 });
 


### PR DESCRIPTION
- Use Clear Sans for body text, Fira Sans for headings.
- Add the font middleware and font sets

Additional work to be done:
- The font set needs updated to serve more minimized locale specific fonts.
- The grunt build step needs to be updated to include fonts.css for each locale to minimize the number of requests.

fixes #196
