### PR TITLE
Fix the intermittent failing front end tests.

### DIFF
--- a/app/tests/spec/lib/session.js
+++ b/app/tests/spec/lib/session.js
@@ -21,6 +21,10 @@ function (mocha, chai, Session) {
 
     afterEach(function () {
       Session.clear();
+      // Since Session is a singleton and channel is not cleared, attaching
+      // the mock Session.channel can interfere with other tests, depending
+      // on the ordering of the tests.
+      delete Session.channel;
     });
 
     describe('set', function () {


### PR DESCRIPTION
The session tests attach a test "channel". "channel" cannot be cleared, and since Session is a singleton, the test channel never goes away. in fxa-clien.js->signIn, we attempt to send a message to a channel without a send function.

fixes #516
