### PR TITLE
Change duration given to /certification/sign to be in milliseconds.

### DIFF
--- a/app/scripts/lib/assertion.js
+++ b/app/scripts/lib/assertion.js
@@ -12,8 +12,7 @@ define([
 function (P, jwcrypto, FxaClient) {
 
   var client = new FxaClient();
-  // cert takes duration in seconds, assertion takes milliseconds. O_o
-  var CERT_DURATION_S = 60 * 60 * 6; // 6hrs
+  var CERT_DURATION_MS = 1000 * 60 * 60 * 6; // 6hrs
   var ASSERTION_DURATION_MS = 1000 * 60 * 5; // 5mins
 
   function keyPair() {
@@ -37,7 +36,7 @@ function (P, jwcrypto, FxaClient) {
       // while certSign is going over the wire, we can also sign the
       // assertion here on the machine
       return P.all([
-        client.certificateSign(kp.publicKey.toSimpleObject(), CERT_DURATION_S),
+        client.certificateSign(kp.publicKey.toSimpleObject(), CERT_DURATION_MS),
         assertion(kp.secretKey, audience)
       ]);
     });

--- a/app/tests/spec/lib/assertion.js
+++ b/app/tests/spec/lib/assertion.js
@@ -59,7 +59,9 @@ function (chai, $, P,
                 var fullAssertion = jwcrypto.cert.unbundle(assertion);
                 var components = jwcrypto.extractComponents(fullAssertion.certs[0]);
                 var assertionPublicKey = jwcrypto.loadPublicKey(JSON.stringify(components.payload['public-key']));
-                var checkDate = new Date(components.payload.exp - 1);
+                // construct the checkDate based on the assertion's expiry time, not the certificate's
+                var assertionComponents = jwcrypto.extractComponents(fullAssertion.signedAssertion);
+                var checkDate = new Date(assertionComponents.payload.exp - 1);
 
                 assert.ok(components.payload.iss, 'Issuer exists');
                 assert.ok(components.payload.iat, 'Issued date exists');


### PR DESCRIPTION
Fixes #1178. This required a slight test fix because the "checkDate" was based on the certs exp time, not the assertion part, which is now the shorter bit.

@nchapman @vladikoff r?
