### PR TITLE
removing inline styles. fixing smart quotes

### DIFF
--- a/app/scripts/templates/tos.mustache
+++ b/app/scripts/templates/tos.mustache
@@ -34,7 +34,7 @@
       <li>
         <h4>Introduction</h4>
         <p>
-          At Mozilla, we are committed to promoting choice and innovation on the web. That’s why we created Firefox online services – a safe and easy way to connect your profile across devices whenever you need, from wherever you are. These Terms of Service ("<u>Terms</u>") govern your use of Firefox online services ("<u>Firefox Online Services</u>" or the "<u>Services</u>").
+          At Mozilla, we are committed to promoting choice and innovation on the web. That's why we created Firefox online services – a safe and easy way to connect your profile across devices whenever you need, from wherever you are. These Terms of Service ("<u>Terms</u>") govern your use of Firefox online services ("<u>Firefox Online Services</u>" or the "<u>Services</u>").
         </p>
       </li>
       <li>
@@ -63,10 +63,10 @@
       </li>
       <li>
         <p>
-          <h4>Mozilla’s Proprietary Rights </h4>
+          <h4>Mozilla's Proprietary Rights </h4>
         </p>
         <p>
-          Mozilla does not grant you any intellectual property rights in the Services that are not specifically stated in these Terms. For example, these Terms do not provide the right to use any of Mozilla’s copyrights, trade names, trademarks, service marks, logos, domain names, or other distinctive brand features. The Services are distributed under and subject to the current version of the <a href="http://www.mozilla.org/MPL/" target="_blank">Mozilla Public License</a>
+          Mozilla does not grant you any intellectual property rights in the Services that are not specifically stated in these Terms. For example, these Terms do not provide the right to use any of Mozilla's copyrights, trade names, trademarks, service marks, logos, domain names, or other distinctive brand features. The Services are distributed under and subject to the current version of the <a href="http://www.mozilla.org/MPL/" target="_blank">Mozilla Public License</a>
         </p>
       </li>
       <li>
@@ -84,7 +84,7 @@
       <li>
         <h4>Third Party Services</h4>
         <p>
-          Third Party Services may have their own Privacy Policies and Terms of Use. You are encouraged to read these, because your use of Third Party Services may subject you to terms, policies, and practices that are separate from Mozilla’s. Mozilla does not represent or imply that it endorses any Third Party Services nor that it believes the operation of any Third Party Services will be accurate, useful, or non-harmful. Third Party Services may have technical inaccuracies, may cause mistakes or errors, and may transmit, store, or otherwise manipulate data in a manner that you find objectionable. You are responsible for taking precautions to protect yourself and your computer systems in connection with the use of Third Party Services.
+          Third Party Services may have their own Privacy Policies and Terms of Use. You are encouraged to read these, because your use of Third Party Services may subject you to terms, policies, and practices that are separate from Mozilla's. Mozilla does not represent or imply that it endorses any Third Party Services nor that it believes the operation of any Third Party Services will be accurate, useful, or non-harmful. Third Party Services may have technical inaccuracies, may cause mistakes or errors, and may transmit, store, or otherwise manipulate data in a manner that you find objectionable. You are responsible for taking precautions to protect yourself and your computer systems in connection with the use of Third Party Services.
         </p>
       </li>
       <li>
@@ -95,17 +95,17 @@
       </li>
       <li>
         <h4>Disclaimer; Limitation of Liability </h4>
