### PR TITLE
chore(l10n): update strings and extraction method

### DIFF
--- a/grunttasks/l10n-extract.js
+++ b/grunttasks/l10n-extract.js
@@ -37,6 +37,7 @@ module.exports = function (grunt) {
     clientWalker.on('end', function() {
       var authWalker = extract({
         'input-dir': path.join(__dirname, '..', 'server'),
+        exclude: /pages\/dist/,
         'output-dir': messagesOutputPath,
         'output': 'server.pot',
         'join-existing': false,

--- a/locale/templates/LC_MESSAGES/client.pot
+++ b/locale/templates/LC_MESSAGES/client.pot
@@ -7,73 +7,73 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2014-05-14 23:00+0000\n"
+"POT-Creation-Date: 2014-05-13 05:41+0000\n"
 
-#: app/scripts/templates/sign_up.mustache:13
+#: app/scripts/templates/sign_up.mustache:11
 msgid "1991"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:14
+#: app/scripts/templates/sign_up.mustache:12
 msgid "1992"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:15
+#: app/scripts/templates/sign_up.mustache:13
 msgid "1993"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:16
+#: app/scripts/templates/sign_up.mustache:14
 msgid "1994"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:17
+#: app/scripts/templates/sign_up.mustache:15
 msgid "1995"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:18
+#: app/scripts/templates/sign_up.mustache:16
 msgid "1996"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:19
+#: app/scripts/templates/sign_up.mustache:17
 msgid "1997"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:20
+#: app/scripts/templates/sign_up.mustache:18
 msgid "1998"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:21
+#: app/scripts/templates/sign_up.mustache:19
 msgid "1999"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:22
+#: app/scripts/templates/sign_up.mustache:20
 msgid "2000"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:23
+#: app/scripts/templates/sign_up.mustache:21
 msgid "2001"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:24
+#: app/scripts/templates/sign_up.mustache:22
 msgid "2002"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:25
+#: app/scripts/templates/sign_up.mustache:23
 msgid "2003"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:26
+#: app/scripts/templates/sign_up.mustache:24
 msgid "2004"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:27
+#: app/scripts/templates/sign_up.mustache:25
 msgid "2005"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:28
+#: app/scripts/templates/sign_up.mustache:26
 msgid "2006"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:29
+#: app/scripts/templates/sign_up.mustache:27
 msgid "2007"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "Session expired. Sign in to continue."
 msgstr ""
 
-#: app/scripts/views/base.js:438
+#: app/scripts/views/base.js:433
 msgid "missing search parameter: %(itemName)s"
 msgstr ""
 
@@ -103,7 +103,7 @@ msgstr ""
 msgid "Passwords do not match"
 msgstr ""
 
-#: app/scripts/views/confirm.js:131
+#: app/scripts/views/confirm.js:101
 #: app/scripts/views/confirm_reset_password.js:87
 msgid "Invalid token"
 msgstr ""
@@ -133,7 +133,7 @@ msgstr ""
 #: app/scripts/lib/strings.js:23
 #: app/scripts/templates/change_password.mustache:6
 #: app/scripts/templates/complete_reset_password.mustache:14
-#: app/scripts/templates/sign_up.mustache:9
+#: app/scripts/templates/sign_up.mustache:7
 msgid "Must be at least 8 characters"
 msgstr ""
 
@@ -155,12 +155,12 @@ msgstr ""
 msgid "Signed out"
 msgstr ""
 
-#: app/scripts/views/sign_up.js:93
+#: app/scripts/views/sign_up.js:92
 #: app/scripts/lib/strings.js:24
 msgid "Year of birth required"
 msgstr ""
 
-#: app/scripts/views/sign_up.js:166
+#: app/scripts/views/sign_up.js:157
 msgid "Account already exists. <a href=\"/signin\">Sign in</a>"
 msgstr ""
 
@@ -169,7 +169,6 @@ msgid "Could not get Terms of Service"
 msgstr ""
 
 #: app/scripts/lib/auth-errors.js:44
-#: app/scripts/lib/oauth-errors.js:27
 msgid "Unexpected error"
 msgstr ""
 
@@ -215,7 +214,6 @@ msgid "Invalid JSON in request body"
 msgstr ""
 
 #: app/scripts/lib/auth-errors.js:55
-#: app/scripts/lib/oauth-errors.js:31
 msgid "Invalid parameter in request body: %(param)s"
 msgstr ""
 
@@ -224,7 +222,6 @@ msgid "Missing parameter in request body: %(param)s"
 msgstr ""
 
 #: app/scripts/lib/auth-errors.js:57
-#: app/scripts/lib/oauth-errors.js:32
 msgid "Invalid request signature"
 msgstr ""
 
@@ -250,18 +247,6 @@ msgstr ""
 
 #: app/scripts/lib/auth-errors.js:63
 msgid "This endpoint is no longer supported"
-msgstr ""
-
-#: app/scripts/lib/oauth-errors.js:28
-msgid "Unknown client"
-msgstr ""
-
-#: app/scripts/lib/oauth-errors.js:29
-msgid "Incorrect redirect_uri"
-msgstr ""
-
-#: app/scripts/lib/oauth-errors.js:30
-msgid "Invalid assertion"
 msgstr ""
 
 #: app/scripts/lib/service-name.js:16
@@ -331,8 +316,8 @@ msgstr ""
 #: app/scripts/templates/complete_reset_password.mustache:13
 #: app/scripts/templates/delete_account.mustache:4
 #: app/scripts/templates/force_auth.mustache:5
-#: app/scripts/templates/sign_in.mustache:7
-#: app/scripts/templates/sign_up.mustache:8
+#: app/scripts/templates/sign_in.mustache:5
+#: app/scripts/templates/sign_up.mustache:6
 msgid "Show"
 msgstr ""
 
@@ -394,7 +379,7 @@ msgstr ""
 
 #: app/scripts/templates/complete_reset_password.mustache:15
 #: app/scripts/templates/reset_password.mustache:4
-#: app/scripts/templates/sign_up.mustache:31
+#: app/scripts/templates/sign_up.mustache:29
 msgid "Next"
 msgstr ""
 
@@ -431,8 +416,8 @@ msgstr ""
 #: app/scripts/templates/confirm_reset_password.mustache:5
 #: app/scripts/templates/confirm_reset_password.mustache:7
 #: app/scripts/templates/force_auth.mustache:6
-#: app/scripts/templates/sign_in.mustache:3
-#: app/scripts/templates/sign_in.mustache:8
+#: app/scripts/templates/sign_in.mustache:1
+#: app/scripts/templates/sign_in.mustache:6
 msgid "Sign in"
 msgstr ""
 
@@ -467,8 +452,8 @@ msgstr ""
 
 #: app/scripts/templates/delete_account.mustache:3
 #: app/scripts/templates/force_auth.mustache:3
-#: app/scripts/templates/sign_in.mustache:5
-#: app/scripts/templates/sign_up.mustache:6
+#: app/scripts/templates/sign_in.mustache:3
+#: app/scripts/templates/sign_up.mustache:4
 msgid "Password"
 msgstr ""
 
@@ -477,13 +462,13 @@ msgid "Sign in to continue"
 msgstr ""
 
 #: app/scripts/templates/force_auth.mustache:7
-#: app/scripts/templates/sign_in.mustache:9
+#: app/scripts/templates/sign_in.mustache:7
 msgid "Forgot password?"
 msgstr ""
 
 #: app/scripts/templates/force_auth.mustache:8
-#: app/scripts/templates/sign_in.mustache:11
-#: app/scripts/templates/sign_up.mustache:30
+#: app/scripts/templates/sign_in.mustache:9
+#: app/scripts/templates/sign_up.mustache:28
 msgid ""
 "By proceeding, I agree to the <a id=\"fxa-tos\" href=\"/legal/terms\">Terms "
 "of Service</a> and <a id=\"fxa-pp\" href=\"/legal/privacy\">Privacy "
@@ -547,8 +532,8 @@ msgid "Enter your email to reset&nbsp;the account password."
 msgstr ""
 
 #: app/scripts/templates/reset_password.mustache:3
-#: app/scripts/templates/sign_in.mustache:4
-#: app/scripts/templates/sign_up.mustache:4
+#: app/scripts/templates/sign_in.mustache:2
+#: app/scripts/templates/sign_up.mustache:2
 msgid "Email"
 msgstr ""
 
@@ -564,34 +549,26 @@ msgstr ""
 msgid "Sign out"
 msgstr ""
 
-#: app/scripts/templates/sign_in.mustache:1
-msgid "Sign in to %(serviceName)s"
-msgstr ""
-
-#: app/scripts/templates/sign_in.mustache:10
+#: app/scripts/templates/sign_in.mustache:8
 msgid "Create an account"
 msgstr ""
 
 #: app/scripts/templates/sign_up.mustache:1
-msgid "Create a Firefox Account for %(serviceName)s"
-msgstr ""
-
-#: app/scripts/templates/sign_up.mustache:3
 msgid "Create a Firefox Account"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:11
+#: app/scripts/templates/sign_up.mustache:9
 msgid "Year of birth"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:12
+#: app/scripts/templates/sign_up.mustache:10
 msgid "1990 or earlier"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:32
+#: app/scripts/templates/sign_up.mustache:30
 msgid "Choose what to sync"
 msgstr ""
 
-#: app/scripts/templates/sign_up.mustache:34
+#: app/scripts/templates/sign_up.mustache:32
 msgid "Already have an account? Sign in."
 msgstr ""

--- a/locale/templates/LC_MESSAGES/server.pot
+++ b/locale/templates/LC_MESSAGES/server.pot
@@ -7,7 +7,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2014-05-14 23:00+0000\n"
+"POT-Creation-Date: 2014-05-13 05:41+0000\n"
 
 #: server/templates/pages/src/404.html:1
 #: server/templates/pages/src/500.html:1

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,38 +1,46 @@
 {
   "name": "fxa-content-server",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "dependencies": {
     "bluebird": {
       "version": "1.2.4",
-      "from": "bluebird@1.2.4"
+      "from": "bluebird@1.2.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz"
     },
     "bower": {
       "version": "1.3.3",
       "from": "bower@1.3.3",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.3.tgz",
       "dependencies": {
         "abbrev": {
           "version": "1.0.5",
-          "from": "abbrev@~1.0.4"
+          "from": "abbrev@1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
         },
         "archy": {
           "version": "0.0.2",
-          "from": "archy@~0.0.2"
+          "from": "archy@0.0.2",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz"
         },
         "bower-config": {
           "version": "0.5.1",
-          "from": "bower-config@~0.5.0",
+          "from": "bower-config@0.5.1",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.1.tgz",
           "dependencies": {
             "optimist": {
               "version": "0.6.1",
-              "from": "optimist@~0.6.0",
+              "from": "optimist@0.6.1",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@~0.0.2"
+                  "from": "wordwrap@0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@~0.0.1"
+                  "from": "minimist@0.0.10",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             }
@@ -40,130 +48,159 @@
         },
         "bower-endpoint-parser": {
           "version": "0.2.1",
-          "from": "bower-endpoint-parser@~0.2.0"
+          "from": "bower-endpoint-parser@0.2.1",
+          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.1.tgz"
         },
         "bower-json": {
           "version": "0.4.0",
-          "from": "bower-json@~0.4.0",
+          "from": "bower-json@0.4.0",
+          "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
           "dependencies": {
             "deep-extend": {
               "version": "0.2.8",
-              "from": "deep-extend@~0.2.5"
+              "from": "deep-extend@0.2.8",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.8.tgz"
             },
             "intersect": {
               "version": "0.0.3",
-              "from": "intersect@~0.0.3"
+              "from": "intersect@0.0.3",
+              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
             }
           }
         },
         "bower-logger": {
           "version": "0.2.2",
-          "from": "bower-logger@~0.2.2"
+          "from": "bower-logger@0.2.2",
+          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
         },
         "bower-registry-client": {
           "version": "0.2.1",
-          "from": "bower-registry-client@~0.2.0",
+          "from": "bower-registry-client@0.2.1",
+          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.1.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.8"
+              "from": "async@0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "lru-cache": {
               "version": "2.3.1",
-              "from": "lru-cache@~2.3.0"
+              "from": "lru-cache@2.3.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
             },
             "request": {
               "version": "2.27.0",
-              "from": "request@~2.27.0",
+              "from": "request@2.27.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
               "dependencies": {
                 "qs": {
                   "version": "0.6.6",
-                  "from": "qs@~0.6.0"
+                  "from": "qs@0.6.6",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0"
+                  "from": "json-stringify-safe@5.0.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0"
+                  "from": "forever-agent@0.5.2",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.3.0",
-                  "from": "tunnel-agent@~0.3.0"
+                  "from": "tunnel-agent@0.3.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.0",
-                  "from": "http-signature@~0.10.0",
+                  "from": "http-signature@0.10.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.2",
-                      "from": "assert-plus@0.1.2"
+                      "from": "assert-plus@0.1.2",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11"
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.2",
-                      "from": "ctype@0.5.2"
+                      "from": "ctype@0.5.2",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
                     }
                   }
                 },
                 "hawk": {
                   "version": "1.0.0",
-                  "from": "hawk@~1.0.0",
+                  "from": "hawk@1.0.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@0.9.x"
+                      "from": "hoek@0.9.1",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@0.4.x"
+                      "from": "boom@0.4.2",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@0.2.x"
+                      "from": "cryptiles@0.2.2",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@0.2.x"
+                      "from": "sntp@0.2.4",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign": {
                   "version": "0.3.0",
-                  "from": "aws-sign@~0.3.0"
+                  "from": "aws-sign@0.3.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.3.0",
-                  "from": "oauth-sign@~0.3.0"
+                  "from": "oauth-sign@0.3.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
                 },
                 "cookie-jar": {
                   "version": "0.3.0",
-                  "from": "cookie-jar@~0.3.0"
+                  "from": "cookie-jar@0.3.0",
+                  "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.1",
-                  "from": "node-uuid@~1.4.0"
+                  "from": "node-uuid@1.4.1",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@~1.2.9",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "form-data": {
                   "version": "0.1.2",
-                  "from": "form-data@~0.1.0",
+                  "from": "form-data@0.1.2",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.4",
-                      "from": "combined-stream@~0.0.4",
+                      "from": "combined-stream@0.0.4",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5"
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     }
@@ -173,110 +210,132 @@
             },
             "request-replay": {
               "version": "0.2.0",
-              "from": "request-replay@~0.2.0"
+              "from": "request-replay@0.2.0",
+              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
             }
           }
         },
         "cardinal": {
           "version": "0.4.4",
-          "from": "cardinal@~0.4.0",
+          "from": "cardinal@0.4.4",
+          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
           "dependencies": {
             "redeyed": {
               "version": "0.4.4",
-              "from": "redeyed@~0.4.0",
+              "from": "redeyed@0.4.4",
+              "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
               "dependencies": {
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@~1.0.4"
+                  "from": "esprima@1.0.4",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
             },
             "ansicolors": {
               "version": "0.2.1",
-              "from": "ansicolors@~0.2.1"
+              "from": "ansicolors@0.2.1",
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
             }
           }
         },
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "chmodr": {
           "version": "0.1.0",
-          "from": "chmodr@~0.1.0"
+          "from": "chmodr@0.1.0",
+          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
         },
         "decompress-zip": {
           "version": "0.0.7",
-          "from": "decompress-zip@~0.0.6",
+          "from": "decompress-zip@0.0.7",
+          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.7.tgz",
           "dependencies": {
             "mkpath": {
               "version": "0.1.0",
-              "from": "mkpath@~0.1.0"
+              "from": "mkpath@0.1.0",
+              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
             },
             "binary": {
               "version": "0.3.0",
-              "from": "binary@~0.3.0",
+              "from": "binary@0.3.0",
+              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
               "dependencies": {
                 "chainsaw": {
                   "version": "0.1.0",
-                  "from": "chainsaw@~0.1.0",
+                  "from": "chainsaw@0.1.0",
+                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.3.9",
-                      "from": "traverse@>=0.3.0 <0.4"
+                      "from": "traverse@0.3.9",
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                     }
                   }
                 },
                 "buffers": {
                   "version": "0.1.1",
-                  "from": "buffers@~0.1.1"
+                  "from": "buffers@0.1.1",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                 }
               }
             },
             "touch": {
               "version": "0.0.2",
               "from": "touch@0.0.2",
+              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "1.0.10",
-                  "from": "nopt@~1.0.10"
+                  "from": "nopt@1.0.10",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "1.1.13-1",
-              "from": "readable-stream@~1.1.8",
+              "from": "readable-stream@1.1.13-1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0"
+                  "from": "core-util-is@1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1"
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.25-1",
-                  "from": "string_decoder@~0.10.x"
+                  "from": "string_decoder@0.10.25-1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1"
+                  "from": "inherits@2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
@@ -284,29 +343,35 @@
         },
         "fstream": {
           "version": "0.1.25",
-          "from": "fstream@~0.1.22",
+          "from": "fstream@0.1.25",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1"
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "fstream-ignore": {
           "version": "0.0.8",
-          "from": "fstream-ignore@~0.0.6",
+          "from": "fstream-ignore@0.0.8",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.8.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2"
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@^0.3.0",
+              "from": "minimatch@0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0"
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             }
@@ -314,19 +379,23 @@
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@~3.2.9",
+          "from": "glob@~3.2.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1"
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@0.3",
+              "from": "minimatch@0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0"
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             }
@@ -334,39 +403,48 @@
         },
         "graceful-fs": {
           "version": "2.0.3",
-          "from": "graceful-fs@~2.0.0"
+          "from": "graceful-fs@2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
         },
         "inquirer": {
           "version": "0.4.1",
-          "from": "inquirer@~0.4.0",
+          "from": "inquirer@0.4.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.4.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.6"
+              "from": "async@0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "cli-color": {
               "version": "0.2.3",
-              "from": "cli-color@~0.2.2",
+              "from": "cli-color@0.2.3",
+              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
               "dependencies": {
                 "es5-ext": {
                   "version": "0.9.2",
-                  "from": "es5-ext@~0.9.2"
+                  "from": "es5-ext@0.9.2",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
                 },
                 "memoizee": {
                   "version": "0.2.6",
-                  "from": "memoizee@~0.2.5",
+                  "from": "memoizee@0.2.6",
+                  "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
                   "dependencies": {
                     "event-emitter": {
                       "version": "0.2.2",
-                      "from": "event-emitter@~0.2.2"
+                      "from": "event-emitter@0.2.2",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                     },
                     "next-tick": {
                       "version": "0.1.0",
-                      "from": "next-tick@0.1.x"
+                      "from": "next-tick@0.1.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                     }
                   }
                 }
@@ -374,114 +452,139 @@
             },
             "mute-stream": {
               "version": "0.0.4",
-              "from": "mute-stream@0.0.4"
+              "from": "mute-stream@0.0.4",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
             },
             "through": {
               "version": "2.3.4",
-              "from": "through@~2.3.4"
+              "from": "through@2.3.4",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.4.tgz"
             },
             "readline2": {
               "version": "0.1.0",
-              "from": "readline2@~0.1.0"
+              "from": "readline2@0.1.0",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.0.tgz"
             }
           }
         },
         "insight": {
           "version": "0.3.1",
-          "from": "insight@~0.3.0",
+          "from": "insight@0.3.1",
+          "resolved": "https://registry.npmjs.org/insight/-/insight-0.3.1.tgz",
           "dependencies": {
             "request": {
               "version": "2.27.0",
-              "from": "request@~2.27.0",
+              "from": "request@2.27.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
               "dependencies": {
                 "qs": {
                   "version": "0.6.6",
-                  "from": "qs@~0.6.0"
+                  "from": "qs@0.6.6",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0"
+                  "from": "json-stringify-safe@5.0.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0"
+                  "from": "forever-agent@0.5.2",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.3.0",
-                  "from": "tunnel-agent@~0.3.0"
+                  "from": "tunnel-agent@0.3.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.0",
-                  "from": "http-signature@~0.10.0",
+                  "from": "http-signature@0.10.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.2",
-                      "from": "assert-plus@0.1.2"
+                      "from": "assert-plus@0.1.2",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11"
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.2",
-                      "from": "ctype@0.5.2"
+                      "from": "ctype@0.5.2",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
                     }
                   }
                 },
                 "hawk": {
                   "version": "1.0.0",
-                  "from": "hawk@~1.0.0",
+                  "from": "hawk@1.0.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@0.9.x"
+                      "from": "hoek@0.9.1",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@0.4.x"
+                      "from": "boom@0.4.2",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@0.2.x"
+                      "from": "cryptiles@0.2.2",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@0.2.x"
+                      "from": "sntp@0.2.4",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign": {
                   "version": "0.3.0",
-                  "from": "aws-sign@~0.3.0"
+                  "from": "aws-sign@0.3.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.3.0",
-                  "from": "oauth-sign@~0.3.0"
+                  "from": "oauth-sign@0.3.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
                 },
                 "cookie-jar": {
                   "version": "0.3.0",
-                  "from": "cookie-jar@~0.3.0"
+                  "from": "cookie-jar@0.3.0",
+                  "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.1",
-                  "from": "node-uuid@~1.4.0"
+                  "from": "node-uuid@1.4.1",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@~1.2.9",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "form-data": {
                   "version": "0.1.2",
-                  "from": "form-data@~0.1.0",
+                  "from": "form-data@0.1.2",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.4",
-                      "from": "combined-stream@~0.0.4",
+                      "from": "combined-stream@0.0.4",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5"
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     }
@@ -491,71 +594,86 @@
             },
             "configstore": {
               "version": "0.2.3",
-              "from": "configstore@~0.2.1",
+              "from": "configstore@0.2.3",
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.2.3.tgz",
               "dependencies": {
                 "js-yaml": {
                   "version": "3.0.2",
-                  "from": "js-yaml@~3.0.1",
+                  "from": "js-yaml@3.0.2",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "0.1.15",
-                      "from": "argparse@~ 0.1.11",
+                      "from": "argparse@0.1.15",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
                       "dependencies": {
                         "underscore": {
                           "version": "1.4.4",
-                          "from": "underscore@~1.4.3"
+                          "from": "underscore@~1.4.4",
+                          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                         },
                         "underscore.string": {
                           "version": "2.3.3",
-                          "from": "underscore.string@~2.3.1"
+                          "from": "underscore.string@2.3.3",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "esprima@~ 1.0.2"
+                      "from": "esprima@1.0.4",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     }
                   }
                 },
                 "uuid": {
                   "version": "1.4.1",
-                  "from": "uuid@~1.4.1"
+                  "from": "uuid@1.4.1",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                 }
               }
             },
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.9"
+              "from": "async@0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "object-assign": {
               "version": "0.1.2",
-              "from": "object-assign@~0.1.2"
+              "from": "object-assign@0.1.2",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.1.2.tgz"
             },
             "lodash.debounce": {
               "version": "2.4.1",
-              "from": "lodash.debounce@~2.4.1",
+              "from": "lodash.debounce@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
               "dependencies": {
                 "lodash.isfunction": {
                   "version": "2.4.1",
-                  "from": "lodash.isfunction@~2.4.1"
+                  "from": "lodash.isfunction@2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
                 },
                 "lodash.isobject": {
                   "version": "2.4.1",
-                  "from": "lodash.isobject@~2.4.1",
+                  "from": "lodash.isobject@2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                   "dependencies": {
                     "lodash._objecttypes": {
                       "version": "2.4.1",
-                      "from": "lodash._objecttypes@~2.4.1"
+                      "from": "lodash._objecttypes@2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                     }
                   }
                 },
                 "lodash.now": {
                   "version": "2.4.1",
-                  "from": "lodash.now@~2.4.1",
+                  "from": "lodash.now@2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "2.4.1",
-                      "from": "lodash._isnative@~2.4.1"
+                      "from": "lodash._isnative@2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     }
                   }
                 }
@@ -565,61 +683,75 @@
         },
         "is-root": {
           "version": "0.1.0",
-          "from": "is-root@~0.1.0"
+          "from": "is-root@0.1.0",
+          "resolved": "https://registry.npmjs.org/is-root/-/is-root-0.1.0.tgz"
         },
         "junk": {
           "version": "0.3.0",
-          "from": "junk@~0.3.0"
+          "from": "junk@0.3.0",
+          "resolved": "https://registry.npmjs.org/junk/-/junk-0.3.0.tgz"
         },
         "lockfile": {
           "version": "0.4.2",
-          "from": "lockfile@~0.4.2"
+          "from": "lockfile@0.4.2",
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-0.4.2.tgz"
         },
         "lru-cache": {
           "version": "2.5.0",
-          "from": "lru-cache@2"
+          "from": "lru-cache@2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
         },
         "mkdirp": {
           "version": "0.3.5",
-          "from": "mkdirp@~0.3.5"
+          "from": "mkdirp@0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
         },
         "mout": {
           "version": "0.9.1",
-          "from": "mout@~0.9.1"
+          "from": "mout@0.9.1",
+          "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
         },
         "nopt": {
           "version": "2.2.1",
-          "from": "nopt@~2.2.0"
+          "from": "nopt@2.2.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz"
         },
         "opn": {
           "version": "0.1.2",
-          "from": "opn@~0.1.1"
+          "from": "opn@0.1.2",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-0.1.2.tgz"
         },
         "osenv": {
           "version": "0.0.3",
-          "from": "osenv@~0.0.3"
+          "from": "osenv@0.0.3",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
         },
         "p-throttler": {
           "version": "0.0.1",
-          "from": "p-throttler@~0.0.1",
+          "from": "p-throttler@0.0.1",
+          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.0.1.tgz",
           "dependencies": {
             "q": {
               "version": "0.9.7",
-              "from": "q@~0.9.2"
+              "from": "q@0.9.7",
+              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
             }
           }
         },
         "promptly": {
           "version": "0.2.0",
-          "from": "promptly@~0.2.0",
+          "from": "promptly@0.2.0",
+          "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
           "dependencies": {
             "read": {
               "version": "1.0.5",
-              "from": "read@~1.0.4",
+              "from": "read@1.0.5",
+              "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.4",
-                  "from": "mute-stream@~0.0.4"
+                  "from": "mute-stream@0.0.4",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                 }
               }
             }
@@ -627,176 +759,215 @@
         },
         "q": {
           "version": "1.0.1",
-          "from": "q@~1.0.1"
+          "from": "q@1.0.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
         },
         "request-progress": {
           "version": "0.3.1",
-          "from": "request-progress@~0.3.0",
+          "from": "request-progress@0.3.1",
+          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
           "dependencies": {
             "throttleit": {
               "version": "0.0.2",
-              "from": "throttleit@~0.0.2"
+              "from": "throttleit@0.0.2",
+              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
             }
           }
         },
         "retry": {
           "version": "0.6.0",
-          "from": "retry@~0.6.0"
+          "from": "retry@0.6.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.0"
+          "from": "rimraf@2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "semver": {
           "version": "2.2.1",
-          "from": "semver@~2.2.1"
+          "from": "semver@2.2.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
         },
         "shell-quote": {
           "version": "1.4.1",
-          "from": "shell-quote@~1.4.1",
+          "from": "shell-quote@1.4.1",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.1.tgz",
           "dependencies": {
             "jsonify": {
               "version": "0.0.0",
-              "from": "jsonify@~0.0.0"
+              "from": "jsonify@0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             },
             "array-filter": {
               "version": "0.0.1",
-              "from": "array-filter@~0.0.0"
+              "from": "array-filter@0.0.1",
+              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
             },
             "array-reduce": {
               "version": "0.0.0",
-              "from": "array-reduce@~0.0.0"
+              "from": "array-reduce@0.0.0",
+              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
             },
             "array-map": {
               "version": "0.0.0",
-              "from": "array-map@~0.0.0"
+              "from": "array-map@0.0.0",
+              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
             }
           }
         },
         "stringify-object": {
           "version": "0.2.1",
-          "from": "stringify-object@~0.2.0"
+          "from": "stringify-object@0.2.1",
+          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-0.2.1.tgz"
         },
         "tar": {
           "version": "0.1.19",
-          "from": "tar@~0.1.17",
+          "from": "tar@0.1.19",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2"
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "block-stream": {
               "version": "0.0.7",
-              "from": "block-stream@*"
+              "from": "block-stream@0.0.7",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
             }
           }
         },
         "tmp": {
           "version": "0.0.23",
-          "from": "tmp@~0.0.20"
+          "from": "tmp@0.0.23",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
         },
         "update-notifier": {
           "version": "0.1.8",
-          "from": "update-notifier@~0.1.8",
+          "from": "update-notifier@0.1.8",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.8.tgz",
           "dependencies": {
             "request": {
               "version": "2.27.0",
-              "from": "request@~2.27.0",
+              "from": "request@2.27.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
               "dependencies": {
                 "qs": {
                   "version": "0.6.6",
-                  "from": "qs@~0.6.0"
+                  "from": "qs@0.6.6",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0"
+                  "from": "json-stringify-safe@5.0.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0"
+                  "from": "forever-agent@0.5.2",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.3.0",
-                  "from": "tunnel-agent@~0.3.0"
+                  "from": "tunnel-agent@0.3.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.0",
-                  "from": "http-signature@~0.10.0",
+                  "from": "http-signature@0.10.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.2",
-                      "from": "assert-plus@0.1.2"
+                      "from": "assert-plus@0.1.2",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11"
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.2",
-                      "from": "ctype@0.5.2"
+                      "from": "ctype@0.5.2",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
                     }
                   }
                 },
                 "hawk": {
                   "version": "1.0.0",
-                  "from": "hawk@~1.0.0",
+                  "from": "hawk@1.0.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@0.9.x"
+                      "from": "hoek@0.9.1",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@0.4.x"
+                      "from": "boom@0.4.2",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@0.2.x"
+                      "from": "cryptiles@0.2.2",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@0.2.x"
+                      "from": "sntp@0.2.4",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign": {
                   "version": "0.3.0",
-                  "from": "aws-sign@~0.3.0"
+                  "from": "aws-sign@0.3.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.3.0",
-                  "from": "oauth-sign@~0.3.0"
+                  "from": "oauth-sign@0.3.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
                 },
                 "cookie-jar": {
                   "version": "0.3.0",
-                  "from": "cookie-jar@~0.3.0"
+                  "from": "cookie-jar@0.3.0",
+                  "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.1",
-                  "from": "node-uuid@~1.4.0"
+                  "from": "node-uuid@1.4.1",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@~1.2.9",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "form-data": {
                   "version": "0.1.2",
-                  "from": "form-data@~0.1.0",
+                  "from": "form-data@0.1.2",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.4",
-                      "from": "combined-stream@~0.0.4",
+                      "from": "combined-stream@0.0.4",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5"
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     },
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@~0.2.9"
+                      "from": "async@0.2.10",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     }
                   }
                 }
@@ -804,105 +975,127 @@
             },
             "configstore": {
               "version": "0.2.3",
-              "from": "configstore@~0.2.1",
+              "from": "configstore@0.2.3",
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.2.3.tgz",
               "dependencies": {
                 "js-yaml": {
                   "version": "3.0.2",
-                  "from": "js-yaml@~3.0.1",
+                  "from": "js-yaml@3.0.2",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "0.1.15",
-                      "from": "argparse@~ 0.1.11",
+                      "from": "argparse@0.1.15",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
                       "dependencies": {
                         "underscore": {
                           "version": "1.4.4",
-                          "from": "underscore@~1.4.3"
+                          "from": "underscore@1.4.4",
+                          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                         },
                         "underscore.string": {
                           "version": "2.3.3",
-                          "from": "underscore.string@~2.3.1"
+                          "from": "underscore.string@2.3.3",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "esprima@~1.0.4"
+                      "from": "esprima@1.0.4",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     }
                   }
                 },
                 "uuid": {
                   "version": "1.4.1",
-                  "from": "uuid@~1.4.1"
+                  "from": "uuid@1.4.1",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                 },
                 "object-assign": {
                   "version": "0.1.2",
-                  "from": "object-assign@~0.1.1"
+                  "from": "object-assign@0.1.2",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.1.2.tgz"
                 }
               }
             },
             "semver": {
               "version": "2.1.0",
-              "from": "semver@~2.1.0"
+              "from": "semver@2.1.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz"
             }
           }
         },
         "which": {
           "version": "1.0.5",
-          "from": "which@~1.0.5"
+          "from": "which@1.0.5",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
         }
       }
     },
     "connect-cachify": {
       "version": "0.0.17",
       "from": "connect-cachify@0.0.17",
+      "resolved": "https://registry.npmjs.org/connect-cachify/-/connect-cachify-0.0.17.tgz",
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@>=1.3.1"
+          "from": "underscore@1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
     },
     "connect-fonts-clearsans": {
       "version": "0.0.1",
-      "from": "connect-fonts-clearsans@0.0.1"
+      "from": "connect-fonts-clearsans@0.0.1",
+      "resolved": "https://registry.npmjs.org/connect-fonts-clearsans/-/connect-fonts-clearsans-0.0.1.tgz"
     },
     "connect-fonts-firasans": {
       "version": "0.0.2",
-      "from": "connect-fonts-firasans@0.0.2"
+      "from": "connect-fonts-firasans@0.0.2",
+      "resolved": "https://registry.npmjs.org/connect-fonts-firasans/-/connect-fonts-firasans-0.0.2.tgz"
     },
     "consolidate": {
       "version": "0.10.0",
-      "from": "consolidate@0.10.0"
+      "from": "consolidate@0.10.0",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.10.0.tgz"
     },
     "convict": {
       "version": "0.4.2",
       "from": "convict@0.4.2",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-0.4.2.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
           "from": "cjson@0.3.0",
+          "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
               "from": "jsonlint@1.6.0",
+              "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.6.2",
-                  "from": "nomnom@>= 1.5.x",
+                  "from": "nomnom@1.6.2",
+                  "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
                   "dependencies": {
                     "colors": {
                       "version": "0.5.1",
-                      "from": "colors@0.5.x"
+                      "from": "colors@0.5.x",
+                      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                     },
                     "underscore": {
                       "version": "1.4.4",
-                      "from": "underscore@~1.4.4"
+                      "from": "underscore@~1.4.4",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                     }
                   }
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>= 4.0.x"
+                  "from": "JSV@>= 4.0.x",
+                  "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
             }
