### PR TITLE
Pass {{link}} url into outlook-specific markup in email templates.

### DIFF
--- a/server/templates/email/reset.html
+++ b/server/templates/email/reset.html
@@ -62,7 +62,7 @@
                                       <tr>
                                         <td align="center" valign="middle" class="buttonContent" style="text-align:center;line-height:100%;font-weight:normal;font-size:20px;font-family:Helvetica;color:#FFFFFF;mso-table-rspace:0pt;mso-table-lspace:0pt;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;">
                                           <!--[if mso]>
-                                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="http://" style="height:40px;v-text-anchor:middle;width:300px;" arcsize="10%" stroke="f" fillcolor="#0095DD">
+                                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{{link}}}" style="height:40px;v-text-anchor:middle;width:300px;" arcsize="10%" stroke="f" fillcolor="#0095DD">
                                           <w:anchorlock/>
                                           <center>
                                             <![endif]-->

--- a/server/templates/email/verify.html
+++ b/server/templates/email/verify.html
@@ -62,7 +62,7 @@
                                       <tr>
                                         <td align="center" valign="middle" class="buttonContent" style="text-align:center;line-height:100%;font-weight:normal;font-size:20px;font-family:Helvetica;color:#FFFFFF;mso-table-rspace:0pt;mso-table-lspace:0pt;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;">
                                           <!--[if mso]>
-                                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="http://" style="height:40px;v-text-anchor:middle;width:300px;" arcsize="10%" stroke="f" fillcolor="#0095DD">
+                                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{{link}}}" style="height:40px;v-text-anchor:middle;width:300px;" arcsize="10%" stroke="f" fillcolor="#0095DD">
                                           <w:anchorlock/>
                                           <center>
                                             <![endif]-->


### PR DESCRIPTION
Fixes #1027 in my testing with Outlook2013
