### PR TITLE
fix(test): Force focus in Mocha tests.

### DIFF
--- a/app/tests/lib/helpers.js
+++ b/app/tests/lib/helpers.js
@@ -8,6 +8,14 @@ define([
   'sinon'
 ], function (sinon) {
   function requiresFocus(callback, done) {
+    // Give the document focus
+    window.focus();
+
+    // Remove focus from any focused element
+    if (document.activeElement) {
+      document.activeElement.blur();
+    }
+
     if (document.hasFocus && document.hasFocus()) {
       callback();
     } else {


### PR DESCRIPTION
From my tests `window.focus();` works well for PhantomJS and Sauce Labs.

Due to the focus requirement if you run the tests on local Selenium then you must keep the browser focused. I am using an alert in the PR because I feel like console.log is not enough and will cause inconsistency in test results. 
