### PR TITLE
feature(style): fix placeholder text legibility for 2x pwd fields

### DIFF
--- a/app/scripts/templates/change_password.mustache
+++ b/app/scripts/templates/change_password.mustache
@@ -8,6 +8,7 @@
 
   <form novalidate>
     <div class="input-row password-row">
+      <label class="label-helper"></label>
       <input type="password" class="password" id="old_password" placeholder="{{#t}}Old password{{/t}}" pattern=".{8,}" autofocus required autocomplete="off" />
 
       <input id="show-old-password" type="checkbox" class="show-password" aria-controls="old_password" data-novalue />
@@ -17,6 +18,7 @@
     </div>
 
     <div class="input-row password-row">
+      <label class="label-helper"></label>
       <input type="password" class="password tooltip-below" id="new_password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" required autocomplete="off" />
 
       <input id="show-new-password" type="checkbox" class="show-password" aria-controls="new_password" data-novalue />

--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -39,6 +39,7 @@
 
   <form novalidate>
     <div class="input-row password-row">
+      <label class="label-helper"></label>
       <input type="password" class="password" id="password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" autofocus required autocomplete="off" />
 
       <input id="show-password" type="checkbox" class="show-password" aria-controls="password" data-novalue />
@@ -48,6 +49,7 @@
     </div>
 
     <div class="input-row password-row">
+      <label class="label-helper"></label>
       <input type="password" class="password tooltip-below" id="vpassword" placeholder="{{#t}}Repeat password{{/t}}" pattern=".{8,}" required autocomplete="off" />
 
       <input id="show-vpassword" type="checkbox" class="show-password" aria-controls="vpassword" data-novalue />

--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -34,6 +34,10 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin) {
       };
     },
 
+    afterRender: function() {
+      this.togglePlaceholderPattern();
+    },
+
     submit: function () {
       var email = Session.email;
       var oldPassword = this.$('#old_password').val();

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -53,6 +53,10 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, Validate, aut
           });
     },
 
+    afterRender: function() {
+      this.togglePlaceholderPattern();
+    },
+
     _doesLinkValidate: function () {
       return Validate.isTokenValid(this.token) &&
              Validate.isCodeValid(this.code) &&

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -84,6 +84,20 @@ function (_, $, p, Validate, BaseView, Tooltip) {
       return values;
     },
 
+    //when a user begins typing in an input, grab the placeholder, 
+    // put it in a label and then unbind the event
+    // this is done to prevent user confustion about multiple password inputs
+    togglePlaceholderPattern: function() {
+      var input = this.$('input');
+      input.one('keypress', function(){
+        var placeholder = $(this).attr('placeholder');
+        if (placeholder !== '') {
+          $(this).attr('placeholder','');
+          $(this).prev('.label-helper').text(placeholder).animate( {'top': '-17px'}, 400);
+        }
+      });
+    },
+
     enableSubmitIfValid: function () {
       // the change event can be called after the form is already
       // submitted if the user presses "enter" in the form. If the

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -274,11 +274,13 @@ strong.email {
   height: 45px;
   outline: none;
   padding: 0 20px;
+  position: relative;
   transition-duration: 150ms;
   transition-property: border-color;
   /*kills inset shadow on ios browsers*/
   -webkit-appearance:none;
   width: 100%;
+  z-index: 2;
 }
 
 .input-row input::-webkit-input-placeholder {
@@ -552,6 +554,7 @@ ul.links li {
   // it is very easy to accidentally select the text when clicking
   -webkit-touch-callout: none;
   user-select: none;
+  z-index: 3;
 }
 
 .password-row > .password:hover {
@@ -622,6 +625,23 @@ input[type="text"] ~ .show-password-label:hover {
 
 .cannot-create-account-content {
   margin-top: 105px;
+}
+
+.change-password .password-row,
+.complete_reset_password .password-row {
+  margin-bottom: 25px;
+}
+
+.label-helper {
+  border-radius: 2px;
+  color: $input-placeholder-color;
+  font-size: 12px;
+  font-weight: normal;
+  height: 16px;
+  margin: 0 10px;
+  position: absolute;
+  top: 0;
+  z-index: 1;
 }
 
 .spinner {


### PR DESCRIPTION
fixes #717
This is a minimal fix...Could be flashier, but this works. I've implemented it on /change_password and /complete_reset_password.

![issue-717](https://cloud.githubusercontent.com/assets/3323249/2745175/2a4f968e-c732-11e3-9992-22d78d54840c.gif)
