### PR TITLE
Ensure the `service` and `redirectTo` URL search parameters make it to the fxa-js-client.

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -58,21 +58,6 @@ function (
   WebChannel,
   FxDesktopChannel
 ) {
-  window.router = new Router();
-
-  // IE8 does not support window.navigator.language. Set a default of English.
-  window.translator = new Translator(window.navigator.language || 'en');
-
-  // Don't start backbone until we have our translations
-  translator.fetch(function () {
-    // Get the party started
-    Backbone.history.start({ pushState: true });
-
-    // The channel must be initialized after Backbone.history so that the
-    // Backbone does not override the page the channel sets.
-    Session.set('channel', getChannel());
-  });
-
   function getChannel() {
     var context = Url.searchParam('context');
     var channel;
@@ -88,6 +73,37 @@ function (
     channel.init();
     return channel;
   }
+
+  function setSessionValueFromUrl(name) {
+    var value = Url.searchParam(name);
+    if (value) {
+      Session.set(name, value);
+    } else {
+      Session.clear(name);
+    }
+  }
+
+  function initSessionFromUrl() {
+    setSessionValueFromUrl('service');
+    setSessionValueFromUrl('redirectTo');
+  }
+
+  window.router = new Router();
+
+  // IE8 does not support window.navigator.language. Set a default of English.
+  window.translator = new Translator(window.navigator.language || 'en');
+
+  initSessionFromUrl();
+
+  // Don't start backbone until we have our translations
+  translator.fetch(function () {
+    // Get the party started
+    Backbone.history.start({ pushState: true });
+
+    // The channel must be initialized after Backbone.history so that the
+    // Backbone does not override the page the channel sets.
+    Session.set('channel', getChannel());
+  });
 });
 
 

