### PR TITLE
fix(client): Fix form validation on browsers that do not have HTML5 form...

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -19,7 +19,9 @@ define([], function () {
     RESET_PASSWORD_POLL_INTERVAL: 2000,
 
     CODE_LENGTH: 32,
-    UID_LENGTH: 32
+    UID_LENGTH: 32,
+
+    PASSWORD_MIN_LENGTH: 8
   };
 });
 

--- a/app/scripts/lib/validate.js
+++ b/app/scripts/lib/validate.js
@@ -72,7 +72,7 @@ define([
     /**
      * Check if a verification uid is valid
      */
-    isUidValid: function(uid) {
+    isUidValid: function (uid) {
       if (typeof uid !== 'string') {
         return false;
       }
@@ -80,6 +80,17 @@ define([
       // uids are fixed length hex strings.
       return uid.length === Constants.UID_LENGTH &&
              HEX_STRING.test(uid);
+    },
+
+    /**
+     * Check if a password is valid
+     */
+    isPasswordValid: function (password) {
+      if (typeof password !== 'string') {
+        return false;
+      }
+
+      return password.length >= Constants.PASSWORD_MIN_LENGTH;
     }
   };
 });

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -5,6 +5,18 @@
   <div class="input-row">
     <input type="text" id="focusMe" autofocus required />
   </div>
+  <div class="input-row">
+    <input type="text" id="notRequired" />
+  </div>
+  <div class="input-row">
+    <input type="text" id="required" required />
+  </div>
+  <div class="input-row">
+    <input type="email" id="email" />
+  </div>
+  <div class="input-row">
+    <input type="password" id="password" />
+  </div>
   <input type="text" id="novalue" value="heyho" data-novalue />
   <button type="submit" class="disabled">Submit</button>
 </form>

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -311,16 +311,16 @@ function (_, $, p, Validate, BaseView, Tooltip, ButtonProgressIndicator) {
      */
     isElementValid: function (selector) {
       var el = this.$(selector);
-      var type = el.attr('type');
+      var type = this.getElementType(el);
 
-      // email follows our own rules.
+      // email and password follow our own rules.
       if (type === 'email') {
         return this.validateEmail(selector);
+      } else if (type === 'password') {
+        return this.validatePassword(selector);
       }
 
-      var value = el.val();
-      var isValid = !!(value && el[0].validity.valid);
-      return isValid;
+      return this.validateInput(selector);
     },
 
     /**
@@ -402,8 +402,45 @@ function (_, $, p, Validate, BaseView, Tooltip, ButtonProgressIndicator) {
       return Validate.isEmailValid(email);
     },
 
+
     showEmailValidationError: function (which) {
       return this.showValidationError(which, t('Valid email required'));
+    },
+
+    /**
+     * Validate a password field
+     *
+     * @return true if password is valid, false otw.
+     */
+    validatePassword: function (selector) {
+      var password = this.$(selector).val();
+      return Validate.isPasswordValid(password);
+    },
+
+    /**
+     * Basic text input validation. By default, only performs `required`
+     * attribute validation. If the browser supports HTML5 form validation,
+     * browser validation will kick in. If validating an email or password
+     * field, call validateEmail or validatePassword instead.
+     */
+    validateInput: function (selector) {
+      var el = this.$(selector);
+      var isRequired = typeof el.attr('required') !== 'undefined';
+
+      var value = el.val();
+
+      if (isRequired && value.length === 0) {
+        return false;
+      }
+
+      // If the browser supports HTML5 form validation, hooray,
+      // use its validation too.
+      var hasHtml5Validation = !! el[0].validity;
+      if (hasHtml5Validation) {
+        return el[0].validity.valid;
+      }
+
+      return true;
     },
 
     showPasswordValidationError: function (which) {

--- a/app/tests/spec/lib/validate.js
+++ b/app/tests/spec/lib/validate.js
@@ -92,5 +92,19 @@ function (chai, _, Validate, Constants, TestHelpers) {
         assert.isTrue(Validate.isUidValid(createRandomHexString(Constants.UID_LENGTH)));
       });
     });
+
+    describe('isPasswordValid', function () {
+      it('returns false with empty password', function () {
+        assert.isFalse(Validate.isPasswordValid(''));
+      });
+
+      it('returns false with one too few characters', function () {
+        assert.isFalse(Validate.isPasswordValid(createRandomHexString(Constants.PASSWORD_MIN_LENGTH - 1)));
+      });
+
+      it('returns true with minimum expected characters', function () {
+        assert.isTrue(Validate.isPasswordValid(createRandomHexString(Constants.PASSWORD_MIN_LENGTH)));
+      });
+    });
   });
 });

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -11,9 +11,10 @@ define([
   'p-promise',
   'views/form',
   'stache!templates/test_template',
+  'lib/constants',
   '../../lib/helpers'
 ],
-function (chai, $, p, FormView, Template, TestHelpers) {
+function (chai, $, p, FormView, Template, Constants, TestHelpers) {
   var assert = chai.assert;
 
   describe('views/form', function () {
@@ -274,6 +275,72 @@ function (chai, $, p, FormView, Template, TestHelpers) {
         assert.equal(values.focusMe, 'the value');
         assert.equal(values.otherElement, 'another value');
         assert.isUndefined(values.novalue);
+      });
+    });
+
+    describe('validateEmail', function () {
+      it('returns false if an empty email', function () {
+        view.$('#email').val('');
+        assert.isFalse(view.validateEmail('#email'));
+        assert.isFalse(view.isElementValid('#email'));
+      });
+
+      it('returns false if an invalid email', function () {
+        view.$('#email').val('invalid');
+        assert.isFalse(view.validateEmail('#email'));
+        assert.isFalse(view.isElementValid('#email'));
+      });
+
+      it('returns true if a valid email', function () {
+        view.$('#email').val('testuser@testuser.com');
+        assert.isTrue(view.validateEmail('#email'));
+        assert.isTrue(view.isElementValid('#email'));
+      });
+    });
+
+    describe('validatePassword', function () {
+      it('returns false if an empty password', function () {
+        view.$('#password').val('');
+        assert.isFalse(view.validatePassword('#password'));
+        assert.isFalse(view.isElementValid('#password'));
+      });
+
+      it('returns false if too short a password', function () {
+        view.$('#password').val('1');
+        assert.isFalse(view.validatePassword('#password'));
+        assert.isFalse(view.isElementValid('#password'));
+      });
+
+      it('returns true if a valid password', function () {
+        view.$('#password').val(TestHelpers.createRandomHexString(Constants.PASSWORD_MIN_LENGTH));
+        assert.isTrue(view.validatePassword('#password'));
+        assert.isTrue(view.isElementValid('#password'));
+      });
+    });
+
+    describe('validateInput', function () {
+      it('returns true for an empty non-required input', function () {
+        view.$('#notRequired').val('');
+        assert.isTrue(view.validateInput('#notRequired'));
+        assert.isTrue(view.isElementValid('#notRequired'));
+      });
+
+      it('returns true for a filled out non-required input', function () {
+        view.$('#notRequired').val('value');
+        assert.isTrue(view.validateInput('#notRequired'));
+        assert.isTrue(view.isElementValid('#notRequired'));
+      });
+
+      it('returns false for an empty required input', function () {
+        view.$('#required').val('');
+        assert.isFalse(view.validateInput('#required'));
+        assert.isFalse(view.isElementValid('#required'));
+      });
+
+      it('returns true for a filled out required input', function () {
+        view.$('#required').val('value');
+        assert.isTrue(view.validateInput('#required'));
+        assert.isTrue(view.isElementValid('#required'));
       });
     });
   });


### PR DESCRIPTION
... field validation.
- IE < 10 do not have native form field validation. Validation must be done manually.
- To form.js, added validatePassword and validateInput.
- validatePassword validates passwords
- validateInput only checks if an input field is required on browsers without HTML5 validation. On other browsers, HTML5 validation will take effect.

fixes #1113
fixes #185 

(the original PR #1115 by @shane-tomlinson for this was auto closed but never was actually merge in to master)
