### PR TITLE
Fix JSHint errors and cleanup of fx-desktop

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -45,9 +45,9 @@ function (FxaClient, Constants) {
       return this.client
                  .signUp(email, password)
                  .then(function () {
-                   // when a user signs up, sign them in immediately
-                   return this.signIn(email, password, { keys: true });
-                 }.bind(this));
+                    // when a user signs up, sign them in immediately
+                    return this.signIn(email, password, { keys: true });
+                  }.bind(this));
     },
 
     verifyCode: function (uid, code) {


### PR DESCRIPTION
- Only one of `done` or `handler` was needed when saving outstanding requests

Initiated by looking at issue #232

@zaach - r?