@@ -910,23 +1103,28 @@
         },
         "validator": {
           "version": "1.5.1",
-          "from": "validator@1.5.1"
+          "from": "validator@1.5.1",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-1.5.1.tgz"
         },
         "moment": {
           "version": "2.3.1",
-          "from": "moment@2.3.1"
+          "from": "moment@2.3.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.3.1.tgz"
         },
         "optimist": {
           "version": "0.6.0",
           "from": "optimist@0.6.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2"
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1"
+              "from": "minimist@0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         }
@@ -935,164 +1133,201 @@
     "express": {
       "version": "3.6.0",
       "from": "express@3.6.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-3.6.0.tgz",
       "dependencies": {
         "connect": {
           "version": "2.15.0",
           "from": "connect@2.15.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.15.0.tgz",
           "dependencies": {
             "basic-auth-connect": {
               "version": "1.0.0",
-              "from": "basic-auth-connect@1.0.0"
+              "from": "basic-auth-connect@1.0.0",
+              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
             },
             "cookie-parser": {
               "version": "1.0.1",
               "from": "cookie-parser@1.0.1",
+              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.0.1.tgz",
               "dependencies": {
                 "cookie": {
                   "version": "0.1.0",
-                  "from": "cookie@0.1.0"
+                  "from": "cookie@0.1.0",
+                  "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
                 }
               }
             },
             "compression": {
               "version": "1.0.2",
               "from": "compression@1.0.2",
+              "resolved": "https://registry.npmjs.org/compression/-/compression-1.0.2.tgz",
               "dependencies": {
                 "negotiator": {
                   "version": "0.4.3",
-                  "from": "negotiator@0.4.3"
+                  "from": "negotiator@0.4.3",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.3.tgz"
                 },
                 "compressible": {
                   "version": "1.0.1",
-                  "from": "compressible@1.0.1"
+                  "from": "compressible@1.0.1",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-1.0.1.tgz"
                 }
               }
             },
             "connect-timeout": {
               "version": "1.1.0",
-              "from": "connect-timeout@1.1.0"
+              "from": "connect-timeout@1.1.0",
+              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.1.0.tgz"
             },
             "csurf": {
               "version": "1.1.0",
               "from": "csurf@1.1.0",
+              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.1.0.tgz",
               "dependencies": {
                 "uid2": {
                   "version": "0.0.3",
-                  "from": "uid2@~0.0.2"
+                  "from": "uid2@0.0.3",
+                  "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
                 },
                 "scmp": {
                   "version": "0.0.3",
-                  "from": "scmp@~0.0.3"
+                  "from": "scmp@0.0.3",
+                  "resolved": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz"
                 }
               }
             },
             "errorhandler": {
               "version": "1.0.1",
-              "from": "errorhandler@1.0.1"
+              "from": "errorhandler@1.0.1",
+              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.0.1.tgz"
             },
             "express-session": {
               "version": "1.0.4",
               "from": "express-session@1.0.4",
+              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.0.4.tgz",
               "dependencies": {
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "utils-merge@1.0.0"
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 },
                 "uid2": {
                   "version": "0.0.3",
-                  "from": "uid2@~0.0.2"
+                  "from": "uid2@0.0.3",
+                  "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
                 }
               }
             },
             "method-override": {
               "version": "1.0.0",
-              "from": "method-override@1.0.0"
+              "from": "method-override@1.0.0",
+              "resolved": "https://registry.npmjs.org/method-override/-/method-override-1.0.0.tgz"
             },
             "morgan": {
               "version": "1.0.1",
-              "from": "morgan@1.0.1"
+              "from": "morgan@1.0.1",
+              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.0.1.tgz"
             },
             "qs": {
               "version": "0.6.6",
-              "from": "qs@0.6.6"
+              "from": "qs@0.6.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
             },
             "raw-body": {
               "version": "1.1.4",
-              "from": "raw-body@1.1.4"
+              "from": "raw-body@1.1.4",
+              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.4.tgz"
             },
             "response-time": {
               "version": "1.0.0",
-              "from": "response-time@1.0.0"
+              "from": "response-time@1.0.0",
+              "resolved": "https://registry.npmjs.org/response-time/-/response-time-1.0.0.tgz"
             },
             "serve-favicon": {
               "version": "2.0.0",
-              "from": "serve-favicon@2.0.0"
+              "from": "serve-favicon@2.0.0",
+              "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.0.0.tgz"
             },
             "serve-index": {
               "version": "1.0.2",
               "from": "serve-index@1.0.2",
+              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.2.tgz",
               "dependencies": {
                 "batch": {
                   "version": "0.5.0",
-                  "from": "batch@0.5.0"
+                  "from": "batch@0.5.0",
+                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
                 },
                 "negotiator": {
                   "version": "0.4.3",
-                  "from": "negotiator@0.4.3"
+                  "from": "negotiator@0.4.3",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.3.tgz"
                 }
               }
             },
             "serve-static": {
               "version": "1.1.0",
               "from": "serve-static@1.1.0",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz",
               "dependencies": {
                 "parseurl": {
                   "version": "1.0.1",
-                  "from": "parseurl@1.0.1"
+                  "from": "parseurl@1.0.1",
+                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
                 }
               }
             },
             "vhost": {
               "version": "1.0.0",
-              "from": "vhost@1.0.0"
+              "from": "vhost@1.0.0",
+              "resolved": "https://registry.npmjs.org/vhost/-/vhost-1.0.0.tgz"
             },
             "bytes": {
               "version": "0.3.0",
-              "from": "bytes@0.3.0"
+              "from": "bytes@0.3.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz"
             },
             "pause": {
               "version": "0.0.1",
-              "from": "pause@0.0.1"
+              "from": "pause@0.0.1",
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
             },
             "multiparty": {
               "version": "2.2.0",
               "from": "multiparty@2.2.0",
+              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13-1",
-                  "from": "readable-stream@~1.1.9",
+                  "from": "readable-stream@1.1.13-1",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0"
+                      "from": "core-util-is@1.0.1",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1"
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.25-1",
-                      "from": "string_decoder@~0.10.x"
+                      "from": "string_decoder@0.10.25-1",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1"
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "stream-counter": {
                   "version": "0.2.0",
-                  "from": "stream-counter@~0.2.0"
+                  "from": "stream-counter@0.2.0",
+                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
                 }
               }
             }
@@ -1101,109 +1336,133 @@
         "commander": {
           "version": "1.3.2",
           "from": "commander@1.3.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
           "dependencies": {
             "keypress": {
               "version": "0.1.0",
-              "from": "keypress@0.1.x"
+              "from": "keypress@0.1.0",
+              "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
             }
           }
         },
         "methods": {
           "version": "1.0.0",
-          "from": "methods@1.0.0"
+          "from": "methods@1.0.0",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.0.tgz"
         },
         "range-parser": {
           "version": "1.0.0",
-          "from": "range-parser@1.0.0"
+          "from": "range-parser@1.0.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
         },
         "cookie": {
           "version": "0.1.2",
-          "from": "cookie@0.1.2"
+          "from": "cookie@0.1.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
         },
         "buffer-crc32": {
           "version": "0.2.1",
-          "from": "buffer-crc32@0.2.1"
+          "from": "buffer-crc32@0.2.1",
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
         },
         "fresh": {
           "version": "0.2.2",
-          "from": "fresh@0.2.2"
+          "from": "fresh@0.2.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
         },
         "send": {
           "version": "0.3.0",
           "from": "send@0.3.0",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.3.0.tgz",
           "dependencies": {
             "debug": {
               "version": "0.8.0",
-              "from": "debug@0.8.0"
+              "from": "debug@0.8.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.0.tgz"
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@~1.2.9",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             }
           }
         },
         "cookie-signature": {
           "version": "1.0.3",
-          "from": "cookie-signature@1.0.3"
+          "from": "cookie-signature@1.0.3",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz"
         },
         "merge-descriptors": {
           "version": "0.0.2",
-          "from": "merge-descriptors@0.0.2"
+          "from": "merge-descriptors@0.0.2",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
         },
         "debug": {
           "version": "0.8.1",
-          "from": "debug@>= 0.8.0 < 1"
+          "from": "debug@0.8.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
         }
       }
     },
     "grunt": {
       "version": "0.4.5",
       "from": "grunt@0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22"
+          "from": "async@0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3"
+          "from": "coffee-script@1.3.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2"
+          "from": "colors@~0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "dateformat@1.0.2-1.2.3"
+          "from": "dateformat@1.0.2-1.2.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.13",
-          "from": "eventemitter2@~0.4.13"
+          "from": "eventemitter2@0.4.13",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.13.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@0.1.3",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "glob@3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2"
+                  "from": "inherits@2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2"
+                      "from": "lru-cache@2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 }
@@ -1211,119 +1470,145 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@~3.1.21",
+          "from": "glob@3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0"
+              "from": "graceful-fs@1.2.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1"
+              "from": "inherits@1.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3"
+          "from": "hooker@~0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11"
+          "from": "iconv-lite@0.2.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.12",
+          "from": "minimatch@~0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2"
+              "from": "lru-cache@2.5.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0"
+              "from": "sigmund@1.0.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1"
+              "from": "abbrev@1.0.5",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.8"
+          "from": "rimraf@2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2"
+          "from": "lodash@0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1"
+          "from": "underscore.string@2.2.1",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.5",
-          "from": "which@~1.0.5"
+          "from": "which@1.0.5",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@2.0.5",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.15",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@0.1.15",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.4.4",
-                  "from": "underscore@1.4.x"
+                  "from": "underscore@1.4.x",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "underscore.string@~2.3.1"
+                  "from": "underscore.string@2.3.3",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2"
+              "from": "esprima@1.0.4",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1"
+          "from": "exit@0.1.2",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0"
+          "from": "getobject@0.1.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@~0.2.0"
+          "from": "grunt-legacy-util@0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
-          "from": "grunt-legacy-log@~0.1.0",
+          "from": "grunt-legacy-log@0.1.1",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3"
+              "from": "underscore.string@2.3.3",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
         }
@@ -1332,46 +1617,56 @@
     "grunt-autoprefixer": {
       "version": "0.7.3",
       "from": "grunt-autoprefixer@0.7.3",
+      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-0.7.3.tgz",
       "dependencies": {
         "autoprefixer": {
           "version": "1.1.20140523",
-          "from": "autoprefixer@~1.1.20140410",
+          "from": "autoprefixer@1.1.20140523",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-1.1.20140523.tgz",
           "dependencies": {
             "postcss": {
               "version": "0.3.4",
-              "from": "postcss@~0.3.4",
+              "from": "postcss@0.3.4",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-0.3.4.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.33",
-                  "from": "source-map@~0.1.33",
+                  "from": "source-map@0.1.33",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4"
+                      "from": "amdefine@0.1.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "base64-js": {
                   "version": "0.0.6",
-                  "from": "base64-js@~0.0.6"
+                  "from": "base64-js@0.0.6",
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.6.tgz"
                 }
               }
             },
             "fs-extra": {
               "version": "0.9.1",
-              "from": "fs-extra@~0.9.1",
+              "from": "fs-extra@0.9.1",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.9.1.tgz",
               "dependencies": {
                 "ncp": {
                   "version": "0.5.1",
-                  "from": "ncp@^0.5.1"
+                  "from": "ncp@0.5.1",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz"
                 },
                 "jsonfile": {
                   "version": "1.1.1",
-                  "from": "jsonfile@~1.1.0"
+                  "from": "jsonfile@1.1.1",
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz"
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@^2.2.8"
+                  "from": "rimraf@2.2.8",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 }
               }
             }
@@ -1379,23 +1674,28 @@
         },
         "diff": {
           "version": "1.0.8",
-          "from": "diff@~1.0.8"
+          "from": "diff@1.0.8",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
         },
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "chalk@0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         }
@@ -1404,84 +1704,103 @@
     "grunt-bower-requirejs": {
       "version": "0.11.0",
       "from": "grunt-bower-requirejs@0.11.0",
+      "resolved": "https://registry.npmjs.org/grunt-bower-requirejs/-/grunt-bower-requirejs-0.11.0.tgz",
       "dependencies": {
         "bower-requirejs": {
           "version": "0.11.0",
-          "from": "bower-requirejs@^0.11.0",
+          "from": "bower-requirejs@0.11.0",
+          "resolved": "https://registry.npmjs.org/bower-requirejs/-/bower-requirejs-0.11.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.4.0",
-              "from": "chalk@^0.4.0",
+              "from": "chalk@0.4.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
               "dependencies": {
                 "has-color": {
                   "version": "0.1.7",
-                  "from": "has-color@~0.1.0"
+                  "from": "has-color@0.1.7",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                 },
                 "ansi-styles": {
                   "version": "1.0.0",
-                  "from": "ansi-styles@~1.0.0"
+                  "from": "ansi-styles@1.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                 },
                 "strip-ansi": {
                   "version": "0.1.1",
-                  "from": "strip-ansi@~0.1.0"
+                  "from": "strip-ansi@0.1.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                 }
               }
             },
             "file-utils": {
               "version": "0.2.0",
-              "from": "file-utils@^0.2.0",
+              "from": "file-utils@0.2.0",
+              "resolved": "https://registry.npmjs.org/file-utils/-/file-utils-0.2.0.tgz",
               "dependencies": {
                 "iconv-lite": {
                   "version": "0.2.11",
-                  "from": "iconv-lite@~0.2.11"
+                  "from": "iconv-lite@0.2.11",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@~2.2.2"
+                  "from": "rimraf@2.2.8",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@~0.2.12",
+                  "from": "minimatch@0.2.14",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2"
+                      "from": "lru-cache@2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "findup-sync": {
                   "version": "0.1.3",
-                  "from": "findup-sync@~0.1.2"
+                  "from": "findup-sync@0.1.3",
+                  "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz"
                 },
                 "isbinaryfile": {
                   "version": "2.0.1",
-                  "from": "isbinaryfile@~2.0.0"
+                  "from": "isbinaryfile@2.0.1",
+                  "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-2.0.1.tgz"
                 }
               }
             },
             "glob": {
               "version": "3.2.11",
-              "from": "glob@^3.2.6",
+              "from": "glob@~3.2.9",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2"
+                  "from": "inherits@2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2"
+                      "from": "lru-cache@2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 }
@@ -1489,119 +1808,422 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@^2.4.1"
+              "from": "lodash@~2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "nopt": {
               "version": "2.2.1",
-              "from": "nopt@^2.2.1",
+              "from": "nopt@2.2.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.5",
-                  "from": "abbrev@1"
+                  "from": "abbrev@1.0.5",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                 }
               }
             },
             "object-assign": {
               "version": "0.3.1",
-              "from": "object-assign@^0.3.1"
+              "from": "object-assign@0.3.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
             },
             "requirejs": {
               "version": "2.1.11",
-              "from": "requirejs@^2.1.5"
+              "from": "requirejs@2.1.11",
+              "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.11.tgz"
             },
             "slash": {
               "version": "0.1.3",
-              "from": "slash@^0.1.0"
+              "from": "slash@0.1.3",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-0.1.3.tgz"
             },
             "sudo-block": {
               "version": "0.4.0",
-              "from": "sudo-block@^0.4.0",
+              "from": "sudo-block@0.4.0",
+              "resolved": "https://registry.npmjs.org/sudo-block/-/sudo-block-0.4.0.tgz",
               "dependencies": {
                 "is-root": {
                   "version": "0.1.0",
-                  "from": "is-root@^0.1.0"
+                  "from": "is-root@0.1.0",
+                  "resolved": "https://registry.npmjs.org/is-root/-/is-root-0.1.0.tgz"
                 }
               }
             },
             "update-notifier": {
               "version": "0.1.8",
-              "from": "update-notifier@^0.1.7",
+              "from": "update-notifier@0.1.8",
+              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.8.tgz",
               "dependencies": {
                 "request": {
                   "version": "2.27.0",
-                  "from": "request@~2.27.0",
+                  "from": "request@2.27.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
                   "dependencies": {
                     "qs": {
                       "version": "0.6.6",
-                      "from": "qs@~0.6.0"
+                      "from": "qs@0.6.6",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                     },
                     "json-stringify-safe": {
                       "version": "5.0.0",
-                      "from": "json-stringify-safe@~5.0.0"
+                      "from": "json-stringify-safe@5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                     },
                     "forever-agent": {
                       "version": "0.5.2",
-                      "from": "forever-agent@~0.5.0"
+                      "from": "forever-agent@0.5.2",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.3.0",
-                      "from": "tunnel-agent@~0.3.0"
+                      "from": "tunnel-agent@0.3.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.0",
+                      "from": "http-signature@0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.2",
+                          "from": "assert-plus@0.1.2",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.2",
+                          "from": "ctype@0.5.2",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "1.0.0",
+                      "from": "hawk@1.0.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.1",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@0.4.2",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@0.2.2",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@0.2.4",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign": {
+                      "version": "0.3.0",
+                      "from": "aws-sign@0.3.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.3.0",
+                      "from": "oauth-sign@0.3.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                    },
+                    "cookie-jar": {
+                      "version": "0.3.0",
+                      "from": "cookie-jar@0.3.0",
+                      "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.1",
+                      "from": "node-uuid@1.4.1",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "form-data": {
+                      "version": "0.1.2",
+                      "from": "form-data@0.1.2",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.4",
+                          "from": "combined-stream@0.0.4",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "async": {
+                          "version": "0.2.10",
+                          "from": "async@0.2.10",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "configstore": {
+                  "version": "0.2.3",
+                  "from": "configstore@0.2.3",
+                  "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.2.3.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.3.5",
+                      "from": "mkdirp@0.3.5",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                    },
+                    "js-yaml": {
+                      "version": "3.0.2",
+                      "from": "js-yaml@3.0.2",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+                      "dependencies": {
+                        "argparse": {
+                          "version": "0.1.15",
+                          "from": "argparse@0.1.15",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+                          "dependencies": {
+                            "underscore": {
+                              "version": "1.4.4",
+                              "from": "underscore@1.4.4",
+                              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                            },
+                            "underscore.string": {
+                              "version": "2.3.3",
+                              "from": "underscore.string@2.3.3",
+                              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                            }
+                          }
+                        },
+                        "esprima": {
+                          "version": "1.0.4",
+                          "from": "esprima@1.0.4",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                        }
+                      }
+                    },
+                    "osenv": {
+                      "version": "0.0.3",
+                      "from": "osenv@0.0.3",
+                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+                    },
+                    "graceful-fs": {
+                      "version": "2.0.3",
+                      "from": "graceful-fs@2.0.3",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                    },
+                    "uuid": {
+                      "version": "1.4.1",
+                      "from": "uuid@1.4.1",
+                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
+                    },
+                    "object-assign": {
+                      "version": "0.1.2",
+                      "from": "object-assign@0.1.2",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.1.2.tgz"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "2.1.0",
+                  "from": "semver@2.1.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "bower": {
+          "version": "1.3.4",
+          "from": "bower@^1.x",
+          "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.4.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@~1.0.4",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            },
+            "archy": {
+              "version": "0.0.2",
+              "from": "archy@~0.0.2",
+              "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz"
+            },
+            "bower-config": {
+              "version": "0.5.1",
+              "from": "bower-config@~0.5.0",
+              "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.1.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@~0.6.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@~0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@~0.0.1",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "bower-endpoint-parser": {
+              "version": "0.2.1",
+              "from": "bower-endpoint-parser@~0.2.0",
+              "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.1.tgz"
+            },
+            "bower-json": {
+              "version": "0.4.0",
+              "from": "bower-json@~0.4.0",
+              "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+              "dependencies": {
+                "deep-extend": {
+                  "version": "0.2.10",
+                  "from": "deep-extend@~0.2.5",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.10.tgz"
+                },
+                "intersect": {
+                  "version": "0.0.3",
+                  "from": "intersect@~0.0.3",
+                  "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
+                }
+              }
+            },
+            "bower-logger": {
+              "version": "0.2.2",
+              "from": "bower-logger@~0.2.2",
+              "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
+            },
+            "bower-registry-client": {
+              "version": "0.2.1",
+              "from": "bower-registry-client@~0.2.0",
+              "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@~0.2.8",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "lru-cache": {
+                  "version": "2.3.1",
+                  "from": "lru-cache@~2.3.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+                },
+                "request": {
+                  "version": "2.27.0",
+                  "from": "request@~2.27.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
+                  "dependencies": {
+                    "qs": {
+                      "version": "0.6.6",
+                      "from": "qs@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "from": "json-stringify-safe@~5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.3.0",
+                      "from": "tunnel-agent@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
                     },
                     "http-signature": {
                       "version": "0.10.0",
                       "from": "http-signature@~0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.2",
-                          "from": "assert-plus@0.1.2"
+                          "from": "assert-plus@0.1.2",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
                         },
                         "asn1": {
                           "version": "0.1.11",
-                          "from": "asn1@0.1.11"
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                         },
                         "ctype": {
                           "version": "0.5.2",
-                          "from": "ctype@0.5.2"
+                          "from": "ctype@0.5.2",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
                         }
                       }
                     },
                     "hawk": {
                       "version": "1.0.0",
                       "from": "hawk@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
                       "dependencies": {
                         "hoek": {
                           "version": "0.9.1",
-                          "from": "hoek@0.9.x"
+                          "from": "hoek@0.9.x",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                         },
                         "boom": {
                           "version": "0.4.2",
-                          "from": "boom@0.4.x"
+                          "from": "boom@0.4.x",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                         },
                         "cryptiles": {
                           "version": "0.2.2",
-                          "from": "cryptiles@0.2.x"
+                          "from": "cryptiles@0.2.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                         },
                         "sntp": {
                           "version": "0.2.4",
-                          "from": "sntp@0.2.x"
+                          "from": "sntp@0.2.x",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                         }
                       }
                     },
                     "aws-sign": {
                       "version": "0.3.0",
-                      "from": "aws-sign@~0.3.0"
+                      "from": "aws-sign@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
                     },
                     "oauth-sign": {
                       "version": "0.3.0",
-                      "from": "oauth-sign@~0.3.0"
+                      "from": "oauth-sign@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
                     },
                     "cookie-jar": {
                       "version": "0.3.0",
-                      "from": "cookie-jar@~0.3.0"
+                      "from": "cookie-jar@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
                     },
                     "node-uuid": {
                       "version": "1.4.1",
-                      "from": "node-uuid@~1.4.0"
+                      "from": "node-uuid@~1.4.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
                     },
                     "mime": {
                       "version": "1.2.11",
@@ -1609,22 +2231,420 @@
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                     },
                     "form-data": {
-                      "version": "0.1.2",
+                      "version": "0.1.3",
                       "from": "form-data@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
                       "dependencies": {
                         "combined-stream": {
                           "version": "0.0.4",
                           "from": "combined-stream@~0.0.4",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                           "dependencies": {
                             "delayed-stream": {
                               "version": "0.0.5",
-                              "from": "delayed-stream@0.0.5"
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                             }
                           }
                         },
                         "async": {
-                          "version": "0.2.10",
-                          "from": "async@~0.2.9"
+                          "version": "0.9.0",
+                          "from": "async@~0.9.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "request-replay": {
+                  "version": "0.2.0",
+                  "from": "request-replay@~0.2.0",
+                  "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
+                }
+              }
+            },
+            "cardinal": {
+              "version": "0.4.4",
+              "from": "cardinal@~0.4.0",
+              "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+              "dependencies": {
+                "redeyed": {
+                  "version": "0.4.4",
+                  "from": "redeyed@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@~1.0.4",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    }
+                  }
+                },
+                "ansicolors": {
+                  "version": "0.2.1",
+                  "from": "ansicolors@~0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+                }
+              }
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "from": "chalk@~0.4.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.7",
+                  "from": "has-color@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "ansi-styles@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "strip-ansi@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            },
+            "chmodr": {
+              "version": "0.1.0",
+              "from": "chmodr@~0.1.0",
+              "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
+            },
+            "decompress-zip": {
+              "version": "0.0.8",
+              "from": "decompress-zip@~0.0.6",
+              "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
+              "dependencies": {
+                "mkpath": {
+                  "version": "0.1.0",
+                  "from": "mkpath@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
+                },
+                "binary": {
+                  "version": "0.3.0",
+                  "from": "binary@~0.3.0",
+                  "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+                  "dependencies": {
+                    "chainsaw": {
+                      "version": "0.1.0",
+                      "from": "chainsaw@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                      "dependencies": {
+                        "traverse": {
+                          "version": "0.3.9",
+                          "from": "traverse@>=0.3.0 <0.4",
+                          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                        }
+                      }
+                    },
+                    "buffers": {
+                      "version": "0.1.1",
+                      "from": "buffers@~0.1.1",
+                      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                    }
+                  }
+                },
+                "touch": {
+                  "version": "0.0.2",
+                  "from": "touch@0.0.2",
+                  "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
+                  "dependencies": {
+                    "nopt": {
+                      "version": "1.0.10",
+                      "from": "nopt@~1.0.10",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.1.13-1",
+                  "from": "readable-stream@~1.1.8",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.25-1",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "3.0.0",
+                  "from": "graceful-fs@~3.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.0.tgz"
+                }
+              }
+            },
+            "fstream": {
+              "version": "0.1.25",
+              "from": "fstream@~0.1.22",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "fstream-ignore": {
+              "version": "0.0.8",
+              "from": "fstream-ignore@~0.0.6",
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.8.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@^0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@~3.2.9",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@~2.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "inquirer": {
+              "version": "0.4.1",
+              "from": "inquirer@~0.4.0",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.4.1.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                },
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@~0.2.8",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "cli-color": {
+                  "version": "0.2.3",
+                  "from": "cli-color@~0.2.2",
+                  "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+                  "dependencies": {
+                    "es5-ext": {
+                      "version": "0.9.2",
+                      "from": "es5-ext@~0.9.2",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
+                    },
+                    "memoizee": {
+                      "version": "0.2.6",
+                      "from": "memoizee@~0.2.5",
+                      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+                      "dependencies": {
+                        "event-emitter": {
+                          "version": "0.2.2",
+                          "from": "event-emitter@~0.2.2",
+                          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
+                        },
+                        "next-tick": {
+                          "version": "0.1.0",
+                          "from": "next-tick@0.1.x",
+                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "mute-stream@~0.0.4",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                },
+                "through": {
+                  "version": "2.3.4",
+                  "from": "through@~2.3.4",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.4.tgz"
+                },
+                "readline2": {
+                  "version": "0.1.0",
+                  "from": "readline2@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.0.tgz"
+                }
+              }
+            },
+            "insight": {
+              "version": "0.3.1",
+              "from": "insight@~0.3.0",
+              "resolved": "https://registry.npmjs.org/insight/-/insight-0.3.1.tgz",
+              "dependencies": {
+                "request": {
+                  "version": "2.27.0",
+                  "from": "request@~2.27.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
+                  "dependencies": {
+                    "qs": {
+                      "version": "0.6.6",
+                      "from": "qs@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "from": "json-stringify-safe@~5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.3.0",
+                      "from": "tunnel-agent@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.0",
+                      "from": "http-signature@~0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.2",
+                          "from": "assert-plus@0.1.2",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.2",
+                          "from": "ctype@0.5.2",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "1.0.0",
+                      "from": "hawk@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.x",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@0.4.x",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@0.2.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@0.2.x",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign": {
+                      "version": "0.3.0",
+                      "from": "aws-sign@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.3.0",
+                      "from": "oauth-sign@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                    },
+                    "cookie-jar": {
+                      "version": "0.3.0",
+                      "from": "cookie-jar@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.1",
+                      "from": "node-uuid@~1.4.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@~1.2.9",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "form-data": {
+                      "version": "0.1.3",
+                      "from": "form-data@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.4",
+                          "from": "combined-stream@~0.0.4",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "async": {
+                          "version": "0.9.0",
+                          "from": "async@~0.9.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                         }
                       }
                     }
@@ -1633,58 +2653,441 @@
                 "configstore": {
                   "version": "0.2.3",
                   "from": "configstore@~0.2.2",
+                  "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.2.3.tgz",
                   "dependencies": {
-                    "mkdirp": {
-                      "version": "0.3.5",
-                      "from": "mkdirp@~0.3.5"
-                    },
                     "js-yaml": {
                       "version": "3.0.2",
                       "from": "js-yaml@~3.0.1",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
                       "dependencies": {
                         "argparse": {
                           "version": "0.1.15",
                           "from": "argparse@~ 0.1.11",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
                           "dependencies": {
                             "underscore": {
                               "version": "1.4.4",
-                              "from": "underscore@~1.4.3"
+                              "from": "underscore@~1.4.3",
+                              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
                             },
                             "underscore.string": {
                               "version": "2.3.3",
-                              "from": "underscore.string@~2.3.1"
+                              "from": "underscore.string@~2.3.1",
+                              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                             }
                           }
                         },
                         "esprima": {
                           "version": "1.0.4",
-                          "from": "esprima@~ 1.0.2"
+                          "from": "esprima@~ 1.0.2",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                         }
                       }
                     },
-                    "osenv": {
-                      "version": "0.0.3",
-                      "from": "osenv@0.0.3"
+                    "uuid": {
+                      "version": "1.4.1",
+                      "from": "uuid@~1.4.1",
+                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
+                    }
+                  }
+                },
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@~0.2.9",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "object-assign": {
+                  "version": "0.1.2",
+                  "from": "object-assign@~0.1.2",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.1.2.tgz"
+                },
+                "lodash.debounce": {
+                  "version": "2.4.1",
+                  "from": "lodash.debounce@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash.isfunction": {
+                      "version": "2.4.1",
+                      "from": "lodash.isfunction@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
                     },
-                    "graceful-fs": {
-                      "version": "2.0.3",
-                      "from": "graceful-fs@~2.0.1"
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "from": "lodash.isobject@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.now": {
+                      "version": "2.4.1",
+                      "from": "lodash.now@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "lodash._isnative@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "is-root": {
+              "version": "0.1.0",
+              "from": "is-root@~0.1.0",
+              "resolved": "https://registry.npmjs.org/is-root/-/is-root-0.1.0.tgz"
+            },
+            "junk": {
+              "version": "0.3.0",
+              "from": "junk@~0.3.0",
+              "resolved": "https://registry.npmjs.org/junk/-/junk-0.3.0.tgz"
+            },
+            "lockfile": {
+              "version": "0.4.2",
+              "from": "lockfile@~0.4.2",
+              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-0.4.2.tgz"
+            },
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@~2.5.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@0.3.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "mout": {
+              "version": "0.9.1",
+              "from": "mout@~0.9.1",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+            },
+            "nopt": {
+              "version": "2.2.1",
+              "from": "nopt@~2.2.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz"
+            },
+            "opn": {
+              "version": "0.1.2",
+              "from": "opn@~0.1.1",
+              "resolved": "https://registry.npmjs.org/opn/-/opn-0.1.2.tgz"
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "osenv@~0.0.3",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+            },
+            "p-throttler": {
+              "version": "0.0.1",
+              "from": "p-throttler@~0.0.1",
+              "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.0.1.tgz",
+              "dependencies": {
+                "q": {
+                  "version": "0.9.7",
+                  "from": "q@~0.9.2",
+                  "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+                }
+              }
+            },
+            "promptly": {
+              "version": "0.2.0",
+              "from": "promptly@~0.2.0",
+              "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+              "dependencies": {
+                "read": {
+                  "version": "1.0.5",
+                  "from": "read@~1.0.4",
+                  "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
+                  "dependencies": {
+                    "mute-stream": {
+                      "version": "0.0.4",
+                      "from": "mute-stream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "q": {
+              "version": "1.0.1",
+              "from": "q@~1.0.1",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+            },
+            "request-progress": {
+              "version": "0.3.1",
+              "from": "request-progress@~0.3.0",
+              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+              "dependencies": {
+                "throttleit": {
+                  "version": "0.0.2",
+                  "from": "throttleit@~0.0.2",
+                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+                }
+              }
+            },
+            "retry": {
+              "version": "0.6.0",
+              "from": "retry@~0.6.0",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@~2.2.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "semver": {
+              "version": "2.2.1",
+              "from": "semver@~2.2.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
+            },
+            "shell-quote": {
+              "version": "1.4.1",
+              "from": "shell-quote@~1.4.1",
+              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.1.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "jsonify@~0.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                },
+                "array-filter": {
+                  "version": "0.0.1",
+                  "from": "array-filter@~0.0.0",
+                  "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+                },
+                "array-reduce": {
+                  "version": "0.0.0",
+                  "from": "array-reduce@~0.0.0",
+                  "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+                },
+                "array-map": {
+                  "version": "0.0.0",
+                  "from": "array-map@~0.0.0",
+                  "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+                }
+              }
+            },
+            "stringify-object": {
+              "version": "0.2.1",
+              "from": "stringify-object@~0.2.0",
+              "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-0.2.1.tgz"
+            },
+            "tar": {
+              "version": "0.1.19",
+              "from": "tar@~0.1.17",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "block-stream": {
+                  "version": "0.0.7",
+                  "from": "block-stream@*",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                }
+              }
+            },
+            "tmp": {
+              "version": "0.0.23",
+              "from": "tmp@~0.0.20",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
+            },
+            "update-notifier": {
+              "version": "0.1.8",
+              "from": "update-notifier@~0.1.8",
+              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.8.tgz",
+              "dependencies": {
+                "request": {
+                  "version": "2.27.0",
+                  "from": "request@~2.27.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
+                  "dependencies": {
+                    "qs": {
+                      "version": "0.6.6",
+                      "from": "qs@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "from": "json-stringify-safe@~5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.3.0",
+                      "from": "tunnel-agent@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.0",
+                      "from": "http-signature@~0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.2",
+                          "from": "assert-plus@0.1.2",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.2",
+                          "from": "ctype@0.5.2",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "1.0.0",
+                      "from": "hawk@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.x",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@0.4.x",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@0.2.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@0.2.x",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign": {
+                      "version": "0.3.0",
+                      "from": "aws-sign@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.3.0",
+                      "from": "oauth-sign@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                    },
+                    "cookie-jar": {
+                      "version": "0.3.0",
+                      "from": "cookie-jar@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.1",
+                      "from": "node-uuid@~1.4.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@~1.2.9",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "form-data": {
+                      "version": "0.1.3",
+                      "from": "form-data@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.4",
+                          "from": "combined-stream@~0.0.4",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "async": {
+                          "version": "0.9.0",
+                          "from": "async@~0.9.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "configstore": {
+                  "version": "0.2.3",
+                  "from": "configstore@~0.2.2",
+                  "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.2.3.tgz",
+                  "dependencies": {
+                    "js-yaml": {
+                      "version": "3.0.2",
+                      "from": "js-yaml@~3.0.1",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+                      "dependencies": {
+                        "argparse": {
+                          "version": "0.1.15",
+                          "from": "argparse@~ 0.1.11",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+                          "dependencies": {
+                            "underscore": {
+                              "version": "1.4.4",
+                              "from": "underscore@~1.4.3",
+                              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                            },
+                            "underscore.string": {
+                              "version": "2.3.3",
+                              "from": "underscore.string@~2.3.1",
+                              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                            }
+                          }
+                        },
+                        "esprima": {
+                          "version": "1.0.4",
+                          "from": "esprima@~ 1.0.2",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                        }
+                      }
                     },
                     "uuid": {
                       "version": "1.4.1",
-                      "from": "uuid@1.4.1"
+                      "from": "uuid@~1.4.1",
+                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                     },
                     "object-assign": {
                       "version": "0.1.2",
-                      "from": "object-assign@~0.1.1"
+                      "from": "object-assign@~0.1.1",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.1.2.tgz"
                     }
                   }
                 },
                 "semver": {
                   "version": "2.1.0",
-                  "from": "semver@~2.1.0"
+                  "from": "semver@~2.1.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-2.1.0.tgz"
                 }
               }
+            },
+            "which": {
+              "version": "1.0.5",
+              "from": "which@~1.0.5",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
             }
           }
         }
@@ -1693,40 +3096,49 @@
     "grunt-cli": {
       "version": "0.1.13",
       "from": "grunt-cli@0.1.13",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1"
+              "from": "abbrev@1.0.5",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
             }
           }
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.0",
+          "from": "findup-sync@0.1.3",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
               "from": "glob@~3.2.9",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2"
+                  "from": "inherits@2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2"
+                      "from": "lru-cache@2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 }
@@ -1734,31 +3146,37 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@~2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "resolve@~0.3.1"
+          "from": "resolve@0.3.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
     "grunt-concurrent": {
       "version": "0.5.0",
       "from": "grunt-concurrent@0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-0.5.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9"
+          "from": "async@0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "pad-stdio": {
           "version": "0.1.1",
-          "from": "pad-stdio@^0.1.0",
+          "from": "pad-stdio@0.1.1",
+          "resolved": "https://registry.npmjs.org/pad-stdio/-/pad-stdio-0.1.1.tgz",
           "dependencies": {
             "lpad": {
               "version": "0.2.1",
-              "from": "lpad@^0.2.0"
+              "from": "lpad@0.2.1",
+              "resolved": "https://registry.npmjs.org/lpad/-/lpad-0.2.1.tgz"
             }
           }
         }
@@ -1767,30 +3185,37 @@
     "grunt-connect-fonts": {
       "version": "0.0.3",
       "from": "grunt-connect-fonts@0.0.3",
+      "resolved": "https://registry.npmjs.org/grunt-connect-fonts/-/grunt-connect-fonts-0.0.3.tgz",
       "dependencies": {
         "connect-fonts": {
           "version": "2.0.1",
           "from": "connect-fonts@2.0.1",
+          "resolved": "https://registry.npmjs.org/connect-fonts/-/connect-fonts-2.0.1.tgz",
           "dependencies": {
             "filed": {
               "version": "0.1.0",
-              "from": "filed@0.1.0"
+              "from": "filed@0.1.0",
+              "resolved": "https://registry.npmjs.org/filed/-/filed-0.1.0.tgz"
             },
             "node-font-face-generator": {
               "version": "0.1.3",
               "from": "node-font-face-generator@0.1.3",
+              "resolved": "https://registry.npmjs.org/node-font-face-generator/-/node-font-face-generator-0.1.3.tgz",
               "dependencies": {
                 "ejs": {
                   "version": "0.8.5",
-                  "from": "ejs@0.8.5"
+                  "from": "ejs@0.8.5",
+                  "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.8.5.tgz"
                 },
                 "useragent": {
                   "version": "2.0.7",
                   "from": "useragent@2.0.7",
+                  "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.7.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.2.4",
-                      "from": "lru-cache@2.2.x"
+                      "from": "lru-cache@2.2.4",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
                     }
                   }
                 }
@@ -1798,30 +3223,35 @@
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@1.2.11",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "oppressor": {
               "version": "0.0.1",
               "from": "oppressor@0.0.1",
+              "resolved": "https://registry.npmjs.org/oppressor/-/oppressor-0.0.1.tgz",
               "dependencies": {
                 "through": {
                   "version": "0.1.4",
-                  "from": "through@~0.1.4"
+                  "from": "through@0.1.4",
+                  "resolved": "https://registry.npmjs.org/through/-/through-0.1.4.tgz"
                 },
                 "response-stream": {
                   "version": "0.0.0",
-                  "from": "response-stream@~0.0.0"
+                  "from": "response-stream@0.0.0",
+                  "resolved": "https://registry.npmjs.org/response-stream/-/response-stream-0.0.0.tgz"
                 },
                 "negotiator": {
                   "version": "0.2.8",
-                  "from": "negotiator@~0.2.5"
+                  "from": "negotiator@0.2.8",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.8.tgz"
                 }
               }
             },
             "tmp": {
               "version": "0.0.23",
-              "from": "tmp@~0.0.20"
+              "from": "tmp@0.0.23",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
             }
           }
         }
@@ -1830,32 +3260,39 @@
     "grunt-contrib-clean": {
       "version": "0.5.0",
       "from": "grunt-contrib-clean@0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.5.0.tgz",
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.1"
+          "from": "rimraf@2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
     },
     "grunt-contrib-concat": {
       "version": "0.4.0",
       "from": "grunt-contrib-concat@0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.4.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "chalk@~0.4",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         }
@@ -1863,75 +3300,92 @@
     },
     "grunt-contrib-copy": {
       "version": "0.5.0",
-      "from": "grunt-contrib-copy@0.5.0"
+      "from": "grunt-contrib-copy@0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz"
     },
     "grunt-contrib-cssmin": {
       "version": "0.9.0",
       "from": "grunt-contrib-cssmin@0.9.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.9.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "chalk@0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "clean-css": {
           "version": "2.1.8",
-          "from": "clean-css@~2.1.0",
+          "from": "clean-css@2.1.8",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.1.8.tgz",
           "dependencies": {
             "commander": {
               "version": "2.1.0",
-              "from": "commander@2.1.x"
+              "from": "commander@2.1.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
             }
           }
         },
         "maxmin": {
           "version": "0.1.0",
-          "from": "maxmin@~0.1.0",
+          "from": "maxmin@0.1.0",
+          "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-0.1.0.tgz",
           "dependencies": {
             "gzip-size": {
               "version": "0.1.1",
-              "from": "gzip-size@^0.1.0",
+              "from": "gzip-size@0.1.1",
+              "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.1.1.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.4.5",
-                  "from": "concat-stream@^1.4.1",
+                  "from": "concat-stream@1.4.5",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.5.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1"
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@~0.0.5"
+                      "from": "typedarray@0.0.6",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13-1",
-                      "from": "readable-stream@~1.1.9",
+                      "from": "readable-stream@1.1.13-1",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0"
+                          "from": "core-util-is@1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1"
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.25-1",
-                          "from": "string_decoder@~0.10.x"
+                          "from": "string_decoder@0.10.25-1",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                         }
                       }
                     }
@@ -1939,23 +3393,28 @@
                 },
                 "zlib-browserify": {
                   "version": "0.0.3",
-                  "from": "zlib-browserify@^0.0.3",
+                  "from": "zlib-browserify@0.0.3",
+                  "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.3.tgz",
                   "dependencies": {
                     "tape": {
                       "version": "0.2.2",
-                      "from": "tape@~0.2.2",
+                      "from": "tape@0.2.2",
+                      "resolved": "https://registry.npmjs.org/tape/-/tape-0.2.2.tgz",
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
-                          "from": "jsonify@~0.0.0"
+                          "from": "jsonify@0.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                         },
                         "deep-equal": {
                           "version": "0.0.0",
-                          "from": "deep-equal@~0.0.0"
+                          "from": "deep-equal@0.0.0",
+                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
                         },
                         "defined": {
                           "version": "0.0.0",
-                          "from": "defined@~0.0.0"
+                          "from": "defined@0.0.0",
+                          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
                         }
                       }
                     }
@@ -1965,7 +3424,8 @@
             },
             "pretty-bytes": {
               "version": "0.1.1",
-              "from": "pretty-bytes@^0.1.0"
+              "from": "pretty-bytes@0.1.1",
+              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.1.tgz"
             }
           }
         }
@@ -1974,128 +3434,158 @@
     "grunt-contrib-htmlmin": {
       "version": "0.3.0",
       "from": "grunt-contrib-htmlmin@0.3.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-htmlmin/-/grunt-contrib-htmlmin-0.3.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "chalk@~0.4",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "html-minifier": {
           "version": "0.6.1",
-          "from": "html-minifier@~0.6.0",
+          "from": "html-minifier@0.6.1",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.1.tgz",
           "dependencies": {
             "change-case": {
               "version": "2.1.1",
-              "from": "change-case@2.1.x",
+              "from": "change-case@2.1.1",
+              "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.1.tgz",
               "dependencies": {
                 "camel-case": {
                   "version": "0.1.0",
-                  "from": "camel-case@^0.1.0"
+                  "from": "camel-case@0.1.0",
+                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-0.1.0.tgz"
                 },
                 "constant-case": {
                   "version": "0.1.0",
-                  "from": "constant-case@^0.1.0"
+                  "from": "constant-case@0.1.0",
+                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-0.1.0.tgz"
                 },
                 "dot-case": {
                   "version": "0.1.0",
-                  "from": "dot-case@^0.1.0"
+                  "from": "dot-case@0.1.0",
+                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-0.1.0.tgz"
                 },
                 "is-lower-case": {
                   "version": "0.0.1",
-                  "from": "is-lower-case@0.0.1"
+                  "from": "is-lower-case@0.0.1",
+                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-0.0.1.tgz"
                 },
                 "is-upper-case": {
                   "version": "0.0.1",
-                  "from": "is-upper-case@0.0.1"
+                  "from": "is-upper-case@0.0.1",
+                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-0.0.1.tgz"
                 },
                 "lower-case": {
                   "version": "0.0.1",
-                  "from": "lower-case@0.0.1"
+                  "from": "lower-case@0.0.1",
+                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-0.0.1.tgz"
                 },
                 "param-case": {
                   "version": "0.1.0",
-                  "from": "param-case@^0.1.0"
+                  "from": "param-case@0.1.0",
+                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-0.1.0.tgz"
                 },
                 "pascal-case": {
                   "version": "0.1.1",
-                  "from": "pascal-case@^0.1.1"
+                  "from": "pascal-case@0.1.1",
+                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-0.1.1.tgz"
                 },
                 "path-case": {
                   "version": "0.1.0",
-                  "from": "path-case@^0.1.0"
+                  "from": "path-case@0.1.0",
+                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-0.1.0.tgz"
                 },
                 "sentence-case": {
                   "version": "0.1.1",
-                  "from": "sentence-case@^0.1.1"
+                  "from": "sentence-case@0.1.1",
+                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-0.1.1.tgz"
                 },
                 "snake-case": {
                   "version": "0.1.1",
-                  "from": "snake-case@^0.1.1"
+                  "from": "snake-case@0.1.1",
+                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-0.1.1.tgz"
                 },
                 "swap-case": {
                   "version": "0.0.1",
-                  "from": "swap-case@0.0.1"
+                  "from": "swap-case@0.0.1",
+                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-0.0.1.tgz"
                 },
                 "title-case": {
                   "version": "0.1.0",
-                  "from": "title-case@^0.1.0"
+                  "from": "title-case@0.1.0",
+                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-0.1.0.tgz"
                 },
                 "upper-case": {
                   "version": "0.0.1",
-                  "from": "upper-case@0.0.1"
+                  "from": "upper-case@0.0.1",
+                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-0.0.1.tgz"
                 },
                 "upper-case-first": {
                   "version": "0.0.1",
-                  "from": "upper-case-first@0.0.1"
+                  "from": "upper-case-first@0.0.1",
+                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-0.0.1.tgz"
                 }
               }
             },
             "clean-css": {
               "version": "2.1.8",
-              "from": "clean-css@2.1.x",
+              "from": "clean-css@2.1.8",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.1.8.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.1.0",
-                  "from": "commander@2.1.x"
+                  "from": "commander@2.1.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                 }
               }
             },
             "cli": {
               "version": "0.6.2",
-              "from": "cli@0.6.x",
+              "from": "cli@0.6.2",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.2.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.0.0",
-                  "from": "glob@>= 3.1.4",
+                  "from": "glob@4.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.0.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2"
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@^0.3.0",
+                      "from": "minimatch@0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2"
+                          "from": "lru-cache@2.5.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0"
+                          "from": "sigmund@1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
                     }
@@ -2103,41 +3593,49 @@
                 },
                 "exit": {
                   "version": "0.1.2",
-                  "from": "exit@0.1.2"
+                  "from": "exit@0.1.2",
+                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.4.13",
-              "from": "uglify-js@2.4.x",
+              "from": "uglify-js@2.4.13",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.13.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@~0.2.6"
+                  "from": "async@0.2.10",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.33",
-                  "from": "source-map@~0.1.33",
+                  "from": "source-map@0.1.33",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4"
+                      "from": "amdefine@0.1.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "optimist": {
                   "version": "0.3.7",
-                  "from": "optimist@~0.3.5",
+                  "from": "optimist@0.3.7",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@~0.0.2"
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@~1.0.0"
+                  "from": "uglify-to-browserify@1.0.2",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 }
               }
             }
@@ -2145,133 +3643,163 @@
         },
         "pretty-bytes": {
           "version": "0.1.1",
-          "from": "pretty-bytes@~0.1.0"
+          "from": "pretty-bytes@0.1.1",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.1.tgz"
         }
       }
     },
     "grunt-contrib-imagemin": {
       "version": "0.5.0",
       "from": "grunt-contrib-imagemin@0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-imagemin/-/grunt-contrib-imagemin-0.5.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9"
+          "from": "async@0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "chalk@0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "filesize": {
           "version": "2.0.3",
-          "from": "filesize@~2.0.0"
+          "from": "filesize@2.0.3",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-2.0.3.tgz"
         },
         "image-min": {
           "version": "0.1.4",
-          "from": "image-min@~0.1.1",
+          "from": "image-min@0.1.4",
+          "resolved": "https://registry.npmjs.org/image-min/-/image-min-0.1.4.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@~0.3.5"
+              "from": "mkdirp@0.3.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "mout": {
               "version": "0.7.1",
-              "from": "mout@~0.7.1"
+              "from": "mout@0.7.1",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.7.1.tgz"
             },
             "gifsicle": {
               "version": "0.1.5",
-              "from": "gifsicle@~0.1.0",
+              "from": "gifsicle@0.1.5",
+              "resolved": "https://registry.npmjs.org/gifsicle/-/gifsicle-0.1.5.tgz",
               "dependencies": {
                 "bin-wrapper": {
                   "version": "0.2.4",
-                  "from": "bin-wrapper@~0.2.0",
+                  "from": "bin-wrapper@0.2.4",
+                  "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-0.2.4.tgz",
                   "dependencies": {
                     "bin-check": {
                       "version": "0.1.5",
-                      "from": "bin-check@^0.1.0"
+                      "from": "bin-check@0.1.5",
+                      "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-0.1.5.tgz"
                     },
                     "download": {
                       "version": "0.1.17",
-                      "from": "download@^0.1.2",
+                      "from": "download@0.1.17",
+                      "resolved": "https://registry.npmjs.org/download/-/download-0.1.17.tgz",
                       "dependencies": {
                         "decompress": {
                           "version": "0.2.3",
-                          "from": "decompress@^0.2.0",
+                          "from": "decompress@0.2.3",
+                          "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.3.tgz",
                           "dependencies": {
                             "adm-zip": {
                               "version": "0.4.4",
-                              "from": "adm-zip@^0.4.3"
+                              "from": "adm-zip@0.4.4",
+                              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
                             },
                             "extname": {
                               "version": "0.1.2",
-                              "from": "extname@^0.1.1",
+                              "from": "extname@0.1.2",
+                              "resolved": "https://registry.npmjs.org/extname/-/extname-0.1.2.tgz",
                               "dependencies": {
                                 "ext-list": {
                                   "version": "0.1.0",
-                                  "from": "ext-list@^0.1.0"
+                                  "from": "ext-list@0.1.0",
+                                  "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.1.0.tgz"
                                 },
                                 "underscore.string": {
                                   "version": "2.3.3",
-                                  "from": "underscore.string@~2.3.3"
+                                  "from": "underscore.string@2.3.3",
+                                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                                 }
                               }
                             },
                             "map-key": {
                               "version": "0.1.4",
-                              "from": "map-key@^0.1.1",
+                              "from": "map-key@0.1.4",
+                              "resolved": "https://registry.npmjs.org/map-key/-/map-key-0.1.4.tgz",
                               "dependencies": {
                                 "lodash": {
                                   "version": "2.4.1",
-                                  "from": "lodash@^2.4.1"
+                                  "from": "lodash@2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                                 },
                                 "underscore.string": {
                                   "version": "2.3.3",
-                                  "from": "underscore.string@^2.3.3"
+                                  "from": "underscore.string@2.3.3",
+                                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                                 }
                               }
                             },
                             "stream-combiner": {
                               "version": "0.0.4",
-                              "from": "stream-combiner@^0.0.4",
+                              "from": "stream-combiner@0.0.4",
+                              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                               "dependencies": {
                                 "duplexer": {
                                   "version": "0.1.1",
-                                  "from": "duplexer@~0.1.1"
+                                  "from": "duplexer@0.1.1",
+                                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                                 }
                               }
                             },
                             "tar": {
                               "version": "0.1.19",
-                              "from": "tar@^0.1.18",
+                              "from": "tar@0.1.19",
+                              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
                               "dependencies": {
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@2"
+                                  "from": "inherits@2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "block-stream": {
                                   "version": "0.0.7",
-                                  "from": "block-stream@*"
+                                  "from": "block-stream@0.0.7",
+                                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
                                 },
                                 "fstream": {
                                   "version": "0.1.25",
-                                  "from": "fstream@~0.1.8",
+                                  "from": "fstream@0.1.25",
+                                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "2.0.3",
-                                      "from": "graceful-fs@~2.0.0"
+                                      "from": "graceful-fs@2.0.3",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                                     }
                                   }
                                 }
@@ -2281,59 +3809,72 @@
                         },
                         "each-async": {
                           "version": "0.1.3",
-                          "from": "each-async@^0.1.1"
+                          "from": "each-async@0.1.3",
+                          "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
                         },
                         "get-stdin": {
                           "version": "0.1.0",
-                          "from": "get-stdin@^0.1.0"
+                          "from": "get-stdin@0.1.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
                         },
                         "get-urls": {
                           "version": "0.1.2",
-                          "from": "get-urls@^0.1.1"
+                          "from": "get-urls@0.1.2",
+                          "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
                         },
                         "nopt": {
                           "version": "2.2.1",
-                          "from": "nopt@^2.2.0",
+                          "from": "nopt@2.2.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
                           "dependencies": {
                             "abbrev": {
                               "version": "1.0.5",
-                              "from": "abbrev@1"
+                              "from": "abbrev@1.0.5",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                             }
                           }
                         },
                         "through2": {
                           "version": "0.4.2",
-                          "from": "through2@^0.4.0",
+                          "from": "through2@0.4.2",
+                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.27-1",
-                              "from": "readable-stream@~1.0.17",
+                              "from": "readable-stream@1.0.27-1",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "core-util-is@~1.0.0"
+                                  "from": "core-util-is@1.0.1",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1"
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.25-1",
-                                  "from": "string_decoder@~0.10.x"
+                                  "from": "string_decoder@0.10.25-1",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.1"
+                                  "from": "inherits@2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "xtend": {
                               "version": "2.1.2",
-                              "from": "xtend@~2.1.1",
+                              "from": "xtend@2.1.2",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                               "dependencies": {
                                 "object-keys": {
                                   "version": "0.4.0",
-                                  "from": "object-keys@~0.4.0"
+                                  "from": "object-keys@0.4.0",
+                                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                                 }
                               }
                             }
@@ -2343,27 +3884,33 @@
                     },
                     "executable": {
                       "version": "0.1.2",
-                      "from": "executable@^0.1.0"
+                      "from": "executable@0.1.2",
+                      "resolved": "https://registry.npmjs.org/executable/-/executable-0.1.2.tgz"
                     },
                     "find-file": {
                       "version": "0.1.4",
-                      "from": "find-file@^0.1.2"
+                      "from": "find-file@0.1.4",
+                      "resolved": "https://registry.npmjs.org/find-file/-/find-file-0.1.4.tgz"
                     },
                     "mout": {
                       "version": "0.9.1",
-                      "from": "mout@^0.9.1"
+                      "from": "mout@0.9.1",
+                      "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "rimraf@^2.2.6"
+                      "from": "rimraf@2.2.8",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     },
                     "tempfile": {
                       "version": "0.1.3",
-                      "from": "tempfile@^0.1.2",
+                      "from": "tempfile@0.1.3",
+                      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
                       "dependencies": {
                         "uuid": {
                           "version": "1.4.1",
-                          "from": "uuid@~1.4.0"
+                          "from": "uuid@1.4.1",
+                          "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                         }
                       }
                     }
@@ -2373,85 +3920,104 @@
             },
             "jpegtran-bin": {
               "version": "0.2.6",
-              "from": "jpegtran-bin@~0.2.0",
+              "from": "jpegtran-bin@0.2.6",
+              "resolved": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-0.2.6.tgz",
               "dependencies": {
                 "bin-wrapper": {
                   "version": "0.2.4",
-                  "from": "bin-wrapper@~0.2.0",
+                  "from": "bin-wrapper@0.2.4",
+                  "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-0.2.4.tgz",
                   "dependencies": {
                     "bin-check": {
                       "version": "0.1.5",
-                      "from": "bin-check@^0.1.0"
+                      "from": "bin-check@0.1.5",
+                      "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-0.1.5.tgz"
                     },
                     "download": {
                       "version": "0.1.17",
-                      "from": "download@^0.1.2",
+                      "from": "download@0.1.17",
+                      "resolved": "https://registry.npmjs.org/download/-/download-0.1.17.tgz",
                       "dependencies": {
                         "decompress": {
                           "version": "0.2.3",
-                          "from": "decompress@^0.2.0",
+                          "from": "decompress@0.2.3",
+                          "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.3.tgz",
                           "dependencies": {
                             "adm-zip": {
                               "version": "0.4.4",
-                              "from": "adm-zip@^0.4.3"
+                              "from": "adm-zip@0.4.4",
+                              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
                             },
                             "extname": {
                               "version": "0.1.2",
-                              "from": "extname@^0.1.1",
+                              "from": "extname@0.1.2",
+                              "resolved": "https://registry.npmjs.org/extname/-/extname-0.1.2.tgz",
                               "dependencies": {
                                 "ext-list": {
                                   "version": "0.1.0",
-                                  "from": "ext-list@^0.1.0"
+                                  "from": "ext-list@0.1.0",
+                                  "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.1.0.tgz"
                                 },
                                 "underscore.string": {
                                   "version": "2.3.3",
-                                  "from": "underscore.string@~2.3.3"
+                                  "from": "underscore.string@2.3.3",
+                                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                                 }
                               }
                             },
                             "map-key": {
                               "version": "0.1.4",
-                              "from": "map-key@^0.1.1",
+                              "from": "map-key@0.1.4",
+                              "resolved": "https://registry.npmjs.org/map-key/-/map-key-0.1.4.tgz",
                               "dependencies": {
                                 "lodash": {
                                   "version": "2.4.1",
-                                  "from": "lodash@^2.4.1"
+                                  "from": "lodash@2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                                 },
                                 "underscore.string": {
                                   "version": "2.3.3",
-                                  "from": "underscore.string@^2.3.3"
+                                  "from": "underscore.string@2.3.3",
+                                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                                 }
                               }
                             },
                             "stream-combiner": {
                               "version": "0.0.4",
-                              "from": "stream-combiner@^0.0.4",
+                              "from": "stream-combiner@0.0.4",
+                              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                               "dependencies": {
                                 "duplexer": {
                                   "version": "0.1.1",
-                                  "from": "duplexer@~0.1.1"
+                                  "from": "duplexer@0.1.1",
+                                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                                 }
                               }
                             },
                             "tar": {
                               "version": "0.1.19",
-                              "from": "tar@^0.1.18",
+                              "from": "tar@0.1.19",
+                              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
                               "dependencies": {
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@2"
+                                  "from": "inherits@2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "block-stream": {
                                   "version": "0.0.7",
-                                  "from": "block-stream@*"
+                                  "from": "block-stream@0.0.7",
+                                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
                                 },
                                 "fstream": {
                                   "version": "0.1.25",
-                                  "from": "fstream@~0.1.8",
+                                  "from": "fstream@0.1.25",
+                                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "2.0.3",
-                                      "from": "graceful-fs@~2.0.0"
+                                      "from": "graceful-fs@2.0.3",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                                     }
                                   }
                                 }
@@ -2461,59 +4027,72 @@
                         },
                         "each-async": {
                           "version": "0.1.3",
-                          "from": "each-async@^0.1.1"
+                          "from": "each-async@0.1.3",
+                          "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
                         },
                         "get-stdin": {
                           "version": "0.1.0",
-                          "from": "get-stdin@^0.1.0"
+                          "from": "get-stdin@0.1.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
                         },
                         "get-urls": {
                           "version": "0.1.2",
-                          "from": "get-urls@^0.1.1"
+                          "from": "get-urls@0.1.2",
+                          "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
                         },
                         "nopt": {
                           "version": "2.2.1",
-                          "from": "nopt@^2.2.0",
+                          "from": "nopt@2.2.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
                           "dependencies": {
                             "abbrev": {
                               "version": "1.0.5",
-                              "from": "abbrev@1"
+                              "from": "abbrev@1.0.5",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                             }
                           }
                         },
                         "through2": {
                           "version": "0.4.2",
-                          "from": "through2@^0.4.0",
+                          "from": "through2@0.4.2",
+                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.27-1",
-                              "from": "readable-stream@~1.0.17",
+                              "from": "readable-stream@1.0.27-1",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "core-util-is@~1.0.0"
+                                  "from": "core-util-is@1.0.1",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1"
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.25-1",
-                                  "from": "string_decoder@~0.10.x"
+                                  "from": "string_decoder@0.10.25-1",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.1"
+                                  "from": "inherits@2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "xtend": {
                               "version": "2.1.2",
-                              "from": "xtend@~2.1.1",
+                              "from": "xtend@2.1.2",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                               "dependencies": {
                                 "object-keys": {
                                   "version": "0.4.0",
-                                  "from": "object-keys@~0.4.0"
+                                  "from": "object-keys@0.4.0",
+                                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                                 }
                               }
                             }
@@ -2523,27 +4102,33 @@
                     },
                     "executable": {
                       "version": "0.1.2",
-                      "from": "executable@^0.1.0"
+                      "from": "executable@0.1.2",
+                      "resolved": "https://registry.npmjs.org/executable/-/executable-0.1.2.tgz"
                     },
                     "find-file": {
                       "version": "0.1.4",
-                      "from": "find-file@^0.1.2"
+                      "from": "find-file@0.1.4",
+                      "resolved": "https://registry.npmjs.org/find-file/-/find-file-0.1.4.tgz"
                     },
                     "mout": {
                       "version": "0.9.1",
-                      "from": "mout@^0.9.1"
+                      "from": "mout@0.9.1",
+                      "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "rimraf@^2.2.6"
+                      "from": "rimraf@2.2.8",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     },
                     "tempfile": {
                       "version": "0.1.3",
-                      "from": "tempfile@^0.1.2",
+                      "from": "tempfile@0.1.3",
+                      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
                       "dependencies": {
                         "uuid": {
                           "version": "1.4.1",
-                          "from": "uuid@~1.4.0"
+                          "from": "uuid@1.4.1",
+                          "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                         }
                       }
                     }
@@ -2553,81 +4138,99 @@
             },
             "optipng-bin": {
               "version": "0.3.8",
-              "from": "optipng-bin@~0.3.0",
+              "from": "optipng-bin@0.3.8",
+              "resolved": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-0.3.8.tgz",
               "dependencies": {
                 "bin-build": {
                   "version": "0.1.1",
-                  "from": "bin-build@^0.1.0",
+                  "from": "bin-build@0.1.1",
+                  "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-0.1.1.tgz",
                   "dependencies": {
                     "download": {
                       "version": "0.1.17",
-                      "from": "download@^0.1.16",
+                      "from": "download@0.1.17",
+                      "resolved": "https://registry.npmjs.org/download/-/download-0.1.17.tgz",
                       "dependencies": {
                         "decompress": {
                           "version": "0.2.3",
-                          "from": "decompress@^0.2.0",
+                          "from": "decompress@0.2.3",
+                          "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.3.tgz",
                           "dependencies": {
                             "adm-zip": {
                               "version": "0.4.4",
-                              "from": "adm-zip@^0.4.3"
+                              "from": "adm-zip@0.4.4",
+                              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
                             },
                             "extname": {
                               "version": "0.1.2",
-                              "from": "extname@^0.1.1",
+                              "from": "extname@0.1.2",
+                              "resolved": "https://registry.npmjs.org/extname/-/extname-0.1.2.tgz",
                               "dependencies": {
                                 "ext-list": {
                                   "version": "0.1.0",
-                                  "from": "ext-list@^0.1.0"
+                                  "from": "ext-list@0.1.0",
+                                  "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.1.0.tgz"
                                 },
                                 "underscore.string": {
                                   "version": "2.3.3",
-                                  "from": "underscore.string@~2.3.3"
+                                  "from": "underscore.string@2.3.3",
+                                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                                 }
                               }
                             },
                             "map-key": {
                               "version": "0.1.4",
-                              "from": "map-key@^0.1.1",
+                              "from": "map-key@0.1.4",
+                              "resolved": "https://registry.npmjs.org/map-key/-/map-key-0.1.4.tgz",
                               "dependencies": {
                                 "lodash": {
                                   "version": "2.4.1",
-                                  "from": "lodash@^2.4.1"
+                                  "from": "lodash@2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                                 },
                                 "underscore.string": {
                                   "version": "2.3.3",
-                                  "from": "underscore.string@^2.3.3"
+                                  "from": "underscore.string@2.3.3",
+                                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                                 }
                               }
                             },
                             "stream-combiner": {
                               "version": "0.0.4",
-                              "from": "stream-combiner@^0.0.4",
+                              "from": "stream-combiner@0.0.4",
+                              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                               "dependencies": {
                                 "duplexer": {
                                   "version": "0.1.1",
-                                  "from": "duplexer@~0.1.1"
+                                  "from": "duplexer@0.1.1",
+                                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                                 }
                               }
                             },
                             "tar": {
                               "version": "0.1.19",
-                              "from": "tar@^0.1.18",
+                              "from": "tar@0.1.19",
+                              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
                               "dependencies": {
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@2"
+                                  "from": "inherits@2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "block-stream": {
                                   "version": "0.0.7",
-                                  "from": "block-stream@*"
+                                  "from": "block-stream@0.0.7",
+                                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
                                 },
                                 "fstream": {
                                   "version": "0.1.25",
-                                  "from": "fstream@~0.1.8",
+                                  "from": "fstream@0.1.25",
+                                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "2.0.3",
-                                      "from": "graceful-fs@~2.0.0"
+                                      "from": "graceful-fs@2.0.3",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                                     }
                                   }
                                 }
@@ -2637,59 +4240,72 @@
                         },
                         "each-async": {
                           "version": "0.1.3",
-                          "from": "each-async@^0.1.1"
+                          "from": "each-async@0.1.3",
+                          "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
                         },
                         "get-stdin": {
                           "version": "0.1.0",
-                          "from": "get-stdin@^0.1.0"
+                          "from": "get-stdin@0.1.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
                         },
                         "get-urls": {
                           "version": "0.1.2",
-                          "from": "get-urls@^0.1.1"
+                          "from": "get-urls@0.1.2",
+                          "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
                         },
                         "nopt": {
                           "version": "2.2.1",
-                          "from": "nopt@^2.2.0",
+                          "from": "nopt@2.2.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
                           "dependencies": {
                             "abbrev": {
                               "version": "1.0.5",
-                              "from": "abbrev@1"
+                              "from": "abbrev@1.0.5",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                             }
                           }
                         },
                         "through2": {
                           "version": "0.4.2",
-                          "from": "through2@^0.4.0",
+                          "from": "through2@0.4.2",
+                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.27-1",
-                              "from": "readable-stream@~1.0.17",
+                              "from": "readable-stream@1.0.27-1",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "core-util-is@~1.0.0"
+                                  "from": "core-util-is@1.0.1",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1"
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.25-1",
-                                  "from": "string_decoder@~0.10.x"
+                                  "from": "string_decoder@0.10.25-1",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.1"
+                                  "from": "inherits@2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "xtend": {
                               "version": "2.1.2",
-                              "from": "xtend@~2.1.1",
+                              "from": "xtend@2.1.2",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                               "dependencies": {
                                 "object-keys": {
                                   "version": "0.4.0",
-                                  "from": "object-keys@~0.4.0"
+                                  "from": "object-keys@0.4.0",
+                                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                                 }
                               }
                             }
@@ -2699,15 +4315,18 @@
                     },
                     "rimraf": {
                       "version": "2.2.8",
-                      "from": "rimraf@^2.2.6"
+                      "from": "rimraf@2.2.8",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     },
                     "tempfile": {
                       "version": "0.1.3",
-                      "from": "tempfile@^0.1.3",
+                      "from": "tempfile@0.1.3",
+                      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
                       "dependencies": {
                         "uuid": {
                           "version": "1.4.1",
-                          "from": "uuid@~1.4.0"
+                          "from": "uuid@1.4.1",
+                          "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                         }
                       }
                     }
@@ -2715,91 +4334,111 @@
                 },
                 "bin-wrapper": {
                   "version": "0.3.4",
-                  "from": "bin-wrapper@^0.3.0",
+                  "from": "bin-wrapper@0.3.4",
+                  "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-0.3.4.tgz",
                   "dependencies": {
                     "bin-check": {
                       "version": "0.1.5",
-                      "from": "bin-check@^0.1.0",
+                      "from": "bin-check@0.1.5",
+                      "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-0.1.5.tgz",
                       "dependencies": {
                         "executable": {
                           "version": "0.1.2",
-                          "from": "executable@^0.1.0"
+                          "from": "executable@0.1.2",
+                          "resolved": "https://registry.npmjs.org/executable/-/executable-0.1.2.tgz"
                         }
                       }
                     },
                     "download": {
                       "version": "0.1.17",
-                      "from": "download@^0.1.2",
+                      "from": "download@0.1.17",
+                      "resolved": "https://registry.npmjs.org/download/-/download-0.1.17.tgz",
                       "dependencies": {
                         "decompress": {
                           "version": "0.2.3",
-                          "from": "decompress@^0.2.0",
+                          "from": "decompress@0.2.3",
+                          "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.3.tgz",
                           "dependencies": {
                             "adm-zip": {
                               "version": "0.4.4",
-                              "from": "adm-zip@^0.4.3"
+                              "from": "adm-zip@0.4.4",
+                              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
                             },
                             "extname": {
                               "version": "0.1.2",
-                              "from": "extname@^0.1.1",
+                              "from": "extname@0.1.2",
+                              "resolved": "https://registry.npmjs.org/extname/-/extname-0.1.2.tgz",
                               "dependencies": {
                                 "ext-list": {
                                   "version": "0.1.0",
-                                  "from": "ext-list@^0.1.0"
+                                  "from": "ext-list@0.1.0",
+                                  "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.1.0.tgz"
                                 },
                                 "underscore.string": {
                                   "version": "2.3.3",
-                                  "from": "underscore.string@~2.3.3"
+                                  "from": "underscore.string@2.3.3",
+                                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                                 }
                               }
                             },
                             "map-key": {
                               "version": "0.1.4",
-                              "from": "map-key@^0.1.1",
+                              "from": "map-key@0.1.4",
+                              "resolved": "https://registry.npmjs.org/map-key/-/map-key-0.1.4.tgz",
                               "dependencies": {
                                 "lodash": {
                                   "version": "2.4.1",
-                                  "from": "lodash@^2.4.1"
+                                  "from": "lodash@2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                                 },
                                 "underscore.string": {
                                   "version": "2.3.3",
-                                  "from": "underscore.string@^2.3.3"
+                                  "from": "underscore.string@2.3.3",
+                                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                                 }
                               }
                             },
                             "rimraf": {
                               "version": "2.2.8",
-                              "from": "rimraf@^2.2.2"
+                              "from": "rimraf@2.2.8",
+                              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                             },
                             "stream-combiner": {
                               "version": "0.0.4",
-                              "from": "stream-combiner@^0.0.4",
+                              "from": "stream-combiner@0.0.4",
+                              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                               "dependencies": {
                                 "duplexer": {
                                   "version": "0.1.1",
-                                  "from": "duplexer@~0.1.1"
+                                  "from": "duplexer@0.1.1",
+                                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                                 }
                               }
                             },
                             "tar": {
                               "version": "0.1.19",
-                              "from": "tar@^0.1.18",
+                              "from": "tar@0.1.19",
+                              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
                               "dependencies": {
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@2"
+                                  "from": "inherits@2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "block-stream": {
                                   "version": "0.0.7",
-                                  "from": "block-stream@*"
+                                  "from": "block-stream@0.0.7",
+                                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
                                 },
                                 "fstream": {
                                   "version": "0.1.25",
-                                  "from": "fstream@~0.1.8",
+                                  "from": "fstream@0.1.25",
+                                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "2.0.3",
-                                      "from": "graceful-fs@~2.0.0"
+                                      "from": "graceful-fs@2.0.3",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                                     }
                                   }
                                 }
@@ -2807,11 +4446,13 @@
                             },
                             "tempfile": {
                               "version": "0.1.3",
-                              "from": "tempfile@^0.1.2",
+                              "from": "tempfile@0.1.3",
+                              "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
                               "dependencies": {
                                 "uuid": {
                                   "version": "1.4.1",
-                                  "from": "uuid@~1.4.0"
+                                  "from": "uuid@1.4.1",
+                                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
                                 }
                               }
                             }
@@ -2819,59 +4460,72 @@
                         },
                         "each-async": {
                           "version": "0.1.3",
-                          "from": "each-async@^0.1.1"
+                          "from": "each-async@0.1.3",
+                          "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
                         },
                         "get-stdin": {
                           "version": "0.1.0",
-                          "from": "get-stdin@^0.1.0"
+                          "from": "get-stdin@0.1.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
                         },
                         "get-urls": {
                           "version": "0.1.2",
-                          "from": "get-urls@^0.1.1"
+                          "from": "get-urls@0.1.2",
+                          "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
                         },
                         "nopt": {
                           "version": "2.2.1",
-                          "from": "nopt@^2.2.0",
+                          "from": "nopt@2.2.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
                           "dependencies": {
                             "abbrev": {
                               "version": "1.0.5",
-                              "from": "abbrev@1"
+                              "from": "abbrev@1.0.5",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
                             }
                           }
                         },
                         "through2": {
                           "version": "0.4.2",
-                          "from": "through2@^0.4.0",
+                          "from": "through2@0.4.2",
+                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.27-1",
-                              "from": "readable-stream@~1.0.17",
+                              "from": "readable-stream@1.0.27-1",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "core-util-is@~1.0.0"
+                                  "from": "core-util-is@1.0.1",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1"
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.25-1",
-                                  "from": "string_decoder@~0.10.x"
+                                  "from": "string_decoder@0.10.25-1",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.1"
+                                  "from": "inherits@2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "xtend": {
                               "version": "2.1.2",
-                              "from": "xtend@~2.1.1",
+                              "from": "xtend@2.1.2",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                               "dependencies": {
                                 "object-keys": {
                                   "version": "0.4.0",
-                                  "from": "object-keys@~0.4.0"
+                                  "from": "object-keys@0.4.0",
+                                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                                 }
                               }
                             }
@@ -2881,7 +4535,8 @@
                     },
                     "find-file": {
                       "version": "0.1.4",
-                      "from": "find-file@^0.1.2"
+                      "from": "find-file@0.1.4",
+                      "resolved": "https://registry.npmjs.org/find-file/-/find-file-0.1.4.tgz"
                     }
                   }
                 }
@@ -2894,94 +4549,115 @@
     "grunt-contrib-uglify": {
       "version": "0.4.0",
       "from": "grunt-contrib-uglify@0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.4.0.tgz",
       "dependencies": {
         "uglify-js": {
           "version": "2.4.13",
-          "from": "uglify-js@^2.4.0",
+          "from": "uglify-js@2.4.13",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.13.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.6"
+              "from": "async@0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.33",
-              "from": "source-map@~0.1.33",
+              "from": "source-map@0.1.33",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4"
+                  "from": "amdefine@0.1.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             },
             "optimist": {
               "version": "0.3.7",
-              "from": "optimist@~0.3.5",
+              "from": "optimist@0.3.7",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@~0.0.2"
+                  "from": "wordwrap@0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@~1.0.0"
+              "from": "uglify-to-browserify@1.0.2",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             }
           }
         },
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "chalk@0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "maxmin": {
           "version": "0.1.0",
-          "from": "maxmin@^0.1.0",
+          "from": "maxmin@0.1.0",
+          "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-0.1.0.tgz",
           "dependencies": {
             "gzip-size": {
               "version": "0.1.1",
-              "from": "gzip-size@^0.1.0",
+              "from": "gzip-size@0.1.1",
+              "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.1.1.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.4.5",
-                  "from": "concat-stream@^1.4.1",
+                  "from": "concat-stream@1.4.5",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.5.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1"
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@~0.0.5"
+                      "from": "typedarray@0.0.6",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13-1",
-                      "from": "readable-stream@~1.1.9",
+                      "from": "readable-stream@1.1.13-1",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0"
+                          "from": "core-util-is@1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1"
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.25-1",
-                          "from": "string_decoder@~0.10.x"
+                          "from": "string_decoder@0.10.25-1",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                         }
                       }
                     }
@@ -2989,23 +4665,28 @@
                 },
                 "zlib-browserify": {
                   "version": "0.0.3",
-                  "from": "zlib-browserify@^0.0.3",
+                  "from": "zlib-browserify@0.0.3",
+                  "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.3.tgz",
                   "dependencies": {
                     "tape": {
                       "version": "0.2.2",
-                      "from": "tape@~0.2.2",
+                      "from": "tape@0.2.2",
+                      "resolved": "https://registry.npmjs.org/tape/-/tape-0.2.2.tgz",
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
-                          "from": "jsonify@~0.0.0"
+                          "from": "jsonify@0.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                         },
                         "deep-equal": {
                           "version": "0.0.0",
-                          "from": "deep-equal@~0.0.0"
+                          "from": "deep-equal@0.0.0",
+                          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
                         },
                         "defined": {
                           "version": "0.0.0",
-                          "from": "defined@~0.0.0"
+                          "from": "defined@0.0.0",
+                          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
                         }
                       }
                     }
@@ -3015,7 +4696,8 @@
             },
             "pretty-bytes": {
               "version": "0.1.1",
-              "from": "pretty-bytes@^0.1.0"
+              "from": "pretty-bytes@0.1.1",
+              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.1.tgz"
             }
           }
         }
@@ -3024,44 +4706,54 @@
     "grunt-marked": {
       "version": "0.1.0",
       "from": "grunt-marked@0.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-marked/-/grunt-marked-0.1.0.tgz",
       "dependencies": {
         "marked": {
           "version": "0.3.2",
-          "from": "marked@~0.3.1"
+          "from": "marked@0.3.2",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.2.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.10"
+          "from": "async@0.2.x",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "highlight.js": {
           "version": "8.0.0",
-          "from": "highlight.js@~8.0.0"
+          "from": "highlight.js@8.0.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.0.0.tgz"
         }
       }
     },
     "grunt-nsp-shrinkwrap": {
       "version": "0.0.3",
       "from": "grunt-nsp-shrinkwrap@0.0.3",
+      "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
       "dependencies": {
         "cli-color": {
           "version": "0.2.3",
-          "from": "cli-color@^0.2.3",
+          "from": "cli-color@0.2.3",
+          "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
           "dependencies": {
             "es5-ext": {
               "version": "0.9.2",
-              "from": "es5-ext@~0.9.2"
+              "from": "es5-ext@0.9.2",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
             },
             "memoizee": {
               "version": "0.2.6",
-              "from": "memoizee@~0.2.5",
+              "from": "memoizee@0.2.6",
+              "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
               "dependencies": {
                 "event-emitter": {
                   "version": "0.2.2",
-                  "from": "event-emitter@~0.2.2"
+                  "from": "event-emitter@0.2.2",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
                 },
                 "next-tick": {
                   "version": "0.1.0",
-                  "from": "next-tick@0.1.x"
+                  "from": "next-tick@0.1.0",
+                  "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
                 }
               }
             }
@@ -3069,11 +4761,13 @@
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@^0.6.2"
+          "from": "colors@0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@~0.2.0"
+          "from": "text-table@~0.2",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
@@ -3085,22 +4779,27 @@
         "po2json": {
           "version": "0.2.3",
           "from": "po2json@*",
+          "resolved": "https://registry.npmjs.org/po2json/-/po2json-0.2.3.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@~2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "gettext-parser": {
               "version": "0.2.0",
               "from": "gettext-parser@~0.2.0",
+              "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.7",
                   "from": "encoding@~0.1",
+                  "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.7.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.2.11",
-                      "from": "iconv-lite@~0.2.11"
+                      "from": "iconv-lite@~0.2.11",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
                     }
                   }
                 }
@@ -3113,50 +4812,62 @@
     "grunt-requirejs": {
       "version": "0.4.2",
       "from": "grunt-requirejs@0.4.2",
+      "resolved": "https://registry.npmjs.org/grunt-requirejs/-/grunt-requirejs-0.4.2.tgz",
       "dependencies": {
         "requirejs": {
           "version": "2.1.11",
-          "from": "requirejs@2.1.x"
+          "from": "requirejs@2.1.11",
+          "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.11.tgz"
         },
         "cheerio": {
           "version": "0.13.1",
-          "from": "cheerio@0.13.x",
+          "from": "cheerio@0.13.1",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
           "dependencies": {
             "htmlparser2": {
               "version": "3.4.0",
-              "from": "htmlparser2@~3.4.0",
+              "from": "htmlparser2@3.4.0",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.0",
-                  "from": "domhandler@2.2"
+                  "from": "domhandler@2.2.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.0.tgz"
                 },
                 "domutils": {
                   "version": "1.3.0",
-                  "from": "domutils@1.3"
+                  "from": "domutils@1.3.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz"
                 },
                 "domelementtype": {
                   "version": "1.1.1",
-                  "from": "domelementtype@1"
+                  "from": "domelementtype@1.1.1",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13-1",
-                  "from": "readable-stream@1.1",
+                  "from": "readable-stream@1.1.13-1",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0"
+                      "from": "core-util-is@1.0.1",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1"
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.25-1",
-                      "from": "string_decoder@~0.10.x"
+                      "from": "string_decoder@0.10.25-1",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1"
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -3164,27 +4875,33 @@
             },
             "underscore": {
               "version": "1.5.2",
-              "from": "underscore@~1.5"
+              "from": "underscore@1.5.2",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "entities@0.x"
+              "from": "entities@0.5.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             },
             "CSSselect": {
               "version": "0.4.1",
-              "from": "CSSselect@~0.4.0",
+              "from": "CSSselect@0.4.1",
+              "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "dependencies": {
                 "CSSwhat": {
                   "version": "0.4.7",
-                  "from": "CSSwhat@0.4"
+                  "from": "CSSwhat@0.4.7",
+                  "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                 },
                 "domutils": {
                   "version": "1.4.3",
-                  "from": "domutils@1.4",
+                  "from": "domutils@1.4.3",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.1",
-                      "from": "domelementtype@1"
+                      "from": "domelementtype@1.1.1",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
                     }
                   }
                 }
@@ -3194,125 +4911,153 @@
         },
         "almond": {
           "version": "0.2.9",
-          "from": "almond@0.2.x"
+          "from": "almond@0.2.9",
+          "resolved": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz"
         },
         "gzip-js": {
           "version": "0.3.2",
-          "from": "gzip-js@0.3.x",
+          "from": "gzip-js@0.3.2",
+          "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
           "dependencies": {
             "crc32": {
               "version": "0.2.2",
-              "from": "crc32@>= 0.2.2"
+              "from": "crc32@0.2.2",
+              "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
             },
             "deflate-js": {
               "version": "0.2.3",
-              "from": "deflate-js@>= 0.2.2"
+              "from": "deflate-js@0.2.3",
+              "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz"
             }
           }
         },
         "q": {
           "version": "0.8.12",
-          "from": "q@0.8.x"
+          "from": "q@0.8.12",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz"
         }
       }
     },
     "grunt-rev": {
       "version": "0.1.0",
-      "from": "grunt-rev@0.1.0"
+      "from": "grunt-rev@0.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-rev/-/grunt-rev-0.1.0.tgz"
     },
     "grunt-sass": {
       "version": "0.12.1",
       "from": "grunt-sass@0.12.1",
+      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.12.1.tgz",
       "dependencies": {
         "node-sass": {
           "version": "0.8.6",
-          "from": "node-sass@^0.8.0",
+          "from": "node-sass@0.8.6",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-0.8.6.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@0.3.x"
+              "from": "mkdirp@~0.3.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "optimist": {
               "version": "0.6.1",
-              "from": "optimist@0.6.x",
+              "from": "optimist@0.6.1",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@~0.0.2"
+                  "from": "wordwrap@0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@~0.0.1"
+                  "from": "minimist@0.0.10",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "node-watch": {
               "version": "0.3.4",
-              "from": "node-watch@0.3.x"
+              "from": "node-watch@0.3.4",
+              "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz"
             },
             "nan": {
               "version": "0.8.0",
-              "from": "nan@~0.8.0"
+              "from": "nan@0.8.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-0.8.0.tgz"
             },
             "mocha": {
               "version": "1.18.2",
-              "from": "mocha@1.18.x",
+              "from": "mocha@1.18.2",
+              "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.18.2.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.0.0",
-                  "from": "commander@2.0.0"
+                  "from": "commander@2.0.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
                 },
                 "growl": {
                   "version": "1.7.0",
-                  "from": "growl@1.7.x"
+                  "from": "growl@1.7.0",
+                  "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
                 },
                 "jade": {
                   "version": "0.26.3",
                   "from": "jade@0.26.3",
+                  "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "0.6.1",
-                      "from": "commander@0.6.1"
+                      "from": "commander@0.6.1",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                     },
                     "mkdirp": {
                       "version": "0.3.0",
-                      "from": "mkdirp@0.3.0"
+                      "from": "mkdirp@0.3.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
                     }
                   }
                 },
                 "diff": {
                   "version": "1.0.7",
-                  "from": "diff@1.0.7"
+                  "from": "diff@1.0.7",
+                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
                 },
                 "debug": {
                   "version": "0.8.1",
-                  "from": "debug@*"
+                  "from": "debug@0.8.1",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
                 },
                 "glob": {
                   "version": "3.2.3",
                   "from": "glob@3.2.3",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
                   "dependencies": {
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
+                      "from": "minimatch@0.2.14",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2"
+                          "from": "lru-cache@2.5.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0"
+                          "from": "sigmund@1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
                     },
                     "graceful-fs": {
                       "version": "2.0.3",
-                      "from": "graceful-fs@~2.0.0"
+                      "from": "graceful-fs@2.0.3",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2"
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -3320,25 +5065,30 @@
             },
             "sinon": {
               "version": "1.10.0",
-              "from": "sinon@^1.9.1",
+              "from": "sinon@1.10.0",
+              "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.10.0.tgz",
               "dependencies": {
                 "formatio": {
                   "version": "1.0.2",
-                  "from": "formatio@~1.0",
+                  "from": "formatio@1.0.2",
+                  "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.0.2.tgz",
                   "dependencies": {
                     "samsam": {
                       "version": "1.1.1",
-                      "from": "samsam@~1.1"
+                      "from": "samsam@1.1.1",
+                      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.1.tgz"
                     }
                   }
                 },
                 "util": {
                   "version": "0.10.3",
-                  "from": "util@>=0.10.3 <1",
+                  "from": "util@0.10.3",
+                  "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2.0.1"
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -3348,93 +5098,113 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "chalk@0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "each-async": {
           "version": "0.1.3",
-          "from": "each-async@^0.1.2"
+          "from": "each-async@0.1.3",
+          "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
         }
       }
     },
     "grunt-text-replace": {
       "version": "0.3.11",
-      "from": "grunt-text-replace@0.3.11"
+      "from": "grunt-text-replace@0.3.11",
+      "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.3.11.tgz"
     },
     "grunt-usemin": {
       "version": "2.1.1",
       "from": "grunt-usemin@2.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-2.1.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "1.0.1",
-          "from": "lodash@~1.0.1"
+          "from": "lodash@1.0.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
         },
         "debug": {
           "version": "0.7.4",
-          "from": "debug@~0.7.2"
+          "from": "debug@0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
         }
       }
     },
     "grunt-z-schema": {
       "version": "0.1.0",
       "from": "grunt-z-schema@0.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-z-schema/-/grunt-z-schema-0.1.0.tgz",
       "dependencies": {
         "z-schema": {
           "version": "2.4.7",
-          "from": "z-schema@~2.4.3"
+          "from": "z-schema@2.4.7",
+          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-2.4.7.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.10"
+          "from": "async@0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@~2.4.1"
+          "from": "lodash@~2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         }
       }
     },
     "handlebars": {
       "version": "1.3.0",
       "from": "handlebars@1.3.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
       "dependencies": {
         "optimist": {
           "version": "0.3.7",
-          "from": "optimist@~0.3",
+          "from": "optimist@0.3.7",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2"
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.3.6",
-          "from": "uglify-js@~2.3",
+          "from": "uglify-js@2.3.6",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.6"
+              "from": "async@0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.33",
-              "from": "source-map@~0.1.7",
+              "from": "source-map@0.1.33",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4"
+                  "from": "amdefine@0.1.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             }
@@ -3445,24 +5215,28 @@
     "helmet": {
       "version": "0.2.1",
       "from": "helmet@0.2.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-0.2.1.tgz",
       "dependencies": {
         "platform": {
           "version": "1.0.0",
-          "from": "platform@1.0.x"
+          "from": "platform@1.0.0",
+          "resolved": "https://registry.npmjs.org/platform/-/platform-1.0.0.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@1.6.x"
+          "from": "underscore@1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
     },
     "i18n-abide": {
       "version": "0.0.20",
       "from": "i18n-abide@0.0.20",
+      "resolved": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.20.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@0.1.22",
+          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "gobbledygook": {
@@ -3473,22 +5247,27 @@
         "jsxgettext": {
           "version": "0.3.9",
           "from": "jsxgettext@0.3.9",
+          "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.3.9.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.4.2",
-              "from": "acorn@0.4.2"
+              "from": "acorn@0.4.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.4.2.tgz"
             },
             "gettext-parser": {
               "version": "0.2.0",
               "from": "gettext-parser@0.2.0",
+              "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.7",
-                  "from": "encoding@~0.1",
+                  "from": "encoding@0.1.7",
+                  "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.7.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.2.11",
-                      "from": "iconv-lite@~0.2.11"
+                      "from": "iconv-lite@0.2.11",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
                     }
                   }
                 }
@@ -3497,84 +5276,102 @@
             "nomnom": {
               "version": "1.5.2",
               "from": "nomnom@1.5.2",
+              "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
-                  "from": "underscore@1.1.x"
+                  "from": "underscore@1.1.7",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                 },
                 "colors": {
                   "version": "0.5.1",
-                  "from": "colors@0.5.x"
+                  "from": "colors@0.5.1",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                 }
               }
             },
             "jade": {
               "version": "0.30.0",
               "from": "jade@0.30.0",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
               "dependencies": {
                 "commander": {
                   "version": "1.1.1",
-                  "from": "commander@~1.1.1",
+                  "from": "commander@1.1.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                   "dependencies": {
                     "keypress": {
                       "version": "0.1.0",
-                      "from": "keypress@0.1.x"
+                      "from": "keypress@0.1.0",
+                      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@0.3.x"
+                  "from": "mkdirp@0.3.5",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 },
                 "transformers": {
                   "version": "2.0.1",
-                  "from": "transformers@~2.0.1",
+                  "from": "transformers@2.0.1",
+                  "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                   "dependencies": {
                     "promise": {
                       "version": "2.0.0",
-                      "from": "promise@~2.0",
+                      "from": "promise@2.0.0",
+                      "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                       "dependencies": {
                         "is-promise": {
                           "version": "1.0.1",
-                          "from": "is-promise@~1"
+                          "from": "is-promise@1.0.1",
+                          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                         }
                       }
                     },
                     "css": {
                       "version": "1.0.8",
-                      "from": "css@~1.0.8",
+                      "from": "css@1.0.8",
+                      "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                       "dependencies": {
                         "css-parse": {
                           "version": "1.0.4",
-                          "from": "css-parse@1.0.4"
+                          "from": "css-parse@1.0.4",
+                          "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                         },
                         "css-stringify": {
                           "version": "1.0.5",
-                          "from": "css-stringify@1.0.5"
+                          "from": "css-stringify@1.0.5",
+                          "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                         }
                       }
                     },
                     "uglify-js": {
                       "version": "2.2.5",
-                      "from": "uglify-js@~2.2.5",
+                      "from": "uglify-js@2.2.5",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.33",
-                          "from": "source-map@~0.1.7",
+                          "from": "source-map@0.1.33",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "amdefine@>=0.0.4"
+                              "from": "amdefine@0.1.0",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
                         },
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "optimist@~0.3.5",
+                          "from": "optimist@0.3.7",
+                          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "wordwrap@~0.0.2"
+                              "from": "wordwrap@0.0.2",
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
                         }
@@ -3584,27 +5381,33 @@
                 },
                 "character-parser": {
                   "version": "1.0.2",
-                  "from": "character-parser@~1.0.0"
+                  "from": "character-parser@1.0.2",
+                  "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
                 },
                 "monocle": {
                   "version": "0.1.50",
-                  "from": "monocle@~0.1.46",
+                  "from": "monocle@0.1.50",
+                  "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                   "dependencies": {
                     "readdirp": {
                       "version": "0.2.5",
-                      "from": "readdirp@~0.2.3",
+                      "from": "readdirp@0.2.5",
+                      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                       "dependencies": {
                         "minimatch": {
                           "version": "0.3.0",
-                          "from": "minimatch@>=0.2.4",
+                          "from": "minimatch@0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.5.0",
-                              "from": "lru-cache@2"
+                              "from": "lru-cache@2.5.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.0",
-                              "from": "sigmund@~1.0.0"
+                              "from": "sigmund@1.0.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                             }
                           }
                         }
@@ -3619,24 +5422,29 @@
         "optimist": {
           "version": "0.3.4",
           "from": "optimist@0.3.4",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.4.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@0.0.x"
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "plist": {
           "version": "0.4.3",
           "from": "plist@0.4.3",
+          "resolved": "https://registry.npmjs.org/plist/-/plist-0.4.3.tgz",
           "dependencies": {
             "xmlbuilder": {
               "version": "0.4.3",
-              "from": "xmlbuilder@0.4.x"
+              "from": "xmlbuilder@0.4.3",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz"
             },
             "xmldom": {
               "version": "0.1.19",
-              "from": "xmldom@0.1.x"
+              "from": "xmldom@0.1.19",
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
             }
           }
         }
@@ -3645,113 +5453,137 @@
     "intel": {
       "version": "0.5.2",
       "from": "intel@0.5.2",
+      "resolved": "https://registry.npmjs.org/intel/-/intel-0.5.2.tgz",
       "dependencies": {
         "bluebird": {
           "version": "1.0.8",
-          "from": "bluebird@1.0.x"
+          "from": "bluebird@1.0.8",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.0.8.tgz"
         },
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@0.4.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "dbug": {
           "version": "0.2.0",
-          "from": "dbug@0.2.x"
+          "from": "dbug@0.2.0",
+          "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.2.0.tgz"
         },
         "stack-trace": {
           "version": "0.0.8",
-          "from": "stack-trace@0.0.8"
+          "from": "stack-trace@0.0.8",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.8.tgz"
         },
         "strftime": {
           "version": "0.8.0",
-          "from": "strftime@0.8.0"
+          "from": "strftime@0.8.0",
+          "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.0.tgz"
         },
         "symbol": {
           "version": "0.1.0",
-          "from": "symbol@0.1.0"
+          "from": "symbol@0.1.0",
+          "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.1.0.tgz"
         },
         "utcstring": {
           "version": "0.1.0",
-          "from": "utcstring@0.1.0"
+          "from": "utcstring@0.1.0",
+          "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
         }
       }
     },
     "jshint-stylish": {
       "version": "0.2.0",
       "from": "jshint-stylish@0.2.0",
+      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-0.2.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "chalk@~0.4",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@~0.2.0"
+          "from": "text-table@~0.2",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
     },
     "jsxgettext-recursive": {
-      "version": "0.0.3",
-      "from": "jsxgettext-recursive@0.0.3",
+      "version": "0.0.4",
+      "from": "jsxgettext-recursive@0.0.4",
+      "resolved": "https://registry.npmjs.org/jsxgettext-recursive/-/jsxgettext-recursive-0.0.4.tgz",
       "dependencies": {
         "walk": {
           "version": "2.3.3",
           "from": "walk@~2.3.1",
+          "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.3.tgz",
           "dependencies": {
             "foreachasync": {
               "version": "3.0.0",
-              "from": "foreachasync@3.x"
+              "from": "foreachasync@3.x",
+              "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
             }
           }
         },
         "jsxgettext": {
-          "version": "0.3.10",
-          "from": "jsxgettext@~0.3.8",
+          "version": "0.4.3",
+          "from": "jsxgettext@~0.4.3",
+          "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.4.3.tgz",
           "dependencies": {
             "acorn": {
-              "version": "0.4.2",
-              "from": "acorn@0.4.2"
+              "version": "0.5.0",
+              "from": "acorn@~0.5.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.5.0.tgz"
             },
             "gettext-parser": {
               "version": "0.2.0",
               "from": "gettext-parser@0.2.0",
+              "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.7",
                   "from": "encoding@~0.1",
+                  "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.7.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.2.11",
-                      "from": "iconv-lite@~0.2.11"
+                      "from": "iconv-lite@~0.2.11",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
                     }
                   }
                 }
@@ -3760,84 +5592,102 @@
             "nomnom": {
               "version": "1.5.2",
               "from": "nomnom@1.5.2",
+              "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
-                  "from": "underscore@1.1.x"
+                  "from": "underscore@1.1.x",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                 },
                 "colors": {
                   "version": "0.5.1",
-                  "from": "colors@0.5.x"
+                  "from": "colors@0.5.x",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                 }
               }
             },
             "jade": {
               "version": "0.30.0",
               "from": "jade@0.30.0",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
               "dependencies": {
                 "commander": {
                   "version": "1.1.1",
                   "from": "commander@~1.1.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                   "dependencies": {
                     "keypress": {
                       "version": "0.1.0",
-                      "from": "keypress@0.1.x"
+                      "from": "keypress@0.1.x",
+                      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@0.3.x"
+                  "from": "mkdirp@0.3.x",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 },
                 "transformers": {
                   "version": "2.0.1",
                   "from": "transformers@~2.0.1",
+                  "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                   "dependencies": {
                     "promise": {
                       "version": "2.0.0",
                       "from": "promise@~2.0",
+                      "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                       "dependencies": {
                         "is-promise": {
                           "version": "1.0.1",
-                          "from": "is-promise@~1"
+                          "from": "is-promise@~1",
+                          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                         }
                       }
                     },
                     "css": {
                       "version": "1.0.8",
                       "from": "css@~1.0.8",
+                      "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                       "dependencies": {
                         "css-parse": {
                           "version": "1.0.4",
-                          "from": "css-parse@1.0.4"
+                          "from": "css-parse@1.0.4",
+                          "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                         },
                         "css-stringify": {
                           "version": "1.0.5",
-                          "from": "css-stringify@1.0.5"
+                          "from": "css-stringify@1.0.5",
+                          "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                         }
                       }
                     },
                     "uglify-js": {
                       "version": "2.2.5",
                       "from": "uglify-js@~2.2.5",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.33",
                           "from": "source-map@~0.1.7",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "amdefine@>=0.0.4"
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
                         },
                         "optimist": {
                           "version": "0.3.7",
                           "from": "optimist@~0.3.5",
+                          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "wordwrap@~0.0.2"
+                              "from": "wordwrap@~0.0.2",
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
                         }
@@ -3847,31 +5697,102 @@
                 },
                 "character-parser": {
                   "version": "1.0.2",
-                  "from": "character-parser@~1.0.0"
+                  "from": "character-parser@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
                 },
                 "monocle": {
                   "version": "0.1.50",
                   "from": "monocle@~0.1.46",
+                  "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                   "dependencies": {
                     "readdirp": {
                       "version": "0.2.5",
                       "from": "readdirp@~0.2.3",
+                      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                       "dependencies": {
                         "minimatch": {
                           "version": "0.3.0",
                           "from": "minimatch@>=0.2.4",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.5.0",
-                              "from": "lru-cache@2"
+                              "from": "lru-cache@2",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.0",
-                              "from": "sigmund@~1.0.0"
+                              "from": "sigmund@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                             }
                           }
                         }
                       }
+                    }
+                  }
+                }
+              }
+            },
+            "swig": {
+              "version": "1.3.2",
+              "from": "swig@1.3.2",
+              "resolved": "https://registry.npmjs.org/swig/-/swig-1.3.2.tgz",
+              "dependencies": {
+                "uglify-js": {
+                  "version": "2.4.13",
+                  "from": "uglify-js@~2.4",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.13.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@~0.2.6",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.33",
+                      "from": "source-map@~0.1.33",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    },
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@~0.3.5",
+                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                      "dependencies": {
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@~0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    },
+                    "uglify-to-browserify": {
+                      "version": "1.0.2",
+                      "from": "uglify-to-browserify@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@~0.6",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@~0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@~0.0.1",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
                 }
@@ -3884,30 +5805,37 @@
     "load-grunt-tasks": {
       "version": "0.4.0",
       "from": "load-grunt-tasks@0.4.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.4.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@^0.1.2",
+          "from": "findup-sync@0.1.3",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@^3.2.6",
+              "from": "glob@~3.2.9",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2"
+                  "from": "inherits@2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2"
+                      "from": "lru-cache@2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0"
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 }
@@ -3915,29 +5843,35 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@^2.4.1"
+              "from": "lodash@~2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
           "version": "0.1.0",
-          "from": "multimatch@^0.1.0",
+          "from": "multimatch@0.1.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.1.0.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1"
+              "from": "lodash@~2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "minimatch": {
               "version": "0.2.14",
               "from": "minimatch@~0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2"
+                  "from": "lru-cache@2.5.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0"
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             }
@@ -3948,158 +5882,193 @@
     "mkdirp": {
       "version": "0.5.0",
       "from": "mkdirp@0.5.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@0.0.8"
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "request": {
       "version": "2.34.0",
       "from": "request@2.34.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
       "dependencies": {
         "qs": {
           "version": "0.6.6",
-          "from": "qs@~0.6.0"
+          "from": "qs@0.6.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@~5.0.0"
+          "from": "json-stringify-safe@5.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@~0.5.0"
+          "from": "forever-agent@0.5.2",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "node-uuid": {
           "version": "1.4.1",
-          "from": "node-uuid@~1.4.0"
+          "from": "node-uuid@1.4.1",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@~1.2.9"
+          "from": "mime@1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "tough-cookie": {
           "version": "0.12.1",
-          "from": "tough-cookie@>=0.12.0",
+          "from": "tough-cookie@0.12.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.2.4",
-              "from": "punycode@>=0.2.0"
+              "from": "punycode@1.2.4",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
             }
           }
         },
         "form-data": {
           "version": "0.1.2",
-          "from": "form-data@~0.1.0",
+          "from": "form-data@0.1.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.4",
-              "from": "combined-stream@~0.0.4",
+              "from": "combined-stream@0.0.4",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5"
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.9"
+              "from": "async@0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.3.0",
-          "from": "tunnel-agent@~0.3.0"
+          "from": "tunnel-agent@0.3.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
         },
         "http-signature": {
           "version": "0.10.0",
-          "from": "http-signature@~0.10.0",
+          "from": "http-signature@0.10.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
-              "from": "assert-plus@0.1.2"
+              "from": "assert-plus@0.1.2",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11"
+              "from": "asn1@0.1.11",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.2",
-              "from": "ctype@0.5.2"
+              "from": "ctype@0.5.2",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.3.0",
-          "from": "oauth-sign@~0.3.0"
+          "from": "oauth-sign@0.3.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
         },
         "hawk": {
           "version": "1.0.0",
-          "from": "hawk@~1.0.0",
+          "from": "hawk@1.0.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "hoek@0.9.x"
+              "from": "hoek@0.9.1",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "boom@0.4.x"
+              "from": "boom@0.4.2",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "cryptiles@0.2.x"
+              "from": "cryptiles@0.2.2",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "sntp@0.2.x"
+              "from": "sntp@0.2.4",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@~0.5.0"
+          "from": "aws-sign2@0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         }
       }
     },
     "time-grunt": {
       "version": "0.3.1",
       "from": "time-grunt@0.3.1",
+      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-0.3.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "chalk@~0.4",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0"
+              "from": "has-color@0.1.7",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0"
+              "from": "ansi-styles@1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0"
+              "from": "strip-ansi@0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@~0.2"
+          "from": "text-table@~0.2",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@^0.2.3"
+          "from": "hooker@~0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "date-time": {
           "version": "0.1.1",
-          "from": "date-time@^0.1.0"
+          "from": "date-time@0.1.1",
+          "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz"
         },
         "pretty-ms": {
           "version": "0.1.0",
-          "from": "pretty-ms@^0.1.0"
+          "from": "pretty-ms@0.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.1.0.tgz"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "i18n-abide": "0.0.20",
     "intel": "0.5.2",
     "jshint-stylish": "0.2.0",
-    "jsxgettext-recursive": "0.0.3",
+    "jsxgettext-recursive": "0.0.4",
     "load-grunt-tasks": "0.4.0",
     "mkdirp": "0.5.0",
     "request": "2.34.0",


### PR DESCRIPTION
Update strings and exclude the `templates/pages/dist` directory from extraction, since that duplicates what's in `src` and adds a ton of noise to the `.po` and `.pot` files.

@pdehaan or @vladikoff r?
