### PR TITLE
chore(build): add interactive=false flag to bower install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "start": "grunt server",
-    "postinstall": "bower install -s;cp node_modules/grunt-blanket-mocha/support/* app/bower_components/blanket/src",
+    "postinstall": "bower install --config.interactive=false -s; cp node_modules/grunt-blanket-mocha/support/* app/bower_components/blanket/src",
     "test": "intern-runner config=tests/intern",
     "test-browser": "intern-runner config=tests/intern_browser",
     "test-remote": "intern-runner config=tests/intern_sauce",


### PR DESCRIPTION
Setting `--config.interactive=false` flag to bower install to silence the following prompts during npm install: 

> _[?] May bower anonymously report usage statistics to improve the tool over time? (Y/n)_

Closes #744
