### PR TITLE
fix(ie8): use a standard font so the password field renders correctly

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -711,6 +711,12 @@ ul.links li {
   }
 }
 
+/* IE8 has trouble rendering bullet characters with custom fonts,
+ * so use something standard */
+.lt-ie9 input[type="password"] {
+    font-family: sans-serif;
+}
+
 .show-password-label:hover,
 .show-password-label:active,
 .show-password-label:focus,


### PR DESCRIPTION
According to various online sources, this should fix #1266.

@shane-tomlinson or @pdehaan  r?
