### PR TITLE
fix(client): Only send a `link_expired` event if the password reset link...

### DIFF
--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -56,7 +56,9 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
       return this.fxaClient.isPasswordResetComplete(this.token)
          .then(function (isComplete) {
             self._isLinkExpired = isComplete;
-            self.logEvent('complete_reset_password:link_expired');
+            if (isComplete) {
+              self.logEvent('complete_reset_password:link_expired');
+            }
             return true;
           });
     },

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -26,6 +26,10 @@ function (chai, p, AuthErrors, Metrics, View, RouterMock, WindowMock, TestHelper
       assert.isTrue(TestHelpers.isEventLogged(metrics, eventName));
     }
 
+    function testEventNotLogged(eventName) {
+      assert.isFalse(TestHelpers.isEventLogged(metrics, eventName));
+    }
+
     beforeEach(function () {
       routerMock = new RouterMock();
       windowMock = new WindowMock();
@@ -62,7 +66,11 @@ function (chai, p, AuthErrors, Metrics, View, RouterMock, WindowMock, TestHelper
 
     describe('render', function () {
       it('shows form if token, code and email are all present', function () {
-        assert.ok(view.$('#fxa-complete-reset-password-header').length);
+        return view.render()
+            .then(function () {
+              testEventNotLogged('complete_reset_password:link_expired');
+              assert.ok(view.$('#fxa-complete-reset-password-header').length);
+            });
       });
 
       it('shows malformed screen if the token is missing', function () {


### PR DESCRIPTION
... is expired.

fixes #1283
