### PR TITLE
fix(oauth): ensure oauth forms are enabled if valid on afterRender

### DIFF
--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -91,7 +91,10 @@ function (_, $, p, Validate, AuthErrors, BaseView, Tooltip, ButtonProgressIndica
             return self.invokeHandler(handler, args);
           })
           .then(function (value) {
-            self._buttonProgressIndicator.done();
+            // Stop the progress indicator unless the page is navigating
+            if (!value || !value.pageNavigation) {
+              self._buttonProgressIndicator.done();
+            }
             return value;
           }, function(err) {
             self._buttonProgressIndicator.done();

--- a/app/scripts/views/mixins/oauth-mixin.js
+++ b/app/scripts/views/mixins/oauth-mixin.js
@@ -81,6 +81,7 @@ define([
         Session.clear('oauth');
         // Redirect to the returned URL
         self.window.location.href = result.redirect;
+        return { pageNavigation: true };
       })
       .fail(function(xhr) {
         Session.clear('oauth');

--- a/app/scripts/views/oauth_sign_in.js
+++ b/app/scripts/views/oauth_sign_in.js
@@ -22,11 +22,16 @@ function (_, p, SignInView, Session, OAuthMixin) {
     },
 
     beforeRender: function() {
-      return this.setServiceInfo();
+      var self = this;
+      return p().then(function () {
+          return SignInView.prototype.beforeRender.call(self);
+        })
+        .then(_.bind(this.setServiceInfo, this));
     },
 
     afterRender: function() {
       this.setupOAuthLinks();
+      return SignInView.prototype.afterRender.call(this);
     },
 
     onSignInSuccess: function() {

--- a/app/scripts/views/oauth_sign_up.js
+++ b/app/scripts/views/oauth_sign_up.js
@@ -6,12 +6,13 @@
 
 define([
   'underscore',
+  'p-promise',
   'views/base',
   'views/sign_up',
   'lib/session',
   'views/mixins/oauth-mixin'
 ],
-function (_, BaseView, SignUpView, Session, OAuthMixin) {
+function (_, p, BaseView, SignUpView, Session, OAuthMixin) {
   var View = SignUpView.extend({
     className: 'sign-up oauth-sign-up',
 
@@ -23,12 +24,17 @@ function (_, BaseView, SignUpView, Session, OAuthMixin) {
       this.setupOAuth();
     },
 
-    beforeRender: function () {
-      return this.setServiceInfo();
+    beforeRender: function() {
+      var self = this;
+      return p().then(function () {
+          return SignUpView.prototype.beforeRender.call(self);
+        })
+        .then(_.bind(this.setServiceInfo, this));
     },
 
     afterRender: function() {
-      this.$('.sign-in').attr('href', '/oauth/signin');
+      this.setupOAuthLinks();
+      return SignUpView.prototype.afterRender.call(this);
     },
 
     onSignUpSuccess: function () {

--- a/app/tests/spec/views/oauth_sign_in.js
+++ b/app/tests/spec/views/oauth_sign_in.js
@@ -56,6 +56,15 @@ function (chai, $, View, Session, FxaClient, WindowMock, RouterMock, TestHelpers
             assert.equal($('.sign-up').attr('href'), '/oauth/signup');
           });
       });
+
+      it('is enabled if prefills are valid', function () {
+        Session.set('prefillEmail', 'testuser@testuser.com');
+        Session.set('prefillPassword', 'prefilled password');
+        return view.render()
+          .then(function () {
+            assert.isFalse(view.$('button').hasClass('disabled'));
+          });
+      });
     });
 
     describe('submit', function () {
@@ -74,7 +83,7 @@ function (chai, $, View, Session, FxaClient, WindowMock, RouterMock, TestHelpers
     });
 
     describe('resetPasswordIfKnownValidEmail', function () {
-      it('goes to the confirm_reset_password page if user types a valid, known email', function () {
+      it('goes to the reset_password page if user types a valid, known email', function () {
         var password = 'password';
         return view.fxaClient.signUp(email, password, { preVerified: true })
               .then(function () {
@@ -83,7 +92,7 @@ function (chai, $, View, Session, FxaClient, WindowMock, RouterMock, TestHelpers
               })
               .then(function () {
                 assert.ok(Session.oauth, 'oauth params are set');
-                assert.equal(router.page, 'confirm_reset_password');
+                assert.equal(router.page, 'reset_password');
               });
       });
 


### PR DESCRIPTION
@ckarlof This fixes the pause issue (#1320) and also the problem where oauth signin/signup weren't enabled after render.

Fixes #1320.

r?
