### PR TITLE
Fixed issue with grunt build not completing correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-autoprefixer": "~0.2.0",
     "grunt-usemin": "~0.1.10",
     "grunt-mocha": "~0.4.0",
-    "grunt-modernizr": "~0.3.0",
+    "grunt-modernizr": "~0.4.1",
     "grunt-requirejs": "~0.4.0",
     "grunt-svgmin": "~0.2.0",
     "grunt-concurrent": "~0.3.0",


### PR DESCRIPTION
Turns out that an issue in the older version of grunt-modernizr was causing grunt-build to not complete correctly. Upgrading from 0.3.1 to 0.4.1 seems to have fixed the issue.

Should fix #229 and #230.

For best results when testing:

```
rm -r node_modules
rm -r dist
npm install
grunt build
```
