### PR TITLE
chore(client): Shorten rate limited error message.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -57,7 +57,7 @@ function () {
     109: t('Invalid request signature'),
     112: t('Missing content-length header'),
     113: t('Request body too large'),
-    114: t('Attempt limit exceeded. Try again later.'),
+    114: t('Attempt limit exceeded.'),
     998: t('System unavailable, try again soon'),
     201: t('Server busy, try again soon'),
     116: t('This endpoint is no longer supported')


### PR DESCRIPTION
- Change to `Attempt limit exceeded.`

fixes #892
