### PR TITLE
Autofocus sensible elements when using a browser that does not have touch events.

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -7,6 +7,7 @@
 define([
   'jquery',
   'backbone',
+  'underscore',
   'views/intro',
   'views/sign_in',
   'views/sign_up',
@@ -25,7 +26,7 @@ define([
   'views/reset_password_complete',
   'transit'
 ],
-function ($, Backbone, IntroView, SignInView, SignUpView, ConfirmView, SettingsView, TosView, PpView, AgeView, BirthdayView, CreateAccountView, CannotCreateAccountView, CompleteSignUpView, ResetPasswordView, ConfirmResetPasswordView, CompleteResetPasswordView, ResetPasswordCompleteView) {
+function ($, Backbone, _, IntroView, SignInView, SignUpView, ConfirmView, SettingsView, TosView, PpView, AgeView, BirthdayView, CreateAccountView, CannotCreateAccountView, CompleteSignUpView, ResetPasswordView, ConfirmResetPasswordView, CompleteResetPasswordView, ResetPasswordCompleteView) {
   var Router = Backbone.Router.extend({
     routes: {
       '': 'showSignUp',
@@ -130,7 +131,8 @@ function ($, Backbone, IntroView, SignInView, SignUpView, ConfirmView, SettingsV
       this.$stage.html(this.currentView.render().el);
 
       // Fade the stage back in
-      this.$stage.transition({ opacity: 100 });
+      this.$stage.transition({ opacity: 100 },
+        _.bind(this.currentView.afterVisible, this.currentView));
     },
 
     watchAnchors: function () {

--- a/app/scripts/templates/age.mustache
+++ b/app/scripts/templates/age.mustache
@@ -9,7 +9,7 @@
 
   <form>
     <div class="input-row">
-      <select id="fxa-age-year">
+      <select id="fxa-age-year" autofocus>
         <option id="fxa-none" value="none">{{#t}}Pick a year{{/t}}</option>
         <option id="fxa-1960" value="1960">{{#t}}1960s or earlier{{/t}}</option>
         <option id="fxa-1970" value="1970">{{#t}}1970s{{/t}}</option>

--- a/app/scripts/templates/birthday.mustache
+++ b/app/scripts/templates/birthday.mustache
@@ -9,7 +9,7 @@
 
   <form>
     <div class="input-row input-row-month-day">
-      <select id="fxa-month">
+      <select id="fxa-month" autofocus>
         <option id="fxa-month-none" value="none">{{#t}}Month{{/t}}</option>
         <option id="fxa-month-jan" value="1">{{#t}}January{{/t}}</option>
         <option id="fxa-month-feb" value="2">{{#t}}February{{/t}}</option>

--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -9,7 +9,7 @@
 
   <form>
     <div class="input-row">
-      <input type="password" class="password" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}">
+      <input type="password" class="password" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" autofocus>
     </div>
 
     <div class="input-row">

--- a/app/scripts/templates/complete_sign_up.mustache
+++ b/app/scripts/templates/complete_sign_up.mustache
@@ -14,7 +14,7 @@
     {{#redirectTo}}
       <p>{{#t}}You are now ready to use{{/t}} {{ siteName }}</p>
 
-      <a href="{{ redirectTo }}">Continue</a>
+      <a href="{{ redirectTo }}" autofocus>Continue</a>
     {{/redirectTo}}
     {{^redirectTo}}
       <p>{{#t}}Your account is ready!{{/t}}</p>

--- a/app/scripts/templates/intro.mustache
+++ b/app/scripts/templates/intro.mustache
@@ -7,7 +7,7 @@
   <p class="description">{{#t}}Sign in to backup and sync all your settings and bookmarks!{{/t}}</p>
 
   <div class="button-row">
-    <a href="/signup" class="button">{{#t}}Sign up{{/t}}</a>
+    <a href="/signup" class="button" autofocus>{{#t}}Sign up{{/t}}</a>
   </div>
 
   <div class="links">

--- a/app/scripts/templates/pp.mustache
+++ b/app/scripts/templates/pp.mustache
@@ -2,4 +2,4 @@
 
 This is some Privacy Policy text
 
-<button id="fxa-pp-back">Back</button>
+<button id="fxa-pp-back" autofocus>Back</button>

--- a/app/scripts/templates/reset_password.mustache
+++ b/app/scripts/templates/reset_password.mustache
@@ -11,7 +11,7 @@
     <p>{{#t}}Enter your email address, and we'll email you instructions on how to reset your password{{/t}}</p>
 
     <div class="input-row">
-      <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}">
+      <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" autofocus>
     </div>
 
     <div class="button-row">

--- a/app/scripts/templates/reset_password_complete.mustache
+++ b/app/scripts/templates/reset_password_complete.mustache
@@ -12,6 +12,6 @@
   {{#redirectTo}}
     <p>{{#t}}Continue to{{/t}} {{ service }} {{#t}}on the <strong>Initial Client</strong>.{{/t}}</p>
 
-    <a href="{{ redirectTo }}">Continue</a>
+    <a href="{{ redirectTo }}" autofocus>Continue</a>
   {{/redirectTo}}
 </section>

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -9,7 +9,7 @@
 
   <form>
     <div class="input-row">
-      <input type="email" class="email" placeholder="{{#t}}Email{{/t}}">
+      <input type="email" class="email" placeholder="{{#t}}Email{{/t}}" autofocus>
     </div>
 
     <div class="input-row">

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -9,7 +9,7 @@
 
   <form>
     <div class="input-row">
-      <input type="email" class="email" placeholder="{{#t}}Email{{/t}}">
+      <input type="email" class="email" placeholder="{{#t}}Email{{/t}}" autofocus>
     </div>
 
     <div class="input-row">

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -1,0 +1,4 @@
+<form>
+  <input type="text" id="focusMe" autofocus />
+</form>
+

--- a/app/scripts/templates/tos.mustache
+++ b/app/scripts/templates/tos.mustache
@@ -2,4 +2,4 @@
 
 This is some Terms of Service text.
 
-<button id="fxa-tos-back">Back</button>
+<button id="fxa-tos-back" autofocus>Back</button>

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -6,9 +6,10 @@
 
 define([
   'underscore',
-  'backbone'
+  'backbone',
+  'jquery'
 ],
-function(_, Backbone) {
+function(_, Backbone, jQuery) {
   var ENTER_BUTTON_CODE = 13;
 
   var BaseView = Backbone.View.extend({
@@ -54,6 +55,20 @@ function(_, Backbone) {
 
     afterRender: function() {
       // Implement in subclasses
+    },
+
+    // called after the view is visible.
+    afterVisible: function() {
+      // make a huge assumption and say if the device does not have touch,
+      // it's a desktop device and autofocus can be applied without
+      // hiding part of the screen. The no-touch class is added by modernizr
+      if (jQuery('html').hasClass('no-touch')) {
+        try {
+          this.$('[autofocus]').get(0).focus();
+        } catch (e) {
+          // IE can blow up if the element is not visible.
+        }
+      }
     },
 
     assign: function(view, selector) {

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -51,12 +51,13 @@ require([
   '../tests/spec/lib/channels/fx-desktop',
   '../tests/spec/lib/xss',
   '../tests/spec/lib/url',
-  '../tests/spec/lib/fxa-client'
+  '../tests/spec/lib/fxa-client',
+  '../tests/spec/views/base'
 ],
 function (Mocha) {
   var runner = Mocha.run();
 
-  runner.on('end', function() {
+  runner.on('end', function () {
 
     // This is our hook to the Selenium tests that run
     // the mocha tests as part of the CI build.

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'mocha',
+  'chai',
+  'jquery',
+  'views/base',
+  'stache!templates/test_template'
+],
+function (mocha, chai, jQuery, BaseView, Template) {
+  var assert = chai.assert;
+  var channel;
+
+  describe('views/base', function () {
+    var view;
+    beforeEach(function() {
+      var View = BaseView.extend({
+        template: Template
+      });
+
+      view = new View();
+      view.render();
+      jQuery('body').append(view.el);
+    });
+
+    afterEach(function() {
+      if (view) {
+        view.destroy();
+        jQuery(view.el).remove();
+        view = null;
+      }
+    });
+
+    describe('render', function() {
+      it('renders the template without attaching it to the body', function() {
+        // render is called in beforeEach
+        assert.ok(jQuery('#focusMe').length);
+      });
+    });
+
+    describe('afterVisible', function() {
+      afterEach(function() {
+        jQuery('html').removeClass('no-touch');
+      });
+
+      it('focuses descendent element containing `autofocus` if html has `no-touch` class', function() {
+        jQuery('html').addClass('no-touch');
+
+        var handlerCalled = false;
+        jQuery('#focusMe').on('focus', function() {
+          handlerCalled = true;
+        });
+        view.afterVisible();
+
+        assert.isTrue(handlerCalled);
+      });
+
+      it('does not focus descendent element containing `autofocus` if html does not have `no-touch` class', function() {
+        var handlerCalled = false;
+        jQuery('#focusMe').on('focus', function() {
+          handlerCalled = true;
+        });
+        view.afterVisible();
+
+        assert.isFalse(handlerCalled);
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
Only autofocus on browsers that do not report touch event support, meaning most desktop browsers. Autofocusing elements on browsers that have touch support (mostly mobile devices) can cause the lower half of the screen to be hidden by the virtual keyboard before the user has an opportunity to read the entire screen's text.

fixes #248 
