### PR TITLE
Fixing a few style warnings from jscs

### DIFF
--- a/app/scripts/views/age.js
+++ b/app/scripts/views/age.js
@@ -53,8 +53,7 @@ function (BaseView, AgeTemplate) {
 
       if (this._requiresMoreVerification(year)) {
         nextStep = 'birthday';
-      }
-      else if (this._canCreateAccount(year)) {
+      } else if (this._canCreateAccount(year)) {
         nextStep = 'create_account';
       }
 

--- a/app/tests/spec/lib/xss.js
+++ b/app/tests/spec/lib/xss.js
@@ -70,7 +70,7 @@ function (mocha, chai, _, XSS, Constants) {
 
       it('allows hrefs of the max length', function() {
         var maxLength = Constants.URL_MAX_LENGTH;
-        var allowed = "http://";
+        var allowed = 'http://';
 
         while (allowed.length < maxLength) {
           allowed += 'a';
@@ -81,7 +81,7 @@ function (mocha, chai, _, XSS, Constants) {
 
       it('disallowed hrefs that are too long', function() {
         var maxLength = Constants.URL_MAX_LENGTH;
-        var tooLong = "http://";
+        var tooLong = 'http://';
 
         while (tooLong.length < maxLength + 1) {
           tooLong += 'a';

--- a/scripts/run_locally.js
+++ b/scripts/run_locally.js
@@ -23,14 +23,19 @@ module.exports = function (done) {
   fxaccntbridge.stderr.on('data', function(data) {
     console.log('fxa-content-server err:', data.toString('utf8').trim());
   });
-  fxaccntbridge.on('exit', function(code, signal) {
+  fxaccntbridge.on('exit', function (code, signal) {
     console.log('fxa-content-server killed, existing');
-    if (done) done(code);
-    else process.exit(code);
+    if (done) {
+      done(code);
+    } else {
+      process.exit(code);
+    }
   });
 };
 
 // only start the server if the file is called directly, otherwise wait until
 // module.exports is called.
-if (process.argv[1] === __filename) module.exports();
+if (process.argv[1] === __filename) {
+  module.exports();
+}
 

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -8,37 +8,37 @@ const path = require('path');
 
 var conf = module.exports = convict({
   port: {
-    format: "port",
+    format: 'port',
     default: 3030,
-    env: "PORT"
+    env: 'PORT'
   },
   cachify_prefix: {
-    doc: "The prefix for cachify hashes in URLs",
-    default: "v"
+    doc: 'The prefix for cachify hashes in URLs',
+    default: 'v'
   },
   client_sessions: {
-    cookie_name: "session",
-    secret: "YOU MUST CHANGE ME",
+    cookie_name: 'session',
+    secret: 'YOU MUST CHANGE ME',
     duration: {
-      format: "duration",
-      default: "1 day"
+      format: 'duration',
+      default: '1 day'
     }
   },
-  default_lang: "en-US",
-  debug_lang: "it-CH",
+  default_lang: 'en-US',
+  debug_lang: 'it-CH',
   disable_locale_check: {
-    doc: "Skip checking for gettext .mo files for supported locales",
+    doc: 'Skip checking for gettext .mo files for supported locales',
     default: false
   },
   env: {
-    doc: "What environment are we running in?  Note: all hosted environments are 'production'.  ",
-    format: ["production", "development"],
-    default: "production",
+    doc: 'What environment are we running in?  Note: all hosted environments are \'production\'.',
+    format: ['production', 'development'],
+    default: 'production',
     env: 'NODE_ENV'
   },
   http_proxy: {
     port: {
-      format: "port",
+      format: 'port',
       default: undefined
     },
     host: {
@@ -47,58 +47,58 @@ var conf = module.exports = convict({
     }
   },
   public_url: {
-    doc: "The publically visible URL of the deployment",
-    default: "http://127.0.0.1:3030",
+    doc: 'The publically visible URL of the deployment',
+    default: 'http://127.0.0.1:3030',
     env: 'PUBLIC_URL'
   },
   process_type: 'ephemeral',
   statsd: {
     enabled: {
-      doc: "enable UDP based statsd reporting",
+      doc: 'enable UDP based statsd reporting',
       default: true,
       env: 'ENABLE_STATSD'
     },
-    host: "localhost",
+    host: 'localhost',
     port: {
-      format: "port",
+      format: 'port',
       default: 8125
     }
   },
-  translation_directory: "static/i18n",
+  translation_directory: 'static/i18n',
   supported_languages: {
-    doc: "List of languages this deployment should detect and display localized strings.",
+    doc: 'List of languages this deployment should detect and display localized strings.',
     format: Array,
-    default: [ "en-US" ],
+    default: [ 'en-US' ],
     env: 'SUPPORTED_LANGUAGES'
   },
   route_log_format: {
-    format: [ "default_fxa", "dev_fxa", "default", "dev", "short", "tiny" ],
-    default: "default_fxa"
+    format: [ 'default_fxa', 'dev_fxa', 'default', 'dev', 'short', 'tiny' ],
+    default: 'default_fxa'
   },
   use_https: false,
   var_path: {
-    doc: "The path where deployment specific resources will be sought (keys, etc), and logs will be kept.",
-    default: path.resolve(__dirname, "..", "var"),
+    doc: 'The path where deployment specific resources will be sought (keys, etc), and logs will be kept.',
+    default: path.resolve(__dirname, '..', 'var'),
     env: 'VAR_PATH'
   },
   fxaccount_url: {
-    doc: "The url of the Firefox Account server",
-    format: "url",
-    default: "http://127.0.0.1:9000/v1",
-    env: "FXA_URL"
+    doc: 'The url of the Firefox Account server',
+    format: 'url',
+    default: 'http://127.0.0.1:9000/v1',
+    env: 'FXA_URL'
   },
   static_directory: {
-    doc: "Directory that static files are served from.",
+    doc: 'Directory that static files are served from.',
     format: String,
-    default: "app"
+    default: 'app'
   },
   font_max_age_ms: {
-    doc: "Cache fonts for this amount of time, in ms",
+    doc: 'Cache fonts for this amount of time, in ms',
     format: Number,
     default: 180 * 24 * 60 * 60 * 1000      // 180 days
   },
   hsts_max_age: {
-    doc: "Max age of the STS directive, in seconds",
+    doc: 'Max age of the STS directive, in seconds',
     format: Number,
     default: 180 * 24 * 60 * 60            // 180 days
   }
@@ -107,7 +107,7 @@ var conf = module.exports = convict({
 // At the time this file is required, we'll determine the "process name" for this proc
 // if we can determine what type of process it is (browserid or verifier) based
 // on the path, we'll use that, otherwise we'll name it 'ephemeral'.
-conf.set('process_type', path.basename(process.argv[1], ".js"));
+conf.set('process_type', path.basename(process.argv[1], '.js'));
 
 var DEV_CONFIG_PATH = path.join(__dirname, '..', 'config', 'local.json');
 if (! process.env.CONFIG_FILES &&


### PR DESCRIPTION
Fixing a few warnings from `$ grunt jscs`. Now down to 5 warnings.

```
$ grunt jscs
Running "jscs:src" (jscs) task

If statement without curly braces at app/scripts/lib/channels/fx-desktop.js :
    48 |    /*jshint validthis: true*/
    49 |    var result = event.data.content;
    50 |    if (! result) return;
------------^
    51 |
    52 |    var type = event.data.type;

If statement without curly braces at app/scripts/lib/channels/fx-desktop.js :
    68 |  function findInitialPage() {
    69 |    this.send('session_status', {}, _.bind(function(err, response) {
    70 |      if (err) return;
--------------^
    71 |
    72 |      if (response.data) {

Keyword `else` should not be placed on new line at app/scripts/lib/channels/fx-desktop.js :
    74 |        this.router.navigate('settings', { trigger: true });
    75 |      }
    76 |      else {
--------------^
    77 |        delete Session.email;
    78 |        this.router.navigate('signup', { trigger: true });

Line must be at most 160 characters at app/scripts/router.js :
    26 |  'transit'
    27 |],
    28 |function ($, Backbone, IntroView, SignInView, SignUpView, ConfirmView, SettingsView, TosView, PpView, AgeView, BirthdayView, CreateAccountView, CannotCreateAccountView, CompleteSignUpView, ResetPasswordView, ConfirmResetPasswordView, CompleteResetPasswordView, ResetPasswordCompleteView) {
--------^
    29 |  var Router = Backbone.Router.extend({
    30 |    routes: {

If statement without curly braces at app/tests/spec/lib/channels/fx-desktop.js :
    47 |
    48 |    afterEach(function() {
    49 |      if (channel) channel.teardown();
--------------^
    50 |    });
    51 |

>> 5 code style errors found!
Warning: Task "jscs:src" failed. Use --force to continue.

Aborted due to warnings.
```
