### PR TITLE
feat(client): Password reset email prefill & /force_auth simplification.

### DIFF
--- a/app/scripts/templates/reset_password.mustache
+++ b/app/scripts/templates/reset_password.mustache
@@ -10,7 +10,7 @@
     <p>{{#t}}Enter your email to reset&nbsp;the account password.{{/t}}</p>
 
     <div class="input-row">
-      <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" autofocus required>
+      <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" autofocus required>
     </div>
 
     <div class="button-row">
@@ -18,12 +18,9 @@
     </div>
   </form>
 
-  <div class="links">
-    {{#forceAuth}}
-      <a id="back" href="/force_auth">{{#t}}Back{{/t}}</a>
-    {{/forceAuth}}
-    {{^forceAuth}}
+  {{#backEnabled}}
+    <div class="links">
       <a id="back" href="/signin">{{#t}}Back{{/t}}</a>
-    {{/forceAuth}}
-  </div>
+    </div>
+  {{/backEnabled}}
 </section>

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -46,7 +46,7 @@
       <a href="/signup" class="right sign-up">{{#t}}Create an account{{/t}}</a>
     {{/forceAuth}}
     {{#forceAuth}}
-      <a href="/reset_password" class="reset-password">{{#t}}Forgot password?{{/t}}</a>
+      <a href="/confirm_reset_password" class="reset-password">{{#t}}Forgot password?{{/t}}</a>
     {{/forceAuth}}
   </div>
 

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -9,20 +9,49 @@ define([
   'views/form',
   'stache!templates/reset_password',
   'lib/fxa-client',
-  'lib/session'
+  'lib/session',
+  'lib/url'
 ],
-function (_, FormView, Template, FxaClient, Session) {
+function (_, FormView, Template, FxaClient, Session, Url) {
   var View = FormView.extend({
     template: Template,
     className: 'reset_password',
 
+    _isBackEnabled: function () {
+      /* If email is specified on the query param, user probably browsed
+       * directly to the page. No back for them.
+       * Users who visit `/force_auth?email=<xxx>` and
+       * click "forgot password" are sent to the
+       * "confirm your email" screen, skipping this step.
+       */
+      return !this._getQueryEmail();
+    },
+
+    _getQueryEmail: function () {
+      return Url.searchParam('email', this.window.location.search);
+    },
+
+    _getPrefillEmail: function () {
+      return this._getQueryEmail() || '';
+    },
+
     context: function () {
       return {
-        // forceAuth is used to determine which secondary links to show
-        // If set to true, only a back link is displayed. If false, create
-        // account and sign in links are displayed.
-        forceAuth: Session.forceAuth
+        email: this._getPrefillEmail(),
+        backEnabled: this._isBackEnabled()
       };
+    },
+
+    afterRender: function () {
+      var value = this.$('.email').val();
+      if (value) {
+        this.enableSubmitIfValid();
+        // place cursor at the end of the text.
+        var emailEl = this.$('.email').get(0);
+        if (emailEl) {
+          emailEl.selectionStart = emailEl.selectionEnd = value.length;
+        }
+      }
     },
 
     submit: function () {
@@ -31,7 +60,7 @@ function (_, FormView, Template, FxaClient, Session) {
       var client = new FxaClient();
       var self = this;
       client.passwordReset(email)
-              .then(function() {
+              .then(function () {
                 self.navigate('confirm_reset_password');
               }, function (err) {
                 self.displayError(err);

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -13,6 +13,7 @@ define([
   '../../mocks/router'
 ],
 function (chai, View, FxaClient, WindowMock, RouterMock) {
+  /*global describe, beforeEach, afterEach, it*/
   var assert = chai.assert;
 
   describe('views/reset_password', function () {
@@ -33,6 +34,7 @@ function (chai, View, FxaClient, WindowMock, RouterMock) {
       view.remove();
       view.destroy();
       view = router = null;
+      $('#container').empty();
     });
 
     describe('constructor creates it', function () {
@@ -101,4 +103,34 @@ function (chai, View, FxaClient, WindowMock, RouterMock) {
     });
   });
 
+  describe('views/reset_password with email specified as query param', function () {
+    var view, windowMock;
+
+    beforeEach(function () {
+      windowMock = new WindowMock();
+      windowMock.location.search = '?email=testuser@testuser.com';
+
+      view = new View({
+        window: windowMock
+      });
+      view.render();
+
+      $('#container').html(view.el);
+    });
+
+    afterEach(function () {
+      view.remove();
+      view.destroy();
+      view = windowMock = null;
+      $('#container').empty();
+    });
+
+    it('pre-fills email address', function () {
+      assert.equal(view.$('.email').val(), 'testuser@testuser.com');
+    });
+
+    it('removes the back button - the user probably browsed here directly', function () {
+      assert.equal(view.$('#back').length, 0);
+    });
+  });
 });

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -62,7 +62,7 @@ define([
         .end();
     },
 
-    'forgot password via force-auth has a back button': function () {
+    'forgot password via force-auth goes directly to confirm email screen': function () {
       return this.get('remote')
         .get(require.toUrl(FORCE_AUTH_URL + '?email=' + email))
         .waitForElementById('fxa-force-auth-header')
@@ -71,11 +71,7 @@ define([
           .click()
         .end()
 
-        .elementById('back')
-          .click()
-        .end()
-
-        .waitForElementById('fxa-force-auth-header')
+        .waitForElementById('fxa-confirm-reset-password-header')
         .end();
     }
 

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -28,7 +28,6 @@ define([
     },
 
     'open page': function () {
-
       return this.get('remote')
         .get(require.toUrl(PAGE_URL))
         .waitForElementById('fxa-reset-password-header')
@@ -36,6 +35,28 @@ define([
         .elementByCssSelector('form input.email')
           .click()
           .type(email)
+        .end()
+
+        .elementByCssSelector('button[type="submit"]')
+          .click()
+        .end()
+
+        .waitForElementById('fxa-confirm-reset-password-header')
+        .end();
+    },
+
+    'open page with email on query params': function () {
+      var url = PAGE_URL + '?email=' + email;
+      return this.get('remote')
+        .get(require.toUrl(url))
+        .waitForElementById('fxa-reset-password-header')
+
+        .elementByCssSelector('form input.email')
+          .getAttribute('value')
+          .then(function (resultText) {
+            // email address should be pre-filled from the query param.
+            assert.equal(resultText, email);
+          })
         .end()
 
         .elementByCssSelector('button[type="submit"]')


### PR DESCRIPTION
- Prefill email address from query string on `/reset_password`.
- If a user clicks "forgot password?" from `/force_auth`, skip `/reset_password` and go directly to `/confirm_reset_password`.

Closes #549
Closes #637
