### PR TITLE
feature(client): Validating sessionToken on views that mustAuth.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -281,8 +281,14 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
               .then(function () {
                 Session.clear();
               });
-    }
+    },
 
+    sessionStatus: function (sessionToken) {
+      return this._getClientAsync()
+              .then(function (client) {
+                return client.sessionStatus(sessionToken);
+              });
+    }
   };
 
   return FxaClientWrapper;

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -309,6 +309,18 @@ function (chai, $, ChannelMock, testHelpers,
           });
       });
     });
+
+    describe('sessionStatus', function () {
+      it('checks sessionStatus', function () {
+        return client.signUp(email, password)
+          .then(function () {
+            return client.sessionStatus(Session.sessionToken);
+          })
+          .then(function (err) {
+            assert.isTrue(realClient.sessionStatus.calledWith(Session.sessionToken));
+          });
+      });
+    });
   });
 });
 

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -18,6 +18,7 @@ define([
 
   var FIRST_PASSWORD = 'password';
   var SECOND_PASSWORD = 'new_password';
+  var THIRD_PASSWORD = 'new_new_password';
   var email;
 
   registerSuite({
@@ -182,6 +183,41 @@ define([
         .end();
     },
 
+    'visit settings page with an invalid sessionToken': function() {
+      var client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+
+      // Changing the password invalidates the current sessionToken
+      client.passwordChange(email, SECOND_PASSWORD, THIRD_PASSWORD);
+
+      return this.get('remote')
+        .get(require.toUrl(SETTINGS_URL))
+        // Expect to get redirected to sign in since the sessionToken is invalid
+        .waitForElementById('fxa-signin-header')
+        .end();
+    },
+
+    'sign in for delete': function () {
+      return this.get('remote')
+        .get(require.toUrl(SIGNIN_URL))
+        .waitForElementById('fxa-signin-header')
+
+        .elementByCssSelector('form input.email')
+          .click()
+          .type(email)
+        .end()
+
+        .elementByCssSelector('form input.password')
+          .click()
+          .type(THIRD_PASSWORD)
+        .end()
+
+        .elementByCssSelector('button[type="submit"]')
+          .click()
+        .end();
+    },
+
     'go to settings page, delete account': function () {
       return this.get('remote')
         .get(require.toUrl(SETTINGS_URL))
@@ -199,7 +235,7 @@ define([
 
         .elementByCssSelector('form input.password')
           .click()
-          .type(SECOND_PASSWORD)
+          .type(THIRD_PASSWORD)
         .end()
 
         // delete account
@@ -211,6 +247,5 @@ define([
         .waitForElementById('fxa-signup-header')
         .end();
     }
-
   });
 });


### PR DESCRIPTION
Views with `mustAuth` enabled now validate the `sessionToken` on every request. It happens asynchronously so there's no negative performance impact on the user. There is the potential for an undesirable flash of the protected content if the `sessionToken` is invalid, but considering that this should be an exceptional case, I don't think we should be overly concerned.

Fixes #743.
