### PR TITLE
Fixing signup animation on low-res media query

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -67,11 +67,6 @@ noscript {
   width: 420px;
 }
 
-@-webkit-keyframes fadein {
-    from { opacity: 0; }
-    to   { opacity: 1; }
-}
-
 .js #stage {
   display: none;
 }
@@ -622,9 +617,14 @@ input[type="text"] ~ .show-password-label:hover {
 
 /* Keyframes */
 
+@-webkit-keyframes fadein {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 @-moz-keyframes fadein {
-    from { opacity: 0; }
-    to   { opacity: 1; }
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 @keyframes fadein {


### PR DESCRIPTION
Fixes #511

Ignore the big chunk of red+green. I just consolidated the keyframe animations in a single spot in the CSS (near the bottom, above the media queries).
