### PR TITLE
Force wrapping long email addresses on confirm and reset password screens

### DIFF
--- a/app/scripts/templates/confirm.mustache
+++ b/app/scripts/templates/confirm.mustache
@@ -9,7 +9,7 @@
 
   <div class="graphic graphic-mail">{{#t}}Email Sent{{/t}}</div>
 
-  <p>{{#t}}A verification link has been sent to:{{/t}}<br/>{{email}}.</p>
+  <p class="verification-email-message">{{#t}}A verification link has been sent to:{{/t}}<br/>{{email}}.</p>
 
   <div class="links">
     <a>{{#t}}Email not showing up? Send again{{/t}}</a>

--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -9,7 +9,7 @@
 
   <div class="graphic graphic-mail">{{#t}}Email Sent{{/t}}</div>
 
-  <p>{{#t}}A reset link has been sent to:{{/t}}<br/><strong>{{email}}.</strong></p>
+  <p class="verification-email-message">{{#t}}A reset link has been sent to:{{/t}}<br/><strong>{{email}}.</strong></p>
 
   <div class="links">
     <a>{{#t}}Email not showing up? Send again{{/t}}</a>

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -222,6 +222,10 @@ section p {
   margin-top: 20px;
 }
 
+.verification-email-message {
+  word-wrap: break-word;
+}
+
 .password-row {
   position: relative;
 }


### PR DESCRIPTION
Fixes #274. Rather than truncating the email as suggested by the issue, I forced it to wrap so the user still sees their whole email address.

![screen shot 2014-01-22 at 9 10 12 pm](https://f.cloud.github.com/assets/3095/1981983/bd9e913a-83ec-11e3-8947-06305b0cd065.png)
