### PR TITLE
chore(build): promoting devDep since it was causing some awsbox errors

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
     },
     "bower": {
       "version": "1.3.1",
-      "from": "bower@1.3.1",
+      "from": "https://registry.npmjs.org/bower/-/bower-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.1.tgz",
       "dependencies": {
         "abbrev": {
@@ -203,7 +203,7 @@
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.4",
-                      "from": "combined-stream@0.0.4",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                       "dependencies": {
                         "delayed-stream": {
@@ -373,7 +373,7 @@
         },
         "glob": {
           "version": "3.2.9",
-          "from": "glob@3.x",
+          "from": "glob@3.2.9",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
@@ -402,7 +402,7 @@
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@2.4.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "async": {
@@ -546,7 +546,7 @@
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.4",
-                  "from": "combined-stream@0.0.4",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -639,7 +639,7 @@
         },
         "semver": {
           "version": "2.2.1",
-          "from": "semver@2"
+          "from": "semver@2.2.1"
         },
         "stringify-object": {
           "version": "0.2.0",
@@ -762,7 +762,7 @@
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.4",
-                      "from": "combined-stream@0.0.4",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                       "dependencies": {
                         "delayed-stream": {
@@ -786,7 +786,7 @@
               "dependencies": {
                 "lodash": {
                   "version": "2.4.1",
-                  "from": "lodash@2.4.1",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 },
                 "js-yaml": {
@@ -951,7 +951,7 @@
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.4",
-                      "from": "combined-stream@0.0.4",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                       "dependencies": {
                         "delayed-stream": {
@@ -996,7 +996,7 @@
                 },
                 "uuid": {
                   "version": "1.4.1",
-                  "from": "uuid@1.4.1",
+                  "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                 }
               }
@@ -1007,7 +1007,7 @@
             },
             "object-assign": {
               "version": "0.1.2",
-              "from": "object-assign@0.1.2",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.1.2.tgz"
             },
             "lodash.debounce": {
@@ -1027,7 +1027,7 @@
                   "dependencies": {
                     "lodash._objecttypes": {
                       "version": "2.4.1",
-                      "from": "lodash._objecttypes@2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                     }
                   }
@@ -1060,7 +1060,7 @@
           "dependencies": {
             "jsonify": {
               "version": "0.0.0",
-              "from": "jsonify@0.0.0",
+              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             },
             "array-filter": {
@@ -1216,7 +1216,7 @@
         },
         "moment": {
           "version": "2.3.1",
-          "from": "moment@2.3.1",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz"
         },
         "optimist": {
@@ -1378,20 +1378,20 @@
     },
     "grunt": {
       "version": "0.4.4",
-      "from": "grunt@0.4.4",
+      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.4.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22"
+          "from": "async@0.1.22"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3"
+          "from": "coffee-script@1.3.3"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@^0.6.2"
+          "from": "colors@0.6.2"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
@@ -1399,125 +1399,125 @@
         },
         "eventemitter2": {
           "version": "0.4.13",
-          "from": "eventemitter2@~0.4.13"
+          "from": "eventemitter2@0.4.13"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@0.1.3",
           "dependencies": {
             "glob": {
               "version": "3.2.9",
-              "from": "glob@~3.2.9",
+              "from": "glob@3.2.9",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2"
+                  "from": "inherits@2.0.1"
                 }
               }
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@2.4.1"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@~3.1.21",
+          "from": "glob@3.1.21",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0"
+              "from": "graceful-fs@1.2.3"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1"
+              "from": "inherits@1.0.0"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3"
+          "from": "hooker@0.2.3"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11"
+          "from": "iconv-lite@0.2.11"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.12",
+          "from": "minimatch@0.2.14",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2"
+              "from": "lru-cache@2.5.0"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0"
+              "from": "sigmund@1.0.0"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@1.0.10",
           "dependencies": {
             "abbrev": {
               "version": "1.0.4",
-              "from": "abbrev@1"
+              "from": "abbrev@1.0.4"
             }
           }
         },
         "rimraf": {
           "version": "2.2.6",
-          "from": "rimraf@~2.2.6"
+          "from": "rimraf@2.2.6"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2"
+          "from": "lodash@0.9.2"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1"
+          "from": "underscore.string@2.2.1"
         },
         "which": {
           "version": "1.0.5",
-          "from": "which@~1.0.5"
+          "from": "which@1.0.5"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@2.0.5",
           "dependencies": {
             "argparse": {
               "version": "0.1.15",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@0.1.15",
               "dependencies": {
                 "underscore": {
                   "version": "1.4.4",
-                  "from": "underscore@~1.4.3"
+                  "from": "underscore@1.4.4"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "underscore.string@~2.3.1"
+                  "from": "underscore.string@2.3.3"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2"
+              "from": "esprima@1.0.4"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1"
+          "from": "exit@0.1.2"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0"
+          "from": "getobject@0.1.0"
         },
         "grunt-legacy-util": {
           "version": "0.1.2",
-          "from": "grunt-legacy-util@~0.1.2"
+          "from": "grunt-legacy-util@0.1.2"
         }
       }
     },
@@ -1715,7 +1715,7 @@
                 },
                 "which": {
                   "version": "1.0.5",
-                  "from": "which@1.0.x"
+                  "from": "which@1.0.5"
                 }
               }
             }
@@ -1819,7 +1819,7 @@
             },
             "nopt": {
               "version": "2.1.2",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+              "from": "nopt@2.1.x",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
               "dependencies": {
                 "abbrev": {
@@ -1884,7 +1884,7 @@
               "dependencies": {
                 "iconv-lite": {
                   "version": "0.2.11",
-                  "from": "iconv-lite@~0.2.11"
+                  "from": "iconv-lite@0.2.11"
                 },
                 "rimraf": {
                   "version": "2.2.6",
@@ -2055,7 +2055,7 @@
                       "dependencies": {
                         "combined-stream": {
                           "version": "0.0.4",
-                          "from": "combined-stream@0.0.4",
+                          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                           "dependencies": {
                             "delayed-stream": {
@@ -2327,7 +2327,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2"
+                      "from": "inherits@2.0.1"
                     },
                     "typedarray": {
                       "version": "0.0.5",
@@ -2532,7 +2532,7 @@
                             },
                             "tar": {
                               "version": "0.1.19",
-                              "from": "tar@0.1.19",
+                              "from": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
                               "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
                               "dependencies": {
                                 "inherits": {
@@ -2550,7 +2550,7 @@
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "2.0.2",
-                                      "from": "graceful-fs@2.0.2",
+                                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz",
                                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz"
                                     }
                                   }
@@ -2564,7 +2564,7 @@
                               "dependencies": {
                                 "uuid": {
                                   "version": "1.4.1",
-                                  "from": "uuid@1.4.1",
+                                  "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz",
                                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                                 }
                               }
@@ -2594,7 +2594,8 @@
                             },
                             "node-uuid": {
                               "version": "1.4.1",
-                              "from": "node-uuid@1.4.1"
+                              "from": "node-uuid@1.4.1",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
                             },
                             "mime": {
                               "version": "1.2.11",
@@ -2617,7 +2618,7 @@
                               "dependencies": {
                                 "combined-stream": {
                                   "version": "0.0.4",
-                                  "from": "combined-stream@0.0.4",
+                                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                                   "dependencies": {
                                     "delayed-stream": {
@@ -2660,19 +2661,23 @@
                               "dependencies": {
                                 "hoek": {
                                   "version": "0.9.1",
-                                  "from": "hoek@0.9.1"
+                                  "from": "hoek@0.9.1",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                                 },
                                 "boom": {
                                   "version": "0.4.2",
-                                  "from": "boom@0.4.2"
+                                  "from": "boom@0.4.2",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                                 },
                                 "cryptiles": {
                                   "version": "0.2.2",
-                                  "from": "cryptiles@0.2.2"
+                                  "from": "cryptiles@0.2.2",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                                 },
                                 "sntp": {
                                   "version": "0.2.4",
-                                  "from": "sntp@0.2.4"
+                                  "from": "sntp@0.2.4",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                                 }
                               }
                             },
@@ -2718,7 +2723,7 @@
                       "dependencies": {
                         "async": {
                           "version": "0.1.22",
-                          "from": "async@0.1.22",
+                          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
                         }
                       }
@@ -2800,7 +2805,7 @@
                             },
                             "tar": {
                               "version": "0.1.19",
-                              "from": "tar@0.1.19",
+                              "from": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
                               "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
                               "dependencies": {
                                 "inherits": {
@@ -2818,7 +2823,7 @@
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "2.0.2",
-                                      "from": "graceful-fs@2.0.2",
+                                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz",
                                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz"
                                     }
                                   }
@@ -2832,7 +2837,7 @@
                               "dependencies": {
                                 "uuid": {
                                   "version": "1.4.1",
-                                  "from": "uuid@1.4.1",
+                                  "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz",
                                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                                 }
                               }
@@ -2862,7 +2867,8 @@
                             },
                             "node-uuid": {
                               "version": "1.4.1",
-                              "from": "node-uuid@1.4.1"
+                              "from": "node-uuid@1.4.1",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
                             },
                             "mime": {
                               "version": "1.2.11",
@@ -2885,7 +2891,7 @@
                               "dependencies": {
                                 "combined-stream": {
                                   "version": "0.0.4",
-                                  "from": "combined-stream@0.0.4",
+                                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                                   "dependencies": {
                                     "delayed-stream": {
@@ -2928,19 +2934,23 @@
                               "dependencies": {
                                 "hoek": {
                                   "version": "0.9.1",
-                                  "from": "hoek@0.9.1"
+                                  "from": "hoek@0.9.1",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                                 },
                                 "boom": {
                                   "version": "0.4.2",
-                                  "from": "boom@0.4.2"
+                                  "from": "boom@0.4.2",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                                 },
                                 "cryptiles": {
                                   "version": "0.2.2",
-                                  "from": "cryptiles@0.2.2"
+                                  "from": "cryptiles@0.2.2",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                                 },
                                 "sntp": {
                                   "version": "0.2.4",
-                                  "from": "sntp@0.2.4"
+                                  "from": "sntp@0.2.4",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                                 }
                               }
                             },
@@ -2986,7 +2996,7 @@
                       "dependencies": {
                         "async": {
                           "version": "0.1.22",
-                          "from": "async@0.1.22",
+                          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
                         }
                       }
@@ -3068,7 +3078,7 @@
                             },
                             "tar": {
                               "version": "0.1.19",
-                              "from": "tar@0.1.19",
+                              "from": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
                               "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
                               "dependencies": {
                                 "inherits": {
@@ -3086,7 +3096,7 @@
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "2.0.2",
-                                      "from": "graceful-fs@2.0.2",
+                                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz",
                                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz"
                                     }
                                   }
@@ -3100,7 +3110,7 @@
                               "dependencies": {
                                 "uuid": {
                                   "version": "1.4.1",
-                                  "from": "uuid@1.4.1",
+                                  "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz",
                                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                                 }
                               }
@@ -3130,7 +3140,8 @@
                             },
                             "node-uuid": {
                               "version": "1.4.1",
-                              "from": "node-uuid@1.4.1"
+                              "from": "node-uuid@1.4.1",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
                             },
                             "mime": {
                               "version": "1.2.11",
@@ -3153,7 +3164,7 @@
                               "dependencies": {
                                 "combined-stream": {
                                   "version": "0.0.4",
-                                  "from": "combined-stream@0.0.4",
+                                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                                   "dependencies": {
                                     "delayed-stream": {
@@ -3196,19 +3207,23 @@
                               "dependencies": {
                                 "hoek": {
                                   "version": "0.9.1",
-                                  "from": "hoek@0.9.1"
+                                  "from": "hoek@0.9.1",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                                 },
                                 "boom": {
                                   "version": "0.4.2",
-                                  "from": "boom@0.4.2"
+                                  "from": "boom@0.4.2",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                                 },
                                 "cryptiles": {
                                   "version": "0.2.2",
-                                  "from": "cryptiles@0.2.2"
+                                  "from": "cryptiles@0.2.2",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                                 },
                                 "sntp": {
                                   "version": "0.2.4",
-                                  "from": "sntp@0.2.4"
+                                  "from": "sntp@0.2.4",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                                 }
                               }
                             },
@@ -3254,7 +3269,7 @@
                       "dependencies": {
                         "async": {
                           "version": "0.1.22",
-                          "from": "async@0.1.22",
+                          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
                         }
                       }
@@ -4032,7 +4047,7 @@
               "dependencies": {
                 "colors": {
                   "version": "0.5.1",
-                  "from": "colors@0.5.1",
+                  "from": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                 },
                 "underscore": {
@@ -4158,7 +4173,7 @@
                 },
                 "which": {
                   "version": "1.0.5",
-                  "from": "which@1.0.x"
+                  "from": "which@1.0.5"
                 }
               }
             }
@@ -4209,7 +4224,7 @@
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@0.x",
+                  "from": "minimatch@0.2.14",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
@@ -4349,7 +4364,7 @@
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.4",
-                  "from": "combined-stream@0.0.4",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -4360,7 +4375,7 @@
                 },
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@0.2.x"
+                  "from": "async@0.2.10"
                 }
               }
             }
@@ -4370,28 +4385,28 @@
     },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",
-      "from": "grunt-nsp-shrinkwrap@0.0.3",
+      "from": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "cli-color@^0.2.3",
+          "from": "cli-color@0.2.3",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "es5-ext@~0.9.2"
+              "from": "es5-ext@0.9.2"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "memoizee@~0.2.5",
+              "from": "memoizee@0.2.6",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "event-emitter@~0.2.2"
+                  "from": "event-emitter@0.2.2"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "next-tick@0.1.x"
+                  "from": "next-tick@0.1.0"
                 }
               }
             }
@@ -4399,38 +4414,38 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@^0.6.2"
+          "from": "colors@0.6.2"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0"
+          "from": "text-table@0.2.0"
         }
       }
     },
     "grunt-po2json": {
       "version": "0.2.0",
-      "from": "grunt-po2json@git://github.com/shane-tomlinson/grunt-po2json.git#c1a7406",
+      "from": "grunt-po2json@git://github.com/shane-tomlinson/grunt-po2json.git#c1a7406a0ba518612e80bfdffd450ab589dfd86d",
       "resolved": "git://github.com/shane-tomlinson/grunt-po2json.git#c1a7406a0ba518612e80bfdffd450ab589dfd86d",
       "dependencies": {
         "po2json": {
           "version": "0.2.3",
-          "from": "po2json@*",
+          "from": "po2json@0.2.3",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@2.4.1"
             },
             "gettext-parser": {
               "version": "0.2.0",
-              "from": "gettext-parser@~0.2.0",
+              "from": "gettext-parser@0.2.0",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.7",
-                  "from": "encoding@~0.1",
+                  "from": "encoding@0.1.7",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.2.11",
-                      "from": "iconv-lite@~0.2.11"
+                      "from": "iconv-lite@0.2.11"
                     }
                   }
                 }
@@ -4600,7 +4615,7 @@
                 },
                 "growl": {
                   "version": "1.7.0",
-                  "from": "growl@1.7.0",
+                  "from": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
                 },
                 "jade": {
@@ -4624,7 +4639,7 @@
                 },
                 "glob": {
                   "version": "3.2.3",
-                  "from": "glob@3.2.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
                   "dependencies": {
                     "minimatch": {
@@ -4643,7 +4658,7 @@
                     },
                     "graceful-fs": {
                       "version": "2.0.2",
-                      "from": "graceful-fs@2.0.2",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.2.tgz"
                     },
                     "inherits": {
@@ -4656,7 +4671,7 @@
             },
             "chalk": {
               "version": "0.3.0",
-              "from": "chalk@0.3.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
               "dependencies": {
                 "has-color": {
@@ -4706,30 +4721,30 @@
     },
     "grunt-todo": {
       "version": "0.2.0",
-      "from": "grunt-todo@0.2.0",
+      "from": "https://registry.npmjs.org/grunt-todo/-/grunt-todo-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-todo/-/grunt-todo-0.2.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4",
+          "from": "chalk@0.4.0",
           "dependencies": {
             "has-color": {
               "version": "0.1.4",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.4"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0"
+          "from": "text-table@0.2.0"
         }
       }
     },
@@ -4757,11 +4772,119 @@
         "z-schema": {
           "version": "2.4.6",
           "from": "https://registry.npmjs.org/z-schema/-/z-schema-2.4.6.tgz",
-          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-2.4.6.tgz"
+          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-2.4.6.tgz",
+          "dependencies": {
+            "request": {
+              "version": "2.34.0",
+              "from": "request@~2.34.0",
+              "dependencies": {
+                "qs": {
+                  "version": "0.6.6",
+                  "from": "qs@~0.6.0"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@~5.0.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@~0.5.0"
+                },
+                "node-uuid": {
+                  "version": "1.4.1",
+                  "from": "node-uuid@~1.4.0"
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@~1.2.9",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.2.4",
+                      "from": "punycode@>=0.2.0"
+                    }
+                  }
+                },
+                "form-data": {
+                  "version": "0.1.2",
+                  "from": "form-data@~0.1.0",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.4",
+                      "from": "combined-stream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.3.0",
+                  "from": "tunnel-agent@~0.3.0"
+                },
+                "http-signature": {
+                  "version": "0.10.0",
+                  "from": "http-signature@~0.10.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.2",
+                      "from": "assert-plus@0.1.2"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.2",
+                      "from": "ctype@0.5.2"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "from": "oauth-sign@~0.3.0"
+                },
+                "hawk": {
+                  "version": "1.0.0",
+                  "from": "hawk@~1.0.0",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@0.9.x"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@0.4.x"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@0.2.x"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@0.2.x"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@~0.5.0"
+                }
+              }
+            }
+          }
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9"
+          "from": "async@0.2.10"
         },
         "lodash": {
           "version": "2.4.1",
@@ -4845,7 +4968,7 @@
               "dependencies": {
                 "encoding": {
                   "version": "0.1.7",
-                  "from": "encoding@0.1.7",
+                  "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.7.tgz",
                   "dependencies": {
                     "iconv-lite": {
@@ -4929,19 +5052,19 @@
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.33",
-                          "from": "source-map@0.1.33",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "amdefine@0.1.0",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
                         },
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "optimist@0.3.7",
+                          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
@@ -5078,7 +5201,7 @@
         },
         "underscore": {
           "version": "1.4.4",
-          "from": "underscore@1.4.4"
+          "from": "underscore@1.4.x"
         },
         "cli": {
           "version": "0.4.5",
@@ -5099,7 +5222,7 @@
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.11",
+          "from": "minimatch@0.x",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
@@ -5309,12 +5432,12 @@
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.33",
-                          "from": "source-map@0.1.33",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "amdefine@0.1.0",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
@@ -5427,7 +5550,7 @@
             },
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@~0.2.11",
+              "from": "minimatch@0.2.14",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
@@ -5446,6 +5569,114 @@
     "mkdirp": {
       "version": "0.3.5",
       "from": "mkdirp@0.3.5"
+    },
+    "request": {
+      "version": "2.34.0",
+      "from": "request@2.34.0",
+      "dependencies": {
+        "qs": {
+          "version": "0.6.6",
+          "from": "qs@~0.6.0"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.0",
+          "from": "json-stringify-safe@~5.0.0"
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "from": "forever-agent@~0.5.0"
+        },
+        "node-uuid": {
+          "version": "1.4.1",
+          "from": "node-uuid@~1.4.0"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@~1.2.9"
+        },
+        "tough-cookie": {
+          "version": "0.12.1",
+          "from": "tough-cookie@>=0.12.0",
+          "dependencies": {
+            "punycode": {
+              "version": "1.2.4",
+              "from": "punycode@>=0.2.0"
+            }
+          }
+        },
+        "form-data": {
+          "version": "0.1.2",
+          "from": "form-data@~0.1.0",
+          "dependencies": {
+            "combined-stream": {
+              "version": "0.0.4",
+              "from": "combined-stream@~0.0.4",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5"
+                }
+              }
+            },
+            "async": {
+              "version": "0.2.10",
+              "from": "async@~0.2.9"
+            }
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.3.0",
+          "from": "tunnel-agent@~0.3.0"
+        },
+        "http-signature": {
+          "version": "0.10.0",
+          "from": "http-signature@~0.10.0",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.2",
+              "from": "assert-plus@0.1.2"
+            },
+            "asn1": {
+              "version": "0.1.11",
+              "from": "asn1@0.1.11"
+            },
+            "ctype": {
+              "version": "0.5.2",
+              "from": "ctype@0.5.2"
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.3.0",
+          "from": "oauth-sign@~0.3.0"
+        },
+        "hawk": {
+          "version": "1.0.0",
+          "from": "hawk@~1.0.0",
+          "dependencies": {
+            "hoek": {
+              "version": "0.9.1",
+              "from": "hoek@0.9.x"
+            },
+            "boom": {
+              "version": "0.4.2",
+              "from": "boom@0.4.x"
+            },
+            "cryptiles": {
+              "version": "0.2.2",
+              "from": "cryptiles@0.2.x"
+            },
+            "sntp": {
+              "version": "0.2.4",
+              "from": "sntp@0.2.x"
+            }
+          }
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "from": "aws-sign2@~0.5.0"
+        }
+      }
     },
     "time-grunt": {
       "version": "0.2.10",

--- a/package.json
+++ b/package.json
@@ -69,13 +69,13 @@
     "jsxgettext-recursive": "0.0.3",
     "load-grunt-tasks": "0.4.0",
     "mkdirp": "0.3.5",
+    "request": "2.34.0",
     "time-grunt": "0.2.10"
   },
   "devDependencies": {
     "awsbox": "0.7.0",
     "fxa-auth-server": "git://github.com/mozilla/fxa-auth-server.git",
     "intern-geezer": "1.5.0",
-    "request": "2.34.0",
     "xmlhttprequest": "git://github.com/zaach/node-XMLHttpRequest.git#onerror"
   },
   "engines": {


### PR DESCRIPTION
We're seeing some error side effects w/ request module and grunt-nsp-shrinkwrap when installing w/ `$ npm install --production`.

Promoting request@2.34.0 to a dependency until we can figure out what the what is happening.
