### PR TITLE
fix(client): Session values only last as long as the browsing session now by default.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -67,6 +67,7 @@ function (FxaClient, $, p, Session, AuthErrors) {
                   unwrapBKey: accountData.unwrapBKey,
                   keyFetchToken: accountData.keyFetchToken,
                   sessionToken: accountData.sessionToken,
+                  sessionTokenContext: Session.context,
                   customizeSync: customizeSync
                 };
 

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -9,9 +9,10 @@ define([
   'views/base',
   'stache!templates/settings',
   'lib/fxa-client',
-  'lib/session'
+  'lib/session',
+  'lib/constants'
 ],
-function (_, BaseView, Template, FxaClient, Session) {
+function (_, BaseView, Template, FxaClient, Session, Constants) {
   var View = BaseView.extend({
     // user must be authenticated to see Settings
     mustAuth: true,
@@ -23,7 +24,7 @@ function (_, BaseView, Template, FxaClient, Session) {
       return {
         // HTML is written here to simplify the l10n community's job
         email: '<strong id="email" class="email">' + Session.email + '</strong>',
-        showSignOut: !Session.isDesktopContext()
+        showSignOut: Session.get('sessionTokenContext') !== Constants.FX_DESKTOP_CONTEXT
       };
     },
 

--- a/app/tests/spec/lib/session.js
+++ b/app/tests/spec/lib/session.js
@@ -82,8 +82,18 @@ function (chai, Session) {
       });
     });
 
+    describe('persist', function () {
+      it('will persist keys in PERSIST_TO_LOCAL_STORAGE to localStorage', function () {
+        Session.set('sessionToken', 'abc123');
+
+        var localStorageValues = JSON.parse(localStorage.getItem('__fxa_session'));
+
+        assert.equal(Session.sessionToken, localStorageValues.sessionToken);
+      });
+    });
+
     describe('load', function () {
-      it('loads data from localStorage', function () {
+      it('loads data from sessionStorage', function () {
         Session.set({
           key7: 'value7',
           key8: 'value8'

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -52,26 +52,11 @@ define([
         .end();
     },
 
-    'go to settings page from the desktop context, make sure the user cannot sign out': function () {
-      return this.get('remote')
-        // Temporary solution to force the correct context.
-        // TODO: (Issue #742) Refactor functional tests to not share state between tests
-        .get(require.toUrl(SETTINGS_URL + '?context=' + Constants.FX_DESKTOP_CONTEXT))
-        .waitForElementById('fxa-settings-header')
-
-        // make sure the sign out element doesn't exist
-        .hasElementById('signout')
-          .then(function(hasElement) {
-            assert(!hasElement);
-          })
-        .end();
-    },
-
     'go to settings page, sign out': function () {
       return this.get('remote')
         // Temporary solution to force the correct context.
         // TODO: (Issue #742) Refactor functional tests to not share state between tests
-        .get(require.toUrl(SETTINGS_URL + '?context=none'))
+        .get(require.toUrl(SETTINGS_URL))
         .waitForElementById('fxa-settings-header')
 
         // sign the user out
@@ -81,6 +66,42 @@ define([
 
         // success is going to the signin page
         .waitForElementById('fxa-signin-header')
+        .end();
+    },
+
+    'sign in to desktop context for signing out': function () {
+      return this.get('remote')
+        .get(require.toUrl(SIGNIN_URL + '?context=' + Constants.FX_DESKTOP_CONTEXT))
+        .waitForElementById('fxa-signin-header')
+
+        .elementByCssSelector('form input.email')
+          .click()
+          .type(email)
+        .end()
+
+        .elementByCssSelector('form input.password')
+          .click()
+          .type(FIRST_PASSWORD)
+        .end()
+
+        .elementByCssSelector('button[type="submit"]')
+          .click()
+        .end();
+    },
+
+    'go to settings page from the desktop context, make sure the user cannot sign out': function () {
+      return this.get('remote')
+        .get(require.toUrl(SETTINGS_URL))
+        .waitForElementById('fxa-settings-header')
+        // make sure the sign out element doesn't exist
+        .hasElementById('signout')
+          .then(function(hasElement) {
+            assert(!hasElement);
+          })
+        // Clear out the session since we didn't sign out. This isn't ideal since it implies too much
+        // knowledge of the implementation of the Session module but it guarantees that we don't
+        // break the other tests.
+        .eval('sessionStorage.clear(); localStorage.clear();') // jshint ignore:line
         .end();
     },
 

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -42,7 +42,7 @@ define([
             .get(require.toUrl(PAGE_URL))
             /*jshint evil:true*/
             .waitForElementById('fxa-signin-header')
-            .eval('localStorage.clear();');
+            .eval('sessionStorage.clear(); localStorage.clear();');
         });
     },
 
@@ -54,7 +54,7 @@ define([
         .get(require.toUrl(PAGE_URL))
         /*jshint evil:true*/
         .waitForElementById('fxa-signin-header')
-        .eval('localStorage.clear();');
+        .eval('sessionStorage.clear(); localStorage.clear();');
     },
 
     'sign in unverified': function () {

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -25,7 +25,7 @@ define([
         .get(require.toUrl(url))
         /*jshint evil:true*/
         .waitForElementById('fxa-signup-header')
-        .eval('localStorage.clear();');
+        .eval('sessionStorage.clear(); localStorage.clear();');
     },
 
     teardown: function () {
@@ -34,7 +34,7 @@ define([
         .get(require.toUrl(url))
         /*jshint evil:true*/
         .waitForElementById('fxa-signup-header')
-        .eval('localStorage.clear();');
+        .eval('sessionStorage.clear(); localStorage.clear();');
     },
 
     'sign up': function () {


### PR DESCRIPTION
The Session module now uses `sessionStorage` by default instead of `localStorage`. Keys such as `email`, `sessionToken`, and `sessionTokenContext` are persisted to `localStorage` as they are included in the `PERSIST_TO_LOCAL_STORAGE` array in Session.

`sessionTokenContext` was added to take the place of using the current context to decide which context was used during Sign in since it will no longer be persisted between browsing sessions. This should give us the desired behavior of the Sign out link on Settings when a user has signed in via Desktop.

Fixes #748.
