### PR TITLE
only log the locale/filename when --verbose

### DIFF
--- a/grunttasks/po2json.js
+++ b/grunttasks/po2json.js
@@ -40,7 +40,6 @@ module.exports = function (grunt) {
           // get rid of the .po extension, replace with .json
           filename = path.basename(filename, '.po') + '.json';
         }
-        grunt.verbose.writeln('locale: %s, filename: %s', locale, filename);
         return locale + '/' + filename;
       },
       output_transform: function (data) {


### PR DESCRIPTION
Removes some of the noise when running po2json (unless you're using `--verbose` and like noise).
This should also reduce our Travis log output by ~200 lines.

Bonus points for using `yeoman.strings_dist`  variable instead of "locale/" path directly.
