### PR TITLE
fix(client): signOut is always a success, even if it is a failure.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -132,6 +132,11 @@ function (FxaClient, $, p, Session, AuthErrors) {
               .then(function () {
                 // user's session is gone
                 Session.clear();
+              }, function() {
+                // Clear the session, even on failure. Everything is A-OK.
+                // See issue #616
+                // - https://github.com/mozilla/fxa-content-server/issues/616
+                Session.clear();
               });
     },
 

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -255,6 +255,25 @@ function (chai, $, ChannelMock, testHelpers,
             done();
           });
       });
+
+      it('resolves to success on XHR failure', function (done) {
+        client.signUp(email, password)
+          .then(function () {
+            return client.signOut();
+          })
+          .then(function () {
+            // user has no session, this will cause an XHR error.
+            return client.signOut();
+          })
+          .then(function () {
+            // positive test to ensure success case has an assertion
+            assert.isTrue(true);
+            done();
+          }, function (err) {
+            assert.fail(err);
+            done();
+          });
+      });
     });
 
     describe('changePassword', function () {


### PR DESCRIPTION
- Clear the local session information even if signOut XHR call fails.

Closes #616
