### PR TITLE
Hookup resend verification email links

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -77,6 +77,12 @@ function (FxaClient, $, p, Session) {
               });
     },
 
+    signUpResend: function () {
+      return this._getClientAsync().then(function (client) {
+                return client.recoveryEmailResendCode(Session.sessionToken);
+              });
+    },
+
     signOut: function () {
       return this._getClientAsync()
               .then(function (client) {
@@ -95,14 +101,22 @@ function (FxaClient, $, p, Session) {
               });
     },
 
-    requestPasswordReset: function (email) {
+    passwordReset: function (email) {
       return this._getClientAsync()
               .then(function (client) {
                 return client.passwordForgotSendCode(email);
               })
-              .then(function () {
+              .then(function (result) {
                 Session.clear();
                 Session.set('email', email);
+                Session.set('passwordForgotToken', result.passwordForgotToken);
+              });
+    },
+
+    passwordResetResend: function () {
+      return this._getClientAsync().then(function (client) {
+                return client.passwordForgotResendCode(
+                            Session.email, Session.passwordForgotToken);
               });
     },
 
@@ -138,12 +152,6 @@ function (FxaClient, $, p, Session) {
               })
               .then(function () {
                 Session.clear();
-              });
-    },
-
-    recoveryEmailResendCode: function (sessionToken) {
-      return this._getClientAsync().then(function (client) {
-                return client.recoveryEmailResendCode(sessionToken);
               });
     }
 

--- a/app/scripts/templates/confirm.mustache
+++ b/app/scripts/templates/confirm.mustache
@@ -12,6 +12,10 @@
   <p class="verification-email-message">{{#t}}A verification link has been sent to:{{/t}}<br/><span id="confirm-email">{{email}}</span>.</p>
 
   <div class="links">
-    <a>{{#t}}Email not showing up? Send again{{/t}}</a>
+    <a id="resend" href="#">{{#t}}Email not showing up? Send again{{/t}}</a>
+  </div>
+
+  <div class="success">
+    {{#t}}Email resent{{/t}}
   </div>
 </section>

--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -12,6 +12,10 @@
   <p class="verification-email-message">{{#t}}A reset link has been sent to:{{/t}}<br/><strong>{{email}}.</strong></p>
 
   <div class="links">
-    <a>{{#t}}Email not showing up? Send again{{/t}}</a>
+    <a id="resend" href="#">{{#t}}Email not showing up? Send again{{/t}}</a>
+  </div>
+
+  <div class="success">
+    {{#t}}Email resent{{/t}}
   </div>
 </section>

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -154,5 +154,33 @@ function (_, Backbone, jQuery, Session) {
     }
   });
 
+  /**
+   * Return a backbone compatible event handler that
+   * prevents the default action, then calls the specified handler.
+   * @method Baseview.preventDefaultThen
+   * handler can be either a string or a function. If a string, this[handler]
+   * will be called. Handler called with context of "this" view and is passed
+   * the event
+   */
+  BaseView.preventDefaultThen = function (handler) {
+    return function (event) {
+      event.preventDefault();
+
+      // convert a name to a function.
+      if (typeof handler === 'string') {
+        handler = this[handler];
+
+        if (typeof handler !== 'function') {
+          console.warn(handler +
+                ' is an invalid function name to use with preventDefaultThen');
+        }
+      }
+
+      if (typeof handler === 'function') {
+        return handler.call(this, event);
+      }
+    };
+  };
+
   return BaseView;
 });

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -7,19 +7,37 @@
 define([
   'views/base',
   'stache!templates/confirm',
-  'lib/session'
+  'lib/session',
+  'lib/fxa-client'
 ],
-function (BaseView, ConfirmTemplate, Session) {
-  var ConfirmView = BaseView.extend({
-    template: ConfirmTemplate,
+function (BaseView, Template, Session, FxaClient) {
+  var View = BaseView.extend({
+    template: Template,
     className: 'confirm',
 
     context: function () {
       return {
         email: Session.email
       };
+    },
+
+    events: {
+      'click': BaseView.preventDefaultThen('resend')
+    },
+
+    resend: function () {
+      var self = this;
+      var client = new FxaClient();
+      client.signUpResend()
+            .then(function () {
+              self.$('.success').show();
+              self.trigger('resent');
+            }, function (err) {
+              self.displayError(err.message);
+            });
     }
+
   });
 
-  return ConfirmView;
+  return View;
 });

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -7,9 +7,10 @@
 define([
   'views/base',
   'stache!templates/confirm_reset_password',
-  'lib/session'
+  'lib/session',
+  'lib/fxa-client'
 ],
-function (BaseView, Template, Session) {
+function (BaseView, Template, Session, FxaClient) {
   var View = BaseView.extend({
     template: Template,
     className: 'confirm-reset-password',
@@ -18,7 +19,24 @@ function (BaseView, Template, Session) {
       return {
         email: Session.email
       };
+    },
+
+    events: {
+      'click': BaseView.preventDefaultThen('resend')
+    },
+
+    resend: function () {
+      var self = this;
+      var client = new FxaClient();
+      client.passwordResetResend()
+            .then(function () {
+              self.$('.success').show();
+              self.trigger('resent');
+            }, function (err) {
+              self.displayError(err.message);
+            });
     }
+
   });
 
   return View;

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -31,7 +31,7 @@ function (_, BaseView, Template, FxaClient) {
       var email = this._getEmail();
 
       var client = new FxaClient();
-      client.requestPasswordReset(email)
+      client.passwordReset(email)
             .done(this._onRequestResetSuccess.bind(this),
                   this._onRequestResetFailure.bind(this));
 

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -40,7 +40,7 @@ function (_, BaseView, SignInTemplate, Session, FxaClient, PasswordMixin) {
               if (accountData.verified) {
                 router.navigate('settings', { trigger: true });
               } else {
-                return client.recoveryEmailResendCode(accountData.sessionToken)
+                return client.signUpResend()
                   .then(function () {
                     router.navigate('confirm', { trigger: true });
                   });

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -60,7 +60,9 @@ require([
   '../tests/spec/views/sign_in',
   '../tests/spec/views/complete_reset_password',
   '../tests/spec/views/settings',
-  '../tests/spec/views/delete_account'
+  '../tests/spec/views/delete_account',
+  '../tests/spec/views/confirm',
+  '../tests/spec/views/confirm_reset_password'
 ],
 function (Mocha) {
   // Use a mock for the translator

--- a/app/tests/mocks/dom-event.js
+++ b/app/tests/mocks/dom-event.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// mock out a DOM event
+
+'use strict';
+
+define([
+], function () {
+  function DOMEventMock() {
+    // nothing to do
+  }
+
+  DOMEventMock.prototype = {
+    preventDefault: function () {
+      this._defaultPrevented = true;
+    },
+
+    isDefaultPrevented: function () {
+      return !!this._defaultPrevented;
+    }
+  };
+
+  return DOMEventMock;
+});
+

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -14,7 +14,7 @@ define([
   'lib/fxa-client'
 ],
 function (mocha, chai, $, ChannelMock, Session, FxaClientWrapper) {
-  /*global beforeEach, describe, it*/
+  /*global beforeEach, afterEach, describe, it*/
   var assert = chai.assert;
   var email;
   var password = 'password';
@@ -36,11 +36,14 @@ function (mocha, chai, $, ChannelMock, Session, FxaClientWrapper) {
       channelMock = null;
     });
 
-    describe('signUp', function () {
+    describe('signUp/signUpResend', function () {
       it('signs up a user with email/password', function (done) {
         client.signUp(email, password)
           .then(function () {
             assert.equal(channelMock.message, 'login');
+            return client.signUpResend();
+          })
+          .then(function () {
             done();
           }, function (err) {
             assert.fail(err);
@@ -65,17 +68,17 @@ function (mocha, chai, $, ChannelMock, Session, FxaClientWrapper) {
       });
     });
 
-    describe('verifyCode', function () {
-    });
-
-    describe('requestPasswordReset', function () {
+    describe('passwordReset/passwordResetResend', function () {
       it('requests a password reset', function (done) {
         client.signUp(email, password)
           .then(function () {
             return client.signIn(email, password);
           })
           .then(function () {
-            return client.requestPasswordReset(email);
+            return client.passwordReset(email);
+          })
+          .then(function () {
+            return client.passwordResetResend();
           })
           .then(function () {
             // positive test to ensure success case has an assertion
@@ -144,14 +147,13 @@ function (mocha, chai, $, ChannelMock, Session, FxaClientWrapper) {
           .then(function () {
             assert.fail('should not be able to signin after account deletion');
             done();
-          }, function (err) {
+          }, function () {
             // positive test to ensure sign in failure case has an assertion
             assert.isTrue(true);
             done();
           });
       });
     });
-
   });
 });
 

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -11,9 +11,10 @@ define([
   'jquery',
   'views/base',
   'lib/translator',
-  'stache!templates/test_template'
+  'stache!templates/test_template',
+  '../../mocks/dom-event'
 ],
-function (mocha, chai, jQuery, BaseView, Translator, Template) {
+function (mocha, chai, jQuery, BaseView, Translator, Template, DOMEventMock) {
   /*global describe, beforeEach, afterEach, it*/
   var assert = chai.assert;
 
@@ -82,6 +83,39 @@ function (mocha, chai, jQuery, BaseView, Translator, Template) {
       it('translates and display an error in the .error element', function () {
         view.displayError('the error message');
         assert.equal($('.error').html(), 'a translated error message');
+      });
+    });
+
+    describe('BaseView.preventDefaultThen', function() {
+      var event;
+
+      it('can take the name of a function as the name of the event handler', function(done) {
+        view.eventHandler = function(event) {
+          assert.isTrue(event.isDefaultPrevented());
+          done();
+        };
+
+        var backboneHandler = BaseView.preventDefaultThen('eventHandler');
+        backboneHandler.call(view, new DOMEventMock());
+      });
+
+      it('can take a function as the event handler', function(done) {
+        function eventHandler(event) {
+          assert.isTrue(event.isDefaultPrevented());
+          done();
+        };
+
+        var backboneHandler = BaseView.preventDefaultThen(eventHandler);
+        backboneHandler.call(view, new DOMEventMock());
+      });
+
+      it('can take no arguments at all', function() {
+        var backboneHandler = BaseView.preventDefaultThen();
+
+        var eventMock = new DOMEventMock();
+        backboneHandler.call(view, eventMock);
+
+        assert.isTrue(eventMock.isDefaultPrevented());
       });
     });
   });

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'mocha',
+  'chai',
+  'views/confirm',
+  'lib/fxa-client',
+  '../../mocks/router'
+],
+function (mocha, chai, View, FxaClient, RouterMock) {
+  /*global describe, beforeEach, afterEach, it*/
+  var assert = chai.assert;
+
+  describe('views/confirm', function () {
+    var view, router;
+
+    beforeEach(function () {
+      router = new RouterMock();
+      view = new View({
+        router: router
+      });
+      view.render();
+
+      $('#container').html(view.el);
+    });
+
+    afterEach(function () {
+      view.remove();
+      view.destroy();
+    });
+
+    describe('constructor creates it', function () {
+      it('is drawn', function () {
+        assert.ok($('#fxa-confirm-header').length);
+      });
+    });
+
+    describe('resend', function () {
+      it('resends the confirmation email', function (done) {
+        var client = new FxaClient();
+        var email = 'user' + Math.random() + '@testuser.com';
+
+        client.signUp(email, 'password')
+              .then(function () {
+                 view.on('resent', done);
+                 view.resend();
+              });
+
+      });
+    });
+
+  });
+});
+
+

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'mocha',
+  'chai',
+  'views/confirm_reset_password',
+  'lib/fxa-client',
+  '../../mocks/router'
+],
+function (mocha, chai, View, FxaClient, RouterMock) {
+  /*global describe, beforeEach, afterEach, it*/
+  var assert = chai.assert;
+
+  describe('views/confirm_reset_password', function () {
+    var view, router;
+
+    beforeEach(function () {
+      router = new RouterMock();
+      view = new View({
+        router: router
+      });
+      view.render();
+
+      $('#container').html(view.el);
+    });
+
+    afterEach(function () {
+      view.remove();
+      view.destroy();
+    });
+
+    describe('constructor creates it', function () {
+      it('is drawn', function () {
+        assert.ok($('#fxa-confirm-reset-password-header').length);
+      });
+    });
+
+    describe('resend', function () {
+      it('resends the confirmation email', function (done) {
+        var client = new FxaClient();
+        var email = 'user' + Math.random() + '@testuser.com';
+
+        client.signUp(email, 'password')
+              .then(function () {
+                return client.passwordReset(email);
+              })
+              .then(function () {
+                   view.on('resent', done);
+                  view.resend();
+                });
+
+      });
+    });
+
+  });
+});
+
+

--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -14,14 +14,26 @@ define([
   registerSuite({
     name: 'confirm',
 
-    'load up the screen': function () {
+    'load up the screen, click resend': function () {
 
       return this.get('remote')
         .get(require.toUrl(url))
         .waitForElementById('fxa-confirm-header')
 
+        .elementById('resend')
+          .click()
+        .end()
+
+        // brittle, but some processing time.
+        .wait(2000)
+
         // Success is showing the screen
+        .elementByCssSelector('.success').isDisplayed()
+          .then(function (isDisplayed) {
+            assert.isTrue(isDisplayed);
+          })
         .end();
     }
+
   });
 });

--- a/tests/functional/confirm_reset_password.js
+++ b/tests/functional/confirm_reset_password.js
@@ -14,12 +14,24 @@ define([
   registerSuite({
     name: 'confirm_password_reset',
 
-    'open page': function () {
+    'open page, click resend': function () {
 
       return this.get('remote')
         .get(require.toUrl(PAGE_URL))
         .waitForElementById('fxa-confirm-reset-password-header')
 
+        .elementById('resend')
+          .click()
+        .end()
+
+        // brittle, but some processing time.
+        .wait(2000)
+
+        // Success is showing the screen
+        .elementByCssSelector('.success').isDisplayed()
+          .then(function (isDisplayed) {
+            assert.isTrue(isDisplayed);
+          })
         .end();
     }
   });


### PR DESCRIPTION
- Add reset password resend to the fxa-client wrapper.
- Rename requestPasswordReset to passwordReset - update consumers.
- Add visual feedback when email is resent.
- Add BaseView.preventDefaultThen to reduce event handling boilerplate. BaseView.preventDefault returns a proxy event handler that backbone can use to call event.preventDefault, then another handler.

fixes #272
