### PR TITLE
fix(client): Added Sign in link to password reset flow

### DIFF
--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -11,8 +11,8 @@
   <p class="verification-email-message">{{#t}}A reset link has been sent to %(email)s{{/t}}</p>
 
   <div class="links">
-    <a id="resend" href="#">{{#t}}Resend email{{/t}}</a>
+    <a href="/signin" class="sign-in">{{#t}}Sign in{{/t}}</a><br>
+    <a id="resend" class="resend-email" href="#">{{#t}}Resend email{{/t}}</a>
   </div>
 
-  
 </section>


### PR DESCRIPTION
Added sign in link to the password reset flow to prevent a dead end in about:accounts. Fixes #793.
