### PR TITLE
feature(client): Add a `/cookies_disabled` page.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// this module starts it all.
+
+/**
+ * the flow:
+ * 1) Initialize session information from URL search parameters.
+ * 2) Fetch /config from the backend, the returned info includes a flag that
+ *    indicates whether cookies are enabled.
+ * 3) Fetch translations from the backend.
+ * 4) Create the web/desktop communication channel.
+ * 5) If cookies are disabled, go to the /cookies_disabled page.
+ * 6) Start the app if cookies are enabled.
+ */
+
+'use strict';
+
+define([
+  'underscore',
+  'backbone',
+  'p-promise',
+  'router',
+  'lib/constants',
+  'lib/translator',
+  'lib/session',
+  'lib/url',
+  'lib/channels/web',
+  'lib/channels/fx-desktop',
+  'lib/config-loader'
+],
+function (
+  _,
+  Backbone,
+  p,
+  Router,
+  Constants,
+  Translator,
+  Session,
+  Url,
+  WebChannel,
+  FxDesktopChannel,
+  ConfigLoader
+) {
+
+  function getChannel() {
+    var context = Url.searchParam('context');
+    var channel;
+
+    if (context === Constants.FX_DESKTOP_CONTEXT) {
+      // Firefox for desktop native=>FxA glue code.
+      channel = new FxDesktopChannel();
+    } else {
+      // default to the web channel that doesn't do anything yet.
+      channel = new WebChannel();
+    }
+
+    channel.init();
+    return channel;
+  }
+
+  function setSessionValueFromUrl(name) {
+    var value = Url.searchParam(name);
+    if (value) {
+      Session.set(name, value);
+    } else {
+      Session.clear(name);
+    }
+  }
+
+  function initSessionFromUrl() {
+    setSessionValueFromUrl('service');
+    setSessionValueFromUrl('redirectTo');
+    setSessionValueFromUrl('context');
+  }
+
+  function Start(options) {
+    options = options || {};
+
+    this._window = options.window || window;
+    this._window.router = this._router = options.router || new Router();
+    this._history = options.history || Backbone.history;
+    this._configLoader = new ConfigLoader();
+  }
+
+  Start.prototype = {
+    startApp: function () {
+      initSessionFromUrl();
+      return this.initializeConfig()
+        .then(_.bind(this.initializeL10n, this))
+        .then(_.bind(this.allResourcesReady, this));
+    },
+
+    initializeConfig: function () {
+      return this._configLoader.fetch()
+                    .then(_.bind(this.useConfig, this));
+    },
+
+    useConfig: function(config) {
+      this._config = config;
+      this._configLoader.useConfig(config);
+      Session.set('config', config);
+    },
+
+    initializeL10n: function () {
+      var deferred = p.defer();
+
+      // IE uses navigator.browserLanguage, all others user navigator.language.
+      var language = this._window.navigator.browserLanguage ||
+                     this._window.navigator.language ||
+                     'en-US';
+
+      var translator = this._window.translator = new Translator(language,
+                                         this._config.i18n.supportedLanguages,
+                                         this._config.i18n.defaultLang);
+
+      Session.set('language', translator.language);
+
+      translator.fetch(function () {
+        deferred.resolve();
+      });
+
+      return deferred.promise;
+    },
+
+    /**
+     * config can be passed in for testing
+     */
+    allResourcesReady: function () {
+      // Get the party started
+      this._history.start({ pushState: true });
+
+      // These must be initialized after Backbone.history so that
+      // Backbone does not override the page the channel sets.
+      Session.set('channel', getChannel());
+      var self = this;
+      return this._configLoader.areCookiesEnabled()
+        .then(function (areCookiesEnabled) {
+          if (! areCookiesEnabled) {
+            self._router.navigate('cookies_disabled');
+          }
+        });
+    }
+  };
+
+  return Start;
+});
+
+
+

