### PR TITLE
 Better signin/signup error messages! 

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// provides functions to work with errors returned by the auth server.
+
 'use strict';
 
 define([
@@ -11,7 +13,29 @@ function () {
     return msg;
   };
 
-  return {
+  var ERROR_TO_CODE = {
+    UNEXPECTED_ERROR: 999,
+    INVALID_TOKEN: 110,
+    INVALID_TIMESTAMP: 111,
+    INVALID_NONCE: 115,
+    ACCOUNT_ALREADY_EXISTS: 101,
+    UNKNOWN_ACCOUNT: 102,
+    INCORRECT_EMAIL_CASE: 120,
+    INCORRECT_PASSWORD: 103,
+    UNVERIFIED_ACCOUNT: 104,
+    INVALID_VERIFICATION_CODE: 105,
+    INVALID_JSON: 106,
+    INVALID_PARAMETER: 107,
+    MISSING_PARAMETER: 108,
+    INVALID_REQUEST_SIGNATURE: 109,
+    MISSING_CONTENT_LENGTH_HEADER: 112,
+    REQUEST_TOO_LARGE: 113,
+    THROTTLED: 114,
+    SERVICE_UNAVAILABLE: 201,
+    ENDPOINT_NOT_SUPPORTED: 116
+  };
+
+  var CODE_TO_MESSAGES = {
     // errors returned by the auth server
     999: t('Unexpected error'),
     110: t('Invalid authentication token in request signature'),
@@ -34,4 +58,30 @@ function () {
     116: t('This endpoint is no longer supported')
   };
 
+  return {
+    /**
+     * Convert a numeric code or string type to a message
+     */
+    toMessage: function (code) {
+      if (typeof code === 'string') {
+        code = this.toCode(code);
+      }
+      return CODE_TO_MESSAGES[code];
+    },
+
+    /**
+     * Convert a text type from ERROR_TO_CODE to a numeric code
+     */
+    toCode: function (type) {
+      return ERROR_TO_CODE[type];
+    },
+
+    /**
+     * Check if an error is of the given type
+     */
+    is: function (error, type) {
+      var code = this.toCode(type);
+      return error.errno === code;
+    }
+  };
 });

--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -14,7 +14,7 @@ define([
 
   // channel is initialized on app startup
   // and should not be saved to localStorage
-  var DO_NOT_PERSIST = ['channel'];
+  var DO_NOT_PERSIST = ['channel', 'password', 'error'];
 
   // channel should not be cleared from memory or else fxa-client.js
   // will blow up when sending the login message.

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -19,7 +19,7 @@
   <form novalidate>
     {{^forceAuth}}
       <div class="input-row">
-        <input type="email" class="email" placeholder="{{#t}}Email{{/t}}" autofocus>
+        <input type="email" class="email" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" {{^email}}autofocus{{/email}}>
       </div>
     {{/forceAuth}}
     {{#forceAuth}}
@@ -27,7 +27,7 @@
     {{/forceAuth}}
 
     <div class="input-row password-row">
-      <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#forceAuth}}autofocus{{/forceAuth}} {{#isSync}}autocomplete="off"{{/isSync}} />
+      <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#email}}autofocus{{/email}} {{#isSync}}autocomplete="off"{{/isSync}} />
 
       <input id="show-password" type="checkbox" class="show-password" aria-controls="password" />
       <label for="show-password" class="show-password-label">

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -9,11 +9,11 @@
 
   <form novalidate>
     <div class="input-row">
-      <input type="email" class="email" placeholder="{{#t}}Email{{/t}}" autofocus required />
+      <input type="email" class="email" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" {{^email}}autofocus{{/email}} required />
     </div>
 
     <div class="input-row password-row">
-      <input id="password" type="password" class="password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#isSync}}autocomplete="off"{{/isSync}} />
+      <input id="password" type="password" class="password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#isSync}}autocomplete="off"{{/isSync}} {{#email}}autofocus{{/email}} />
       <input id="show-password" type="checkbox" class="show-password" aria-controls="password" />
       <label for="show-password" class="show-password-label">
         {{#t}}Show{{/t}}

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -170,7 +170,7 @@ function (_, Backbone, jQuery, Session, authErrors) {
     },
 
     /**
-     * Display an error message
+     * Display an error message.
      * @method displayError
      * If msg is not given, the contents of the .error element's text
      * will not be updated.
@@ -180,7 +180,7 @@ function (_, Backbone, jQuery, Session, authErrors) {
       this.$('.spinner').hide();
 
       if (typeof msg === 'number') {
-        msg = authErrors[msg];
+        msg = authErrors.toMessage(msg);
       }
 
       if (msg) {
@@ -189,6 +189,23 @@ function (_, Backbone, jQuery, Session, authErrors) {
 
       this.$('.error').show();
       this.trigger('error', msg);
+    },
+
+    /**
+     * Display an error message that may contain HTML. Marked unsafe
+     * because msg could contain XSS. Use with caution and never
+     * with unsanitized user generated content.
+     *
+     * @method displayErrorUnsafe
+     * If msg is not given, the contents of the .error element's text
+     * will not be updated.
+     */
+    displayErrorUnsafe: function (msg) {
+      this.displayError(msg);
+
+      if (msg) {
+        this.$('.error').html(this.translator.get(msg));
+      }
     },
 
     hideError: function () {

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -11,9 +11,10 @@ define([
   'stache!templates/sign_up',
   'lib/session',
   'lib/fxa-client',
-  'lib/password-mixin'
+  'lib/password-mixin',
+  'lib/auth-errors'
 ],
-function (_, BaseView, FormView, Template, Session, FxaClient, PasswordMixin) {
+function (_, BaseView, FormView, Template, Session, FxaClient, PasswordMixin, AuthErrors) {
   var t = BaseView.t;
 
   var now = new Date();
@@ -55,6 +56,7 @@ function (_, BaseView, FormView, Template, Session, FxaClient, PasswordMixin) {
 
     context: function () {
       return {
+        email: Session.prefillEmail,
         service: Session.service,
         isSync: Session.service === 'sync'
       };
@@ -109,14 +111,28 @@ function (_, BaseView, FormView, Template, Session, FxaClient, PasswordMixin) {
       var password = this.$('.password').val();
       var customizeSync = this.$('.customize-sync').is(':checked');
 
+      var self = this;
       var client = new FxaClient();
       client.signUp(email, password, customizeSync)
-        .done(_.bind(function () {
-          this.navigate('confirm');
-        }, this),
-        _.bind(function (err) {
-          this.displayError(err.errno || err.message);
-        }, this));
+        .then(function (accountData) {
+          // this means a user successfully signed in with an already
+          // existing account and should be sent on their merry way.
+          if (accountData.verified) {
+            self.navigate('settings');
+          } else {
+            self.navigate('confirm');
+          }
+        })
+        .then(null, function (err) {
+          // account already exists, and the user
+          // entered a bad password they should sign in insted.
+          if (AuthErrors.is(err, 'INCORRECT_PASSWORD')) {
+            Session.set('prefillEmail', email);
+            var msg = t('Account already exists. <a href="/signin">Sign in</a>');
+            return self.displayErrorUnsafe(msg);
+          }
+          self.displayError(err.errno || err.message);
+        });
     }
 
   });

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -146,6 +146,10 @@ strong.email {
   display: none;
 }
 
+.error a {
+  color: #fff;
+}
+
 .success {
   background: #5FAD47;
   display: none;

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -63,6 +63,7 @@ require([
   '../tests/spec/lib/translator',
   '../tests/spec/lib/router',
   '../tests/spec/lib/strings',
+  '../tests/spec/lib/auth-errors',
   '../tests/spec/views/base',
   '../tests/spec/views/tooltip',
   '../tests/spec/views/form',

--- a/app/tests/spec/lib/auth-errors.js
+++ b/app/tests/spec/lib/auth-errors.js
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// test the interpolated library
+
+'use strict';
+
+
+define([
+  'mocha',
+  'chai',
+  'lib/auth-errors'
+],
+function (mocha, chai, AuthErrors) {
+  /*global describe, it*/
+  var assert = chai.assert;
+
+  describe('lib/auth-errors', function () {
+    describe('toMessage', function () {
+      it('converts a code to a message', function () {
+        assert.equal(AuthErrors.toMessage(102), 'Unknown account');
+      });
+
+      it('converts a string type to a message', function () {
+        assert.equal(
+            AuthErrors.toMessage('UNKNOWN_ACCOUNT'), 'Unknown account');
+      });
+    });
+
+    describe('toCode', function () {
+      it('converts a string type to a numeric code', function () {
+        assert.equal(AuthErrors.toCode('UNKNOWN_ACCOUNT'), 102);
+      });
+    });
+
+    describe('is', function () {
+      it('checks if an error returned from the server is of a given type',
+          function () {
+        assert.isTrue(AuthErrors.is({ errno: 102 }, 'UNKNOWN_ACCOUNT'));
+        assert.isFalse(AuthErrors.is({ errno: 103 }, 'UNKNOWN_ACCOUNT'));
+      });
+    });
+  });
+});
+
+
+

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -106,6 +106,18 @@ function (mocha, chai, jQuery, BaseView, Translator, Template, DOMEventMock,
         view.displayError('the error message');
         assert.isFalse(view.$('.success').is(':visible'));
       });
+
+      it('removes HTML from error messages', function () {
+        view.displayError('an error message<div>with html</div>');
+        assert.equal(view.$('.error').html(), 'an error message&lt;div&gt;with html&lt;/div&gt;');
+      });
+    });
+
+    describe('displayErrorUnsafe', function () {
+      it('allows HTML in error messages', function () {
+        view.displayErrorUnsafe('an error message<div>with html</div>');
+        assert.equal(view.$('.error').html(), 'an error message<div>with html</div>');
+      });
     });
 
     describe('displaySuccess', function () {

--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -9,16 +9,53 @@ define([
 ], function (registerSuite, assert, require) {
   'use strict';
 
-  var url = 'http://localhost:3030/confirm';
+  var url = 'http://localhost:3030/signup';
+  var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
 
   registerSuite({
     name: 'confirm',
 
-    'load up the screen, click resend': function () {
+    'sign up, wait for confirmation screen, click resend': function () {
+      var email = 'signup' + Math.random() + '@example.com';
+      var password = '12345678';
 
       return this.get('remote')
         .get(require.toUrl(url))
+        .waitForElementById('fxa-signup-header')
+
+        .elementByCssSelector('form input.email')
+          .click()
+          .type(email)
+        .end()
+
+        .elementByCssSelector('form input.password')
+          .click()
+          .type(password)
+        .end()
+
+        .elementByCssSelector('#fxa-age-year')
+          .click()
+        .end()
+
+        .elementById('fxa-' + (TOO_YOUNG_YEAR - 1))
+          .buttonDown()
+          .buttonUp()
+          .click()
+        .end()
+
+        .elementByCssSelector('button[type="submit"]')
+          .click()
+        .end()
+
+        // Being pushed to the confirmation screen is success.
         .waitForElementById('fxa-confirm-header')
+        .elementById('confirm-email')
+          .text()
+          .then(function (resultText) {
+            // check the email address was written
+            assert.equal(resultText, email);
+          })
+        .end()
 
         .elementById('resend')
           .click()
@@ -34,6 +71,5 @@ define([
           })
         .end();
     }
-
   });
 });

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -5,16 +5,37 @@
 define([
   'intern!object',
   'intern/chai!assert',
-  'require'
-], function (registerSuite, assert, require) {
+  'require',
+  'intern/node_modules/dojo/node!xmlhttprequest',
+  'app/bower_components/fxa-js-client/fxa-client'
+], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient) {
   'use strict';
 
   var url = 'http://localhost:3030/signup';
+  var AUTH_SERVER_ROOT = 'http://127.0.0.1:9000/v1';
 
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
 
   registerSuite({
     name: 'sign_up',
+
+    setup: function () {
+      // clear localStorage to avoid pollution from other tests.
+      return this.get('remote')
+        .get(require.toUrl(url))
+        /*jshint evil:true*/
+        .waitForElementById('fxa-signup-header')
+        .eval('localStorage.clear();');
+    },
+
+    teardown: function () {
+      // clear localStorage to avoid polluting other tests.
+      return this.get('remote')
+        .get(require.toUrl(url))
+        /*jshint evil:true*/
+        .waitForElementById('fxa-signup-header')
+        .eval('localStorage.clear();');
+    },
 
     'sign up': function () {
       var email = 'signup' + Math.random() + '@example.com';
@@ -142,6 +163,63 @@ define([
         // Being pushed to the confirmation screen is success.
         .waitForElementById('fxa-confirm-header')
         .end();
+    },
+
+    'sign up with an known account and wrong password allows the user to sign in': function () {
+
+      var self = this;
+      var email = 'signup' + Math.random() + '@example.com';
+      var password = '12345678';
+
+      var client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+
+      return client.signUp(email, password)
+        .then(function () {
+          return self.get('remote')
+            .get(require.toUrl(url))
+            .waitForElementById('fxa-signup-header')
+
+            .elementByCssSelector('input[type=email]')
+              .click()
+              .type(email)
+            .end()
+
+            .elementByCssSelector('input[type=password]')
+              .click()
+              .type('wrong_password')
+            .end()
+
+            .elementByCssSelector('#fxa-age-year')
+              .click()
+            .end()
+
+            .elementById('fxa-' + (TOO_YOUNG_YEAR - 1))
+              .buttonDown()
+              .buttonUp()
+              .click()
+            .end()
+
+            .elementByCssSelector('button[type="submit"]')
+              .click()
+            .end()
+
+            // The error area shows a link to /signin
+            .waitForElementByCssSelector('.error a[href="/signin"]')
+            .elementByCssSelector('.error a[href="/signin"]')
+              .click()
+            .end()
+
+            .waitForElementById('fxa-signin-header')
+            .elementByCssSelector('input[type=email]')
+              .getAttribute('value')
+              .then(function (resultText) {
+                // check the email address was written
+                assert.equal(resultText, email);
+              })
+            .end();
+        });
     }
   });
 });


### PR DESCRIPTION
- Allow users who sign up with an existing account to sign in. If they type an  incorrect password, show them a link to the /signin page.
- Show users who sign in with a non-existent account a link to the /signup page.
- Clarify & simplify error processing of errors returned by the auth server
- Add a table of human understandable string types->numeric codes returned by the auth server to auth-errors.js
- All access to auth-errors goes through three functions, toMessage, toCode, and is;
- Add displayErrorUnsafe - no conversion on HTML before being displayed.
- Add functional tests for /signin and /signup error cases.

fixes #182
