### PR TITLE
feat(server): Add `x-content-type-options: nosniff` headers to prevent browser content type sniffing.

### DIFF
--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -70,6 +70,7 @@ function makeApp() {
   app.use(helmet.xframe('deny'));
   app.use(helmet.iexss());
   app.use(helmet.hsts(config.get('hsts_max_age'), true));
+  app.use(helmet.contentTypeOptions());
 
   // only send CSP headers in development mode
   if (config.get('env') === 'development') {

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -99,6 +99,8 @@ define([
           url.parse(route).pathname !== '/tests/index.html') {
       assert.ok(headers.hasOwnProperty('content-security-policy'));
     }
+
+    assert.equal(headers['x-content-type-options'], 'nosniff');
   }
 
 });


### PR DESCRIPTION
fixes #1165
