### PR TITLE
Tweaking a few of the styles per csslint

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -105,7 +105,7 @@ header h2 {
 
 #legal-header h3 {
   font-size: 12px;
-  padding:5px 0 10px;
+  padding: 5px 0 10px;
 }
 
 #legal-copy ul,
@@ -128,10 +128,6 @@ section p {
 
 strong.email {
   display: block;
-}
-
-.allcaps {
-  text-transform: uppercase;
 }
 
 .error,
@@ -164,7 +160,7 @@ strong.email {
 }
 
 .graphic {
-  background-repeat: none;
+  background-repeat: no-repeat;
   background-size: 150px 130px;
   height: 130px;
   margin: 0 auto;
@@ -276,7 +272,7 @@ strong.email {
   // Some hackery for Firefox since moz-appearance: none doesn't remove the arrow
   text-indent: 0.01px;
   text-overflow: "";
-  -moz-user-select: none;
+  user-select: none;
   width: 100%;
 }
 

--- a/grunttasks/csslint.js
+++ b/grunttasks/csslint.js
@@ -9,11 +9,15 @@ module.exports = function (grunt) {
     strict: {
       options: {
         'box-model': 0,
+        'box-sizing': 0,
         'compatible-vendor-prefixes': 0,
+        'duplicate-background-images': 0,
         'errors': 0,
         'ids': 0,
         'import': 2,
-        'important': 1,
+        'important': 0,
+        'outline-none': 0,
+        'overqualified-elements': 0,
         'qualified-headings': 0,
         'unique-headings': 0,
         'universal-selector': 0,


### PR DESCRIPTION
1. Removes `.allcaps` style since it was only used in the TOS/PP (which has since moved to a legal repo).
2. Changed `background-repeat: none;` to `background-repeat: no-repeat;`.
3. Changed `-moz-user-select: none;` to the non-prefixed `user-select: none;` (since autoprefixer will add the correct vender prefixes back in).
4. Relaxed some of the noise from grunt CSSLint task.

You can run CSSLint directly using `$ grunt css csslint`. (First target converts sass to css and adds vendor prefixes. Second target runs CSSLint on the generated *.css file(s))

Closes #652
