### PR TITLE
feature(contributors): Adding CONTRIBUTING and CONTRIBUTORS files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contribution Guidelines for the Firefox Accounts Content Server
+
+## Grunt Commands
+
+[Grunt](http://gruntjs.com/) is used to run common tasks to build, test, and run local servers.
+
+| Task | Description |
+|------|-------------|
+| `grunt jshint` | run JSHint on client side and testing JavaScript. |
+| `grunt build` | build production resources. |
+| `grunt clean` | remove any built production resources. |
+| `grunt test` | run local Intern tests. |
+| `grunt server` | run a local server running on port 3030 with development resources. |
+| `grunt server:dist` | run a local server running on port 3030 with production resources. Production resources will be built as part of the task. |
+| `grunt version` | stamp a new version. Updates the version number and creates a new CHANGELOG.md file. |
+
+## Servers
+
+- **latest development** - https://accounts-latest.dev.lcip.org/
+- **testing** - https://accounts.dev.lcip.org/
+- **stage** - https://accounts.stage.mozaws.net/
+- **production** - https://accounts.firefox.com/
+
+## License
+
+MPL 2.0

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,27 @@
+Andrew Chilton
+Austin King
+Benson Wong
+besnik@programeshqip.org
+Brian Warner
+Chris Karlof
+ckarlof
+Jed Parsons
+John Gruen
+johngruen
+markh@babelzilla.org
+matjaz@mozilla.com
+michael.koehler1@gmx.de
+Nick Chapman
+Peter deHaan
+petercpg@mail.moztw.org
+Ryan Kelly
+Sam Penrose
+Shane Tomlinson
+steekid
+Tim Taubert
+tomer@gmx.net
+verbatim updates user
+Vlad Filippov
+vladikoff
+Zach Carter
+Zachary Carter

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "intern-runner config=tests/intern",
     "test-browser": "intern-runner config=tests/intern_browser",
     "test-remote": "intern-runner config=tests/intern_sauce",
-    "test-server": "intern-client config=tests/intern_server"
+    "test-server": "intern-client config=tests/intern_server",
+    "contributors": "git shortlog -s | cut -c8- | sort -f > CONTRIBUTORS.md"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
You can now generate a list of repo contributors by running `$ npm run contributors`.

Closes #630
