### PR TITLE
fix(client): Hide sign out from users who signed in from Firefox desktop.

### DIFF
--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -8,8 +8,9 @@
 'use strict';
 
 define([
-  'underscore'
-], function (_) {
+  'underscore',
+  'lib/constants'
+], function (_, Constants) {
   var NAMESPACE = '__fxa_session';
 
   // channel is initialized on app startup
@@ -104,6 +105,12 @@ define([
         delete this[key];
         this.persist();
       }
+    },
+
+    // Convenience functions for data stored in session
+
+    isDesktopContext: function () {
+      return this.get('context') === Constants.FX_DESKTOP_CONTEXT;
     },
 
     // BEGIN TEST API

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -54,7 +54,7 @@ function (
 
   var Router = Backbone.Router.extend({
     routes: {
-      '(/)': 'redirectToSignup',
+      '(/)': 'redirectToSignupOrSettings',
       'signin(/)': showView(SignInView),
       'signin_complete(/)': showView(ReadyView, { type: 'sign_in' }),
       'signup(/)': showView(SignUpView),
@@ -99,8 +99,12 @@ function (
                             this, url, { trigger: true });
     },
 
-    redirectToSignup: function () {
-      this.navigate('/signup');
+    redirectToSignupOrSettings: function () {
+      if (Session.sessionToken) {
+        this.navigate('/settings');
+      } else {
+        this.navigate('/signup');
+      }
     },
 
     showView: function (view) {

--- a/app/scripts/templates/settings.mustache
+++ b/app/scripts/templates/settings.mustache
@@ -9,9 +9,11 @@
 
 
   <ul class="links">
-    <li>
-      <a id="signout" href="#">{{#t}}Sign out{{/t}}</a>
-    </li>
+    {{#showSignOut}}
+      <li>
+        <a id="signout" href="#">{{#t}}Sign out{{/t}}</a>
+      </li>
+    {{/showSignOut}}
     <li>
       <a id="change-password" href="/change_password">{{#t}}Change password{{/t}}</a>
     </li>

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -22,7 +22,8 @@ function (_, BaseView, Template, FxaClient, Session) {
     context: function () {
       return {
         // HTML is written here to simplify the l10n community's job
-        email: '<strong id="email" class="email">' + Session.email + '</strong>'
+        email: '<strong id="email" class="email">' + Session.email + '</strong>',
+        showSignOut: !Session.isDesktopContext()
       };
     },
 

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -14,8 +14,9 @@ define([
   'views/sign_up',
   'lib/session',
   '../../mocks/window',
+  'lib/constants'
 ],
-function (chai, _, Backbone, Router, SignInView, SignUpView, Session, WindowMock) {
+function (chai, _, Backbone, Router, SignInView, SignUpView, Session, WindowMock, Constants) {
   /*global describe, beforeEach, afterEach, it*/
   var assert = chai.assert;
 
@@ -55,18 +56,27 @@ function (chai, _, Backbone, Router, SignInView, SignUpView, Session, WindowMock
 
       it('preserves window search parameters across screen transition',
         function () {
-        windowMock.location.search = '?context=fx_desktop_v1';
+        windowMock.location.search = '?context=' + Constants.FX_DESKTOP_CONTEXT;
         router.navigate('/forgot');
-        assert.equal(navigateUrl, '/forgot?context=fx_desktop_v1');
+        assert.equal(navigateUrl, '/forgot?context=' + Constants.FX_DESKTOP_CONTEXT);
         assert.deepEqual(navigateOptions, { trigger: true });
       });
     });
 
-    describe('redirectToSignup', function () {
+    describe('redirectToSignupOrSettings', function () {
       it('go to the signup page', function () {
         windowMock.location.search = '';
-        router.redirectToSignup();
+        Session.set('sessionToken', null);
+        router.redirectToSignupOrSettings();
         assert.equal(navigateUrl, '/signup');
+        assert.deepEqual(navigateOptions, { trigger: true });
+      });
+
+      it('go to the settings page', function () {
+        windowMock.location.search = '';
+        Session.set('sessionToken', 'abc123');
+        router.redirectToSignupOrSettings();
+        assert.equal(navigateUrl, '/settings');
         assert.deepEqual(navigateOptions, { trigger: true });
       });
     });

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -7,8 +7,9 @@ define([
   'intern/chai!assert',
   'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client'
-], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient) {
+  'app/bower_components/fxa-js-client/fxa-client',
+  'app/scripts/lib/constants'
+], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Constants) {
   'use strict';
 
   var AUTH_SERVER_ROOT = 'http://127.0.0.1:9000/v1';
@@ -51,9 +52,26 @@ define([
         .end();
     },
 
+    'go to settings page from the desktop context, make sure the user cannot sign out': function () {
+      return this.get('remote')
+        // Temporary solution to force the correct context.
+        // TODO: (Issue #742) Refactor functional tests to not share state between tests
+        .get(require.toUrl(SETTINGS_URL + '?context=' + Constants.FX_DESKTOP_CONTEXT))
+        .waitForElementById('fxa-settings-header')
+
+        // make sure the sign out element doesn't exist
+        .hasElementById('signout')
+          .then(function(hasElement) {
+            assert(!hasElement);
+          })
+        .end();
+    },
+
     'go to settings page, sign out': function () {
       return this.get('remote')
-        .get(require.toUrl(SETTINGS_URL))
+        // Temporary solution to force the correct context.
+        // TODO: (Issue #742) Refactor functional tests to not share state between tests
+        .get(require.toUrl(SETTINGS_URL + '?context=none'))
         .waitForElementById('fxa-settings-header')
 
         // sign the user out


### PR DESCRIPTION
This started out as a complicated combination of changes but is now a very simple change to hide the "Sign out" link from users who signed in from Firefox desktop. Fixes the most critical piece of #612.
