### PR TITLE
fix(client): Fix the "Sign in" link on `/confirm_reset_password` if the user is in the force auth flow.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -257,6 +257,7 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
       var service = Session.service;
       var redirectTo = Session.redirectTo;
       var email = trim(originalEmail);
+      var forceAuth = Session.forceAuth;
 
       // ensure resend works again
       passwordResetResendCount = 0;
@@ -278,6 +279,7 @@ function (FxaClient, $, p, Session, AuthErrors, Constants) {
                 Session.set('service', service);
                 Session.set('redirectTo', redirectTo);
                 Session.set('email', email);
+                Session.set('forceAuth', forceAuth);
                 Session.set('passwordForgotToken', result.passwordForgotToken);
               });
     },

--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -11,7 +11,15 @@
   <p class="verification-email-message">{{#t}}A reset link has been sent to %(email)s{{/t}}</p>
 
   <div class="links">
-    <a href="/signin" class="sign-in">{{#t}}Sign in{{/t}}</a><br>
+    {{#forceAuth}}
+      <a href="/force_auth?email={{ encodedEmail }}" class="sign-in">{{#t}}Sign in{{/t}}</a>
+    {{/forceAuth}}
+
+    {{^forceAuth}}
+      <a href="/signin" class="sign-in">{{#t}}Sign in{{/t}}</a>
+    {{/forceAuth}}
+
+    <br>
     <a id="resend" class="resend-email" href="#">{{#t}}Resend email{{/t}}</a>
   </div>
 

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -27,6 +27,14 @@ function (_, ConfirmView, BaseView, Template, Session, Constants, authErrors) {
       ConfirmView.prototype.beforeDestroy.call(this);
     },
 
+    context: function () {
+      return {
+        email: Session.email,
+        encodedEmail: encodeURIComponent(Session.email),
+        forceAuth: Session.forceAuth
+      };
+    },
+
     beforeRender: function () {
       // user cannot confirm if they have not initiated a reset password
       if (! Session.passwordForgotToken) {

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -42,15 +42,28 @@ function (chai, p, authErrors, View, Session, RouterMock, WindowMock) {
     });
 
     describe('constructor', function () {
-      it('draws view if passwordForgotToken exists', function () {
-        assert.ok($('#fxa-confirm-reset-password-header').length);
-      });
-
       it('redirects to /reset_password if no passwordForgotToken', function () {
         Session.clear('passwordForgotToken');
         view.render()
           .then(function () {
             assert.equal(routerMock.page, 'reset_password');
+          });
+      });
+
+      it('`sign in` link goes to /signin in normal flow', function () {
+        // Check to make sure the normal signin link is drawn
+        assert.equal(view.$('a[href="/signin"]').length, 1);
+        assert.equal(view.$('a[href="/force_auth?email=testuser%40testuser.com"]').length, 0);
+        assert.ok($('#fxa-confirm-reset-password-header').length);
+      });
+
+      it('`sign in` link goes to /force_auth in force auth flow', function () {
+        Session.set('forceAuth', true);
+        view.render()
+          .then(function () {
+            // Check to make sure the signin link goes "back"
+            assert.equal(view.$('a[href="/signin"]').length, 0);
+            assert.equal(view.$('a[href="/force_auth?email=testuser%40testuser.com"]').length, 1);
           });
       });
     });

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -63,7 +63,7 @@ define([
         .end();
     },
 
-    'forgot password via force-auth goes directly to confirm email screen': function () {
+    'forgot password flow via force-auth goes directly to confirm email screen': function () {
       return this.get('remote')
         .get(require.toUrl(FORCE_AUTH_URL + '?email=' + email))
         .waitForElementById('fxa-force-auth-header')
@@ -73,7 +73,15 @@ define([
         .end()
 
         .waitForElementById('fxa-confirm-reset-password-header')
-        .end();
+        .end()
+
+        // user remembers her password, clicks the "sign in" link. They
+        // should go back to the /force_auth screen.
+        .elementByClassName('sign-in')
+          .click()
+        .end()
+
+        .waitForElementById('fxa-force-auth-header');
     }
 
 


### PR DESCRIPTION
- The user should be returned to /force_auth instead of /sign_in

fixes #926
