### PR TITLE
fix(tests): Use `assert(false, <message>)` instead of `assert.fail(<message>)`.

### DIFF
--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -180,7 +180,7 @@ function (chai, $, ChannelMock, testHelpers,
         channelMock.canLinkAccountOk = false;
         return client.signUp(email, password)
           .then(function() {
-            assert.fail('should throw USER_CANCELED_LOGIN');
+            assert(false, 'should throw USER_CANCELED_LOGIN');
           }, function (err) {
             assert.isTrue(AuthErrors.is(err, 'USER_CANCELED_LOGIN'));
             // check can_link_account was called once
@@ -193,7 +193,7 @@ function (chai, $, ChannelMock, testHelpers,
       it('signin with unknown user should call errorback', function () {
         return client.signIn('unknown@unknown.com', 'password')
           .then(function (info) {
-            assert.fail('unknown user cannot sign in');
+            assert(false, 'unknown user cannot sign in');
           }, function (err) {
             assert.isTrue(true);
           });
@@ -267,7 +267,7 @@ function (chai, $, ChannelMock, testHelpers,
         channelMock.canLinkAccountOk = false;
         return client.signIn(email, password)
           .then(function() {
-            assert.fail('should throw USER_CANCELED_LOGIN');
+            assert(false, 'should throw USER_CANCELED_LOGIN');
           }, function (err) {
             assert.isTrue(AuthErrors.is(err, 'USER_CANCELED_LOGIN'));
             // check can_link_account was called once

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -64,7 +64,7 @@ function (chai, p, View, FxaClient, RouterMock) {
 
         return view.submit()
               .then(function () {
-                assert.fail();
+                assert(false, 'unexpected success');
               }, function (err) {
                 assert.equal(err.message, 'synthesized error from auth server');
               });

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -66,7 +66,7 @@ function (chai, p, View, FxaClient, RouterMock) {
 
         return view.submit()
               .then(function () {
-                assert.fail();
+                assert(false, 'unexpected success');
               }, function (err) {
                 assert.equal(err.message, 'synthesized error from auth server');
               });

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -44,7 +44,7 @@ function (chai, $, p, FormView, Template, TestHelpers) {
       return view.validateAndSubmit()
           .then(function () {
             // success callback should not be called on failure.
-            assert.fail();
+            assert(false, 'unexpected success');
           }, function (err) {
             assert.equal(err, expectedMessage);
           });

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -104,7 +104,7 @@ function (chai, View, FxaClient, WindowMock, RouterMock, TestHelpers) {
 
         return view.submit()
                   .then(function () {
-                    assert.fail('unexpected success');
+                    assert(false, 'unexpected success');
                   }, function (err) {
                     // Turn that frown upside down.
                     // Error is expected.

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -108,7 +108,7 @@ function (chai, $, View, Session, FxaClient,
                 return view.submit();
               })
               .then(function () {
-                assert.fail();
+                assert(false, 'unexpected success');
               }, function (err) {
                 assert.ok(err.message.indexOf('Incorrect') > -1);
               });
@@ -278,7 +278,7 @@ function (chai, $, View, Session, FxaClient,
       view.submitting = true;
       return view.resetPasswordNow(event)
             .then(function () {
-              assert.fail('unexpected success');
+              assert(false, 'unexpected success');
             }, function (err) {
               assert.equal(err.message, 'submitting already in progress');
             });


### PR DESCRIPTION
- The latter is incorrect usage according to the Chai docs.

fixes #861
