### PR TITLE
fix(client): Replaced cookie checks with localStorage checks

### DIFF
--- a/app/scripts/lib/config-loader.js
+++ b/app/scripts/lib/config-loader.js
@@ -65,15 +65,43 @@ function (
     },
 
     areCookiesEnabled: function (force) {
+      var self = this;
       return this.fetch(force)
           .then(function (config) {
             // use the search parameter for selenium testing. There is
             // no way to disable cookies using wd, so the search parameter
             // is used as a dirty hack.
-            var cookiesEnabled = Url.searchParam('disable_cookies') ?
-                                        false : config.cookiesEnabled;
-            return cookiesEnabled;
+            // var cookiesEnabled = Url.searchParam('disable_cookies') ?
+            //                            false : config.cookiesEnabled;
+
+            // HACK: This is a gross work around for 3rd party cookie issues in
+            //       Firefox Nightly (2014-04-18). Ignoring cookiesEnabled
+            //       altogether for now.
+            var localStorageEnabled;
+
+            if (Url.searchParam('disable_local_storage') === '1') {
+              localStorageEnabled = false;
+            } else if (typeof config.localStorageEnabled !== 'undefined') {
+              localStorageEnabled = config.localStorageEnabled;
+            } else {
+              localStorageEnabled = self.isLocalStorageEnabled();
+            }
+
+            return localStorageEnabled;
           });
+    },
+
+    // HACK: Part of a temporary work around for Firefox Nightly (2014-04-18)
+    isLocalStorageEnabled: function() {
+      var testData = 'local-storage-test';
+
+      try {
+        localStorage.setItem(testData, testData);
+        localStorage.removeItem(testData);
+        return true;
+      } catch(e) {
+        return false;
+      }
     }
   };
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -26,6 +26,9 @@ require.config({
         'jquery'
       ],
       exports: 'Backbone'
+    },
+    modernizr: {
+      exports: 'Modernizr'
     }
   },
   stache: {

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -32,6 +32,9 @@ require.config({
     },
     sinon: {
       exports: 'sinon'
+    },
+    modernizr: {
+      exports: 'Modernizr'
     }
   },
   stache: {

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -51,9 +51,9 @@ function (chai, AppStart, Session, WindowMock, RouterMock, HistoryMock) {
                     });
       });
 
-      it('redirects to /cookies_disabled if cookies are disabled', function () {
+      it('redirects to /cookies_disabled if localStorage is disabled', function () {
         appStart.useConfig({
-          cookiesEnabled: false,
+          localStorageEnabled: false,
           i18n: {
             supportedLanguages: ['en'],
             defaultLang: 'en'

--- a/app/tests/spec/views/cookies_disabled.js
+++ b/app/tests/spec/views/cookies_disabled.js
@@ -53,9 +53,9 @@ function ($, chai, p, View, WindowMock) {
     });
 
     describe('backIfCookiesEnabled', function () {
-      it('goes back in history if cookies are enabled', function () {
+      it('goes back in history if localStorage is enabled', function () {
         serverConfig = {
-          cookiesEnabled: true
+          localStorageEnabled: true
         };
 
         return view.backIfCookiesEnabled()
@@ -65,9 +65,9 @@ function ($, chai, p, View, WindowMock) {
           });
       });
 
-      it('shows an error message if cookies are still disabled', function () {
+      it('shows an error message if localStorage is still disabled', function () {
         serverConfig = {
-          cookiesEnabled: false
+          localStorageEnabled: false
         };
 
         return view.backIfCookiesEnabled()

--- a/tests/functional/cookies_disabled.js
+++ b/tests/functional/cookies_disabled.js
@@ -11,14 +11,14 @@ define([
 
   // there is no way to disable cookies using wd. Add `disable_cookies`
   // to the URL to synthesize cookies being disabled.
-  var SIGNUP_COOKIES_DISABLED_URL = 'http://localhost:3030/signup?disable_cookies=1';
+  var SIGNUP_COOKIES_DISABLED_URL = 'http://localhost:3030/signup?disable_local_storage=1';
   var SIGNUP_COOKIES_ENABLED_URL = 'http://localhost:3030/signup';
   var COOKIES_DISABLED_URL = 'http://localhost:3030/cookies_disabled';
 
   registerSuite({
     name: 'cookies_disabled',
 
-    'visit signup page with cookies disabled': function () {
+    'visit signup page with localStorage disabled': function () {
       return this.get('remote')
         .get(require.toUrl(SIGNUP_COOKIES_DISABLED_URL))
 


### PR DESCRIPTION
I tried to change as little as possible to accomplish our goal of relying on `localStorage` checks to determine if we should show the "cookies disabled" page. I consider this a very temporary (and gross) fix. I will happily do something more involved if we'd rather use something like this method going forward.

@ckarlof and @zaach let me know what you guys think. I'm totally open to suggestions here.
