### PR TITLE
Fix Modernizr and focus issues when embedded in about:accounts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,8 +73,6 @@ module.exports = function (grunt) {
     'concurrent:test',
     'autoprefixer',
     'serverproc:test'
-    // XXX Mocha is removed from here, we should do something else that's
-    // awesome instead.
   ]);
 
   grunt.registerTask('build', [
@@ -88,8 +86,10 @@ module.exports = function (grunt) {
     'concat',
     'cssmin',
     'uglify',
-    'modernizr',
     'copy:dist',
+    // modernizer must come after copy or else the custom
+    // modernizr is overwritten with the dev version.
+    'modernizr',
     'rev',
     'usemin'
   ]);

--- a/app/index.html
+++ b/app/index.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="bower_components/normalize-css/normalize.css">
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild -->
-        <!-- build:js scripts/vendor/modernizr.js -->
+        <!-- build:js bower_components/modernizr/modernizr.js -->
         <script src="bower_components/modernizr/modernizr.js"></script>
         <!-- endbuild -->
     </head>

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -110,7 +110,10 @@ function (
         // Render the new view
         this.$stage.html(this.currentView.el);
 
-        this.$stage.show();
+        // explicitly set the display: block using .css. When embedded
+        // in about:accounts, the content is not yet visible and show will
+        // not display the element.
+        this.$stage.css('display', 'block');
         this.currentView.afterVisible();
       }
     },

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -81,11 +81,29 @@ function (_, Backbone, jQuery, Session) {
       // it's a desktop device and autofocus can be applied without
       // hiding part of the screen. The no-touch class is added by modernizr
       if (jQuery('html').hasClass('no-touch')) {
+        // only elements that are visibile can be focused. When embedded in
+        // about:accounts, the content is hidden when the first "focus" is
+        // done. Keep trying to focus until the element is actually focused,
+        // and then stop trying.
+        var autofocusEl = this.$('[autofocus]');
         try {
-          this.$('[autofocus]').get(0).focus();
+          autofocusEl.get(0).focus();
         } catch (e) {
           // IE can blow up if the element is not visible.
         }
+        this.focusInterval = setInterval(function() {
+          if (autofocusEl.is(':focus')) {
+            clearInterval(this.focusInterval);
+            this.focusInterval = null;
+            return;
+          }
+
+          try {
+            autofocusEl.get(0).focus();
+          } catch (e) {
+            // IE can blow up if the element is not visible.
+          }
+        }, 50);
       }
     },
 
@@ -97,6 +115,10 @@ function (_, Backbone, jQuery, Session) {
     destroy: function (remove) {
       if (this.beforeDestroy) {
         this.beforeDestroy();
+      }
+
+      if (this.focusInterval) {
+        clearInterval(this.focusInterval);
       }
 
       if (remove) {

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -59,18 +59,6 @@ function (_, BaseView, Template, Session, FxaClient, PasswordMixin, Url) {
       };
     },
 
-    afterRender: function () {
-      // autofocus doesn't seem to work in the context of about:accounts
-      // where it's loaded in an iframe, so try mantually here
-      setTimeout(function() {
-        try {
-          this.$('input.email')[0].focus();
-        } catch(e) {
-          // blows up if there is no element or hidden in IE.
-        }
-      }, 0);
-    },
-
     onSubmit: function (event) {
       event.preventDefault();
       this.signUp();

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "requirejs": "~2.1.9",
     "underscore": "~1.5.2",
     "backbone": "~1.1.0",
-    "modernizr": "~2.6.2",
+    "modernizr": "~2.7.1",
     "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.8",
     "normalize-css": "~2.1.3",
     "jquery.transit": "~0.9.9",

--- a/grunttasks/modernizr.js
+++ b/grunttasks/modernizr.js
@@ -13,6 +13,27 @@ module.exports = function (grunt) {
       '<%= yeoman.dist %>/styles/{,*/}*.css',
       '!<%= yeoman.dist %>/scripts/vendor/*'
     ],
-    uglify: true
+    extra: {
+      shiv: true,
+      printshiv: false,
+      load: false,
+      mq: false,
+      cssclasses: true
+    },
+    // Based on default settings on http://modernizr.com/download/
+    extensibility: {
+      addtest: false,
+      prefixed: false,
+      teststyles: true,
+      testprops: false,
+      testallprops: false,
+      hasevents: false,
+      prefixes: true,
+      domprefixes: false
+    },
+    tests: ['touch'],
+    // this will be uglified in the build step.
+    uglify: false,
+    parseFiles: true
   });
 };

--- a/grunttasks/rev.js
+++ b/grunttasks/rev.js
@@ -9,6 +9,7 @@ module.exports = function (grunt) {
     dist: {
       files: {
         src: [
+          '<%= yeoman.dist %>/bower_components/{,*/}*.js',
           '<%= yeoman.dist %>/scripts/{,*/}*.js',
           '<%= yeoman.dist %>/styles/{,*/}*.css',
           '<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}',


### PR DESCRIPTION
- Modernizr blows up when trying to query for indexedDB. To get around this, for prod, we build modernizr with only the components we need. This has the advantage of being a smaller download as well. Since modernizr was throwing an exception, there were some interesting side effects - like the #stage element was never hidden in the embedded context. With modernizr working, content remained hidden because of the way $.show works, and this had to be fixed.
- Only elements that are visible can be focused. Keep trying to autofocus an element until it is focused.
- Ensure requirejs has a cache busting URL.

issue #384
fixes #353
