### PR TITLE
feat(metrics): Add metrics gathering.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -36,13 +36,16 @@ function () {
     SERVICE_UNAVAILABLE: 998,
     SERVER_BUSY: 201,
     ENDPOINT_NOT_SUPPORTED: 116,
-    USER_CANCELED_LOGIN: 1001 // local only error code for when user cancels desktop login
+
+    // local only error codes
+    USER_CANCELED_LOGIN: 1001,
+    SESSION_EXPIRED: 1002
   };
 
   var CODE_TO_MESSAGES = {
     // errors returned by the auth server
     999: t('Unexpected error'),
-    110: t('Invalid authentication token in request signature'),
+    110: t('Invalid token'),
     111: t('Invalid timestamp in request signature'),
     115: t('Invalid nonce in request signature'),
     101: t('Account already exists'),
@@ -60,7 +63,10 @@ function () {
     114: t('Attempt limit exceeded.'),
     998: t('System unavailable, try again soon'),
     201: t('Server busy, try again soon'),
-    116: t('This endpoint is no longer supported')
+    116: t('This endpoint is no longer supported'),
+
+    // local only error messages
+    1002: t('Session expired. Sign in to continue.')
   };
 
   return {
@@ -72,6 +78,8 @@ function () {
 
       if (typeof err === 'number') {
         code = err;
+      } else if (err && err.forceMessage) {
+        return err.forceMessage;
       // error from backend
       } else if (err && typeof err.errno === 'number') {
         code = err.errno;
@@ -118,10 +126,10 @@ function () {
     },
 
     /**
-     * Convert a text type from ERROR_TO_CODE to a numeric code
+     * Convert an error or a text type from ERROR_TO_CODE to a numeric code
      */
     toCode: function (type) {
-      return ERROR_TO_CODE[type];
+      return type.errno || ERROR_TO_CODE[type] || type;
     },
 
     /**

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -1,0 +1,230 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * A metrics module!
+ *
+ * An instantiated metrics object has two primary APIs:
+ *
+ * metrics.logEvent(<event_name>);
+ * metrics.startTimer(<timer_name>)/metrics.stopTimer(<timer_name);
+ *
+ * Metrics are automatically sent to the server on window.unload
+ * but can also be sent by calling metrics.flush();
+ */
+
+define([
+  'underscore',
+  'backbone',
+  'jquery',
+  'speedTrap',
+  'p-promise',
+  'lib/url'
+], function (_, Backbone, $, speedTrap, p, Url) {
+  'use strict';
+
+  // Speed trap is a singleton, convert it
+  // to an instantiable function.
+  var SpeedTrap = function() {};
+  SpeedTrap.prototype = speedTrap;
+
+  var ALLOWED_FIELDS = [
+    'date',
+    'navigationTiming',
+    'referrer',
+    'duration',
+    'timers',
+    'events',
+    'context',
+    'service'
+  ];
+
+  var TEN_MINS_MS = 10 * 60 * 1000;
+
+  function getDate() {
+    var roundedDate = new Date();
+    roundedDate.setHours(0, 0, 0, 0);
+
+    return roundedDate;
+  }
+
+  function Metrics (options) {
+    options = options || {};
+
+    // by default, send the metrics to the content server.
+    this._collector = options.collector || '';
+
+    this._ajax = options.ajax || $.ajax;
+
+    this._speedTrap = new SpeedTrap();
+    this._speedTrap.init();
+
+    // `timers` and `events` are part of the public API
+    this.timers = this._speedTrap.timers;
+    this.events = this._speedTrap.events;
+
+    this._date = getDate();
+
+    this._window = options.window || window;
+
+    var searchParams = this._window.location.search;
+    this._context = Url.searchParam('context', searchParams);
+    this._service = Url.searchParam('service', searchParams);
+
+    this._inactivityFlushMs = options.inactivityFlushMs || TEN_MINS_MS;
+  }
+
+  _.extend(Metrics.prototype, Backbone.Events, {
+    ALLOWED_FIELDS: ALLOWED_FIELDS,
+
+    init: function () {
+      this._flush = _.bind(this.flush, this);
+      $(this._window).on('unload', this._flush);
+
+      // Set the initial inactivity timeout to clear navigation timing data.
+      this._resetInactivityFlushTimeout();
+    },
+
+    destroy: function () {
+      $(this._window).off('unload', this._flush);
+      this._clearInactivityFlushTimeout();
+    },
+
+    /**
+     * Send the collected data to the backend.
+     */
+    flush: function () {
+      // Inactivity timer is restarted when the next event/timer comes in.
+      // This avoids sending empty result sets if the tab is
+      // just sitting there open with no activity.
+      this._clearInactivityFlushTimeout();
+
+      var filteredData = this.getFilteredData();
+      this._speedTrap.events.clear();
+      this._speedTrap.timers.clear();
+
+      var url = this._collector + '/metrics';
+
+      // use a synchronous request to block the page from unloading
+      // until the request is complete.
+      return this._send(filteredData, url, false);
+    },
+
+    _clearInactivityFlushTimeout: function () {
+      clearTimeout(this._inactivityFlushTimeout);
+    },
+
+    _resetInactivityFlushTimeout: function () {
+      this._clearInactivityFlushTimeout();
+
+      var self = this;
+      this._inactivityFlushTimeout =
+          setTimeout(function () {
+            self.logEvent('inactivity:flush');
+            self.flush();
+          }, this._inactivityFlushMs);
+    },
+
+
+    /**
+     * Get all the data, whether it's allowed to be sent or not.
+     */
+    getAllData: function () {
+      var loadData = this._speedTrap.getLoad();
+      var unloadData = this._speedTrap.getUnload();
+
+      var allData = _.extend({
+        date: this._date.toISOString(),
+        context: this._context,
+        service: this._service
+      }, loadData, unloadData);
+
+      return allData;
+    },
+
+    /**
+     * Get the filtered data.
+     * Filtered data is data that is allowed to be sent,
+     * that is defined and not an empty string.
+     */
+    getFilteredData: function () {
+      var allData = this.getAllData();
+
+      var filteredData = {};
+      _.forEach(ALLOWED_FIELDS, function (itemName) {
+        if (typeof allData[itemName] !== 'undefined' &&
+            allData[itemName] !== '') {
+          filteredData[itemName] = allData[itemName];
+        }
+      });
+
+      return filteredData;
+    },
+
+    _send: function (data, url, async) {
+      var deferred = p.defer();
+
+      var self = this;
+      this._ajax({
+        async: async !== false,
+        type: 'POST',
+        url: url,
+        contentType: 'application/json',
+        data: JSON.stringify(data),
+        error: function (jqXHR, textStatus, errorThrown) {
+          self.trigger('flush:error');
+          deferred.reject(errorThrown);
+        },
+        success: function () {
+          self.trigger('flush:success', data);
+          deferred.resolve(data);
+        }
+      });
+
+      return deferred.promise;
+    },
+
+    /**
+     * Log an event
+     */
+    logEvent: function (eventName) {
+      this._resetInactivityFlushTimeout();
+      this.events.capture(eventName);
+    },
+
+    /**
+     * Start a timer
+     */
+    startTimer: function (timerName) {
+      this._resetInactivityFlushTimeout();
+      this.timers.start(timerName);
+    },
+
+    /**
+     * Stop a timer
+     */
+    stopTimer: function (timerName) {
+      this._resetInactivityFlushTimeout();
+      this.timers.stop(timerName);
+    },
+
+    /**
+     * Convert an error to an identifier
+     */
+    errorToId: function (err, errors) {
+      return 'error:' + errors.toCode(err);
+    },
+
+    /**
+     * Convert a pathname from a URL to an identifier
+     */
+    pathToId: function (path) {
+      return 'screen:' + Url.pathToScreenName(path);
+    }
+  });
+
+  return Metrics;
+});
+
+

--- a/app/scripts/lib/null-metrics.js
+++ b/app/scripts/lib/null-metrics.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * A null metrics module. For use as a standin if metrics are disabled
+ * or for unit tests.
+ */
+
+define([
+  'underscore',
+  'p-promise',
+  'lib/metrics'
+], function (_, p, Metrics) {
+  'use strict';
+
+  function NullMetrics () {
+    // do nothing
+  }
+
+  _.forEach(_.keys(Metrics.prototype), function(key) {
+    NullMetrics.prototype[key] = function () {
+      // do nothing
+    };
+  });
+
+  // Metrics.flush returns a promise.
+  NullMetrics.prototype.flush = function () {
+    return p();
+  };
+
+  return NullMetrics;
+});
+
+

--- a/app/scripts/lib/url.js
+++ b/app/scripts/lib/url.js
@@ -31,7 +31,17 @@ function (_) {
       var terms = searchParams(str);
 
       return terms[name];
+    },
+
+    pathToScreenName: function (path) {
+                // strip leading /
+      return path.replace(/^\//, '')
+                // strip trailing /
+                .replace(/\/$/, '')
+                // search params can contain sensitive info
+                .replace(/\?.*/, '');
     }
+
   };
 });
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -13,7 +13,8 @@ require.config({
     text: '../bower_components/requirejs-text/text',
     mustache: '../bower_components/mustache/mustache',
     stache: '../bower_components/requirejs-mustache/stache',
-    'p-promise': '../bower_components/p/p'
+    'p-promise': '../bower_components/p/p',
+    speedTrap: '../bower_components/speed-trap/dist/speed-trap'
   },
   shim: {
     underscore: {

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -57,7 +57,15 @@ function (
 
   function showView(View, options) {
     return function () {
-      this.showView(new View(options || {}));
+      // passed in options block can override
+      // default options.
+      options = _.extend({
+        metrics: this.metrics,
+        window: this.window,
+        router: this
+      }, options || {});
+
+      this.showView(new View(options));
     };
   }
 
@@ -91,6 +99,8 @@ function (
       options = options || {};
 
       this.window = options.window || window;
+
+      this.metrics = options.metrics;
 
       this.$stage = $('#stage');
 

--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -60,8 +60,8 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, AuthErrors) {
                   });
                 }, function (err) {
                   if (AuthErrors.is(err, 'UNVERIFIED_ACCOUNT')) {
-                    var msg = t('Unverified account. <a href="#" id="resend">Resend verification email</a>.');
-                    return self.displayErrorUnsafe(msg);
+                    err.forceMessage = t('Unverified account. <a href="#" id="resend">Resend verification email</a>.');
+                    return self.displayErrorUnsafe(err);
                   }
 
                   throw err;
@@ -76,7 +76,9 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, AuthErrors) {
                 self.navigate('confirm');
               }, function (err) {
                 if (AuthErrors.is(err, 'INVALID_TOKEN')) {
-                  return self.navigate('signup');
+                  return self.navigate('signup', {
+                    error: err
+                  });
                 }
 
                 throw self.displayError(err);

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -36,12 +36,14 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, Validate, Aut
       } catch(e) {
         // This is an invalid link. Abort and show an error message
         // before doing any more checks.
+        this.logEvent('complete_reset_password:link_damaged');
         return true;
       }
 
       if (! this._doesLinkValidate()) {
         // One or more parameters fails validation. Abort and show an
         // error message before doing any more checks.
+        this.logEvent('complete_reset_password:link_damaged');
         return true;
       }
 
@@ -49,6 +51,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, Validate, Aut
       return this.fxaClient.isPasswordResetComplete(this.token)
          .then(function (isComplete) {
             self._isLinkExpired = isComplete;
+            self.logEvent('complete_reset_password:link_expired');
             return true;
           });
     },
@@ -95,6 +98,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, Validate, Aut
             self.navigate('reset_password_complete');
           }, function (err) {
             if (AuthErrors.is(err, 'INVALID_TOKEN')) {
+              self.logError(err);
               // The token has expired since the first check, re-render to
               // show a screen that allows the user to receive a new link.
               return self.render();

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -23,6 +23,7 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, FxaClient, AuthErrors, 
         this.importSearchParam('uid');
         this.importSearchParam('code');
       } catch(e) {
+        this.logEvent('complete_sign_up:link_damaged');
         // This is an invalid link. Abort and show an error message
         // before doing any more checks.
         return true;
@@ -31,6 +32,7 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, FxaClient, AuthErrors, 
       if (! this._doesLinkValidate()) {
         // One or more parameters fails validation. Abort and show an
         // error message before doing any more checks.
+        this.logEvent('complete_sign_up:link_damaged');
         return true;
       }
 
@@ -46,6 +48,7 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, FxaClient, AuthErrors, 
                 AuthErrors.is(err, 'INVALID_PARAMETER')) {
               // These errors show a link damaged screen
               self._isLinkDamaged = true;
+              self.logEvent('complete_sign_up:link_damaged');
             } else {
               // all other errors show the standard error box.
               self._error = self.translateError(err);

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -12,7 +12,6 @@ define([
   'lib/auth-errors'
 ],
 function (FormView, BaseView, Template, Session, AuthErrors) {
-  var t = BaseView.t;
   var SHOW_RESEND_IN_MS = 5 * 60 * 1000; // 5 minutes.
   var VERIFICATION_POLL_IN_MS = 4000; // 4 seconds
 
@@ -110,6 +109,7 @@ function (FormView, BaseView, Template, Session, AuthErrors) {
       var self = this;
       // Hide the button after 4 attempts. Redisplay button after a delay.
       if (self._attemptedSubmits === 4) {
+        self.logEvent('confirm:too_many_attempts');
         self.$('#resend').hide();
         self._displayResendTimeout = setTimeout(function () {
           self._displayResendTimeout = null;
@@ -122,13 +122,14 @@ function (FormView, BaseView, Template, Session, AuthErrors) {
     submit: function () {
       var self = this;
 
+      self.logEvent('confirm:resend');
       return this.fxaClient.signUpResend()
               .then(function () {
                 self.displaySuccess();
               }, function (err) {
                 if (AuthErrors.is(err, 'INVALID_TOKEN')) {
                   return self.navigate('signup', {
-                    error: t('Invalid token')
+                    error: err
                   });
                 }
 

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -78,13 +78,14 @@ function (_, ConfirmView, BaseView, Template, Session, Constants, AuthErrors) {
     submit: function () {
       var self = this;
 
+      self.logEvent('confirm_reset_password:resend');
       return this.fxaClient.passwordResetResend()
               .then(function () {
                 self.displaySuccess();
               }, function (err) {
                 if (AuthErrors.is(err, 'INVALID_TOKEN')) {
                   return self.navigate('reset_password', {
-                    error: t('Invalid token')
+                    error: err
                   });
                 }
 

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -66,9 +66,10 @@ function (_, BaseView, FormView, Template, Session, Url, AuthErrors) {
             // email indicates the signed in email. Use prefillEmail
             // to avoid collisions across sessions.
             Session.set('prefillEmail', email);
-            var msg = t('Unknown account. <a href="/signup">Sign up</a>');
-            return self.displayErrorUnsafe(msg);
+            err.forceMessage = t('Unknown account. <a href="/signup">Sign up</a>');
+            return self.displayErrorUnsafe(err);
           } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
+            self.logEvent('login:canceled');
             // if user canceled login, just stop
             return;
           }

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -74,8 +74,9 @@ function (_, p, BaseView, FormView, SignInTemplate, Constants, Session, Password
         })
         .then(null, function (err) {
           if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
-            return self._suggestSignUp();
+            return self._suggestSignUp(err);
           } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
+            self.logEvent('login:canceled');
             // if user canceled login, just stop
             return;
           }
@@ -94,9 +95,9 @@ function (_, p, BaseView, FormView, SignInTemplate, Constants, Session, Password
       return true;
     },
 
-    _suggestSignUp: function () {
-      var msg = t('Unknown account. <a href="/signup">Sign up</a>');
-      return this.displayErrorUnsafe(msg);
+    _suggestSignUp: function (err) {
+      err.forceMessage = t('Unknown account. <a href="/signup">Sign up</a>');
+      return this.displayErrorUnsafe(err);
     },
 
     _savePrefillInfo: function () {
@@ -125,7 +126,7 @@ function (_, p, BaseView, FormView, SignInTemplate, Constants, Session, Password
             self.navigate('confirm_reset_password');
           }, function (err) {
             if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
-              return self._suggestSignUp();
+              return self._suggestSignUp(err);
             }
 
             // resetPassword is not called from `submit` and must

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -143,8 +143,9 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, AuthErrors) {
           // user in directly, instead, point the user to the signin page
           // where the entered email/password will be prefilled.
           if (AuthErrors.is(err, 'ACCOUNT_ALREADY_EXISTS')) {
-            return self._suggestSignIn();
+            return self._suggestSignIn(err);
           } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
+            self.logEvent('login:canceled');
             // if user canceled login, just stop
             return;
           }
@@ -162,9 +163,9 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, AuthErrors) {
       }
     },
 
-    _suggestSignIn: function () {
-      var msg = t('Account already exists. <a href="/signin">Sign in</a>');
-      return this.displayErrorUnsafe(msg);
+    _suggestSignIn: function (err) {
+      err.forceMessage = t('Account already exists. <a href="/signin">Sign in</a>');
+      return this.displayErrorUnsafe(err);
     },
 
     _savePrefillInfo: function () {

--- a/app/tests/lib/helpers.js
+++ b/app/tests/lib/helpers.js
@@ -77,6 +77,19 @@ define([
     return email.split('@')[0];
   }
 
+  function isEventLogged(metrics, eventName) {
+    var events = metrics.getFilteredData().events;
+
+    for (var i = 0; i < events.length; ++i) {
+      var event = events[i];
+      if (event.type === eventName) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   return {
     requiresFocus: requiresFocus,
     addFxaClientSpy: addFxaClientSpy,
@@ -84,6 +97,7 @@ define([
     wrapAssertion: wrapAssertion,
     createRandomHexString: createRandomHexString,
     createEmail: createEmail,
-    emailToUser: emailToUser
+    emailToUser: emailToUser,
+    isEventLogged: isEventLogged
   };
 });

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -14,7 +14,8 @@ require.config({
     stache: '/bower_components/requirejs-mustache/stache',
     chai: '/bower_components/chai/chai',
     'p-promise': '/bower_components/p/p',
-    sinon: '/bower_components/sinon/index'
+    sinon: '/bower_components/sinon/index',
+    speedTrap: '/bower_components/speed-trap/dist/speed-trap'
   },
   shim: {
     underscore: {
@@ -56,6 +57,8 @@ require([
   '../tests/spec/lib/app-start',
   '../tests/spec/lib/validate',
   '../tests/spec/lib/service-name',
+  '../tests/spec/lib/metrics',
+  '../tests/spec/lib/null-metrics',
   '../tests/spec/views/base',
   '../tests/spec/views/tooltip',
   '../tests/spec/views/form',

--- a/app/tests/spec/lib/auth-errors.js
+++ b/app/tests/spec/lib/auth-errors.js
@@ -30,6 +30,13 @@ function (chai, AuthErrors) {
             AuthErrors.toMessage('this is an error'), 'this is an error');
       });
 
+      it('uses forceMessage as the message if it exists', function () {
+        assert.equal(AuthErrors.toMessage({
+          errno: 102,
+          forceMessage: 'this is my message'
+        }), 'this is my message');
+      });
+
       it('converts an error from the backend containing an errno to a message', function () {
         assert.equal(
           AuthErrors.toMessage({
@@ -88,8 +95,17 @@ function (chai, AuthErrors) {
     });
 
     describe('toCode', function () {
-      it('converts a string type to a numeric code', function () {
+      it('returns the errno from an error object', function () {
+        var err = AuthErrors.toError('INVALID_TOKEN', 'bad token, man');
+        assert.equal(AuthErrors.toCode(err), 110);
+      });
+
+      it('converts a string type to a numeric code, if valid code', function () {
         assert.equal(AuthErrors.toCode('UNKNOWN_ACCOUNT'), 102);
+      });
+
+      it('returns the string if an invalid code', function () {
+        assert.equal(AuthErrors.toCode('this is an invalid code'), 'this is an invalid code');
       });
     });
 

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// test the metrics library
+
+define([
+  'chai',
+  'lib/metrics',
+  '../../mocks/window'
+],
+function (chai, Metrics, WindowMock) {
+  'use strict';
+
+  /*global describe, it*/
+  var assert = chai.assert;
+
+  describe('lib/metrics', function () {
+    var metrics, windowMock;
+
+    beforeEach(function () {
+      windowMock = new WindowMock();
+
+      windowMock.location.search = '?service=sync&context=fxa_desktop_v1';
+      metrics = new Metrics({
+        window: windowMock
+      });
+      metrics.init();
+    });
+
+    afterEach(function () {
+      metrics.destroy();
+      metrics = null;
+    });
+
+    describe('getFilteredData', function () {
+      it('gets data that is allowed to be sent to the server', function () {
+        var filteredData = metrics.getFilteredData();
+
+        // ensure results are filtered and no unexpected data makes it through.
+        for (var key in filteredData) {
+          assert.isTrue(metrics.ALLOWED_FIELDS.indexOf(key) > -1);
+        }
+      });
+
+      it('gets non-optional fields', function () {
+        var filteredData = metrics.getFilteredData();
+
+        assert.isTrue(filteredData.hasOwnProperty('date'));
+        assert.isTrue(filteredData.hasOwnProperty('events'));
+        assert.isTrue(filteredData.hasOwnProperty('timers'));
+        assert.isTrue(filteredData.hasOwnProperty('navigationTiming'));
+        assert.isTrue(filteredData.hasOwnProperty('duration'));
+        assert.isTrue(filteredData.hasOwnProperty('context'));
+        assert.isTrue(filteredData.hasOwnProperty('service'));
+      });
+    });
+
+    describe('logEvent', function () {
+      it('adds events to output data', function () {
+        metrics.logEvent('event1');
+        metrics.logEvent('event2');
+        metrics.logEvent('event3');
+
+        var filteredData = metrics.getFilteredData();
+        assert.equal(filteredData.events.length, 3);
+        assert.equal(filteredData.events[0].type, 'event1');
+        assert.equal(filteredData.events[1].type, 'event2');
+        assert.equal(filteredData.events[2].type, 'event3');
+      });
+    });
+
+    describe('startTimer/stopTimer', function () {
+      it('adds a timer to output data', function () {
+        metrics.startTimer('timer1');
+        metrics.stopTimer('timer1');
+
+        var filteredData = metrics.getFilteredData();
+        assert.equal(filteredData.timers.timer1.length, 1);
+
+        var timerData = filteredData.timers.timer1[0];
+        assert.ok(timerData.hasOwnProperty('start'));
+        assert.ok(timerData.hasOwnProperty('stop'));
+        assert.ok(timerData.hasOwnProperty('elapsed'));
+      });
+    });
+
+    describe('flush', function () {
+      var sentData, serverError;
+
+      function ajaxMock(options) {
+        sentData = options.data;
+
+        if (serverError) {
+          options.error({}, 'bad jiji', serverError);
+        } else {
+          options.success();
+        }
+      }
+
+      beforeEach(function () {
+        metrics.destroy();
+
+        metrics = new Metrics({
+          ajax: ajaxMock,
+          window: windowMock,
+          inactivityFlushMs: 100
+        });
+        metrics.init();
+
+        sentData = serverError = null;
+      });
+
+      it('sends filtered data to the server and clears the event stream', function () {
+        metrics.logEvent('event1');
+        metrics.logEvent('event2');
+
+        return metrics.flush()
+            .then(function (data) {
+              var parsedSentData = JSON.parse(sentData);
+              assert.deepEqual(data, parsedSentData);
+
+              var events = metrics.getFilteredData().events;
+              assert.equal(events.length, 0);
+            });
+      });
+
+      it('sends filtered data to the server on window unload', function (done) {
+        metrics.logEvent('event10');
+        metrics.logEvent('event20');
+
+        var filteredData = metrics.getFilteredData();
+        metrics.on('flush:success', function () {
+          var parsedSentData = JSON.parse(sentData);
+
+          // `duration` fields are different if the above `getFilteredData`
+          // is called in a different millisecond than the one used to
+          // generate data that is sent to the server.
+          // Ensure `duration` is in the results, but do not compare the two.
+          assert.isTrue(parsedSentData.hasOwnProperty('duration'));
+
+          delete parsedSentData.duration;
+          delete filteredData.duration;
+
+          assert.deepEqual(filteredData, parsedSentData);
+
+          done();
+        });
+
+        $(windowMock).trigger('unload');
+      });
+
+      it('handles server errors', function () {
+        metrics.logEvent('event100');
+        metrics.logEvent('event200');
+
+        serverError = 'server down';
+
+        return metrics.flush()
+            .then(null, function (err) {
+              // to ensure the failure branch is called, pass the error
+              // on to the next success callback which is called on
+              // success or failure.
+              return err;
+            })
+            .then(function(err) {
+              assert.equal(err, 'server down');
+            });
+      });
+
+      it('automatically flushes after inactivityFlushMs', function (done) {
+        metrics.events.clear();
+        metrics.logEvent('event-is-autoflushed');
+
+        metrics.on('flush:success', function (sentData) {
+          assert.equal(sentData.events[0].type, 'event-is-autoflushed');
+          done();
+        });
+      });
+    });
+  });
+});

--- a/app/tests/spec/lib/null-metrics.js
+++ b/app/tests/spec/lib/null-metrics.js
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// test the metrics library
+
+define([
+  'chai',
+  'lib/null-metrics',
+  'lib/metrics'
+],
+function (chai, NullMetrics, Metrics) {
+  'use strict';
+
+  /*global describe, it*/
+  var assert = chai.assert;
+
+  describe('lib/null-metrics', function () {
+    var nullMetrics;
+
+    beforeEach(function () {
+      nullMetrics = new NullMetrics();
+    });
+
+    afterEach(function () {
+      nullMetrics = null;
+    });
+
+    it('has the same function signature as Metrics', function () {
+      for (var key in Metrics.prototype) {
+        if (typeof Metrics.prototype[key] === 'function') {
+          assert.isFunction(nullMetrics[key], key);
+        }
+      }
+    });
+
+    it('flush returns a promise', function () {
+      return nullMetrics.flush()
+        .then(function () {
+          assert.isTrue(true);
+        });
+    });
+  });
+});

--- a/app/tests/spec/lib/url.js
+++ b/app/tests/spec/lib/url.js
@@ -28,6 +28,24 @@ function (chai, _, Url) {
         assert.isUndefined(Url.searchParam('animal'));
       });
     });
+
+    describe('pathToScreenName', function () {
+      it('strips leading /', function () {
+        assert.equal(Url.pathToScreenName('/signin'), 'signin');
+      });
+
+      it('strips trailing /', function () {
+        assert.equal(Url.pathToScreenName('signup/'), 'signup');
+      });
+
+      it('leaves middle / alone', function () {
+        assert.equal(Url.pathToScreenName('/legal/tos/'), 'legal/tos');
+      });
+
+      it('strips search parameters', function () {
+        assert.equal(Url.pathToScreenName('complete_sign_up?email=testuser@testuser.com'), 'complete_sign_up');
+      });
+    });
   });
 });
 

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "requirejs-mustache": "https://github.com/jfparadis/requirejs-mustache.git#5fb8c0a3e8560526e8f9617a689e2924a8532d0a",
     "requirejs-text": "2.0.10",
     "sinon": "http://sinonjs.org/releases/sinon-1.7.1.js",
+    "speed-trap": "0.0.2",
     "tos-pp": "https://github.com/mozilla/legal-docs.git",
     "underscore": "1.5.2"
   },

--- a/server/config/awsbox.json
+++ b/server/config/awsbox.json
@@ -5,5 +5,8 @@
   "static_max_age" : 0,
   "i18n": {
     "supportedLanguages": ["af", "an", "ar", "as", "ast", "be", "bg", "bn-BD", "bn-IN", "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en-GB", "en-US", "en-ZA", "eo", "es", "es-AR", "es-CL", "es-MX", "et", "eu", "fa", "ff", "fi", "fr", "fy", "fy-NL", "ga", "ga-IE", "gd", "gl", "gu", "gu-IN", "he", "hi-IN", "hr", "ht", "hu", "hy-AM", "id", "is", "it", "it-CH", "ja", "kk", "km", "kn", "ko", "ku", "lij", "lt", "lv", "mai", "mk", "ml", "mr", "ms", "nb-NO", "ne-NP", "nl", "nn-NO", "or", "pa", "pa-IN", "pl", "pt", "pt-BR", "pt-PT", "rm", "ro", "ru", "si", "sk", "sl", "son", "sq", "sr", "sr-LATN", "sv", "sv-SE", "ta", "te", "th", "tr", "uk", "ur", "vi", "xh", "zh-CN", "zh-TW", "zu"]
+  },
+  "metrics": {
+    "sample_rate": 1
   }
 }

--- a/server/config/local.json-dist
+++ b/server/config/local.json-dist
@@ -13,5 +13,8 @@
     "supportedLanguages": ["af", "an", "ar", "as", "ast", "be", "bg", "bn-BD", "bn-IN", "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en-GB", "en-US", "en-ZA", "eo", "es", "es-AR", "es-CL", "es-MX", "et", "eu", "fa", "ff", "fi", "fr", "fy", "fy-NL", "ga", "ga-IE", "gd", "gl", "gu", "gu-IN", "he", "hi-IN", "hr", "ht", "hu", "hy-AM", "id", "is", "it", "it-CH", "ja", "kk", "km", "kn", "ko", "ku", "lij", "lt", "lv", "mai", "mk", "ml", "mr", "ms", "nb-NO", "ne-NP", "nl", "nn-NO", "or", "pa", "pa-IN", "pl", "pt", "pt-BR", "pt-PT", "rm", "ro", "ru", "si", "sk", "sl", "son", "sq", "sr", "sr-LATN", "sv", "sv-SE", "ta", "te", "th", "tr", "uk", "ur", "vi", "xh", "zh-CN", "zh-TW", "zu"]
   },
   "route_log_format": "dev_fxa",
-  "static_directory": "app"
+  "static_directory": "app",
+  "metrics": {
+    "sample_rate": 1
+  }
 }

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -159,6 +159,14 @@ var conf = module.exports = convict({
       default: 'key-value-json',
       env: 'I18N_TRANSLATION_TYPE'
     }
+  },
+  metrics: {
+    sample_rate: {
+      doc: 'Front end metrics sample rate - must be between 0 and 1',
+      format: Number,
+      default: 0,
+      env: 'METRICS_SAMPLE_RATE'
+    }
   }
 });
 

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -28,7 +28,8 @@ module.exports = function (config, templates, i18n) {
     require('./routes/get-ver.json'),
     require('./routes/get-terms-privacy')(i18n),
     require('./routes/get-config')(i18n),
-    require('./routes/get-client.json')(i18n)
+    require('./routes/get-client.json')(i18n),
+    require('./routes/post-metrics')()
   ];
 
   var authServerHost = url.parse(config.get('fxaccount_url')).hostname;

--- a/server/lib/routes/get-config.js
+++ b/server/lib/routes/get-config.js
@@ -32,7 +32,8 @@ module.exports = function(i18n) {
       fxaccountUrl: config.get('fxaccount_url'),
       oauthUrl: config.get('oauth_url'),
       // req.lang is set by abide in a previous middleware.
-      language: req.lang
+      language: req.lang,
+      metricsSampleRate: config.get('metrics.sample_rate')
     });
   };
 

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+var logger = require('intel').getLogger('server.metrics');
+
+module.exports = function() {
+  var route = {};
+
+  route.method = 'post';
+  route.path = '/metrics';
+
+  route.process = function(req, res) {
+
+    logger.info('metrics:\n%s', JSON.stringify(req.body, null, 2));
+
+    res.json({ success: true });
+  };
+
+  return route;
+};

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -16,7 +16,8 @@ define([
     'tests/server/routes',
     'tests/server/ver.json.js',
     'tests/server/cookies_disabled',
-    'tests/server/l10n'
+    'tests/server/l10n',
+    'tests/server/metrics'
   ];
 
   return intern;

--- a/tests/server/metrics.js
+++ b/tests/server/metrics.js
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../server/lib/configuration',
+  'intern/dojo/node!request'
+], function (registerSuite, assert, config, request) {
+  'use strict';
+
+  var serverUrl = config.get('public_url');
+
+  var suite = {
+    name: 'metrics'
+  };
+
+  suite['#get /config returns a `metricsSampleRate`'] = function () {
+    var dfd = this.async(1000);
+
+    request(serverUrl + '/config',
+    dfd.callback(function (err, res) {
+      var results = JSON.parse(res.body);
+
+      assert.equal(results.metricsSampleRate, config.get('metrics.sample_rate'));
+    }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#post /metrics - does nothing yet'] = function () {
+    var dfd = this.async(1000);
+
+    request.post(serverUrl + '/metrics', {
+      data: {
+        events: [ { type: 'event1', offset: 1 } ]
+      }
+    },
+    dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+    }, dfd.reject.bind(dfd)));
+  };
+
+  registerSuite(suite);
+});


### PR DESCRIPTION
- Use SpeedTrap to collect client side metrics
- Add screen views and errors to an event stream.
- Metrics are sent to the `/metrics` endpoint on document unload.
- Data that is sent to the backend is filtered - only data we expect is sent.
- auth-errors.toMessage now accepts `forceMessage`