--- a/app/scripts/templates/complete_sign_up.mustache
+++ b/app/scripts/templates/complete_sign_up.mustache
@@ -14,7 +14,7 @@
     {{#redirectTo}}
       <p>{{#t}}You are now ready to use %(service)s{{/t}}</p>
 
-      <a href="{{ redirectTo }}" autofocus>{{#t}}Continue{{/t}}</a>
+      <a id="redirectTo" href="{{ redirectTo }}" autofocus>{{#t}}Continue{{/t}}</a>
     {{/redirectTo}}
     {{^redirectTo}}
       <p>{{#t}}Your account is ready!{{/t}}</p>

--- a/app/scripts/templates/reset_password_complete.mustache
+++ b/app/scripts/templates/reset_password_complete.mustache
@@ -12,6 +12,6 @@
   {{#redirectTo}}
     <p>{{#t}}Continue to %(service)s on the <strong>Initial Client</strong>.{{/t}}</p>
 
-    <a href="{{ redirectTo }}" autofocus>{{#t}}Continue{{/t}}</a>
+    <a id="redirectTo" href="{{ redirectTo }}" autofocus>{{#t}}Continue{{/t}}</a>
   {{/redirectTo}}
 </section>

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -19,8 +19,9 @@ function (_, Backbone, jQuery, Session, authErrors) {
       options = options || {};
 
       this.subviews = [];
-      this.translator = options.translator || window.translator;
-      this.router = options.router || window.router;
+      this.window = options.window || window;
+      this.translator = options.translator || this.window.translator;
+      this.router = options.router || this.window.router;
 
       Backbone.View.call(this, options);
     },

--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -11,10 +11,9 @@ define([
   'stache!templates/change_password',
   'lib/fxa-client',
   'lib/session',
-  'lib/password-mixin',
-  'lib/url'
+  'lib/password-mixin'
 ],
-function (_, BaseView, FormView, Template, FxaClient, Session, PasswordMixin, Url) {
+function (_, BaseView, FormView, Template, FxaClient, Session, PasswordMixin) {
   var t = BaseView.t;
 
   var View = FormView.extend({
@@ -32,7 +31,7 @@ function (_, BaseView, FormView, Template, FxaClient, Session, PasswordMixin, Ur
 
     context: function () {
       return {
-        isSync: Url.searchParam('service') === 'sync'
+        isSync: Session.service === 'sync'
       };
     },
 

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -27,7 +27,7 @@ function (_, BaseView, FormView, Template, FxaClient, Session, Url, PasswordMixi
 
     context: function () {
       return {
-        isSync: Url.searchParam('service') === 'sync'
+        isSync: Session.service === 'sync'
       };
     },
 
@@ -71,12 +71,6 @@ function (_, BaseView, FormView, Template, FxaClient, Session, Url, PasswordMixi
     },
 
     _onResetCompleteSuccess: function () {
-      // This information will be displayed on the
-      // reset_password_complete screen.
-      Session.set({
-        service: Url.searchParam('service'),
-        redirectTo: Url.searchParam('redirectTo')
-      });
       this.navigate('reset_password_complete');
     },
 

--- a/app/scripts/views/delete_account.js
+++ b/app/scripts/views/delete_account.js
@@ -10,10 +10,9 @@ define([
   'stache!templates/delete_account',
   'lib/session',
   'lib/fxa-client',
-  'lib/password-mixin',
-  'lib/url'
+  'lib/password-mixin'
 ],
-function (_, FormView, Template, Session, FxaClient, PasswordMixin, Url) {
+function (_, FormView, Template, Session, FxaClient, PasswordMixin) {
   var View = FormView.extend({
     // user must be authenticated to delete their account
     mustAuth: true,
@@ -29,7 +28,7 @@ function (_, FormView, Template, Session, FxaClient, PasswordMixin, Url) {
 
     context: function () {
       return {
-        isSync: Url.searchParam('service') === 'sync'
+        isSync: Session.service === 'sync'
       };
     },
 

--- a/app/scripts/views/reset_password_complete.js
+++ b/app/scripts/views/reset_password_complete.js
@@ -9,10 +9,9 @@ define([
   'views/base',
   'stache!templates/reset_password_complete',
   'lib/session',
-  'lib/xss',
-  'lib/url'
+  'lib/xss'
 ],
-function (_, BaseView, Template, Session, Xss, Url) {
+function (_, BaseView, Template, Session, Xss) {
   var View = BaseView.extend({
     template: Template,
     className: 'reset_password_complete',
@@ -20,8 +19,7 @@ function (_, BaseView, Template, Session, Xss, Url) {
     context: function () {
       return {
         email: Session.email,
-        service: Url.searchParam('service'),
-        isSync: Url.searchParam('service') === 'sync',
+        service: Session.service,
         redirectTo: Xss.href(Session.redirectTo)
       };
     }

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -21,8 +21,6 @@ function (_, FormView, SignInTemplate, Session, FxaClient, PasswordMixin, Url) {
     initialize: function (options) {
       options = options || {};
 
-      this.window = options.window || window;
-
       // reset any force auth status.
       Session.set('forceAuth', false);
 
@@ -50,7 +48,7 @@ function (_, FormView, SignInTemplate, Session, FxaClient, PasswordMixin, Url) {
         email: Session.email,
         forceAuth: Session.forceAuth,
         error: error,
-        isSync: Url.searchParam('service') === 'sync'
+        isSync: Session.service === 'sync'
       };
     },
 

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -11,10 +11,9 @@ define([
   'stache!templates/sign_up',
   'lib/session',
   'lib/fxa-client',
-  'lib/password-mixin',
-  'lib/url'
+  'lib/password-mixin'
 ],
-function (_, BaseView, FormView, Template, Session, FxaClient, PasswordMixin, Url) {
+function (_, BaseView, FormView, Template, Session, FxaClient, PasswordMixin) {
   var t = BaseView.t;
 
   var now = new Date();
@@ -56,8 +55,8 @@ function (_, BaseView, FormView, Template, Session, FxaClient, PasswordMixin, Ur
 
     context: function () {
       return {
-        service: Url.searchParam('session'),
-        isSync: Url.searchParam('service') === 'sync'
+        service: Session.service,
+        isSync: Session.service === 'sync'
       };
     },
 

--- a/app/tests/lib/helpers.js
+++ b/app/tests/lib/helpers.js
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict';
+
 define([
-], function() {
+  'sinon'
+], function (sinon) {
   function requiresFocus(callback, done) {
     if (document.hasFocus && document.hasFocus()) {
       callback();
@@ -21,7 +24,32 @@ define([
     }
   }
 
+  function addFxaClientSpy(fxaClient) {
+    // create spies that can be used to check which parameters
+    // are passed to the FxaClient
+    for (var key in fxaClient) {
+      if (typeof fxaClient[key] === 'function') {
+        try {
+          sinon.spy(fxaClient, key);
+        } catch (e) {
+          console.error('error with spy: %s', String(e));
+        }
+      }
+    }
+  }
+
+  function removeFxaClientSpy(fxaClient) {
+    // return the client to its original state.
+    for (var key in fxaClient) {
+      if (typeof fxaClient[key] === 'function') {
+        fxaClient[key].restore();
+      }
+    }
+  }
+
   return {
-    requiresFocus: requiresFocus
+    requiresFocus: requiresFocus,
+    addFxaClientSpy: addFxaClientSpy,
+    removeFxaClientSpy: removeFxaClientSpy
   };
 });

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -18,7 +18,8 @@ require.config({
     modernizr: '../bower_components/modernizr/modernizr',
     mocha: '../bower_components/mocha/mocha',
     chai: '../bower_components/chai/chai',
-    p: '../bower_components/p/p'
+    p: '../bower_components/p/p',
+    sinon: '../bower_components/sinon/index'
   },
   shim: {
     underscore: {
@@ -39,6 +40,9 @@ require.config({
         'jquery'
       ],
       exports: 'jQuery.fn.transition'
+    },
+    sinon: {
+      exports: 'sinon'
     }
   },
   stache: {
@@ -48,6 +52,7 @@ require.config({
 
 require([
   'mocha',
+  'lib/translator',
   '../tests/setup',
   '../tests/spec/lib/channels/web',
   '../tests/spec/lib/channels/fx-desktop',
@@ -60,6 +65,7 @@ require([
   '../tests/spec/views/base',
   '../tests/spec/views/form',
   '../tests/spec/views/sign_up',
+  '../tests/spec/views/complete_sign_up',
   '../tests/spec/views/sign_in',
   '../tests/spec/views/settings',
   '../tests/spec/views/change_password',
@@ -69,15 +75,12 @@ require([
   '../tests/spec/views/pp',
   '../tests/spec/views/reset_password',
   '../tests/spec/views/confirm_reset_password',
-  '../tests/spec/views/complete_reset_password'
+  '../tests/spec/views/complete_reset_password',
+  '../tests/spec/views/reset_password_complete'
 ],
-function (Mocha) {
-  // Use a mock for the translator
-  window.translator = {
-    get: function (key) {
-      return key;
-    }
-  };
+function (Mocha, Translator) {
+  // The translator is expected to be on the window object.
+  window.translator = new Translator();
 
   var runner = Mocha.run();
 

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -12,7 +12,11 @@ define([
 ],
 function (_, Backbone) {
   function WindowMock() {
-    // nothing to do here.
+    this.translator = window.translator;
+    this.location = {
+      href: window.location.href,
+      search: window.location.search
+    };
   }
 
   _.extend(WindowMock.prototype, Backbone.Events, {
@@ -41,10 +45,6 @@ function (_, Backbone) {
 
     CustomEvent: function(command, data) {
       return data;
-    },
-    location: {
-      href: window.location.href,
-      search: window.location.search
     }
   });
 

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -10,40 +10,69 @@ define([
   'chai',
   'jquery',
   '../../mocks/channel',
+  '../../lib/helpers',
   'lib/session',
   'lib/fxa-client'
 ],
-function (mocha, chai, $, ChannelMock, Session, FxaClientWrapper) {
+// FxaClientWrapper is the object that is used in
+// fxa-content-server views. It wraps FxaClient to
+// take care of some app-specific housekeeping.
+function (mocha, chai, $, ChannelMock, testHelpers,
+              Session, FxaClientWrapper) {
   /*global beforeEach, afterEach, describe, it*/
   var assert = chai.assert;
   var email;
   var password = 'password';
   var client;
+  var realClient;
   var channelMock;
 
 
   describe('lib/fxa-client', function () {
-    beforeEach(function () {
+    beforeEach(function (done) {
       channelMock = new ChannelMock();
       Session.clear();
       Session.set('channel', channelMock);
-      client = new FxaClientWrapper();
       email = 'testuser' + Math.random() + '@testuser.com';
+
+      client = new FxaClientWrapper();
+      client._getClientAsync()
+              .then(function (_realClient) {
+                realClient = _realClient;
+                // create spies that can be used to check
+                // parameters that are passed to the FxaClient
+                testHelpers.addFxaClientSpy(realClient);
+                done();
+              });
     });
 
     afterEach(function () {
       Session.clear();
       channelMock = null;
+
+      // return the client to its original state.
+      testHelpers.removeFxaClientSpy(realClient);
     });
 
     describe('signUp/signUpResend', function () {
-      it('signs up a user with email/password', function (done) {
+      it('signUp signs up a user with email/password', function (done) {
+        Session.set('service', 'sync');
+        Session.set('redirectTo', 'https://sync.firefox.com');
+
         client.signUp(email, password)
           .then(function () {
             assert.equal(channelMock.message, 'login');
             assert.isUndefined(channelMock.data.customizeSync);
+
+            assert.isTrue(realClient.signUp.calledWith(email, password, {
+              keys: true,
+              service: 'sync',
+              redirectTo: 'https://sync.firefox.com'
+            }));
+
             done();
-          }, function (err) {
+          })
+          .then(null, function (err) {
             assert.fail(err);
             done();
           });
@@ -52,13 +81,37 @@ function (mocha, chai, $, ChannelMock, Session, FxaClientWrapper) {
       it('informs browser of customizeSync option', function (done) {
         client.signUp(email, password, true)
           .then(function () {
-            assert.equal(channelMock.message, 'login');
             assert.isTrue(channelMock.data.customizeSync);
+
+            done();
+          })
+          .then(null, function (err) {
+            assert.fail(err);
+            done();
+          });
+      });
+
+      it('signUpResend resends the validation email', function (done) {
+        Session.set('service', 'sync');
+        Session.set('redirectTo', 'https://sync.firefox.com');
+
+        client.signUp(email, password)
+          .then(function () {
             return client.signUpResend();
           })
           .then(function () {
+            assert.isTrue(
+                realClient.recoveryEmailResendCode.calledWith(
+                    Session.sessionToken,
+                    {
+                      service: 'sync',
+                      redirectTo: 'https://sync.firefox.com'
+                    }
+                ));
+
             done();
-          }, function (err) {
+          })
+          .then(null, function (err) {
             assert.fail(err);
             done();
           });
@@ -69,7 +122,7 @@ function (mocha, chai, $, ChannelMock, Session, FxaClientWrapper) {
       it('signin with unknown user should call errorback', function (done) {
         client.signIn('unknown@unknown.com', 'password')
           .then(function (info) {
-            assert.isTrue(false, 'unknown user cannot sign in');
+            assert.fail('unknown user cannot sign in');
             done();
           }, function (err) {
             assert.isTrue(true);
@@ -112,19 +165,34 @@ function (mocha, chai, $, ChannelMock, Session, FxaClientWrapper) {
       it('requests a password reset', function (done) {
         client.signUp(email, password)
           .then(function () {
-            return client.signIn(email, password);
-          })
-          .then(function () {
+            Session.set('service', 'sync');
+            Session.set('redirectTo', 'https://sync.firefox.com');
             return client.passwordReset(email);
           })
           .then(function () {
+            assert.isTrue(
+                realClient.passwordForgotSendCode.calledWith(
+                    email,
+                    {
+                      service: 'sync',
+                      redirectTo: 'https://sync.firefox.com'
+                    }
+                ));
             return client.passwordResetResend();
           })
           .then(function () {
-            // positive test to ensure success case has an assertion
-            assert.isTrue(true);
+            assert.isTrue(
+                realClient.passwordForgotResendCode.calledWith(
+                    email,
+                    Session.passwordForgotToken,
+                    {
+                      service: 'sync',
+                      redirectTo: 'https://sync.firefox.com'
+                    }
+                ));
             done();
-          }, function (err) {
+          })
+          .then(null, function (err) {
             assert.fail(err);
             done();
           });

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'mocha',
+  'chai',
+  'views/complete_sign_up',
+  'lib/session',
+  'lib/fxa-client',
+  '../../mocks/window',
+  '../../lib/helpers'
+],
+function (mocha, chai, View, Session, FxaClientWrapper,
+                WindowMock, testHelpers) {
+  /*global describe, beforeEach, afterEach, it*/
+  var assert = chai.assert;
+
+  describe('views/complete_sign_up', function () {
+    var view, windowMock, client;
+
+    beforeEach(function (done) {
+      Session.clear();
+
+      windowMock = new WindowMock();
+      view = new View({
+        window: windowMock
+      });
+      $('#container').html(view.el);
+      var clientWrapper = new FxaClientWrapper();
+      clientWrapper._getClientAsync()
+              .then(function (_client) {
+                client = _client;
+                // create spies that can be used to check
+                // parameters that are passed to the Fxaclient
+                testHelpers.addFxaClientSpy(client);
+                done();
+              });
+    });
+
+    afterEach(function () {
+      Session.clear();
+
+      view.remove();
+      view.destroy();
+      view = windowMock = null;
+
+      // return the client to its original state.
+      testHelpers.removeFxaClientSpy(client);
+    });
+
+    describe('constructor creates it', function () {
+      it('is drawn', function () {
+        windowMock.location.search = '?uid=uid&code=code';
+        view.render();
+        assert.ok($('#fxa-complete-sign-up-header').length);
+      });
+    });
+
+    describe('afterRender', function () {
+      it('shows an error if uid is not available on the URL', function (done) {
+        windowMock.location.search = '?code=code';
+
+        view.on('error', function (msg) {
+          assert.ok(msg);
+          assert.isFalse(client.verifyCode.called);
+
+          done();
+        });
+        view.render();
+      });
+
+      it('throws an error if code is not available on the URL', function (done) {
+        windowMock.location.search = '?uid=uid';
+
+        view.on('error', function (msg) {
+          assert.ok(msg);
+          assert.isFalse(client.verifyCode.called);
+
+          done();
+        });
+        view.render();
+      });
+
+      it('attempts to complete verification if code and uid are available', function (done) {
+        windowMock.location.search = '?code=code&uid=uid';
+
+        view.on('verify_code_complete', function () {
+          assert.isTrue(client.verifyCode.called);
+          done();
+        });
+
+        view.render();
+      });
+
+      it('shows redirectTo button if redirectTo is available', function () {
+        windowMock.location.search = '?code=code&uid=uid';
+        Session.set('redirectTo', 'https://sync.firefox.com');
+        view.render();
+
+        assert.equal(view.$('#redirectTo').length, 1);
+      });
+
+      it('does not show redirectTo button if redirectTo is not available',
+         function () {
+        windowMock.location.search = '?code=code&uid=uid';
+        view.render();
+
+        assert.equal(view.$('#redirectTo').length, 0);
+      });
+
+    });
+  });
+});
+
+
+

--- a/app/tests/spec/views/reset_password_complete.js
+++ b/app/tests/spec/views/reset_password_complete.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'mocha',
+  'chai',
+  'views/reset_password_complete',
+  'lib/session'
+],
+function (mocha, chai, View, Session) {
+  /*global describe, beforeEach, afterEach, it*/
+  var assert = chai.assert;
+
+  describe('views/reset_password_complete', function () {
+    var view;
+
+    beforeEach(function () {
+      Session.clear();
+
+      view = new View({});
+    });
+
+    afterEach(function () {
+      Session.clear();
+
+      view.remove();
+      view.destroy();
+      view = null;
+    });
+
+    describe('render', function () {
+      it('renders', function () {
+        view.render();
+
+        assert.ok(view.$('#fxa-reset-password-complete-header').length);
+      });
+
+      it('shows redirectTo link and service name if available', function () {
+        Session.set('redirectTo', 'https://sync.firefox.com');
+        Session.set('service', 'Firefox Sync');
+        view.render();
+
+        assert.equal(view.$('#redirectTo').length, 1);
+        var html = view.$('section').text();
+        assert.notEqual(html.indexOf('Firefox Sync'), -1);
+      });
+
+      it('does not show redirectTo link if unavailable', function () {
+        view.render();
+        assert.equal(view.$('#redirectTo').length, 0);
+      });
+    });
+  });
+});
+
+
+

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
     "requirejs-text": "~2.0.10",
     "mocha": "~1.16.2",
     "chai": "~1.8.1",
-    "p": "https://github.com/rkatic/p.git"
+    "p": "https://github.com/rkatic/p.git",
+    "sinon": "http://sinonjs.org/releases/sinon-1.7.1.js"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
- Pick `service` and `redirectTo` out of the URL search parameters on startup, add it to Session.
- Add sinon.js to ensure the fxa-js-client recieves the `service` and `redirectTo` parameters when expected.
- Update the views to get `service` from Session instead of the URL.
- Add two new test suites, complete_sign_up and reset_password_complete.
- Check whether service and redirectTo make it to the complete screens.
- Check whether the expected backend calls are made when expected.
- Hook up the real translator in the tests so string interpolation can be tested.

NOTE: I updated bower to use a specific version of sinon because the official sinon.js package in bower is not set up to correctly handle amd installs and does not give spy functionality.