--- a/app/scripts/lib/config-loader.js
+++ b/app/scripts/lib/config-loader.js
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// fetch config from the backend and provide some helper functions.
+
+'use strict';
+
+define([
+  'underscore',
+  'jquery',
+  'p-promise',
+  'lib/url'
+],
+function (
+  _,
+  $,
+  p,
+  Url
+) {
+
+  function ConfigLoader() {
+  }
+
+  ConfigLoader.prototype = {
+    /**
+     * Pass in a configuration to use. Useful for unit testing.
+     */
+    useConfig: function(config) {
+      this._config = config;
+    },
+
+    fetch: function (force) {
+      if (force !== true && this._config) {
+        return p(this._config);
+      }
+
+      var deferred = p.defer();
+
+      // The content server sets no cookies of its own, and cannot check for
+      // the existence of a session cookie. So, we send them a cookie
+      // from the client to see if the backend receives it.
+      // If cookies are disabled, config.cookiesEnabled will be `false`.
+      //
+      // A cookie is sent to the backend instead of written then immediately
+      // read in JS because the Android 3.2 and 4.0 default browsers happily
+      // read JS written cookies, even if cookies are disabled.
+      // See https://github.com/mozilla/persona/commit/013b48c9e0bcd9e04243ea578e117537cf8aeea8
+
+      try {
+        document.cookie = '__cookie_check=1; path=/config;';
+      } catch(e) {
+        // some browsers explode when trying to set cookies if they are
+        // disabled. Ignore the error, the server will report back that it
+        // did not receive the cookie.
+      }
+
+      var self = this;
+      $.getJSON('/config', function (config) {
+        self._config = config;
+        deferred.resolve(config);
+      });
+
+      return deferred.promise;
+    },
+
+    areCookiesEnabled: function (force) {
+      return this.fetch(force)
+          .then(function (config) {
+            // use the search parameter for selenium testing. There is
+            // no way to disable cookies using wd, so the search parameter
+            // is used as a dirty hack.
+            var cookiesEnabled = Url.searchParam('disable_cookies') ?
+                                        false : config.cookiesEnabled;
+            return cookiesEnabled;
+          });
+    }
+  };
+
+  return ConfigLoader;
+});
+

--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -94,8 +94,17 @@ define([
         }
       });
 
