### PR TITLE
fix(styles): Removing explicit Show button width

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -517,13 +517,14 @@ ul.links li {
   font-size: 16px;
   height: 43px;
   line-height: 44px;
+  min-width: 55px;
+  padding: 0 7px;
   position: absolute;
   right: 1px;
   top: 1px;
   // it is very easy to accidentally select the text when clicking
   -webkit-touch-callout: none;
   user-select: none;
-  width: 55px;
 }
 
 .password-row > .password:hover {


### PR DESCRIPTION
Per @johngruen's comment: https://github.com/mozilla/fxa-content-server/issues/676#issuecomment-36924532

Replace `width` with `min-width` to preserve original UX. Set `padding` to keep things looking good w/ longer Show button translations which require the Show button to grow larger than 55px.

Closes #676
