### PR TITLE
Updates fxa-js-client to 0.1.10

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "underscore": "~1.5.2",
     "backbone": "~1.1.0",
     "modernizr": "~2.7.1",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.9",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.10",
     "normalize-css": "~2.1.3",
     "jquery.transit": "~0.9.9",
     "requirejs-mustache": "*",


### PR DESCRIPTION
v0.1.10 of the fxa-jsclient fixes an issue where `/certificate/sign` would go to `/session/destroy` instead.