-      localStorage.setItem(NAMESPACE, JSON.stringify(toSaveToLocalStorage));
-      sessionStorage.setItem(NAMESPACE, JSON.stringify(toSaveToSessionStorage));
+      // Wrap browser storage access in a try/catch block because some browsers
+      // (Firefox, Chrome) except when trying to access browser storage and
+      // cookies are disabled.
+      try {
+        localStorage.setItem(NAMESPACE, JSON.stringify(toSaveToLocalStorage));
+        sessionStorage.setItem(NAMESPACE, JSON.stringify(toSaveToSessionStorage));
+
+      } catch(e) {
+        // some browsers disable access to browser storage
+        // if cookies are disabled.
+      }
     },
 
     /**

--- a/app/scripts/lib/translator.js
+++ b/app/scripts/lib/translator.js
@@ -37,9 +37,9 @@ function (_, $, Strings) {
     // Fetches our JSON translation file
     fetch: function (done) {
       $.ajax({ dataType: 'json', url: '/i18n/' + this.language.replace(/-/, '_') + '/client.json' })
-        .done(function (data) {
+        .done(_.bind(function (data) {
           this.translations = data;
-        }.bind(this))
+        }, this))
         .always(done);
     },
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -34,83 +34,11 @@ require.config({
 });
 
 require([
-  'backbone',
-  'router',
-  'lib/constants',
-  'lib/translator',
-  'lib/session',
-  'lib/url',
-  'lib/channels/web',
-  'lib/channels/fx-desktop'
+  './lib/app-start'
 ],
-function (
-  Backbone,
-  Router,
-  Constants,
-  Translator,
-  Session,
-  Url,
-  WebChannel,
-  FxDesktopChannel
-) {
-  function getChannel() {
-    var context = Url.searchParam('context');
-    var channel;
-
-    if (context === Constants.FX_DESKTOP_CONTEXT) {
-      // Firefox for desktop native=>FxA glue code.
-      channel = new FxDesktopChannel();
-    } else {
-      // default to the web channel that doesn't do anything yet.
-      channel = new WebChannel();
-    }
-
-    channel.init();
-    return channel;
-  }
-
-  function setSessionValueFromUrl(name) {
-    var value = Url.searchParam(name);
-    if (value) {
-      Session.set(name, value);
-    } else {
-      Session.clear(name);
-    }
-  }
-
-  function initSessionFromUrl() {
-    setSessionValueFromUrl('service');
-    setSessionValueFromUrl('redirectTo');
-    setSessionValueFromUrl('context');
-  }
-
-  window.router = new Router();
-
-  initSessionFromUrl();
-
-  // Don't start backbone until we have our config and translations
-  $.getJSON('/config', function (config) {
-
-    Session.set('config', config);
-
-    // IE uses navigator.browserLanguage, all others user navigator.language.
-    var language = window.navigator.browserLanguage || window.navigator.language || 'en-US';
-
-    window.translator = new Translator(language,
-                                       config.i18n.supportedLanguages,
-                                       config.i18n.defaultLang);
-
-    Session.set('language', window.translator.language);
-
-    translator.fetch(function () {
-      // Get the party started
-      Backbone.history.start({ pushState: true });
-
-      // The channel must be initialized after Backbone.history so that the
-      // Backbone does not override the page the channel sets.
-      Session.set('channel', getChannel());
-    });
-  });
+function (AppStart) {
+  var appStart = new AppStart();
+  appStart.startApp();
 });
 
 

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -23,7 +23,8 @@ define([
   'views/ready',
   'views/settings',
   'views/change_password',
-  'views/delete_account'
+  'views/delete_account',
+  'views/cookies_disabled'
 ],
 function (
   _,
@@ -44,7 +45,8 @@ function (
   ReadyView,
   SettingsView,
   ChangePasswordView,
-  DeleteAccountView
+  DeleteAccountView,
+  CookiesDisabledView
 ) {
 
   function showView(View, options) {
@@ -73,7 +75,8 @@ function (
       'confirm_reset_password(/)': showView(ConfirmResetPasswordView),
       'complete_reset_password(/)': showView(CompleteResetPasswordView),
       'reset_password_complete(/)': showView(ReadyView, { type: 'reset_password' }),
-      'force_auth(/)': showView(SignInView, { forceAuth: true })
+      'force_auth(/)': showView(SignInView, { forceAuth: true }),
+      'cookies_disabled(/)': showView(CookiesDisabledView)
     },
 
     initialize: function (options) {

--- a/app/scripts/templates/cookies_disabled.mustache
+++ b/app/scripts/templates/cookies_disabled.mustache
@@ -1,0 +1,20 @@
+<header>
+  <h1 id="fxa-cookies-disabled-header">{{#t}}Cookies Required{{/t}}</h1>
+</header>
+
+<section>
+  <div class="error"></div>
+  
+  <p>
+    {{#t}}Please enable cookies in your browser which are required by Firefox Accounts. Cookies are small pieces of data stored in your browser that provide functionality such as remembering you between sessions.{{/t}}
+  </p>
+
+  <p>
+    <a href="https://support.mozilla.org/kb/cookies-information-websites-store-on-your-computer" target="_blank">{{#t}}Learn more{{/t}}</a>
+  </p>
+
+  <div class="button-row">
+    <button id="submit-btn" type="submit">{{#t}}Try again{{/t}}</button>
+  </div>
+
+</section>

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -312,12 +312,12 @@ function (_, Backbone, jQuery, p, Session, authErrors, FxaClient) {
         event.preventDefault();
       }
 
-      window.history.back();
+      this.window.history.back();
     },
 
     backOnEnter: function (event) {
       if (event.which === ENTER_BUTTON_CODE) {
-        window.history.back();
+        this.window.history.back();
       }
     },
 

--- a/app/scripts/views/cookies_disabled.js
+++ b/app/scripts/views/cookies_disabled.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'views/base',
+  'lib/config-loader',
+  'stache!templates/cookies_disabled'
+],
+function (BaseView, ConfigLoader, Template) {
+  var t = BaseView.t;
+
+  var View = BaseView.extend({
+    constructor: function (options) {
+      BaseView.call(this, options);
+
+      this._configLoader = new ConfigLoader();
+    },
+
+    template: Template,
+    className: 'cookies-disabled',
+
+    events: {
+      'click #submit-btn': 'backIfCookiesEnabled'
+    },
+
+    backIfCookiesEnabled: function () {
+      var self = this;
+      return this._configLoader.areCookiesEnabled(true)
+        .then(function (areCookiesEnabled) {
+          if (! areCookiesEnabled) {
+            return self.displayError(t('Cookies are still disabled'));
+          }
+
+          self.back();
+        });
+    }
+  });
+
+  return View;
+});

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -54,6 +54,7 @@ require([
   '../tests/spec/lib/router',
   '../tests/spec/lib/strings',
   '../tests/spec/lib/auth-errors',
+  '../tests/spec/lib/app-start',
   '../tests/spec/views/base',
   '../tests/spec/views/tooltip',
   '../tests/spec/views/form',
@@ -69,7 +70,8 @@ require([
   '../tests/spec/views/reset_password',
   '../tests/spec/views/confirm_reset_password',
   '../tests/spec/views/complete_reset_password',
-  '../tests/spec/views/ready'
+  '../tests/spec/views/ready',
+  '../tests/spec/views/cookies_disabled'
 ],
 function (Translator, Session, FxaClientWrapper) {
 

--- a/app/tests/mocks/history.js
+++ b/app/tests/mocks/history.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// A mock for Backbone.history
+define([
+], function () {
+  function History() {}
+
+  History.prototype = {
+    start: function () {
+    }
+  };
+
+  return History;
+});
+

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -12,6 +12,8 @@ define([
 ],
 function (_, Backbone) {
   function WindowMock() {
+    var self = this;
+
     this.translator = window.translator;
     this.location = {
       href: window.location.href,
@@ -21,6 +23,12 @@ function (_, Backbone) {
 
     this.document = {
       title: window.document.title
+    };
+
+    this.history = {
+      back: function () {
+        self.history.back.called = true;
+      }
     };
   }
 
@@ -65,6 +73,10 @@ function (_, Backbone) {
     },
 
     clearTimeout: function (timeout) {
+    },
+
+    navigator: {
+      language: 'en-US'
     }
   });
 

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'chai',
+  'lib/app-start',
+  'lib/session',
+  '../../mocks/window',
+  '../../mocks/router',
+  '../../mocks/history'
+],
+function (chai, AppStart, Session, WindowMock, RouterMock, HistoryMock) {
+  /*global describe, beforeEach, it*/
+  var assert = chai.assert;
+
+  describe('lib/start-app', function () {
+    var windowMock;
+    var routerMock;
+    var historyMock;
+    var appStart;
+
+    beforeEach(function () {
+      windowMock = new WindowMock();
+      routerMock = new RouterMock();
+      historyMock = new HistoryMock();
+
+      appStart = new AppStart({
+        window: windowMock,
+        router: routerMock,
+        history: historyMock
+      });
+    });
+
+    describe('start', function () {
+      it('start starts the app', function () {
+        return appStart.startApp()
+                    .then(function () {
+                      assert.equal(Session.language, 'en-US');
+                      assert.ok(Session.config);
+                      assert.ok(Session.channel);
+
+                      // translator is put on the global object.
+                      assert.ok(windowMock.translator);
+                    });
+      });
+
+      it('redirects to /cookies_disabled if cookies are disabled', function () {
+        appStart.useConfig({
+          cookiesEnabled: false,
+          i18n: {
+            supportedLanguages: ['en'],
+            defaultLang: 'en'
+          }
+        });
+
+        return appStart.startApp()
+            .then(function () {
+              assert.equal(routerMock.page, 'cookies_disabled');
+            });
+      });
+    });
+  });
+});
+
+

