### PR TITLE
feature(client): Error and tooltip fixes!

### DIFF
--- a/app/scripts/templates/change_password.mustache
+++ b/app/scripts/templates/change_password.mustache
@@ -10,7 +10,7 @@
     <div class="input-row password-row">
       <input type="password" class="password" id="old_password" placeholder="{{#t}}Old password{{/t}}" pattern=".{8,}" autofocus required autocomplete="off" />
 
-      <input id="show-old-password" type="checkbox" class="show-password" aria-controls="old_password">
+      <input id="show-old-password" type="checkbox" class="show-password" aria-controls="old_password" data-novalue />
       <label for="show-old-password" class="show-password-label">
         {{#t}}Show{{/t}}
       </label>
@@ -19,7 +19,7 @@
     <div class="input-row password-row">
       <input type="password" class="password tooltip-below" id="new_password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" required autocomplete="off" />
 
-      <input id="show-new-password" type="checkbox" class="show-password" aria-controls="new_password">
+      <input id="show-new-password" type="checkbox" class="show-password" aria-controls="new_password" data-novalue />
       <label for="show-new-password" class="show-password-label">
         {{#t}}Show{{/t}}
       </label>

--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -9,7 +9,7 @@
     <div class="input-row password-row">
       <input type="password" class="password" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" autofocus required autocomplete="off" />
 
-      <input id="show-password" type="checkbox" class="show-password" aria-controls="password">
+      <input id="show-password" type="checkbox" class="show-password" aria-controls="password" data-novalue />
       <label for="show-password" class="show-password-label">
         {{#t}}Show{{/t}}
       </label>
@@ -18,7 +18,7 @@
     <div class="input-row password-row">
       <input type="password" class="password tooltip-below" id="vpassword" placeholder="{{#t}}Repeat Password{{/t}}" pattern=".{8,}" required autocomplete="off" />
 
-      <input id="show-vpassword" type="checkbox" class="show-password" aria-controls="vpassword">
+      <input id="show-vpassword" type="checkbox" class="show-password" aria-controls="vpassword" data-novalue />
       <label for="show-vpassword" class="show-password-label">
         {{#t}}Show{{/t}}
       </label>

--- a/app/scripts/templates/delete_account.mustache
+++ b/app/scripts/templates/delete_account.mustache
@@ -12,7 +12,7 @@
     <div class="input-row password-row">
       <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required autocomplete="off" />
 
-      <input id="show-password" type="checkbox" class="show-password" aria-controls="password" />
+      <input id="show-password" type="checkbox" class="show-password" aria-controls="password" data-novalue />
       <label for="show-password" class="show-password-label">
         {{#t}}Show{{/t}}
       </label>

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -27,7 +27,7 @@
     <div class="input-row password-row">
       <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#email}}autofocus{{/email}} autocomplete="off" />
 
-      <input id="show-password" type="checkbox" class="show-password" aria-controls="password" />
+      <input id="show-password" type="checkbox" class="show-password" aria-controls="password" data-novalue />
       <label for="show-password" class="show-password-label">
         {{#t}}Show{{/t}}
       </label>

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -12,7 +12,7 @@
 
     <div class="input-row password-row">
       <input id="password" type="password" class="password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required autocomplete="off" {{#email}}autofocus{{/email}} />
-      <input id="show-password" type="checkbox" class="show-password" aria-controls="password" />
+      <input id="show-password" type="checkbox" class="show-password" aria-controls="password" data-novalue />
       <label for="show-password" class="show-password-label">
         {{#t}}Show{{/t}}
       </label>

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -5,6 +5,7 @@
   <div class="input-row">
     <input type="text" id="focusMe" autofocus required />
   </div>
+  <input type="text" id="novalue" value="heyho" data-novalue />
   <button type="submit" class="disabled">Submit</button>
 </form>
 

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -249,6 +249,8 @@ function (_, Backbone, jQuery, Session, authErrors, FxaClient) {
       this.$('.error').show();
       this.trigger('error', translated);
 
+      this._isErrorVisible = true;
+
       return translated;
     },
 
@@ -277,11 +279,18 @@ function (_, Backbone, jQuery, Session, authErrors, FxaClient) {
       this.$('.error').show();
       this.trigger('error', translated);
 
+      this._isErrorVisible = true;
+
       return translated;
     },
 
     hideError: function () {
       this.$('.error').hide();
+      this._isErrorVisible = false;
+    },
+
+    isErrorVisible: function () {
+      return !!this._isErrorVisible;
     },
 
     back: function (event) {
@@ -314,6 +323,28 @@ function (_, Backbone, jQuery, Session, authErrors, FxaClient) {
       } catch (e) {
         // IE can blow up if the element is not visible.
       }
+    },
+
+    /**
+     * Invoke the specified handler with the given event. Handler
+     * can either be a function or a string. If a string, looks for
+     * the handler on `this`.
+     *
+     * @method invokeHandler
+     */
+    invokeHandler: function (handler, event) {
+      // convert a name to a function.
+      if (typeof handler === 'string') {
+        handler = this[handler];
+
+        if (typeof handler !== 'function') {
+          console.warn(handler + ' is an invalid function name');
+        }
+      }
+
+      if (typeof handler === 'function') {
+        return handler.call(this, event);
+      }
     }
   });
 
@@ -328,20 +359,7 @@ function (_, Backbone, jQuery, Session, authErrors, FxaClient) {
   BaseView.preventDefaultThen = function (handler) {
     return function (event) {
       event.preventDefault();
-
-      // convert a name to a function.
-      if (typeof handler === 'string') {
-        handler = this[handler];
-
-        if (typeof handler !== 'function') {
-          console.warn(handler +
-                ' is an invalid function name to use with preventDefaultThen');
-        }
-      }
-
-      if (typeof handler === 'function') {
-        return handler.call(this, event);
-      }
+      return this.invokeHandler(handler, event);
     };
   };
 

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -72,6 +72,7 @@ function (_, p, BaseView, FormView, SignInTemplate, Constants, Session, Password
       var password = this.$('.password').val();
 
       var self = this;
+
       return this.fxaClient.signIn(email, password)
         .then(function (accountData) {
           if (accountData.verified) {
@@ -124,17 +125,17 @@ function (_, p, BaseView, FormView, SignInTemplate, Constants, Session, Password
 
         // If the user is already making a request, ban submission.
         if (self.isSubmitting()) {
-          throw new Error('submitting already in progress');
+          throw new Error('submit already in progress');
         }
 
         var email = Session.forceEmail;
-        self.submitting = true;
+        self._isSubmitting = true;
         return self.fxaClient.passwordReset(email)
                 .then(function () {
-                  self.submitting = false;
+                  self._isSubmitting = false;
                   self.navigate('confirm_reset_password');
                 }, function (err) {
-                  self.submitting = false;
+                  self._isSubmitting = false;
                   self.displayError(err);
                 });
       });

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -122,12 +122,16 @@ function (chai, jQuery, BaseView, Translator, Template, DOMEventMock,
       });
     });
 
-    describe('displayError', function () {
+    describe('displayError/isErrorVisible/hideError', function () {
       it('translates and display an error in the .error element', function () {
         var msg = view.displayError('the error message');
         var expected = 'a translated error message';
         assert.equal(view.$('.error').html(), expected);
         assert.equal(msg, expected);
+
+        assert.isTrue(view.isErrorVisible());
+        view.hideError();
+        assert.isFalse(view.isErrorVisible());
       });
 
       it('hides any previously displayed success messages', function () {
@@ -148,6 +152,10 @@ function (chai, jQuery, BaseView, Translator, Template, DOMEventMock,
         var expected = 'an error message<div>with html</div>';
         assert.equal(view.$('.error').html(), expected);
         assert.equal(msg, expected);
+
+        assert.isTrue(view.isErrorVisible());
+        view.hideError();
+        assert.isFalse(view.isErrorVisible());
       });
     });
 

--- a/app/tests/spec/views/change_password.js
+++ b/app/tests/spec/views/change_password.js
@@ -14,6 +14,7 @@ define([
   '../../lib/helpers'
 ],
 function (chai, _, $, View, RouterMock, TestHelpers) {
+  /*global describe, beforeEach, afterEach, it*/
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
 

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -45,7 +45,7 @@ function (chai, p, View, RouterMock) {
 
         return view.fxaClient.signUp(email, 'password')
               .then(function () {
-                 return view.submit();
+                return view.submit();
               })
               .then(function () {
                 assert.isTrue(view.$('.success').is(':visible'));

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -32,7 +32,7 @@ function (chai, $, p, FormView, Template, TestHelpers) {
       },
 
       showValidationErrors: function () {
-        return 'invalid form';
+        return this.showValidationError('body', 'invalid form');
       },
 
       submit: function () {
@@ -41,6 +41,17 @@ function (chai, $, p, FormView, Template, TestHelpers) {
     });
 
     function testErrorDisplayed(expectedMessage) {
+      return view.validateAndSubmit()
+          .then(function () {
+            // success callback should not be called on failure.
+            assert(false, 'unexpected success');
+          }, function (err) {
+            assert.equal(err, expectedMessage);
+            assert.isTrue(view.isErrorVisible());
+          });
+    }
+
+    function testValidationErrorDisplayed(expectedMessage) {
       return view.validateAndSubmit()
           .then(function () {
             // success callback should not be called on failure.
@@ -79,6 +90,13 @@ function (chai, $, p, FormView, Template, TestHelpers) {
         assert.isFalse(view.$('button').hasClass('disabled'));
       });
 
+      it('hides errors if isValid returns true', function () {
+        view.displayError('this is an error');
+        view.formIsValid = true;
+        view.enableSubmitIfValid();
+        assert.isFalse(view.$('.error').is(':visible'));
+      });
+
       it('disabled submit button if isValid returns false', function () {
         view.formIsValid = false;
         view.enableSubmitIfValid();
@@ -94,16 +112,42 @@ function (chai, $, p, FormView, Template, TestHelpers) {
 
       it('shows validation errors if isValid returns false', function () {
         view.formIsValid = false;
-        return testErrorDisplayed('invalid form');
+        return testValidationErrorDisplayed('invalid form');
       });
 
-      it('displays error message if beforeSubmit throws an error', function () {
+      it('only allows one submit at a time', function () {
+        view.formIsValid = true;
+        view.validateAndSubmit();
+        return view.validateAndSubmit()
+                  .then(function () {
+                    assert(false, 'unexpected success');
+                  }, function (err) {
+                    assert.equal(err.message, 'submit already in progress');
+                  });
+
+      });
+
+      it('does not submit if form is disabled', function () {
+        view.formIsValid = true;
+        view.disableForm();
+        return view.validateAndSubmit()
+                  .then(function () {
+                    assert(false, 'unexpected success');
+                  }, function (err) {
+                    assert.equal(err.message, 'form is disabled');
+                  });
+      });
+
+      it('displays error message and does not disable form if beforeSubmit throws an error', function () {
         view.formIsValid = true;
         view.beforeSubmit = function () {
           throw 'an error message';
         };
 
-        return testErrorDisplayed('an error message');
+        return testErrorDisplayed('an error message')
+                  .then(function () {
+                    assert.isTrue(view.isFormEnabled());
+                  });
       });
 
       it('beforeSubmit can return a false to stop form submission', function () {
@@ -127,13 +171,16 @@ function (chai, $, p, FormView, Template, TestHelpers) {
         return testFormSubmitted();
       });
 
-      it('displays error message if submit throws an error', function () {
+      it('displays error message and does not re-enable form if submit throws an error', function () {
         view.formIsValid = true;
         view.submit = function () {
           throw 'an error message';
         };
 
-        return testErrorDisplayed('an error message');
+        return testErrorDisplayed('an error message')
+                  .then(function () {
+                    assert.isFalse(view.isFormEnabled());
+                  });
       });
 
       it('submit can return a promise for asynchronous operations', function () {
@@ -147,13 +194,18 @@ function (chai, $, p, FormView, Template, TestHelpers) {
         return testFormSubmitted();
       });
 
-      it('displays error message if afterSubmit throws an error', function () {
+      it('override afterSubmit to prevent form from being re-enabled - afterSubmit errors are not displayed', function () {
         view.formIsValid = true;
         view.afterSubmit = function () {
-          throw 'an error message';
+          // do not re-enable form.
+          throw new Error('error that is not displayed');
         };
 
-        return testErrorDisplayed('an error message');
+        return view.validateAndSubmit()
+                  .then(null, function(err) {
+                    assert.equal(err.message, 'error that is not displayed');
+                    assert.isFalse(view.isFormEnabled());
+                  });
       });
 
       it('afterSubmit can return a promise for asynchronous operations', function () {
@@ -199,6 +251,17 @@ function (chai, $, p, FormView, Template, TestHelpers) {
       });
     });
 
+    describe('getFormValues', function () {
+      it('gets the value of form fields that do not have the `data-novalue` attribute', function () {
+        view.$('#focusMe').val('the value');
+        view.$('#otherElement').val('another value');
+
+        var values = view.getFormValues();
+        assert.equal(values.focusMe, 'the value');
+        assert.equal(values.otherElement, 'another value');
+        assert.isUndefined(values.novalue);
+      });
+    });
   });
 });
 

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -75,22 +75,16 @@ function (chai, View, WindowMock, RouterMock, TestHelpers) {
     });
 
     describe('submit with valid input', function () {
-      it('submits the email address', function (done) {
+      it('submits the email address', function () {
         var email = 'testuser.' + Math.random() + '@testuser.com';
-        view.fxaClient.signUp(email, 'password')
+        return view.fxaClient.signUp(email, 'password')
               .then(function () {
                 view.$('input[type=email]').val(email);
 
-                router.on('navigate', function () {
-                  wrapAssertion(function() {
-                    assert.equal(router.page, 'confirm_reset_password');
-                  }, done);
-                });
-
-                view.submit();
+                return view.submit();
               })
-              .then(null, function (err) {
-                done(new Error(err.toString()));
+              .then(function () {
+                assert.equal(router.page, 'confirm_reset_password');
               });
       });
     });

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -14,6 +14,7 @@ define([
   '../../lib/helpers'
 ],
 function (chai, _, $, View, RouterMock, TestHelpers) {
+  /*global describe, beforeEach, afterEach, it*/
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -87,7 +87,7 @@ function (chai, $, View, Session, WindowMock, RouterMock, TestHelpers) {
               .then(function () {
                 $('[type=email]').val(email);
                 $('[type=password]').val(password);
-                return view.submit()
+                return view.submit();
               })
               .then(function () {
                 assert.equal(router.page, 'confirm');
@@ -174,6 +174,7 @@ function (chai, $, View, Session, WindowMock, RouterMock, TestHelpers) {
         assert.isFalse(client.passwordForgotSendCode.called);
       });
     });
+
   });
 
   describe('missing email address when calling /force_auth', function () {
@@ -267,13 +268,13 @@ function (chai, $, View, Session, WindowMock, RouterMock, TestHelpers) {
     it('only one forget password request at a time', function () {
       var event = $.Event('click');
 
-      view.submitting = true;
+      view.resetPasswordNow(event);
       return view.resetPasswordNow(event)
-            .then(function () {
-              assert(false, 'unexpected success');
-            }, function (err) {
-              assert.equal(err.message, 'submitting already in progress');
-            });
+              .then(function () {
+                assert(false, 'unexpected success');
+              }, function (err) {
+                assert.equal(err.message, 'submit already in progress');
+              });
     });
   });
 


### PR DESCRIPTION
- Hide errors on form change if form is valid. Help with issue #765 where "Incorrect password" error is shown even after the user updates the password.
- Prevent form re-submission while form is disabled.
- Allow tooltips to be displayed when clicking "next" button even if form is disabled.

fixes #765
fixes #858
