### PR TITLE
DO NOT MERGE: install fxa-auth-server npm deps verbosely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
 # install the resources necessary for the auth server.
   - npm install git://github.com/mozilla/fxa-auth-server.git
   - cd node_modules/fxa-auth-server
+  - npm install
   - node ./scripts/gen_keys.js
   - LOG_LEVEL=error npm start &
   - cd ../..


### PR DESCRIPTION
This is to try to figure out why npm is dying when installing the deps for fxa-auth-server. 

Link to #1235 
