### PR TITLE
fix(client): Enable back button functionality when visiting `/`.

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -86,7 +86,7 @@ function (
       this.watchAnchors();
     },
 
-    navigate: function (url) {
+    navigate: function (url, options) {
       // Only add search parameters if they do not already exist.
       // Search parameters are added to the URLs because they are sometimes
       // used to pass state from the browser to the screens. Perhaps we should
@@ -96,16 +96,13 @@ function (
         url = url + this.window.location.search;
       }
 
-      return Backbone.Router.prototype.navigate.call(
-                            this, url, { trigger: true });
+      options = options || { trigger: true };
+      return Backbone.Router.prototype.navigate.call(this, url, options);
     },
 
     redirectToSignupOrSettings: function () {
-      if (Session.sessionToken) {
-        this.navigate('/settings');
-      } else {
-        this.navigate('/signup');
-      }
+      var url = Session.sessionToken ? '/settings' : '/signup';
+      this.navigate(url, { trigger: true, replace: true });
     },
 
     showView: function (viewToShow) {

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -64,20 +64,20 @@ function (chai, _, Backbone, Router, SignInView, SignUpView, Session, WindowMock
     });
 
     describe('redirectToSignupOrSettings', function () {
-      it('go to the signup page', function () {
+      it('replaces current page with the signup page if there is no sessionToken', function () {
         windowMock.location.search = '';
         Session.set('sessionToken', null);
         router.redirectToSignupOrSettings();
         assert.equal(navigateUrl, '/signup');
-        assert.deepEqual(navigateOptions, { trigger: true });
+        assert.deepEqual(navigateOptions, { trigger: true, replace: true });
       });
 
-      it('go to the settings page', function () {
+      it('replaces the current page with the settings page if there is a sessionToken', function () {
         windowMock.location.search = '';
         Session.set('sessionToken', 'abc123');
         router.redirectToSignupOrSettings();
         assert.equal(navigateUrl, '/settings');
-        assert.deepEqual(navigateOptions, { trigger: true });
+        assert.deepEqual(navigateOptions, { trigger: true, replace: true });
       });
     });
 

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -16,6 +16,7 @@ define([
   './functional/force_auth',
   './functional/404',
   './functional/pages',
+  './functional/back_button_after_start',
   './functional/mocha'
 ], function () {
   'use strict';

--- a/tests/functional/back_button_after_start.js
+++ b/tests/functional/back_button_after_start.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'require'
+], function (registerSuite, assert, require) {
+  'use strict';
+
+  var FROM_URL = 'https://github.com/mozilla/fxa-content-server';
+  var FXA_ROOT_URL = 'http://localhost:3030/';
+
+  registerSuite({
+    name: 'back button after navigating to the root',
+
+    'start at github, visit Fxa root, click `back` - should go back to github': function () {
+      return this.get('remote')
+        .get(require.toUrl(FROM_URL))
+        .get(require.toUrl(FXA_ROOT_URL))
+
+        .waitForElementById('fxa-signup-header')
+
+        // click back.
+        .back()
+
+        .url()
+          .then(function (resultUrl) {
+            assert.equal(resultUrl, FROM_URL);
+          })
+        .end();
+    }
+  });
+});


### PR DESCRIPTION
- use history.replaceState instead of history.pushState when redirecting from `/`.

fixes #763
