### PR TITLE
fix(server): `utf8` is not a valid content-type, `utf-8` is.

### DIFF
--- a/app/scripts/lib/translator.js
+++ b/app/scripts/lib/translator.js
@@ -27,9 +27,14 @@ function (_, $, Strings) {
     // Fetches our JSON translation file
     fetch: function (done) {
       var self = this;
-      $.ajax({ dataType: 'json', url: '/i18n/client.json' })
+      $.getJSON('/i18n/client.json')
         .done(function (data) {
-          self.translations = data;
+          // Only update the translations if some came back
+          // from the server. If the server sent no translations,
+          // english strings will be served.
+          if (data) {
+            self.translations = data;
+          }
         })
         .fail(function () {
           // allow for 404's. `.get` will use the key for the translation

--- a/server/lib/routes/get-client.json.js
+++ b/server/lib/routes/get-client.json.js
@@ -24,7 +24,7 @@ module.exports = function(i18n) {
     res.set('Vary', 'accept-language');
 
     // charset must be set on json responses.
-    res.charset = 'utf8';
+    res.charset = 'utf-8';
 
     // let the static middleware handle the rest.
     next();

--- a/server/lib/routes/get-config.js
+++ b/server/lib/routes/get-config.js
@@ -22,7 +22,7 @@ module.exports = function(i18n) {
     res.set('Vary', 'accept-language');
 
     // charset must be set on json responses.
-    res.charset = 'utf8';
+    res.charset = 'utf-8';
 
     res.json({
       // The `__cookies_check` cookie is set in client code

--- a/server/lib/routes/get-ver.json.js
+++ b/server/lib/routes/get-ver.json.js
@@ -97,7 +97,7 @@ exports.process = function (req, res) {
   getVersionInfo()
     .then(function (versionInfo) {
       // charset must be set on json responses.
-      res.charset = 'utf8';
+      res.charset = 'utf-8';
       res.json(versionInfo);
     });
 };

--- a/tests/server/cookies_disabled.js
+++ b/tests/server/cookies_disabled.js
@@ -26,7 +26,7 @@ define([
     },
     dfd.callback(function (err, res) {
       assert.equal(res.statusCode, 200);
-      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
 
       var results = JSON.parse(res.body);
 
@@ -44,7 +44,7 @@ define([
     },
     dfd.callback(function (err, res) {
       assert.equal(res.statusCode, 200);
-      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
 
       var results = JSON.parse(res.body);
       assert.equal(results.cookiesEnabled, true);

--- a/tests/server/l10n.js
+++ b/tests/server/l10n.js
@@ -33,7 +33,7 @@ define([
       headers: headers
     }, dfd.callback(function (err, res) {
       assert.equal(res.statusCode, 200);
-      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
       // Response differs depending on the Accept-Language, let all
       // intermediaries know this.
       assert.equal(res.headers.vary, 'accept-language');
@@ -55,7 +55,7 @@ define([
       }
     }, dfd.callback(function (err, res) {
       assert.equal(res.statusCode, 200);
-      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
       // Response differs depending on the Accept-Language, let all
       // intermediaries know this.
       assert.equal(res.headers.vary, 'accept-language');

--- a/tests/server/ver.json.js
+++ b/tests/server/ver.json.js
@@ -21,7 +21,7 @@ define([
 
     request(serverUrl + '/ver.json', dfd.callback(function (err, res) {
       assert.equal(res.statusCode, 200);
-      assert.equal(res.headers['content-type'], 'application/json; charset=utf8');
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
 
       var body = JSON.parse(res.body);
       assert.ok('version' in body);


### PR DESCRIPTION
- JSON responses were being sent with a content type of `utf8` instead of `utf-8`. `utf8` is invalid and IE would not parse the JSON. This resulted in neither config nor translations being loaded.

fixes #1095