-        <p style="text-transform:uppercase">
-          The Services are provided “as is” with all faults. To the extent permitted by law, Mozilla AND THE INDEMNIFIED PARTIES hereby disclaim all warranties, whether express or implied, including without limitation warranties that the Services are free of defects, merchantable, fit for a particular purpose, and non-infringing. You bear the entire risk as to selecting the Services for your purposes and as to the quality and performance of the Services, including without limitation the risk that your Content is deleted or corrupted or that someone else uses your username and password to access your ACCOUNT. This limitation will apply notwithstanding the failure of essential purpose of any remedy. Some jurisdictions do not allow the exclusion or limitation of implied warranties, so this disclaimer may not apply to you.
+        <p class="allcaps">
+          The Services are provided "as is" with all faults. To the extent permitted by law, Mozilla AND THE INDEMNIFIED PARTIES hereby disclaim all warranties, whether express or implied, including without limitation warranties that the Services are free of defects, merchantable, fit for a particular purpose, and non-infringing. You bear the entire risk as to selecting the Services for your purposes and as to the quality and performance of the Services, including without limitation the risk that your Content is deleted or corrupted or that someone else uses your username and password to access your ACCOUNT. This limitation will apply notwithstanding the failure of essential purpose of any remedy. Some jurisdictions do not allow the exclusion or limitation of implied warranties, so this disclaimer may not apply to you.
         </p>
-        <p style="text-transform:uppercase">
+        <p class="allcaps">
           Except as required by law, Mozilla AND THE INDEMNIFIED PARTIES will not be liable for any indirect, special, incidental, consequential, or exemplary damages arising out of or in any way relating to these Terms or the use of or inability to use the Services, including without limitation DIRECT AND INDIRECT damages for loss of goodwill, work stoppage, lost profits, loss of data, and computer failure or malfunction, even if advised of the possibility of such damages and regardless of the theory (contract, tort, or otherwise) upon which such claim is based. The collective liability of Mozilla AND THE INDEMNIFIED PARTIES under this Agreement will not exceed $500 (five hundred dollars). Some jurisdictions do not allow the exclusion or limitation of incidental, consequential, or special damages, so this exclusion and limitation may not apply to you.
         </p>
       </li>
       <li>
         <h4>Modifications to these Terms</h4>
         <p>
-          Mozilla may update these Terms from time to time to address a new feature of the Services or to clarify a provision. The updated Terms will be posted online. If the changes are substantive, we will announce the update through Mozilla’s usual channels for such announcements such as blog posts and forums. Your continued use of the Services after the effective date of such changes constitutes your acceptance of such changes. To make your review more convenient, we will post an effective date at the top of this page.
+          Mozilla may update these Terms from time to time to address a new feature of the Services or to clarify a provision. The updated Terms will be posted online. If the changes are substantive, we will announce the update through Mozilla's usual channels for such announcements such as blog posts and forums. Your continued use of the Services after the effective date of such changes constitutes your acceptance of such changes. To make your review more convenient, we will post an effective date at the top of this page.
         </p>
       </li>
       <li>

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -157,6 +157,10 @@ strong.email {
   display: block;
 }
 
+.allcaps {
+  text-transform: uppercase;
+}
+
 .error,
 .success {
   background: #D63920;

--- a/app/styles/sync.css
+++ b/app/styles/sync.css
@@ -1,4 +1,5 @@
 #stage {
+  min-height: 300px;
   opacity: 1;
 }
 

--- a/app/sync/intro.html
+++ b/app/sync/intro.html
@@ -20,8 +20,7 @@
     <body>
         <div id="stage">
             <header>
-              <h1><span>Firefox Accounts<span></h1>
-
+              <h1><span>Firefox Accounts</span></h1>
               <h2>Welcome to Sync</h2>
             </header>
 

--- a/app/sync/manage.html
+++ b/app/sync/manage.html
@@ -18,10 +18,9 @@
         <!-- endbuild -->
     </head>
     <body>
-        <div id="stage" style="min-height:300px">
+        <div id="stage">
             <header>
               <h1><span>Firefox Accounts</span></h1>
-
               <h2>Welcome to Sync</h2>
             </header>
 


### PR DESCRIPTION
Fixes #535, **A few inline styles**.

Since the /sync/*.html files both include sync.css, I moved the inline `min-height` style into the `#stage {}` declaration there. Worked well locally.
