### PR TITLE
fix(oauth): keep the oauth context after a page refresh

### DIFF
--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -65,6 +65,14 @@ function (chai, AppStart, Session, WindowMock, RouterMock, HistoryMock) {
               assert.equal(routerMock.page, 'cookies_disabled');
             });
       });
+
+      it('sets the session service from a client_id query parameter', function () {
+        windowMock.location.search = '?client_id=testing';
+        return appStart.startApp()
+                    .then(function () {
+                      assert.equal(Session.service, 'testing');
+                    });
+      });
     });
   });
 });


### PR DESCRIPTION
This fixes #1251.

When you start an OAuth flow the original browser tab will have a `client_id` query parameter instead of the `service` parameter, which the current code expects. This PR will use the `client_id` when available if the service hasn't been set.

@vladikoff r?
