### PR TITLE
chore(build): Fixing line breaks from markdown

### DIFF
--- a/grunttasks/marked.js
+++ b/grunttasks/marked.js
@@ -18,8 +18,9 @@ module.exports = function (grunt) {
 
   grunt.config('marked', {
     options: {
-      sanitize: false,
-      gfm: true
+      breaks: true,
+      gfm: true,
+      sanitize: false
     },
     tos_pp: {
       files: [


### PR DESCRIPTION
Added `breaks: true` and alphabetized.

Fixes #937
