### PR TITLE
feat(client): update document title on screen transition.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -13,6 +13,7 @@ define([
 ],
 function (_, Backbone, jQuery, Session, authErrors) {
   var ENTER_BUTTON_CODE = 13;
+  var DEFAULT_TITLE = window.document.title;
 
   var BaseView = Backbone.View.extend({
     constructor: function (options) {
@@ -44,7 +45,23 @@ function (_, Backbone, jQuery, Session, authErrors) {
 
       this.afterRender();
 
+      this.setTitleFromView();
+
       return this;
+    },
+
+    setTitleFromView: function () {
+      var title = DEFAULT_TITLE;
+      var titleText = this.$('h1').text();
+      var subText = this.$('h2').text();
+
+      if (titleText && subText) {
+        title = titleText + ': ' + subText;
+      } else if (titleText) {
+        title = titleText;
+      }
+
+      this.window.document.title = title;
     },
 
     getContext: function () {
@@ -281,10 +298,11 @@ function (_, Backbone, jQuery, Session, authErrors) {
    * translate it. t is put onto BaseView instead of
    * Translator to reduce the number of dependencies in the views.
    */
-  BaseView.t = function (str) {
+  function t(str) {
     return str;
-  };
+  }
 
+  BaseView.t = t;
 
   return BaseView;
 });

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -18,6 +18,10 @@ function (_, Backbone) {
       search: window.location.search,
       pathname: '/',
     };
+
+    this.document = {
+      title: window.document.title
+    };
   }
 
   _.extend(WindowMock.prototype, Backbone.Events, {
@@ -47,6 +51,7 @@ function (_, Backbone) {
     CustomEvent: function(command, data) {
       return data;
     },
+
     scrollTo: function(x, y) {
     }
   });

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -13,17 +13,18 @@ define([
   'stache!templates/test_template',
   '../../mocks/dom-event',
   '../../mocks/router',
+  '../../mocks/window',
   '../../lib/helpers'
 ],
 function (chai, jQuery, BaseView, Translator, Template, DOMEventMock,
-          RouterMock, TestHelpers) {
+          RouterMock, WindowMock, TestHelpers) {
   var requiresFocus = TestHelpers.requiresFocus;
 
   /*global describe, beforeEach, afterEach, it*/
   var assert = chai.assert;
 
   describe('views/base', function () {
-    var view, router;
+    var view, router, windowMock;
 
     beforeEach(function () {
       translator = new Translator();
@@ -33,13 +34,16 @@ function (chai, jQuery, BaseView, Translator, Template, DOMEventMock,
       });
 
       router = new RouterMock();
+      windowMock = new WindowMock();
+
       var View = BaseView.extend({
         template: Template
       });
 
       view = new View({
         translator: translator,
-        router: router
+        router: router,
+        window: windowMock
       });
 
       view.render();
@@ -50,8 +54,7 @@ function (chai, jQuery, BaseView, Translator, Template, DOMEventMock,
       if (view) {
         view.destroy();
         jQuery(view.el).remove();
-        view = null;
-        router = null;
+        view = router = windowMock = null;
       }
     });
 
@@ -59,6 +62,30 @@ function (chai, jQuery, BaseView, Translator, Template, DOMEventMock,
       it('renders the template without attaching it to the body', function () {
         // render is called in beforeEach
         assert.ok(jQuery('#focusMe').length);
+      });
+
+      it('updates the page title with the embedded h1 and h2 tags', function () {
+        view.template = function () {
+          return '<h1>Main title</h1><h2>Sub title</h2>';
+        };
+        view.render();
+        assert.equal(windowMock.document.title, 'Main title: Sub title');
+      });
+
+      it('updates the page title with the embedded h1 tag if no h2 tag', function () {
+        view.template = function () {
+          return '<h1>Title only</h1>';
+        };
+        view.render();
+        assert.equal(windowMock.document.title, 'Title only');
+      });
+
+      it('updates the page title with the startup page title if no h1 or h2 tag', function () {
+        view.template = function () {
+          return '<div>no titles anywhere</div>';
+        };
+        view.render();
+        assert.equal(windowMock.document.title, 'Firefox Accounts Unit Tests');
       });
     });
 


### PR DESCRIPTION
- Look for h1 and h2 elements in the view. Use these to set the title.

Closes #531
