### PR TITLE
fix issue with email interpolation in templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "connect-cachify": "0.0.15",
     "convict": "0.4.0",
     "express": "3.3.4",
-    "i18n-abide": "0.0.14",
+    "i18n-abide": "0.0.17",
     "jwcrypto": "0.4.3",
     "intel": "0.4.0",
     "helmet": "0.1.2",

--- a/server/lib/templates.js
+++ b/server/lib/templates.js
@@ -19,7 +19,7 @@ function loadTemplate (name) {
 // Make the 'gettext' function available in the templates.
 handlebars.registerHelper('t', function(string) {
   if (this.l10n) {
-    return this.l10n.gettext(string);
+    return this.l10n.format(this.l10n.gettext(string), this);
   }
   return string;
 });
@@ -53,7 +53,7 @@ module.exports = function (lang, type) {
   var values = {
     l10n: l10n,
     link: '{{{link}}}',
-    code: '{{{code}}}'
+    email: '{{{email}}}'
   };
 
   return {

--- a/tests/server/templates.js
+++ b/tests/server/templates.js
@@ -46,6 +46,11 @@ define([
           assert.match(json.text, matches.text);
           assert.match(json.html, matches.html);
 
+          assert.match(json.text, /{{{link}}}/);
+          assert.match(json.html, /{{{link}}}/);
+          assert.match(json.text, /{{{email}}}/);
+          assert.match(json.html, /{{{email}}}/);
+
         }, dfd.reject.bind(dfd)));
     };
   }


### PR DESCRIPTION
The auth-server needs this fix to correctly substitute template variables.

/cc @chilts 
