### PR TITLE
fix(l10n): normalize locale when fetching client.json

### DIFF
--- a/server/lib/routes/get-client.json.js
+++ b/server/lib/routes/get-client.json.js
@@ -14,7 +14,9 @@ module.exports = function(i18n) {
 
   route.process = function (req, res, next) {
     // req.locale is set by abide in a previous middleware.
-    req.url = '/i18n/' + req.locale + '/client.json';
+    var locale = i18n.localeFrom(i18n.languageFrom(req.locale));
+
+    req.url = '/i18n/' + locale + '/client.json';
 
     // Let any intermediaries know that client.json can vary based
     // on the accept-language. This will also be useful if client.json

--- a/tests/server/l10n.js
+++ b/tests/server/l10n.js
@@ -75,5 +75,37 @@ define([
     }, dfd.reject.bind(dfd)));
   };
 
+  suite['#get /i18n/client.json with lowercase language'] = function () {
+    var dfd = this.async(1000);
+
+    request(serverUrl + '/i18n/client.json', {
+      headers: {
+        'Accept-Language': 'en-gb'
+      }
+    }, dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+      var body = JSON.parse(res.body);
+
+      assert.equal(body[''].language, 'en_GB');
+    }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#get /i18n/client.json with unsupported locale'] = function () {
+    var dfd = this.async(1000);
+
+    request(serverUrl + '/i18n/client.json', {
+      headers: {
+        'Accept-Language': 'no-OP'
+      }
+    }, dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+      var body = JSON.parse(res.body);
+
+      assert.equal(body[''].language, 'en_US');
+    }, dfd.reject.bind(dfd)));
+  };
+
   registerSuite(suite);
 });


### PR DESCRIPTION
Fixes #1024.

To test this locally, you'll have to `rm -rf app/bower_components && bower install && grunt l10n-create-json` because the test depends on an updated en_US `.po` file.

/cc @shane-tomlinson @nchapman @pdehaan @jrgm 

Want to r? @pdehaan?
