### PR TITLE
adding stubs for 500 or 503 pages

### DIFF
--- a/server/lib/500.js
+++ b/server/lib/500.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+// It's a 500 system unavailable response.
+
+module.exports = function (req, res, next) {
+  res.status(500);
+
+  if (req.accepts('html')) {
+    return res.render('500');
+  }
+
+  if (req.accepts('json')) {
+    return res.send({ error: 'System unavailable, try again soon' });
+  }
+
+  res.type('txt').send('System unavailable, try again soon');
+};

--- a/server/lib/503.js
+++ b/server/lib/503.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+// It's a 503 server busy response.
+
+module.exports = function (req, res, next) {
+  res.status(503);
+
+  if (req.accepts('html')) {
+    return res.render('503');
+  }
+
+  if (req.accepts('json')) {
+    return res.send({ error: 'Server busy, try again soon' });
+  }
+
+  res.type('txt').send('Server busy, try again soon');
+};

--- a/server/templates/pages/src/500.html
+++ b/server/templates/pages/src/500.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>{{#t}}Firefox Accounts{{/t}}</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" href="/latin/firasans-regular,firasans-light,clearsans-regular/fonts.css">
+        <!-- build:css(.tmp) /styles/main.css -->
+        <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">
+        <link rel="stylesheet" href="/styles/main.css">
+        <!-- endbuild -->
+    </head>
+    <body>
+        <div id="fox-logo"></div>
+        <div id="stage">
+          <header>
+            <h1 id="fxa-500-header">{{#t}}System unavailable, try again soon{{/t}}</h1>
+          </header>
+
+          <section>
+            {{#t}}We are currently performing some maintenance on the system, and will return momentarily.{{/t}}
+          </section>
+
+          <div class="button-row">
+            <a href="/signup" class="button" id="fxa-500-home">{{#t}}Home{{/t}}</a>
+          </div>
+        </div>
+    </body>
+</html>

--- a/server/templates/pages/src/503.html
+++ b/server/templates/pages/src/503.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>{{#t}}Firefox Accounts{{/t}}</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" href="/latin/firasans-regular,firasans-light,clearsans-regular/fonts.css">
+        <!-- build:css(.tmp) /styles/main.css -->
+        <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">
+        <link rel="stylesheet" href="/styles/main.css">
+        <!-- endbuild -->
+    </head>
+    <body>
+        <div id="fox-logo"></div>
+        <div id="stage">
+          <header>
+            <h1 id="fxa-503-header">{{#t}}Server busy, try again soon{{/t}}</h1>
+          </header>
+
+          <section>
+            {{#t}}We are currently under heavy strain and are working to return the system to normal as soon as possible.{{/t}}
+          </section>
+
+          <div class="button-row">
+            <a href="/signup" class="button" id="fxa-503-home">{{#t}}Home{{/t}}</a>
+          </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
Not entirely sure how to wire these up to the app.
I noticed for 404 errors, we have a couple hooks in fxa-content-server.js:
- [server/bin/fxa-content-server.js:42](https://github.com/mozilla/fxa-content-server/blob/master/server/bin/fxa-content-server.js#L42)
- [server/bin/fxa-content-server.js:88](https://github.com/mozilla/fxa-content-server/blob/master/server/bin/fxa-content-server.js#L88)
