### PR TITLE
fix(client): Gracefully handle server errors when fetching translations.

### DIFF
--- a/app/scripts/lib/translator.js
+++ b/app/scripts/lib/translator.js
@@ -31,7 +31,19 @@ function (_, $, Strings) {
         .done(function (data) {
           self.translations = data;
         })
-        .always(done);
+        .fail(function () {
+          // allow for 404's. `.get` will use the key for the translation
+          // if a value is not found in the translations table. This means
+          // English will be the fallback.
+          self.translations = {};
+        })
+        .always(function () {
+          // do not surface any errors, allow the app to load even
+          // if there are no translations for this locale.
+          if (done) {
+            done();
+          }
+        });
     },
 
     /**

--- a/app/tests/spec/lib/translator.js
+++ b/app/tests/spec/lib/translator.js
@@ -9,11 +9,13 @@
 
 define([
   'chai',
-  'lib/translator'
+  'lib/translator',
+  '/tests/lib/helpers.js'
 ],
-function (chai, Translator) {
+function (chai, Translator, TestHelpers) {
   /*global beforeEach, afterEach, describe, it*/
   var assert = chai.assert;
+  var wrapAssertion = TestHelpers.wrapAssertion;
 
   // translations taken from Persona's db_LB translations.
   var TRANSLATIONS = {
@@ -39,6 +41,31 @@ function (chai, Translator) {
 
     afterEach(function () {
       translator = null;
+    });
+
+    describe('fetch', function () {
+      it('fetches translations from the server', function (done) {
+        translator.fetch(function() {
+          wrapAssertion(function () {
+            // Check that an expected key is empty
+            assert.isDefined(translator.translations['Show']);
+          }, done);
+        });
+      });
+
+      it('fails gracefully when receiving a 404', function (done) {
+        // Monkey patch jQuery ajax to to request an invalid URL
+        $(document).one('ajaxSend', function(event, jqXHR, ajaxOptions) {
+          ajaxOptions.url = '/i18n/client-not-here.json';
+        });
+
+        translator.fetch(function() {
+          wrapAssertion(function () {
+            // Check that an expected key is undefined
+            assert.isUndefined(translator.translations['Show']);
+          }, done);
+        });
+      });
     });
 
     describe('get', function () {


### PR DESCRIPTION
This is a [lovely little fix](https://github.com/mozilla/fxa-content-server/issues/1017#issuecomment-41599566) proposed by @shane-tomlinson to gracefully handle errors received from the server when fetching translations. When an error occurs while fetching the translations, English strings will be used instead of the requested language.
