### PR TITLE
fix(templates): make firefox logo visible on templates and add mozilla l...

### DIFF
--- a/server/templates/pages/src/404.html
+++ b/server/templates/pages/src/404.html
@@ -17,7 +17,7 @@
         <!-- endbuild -->
     </head>
     <body>
-        <div id="fox-logo"></div>
+        <div id="fox-logo" class="static"></div>
         <div id="stage">
           <header>
             <h1 id="fxa-404-header">{{#t}}Page not found{{/t}}</h1>
@@ -32,5 +32,7 @@
             <a href="/signup" class="button" id="fxa-404-home">{{#t}}Home{{/t}}</a>
           </div>
         </div>
+
+        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
     </body>
 </html>

--- a/server/templates/pages/src/500.html
+++ b/server/templates/pages/src/500.html
@@ -30,5 +30,7 @@
             <a href="/" class="button" id="fxa-500-home">{{#t}}Home{{/t}}</a>
           </div>
         </div>
+
+        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
     </body>
 </html>

--- a/server/templates/pages/src/503.html
+++ b/server/templates/pages/src/503.html
@@ -30,5 +30,7 @@
             <a href="/" class="button" id="fxa-503-home">{{#t}}Home{{/t}}</a>
           </div>
         </div>
+
+        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
     </body>
 </html>

--- a/server/templates/pages/src/privacy.html
+++ b/server/templates/pages/src/privacy.html
@@ -20,7 +20,7 @@
         <!--[if lt IE 8]>
             <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->
-        <div id="fox-logo"></div>
+        <div id="fox-logo" class="static"></div>
         <div id="stage">
           <header id="legal-header">
             <h3>{{#t}}Firefox cloud services{{/t}}</h3>
@@ -34,5 +34,6 @@
           </section>
         </div>
 
+        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
     </body>
 </html>

--- a/server/templates/pages/src/terms.html
+++ b/server/templates/pages/src/terms.html
@@ -20,7 +20,7 @@
         <!--[if lt IE 8]>
             <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->
-        <div id="fox-logo"></div>
+        <div id="fox-logo" class="static"></div>
         <div id="stage">
           <header id="legal-header">
             <h3>{{#t}}Firefox cloud services{{/t}}</h3>
@@ -34,5 +34,6 @@
           </section>
         </div>
 
+        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
     </body>
 </html>


### PR DESCRIPTION
...ogo

fixes #920.

In addition to the legal pages, some other templates were missing the logos. This fixes those, too.

@nchapman r?
