### PR TITLE
fix(build): Adding l10n-create-json task and moving copyright task

### DIFF
--- a/grunttasks/default.js
+++ b/grunttasks/default.js
@@ -8,9 +8,10 @@ module.exports = function (grunt) {
   'use strict';
 
   grunt.registerTask('default', [
+    'l10n-create-json',
     'lint',
+    'copyright',
     'test',
-    'build',
-    'copyright'
+    'build'
   ]);
 };


### PR DESCRIPTION
Looks like the grunt copyright task wasn't getting run at the end and I missed a copyright header. :sadtrombone:

Currently the default `$ grunt` task will fail locally due to #626; **fix(build): Adds missing copyright header**.

Closes #628
