### PR TITLE
chore: Remove font dependencies from bower.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,6 @@
     "backbone": "1.1.0",
     "blanket": "1.1.5",
     "chai": "1.8.1",
-    "connect-fonts-clearsans": "https://github.com/shane-tomlinson/connect-fonts-clearsans.git",
-    "connect-fonts-firasans": "https://github.com/shane-tomlinson/connect-fonts-firasans.git",
     "fxa-content-server-l10n": "https://github.com/mozilla/fxa-content-server-l10n.git",
     "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.20",
     "html5shiv": "3.7.2",


### PR DESCRIPTION
- Fonts are installed via npm and copied to the correct location using grunt.

fixes #1230
