### PR TITLE
feature(client): Add input field validation errors to the event stream.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -46,7 +46,11 @@ function () {
     WORKING: 1005,
     COULD_NOT_GET_PP: 1006,
     COULD_NOT_GET_TOS: 1007,
-    PASSWORDS_MUST_BE_DIFFERENT: 1008
+    PASSWORDS_MUST_BE_DIFFERENT: 1008,
+    PASSWORD_TOO_SHORT: 1009,
+    PASSWORD_REQUIRED: 1010,
+    EMAIL_REQUIRED: 1011,
+    YEAR_OF_BIRTH_REQUIRED: 1012
   };
 
   var CODE_TO_MESSAGES = {
@@ -79,7 +83,11 @@ function () {
     1005: t('Working…'),
     1006: t('Could not get Privacy Notice'),
     1007: t('Could not get Terms of Service'),
-    1008: t('Your new password must be different')
+    1008: t('Your new password must be different'),
+    1009: t('Must be at least 8 characters'),
+    1010: t('Valid password required'),
+    1011: t('Valid email required'),
+    1012: t('Year of birth required')
   };
 
   return {

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -30,8 +30,6 @@ define([
   'views/button_progress_indicator'
 ],
 function (_, $, p, Validate, AuthErrors, BaseView, Tooltip, ButtonProgressIndicator) {
-  var t = BaseView.t;
-
   /**
    * Decorator that checks whether the form has changed, and if so, call
    * the specified handler.
@@ -430,7 +428,7 @@ function (_, $, p, Validate, AuthErrors, BaseView, Tooltip, ButtonProgressIndica
 
 
     showEmailValidationError: function (which) {
-      return this.showValidationError(which, t('Valid email required'));
+      return this.showValidationError(which, AuthErrors.toError('EMAIL_REQUIRED'));
     },
 
     /**
@@ -472,17 +470,19 @@ function (_, $, p, Validate, AuthErrors, BaseView, Tooltip, ButtonProgressIndica
     showPasswordValidationError: function (which) {
       var passwordVal = this.$(which).val();
 
-      var msg = passwordVal ? t('Must be at least 8 characters')
-                            : t('Valid password required');
+      var errType = passwordVal ? 'PASSWORD_TOO_SHORT' : 'PASSWORD_REQUIRED';
 
-      return this.showValidationError(which, msg);
+      return this.showValidationError(which, AuthErrors.toError(errType));
     },
 
     /**
      * Show a form validation error to the user in the form of a tooltip.
      */
-    showValidationError: function (which, message) {
+    showValidationError: function (which, err) {
+      this.logError(err);
+
       var invalidEl = this.$(which);
+      var message = AuthErrors.toMessage(err);
 
       var tooltip = new Tooltip({
         message: message,

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -118,7 +118,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, AuthErrors) {
         var selectRow = this.$el.find('.select-row');
         selectRow.addClass('invalid-row');
 
-        this.showValidationError('#fxa-age-year', t('Year of birth required'));
+        this.showValidationError('#fxa-age-year', AuthErrors.toError('YEAR_OF_BIRTH_REQUIRED'));
       }
     },
 


### PR DESCRIPTION
fixes #1297 

@kparlante - is this what you had in mind?

New fields are listed here: https://github.com/mozilla/fxa-content-server/compare/issue-1297-local-errors?expand=1#diff-98234698cca25a1c555fdd19fc416628R86
