### PR TITLE
refactor(view): use shortened url for Android marketing banner

### DIFF
--- a/app/scripts/templates/ready.mustache
+++ b/app/scripts/templates/ready.mustache
@@ -27,7 +27,7 @@
       <span class="android-logo" />
       {{#t}}Stay in sync on the go:{{/t}}
       <br />
-      <a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">{{#t}}Get Firefox for Android{{/t}}</a>
+      <a href="http://mzl.la/KBozcn">{{#t}}Get Firefox for Android{{/t}}</a>
     </aside>
   {{/showSignUpMarketing}}
 </section>


### PR DESCRIPTION
Fixes #1036.
