### PR TITLE
Fixes #407

### DIFF
--- a/app/scripts/templates/reset_password.mustache
+++ b/app/scripts/templates/reset_password.mustache
@@ -1,29 +1,25 @@
 <header>
   <h1 id='fxa-reset-password-header'>{{#t}}Firefox Accounts{{/t}}</h1>
 
-  <h2>{{#t}}Reset Password{{/t}}</h2>
+  <h2>{{#t}}Reset password{{/t}}</h2>
 </header>
 
 <section>
   <div class="error"></div>
 
   <form>
-    <p>{{#t}}Enter your email address, and we'll email you instructions on how to reset your password{{/t}}</p>
+    <p>{{#t}}Enter your account email to reset the password.{{/t}}</p>
 
     <div class="input-row">
       <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" autofocus>
     </div>
 
     <div class="button-row">
-      <button type="submit" disabled>{{#t}}Submit{{/t}}</button>
+      <button type="submit" disabled>{{#t}}Next{{/t}}</button>
     </div>
   </form>
 
   <div class="links">
-    {{^forceAuth}}
-      <a href="/signin" class="left sign-in">{{#t}}Sign in{{/t}}</a>
-      <a href="/signup" class="right sign-up">{{#t}}Create an account{{/t}}</a>
-    {{/forceAuth}}
     {{#forceAuth}}
       <a id="back" href="/force_auth">{{#t}}Back{{/t}}</a>
     {{/forceAuth}}


### PR DESCRIPTION
Changed copy to match latest UX PDF.
Deleted some `{{^forceAuth}}` block, for giggles (plus, to remove /signin and /signup links -- didn't touch the other forceAuth bits since it was a back button, and I don't fully understand forceAuth).

Should fix #407
