### PR TITLE
fix(client): Convert all inline error strings to use an error object.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -39,7 +39,14 @@ function () {
 
     // local only error codes
     USER_CANCELED_LOGIN: 1001,
-    SESSION_EXPIRED: 1002
+    SESSION_EXPIRED: 1002,
+
+    COOKIES_STILL_DISABLED: 1003,
+    PASSWORDS_DO_NOT_MATCH: 1004,
+    WORKING: 1005,
+    COULD_NOT_GET_PP: 1006,
+    COULD_NOT_GET_TOS: 1007,
+    PASSWORDS_MUST_BE_DIFFERENT: 1008
   };
 
   var CODE_TO_MESSAGES = {
@@ -66,7 +73,13 @@ function () {
     116: t('This endpoint is no longer supported'),
 
     // local only error messages
-    1002: t('Session expired. Sign in to continue.')
+    1002: t('Session expired. Sign in to continue.'),
+    1003: t('Cookies are still disabled'),
+    1004: t('Passwords do not match'),
+    1005: t('Working…'),
+    1006: t('Could not get Privacy Notice'),
+    1007: t('Could not get Terms of Service'),
+    1008: t('Your new password must be different')
   };
 
   return {

--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -47,8 +47,8 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
       var newPassword = this.$('#new_password').val();
 
       if (oldPassword === newPassword) {
-        return this.displayError(
-                    t('Your new password must be different'));
+        var err = AuthErrors.toError('PASSWORDS_MUST_BE_DIFFERENT');
+        return this.displayError(err);
       }
 
       this.hideError();

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -17,8 +17,6 @@ define([
   'lib/oauth-mixin'
 ],
 function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlaceholderMixin, Validate, AuthErrors, OAuthMixin) {
-  var t = BaseView.t;
-
   var View = FormView.extend({
     template: Template,
     className: 'complete_reset_password',
@@ -92,7 +90,8 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
 
     showValidationErrorsEnd: function () {
       if (this._getPassword() !== this._getVPassword()) {
-        this.displayError(t('Passwords do not match'));
+        var err = AuthErrors.toError('PASSWORDS_DO_NOT_MATCH');
+        this.displayError(err);
       }
     },
 

--- a/app/scripts/views/cookies_disabled.js
+++ b/app/scripts/views/cookies_disabled.js
@@ -7,11 +7,10 @@
 define([
   'views/base',
   'lib/config-loader',
+  'lib/auth-errors',
   'stache!templates/cookies_disabled'
 ],
-function (BaseView, ConfigLoader, Template) {
-  var t = BaseView.t;
-
+function (BaseView, ConfigLoader, AuthErrors, Template) {
   var View = BaseView.extend({
     constructor: function (options) {
       BaseView.call(this, options);
@@ -31,7 +30,8 @@ function (BaseView, ConfigLoader, Template) {
       return this._configLoader.areCookiesEnabled(true)
         .then(function (areCookiesEnabled) {
           if (! areCookiesEnabled) {
-            return self.displayError(t('Cookies are still disabled'));
+            var err = AuthErrors.toError('COOKIES_STILL_DISABLED');
+            return self.displayError(err);
           }
 
           self.back();

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -24,11 +24,12 @@ define([
   'jquery',
   'p-promise',
   'lib/validate',
+  'lib/auth-errors',
   'views/base',
   'views/tooltip',
   'views/button_progress_indicator'
 ],
-function (_, $, p, Validate, BaseView, Tooltip, ButtonProgressIndicator) {
+function (_, $, p, Validate, AuthErrors, BaseView, Tooltip, ButtonProgressIndicator) {
   var t = BaseView.t;
 
   /**
@@ -114,7 +115,8 @@ function (_, $, p, Validate, BaseView, Tooltip, ButtonProgressIndicator) {
       this.window.clearTimeout(this._workingTimeout);
 
       this._workingTimeout = this.window.setTimeout(function () {
-        workingText = self.displayError(t('Working…'));
+        var err = AuthErrors.toError('WORKING');
+        workingText = self.displayError(err);
       }, this.LONGER_THAN_EXPECTED);
 
       return p()

--- a/app/scripts/views/pp.js
+++ b/app/scripts/views/pp.js
@@ -9,11 +9,10 @@ define([
   'views/base',
   'stache!templates/pp',
   'lib/session',
-  'lib/strings'
+  'lib/strings',
+  'lib/auth-errors'
 ],
-function ($, BaseView, Template, Session, Strings) {
-  var t = BaseView.t;
-
+function ($, BaseView, Template, Session, Strings, AuthErrors) {
   var View = BaseView.extend({
     template: Template,
     className: 'pp',
@@ -38,7 +37,8 @@ function ($, BaseView, Template, Session, Strings) {
         self.$('.hidden').removeClass('hidden');
       })
       .fail(function() {
-        self.displayError(t('Could not get Privacy Notice'));
+        var err = AuthErrors.toError('COULD_NOT_GET_PP');
+        self.displayError(err);
         self.$('.hidden').removeClass('hidden');
       })
       .always(function() {

--- a/app/scripts/views/tos.js
+++ b/app/scripts/views/tos.js
@@ -9,11 +9,10 @@ define([
   'views/base',
   'stache!templates/tos',
   'lib/session',
-  'lib/strings'
+  'lib/strings',
+  'lib/auth-errors'
 ],
-function ($, BaseView, Template, Session, Strings) {
-  var t = BaseView.t;
-
+function ($, BaseView, Template, Session, Strings, AuthErrors) {
   var View = BaseView.extend({
     template: Template,
     className: 'tos',
@@ -38,7 +37,8 @@ function ($, BaseView, Template, Session, Strings) {
         self.$('.hidden').removeClass('hidden');
       })
       .fail(function() {
-        self.displayError(t('Could not get Terms of Service'));
+        var err = AuthErrors.toError('COULD_NOT_GET_TOS');
+        self.displayError(err);
         self.$('.hidden').removeClass('hidden');
       })
       .always(function() {


### PR DESCRIPTION
- Add inline strings to list of errors.
- All errors will be normalized in the event log no matter what locale the user  uses.

fixes #1164 
