### PR TITLE
fix(i18n): Ensure i18n works in Chrome.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -32,13 +32,7 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
     return str && str.replace(/^\s+|\s+$/g, '');
   }
 
-  function FxaClientWrapper(options) {
-    options = options || {};
-    // IE uses navigator.browserLanguage, all others user navigator.language.
-    var language = options.language ||
-                   navigator.browserLanguage ||
-                   navigator.language;
-    this.language = language;
+  function FxaClientWrapper() {
   }
 
   FxaClientWrapper.prototype = {
@@ -177,7 +171,7 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
                   keys: true,
                   service: service,
                   redirectTo: redirectTo,
-                  lang: self.language
+                  lang: Session.language
                 };
 
                 if (options.preVerified) {
@@ -216,7 +210,6 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
     },
 
     signUpResend: function () {
-      var self = this;
       return this._getClientAsync()
         .then(function (client) {
           if (signUpResendCount >= Constants.SIGNUP_RESEND_MAX_TRIES) {
@@ -232,7 +225,7 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
             {
               service: Session.service,
               redirectTo: Session.redirectTo,
-              lang: self.language
+              lang: Session.language
             });
         });
     },
@@ -261,7 +254,6 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
     },
 
     passwordReset: function (originalEmail) {
-      var self = this;
       var service = Session.service;
       var redirectTo = Session.redirectTo;
       var email = trim(originalEmail);
@@ -274,7 +266,7 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
                 return client.passwordForgotSendCode(email, {
                   service: service,
                   redirectTo: redirectTo,
-                  lang: self.language
+                  lang: Session.language
                 });
               })
               .then(function (result) {
@@ -291,7 +283,6 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
     },
 
     passwordResetResend: function () {
-      var self = this;
       return this._getClientAsync()
         .then(function (client) {
           if (passwordResetResendCount >= Constants.PASSWORD_RESET_RESEND_MAX_TRIES) {
@@ -306,7 +297,7 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
           var options = {
             service: Session.service,
             redirectTo: Session.redirectTo,
-            lang: self.language
+            lang: Session.language
           };
           return client.passwordForgotResendCode(
                    Session.email,

--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -21,7 +21,9 @@ define([
   // will blow up when sending the login message.
   // Don't clear service because the signup page needs that state
   //  even when user credentials are cleared.
-  var DO_NOT_CLEAR = ['channel', 'context', 'service'];
+  // Don't clear `language`, this is set on startup based on the user's
+  // Accept-Language headers and does not change when user's sign in and out.
+  var DO_NOT_CLEAR = ['channel', 'context', 'service', 'language'];
 
   // these keys will be persisted to localStorage so that they live between browser sessions
   var PERSIST_TO_LOCAL_STORAGE = ['email', 'sessionToken', 'sessionTokenContext'];

--- a/app/scripts/lib/translator.js
+++ b/app/scripts/lib/translator.js
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Translate `en` strings into a language suitable for the user.
+// Translated strings are fetched from the server. The translation
+// is chosen on the backend based on the user's `Accept-Language`
+// headers.
 'use strict';
 
 define([
@@ -11,21 +15,7 @@ define([
 ],
 function (_, $, Strings) {
 
-  var bestLanguage = function (language, supportedLanguages, defaultLanguage) {
-    var lower = _.map(supportedLanguages, function (l) {
-      return l.toLowerCase();
-    });
-
-    if (lower.indexOf(language.toLowerCase()) !== -1) {
-      return language;
-    } else if (lower.indexOf(language.split('-')[0].toLowerCase()) !== -1) {
-      return language.split('-')[0];
-    }
-    return defaultLanguage;
-  };
-
-  var Translator = function (language, supportedLanguages, defaultLanguage) {
-    this.language = bestLanguage(language, supportedLanguages, defaultLanguage);
+  var Translator = function () {
     this.translations = {};
   };
 
@@ -36,10 +26,11 @@ function (_, $, Strings) {
 
     // Fetches our JSON translation file
     fetch: function (done) {
-      $.ajax({ dataType: 'json', url: '/i18n/' + this.language.replace(/-/, '_') + '/client.json' })
-        .done(_.bind(function (data) {
-          this.translations = data;
-        }, this))
+      var self = this;
+      $.ajax({ dataType: 'json', url: '/i18n/client.json' })
+        .done(function (data) {
+          self.translations = data;
+        })
         .always(done);
     },
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -40,5 +40,3 @@ function (AppStart) {
   var appStart = new AppStart();
   appStart.startApp();
 });
-
-

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -17,7 +17,7 @@ function (chai, AppStart, Session, WindowMock, RouterMock, HistoryMock) {
   /*global describe, beforeEach, it*/
   var assert = chai.assert;
 
-  describe('lib/start-app', function () {
+  describe('lib/app-start', function () {
     var windowMock;
     var routerMock;
     var historyMock;
@@ -39,7 +39,10 @@ function (chai, AppStart, Session, WindowMock, RouterMock, HistoryMock) {
       it('start starts the app', function () {
         return appStart.startApp()
                     .then(function () {
-                      assert.equal(Session.language, 'en-US');
+                      // language will be chosen by the backend depending
+                      // on the user's Accept-Language headers and could
+                      // be different for everybody.
+                      assert.ok(Session.language);
                       assert.ok(Session.config);
                       assert.ok(Session.channel);
 

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -36,11 +36,10 @@ function (chai, $, ChannelMock, testHelpers,
     beforeEach(function () {
       channelMock = new ChannelMock();
       Session.set('channel', channelMock);
+      Session.set('language', 'it-CH');
       email = ' testuser' + Math.random() + '@testuser.com ';
 
-      client = new FxaClientWrapper({
-        language: 'it-CH'
-      });
+      client = new FxaClientWrapper();
       return client._getClientAsync()
               .then(function (_realClient) {
                 realClient = _realClient;

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -24,14 +24,11 @@ function isValidRoute(route) {
 
 module.exports = function (config, templates, i18n) {
 
-  var ver = require('./routes/get-ver.json');
-  var termsPrivacy = require('./routes/get-terms-privacy')(i18n);
-  var configRoute = require('./routes/get-config');
-
   var routes = [
-    ver,
-    termsPrivacy,
-    configRoute
+    require('./routes/get-ver.json'),
+    require('./routes/get-terms-privacy')(i18n),
+    require('./routes/get-config')(i18n),
+    require('./routes/get-client.json')(i18n)
   ];
 
   var authServerHost = url.parse(config.get('fxaccount_url')).hostname;

--- a/server/lib/routes/get-client.json.js
+++ b/server/lib/routes/get-client.json.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Fetch a translated strings bundle. The best match will be found
+// by i18n-abide based on the users `accept-language` headers.
+
+'use strict';
+
+module.exports = function(i18n) {
+  var route = {};
+  route.method = 'get';
+  route.path = '/i18n/client.json';
+
+  route.process = function (req, res, next) {
+    // req.locale is set by abide in a previous middleware.
+    req.url = '/i18n/' + req.locale + '/client.json';
+
+    // Let any intermediaries know that client.json can vary based
+    // on the accept-language. This will also be useful if client.json
+    // gains long lived cache-control headers.
+    res.set('Vary', 'accept-language');
+
+    // charset must be set on json responses.
+    res.charset = 'utf8';
+
+    // let the static middleware handle the rest.
+    next();
+  };
+
+  return route;
+};

--- a/server/lib/routes/get-config.js
+++ b/server/lib/routes/get-config.js
@@ -6,18 +6,31 @@
 
 var config = require('../configuration');
 
-exports.method = 'get';
-exports.path = '/config';
+module.exports = function(i18n) {
+  var route = {};
 
-exports.process = function(req, res) {
-  // charset must be set on json responses.
-  res.charset = 'utf8';
-  res.json({
-    // The `__cookies_check` cookie is set in client code
-    // to see if cookies are enabled. If cookies are disabled,
-    // the `__cookie_check` cookie will not arrive.
-    cookiesEnabled: !!req.cookies['__cookie_check'],
-    fxaccountUrl: config.get('fxaccount_url'),
-    i18n: config.get('i18n')
-  });
+  route.method = 'get';
+  route.path = '/config';
+
+  route.process = function(req, res) {
+    // Let any intermediaries know that /config can vary based
+    // on the accept-language. This will also be useful if client.json
+    // gains long lived cache-control headers.
+    res.set('Vary', 'accept-language');
+
+    // charset must be set on json responses.
+    res.charset = 'utf8';
+
+    res.json({
+      // The `__cookies_check` cookie is set in client code
+      // to see if cookies are enabled. If cookies are disabled,
+      // the `__cookie_check` cookie will not arrive.
+      cookiesEnabled: !!req.cookies['__cookie_check'],
+      fxaccountUrl: config.get('fxaccount_url'),
+      // req.locale is set by abide in a previous middleware.
+      language: req.locale
+    });
+  };
+
+  return route;
 };

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -15,7 +15,8 @@ define([
     'tests/server/templates',
     'tests/server/routes',
     'tests/server/ver.json.js',
-    'tests/server/cookies_disabled'
+    'tests/server/cookies_disabled',
+    'tests/server/l10n'
   ];
 
   return intern;

--- a/tests/server/l10n.js
+++ b/tests/server/l10n.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+// Ensure l10n is working as expected based on the
+// user's `Accept-Language` headers
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../server/lib/configuration',
+  'intern/dojo/node!request'
+], function (registerSuite, assert, config, request) {
+  'use strict';
+
+  var serverUrl = config.get('public_url');
+
+  var suite = {
+    name: 'i18n'
+  };
+
+  suite['#get /config'] = function () {
+    var dfd = this.async(1000);
+
+    request(serverUrl + '/config', {
+      headers: {
+        'Accept-Language': 'es,en;q=0.8,de;q=0.6,en-gb;q=0.4,chrome://global/locale/intl.properties;q=0.2'
+      }
+    }, dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+      // Response differs depending on the Accept-Language, let all
+      // intermediaries know this.
+      assert.equal(res.headers.vary, 'accept-language');
+
+      var body = JSON.parse(res.body);
+      assert.equal(body.language, 'es');
+    }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#get /i18n/client.json'] = function () {
+    var dfd = this.async(1000);
+
+    request(serverUrl + '/i18n/client.json', {
+      headers: {
+        'Accept-Language': 'de,en;q=0.8,en;q=0.6,en-gb;q=0.4,chrome://global/locale/intl.properties;q=0.2'
+      }
+    }, dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+      // Response differs depending on the Accept-Language, let all
+      // intermediaries know this.
+      assert.equal(res.headers.vary, 'accept-language');
+
+      var body = JSON.parse(res.body);
+      // yes, body[''] is correct. Language pack meta
+      // info is in the '' field.
+      assert.equal(body[''].language, 'de');
+    }, dfd.reject.bind(dfd)));
+  };
+
+  registerSuite(suite);
+});


### PR DESCRIPTION
- Remove the bulk of the client side code used to determine the user's language.
- Use the `Accept-Language` header to allow the server to determine which language to show to the user.

fixes #823
