### PR TITLE
WIP: Use Almond instead of Require.js in dist

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,7 +82,6 @@ module.exports = function (grunt) {
     'clean:dist',
     'useminPrepare',
     'selectconfig:dist',
-    'requirejs',
     'concurrent:dist',
     'autoprefixer',
     'concat',
@@ -90,6 +89,7 @@ module.exports = function (grunt) {
     'uglify',
     'modernizr',
     'copy:dist',
+    'requirejs',
     'rev',
     'usemin'
   ]);

--- a/app/index.html
+++ b/app/index.html
@@ -33,8 +33,6 @@
 
         </div>
 
-        <!-- build:js scripts/main.js -->
         <script data-main="scripts/main" src="bower_components/requirejs/require.js"></script>
-        <!-- endbuild -->
     </body>
 </html>

--- a/grunttasks/requirejs.js
+++ b/grunttasks/requirejs.js
@@ -9,18 +9,19 @@ module.exports = function (grunt) {
     dist: {
       // Options: https://github.com/jrburke/r.js/blob/master/build/example.build.js
       options: {
-        // `name` and `out` are set by grunt-usemin
+        almond: true,
+        replaceRequireScript: [{
+          files: ['<%= yeoman.dist %>/index.html'],
+          module: 'main'
+        }],
+        modules: [{name: 'main'}],
+        mainConfigFile: '<%= yeoman.app %>/scripts/main.js',
+        dir: '<%= yeoman.dist %>/scripts',
         baseUrl: '<%= yeoman.app %>/scripts',
-        optimize: 'none',
-        // TODO: Figure out how to make sourcemaps work with grunt-usemin
-        // https://github.com/yeoman/grunt-usemin/issues/30
-        //generateSourceMaps: true,
-        // required to support SourceMaps
-        // http://requirejs.org/docs/errors.html#sourcemapcomments
-        preserveLicenseComments: false,
         useStrict: true,
-        wrap: true,
-        stubModules: ['text', 'stache']
+        stubModules: ['text', 'stache'],
+        optimize: 'none',
+        wrap: true
       }
     }
   });


### PR DESCRIPTION
This is almost is a fix for #286 and would be a great improvement over what we have now. With these changes, `grunt build` will embed almond in the main.js file and negate the need for the separate require.js file. Unfortunately there seems to be a conflict with fxa-js-client. It gives an error about require being undefined when attempting to load the page from dist. If I replace fxa-js-client with a dummy file then the page loads correctly. This seems to be related:

https://groups.google.com/forum/?fromgroups=#!topic/requirejs/k7-v2VTLEsw

It looks like the recommendation is to use the source files from fxa-js-client instead of the "compiled" version. @zaach @vladikoff have you guys run into anything like this before?
