### PR TITLE
fix(l10n): config should return the language not locale

### DIFF
--- a/server/lib/routes/get-config.js
+++ b/server/lib/routes/get-config.js
@@ -30,8 +30,8 @@ module.exports = function(i18n) {
       // the `__cookie_check` cookie will not arrive.
       cookiesEnabled: !!req.cookies['__cookie_check'],
       fxaccountUrl: config.get('fxaccount_url'),
-      // req.locale is set by abide in a previous middleware.
-      language: req.locale
+      // req.lang is set by abide in a previous middleware.
+      language: req.lang
     });
   };
 

--- a/tests/server/l10n.js
+++ b/tests/server/l10n.js
@@ -39,6 +39,21 @@ define([
     }, dfd.reject.bind(dfd)));
   };
 
+  suite['#get /config should return language not locale'] = function () {
+    var dfd = this.async(1000);
+
+    request(serverUrl + '/config', {
+      headers: {
+        'Accept-Language': 'en-us'
+      }
+    }, dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+
+      var body = JSON.parse(res.body);
+      assert.equal(body.language, 'en-us');
+    }, dfd.reject.bind(dfd)));
+  };
+
   suite['#get /i18n/client.json'] = function () {
     var dfd = this.async(1000);
 


### PR DESCRIPTION
@pdehaan r?

`locale` codes should never be exposed outside the server– they're only used (or should be) for file names. This fixes #963.
