### PR TITLE
Filing all the TODOs as issues

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -25,7 +25,7 @@
         <![endif]-->
         <div id="stage">
           <!-- this will be overwritten if JS is enabled -->
-          <!-- TODO - this needs to be translated on the server -->
+          <!-- TODO - (Issue #556) this needs to be translated on the server -->
           <noscript>
             Firefox Accounts requires JavaScript.
           </noscript>

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -51,7 +51,7 @@ function (_, BaseView, CompleteSignUpTemplate, Session, FxaClient, Url, Xss, Str
       var client = new FxaClient();
       client.verifyCode(uid, code)
             .then(function () {
-              // TODO - we could go to a "sign_up_complete" screen here.
+              // TODO - (Issue #557) we could go to a "sign_up_complete" screen here.
               self.$('#fxa-complete-sign-up-success').show();
 
               self.$('.complete').show();

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -682,7 +682,7 @@ input[type="text"] ~ .show-password-label:hover {
   }
 }
 
-/* TODO: These need further consideration */
+/* TODO: (Issue #558) These need further consideration */
 
 .hidden {
   display: none;
@@ -690,7 +690,7 @@ input[type="text"] ~ .show-password-label:hover {
 
 /* Responsiveness */
 
-/* TODO: Confirm breakpoint sizes */
+/* TODO: (Issue #559) Confirm breakpoint sizes */
 @media only screen and (max-width: 500px) {
   html {
     background: #fff;

--- a/grunttasks/requirejs.js
+++ b/grunttasks/requirejs.js
@@ -12,7 +12,7 @@ module.exports = function (grunt) {
         // `name` and `out` are set by grunt-usemin
         baseUrl: '<%= yeoman.app %>/scripts',
         optimize: 'none',
-        // TODO: Figure out how to make sourcemaps work with grunt-usemin
+        // TODO: (Issue #560) Figure out how to make sourcemaps work with grunt-usemin
         // https://github.com/yeoman/grunt-usemin/issues/30
         //generateSourceMaps: true,
         // required to support SourceMaps

--- a/grunttasks/todo.js
+++ b/grunttasks/todo.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.config('todo', {
+    app: {
+      files: {
+        src: [
+          '<%= yeoman.app %>/**/*.{js,css,scss,html}',
+          '!<%= yeoman.app %>/bower_components/**',
+          '!<%= yeoman.app %>/scripts/vendor/**',
+          'grunttasks/*.js',
+          'scripts/*.js',
+          'server/**/*.{js,css,html}',
+          '<%= yeoman.tests %>/**/*.js'
+        ]
+      }
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "jsxgettext-recursive": "0.0.3",
     "load-grunt-tasks": "0.2.1",
     "mkdirp": "~0.3.5",
-    "time-grunt": "~0.1.1"
+    "time-grunt": "~0.1.1",
+    "grunt-todo": "~0.1.2"
   },
   "devDependencies": {
     "awsbox": "0.6.2",

--- a/tests/functional/complete_sign_up.js
+++ b/tests/functional/complete_sign_up.js
@@ -29,8 +29,8 @@ define([
 
     'open email verification link': function () {
 
-      // TODO - get the REAL token and UID, either programatically or from
-      // the email
+      // TODO - (Issue #561) get the REAL token and UID, either programmatically
+      // or from the email
       var token = 'token';
       var uid = 'uid';
       var url = PAGE_URL_ROOT + '?uid=' + uid + '&code=' + token;

--- a/tests/intern_sauce.js
+++ b/tests/intern_sauce.js
@@ -16,7 +16,7 @@ define([
     //{ browserName: 'iphone', version: '6.0', platform: 'OS X 10.8' },
     //{ browserName: 'android', version: '4.0', platform: 'Linux' },
 
-    // TODO No IE support yet
+    // TODO (Issue #562) No IE support yet
     //{ browserName: 'internet explorer', version: '11', platform: 'Windows 8.1' },
     //{ browserName: 'internet explorer', version: '10', platform: 'Windows 8' },
     //{ browserName: 'internet explorer', version: '9', platform: 'Windows 7' },


### PR DESCRIPTION
Fixes #555

Now running `$grunt todo` will give you a list of all the "TODO" comments in the repo (along with their corresponding bug numbers).

```
$ grunt todo
Running "todo:app" (todo) task

app/index.html

    line 28  TODO  - (Issue #556) this needs to be translated on the server -->

app/scripts/views/complete_sign_up.js

    line 54  TODO  - (Issue #557) we could go to a "sign_up_complete" screen here.

app/styles/main.css

    line 685  TODO  : (Issue #558) These need further consideration */
    line 693  TODO  : (Issue #559) Confirm breakpoint sizes */

grunttasks/requirejs.js

    line 15  TODO  : (Issue #560) Figure out how to make sourcemaps work with grunt-usemin

tests/functional/complete_sign_up.js

    line 32  TODO  - (Issue #561) get the REAL token and UID, either programmatically

tests/intern_sauce.js

    line 19  TODO  (Issue #562) No IE support yet

Done, without errors.
```
