### PR TITLE
WIP: refactor(client): Add FormView.submitter to handle generic submit-like functionality.

### DIFF
--- a/app/scripts/lib/silent-error.js
+++ b/app/scripts/lib/silent-error.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// An error that is not displayed to the user.
+
+'use strict';
+
+define([
+], function () {
+  function SilentError(msg) {
+    this.message = msg;
+    Error.apply(this, arguments);
+  }
+
+  SilentError.prototype = new Error();
+
+  return SilentError;
+});
+

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -13,9 +13,10 @@ define([
   'lib/auth-errors',
   'lib/fxa-client',
   'lib/url',
-  'lib/strings'
+  'lib/strings',
+  'lib/silent-error'
 ],
-function (_, Backbone, jQuery, p, Session, authErrors, FxaClient, Url, Strings) {
+function (_, Backbone, jQuery, p, Session, authErrors, FxaClient, Url, Strings, SilentError) {
   var ENTER_BUTTON_CODE = 13;
   var DEFAULT_TITLE = window.document.title;
 
@@ -245,6 +246,9 @@ function (_, Backbone, jQuery, p, Session, authErrors, FxaClient, Url, Strings) 
 
     /**
      * Display an error message.
+     *
+     * Note: SilentError instances are neither displayed nor translated.
+     *
      * @method displayError
      * @param {string} err - If err is not given, the contents of the
      *   `.error` element's text will not be updated.
@@ -255,6 +259,11 @@ function (_, Backbone, jQuery, p, Session, authErrors, FxaClient, Url, Strings) 
     displayError: function (err) {
       this.hideSuccess();
       this.$('.spinner').hide();
+
+      // This is an error that should not be displayed.
+      if (err instanceof SilentError) {
+        return err;
+      }
 
       var translated = this.translateError(err);
 
@@ -275,6 +284,8 @@ function (_, Backbone, jQuery, p, Session, authErrors, FxaClient, Url, Strings) 
      * because msg could contain XSS. Use with caution and never
      * with unsanitized user generated content.
      *
+     * Note: SilentError instances are neither displayed nor translated.
+     *
      * @method displayErrorUnsafe
      * @param {string} err - If err is not given, the contents of the
      *   `.error` element's text will not be updated.
@@ -285,6 +296,10 @@ function (_, Backbone, jQuery, p, Session, authErrors, FxaClient, Url, Strings) 
     displayErrorUnsafe: function (err) {
       this.hideSuccess();
       this.$('.spinner').hide();
+
+      if (err instanceof SilentError) {
+        return err;
+      }
 
       var translated = this.translateError(err);
 

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -23,7 +23,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, Validate, aut
 
     events: {
       'change .show-password': 'onPasswordVisibilityChange',
-      'click #resend': BaseView.preventDefaultThen('resendResetEmail')
+      'click #resend': 'resendResetEmail'
     },
 
     // beforeRender is asynchronous and returns a promise. Only render
@@ -113,15 +113,13 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, Validate, aut
       return this.$('#vpassword').val();
     },
 
-    resendResetEmail: function () {
+    resendResetEmail: BaseView.cancelEventThen(FormView.submitter(function () {
       var self = this;
       return this.fxaClient.passwordReset(this.email)
-              .then(function () {
-                self.navigate('confirm_reset_password');
-              }, function (err) {
-                self.displayError(err);
-              });
-    }
+          .then(function () {
+            self.navigate('confirm_reset_password');
+          });
+    }))
   });
 
   _.extend(View.prototype, PasswordMixin);

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -7,12 +7,13 @@
 define([
   'p-promise',
   'views/base',
+  'views/form',
   'views/sign_in',
   'stache!templates/force_auth',
   'lib/session',
   'lib/url'
 ],
-function (p, BaseView, SignInView, Template, Session, Url) {
+function (p, BaseView, FormView, SignInView, Template, Session, Url) {
   var t = BaseView.t;
 
   var View = SignInView.extend({
@@ -62,26 +63,13 @@ function (p, BaseView, SignInView, Template, Session, Url) {
       return this.signIn(email, password);
     },
 
-    resetPasswordNow: BaseView.cancelEventThen(function () {
+    resetPasswordNow: BaseView.cancelEventThen(FormView.submitter(function () {
       var self = this;
-      return p().then(function () {
-        // If the user is already making a request, ban submission.
-        if (self.isSubmitting()) {
-          throw new Error('submit already in progress');
-        }
-
-        var email = Session.forceEmail;
-        self._isSubmitting = true;
-        return self.fxaClient.passwordReset(email)
-                .then(function () {
-                  self._isSubmitting = false;
-                  self.navigate('confirm_reset_password');
-                }, function (err) {
-                  self._isSubmitting = false;
-                  self.displayError(err);
-                });
-      });
-    })
+      return self.fxaClient.passwordReset(Session.forceEmail)
+              .then(function () {
+                self.navigate('confirm_reset_password');
+              });
+    }))
   });
 
   return View;

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -29,7 +29,7 @@ function (_, FormView, BaseView, Template, Session, Constants) {
 
     events: {
       // validateAndSubmit is used to prevent multiple concurrent submissions.
-      'click #signout': BaseView.preventDefaultThen('validateAndSubmit')
+      'click #signout': 'validateAndSubmit'
     },
 
     submit: function () {

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -10,14 +10,15 @@ define([
   'jquery',
   'views/base',
   'lib/translator',
+  'lib/silent-error',
   'stache!templates/test_template',
   '../../mocks/dom-event',
   '../../mocks/router',
   '../../mocks/window',
   '../../lib/helpers'
 ],
-function (chai, jQuery, BaseView, Translator, Template, DOMEventMock,
-          RouterMock, WindowMock, TestHelpers) {
+function (chai, jQuery, BaseView, Translator, SilentError, Template,
+          DOMEventMock, RouterMock, WindowMock, TestHelpers) {
   var requiresFocus = TestHelpers.requiresFocus;
   var wrapAssertion = TestHelpers.wrapAssertion;
 
@@ -152,6 +153,11 @@ function (chai, jQuery, BaseView, Translator, Template, DOMEventMock,
         view.displayError('an error message<div>with html</div>');
         assert.equal(view.$('.error').html(), 'an error message&lt;div&gt;with html&lt;/div&gt;');
       });
+
+      it('does not display silent error messages', function () {
+        view.displayError(new SilentError('silent error'));
+        assert.isFalse(view.isErrorVisible());
+      });
     });
 
     describe('displayErrorUnsafe', function () {
@@ -163,6 +169,11 @@ function (chai, jQuery, BaseView, Translator, Template, DOMEventMock,
 
         assert.isTrue(view.isErrorVisible());
         view.hideError();
+        assert.isFalse(view.isErrorVisible());
+      });
+
+      it('does not display silent error messages', function () {
+        view.displayErrorUnsafe(new SilentError('silent error'));
         assert.isFalse(view.isErrorVisible());
       });
     });

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -245,7 +245,7 @@ function (chai, p, authErrors, View, RouterMock, WindowMock, TestHelpers) {
         };
 
         return view.resendResetEmail()
-            .then(function () {
+            .then(null, function () {
               assert.equal(view.$('.error').text(), 'server error');
             });
       });

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -95,7 +95,7 @@ function (chai, $, View, Session, WindowMock, RouterMock, TestHelpers) {
       it('forgot password request redirects directly to confirm_reset_password', function () {
         var password = 'password';
         var event = $.Event('click');
-        return view.fxaClient.signUp(email, password)
+        return view.fxaClient.signUp(email, password, { preVerified: true })
               .then(function () {
                 // the call to client.signUp clears Session.
                 // These fields are reset to complete the test.

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -57,7 +57,7 @@ function (chai, $, p, FormView, Template, TestHelpers) {
             // success callback should not be called on failure.
             assert(false, 'unexpected success');
           }, function (err) {
-            assert.equal(err, expectedMessage);
+            assert.equal(err.message, expectedMessage);
           });
     }
 
@@ -196,16 +196,17 @@ function (chai, $, p, FormView, Template, TestHelpers) {
         return testFormSubmitted();
       });
 
-      it('override afterSubmit to prevent form from being re-enabled - afterSubmit errors are not displayed', function () {
+      it('override afterSubmit to prevent form from being re-enabled', function () {
         view.formIsValid = true;
         view.afterSubmit = function () {
           // do not re-enable form.
-          throw new Error('error that is not displayed');
+          throw new Error('error from afterSubmit');
         };
 
         return view.validateAndSubmit()
                   .then(null, function(err) {
-                    assert.equal(err.message, 'error that is not displayed');
+                    assert.equal(err, 'error from afterSubmit');
+                    assert.isTrue(view.isErrorVisible());
                     assert.isFalse(view.isFormEnabled());
                   });
       });


### PR DESCRIPTION
We have to handle submit-like functionality in things other than forms. We only want one "submission" to occur at a time, and we want to properly handle and display any error messages.
- Prevents multiple concurrent submissions.
- A new type of error is added, SilentError - an error that is not meant to be displayed to the user.
- Display error messages that are not of type SilentError.

@zaach and @nchapman - this is an idea that I have been tossing around and would like to get feedback. Does it make sense? Should submitter be in BaseView instead of FormView? Is it too complex?

Follow on from issue #887
