### PR TITLE
fix(client): Use /settings as the landing page when logging in to the accounts portal.

### DIFF
--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -79,7 +79,7 @@ function (_, BaseView, FormView, SignInTemplate, Constants, Session, FxaClient, 
                 // Don't switch to settings if we're trying to log in to
                 // Firefox. Firefox will show its own landing page
                 if (Session.get('context') !== Constants.FX_DESKTOP_CONTEXT) {
-                  self.navigate('signin_complete');
+                  self.navigate('settings');
                 }
               } else {
                 return client.signUpResend()

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -58,7 +58,7 @@ define([
           .click()
         .end()
 
-        .waitForElementById('fxa-sign-in-complete-header')
+        .waitForElementById('fxa-settings-header')
         .end();
     },
 

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -115,7 +115,7 @@ define([
             .end()
 
             // success is seeing the sign-in-complete screen.
-            .waitForElementById('fxa-sign-in-complete-header')
+            .waitForElementById('fxa-settings-header')
             .end();
         });
     },


### PR DESCRIPTION
Fixes #704.
