### PR TITLE
fix(client): Prefill the user's email on /signin if the user clicks the "sign in" link from "/confirm_reset_password"

### DIFF
--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -20,6 +20,11 @@ function (_, ConfirmView, BaseView, Template, Session, Constants, authErrors) {
     template: Template,
     className: 'confirm-reset-password',
 
+    events: {
+      'click #resend': BaseView.preventDefaultThen('validateAndSubmit'),
+      'click a[href="/signin"]': 'savePrefillEmailForSignin'
+    },
+
     beforeDestroy: function () {
       if (this._timeout) {
         this.window.clearTimeout(this._timeout);
@@ -78,8 +83,11 @@ function (_, ConfirmView, BaseView, Template, Session, Constants, authErrors) {
                 // unexpected error, rethrow for display.
                 throw err;
               });
-    }
+    },
 
+    savePrefillEmailForSignin: function () {
+      Session.set('prefillEmail', Session.email);
+    }
   });
 
   return View;

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -159,6 +159,15 @@ function (chai, p, authErrors, View, Session, RouterMock, WindowMock) {
       });
     });
 
+    describe('a click on the signin link', function () {
+      it('saves Session.email to Session.prefillEmail so user\'s email address is prefilled when browsing to /signIn', function () {
+        Session.set('email', 'testuser@testuser.com');
+
+        view.$('a[href="/signin"]').click();
+        assert.equal(Session.prefillEmail, 'testuser@testuser.com');
+      });
+    });
+
   });
 });
 


### PR DESCRIPTION
fixes #1038
