### PR TITLE
Add HSTS headers.

### DIFF
--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -34,6 +34,7 @@ function makeApp() {
 
   app.use(helmet.xframe('deny'));
   app.use(helmet.iexss());
+  app.use(helmet.hsts(config.get('hsts_max_age'), true));
   app.disable('x-powered-by');
 
   app.use(connect_fonts.setup({

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -96,6 +96,11 @@ var conf = module.exports = convict({
     doc: "Cache fonts for this amount of time, in ms",
     format: Number,
     default: 180 * 24 * 60 * 60 * 1000      // 180 days
+  },
+  hsts_max_age: {
+    doc: "Max age of the STS directive, in seconds",
+    format: Number,
+    default: 180 * 24 * 60 * 60            // 180 days
   }
 });
 


### PR DESCRIPTION
- Helmet only adds HSTS headers in https mode.
- max-age set to 6 months.

fixes #208
