### PR TITLE
chore(client): Change `too many retries` to `Unexpected error`.

### DIFF
--- a/app/scripts/lib/channels/fx-desktop.js
+++ b/app/scripts/lib/channels/fx-desktop.js
@@ -31,10 +31,11 @@ function (_, Backbone, Session) {
 
   function errorIfNoResponse(outstandingRequest) {
     /*jshint validthis: true*/
-    outstandingRequest.timeout = setTimeout(_.bind(function () {
+    outstandingRequest.timeout = setTimeout(function () {
       // only called if the request has not been responded to.
-      outstandingRequest.done(new Error('too many retries'));
-    }, this), this.sendTimeoutLength);
+      console.error('no response from browser');
+      outstandingRequest.done(new Error('Unexpected error'));
+    }, this.sendTimeoutLength);
   }
 
   function receiveMessage(event) {

--- a/app/tests/spec/lib/channels/fx-desktop.js
+++ b/app/tests/spec/lib/channels/fx-desktop.js
@@ -101,7 +101,7 @@ function (chai, WindowMock, RouterMock, Session, FxDesktopChannel, TestHelpers) 
       it('times out if browser does not respond', function (done) {
         channel.send('wait-for-response', { key: 'value' }, function (err) {
           wrapAssertion(function () {
-            assert.equal(String(err), 'Error: too many retries');
+            assert.equal(String(err), 'Error: Unexpected error');
           }, done);
         });
       });


### PR DESCRIPTION
- Used if browser does not respond to a message sent to it.

fixes #725
