### PR TITLE
Adding years 2007-1950 to age dropdown

### DIFF
--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -25,18 +25,64 @@
     <div class="input-row">
       <select id="fxa-age-year" value="none">
         <option id="fxa-none" value="none">{{#t}}Year of birth{{/t}}</option>
-        <option id="fxa-1960" value="1960">{{#t}}1960s or earlier{{/t}}</option>
-        <option id="fxa-1970" value="1970">{{#t}}1970s{{/t}}</option>
-        <option id="fxa-1980" value="1980">{{#t}}1980s{{/t}}</option>
-        <option id="fxa-1990" value="1990">{{#t}}1990s{{/t}}</option>
-        <option id="fxa-2000" value="2000">{{#t}}2000{{/t}}</option>
-        <option id="fxa-2001" value="2001">{{#t}}2001{{/t}}</option>
-        <option id="fxa-2002" value="2002">{{#t}}2002{{/t}}</option>
-        <option id="fxa-2003" value="2003">{{#t}}2003{{/t}}</option>
-        <option id="fxa-2004" value="2004">{{#t}}2004{{/t}}</option>
-        <option id="fxa-2005" value="2005">{{#t}}2005{{/t}}</option>
-        <option id="fxa-2006" value="2006">{{#t}}2006{{/t}}</option>
         <option id="fxa-2007" value="2007">{{#t}}2007{{/t}}</option>
+        <option id="fxa-2006" value="2006">{{#t}}2006{{/t}}</option>
+        <option id="fxa-2005" value="2005">{{#t}}2005{{/t}}</option>
+        <option id="fxa-2004" value="2004">{{#t}}2004{{/t}}</option>
+        <option id="fxa-2003" value="2003">{{#t}}2003{{/t}}</option>
+        <option id="fxa-2002" value="2002">{{#t}}2002{{/t}}</option>
+        <option id="fxa-2001" value="2001">{{#t}}2001{{/t}}</option>
+        <option id="fxa-2000" value="2000">{{#t}}2000{{/t}}</option>
+        <option id="fxa-1999" value="1999">{{#t}}1999{{/t}}</option>
+        <option id="fxa-1998" value="1998">{{#t}}1998{{/t}}</option>
+        <option id="fxa-1997" value="1997">{{#t}}1997{{/t}}</option>
+        <option id="fxa-1996" value="1996">{{#t}}1996{{/t}}</option>
+        <option id="fxa-1995" value="1995">{{#t}}1995{{/t}}</option>
+        <option id="fxa-1994" value="1994">{{#t}}1994{{/t}}</option>
+        <option id="fxa-1993" value="1993">{{#t}}1993{{/t}}</option>
+        <option id="fxa-1992" value="1992">{{#t}}1992{{/t}}</option>
+        <option id="fxa-1991" value="1991">{{#t}}1991{{/t}}</option>
+        <option id="fxa-1990" value="1990">{{#t}}1990{{/t}}</option>
+        <option id="fxa-1989" value="1989">{{#t}}1989{{/t}}</option>
+        <option id="fxa-1988" value="1988">{{#t}}1988{{/t}}</option>
+        <option id="fxa-1987" value="1987">{{#t}}1987{{/t}}</option>
+        <option id="fxa-1986" value="1986">{{#t}}1986{{/t}}</option>
+        <option id="fxa-1985" value="1985">{{#t}}1985{{/t}}</option>
+        <option id="fxa-1984" value="1984">{{#t}}1984{{/t}}</option>
+        <option id="fxa-1983" value="1983">{{#t}}1983{{/t}}</option>
+        <option id="fxa-1982" value="1982">{{#t}}1982{{/t}}</option>
+        <option id="fxa-1981" value="1981">{{#t}}1981{{/t}}</option>
+        <option id="fxa-1980" value="1980">{{#t}}1980{{/t}}</option>
+        <option id="fxa-1979" value="1979">{{#t}}1979{{/t}}</option>
+        <option id="fxa-1978" value="1978">{{#t}}1978{{/t}}</option>
+        <option id="fxa-1977" value="1977">{{#t}}1977{{/t}}</option>
+        <option id="fxa-1976" value="1976">{{#t}}1976{{/t}}</option>
+        <option id="fxa-1975" value="1975">{{#t}}1975{{/t}}</option>
+        <option id="fxa-1974" value="1974">{{#t}}1974{{/t}}</option>
+        <option id="fxa-1973" value="1973">{{#t}}1973{{/t}}</option>
+        <option id="fxa-1972" value="1972">{{#t}}1972{{/t}}</option>
+        <option id="fxa-1971" value="1971">{{#t}}1971{{/t}}</option>
+        <option id="fxa-1970" value="1970">{{#t}}1970{{/t}}</option>
+        <option id="fxa-1969" value="1969">{{#t}}1969{{/t}}</option>
+        <option id="fxa-1968" value="1968">{{#t}}1968{{/t}}</option>
+        <option id="fxa-1967" value="1967">{{#t}}1967{{/t}}</option>
+        <option id="fxa-1966" value="1966">{{#t}}1966{{/t}}</option>
+        <option id="fxa-1965" value="1965">{{#t}}1965{{/t}}</option>
+        <option id="fxa-1964" value="1964">{{#t}}1964{{/t}}</option>
+        <option id="fxa-1963" value="1963">{{#t}}1963{{/t}}</option>
+        <option id="fxa-1962" value="1962">{{#t}}1962{{/t}}</option>
+        <option id="fxa-1961" value="1961">{{#t}}1961{{/t}}</option>
+        <option id="fxa-1960" value="1960">{{#t}}1960{{/t}}</option>
+        <option id="fxa-1959" value="1959">{{#t}}1959{{/t}}</option>
+        <option id="fxa-1958" value="1958">{{#t}}1958{{/t}}</option>
+        <option id="fxa-1957" value="1957">{{#t}}1957{{/t}}</option>
+        <option id="fxa-1956" value="1956">{{#t}}1956{{/t}}</option>
+        <option id="fxa-1955" value="1955">{{#t}}1955{{/t}}</option>
+        <option id="fxa-1954" value="1954">{{#t}}1954{{/t}}</option>
+        <option id="fxa-1953" value="1953">{{#t}}1953{{/t}}</option>
+        <option id="fxa-1952" value="1952">{{#t}}1952{{/t}}</option>
+        <option id="fxa-1951" value="1951">{{#t}}1951{{/t}}</option>
+        <option id="fxa-1950" value="1950">{{#t}}1950 or earlier{{/t}}</option>
       </select>
     </div>
 


### PR DESCRIPTION
Fixes #383

Not sure if/why we need each option to have an explicit `id` on each option or if each year needs to be translated (`{{#t}}1976{{/t}}`), but I just kept the same format.
