### PR TITLE
feat(polint): Lint the i18n .po files

### DIFF
--- a/grunttasks/jsonlint.js
+++ b/grunttasks/jsonlint.js
@@ -16,10 +16,17 @@ module.exports = function (grunt) {
       src: [
         '**/*.json',
         '!<%= yeoman.app %>/bower_components/**',
+        '!<%= yeoman.app %>/i18n/**',
         '!<%= yeoman.app %>/scripts/vendor/**',
         '!<%= yeoman.app %>/tests/**',
+        '!<%= yeoman.dist %>/**',
         '!<%= yeoman.server %>/**',
         '!node_modules/**'
+      ]
+    },
+    i18n: {
+      src: [
+        '<%= yeoman.app %>/i18n/**/*.json'
       ]
     }
   });

--- a/grunttasks/lint.js
+++ b/grunttasks/lint.js
@@ -9,7 +9,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('lint', [
     'jshint',
-    'jsonlint',
+    'jsonlint:app',
     'jscs'
   ]);
 };

--- a/grunttasks/localeschema.js
+++ b/grunttasks/localeschema.js
@@ -1,0 +1,41 @@
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.config('localeschema', {
+    app: {
+      files: [
+        {
+          '<%= yeoman.tmp %>/i18n/schemas/client-schema.json': '<%= yeoman.tmp %>/i18n/templates/client.pot.json',
+          '<%= yeoman.tmp %>/i18n/schemas/server-schema.json': '<%= yeoman.tmp %>/i18n/templates/server.pot.json'
+        }
+      ]
+    }
+  });
+
+  grunt.registerMultiTask('localeschema', 'Create a schema', function () {
+    this.files.forEach(function (file) {
+      var src = file.orig.src[0];
+      var dest = file.dest;
+
+      var schema = createSchema(src);
+
+      grunt.file.write(dest, JSON.stringify(schema, null, 2));
+      grunt.log.writeln('%s schema created', dest);
+    });
+  });
+
+  function createSchema(file) {
+    var data = grunt.file.readJSON(file);
+    var keys = Object.keys(data).sort();
+    var schema = {
+      properties: {},
+      required: keys
+    };
+
+    keys.forEach(function (key) {
+      var value = data[key];
+      schema.properties[key] = {type: typeof value};
+    });
+    return schema;
+  }
+};

--- a/grunttasks/po2json.js
+++ b/grunttasks/po2json.js
@@ -66,6 +66,10 @@ module.exports = function (grunt) {
     all: {
       src: ['locale/**/*.po'],
       dest: '<%= yeoman.app %>/i18n'
+    },
+    template: {
+      src: ['locale/**/*.pot'],
+      dest: '<%= yeoman.tmp %>/i18n'
     }
   });
 };

--- a/grunttasks/polint.js
+++ b/grunttasks/polint.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// meta grunt task to run other .po lint scripts.
+
+
+// This task verifies the values in the `app/i18n/**/*.json` files contain key
+// values and all the required properties from the .POT files. This should fail
+// the build/task if the locale JSON file values aren't string values or if
+// required properties from the .POT files are missing.
+//
+// NOTE: It won't complain if you add extra keys to the JSON files.
+//
+// The task does the following actions:
+//
+// 0. Runs each of the /app/i18n/**/.json files through JSONLint.
+//
+// 1. Converts the `/locale/templates/LC_MESSAGES/{client,server}.pot` files to
+// `/.tmp/i18n/templates/{client,server}.pot.json` (via the existing po2json task).
+//
+// 2. Converts the `{client,server}.pot.json` files to z-schema happy schemas
+// (via the new localeschema Grunt task).
+//
+// 3. Lints the `/app/i18n/**/{client,server}.json` files against the proper
+// schemas created in step 2 (via the new zschema task and grunt-z-schema module).
+
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.registerTask('polint', [
+    'jsonlint:i18n',
+    'po2json:template',
+    'localeschema',
+    'zschema'
+  ]);
+};

--- a/grunttasks/zschema.js
+++ b/grunttasks/zschema.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.config('zschema', {
+    options: {
+      noExtraKeywords: true
+    },
+    locales: {
+      files: {
+        '<%= yeoman.tmp %>/i18n/schemas/client-schema.json': ['<%= yeoman.app %>/i18n/**/client.json'],
+        '<%= yeoman.tmp %>/i18n/schemas/server-schema.json': ['<%= yeoman.app %>/i18n/**/server.json']
+      }
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "grunt-svgmin": "~0.2.0",
     "grunt-todo": "~0.1.2",
     "grunt-usemin": "~0.1.10",
+    "grunt-z-schema": "~0.1.0",
     "handlebars": "~1.3.0",
     "helmet": "0.1.2",
     "i18n-abide": "0.0.17",

--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -51,7 +51,7 @@ function makeApp() {
 
   routes(app);
 
-  // woraround for reserved word bug:
+  // workaround for reserved word bug:
   // https://github.com/marijnh/acorn/issues/85
   app.use(express['static'](STATIC_DIRECTORY));
   return app;


### PR DESCRIPTION
In my efforts to better understand Grunt file I/O, I give you .po file linting against a .pot file schema!

It should verify that the values in the app/i18n/*_/_.json files contain key values and all the required properties from the .POT files. Based on my testing it will fail the build/task if the locale JSON file values aren't string values or if required properties from the .POT files are missing. (But it won't complain if you add extra keys to the JSON files.)
1. Converts the `/locale/templates/LC_MESSAGES/{client,server}.pot` files to `/.tmp/i18n/templates/{client,server}.pot.json` (via the existing **po2json** task).
2. Converts the `{client,server}.pot.json` files to z-schema happy schemas (via the new **localeschema** Grunt task).
3. Lints the `/app/i18n/**/{client,server}.json` files against the proper schemas created in step 2 (via the new **zschema** task and grunt-z-schema module).

This is triggered by running the existing lint task (`$ grunt lint` -- with all the other linters) or more directly via `$ grunt polint`, which is an alias for `['po2json:template', 'localeschema', 'zschema']`.

Sure, possibly/probably useless, so feel free to kick to the curb and attach a whimsical GIF.
