### PR TITLE
Fix the "Done not a function" error.

### DIFF
--- a/app/scripts/lib/channels/fx-desktop.js
+++ b/app/scripts/lib/channels/fx-desktop.js
@@ -115,7 +115,7 @@ function (_, Backbone, Session) {
     },
 
     send: function (command, data, done) {
-      done = done || noOp();
+      done = done || noOp;
 
       var outstanding = this.outstandingRequests[command];
       if (! outstanding) {

--- a/app/tests/spec/lib/channels/fx-desktop.js
+++ b/app/tests/spec/lib/channels/fx-desktop.js
@@ -99,6 +99,12 @@ function(mocha, chai, WindowMock, RouterMock, Session, FxDesktopChannel) {
           done();
         });
       });
+
+      it('does not except on timeout if callback is not given', function(done) {
+        // if there is an exception, done is never called.
+        setTimeout(done, 500);
+        channel.send('wait-for-response', { key: 'value' });
+      });
     });
 
     describe('on', function() {


### PR DESCRIPTION
@zaach - could you review this one?
- In init, if `done` was not passed, we called `noOp()` instead of setting a reference to it.
- Added a unit test to check for the problem

fixes #232
