### PR TITLE
fix(client): Throw an exception if invokeHandler is passed an invalid handler.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -459,7 +459,7 @@ function (_, Backbone, $, p, Session, AuthErrors, FxaClient, Url, Strings, Ephem
         handler = this[handler];
 
         if (typeof handler !== 'function') {
-          console.warn(handler + ' is an invalid function name');
+          throw new Error(handler + ' is an invalid function name');
         }
       }
 


### PR DESCRIPTION
This is for you @pdehaan!
- This will help devs catch errors faster.

fixes #1105
