### PR TITLE
removing the password length notice on the sign_in page

### DIFF
--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -33,8 +33,6 @@
         <div class="show-password-label-text">{{#t}}Show{{/t}}</div>
         <input id="show-password" type="checkbox" class="show-password">
       </label>
-
-      <div class="input-help">{{#t}}Must be at least 8 characters{{/t}}</div>
     </div>
 
     <div class="button-row">


### PR DESCRIPTION
Remove the password hint. Fixes #379
