### PR TITLE
fix(test): Remove cache busting URLs in dev mode.

### DIFF
--- a/server/templates/pages/src/mocha.html
+++ b/server/templates/pages/src/mocha.html
@@ -17,12 +17,6 @@
         -->
         <script src="/bower_components/mocha/mocha.js"></script>
         <script data-main="main" src="/bower_components/requirejs/require.js"></script>
-        <script>
-          // Avoid caching files that are loaded with Require.JS
-          require.config({
-            urlArgs: "bust=" + (new Date()).getTime()
-          });
-        </script>
         {{#check_coverage}}
           <!--
                Blanket rewrites the JS to do analysis, rendering the


### PR DESCRIPTION
- If `static_max_age` is set in `local.json`, .JS files are served with a maxAge of 0 already. ETags will still be checked.
- Enables the use of browser dev tools. With dynamic cache busting URLs, filenames would change from one run to the next.

fixes #1145
