### PR TITLE
fix(csp): turn on report only mode until CSP issues are resolved

### DIFF
--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -70,7 +70,8 @@ function makeApp() {
   app.use(helmet.hsts(config.get('hsts_max_age'), true));
   if (config.get('env') === 'development') {
     app.use(helmet.csp({'default-src': ['\'self\''],
-                        'report-uri': '/_/csp-violation'
+                        'report-uri': '/_/csp-violation',
+                        'reportOnly': true
                        }));
   }
   app.disable('x-powered-by');

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -94,7 +94,7 @@ define([
       assert.ok(headers.hasOwnProperty('x-frame-options'));
     }
     if (config.get('env') === 'development') {
-      assert.ok(headers.hasOwnProperty('content-security-policy'));
+      assert.ok(headers.hasOwnProperty('content-security-policy-report-only'));
     }
   }
 


### PR DESCRIPTION
We should fix the CSP errors, but currently it's difficult for anyone to work on anything else while CSP is enforced. We can turn enforcement back on once the issues are resolved.

@vladikoff r?

cc @warner 
