### PR TITLE
chore(build): changing server version to follow SemVer

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ edit `server/config/*.json` on your deployed instance.
 * `grunt test` - run local Intern tests.
 * `grunt server` - run a local server running on port 3030 with development resources.
 * `grunt server:dist` - run a local server running on port 3030 with production resources. Production resources will be built as part of the task.
-* `grunt version` - stamp a new version. Updates the version number and creates a new CHANGELOG.md
+* `grunt version` - stamp a new minor version. Updates the version number and creates a new CHANGELOG.md
+* `grunt version:patch` - stamp a new patch version. Updates the version number and creates a new CHANGELOG.md
 
 ## Servers
 

--- a/grunttasks/version.js
+++ b/grunttasks/version.js
@@ -13,7 +13,13 @@ module.exports = function (grunt) {
   'use strict';
 
   grunt.registerTask('version', [
-    'bump-only',
+    'bump-only:minor',
+    'changelog',
+    'bump-commit'
+  ]);
+
+  grunt.registerTask('version:patch', [
+    'bump-only:patch',
     'changelog',
     'bump-commit'
   ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "0.0.7",
+  "version": "0.7.0",
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "start": "grunt server",


### PR DESCRIPTION
We talked about this last week. If we change the versioning to 'minor' SemVer then we will be able to introduce hot-fix patch versions. 
Another idea is to maybe use "0.1.0" as the release version for the next train? 

@gene1wood warned that deployment may need to be adjusted to work with this change. 
cc // @ckarlof @mostlygeek thoughts?
