### PR TITLE
feat(server): serve directly over https

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ besnik@programeshqip.org
 Brian Warner
 Chris Karlof
 ckarlof
+Eric Le Lay
 Jed Parsons
 John Gruen
 johngruen

--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+var fs = require('fs');
+var https = require('https');
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -99,8 +101,12 @@ function listen(theApp) {
   app = theApp || app;
   if (config.get('use_https')) {
     // Development only... Ops runs this behind nginx
-    port = 443;
-    app.listen(443);
+    port = config.get('port');
+    var tlsoptions = {
+        key: fs.readFileSync(config.get('key_path')),
+        cert: fs.readFileSync(config.get('cert_path'))
+    }
+    https.createServer(tlsoptions, app).listen(port);
     app.on('error', function (e) {
       if ('EACCES' === e.code) {
         logger.error('Permission Denied, maybe you should run this with sudo?');

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -178,6 +178,14 @@ var conf = module.exports = convict({
       default: 0,
       env: 'METRICS_SAMPLE_RATE'
     }
+  },
+  key_path: {
+      doc: 'The location of the SSL key in pem format',
+      default: path.resolve(__dirname, '..', '..','key.pem')
+  },
+  cert_path: {
+	doc: 'The location of the SSL certificate in pem format',
+	default: path.resolve(__dirname, '..', '..','cert.pem')
   }
 });
 


### PR DESCRIPTION
new config options key_path, cert_path

this eases local development against firefox, which requires
everything over https.