--- a/app/tests/spec/views/cookies_disabled.js
+++ b/app/tests/spec/views/cookies_disabled.js
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'jquery',
+  'chai',
+  'p-promise',
+  'views/cookies_disabled',
+  '../../mocks/window'
+],
+function ($, chai, p, View, WindowMock) {
+  /*global describe, beforeEach, afterEach, it*/
+  var assert = chai.assert;
+
+  describe('views/cookies_disabled', function () {
+    var view, windowMock, serverConfig;
+
+    var origGetJSON = $.getJSON;
+
+    beforeEach(function () {
+      // Going deep into the internals, which isn't great. Monkey patch
+      // $.getJSON so that we do not have to actually make a request to
+      // the backend and can control the return value.
+      $.getJSON = function (url, done) {
+        done(serverConfig);
+      };
+
+      windowMock = new WindowMock();
+      view = new View({
+        window: windowMock
+      });
+      return view.render()
+          .then(function () {
+            $('#container').html(view.el);
+          });
+    });
+
+    afterEach(function () {
+      view.remove();
+      view.destroy();
+
+      $.getJSON = origGetJSON;
+    });
+
+    describe('constructor creates it', function () {
+      it('is drawn', function () {
+        assert.ok(view.$('#fxa-cookies-disabled-header').length);
+      });
+    });
+
+    describe('backIfCookiesEnabled', function () {
+      it('goes back in history if cookies are enabled', function () {
+        serverConfig = {
+          cookiesEnabled: true
+        };
+
+        return view.backIfCookiesEnabled()
+          .then(function () {
+            assert.isTrue(view.window.history.back.called);
+            assert.equal(view.$('.error').text(), '');
+          });
+      });
+
+      it('shows an error message if cookies are still disabled', function () {
+        serverConfig = {
+          cookiesEnabled: false
+        };
+
+        return view.backIfCookiesEnabled()
+          .then(function () {
+            assert.isUndefined(view.window.history.back.called);
+            assert.ok(view.$('.error').text());
+          });
+      });
+    });
+  });
+});
+
+

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -26,10 +26,12 @@ module.exports = function (config, templates, i18n) {
 
   var ver = require('./routes/get-ver.json');
   var termsPrivacy = require('./routes/get-terms-privacy')(i18n);
+  var configRoute = require('./routes/get-config');
 
   var routes = [
     ver,
-    termsPrivacy
+    termsPrivacy,
+    configRoute
   ];
 
   var authServerHost = url.parse(config.get('fxaccount_url')).hostname;
@@ -38,13 +40,6 @@ module.exports = function (config, templates, i18n) {
     // handle password reset links
     app.get('/v1/complete_reset_password', function (req, res) {
       res.redirect(req.originalUrl.slice(3));
-    });
-
-    app.get('/config', function (req, res) {
-      res.json({
-        fxaccountUrl: config.get('fxaccount_url'),
-        i18n: config.get('i18n')
-      });
     });
 
     // handle email verification links
@@ -85,7 +80,8 @@ module.exports = function (config, templates, i18n) {
       '/complete_reset_password',
       '/reset_password_complete',
       '/delete_account',
-      '/force_auth'
+      '/force_auth',
+      '/cookies_disabled'
     ];
 
     FRONTEND_ROUTES.forEach(function (route) {

--- a/server/lib/routes/get-config.js
+++ b/server/lib/routes/get-config.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+var config = require('../configuration');
+
+exports.method = 'get';
+exports.path = '/config';
+
+exports.process = function(req, res) {
+  // charset must be set on json responses.
+  res.charset = 'utf8';
+  res.json({
+    // The `__cookies_check` cookie is set in client code
+    // to see if cookies are enabled. If cookies are disabled,
+    // the `__cookie_check` cookie will not arrive.
+    cookiesEnabled: !!req.cookies['__cookie_check'],
+    fxaccountUrl: config.get('fxaccount_url'),
+    i18n: config.get('i18n')
+  });
+};

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -17,6 +17,7 @@ define([
   './functional/404',
   './functional/pages',
   './functional/back_button_after_start',
+  './functional/cookies_disabled',
   './functional/mocha'
 ], function () {
   'use strict';

--- a/tests/functional/cookies_disabled.js
+++ b/tests/functional/cookies_disabled.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'require'
+], function (registerSuite, assert, require) {
+  'use strict';
+
+  // there is no way to disable cookies using wd. Add `disable_cookies`
+  // to the URL to synthesize cookies being disabled.
+  var SIGNUP_COOKIES_DISABLED_URL = 'http://localhost:3030/signup?disable_cookies=1';
+  var SIGNUP_COOKIES_ENABLED_URL = 'http://localhost:3030/signup';
+  var COOKIES_DISABLED_URL = 'http://localhost:3030/cookies_disabled';
+
+  registerSuite({
+    name: 'cookies_disabled',
+
+    'visit signup page with cookies disabled': function () {
+      return this.get('remote')
+        .get(require.toUrl(SIGNUP_COOKIES_DISABLED_URL))
+
+        .waitForElementById('fxa-cookies-disabled-header')
+        .end()
+
+        // try again, cookies are still disabled.
+        .elementById('submit-btn')
+          .click()
+        .end()
+
+        // show an error message after second try
+        .waitForVisibleByCssSelector('#stage .error')
+        .elementByCssSelector('#stage .error').isDisplayed()
+        .then(function (isDisplayed) {
+          assert.equal(isDisplayed, true);
+        });
+    },
+
+    'synthesize enabling cookies by visiting the sign up page, then cookies_disabled, then clicking "try again"': function () {
+      return this.get('remote')
+        .get(require.toUrl(SIGNUP_COOKIES_ENABLED_URL))
+        // wd has no way of disabling/enabling cookies, so we have to
+        // manually seed history.
+        .waitForElementById('fxa-signup-header')
+        .end()
+
+        .get(require.toUrl(COOKIES_DISABLED_URL))
+
+        .waitForElementById('fxa-cookies-disabled-header')
+        .end()
+
+        // try again, cookies are enabled.
+        .elementById('submit-btn')
+          .click()
+        .end()
+
+        // Should be redirected back to the signup page.
+        .waitForElementById('fxa-signup-header');
+    }
+  });
+});

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -14,7 +14,8 @@ define([
   intern.suites = [
     'tests/server/templates',
     'tests/server/routes',
-    'tests/server/ver.json.js'
+    'tests/server/ver.json.js',
+    'tests/server/cookies_disabled'
   ];
 
   return intern;

--- a/tests/server/cookies_disabled.js
+++ b/tests/server/cookies_disabled.js
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../server/lib/configuration',
+  'intern/dojo/node!request'
+], function (registerSuite, assert, config, request) {
+  'use strict';
+
+  var serverUrl = config.get('public_url');
+
+  var suite = {
+    name: 'config'
+  };
+
+  suite['#get /config without cookies returns `cookiesEnabled=false`'] = function () {
+    var dfd = this.async(1000);
+
+    request(serverUrl + '/config', {
+      headers: {
+        'Cookie': ''
+      }
+    },
+    dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+
+      var results = JSON.parse(res.body);
+
+      assert.equal(results.cookiesEnabled, false);
+    }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#get /config with cookies returns `cookiesEnabled=true`'] = function () {
+    var dfd = this.async(1000);
+
+    request(serverUrl + '/config', {
+      headers: {
+        'Cookie': '__cookie_check=1; path=/config;'
+      }
+    },
+    dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+
+      var results = JSON.parse(res.body);
+      assert.equal(results.cookiesEnabled, true);
+    }, dfd.reject.bind(dfd)));
+  };
+
+  registerSuite(suite);
+
+});

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -42,7 +42,8 @@ define([
     '/ver.json': 200,
     '/non_existent': 404,
     '/legal/non_existent': 404,
-    '/en-US/legal/non_existent': 404
+    '/en-US/legal/non_existent': 404,
+    '/cookies_disabled': 200
   };
 
   function routeTest(route, expectedStatusCode) {


### PR DESCRIPTION
- Add a cookies_disabled template, view, and test.
- Split off most of the code from main.js into lib/start-app.js so that it can be tested.

fixes #738
