### PR TITLE
fix(client): Ensure auth-server errors are displayed on confirm pages.

### DIFF
--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -32,7 +32,6 @@ function (FormView, BaseView, Template, Session) {
 
       return this.fxaClient.signUpResend()
               .then(function () {
-                self.trigger('resent');
                 self.displaySuccess();
               });
     }

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -30,11 +30,10 @@ function (FormView, BaseView, Template, Session) {
     submit: function () {
       var self = this;
 
-      this.fxaClient.passwordResetResend()
-            .then(function () {
-              self.trigger('resent');
-              self.displaySuccess();
-            });
+      return this.fxaClient.passwordResetResend()
+              .then(function () {
+                self.displaySuccess();
+              });
     }
 
   });

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -7,11 +7,12 @@
 
 define([
   'chai',
+  'p-promise',
   'views/confirm',
   'lib/fxa-client',
   '../../mocks/router'
 ],
-function (chai, View, FxaClient, RouterMock) {
+function (chai, p, View, FxaClient, RouterMock) {
   /*global describe, beforeEach, afterEach, it*/
   var assert = chai.assert;
 
@@ -40,17 +41,32 @@ function (chai, View, FxaClient, RouterMock) {
     });
 
     describe('submit', function () {
-      it('resends the confirmation email', function (done) {
+      it('resends the confirmation email, shows success message', function () {
         var client = new FxaClient();
         var email = 'user' + Math.random() + '@testuser.com';
 
-        client.signUp(email, 'password')
+        return client.signUp(email, 'password')
               .then(function () {
-                 view.on('resent', done);
-                 view.submit();
+                 return view.submit();
               })
-              .then(null, function (err) {
-                done(new Error(err));
+              .then(function () {
+                assert.isTrue(view.$('.success').is(':visible'));
+              });
+
+      });
+
+      it('displays error messages if there is a problem', function () {
+        view.fxaClient.signUpResend = function () {
+          return p().then(function () {
+            throw new Error('synthesized error from auth server');
+          });
+        };
+
+        return view.submit()
+              .then(function () {
+                assert.fail();
+              }, function (err) {
+                assert.equal(err.message, 'synthesized error from auth server');
               });
       });
     });


### PR DESCRIPTION
- submit returns a promise, and this is used to simplify the tests.

fixes #843
fixes #844
