### PR TITLE
feature(client): Prevent users from seeing confirmation pages if they have not initiated the process.

### DIFF
--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -29,6 +29,14 @@ function (FormView, BaseView, Template, Session, authErrors) {
       'click #resend': BaseView.preventDefaultThen('validateAndSubmit')
     },
 
+    beforeRender: function () {
+      // user cannot confirm if they have not initiated a sign up.
+      if (! Session.sessionToken) {
+        this.navigate('signup');
+        return false;
+      }
+    },
+
     afterRender: function() {
       var graphic = this.$el.find('.graphic');
       graphic.addClass('pulse');

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -37,6 +37,14 @@ function (_, FormView, BaseView, Template, Session, Constants, authErrors) {
       }
     },
 
+    beforeRender: function () {
+      // user cannot confirm if they have not initiated a reset password
+      if (! Session.passwordForgotToken) {
+        this.navigate('reset_password');
+        return false;
+      }
+    },
+
     afterRender: function () {
       var bounceGraphic = this.$el.find('.graphic');
       bounceGraphic.addClass('pulse');

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -8,11 +8,12 @@
 define([
   'chai',
   'p-promise',
+  'lib/session',
   'lib/auth-errors',
   'views/confirm',
   '../../mocks/router'
 ],
-function (chai, p, authErrors, View, RouterMock) {
+function (chai, p, Session, authErrors, View, RouterMock) {
   /*global describe, beforeEach, afterEach, it*/
   var assert = chai.assert;
 
@@ -20,6 +21,8 @@ function (chai, p, authErrors, View, RouterMock) {
     var view, router;
 
     beforeEach(function () {
+      Session.set('sessionToken', 'fake session token');
+
       router = new RouterMock();
       view = new View({
         router: router
@@ -38,6 +41,14 @@ function (chai, p, authErrors, View, RouterMock) {
     describe('constructor creates it', function () {
       it('is drawn', function () {
         assert.ok($('#fxa-confirm-header').length);
+      });
+
+      it('redirects to /signup if no sessionToken', function () {
+        Session.clear('sessionToken');
+        view.render()
+          .then(function () {
+            assert.equal(routerMock.page, 'signup');
+          });
       });
     });
 

--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -9,18 +9,38 @@ define([
 ], function (registerSuite, assert, require) {
   'use strict';
 
-  var url = 'http://localhost:3030/signup';
+  var CONFIRM_URL = 'http://localhost:3030/confirm';
+  var SIGNUP_URL = 'http://localhost:3030/signup';
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
 
   registerSuite({
     name: 'confirm',
+
+    beforeEach: function () {
+      // clear localStorage to avoid pollution from other tests.
+      return this.get('remote')
+        .get(require.toUrl(SIGNUP_URL))
+        /*jshint evil:true*/
+        .waitForElementById('fxa-signup-header')
+        .safeEval('sessionStorage.clear(); localStorage.clear();');
+    },
+
+    'visit confirmation screen without initiating sign up, user is redirected to /signup': function () {
+      return this.get('remote')
+        .get(require.toUrl(CONFIRM_URL))
+
+        // user is immediately redirected to /signup if they have no
+        // sessionToken.
+        // Success is showing the screen
+        .waitForElementById('fxa-signup-header');
+    },
 
     'sign up, wait for confirmation screen, click resend': function () {
       var email = 'signup' + Math.random() + '@example.com';
       var password = '12345678';
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(require.toUrl(SIGNUP_URL))
         .waitForElementById('fxa-signup-header')
 
         .elementByCssSelector('form input.email')

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -46,12 +46,31 @@ define([
       // timeout after 90 seconds
       this.timeout = 90000;
 
+      var self = this;
       user = 'signin' + Math.random();
       email = user + '@restmail.net';
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });
-      return client.signUp(email, PASSWORD, { preVerified: true });
+      return client.signUp(email, PASSWORD, { preVerified: true })
+          .then(function () {
+            // clear localStorage to avoid pollution from other tests.
+            return self.get('remote')
+              .get(require.toUrl(RESET_PAGE_URL))
+              /*jshint evil:true*/
+              .waitForElementById('fxa-reset-password-header')
+              .safeEval('sessionStorage.clear(); localStorage.clear();');
+          });
+    },
+
+    'visit confirmation screen without initiating reset_password, user is redirected to /reset_password': function () {
+      return this.get('remote')
+        .get(require.toUrl(CONFIRM_PAGE_URL))
+
+        // user is immediately redirected to /reset_password if they have no
+        // sessionToken.
+        // Success is showing the screen
+        .waitForElementById('fxa-reset-password-header');
     },
 
     'open reset_password page': function () {


### PR DESCRIPTION
- For /confirm, redirect to /signup
- For /confirm_reset_password, redirect to /reset_password

fixes #847 

@ryanfeeley and @johngruen - I need help from the master wordsmiths! "Invalid token" isn't really a helpful message, and we use it in a couple of places.

If a user visits one of the confirmation screens without initiating /signup or /reset_password, I send them back to the /signup or /reset_password. I'd like to print a helpful message, right now it just says "invalid token" to be consistent with an already existing error message. HALP!

Something like `You must sign up first` or `You must start a password reset first`?
