### PR TITLE
fix(client): Do not show Fx for Android marketing material if completing sign up on B2G or Fennec.

### DIFF
--- a/app/scripts/templates/ready.mustache
+++ b/app/scripts/templates/ready.mustache
@@ -22,12 +22,12 @@
     <p>{{#t}}Your account is ready!{{/t}}</p>
   {{/service}}
 
-  {{#signUp}}
+  {{#showSignUpMarketing}}
     <aside class="marketing desktop">
       <span class="android-logo" />
       {{#t}}Stay in sync on the go:{{/t}}
       <br />
       <a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">{{#t}}Get Firefox for Android{{/t}}</a>
     </aside>
-  {{/signUp}}
+  {{/showSignUpMarketing}}
 </section>

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -45,9 +45,29 @@ function (_, BaseView, Template, Session, Xss, Strings, ServiceName) {
         service: service,
         serviceName: serviceName,
         signIn: this.is('sign_in'),
+
         signUp: this.is('sign_up'),
+        showSignUpMarketing: this._showSignUpMarketing(),
+
         resetPassword: this.is('reset_password')
       };
+    },
+
+    _showSignUpMarketing: function () {
+      if (! this.is('sign_up')) {
+        return false;
+      }
+
+      // For UA information, see
+      // https://developer.mozilla.org/docs/Gecko_user_agent_string_reference
+
+      var ua = this.window.navigator.userAgent;
+
+      // covers both B2G and Firefox for Android
+      var isMobileFirefox = ua.indexOf('Mobile') > -1 && ua.indexOf('Firefox') > -1;
+      var isTabletFirefox = ua.indexOf('Tablet') > -1 && ua.indexOf('Firefox') > -1;
+
+      return ! (isMobileFirefox || isTabletFirefox);
     },
 
     afterRender: function() {

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -30,6 +30,10 @@ function (_, Backbone) {
         self.history.back.called = true;
       }
     };
+
+    this.navigator = {
+      userAgent: window.navigator.userAgent
+    }
   }
 
   _.extend(WindowMock.prototype, Backbone.Events, {

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -8,17 +8,22 @@
 define([
   'chai',
   'views/ready',
-  'lib/session'
+  'lib/session',
+  '../../mocks/window'
 ],
-function (chai, View, Session) {
+function (chai, View, Session, WindowMock) {
   /*global describe, beforeEach, afterEach, it*/
   var assert = chai.assert;
 
   describe('views/ready', function () {
-    var view;
+    var view, windowMock;
 
     beforeEach(function () {
-      view = new View({});
+      windowMock = new WindowMock();
+
+      view = new View({
+        window: windowMock
+      });
     });
 
     afterEach(function () {
@@ -68,6 +73,36 @@ function (chai, View, Session) {
         return view.render()
             .then(function () {
               assert.equal(view.$('#redirectTo').length, 0);
+            });
+      });
+
+      it('normally shows sign up marketing material', function () {
+        view.type = 'sign_up';
+        windowMock.navigator.userAgent = 'Mozilla/5.0 (Windows NT x.y; rv:31.0) Gecko/20100101 Firefox/31.0';
+
+        return view.render()
+            .then(function () {
+              assert.equal(view.$('.marketing').length, 1);
+            });
+      });
+
+      it('does not show sign up marketing material if on Firefox for Android', function () {
+        view.type = 'sign_up';
+        windowMock.navigator.userAgent = 'Mozilla/5.0 (Android; Tablet; rv:26.0) Gecko/26.0 Firefox/26.0';
+
+        return view.render()
+            .then(function () {
+              assert.equal(view.$('.marketing').length, 0);
+            });
+      });
+
+      it('does not show sign up marketing material if on B2G', function () {
+        view.type = 'sign_up';
+        windowMock.navigator.userAgent = 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0';
+
+        return view.render()
+            .then(function () {
+              assert.equal(view.$('.marketing').length, 0);
             });
       });
     });


### PR DESCRIPTION
This is a straw man until we decide whether we really need to hide marketing material if the user starts on Fennec or B2G. This PR hides marketing material if the user completes on Fennec or B2G. Marketing material is still shown if the user is in a desktop browser or a tablet where the user is not using Fennec (and media queries do not hide the material, of course).

issue #1041
