### PR TITLE
feature(client): debounce resend button clicks.

### DIFF
--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -13,10 +13,17 @@ define([
 ],
 function (FormView, BaseView, Template, Session, authErrors) {
   var t = BaseView.t;
+  var SHOW_RESEND_IN_MS = 5 * 60 * 1000; // 5 minutes.
 
   var View = FormView.extend({
     template: Template,
     className: 'confirm',
+
+    beforeDestroy: function () {
+      if (this._displayResendTimeout) {
+        this.window.clearTimeout(this._displayResendTimeout);
+      }
+    },
 
     context: function () {
       return {
@@ -32,6 +39,46 @@ function (FormView, BaseView, Template, Session, authErrors) {
     afterRender: function() {
       var graphic = this.$el.find('.graphic');
       graphic.addClass('pulse');
+    },
+
+    _attemptedSubmits: 0,
+    beforeSubmit: function () {
+      // See https://github.com/mozilla/fxa-content-server/issues/885.
+      // The first click of the resend button sends an email.
+      // The forth click of the resend button sends an email.
+      // All other clicks are ignored.
+      // The button is hidden after the forth click for 5 minutes, then
+      // start the process again.
+
+      this._attemptedSubmits++;
+
+      this._updateSuccessMessage();
+      this._updateResendButton();
+
+      return this._attemptedSubmits === 1 || this._attemptedSubmits === 4;
+    },
+
+    _updateSuccessMessage: function () {
+      // if a success message is already being displayed, shake it.
+      var successEl = this.$('.success:visible');
+      if (successEl) {
+        successEl.one('animationend', function () {
+          successEl.removeClass('shake');
+        }).addClass('shake');
+      }
+    },
+
+    _updateResendButton: function () {
+      var self = this;
+      // Hide the button after 4 attempts. Redisplay button after a delay.
+      if (self._attemptedSubmits === 4) {
+        self.$('#resend').hide();
+        self._displayResendTimeout = setTimeout(function () {
+          self._displayResendTimeout = null;
+          self._attemptedSubmits = 0;
+          self.$('#resend').show();
+        }, SHOW_RESEND_IN_MS);
+      }
     },
 
     submit: function () {
@@ -51,7 +98,6 @@ function (FormView, BaseView, Template, Session, authErrors) {
                 throw err;
               });
     }
-
   });
 
   return View;

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -6,35 +6,25 @@
 
 define([
   'underscore',
-  'views/form',
+  'views/confirm',
   'views/base',
   'stache!templates/confirm_reset_password',
   'lib/session',
   'lib/constants',
   'lib/auth-errors'
 ],
-function (_, FormView, BaseView, Template, Session, Constants, authErrors) {
+function (_, ConfirmView, BaseView, Template, Session, Constants, authErrors) {
   var t = BaseView.t;
 
-  var View = FormView.extend({
+  var View = ConfirmView.extend({
     template: Template,
     className: 'confirm-reset-password',
-
-    context: function () {
-      return {
-        email: Session.email
-      };
-    },
-
-    events: {
-      // validateAndSubmit is used to prevent multiple concurrent submissions.
-      'click #resend': BaseView.preventDefaultThen('validateAndSubmit')
-    },
 
     beforeDestroy: function () {
       if (this._timeout) {
         this.window.clearTimeout(this._timeout);
       }
+      ConfirmView.prototype.beforeDestroy.call(this);
     },
 
     afterRender: function () {

--- a/app/styles/_keyframes.scss
+++ b/app/styles/_keyframes.scss
@@ -75,24 +75,24 @@
   }
 }
 
-//used to add shake to error message
-@keyframes error-shake {
+//used to add shake to error/success message
+@keyframes shake {
   0%, 100% {
     transform: translateX(0);
   }
 
   10%, 30%, 50%, 70%, 90% {
-    transform: translateX(-50px);
+    transform: translateX(-4px);
   }
 
   20%, 40%, 60%, 80% {
-    transform: translateX(50px);
+    transform: translateX(4px);
   }
 
 }
 
-.error-shake {
-  animation: error-shake 1s;
+.shake {
+  animation: shake 1s;
 }
 
 .fade-down-logo {

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -103,6 +103,33 @@ function (chai, p, authErrors, View, RouterMock) {
                });
 
       });
+
+      it('debounces resend calls - submit on first and forth attempt', function () {
+        var email = 'user' + Math.random() + '@testuser.com';
+        var count = 0;
+
+        return view.fxaClient.signUp(email, 'password')
+               .then(function () {
+                 view.fxaClient.signUpResend = function() {
+                   count++;
+                   return p(true);
+                 };
+
+                 return view.validateAndSubmit();
+               }).then(function () {
+                 assert.equal(count, 1);
+                 return view.validateAndSubmit();
+               }).then(function () {
+                 assert.equal(count, 1);
+                 return view.validateAndSubmit();
+               }).then(function () {
+                 assert.equal(count, 1);
+                 return view.validateAndSubmit();
+               }).then(function () {
+                 assert.equal(count, 2);
+                 assert.equal(view.$('#resend:visible').length, 0);
+               });
+      });
     });
 
   });


### PR DESCRIPTION
- Send emails on the first and forth attempt. Shake the success message otherwise.
- After the forth attempt, hide the resend button for 5 minutes.

issue #885 

@johngruen and @ryanfeeley - would you guys have a look at this to see what you think?
