### PR TITLE
Update the email verified screens to match the mocks.

### DIFF
--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// This is a temporary file that contains strings that can be extracted for the
-// l10n team to start translations.
-
 'use strict';
 
 define([
@@ -14,6 +11,9 @@ function () {
     return msg;
   };
 
+  // temporary strings that can be extracted for the
+  // l10n team to start translations.
+  //
   // tooltips specified by rfeeley and johngruen
   t('Valid email required');
   t('Valid password required');
@@ -28,6 +28,35 @@ function () {
   t('Passwords don\'t match');
   t('Please enter an email');
   t('Cannot connect to the internet');
+
+  /**
+   * Replace instances of %s and %(name)s with their corresponding values in
+   * the context
+   * @method interpolate
+   */
+  function interpolate(string, context) {
+    if (! context) {
+      context = [];
+    }
+
+    var interpolated = string.replace(/\%s/g, function (match) {
+      // boot out non arrays and arrays with not enough items.
+      if (! (context.shift && context.length > 0)) {
+        return match;
+      }
+      return context.shift();
+    });
+
+    interpolated = interpolated.replace(/\%\(([a-zA-Z]+)\)s/g, function (match, name) {
+      return name in context ? context[name] : match;
+    });
+
+    return interpolated;
+  }
+
+  return {
+    interpolate: interpolate
+  };
 
 });
 

--- a/app/scripts/lib/translator.js
+++ b/app/scripts/lib/translator.js
@@ -6,9 +6,10 @@
 
 define([
   'underscore',
-  'jquery'
+  'jquery',
+  'lib/strings'
 ],
-function (_, $) {
+function (_, $, Strings) {
   var Translator = function (language) {
     this.language = language;
     this.translations = {};
@@ -68,30 +69,7 @@ function (_, $) {
       return this.interpolate(translation, context);
     },
 
-    /**
-     * Replace instances of %s and %(name)s with their corresponding values in
-     * the context
-     * @method interpolate
-     */
-    interpolate: function (string, context) {
-      if (! context) {
-        context = [];
-      }
-
-      var interpolated = string.replace(/\%s/g, function (match) {
-        // boot out non arrays and arrays with not enough items.
-        if (! (context.shift && context.length > 0)) {
-          return match;
-        }
-        return context.shift();
-      });
-
-      interpolated = interpolated.replace(/\%\(([a-zA-Z]+)\)s/g, function (match, name) {
-        return name in context ? context[name] : match;
-      });
-
-      return interpolated;
-    }
+    interpolate: Strings.interpolate
   };
 
   return Translator;

--- a/app/scripts/templates/complete_sign_up.mustache
+++ b/app/scripts/templates/complete_sign_up.mustache
@@ -1,23 +1,20 @@
 <header>
-  <h1 id='fxa-complete-sign-up-header' class="fox-logo"><span>{{#t}}Firefox Accounts{{/t}}</span></h1>
+  <h1 class="fox-logo"><span>{{#t}}Firefox Accounts{{/t}}</span></h1>
 
-  <h2 class="success hidden">{{#t}}Email verified{{/t}}</h2>
-  <h2 class="failure">{{#t}}Email not verified{{/t}}</h2>
+  <h2 id="fxa-complete-sign-up-header" class="complete">{{#t}}Account verified{{/t}}</h2>
 </header>
 
 <section>
   <div class="error"></div>
 
-  <div id="fxa-complete-sign-up-success" class="hidden">
+  <div id="fxa-complete-sign-up-ready" class="complete">
     <div class="graphic graphic-checkbox">{{#t}}Success{{/t}}</div>
 
-    {{#redirectTo}}
-      <p>{{#t}}You are now ready to use %(service)s{{/t}}</p>
-
-      <a id="redirectTo" href="{{ redirectTo }}" autofocus>{{#t}}Continue{{/t}}</a>
-    {{/redirectTo}}
-    {{^redirectTo}}
+    {{#service}}
+    <p>{{#t}}You are now ready to use %(service)s.{{/t}}</p>
+    {{/service}}
+    {{^service}}
       <p>{{#t}}Your account is ready!{{/t}}</p>
-    {{/redirectTo}}
+    {{/service}}
   </div>
 </section>

--- a/app/scripts/templates/reset_password_complete.mustache
+++ b/app/scripts/templates/reset_password_complete.mustache
@@ -1,7 +1,7 @@
 <header>
-  <h1 id='fxa-reset-password-complete-header' class="fox-logo"><span>{{#t}}Firefox Accounts{{/t}}</span></h1>
+  <h1 class="fox-logo"><span>{{#t}}Firefox Accounts{{/t}}</span></h1>
 
-  <h2>{{#t}}Password reset{{/t}}</h2>
+  <h2 id='fxa-reset-password-complete-header'>{{#t}}Password reset{{/t}}</h2>
 </header>
 
 <section>
@@ -9,9 +9,10 @@
 
   <div class="graphic graphic-checkbox">{{#t}}Success{{/t}}</div>
 
-  {{#redirectTo}}
-    <p>{{#t}}Continue to %(service)s on the <strong>Initial Client</strong>.{{/t}}</p>
-
-    <a id="redirectTo" href="{{ redirectTo }}" autofocus>{{#t}}Continue{{/t}}</a>
-  {{/redirectTo}}
+  {{#service}}
+  <p>{{#t}}You are now ready to use %(service)s.{{/t}}</p>
+  {{/service}}
+  {{^service}}
+    <p>{{#t}}Your account is ready!{{/t}}</p>
+  {{/service}}
 </section>

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -11,9 +11,10 @@ define([
   'lib/session',
   'lib/fxa-client',
   'lib/url',
-  'lib/xss'
+  'lib/xss',
+  'lib/strings'
 ],
-function (_, BaseView, CompleteSignUpTemplate, Session, FxaClient, Url, Xss) {
+function (_, BaseView, CompleteSignUpTemplate, Session, FxaClient, Url, Xss, Strings) {
   var t = BaseView.t;
 
   var CompleteSignUpView = BaseView.extend({
@@ -21,10 +22,16 @@ function (_, BaseView, CompleteSignUpTemplate, Session, FxaClient, Url, Xss) {
     className: 'complete_sign_up',
 
     context: function () {
+      var service = Session.service;
+
+      if (Session.redirectTo) {
+        service = Strings.interpolate('<a href="%s" class="no-underline" id="redirectTo">%s</a>', [
+          Xss.href(Session.redirectTo), Session.service
+        ]);
+      }
+
       return {
-        email: Session.email,
-        service: Session.service,
-        redirectTo: Xss.href(Session.redirectTo)
+        service: service
       };
     },
 
@@ -47,15 +54,12 @@ function (_, BaseView, CompleteSignUpTemplate, Session, FxaClient, Url, Xss) {
               // TODO - we could go to a "sign_up_complete" screen here.
               self.$('#fxa-complete-sign-up-success').show();
 
-              self.$('h2.success').show();
-              self.$('h2.failure').hide();
+              self.$('.complete').show();
               self.trigger('verify_code_complete');
             })
             .then(null, function (err) {
               self.displayError(err.errno || err.message);
 
-              self.$('h2.success').hide();
-              self.$('h2.failure').show();
               self.trigger('verify_code_complete');
             });
     }

--- a/app/scripts/views/reset_password_complete.js
+++ b/app/scripts/views/reset_password_complete.js
@@ -9,18 +9,25 @@ define([
   'views/base',
   'stache!templates/reset_password_complete',
   'lib/session',
-  'lib/xss'
+  'lib/xss',
+  'lib/strings'
 ],
-function (_, BaseView, Template, Session, Xss) {
+function (_, BaseView, Template, Session, Xss, Strings) {
   var View = BaseView.extend({
     template: Template,
     className: 'reset_password_complete',
 
     context: function () {
+      var service = Session.service;
+
+      if (Session.redirectTo) {
+        service = Strings.interpolate('<a href="%s" class="no-underline" id="redirectTo">%s</a>', [
+          Xss.href(Session.redirectTo), Session.service
+        ]);
+      }
+
       return {
-        email: Session.email,
-        service: Session.service,
-        redirectTo: Xss.href(Session.redirectTo)
+        service: service
       };
     }
   });

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -28,6 +28,10 @@ a:active {
   outline: none;
 }
 
+a.no-underline {
+  text-decoration: none;
+}
+
 noscript {
   color: #d63920;
   display: block;
@@ -170,6 +174,13 @@ strong.email {
 
 .success {
   background: #5FAD47;
+  display: none;
+}
+
+/**
+ * complete is like success, but without the associated styles.
+ */
+.complete {
   display: none;
 }
 

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -62,6 +62,7 @@ require([
   '../tests/spec/lib/fxa-client',
   '../tests/spec/lib/translator',
   '../tests/spec/lib/router',
+  '../tests/spec/lib/strings',
   '../tests/spec/views/base',
   '../tests/spec/views/form',
   '../tests/spec/views/sign_up',

--- a/app/tests/spec/lib/strings.js
+++ b/app/tests/spec/lib/strings.js
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// test the interpolated library
+
+'use strict';
+
+
+define([
+  'mocha',
+  'chai',
+  'lib/strings'
+],
+function (mocha, chai, Strings) {
+  /*global describe, it*/
+  var assert = chai.assert;
+
+  describe('lib/strings', function () {
+    describe('interpolate', function () {
+      it('can do string interpolation on unnamed `%s` when given array context', function () {
+        var stringToInterpolate = 'Hi %s, this is interpolated.';
+        var interpolated = Strings.interpolate(stringToInterpolate, ['testuser@testuser.com']);
+        assert.equal(interpolated,
+              'Hi testuser@testuser.com, this is interpolated.');
+      });
+
+      it('can do string interpolation on named `%(name)s` when given array context', function () {
+        var stringToInterpolate = 'Error encountered trying to register: %(email)s.';
+        var interpolated = Strings.interpolate(stringToInterpolate, {
+          email: 'testuser@testuser.com'
+        });
+        assert.equal(interpolated,
+              'Error encountered trying to register: testuser@testuser.com.');
+      });
+
+      it('can do interpolation multiple times with an array', function () {
+        var stringToInterpolate = 'Hi %s, you have been signed in since %s';
+        var interpolated = Strings.interpolate(stringToInterpolate, [
+          'testuser@testuser.com', 'noon'
+        ]);
+
+        assert.equal(interpolated,
+              'Hi testuser@testuser.com, you have been signed in since noon');
+      });
+
+      it('can do interpolation multiple times with an object', function () {
+        var stringToInterpolate = 'Hi %(email)s, you have been signed in since %(time)s';
+        var interpolated = Strings.interpolate(stringToInterpolate, {
+          email: 'testuser@testuser.com',
+          time: 'noon'
+        });
+
+        assert.equal(interpolated,
+              'Hi testuser@testuser.com, you have been signed in since noon');
+      });
+
+      it('does no replacement on %s and %(name)s if not in context', function () {
+        var stringToInterpolate = 'Hi %s, you have been signed in since %(time)s';
+        var interpolated = Strings.interpolate(stringToInterpolate);
+
+        assert.equal(interpolated, stringToInterpolate);
+      });
+
+      it('leaves remaining %s if not enough items in context', function () {
+        var stringToInterpolate = 'Hi %s, you have been signed in since %s';
+        var interpolated = Strings.interpolate(stringToInterpolate, ['testuser@testuser.com']);
+
+        assert.equal(interpolated, 'Hi testuser@testuser.com, you have been signed in since %s');
+      });
+    });
+  });
+});
+
+


### PR DESCRIPTION
- Move translation.js->interpolate into strings.js so it can be reused.
- Update the templates to match the mocks.
- Linkify the service name if redirectTo is available.

The screens now look like:

![screen shot 2014-02-12 at 17 44 24](https://f.cloud.github.com/assets/848085/2151531/7b0a09c2-940d-11e3-9eb0-2c7b83008fe6.png)

fixes #455
fixes #502
