### PR TITLE
fix(test) - use a real uid/code when verifying emails in complete_sign_up.js test

### DIFF
--- a/tests/functional/complete_sign_up.js
+++ b/tests/functional/complete_sign_up.js
@@ -7,39 +7,51 @@ define([
   'intern/chai!assert',
   'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client'
-], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient) {
+  'app/bower_components/fxa-js-client/fxa-client',
+  'tests/lib/restmail'
+], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail) {
   'use strict';
 
   var AUTH_SERVER_ROOT = 'http://127.0.0.1:9000/v1';
+  var EMAIL_SERVER_ROOT = 'http://127.0.0.1:9001';
   var PAGE_URL_ROOT = 'http://localhost:3030/verify_email';
   var PASSWORD = 'password';
+  var user;
   var email;
+  var accountData;
+  var client;
 
   registerSuite({
     name: 'complete_sign_up',
 
     setup: function () {
-      email = 'signin' + Math.random() + '@example.com';
-      var client = new FxaClient(AUTH_SERVER_ROOT, {
+      user = 'sginin' + Math.random();
+      email = user + '@restmail.net';
+      client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });
-      return client.signUp(email, PASSWORD);
+      return client.signUp(email, PASSWORD)
+        .then(function (result) {
+          accountData = result;
+          return result;
+        });
     },
 
     'open email verification link': function () {
 
-      // TODO - (Issue #561) get the REAL token and UID, either programmatically
-      // or from the email
-      var token = 'token';
-      var uid = 'uid';
-      var url = PAGE_URL_ROOT + '?uid=' + uid + '&code=' + token;
+      var self = this;
+      return restmail(EMAIL_SERVER_ROOT + '/mail/' + user)
+        .then(function (emails) {
+          var code = emails[0].html.match(/code=([A-Za-z0-9]+)/)[1];
+          var uid = accountData.uid;
+          var url = PAGE_URL_ROOT + '?uid=' + uid + '&code=' + code;
 
-      return this.get('remote')
-        .get(require.toUrl(url))
-        .waitForElementById('fxa-complete-sign-up-header')
+          return self.get('remote')
+            .get(require.toUrl(url))
+            .waitForElementById('fxa-complete-sign-up-header')
 
-        .end();
+            .end();
+        });
     }
   });
 });

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -8,9 +8,8 @@ define([
   'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
-  'intern/node_modules/dojo/Deferred',
   'tests/lib/restmail'
-], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Deferred, restmail) {
+], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail) {
   'use strict';
 
   var AUTH_SERVER_ROOT = 'http://127.0.0.1:9000/v1';


### PR DESCRIPTION
fixes #561
