### PR TITLE
fix(config): set default oauth url to dev deployment

### DIFF
--- a/server/config/local.json-dist
+++ b/server/config/local.json-dist
@@ -1,5 +1,6 @@
 {
   "public_url": "http://127.0.0.1:3030",
+  "oauth_url": "http://127.0.0.1:9010",
   "client_sessions": {
     "cookie_name": "session",
     "secret": "YOU MUST CHANGE ME",

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -93,7 +93,7 @@ var conf = module.exports = convict({
   oauth_url: {
     doc: 'The url of the Firefox Account OAuth server',
     format: 'url',
-    default: 'http://127.0.0.1:9010',
+    default: 'https://oauth.dev.lcip.org',
     env: 'FXA_OAUTH_URL'
   },
   static_directory: {


### PR DESCRIPTION
Logging into https://123done.dev.lcip.org currently fails because the `oauth_url` on https://latest.dev.lcip.org points to localhost. This will fix that.
