### PR TITLE
Fix browse happy text and the firefox logo on IE8, disable IE9 support.

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -76,6 +76,13 @@ noscript {
 }
 
 /**
+ * IE < 10 does not support CSS transforms 
+ */ 
+.lt-ie10 #fox-logo {
+  opacity: 1;
+}
+
+/**
  * IE7/8 specific hacks to fix the firefox logo
  */
 .lt-ie9 #fox-logo {
@@ -105,6 +112,10 @@ noscript {
 
 .js #stage {
   display: none;
+}
+
+.lt-ie10 #stage {
+  display: block;
 }
 
 header h1,

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html class="lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+<!--[if lt IE 7]>      <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie10 lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="lt-ie10 lt-ie9"> <![endif]-->
+<!--[if IE 9]>         <html class="lt-ie10"> <![endif]-->
+<!--[if gt IE 9]><!--> <html class="no-js"> <!--<![endif]-->
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -29,7 +30,7 @@
     <body>
         <div id="fox-logo"></div>
         <div id="stage">
-          <!--[if lt IE 9]>
+          <!--[if lt IE 10]>
               <p class="error browsehappy">
                 {{#t}}You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.{{/t}}</p>
           <![endif]-->
@@ -47,6 +48,8 @@
              rev/usemin will still replace the URL
              with a cache aware URL.
          -->
+        <!--[if gt IE 9]><!-->
         <script data-main="/scripts/main" src="/bower_components/requirejs/require.js"></script>
+        <!--<![endif]-->
     </body>
 </html>

--- a/server/templates/pages/src/privacy.html
+++ b/server/templates/pages/src/privacy.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html class="lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html> <!--<![endif]-->
+<!--[if lt IE 7]>      <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie10 lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="lt-ie10 lt-ie9"> <![endif]-->
+<!--[if IE 9]>         <html class="lt-ie10"> <![endif]-->
+<!--[if gt IE 9]><!--> <html> <!--<![endif]-->
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -17,11 +18,11 @@
         <!-- endbuild -->
     </head>
     <body>
-        <!--[if lt IE 8]>
-            <p class="browsehappy">{{#t}}You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.{{/t}}</p>
-        <![endif]-->
         <div id="fox-logo" class="static"></div>
         <div id="stage">
+          <!--[if lt IE 10]>
+              <p class="browsehappy">{{#t}}You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.{{/t}}</p>
+          <![endif]-->
           <header id="legal-header">
             <h3>{{#t}}Firefox cloud services{{/t}}</h3>
             <h1 id="fxa-pp-header">{{#t}}Privacy Notice{{/t}}</h1>

--- a/server/templates/pages/src/terms.html
+++ b/server/templates/pages/src/terms.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html class="lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html> <!--<![endif]-->
+<!--[if lt IE 7]>      <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie10 lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="lt-ie10 lt-ie9"> <![endif]-->
+<!--[if IE 9]>         <html class="lt-ie10"> <![endif]-->
+<!--[if gt IE 9]><!--> <html> <!--<![endif]-->
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -17,11 +18,11 @@
         <!-- endbuild -->
     </head>
     <body>
-        <!--[if lt IE 8]>
-            <p class="browsehappy">{{#t}}You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.{{/t}}</p>
-        <![endif]-->
         <div id="fox-logo" class="static"></div>
         <div id="stage">
+          <!--[if lt IE 10]>
+              <p class="browsehappy">{{#t}}You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.{{/t}}</p>
+          <![endif]-->
           <header id="legal-header">
             <h3>{{#t}}Firefox cloud services{{/t}}</h3>
             <h1 id="fxa-tos-header">{{#t}}Terms of Service{{/t}}</h1>


### PR DESCRIPTION
~~This fix contains #1096 and #1097 and should be reviewed afterwards.~~ This patch depends on #1096 and #1097 and should be reviewed afterwards.

fix(client): Fix the styling on outdated browsers.
- Show the "browse happy" link to IE < 9
- Make the firefox logo look respectable on IE < 9

fixes #999
fixes #1014
fixes #1098
issue #1095
