### PR TITLE
refactor(build): Speed up lint task with with grunt concurrent

### DIFF
--- a/grunttasks/concurrent.js
+++ b/grunttasks/concurrent.js
@@ -17,6 +17,11 @@ module.exports = function (grunt) {
       'imagemin',
       'svgmin',
       'htmlmin'
+    ],
+    lint: [
+      'jshint',
+      'jsonlint:app',
+      'jscs'
     ]
   });
 };

--- a/grunttasks/lint.js
+++ b/grunttasks/lint.js
@@ -7,9 +7,7 @@
 module.exports = function (grunt) {
   'use strict';
 
-  grunt.registerTask('lint', [
-    'jshint',
-    'jsonlint:app',
-    'jscs'
+  grunt.registerTask('lint', 'lint all the things', [
+    'concurrent:lint'
   ]);
 };


### PR DESCRIPTION
Waiting for lint makes me impatient. To speed things up, I have made all the lint tasks run concurrently. Give it a try, see what you think!
