### PR TITLE
fix(client): No longer automatically sign in existing users on signup.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -180,15 +180,6 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
 
                 return client.signUp(email, password, signUpOptions);
               })
-              .then(null, function (err) {
-                // if the account already exists, swallow the error and
-                // attempt to sign the user in instead.
-                if (AuthErrors.is(err, 'ACCOUNT_ALREADY_EXISTS')) {
-                  return;
-                }
-
-                throw err;
-              })
               .then(function () {
                 var signInOptions = {
                   customizeSync: options.customizeSync,

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -129,7 +129,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, AuthErrors) {
         .then(null, function (err) {
           // account already exists, and the user
           // entered a bad password they should sign in insted.
-          if (AuthErrors.is(err, 'INCORRECT_PASSWORD')) {
+          if (AuthErrors.is(err, 'ACCOUNT_ALREADY_EXISTS')) {
             Session.set('prefillEmail', email);
             var msg = t('Account already exists. <a href="/signin">Sign in</a>');
             return self.displayErrorUnsafe(msg);

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -135,26 +135,15 @@ function (chai, $, ChannelMock, testHelpers,
           });
       });
 
-      it('signUp existing user attempts to sign the user in', function () {
-        return client.signUp(email, password)
+      it('signUp existing verified user returns ACCOUNT_ALREADY_EXISTS error', function () {
+        return client.signUp(email, password, { preVerified: true })
           .then(function () {
             return client.signUp(email, password);
           })
           .then(function () {
-            assert.isTrue(realClient.signIn.called);
-          });
-      });
-
-      it('signUp existing verified user with incorrect password returns ' +
-              'incorrect password error', function () {
-        return client.signUp(email, password, { preVerified: true })
-          .then(function () {
-            return client.signUp(email, 'incorrect');
-          })
-          .then(function () {
-            throw new Error('incorrect password should not lead to success');
+            assert(false, 'unexpected success');
           }, function (err) {
-            assert.isTrue(AuthErrors.is(err, 'INCORRECT_PASSWORD'));
+            assert.isTrue(AuthErrors.is(err, 'ACCOUNT_ALREADY_EXISTS'));
           });
       });
 


### PR DESCRIPTION
- Show them the "Account already exists. Sign in" error message instead.

fixes #877
