### PR TITLE
tests(travis): disable route logging during travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     # please get your own free key if you want to test yourself
     - SAUCE_USERNAME: fxa-content
     - SAUCE_ACCESS_KEY: ee5354a4-3d5e-47a0-84b0-0b7aaa12a720
+    - DISABLE_ROUTE_LOGGING: true
 
 before_install:
   - sudo apt-get install libgmp3-dev

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -73,6 +73,11 @@ var conf = module.exports = convict({
     format: [ 'default_fxa', 'dev_fxa', 'default', 'dev', 'short', 'tiny' ],
     default: 'default_fxa'
   },
+  disable_route_logging: {
+    doc: 'Disable route logging completely. Useful for trimming travis logs.',
+    default: false,
+    env: 'DISABLE_ROUTE_LOGGING'
+  },
   use_https: false,
   var_path: {
     doc: 'The path where deployment specific resources will be sought (keys, etc), and logs will be kept.',

--- a/server/lib/logging/route_logging.js
+++ b/server/lib/logging/route_logging.js
@@ -17,16 +17,22 @@ expressLogger.format('default_fxa',
 
 expressLogger.format('dev_fxa', ':method :url :status :response-time');
 
+// Used when logging is disabled
+var disabled = function (req, res, next) {
+  next();
+};
 
 module.exports = function () {
   'use strict';
 
-  return expressLogger({
-    format: config.get('route_log_format'),
-    stream: {
-      write: function (x) {
-        logger.info(typeof x === 'string' ? x.trim() : x);
-      }
-    }
-  });
+  return config.get('disable_route_logging')
+          ? disabled
+          : expressLogger({
+              format: config.get('route_log_format'),
+              stream: {
+                write: function (x) {
+                  logger.info(typeof x === 'string' ? x.trim() : x);
+                }
+              }
+            });
 };


### PR DESCRIPTION
This should reduce the log lines a bit in travis. I've never found these logs useful in tests but we can do some sort of filtering later if needed.

@nchapman or @pdehaan r?
