### PR TITLE
fix(client): Correctly handle the THROTTLED error from fxa-client.js->signUp

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -193,11 +193,7 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
                   return;
                 }
 
-                if (err instanceof Error) {
-                  throw err;
-                } else {
-                  throw new Error(err);
-                }
+                throw err;
               })
               .then(function () {
                 var signInOptions = {

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -76,6 +76,22 @@ function (chai, $, ChannelMock, testHelpers,
           });
       });
 
+      it('a throttled signUp returns a THROTTLED error', function () {
+        return client.signUp(email, password)
+          .then(function () {
+            return client.signUp(email, password);
+          })
+          .then(function () {
+            return client.signUp(email, password);
+          })
+          .then(function () {
+            return client.signUp(email, password);
+          })
+          .then(null, function (err) {
+            assert.isTrue(AuthErrors.is(err, 'THROTTLED'));
+          });
+      });
+
       it('informs browser of customizeSync option', function () {
         return client.signUp(email, password, { customizeSync: true })
           .then(function () {


### PR DESCRIPTION
fixes #905
