### PR TITLE
refactor(test): Use a single function to create email addresses.

### DIFF
--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -7,8 +7,9 @@ define([
   'intern/chai!assert',
   'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client'
-], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient) {
+  'app/bower_components/fxa-js-client/fxa-client',
+  'tests/lib/helpers'
+], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers) {
   'use strict';
 
   var AUTH_SERVER_ROOT = 'http://127.0.0.1:9000/v1';
@@ -40,7 +41,7 @@ define([
     name: 'settings->change password with verified email',
 
     beforeEach: function () {
-      email = 'signin' + Math.random() + '@example.com';
+      email = TestHelpers.createEmail();
 
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
@@ -216,7 +217,7 @@ define([
     name: 'settings->change password with unverified email',
 
     beforeEach: function () {
-      email = 'signin' + Math.random() + '@example.com';
+      email = TestHelpers.createEmail();
 
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest

--- a/tests/functional/complete_sign_up.js
+++ b/tests/functional/complete_sign_up.js
@@ -31,8 +31,8 @@ define([
     name: 'complete_sign_up',
 
     setup: function () {
-      user = 'signin' + Math.random();
-      email = user + '@restmail.net';
+      email = TestHelpers.createEmail();
+      user = TestHelpers.emailToUser(email);
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });

--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -5,8 +5,9 @@
 define([
   'intern!object',
   'intern/chai!assert',
-  'require'
-], function (registerSuite, assert, require) {
+  'require',
+  'tests/lib/helpers'
+], function (registerSuite, assert, require, TestHelpers) {
   'use strict';
 
   var CONFIRM_URL = 'http://localhost:3030/confirm';
@@ -36,7 +37,7 @@ define([
     },
 
     'sign up, wait for confirmation screen, click resend': function () {
-      var email = 'signup' + Math.random() + '@example.com';
+      var email = TestHelpers.createEmail();
       var password = '12345678';
 
       return this.get('remote')

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -9,8 +9,9 @@ define([
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'intern/node_modules/dojo/Deferred',
-  'tests/lib/restmail'
-], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Deferred, restmail) {
+  'tests/lib/restmail',
+  'tests/lib/helpers'
+], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Deferred, restmail, TestHelpers) {
   'use strict';
 
   var AUTH_SERVER_ROOT = 'http://127.0.0.1:9000/v1';
@@ -26,8 +27,8 @@ define([
     name: 'force_auth',
 
     setup: function () {
-      user = 'signin' + Math.random();
-      email = user + '@restmail.net';
+      email = TestHelpers.createEmail();
+      user = TestHelpers.emailToUser(email);
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -47,8 +47,8 @@ define([
       this.timeout = 90000;
 
       var self = this;
-      user = 'signin' + Math.random();
-      email = user + '@restmail.net';
+      email = TestHelpers.createEmail();
+      user = TestHelpers.emailToUser(email);
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });
@@ -238,8 +238,8 @@ define([
       // timeout after 90 seconds
       this.timeout = 90000;
 
-      user = 'signin' + Math.random();
-      email = user + '@restmail.net';
+      email = TestHelpers.createEmail();
+      user = TestHelpers.emailToUser(email);
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });
@@ -300,7 +300,7 @@ define([
     name: 'reset_password with email specified on URL',
 
     setup: function () {
-      email = 'signin' + Math.random() + '@restmail.net';
+      email = TestHelpers.createEmail();
       var client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });
@@ -335,8 +335,8 @@ define([
     name: 'confirm_password page transition',
 
     setup: function () {
-      var user = 'signin' + Math.random();
-      email = user + '@restmail.net';
+      email = TestHelpers.createEmail();
+      user = TestHelpers.emailToUser(email);
 
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -8,8 +8,9 @@ define([
   'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
-  'app/scripts/lib/constants'
-], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Constants) {
+  'app/scripts/lib/constants',
+  'tests/lib/helpers'
+], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Constants, TestHelpers) {
   'use strict';
 
   var AUTH_SERVER_ROOT = 'http://127.0.0.1:9000/v1';
@@ -26,7 +27,7 @@ define([
     name: 'settings',
 
     beforeEach: function () {
-      email = 'signin' + Math.random() + '@example.com';
+      email = TestHelpers.createEmail();
 
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -8,8 +8,9 @@ define([
   'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
-  'tests/lib/restmail'
-], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail) {
+  'tests/lib/restmail',
+  'tests/lib/helpers'
+], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers) {
   'use strict';
 
   var AUTH_SERVER_ROOT = 'http://127.0.0.1:9000/v1';
@@ -25,8 +26,8 @@ define([
     name: 'sign_in',
 
     setup: function () {
-      user = 'signin' + Math.random();
-      email = user + '@restmail.net';
+      email = TestHelpers.createEmail();
+      user = TestHelpers.emailToUser(email);
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -7,8 +7,9 @@ define([
   'intern/chai!assert',
   'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client'
-], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient) {
+  'app/bower_components/fxa-js-client/fxa-client',
+  'tests/lib/helpers'
+], function (registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers) {
   'use strict';
 
   var url = 'http://localhost:3030/signup';
@@ -38,7 +39,7 @@ define([
     },
 
     'sign up': function () {
-      var email = 'signup' + Math.random() + '@example.com';
+      var email = TestHelpers.createEmail();
       var password = '12345678';
 
       return this.get('remote')
@@ -81,7 +82,7 @@ define([
     },
 
     'select an age that is too young': function () {
-      var email = 'signup' + Math.random() + '@example.com';
+      var email = TestHelpers.createEmail();
       var password = '12345678';
 
       return this.get('remote')
@@ -125,7 +126,7 @@ define([
     'choose option to customize sync': function () {
       var urlForSync = url + '?service=sync';
 
-      var email = 'signup' + Math.random() + '@example.com';
+      var email = TestHelpers.createEmail();
       var password = '12345678';
 
       return this.get('remote')
@@ -168,7 +169,7 @@ define([
     'sign up with a verified account and wrong password allows the user to sign in': function () {
 
       var self = this;
-      var email = 'signup' + Math.random() + '@example.com';
+      var email = TestHelpers.createEmail();
       var password = '12345678';
 
       var client = new FxaClient(AUTH_SERVER_ROOT, {
@@ -225,7 +226,7 @@ define([
     'sign up with an unverified account and different password re-signs up user': function () {
 
       var self = this;
-      var email = 'signup' + Math.random() + '@example.com';
+      var email = TestHelpers.createEmail();
       var password = '12345678';
 
       var client = new FxaClient(AUTH_SERVER_ROOT, {

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -18,8 +18,18 @@ define([], function () {
     return str;
   }
 
+  function createEmail() {
+    return 'signin' + Math.random() + '@restmail.net';
+  }
+
+  function emailToUser(email) {
+    return email.split('@')[0];
+  }
+
   return {
-    createRandomHexString: createRandomHexString
+    createRandomHexString: createRandomHexString,
+    createEmail: createEmail,
+    emailToUser: emailToUser
   };
 });
 


### PR DESCRIPTION
- TestHelpers->createEmail will create a restmail address
- Update ad-hoc email address creations to use this
- Add TestHelpers->emailToUser to get the user from the email address.

fixes #1050 

This is for you, @pdehaan!
