### PR TITLE
fix(client): All error strings should have a Capitalized first letter.

### DIFF
--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -34,17 +34,17 @@ function (_, BaseView, FormView, Template, Session, Url, PasswordMixin) {
       var search = this.window.location.search;
       this.token = Url.searchParam('token', search);
       if (! this.token) {
-        return this.displayError(t('no token specified'));
+        return this.displayError(t('No token specified'));
       }
 
       this.code = Url.searchParam('code', search);
       if (! this.code) {
-        return this.displayError(t('no code specified'));
+        return this.displayError(t('No code specified'));
       }
 
       this.email = Url.searchParam('email', search);
       if (! this.email) {
-        return this.displayError(t('no email specified'));
+        return this.displayError(t('No email specified'));
       }
     },
 
@@ -57,7 +57,7 @@ function (_, BaseView, FormView, Template, Session, Url, PasswordMixin) {
 
     showValidationErrorsEnd: function () {
       if (this._getPassword() !== this._getVPassword()) {
-        this.displayError(t('passwords do not match'));
+        this.displayError(t('Passwords do not match'));
       }
     },
 

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -31,13 +31,13 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, FxaClient, Url) {
       var uid = Url.searchParam('uid', searchParams);
       if (! uid) {
         completeElChildren.show();
-        return this.displayError(t('no uid specified'));
+        return this.displayError(t('No uid specified'));
       }
 
       var code = Url.searchParam('code', searchParams);
       if (! code) {
         completeElChildren.show();
-        return this.displayError(t('no code specified'));
+        return this.displayError(t('No code specified'));
       }
 
       var self = this;


### PR DESCRIPTION
- The "old and new passwords..." string is updated in #851

@ryanfeeley  - these are the last remaining error strings that started with a lowercase. Thanks for the great explanation!

fixes #852
