### PR TITLE
fix typo in desktop channel code

### DIFF
--- a/app/scripts/lib/channels/fx-desktop.js
+++ b/app/scripts/lib/channels/fx-desktop.js
@@ -137,7 +137,7 @@ function (_, Backbone, Session) {
       } catch (e) {
         // something went wrong sending the message and we are not going to
         // retry, no need to keep track of it any longer.
-        delete this.outstandingRequest[command];
+        delete this.outstandingRequests[command];
         return done && done(e);
       }
 


### PR DESCRIPTION
This was breaking some tests for me and throwing errors in phantomjs. @nchapman r?
