### PR TITLE
refactor(oauth): use a generic "service" name for the oauth mixin

### DIFF
--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -14,9 +14,9 @@ define([
   'views/mixins/floating-placeholder-mixin',
   'lib/validate',
   'lib/auth-errors',
-  'views/mixins/oauth-mixin'
+  'views/mixins/service-mixin'
 ],
-function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlaceholderMixin, Validate, AuthErrors, OAuthMixin) {
+function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlaceholderMixin, Validate, AuthErrors, ServiceMixin) {
   var View = FormView.extend({
     template: Template,
     className: 'complete_reset_password',
@@ -150,7 +150,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
   });
 
   _.extend(View.prototype, PasswordMixin);
-  _.extend(View.prototype, OAuthMixin);
+  _.extend(View.prototype, ServiceMixin);
   _.extend(View.prototype, FloatingPlaceholderMixin);
 
   return View;

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -12,9 +12,9 @@ define([
   'lib/session',
   'lib/constants',
   'lib/auth-errors',
-  'views/mixins/oauth-mixin'
+  'views/mixins/service-mixin'
 ],
-function (_, ConfirmView, BaseView, Template, Session, Constants, AuthErrors, OAuthMixin) {
+function (_, ConfirmView, BaseView, Template, Session, Constants, AuthErrors, ServiceMixin) {
   var t = BaseView.t;
 
   var View = ConfirmView.extend({
@@ -104,7 +104,7 @@ function (_, ConfirmView, BaseView, Template, Session, Constants, AuthErrors, OA
     }
   });
 
-  _.extend(View.prototype, OAuthMixin);
+  _.extend(View.prototype, ServiceMixin);
 
   return View;
 });

--- a/app/scripts/views/mixins/service-mixin.js
+++ b/app/scripts/views/mixins/service-mixin.js
@@ -89,7 +89,7 @@ define([
       });
     },
 
-    isOAuth: function () {
+    hasService: function () {
       return !!Session.service;
     },
 
@@ -111,8 +111,8 @@ define([
     // override this method so we can fix signup/signin links in errors
     displayErrorUnsafe: function (err, errors) {
       var result = BaseView.prototype.displayErrorUnsafe.call(this, err, errors);
-      var isOAuthView = this.className.match('oauth');
-      if (isOAuthView || this.isOAuthSameBrowser()) {
+      var hasServiceView = this.className.match('oauth');
+      if (hasServiceView || this.isOAuthSameBrowser()) {
         this.setupOAuthLinks();
       }
       return result;

--- a/app/scripts/views/oauth_sign_in.js
+++ b/app/scripts/views/oauth_sign_in.js
@@ -9,9 +9,9 @@ define([
   'p-promise',
   'views/sign_in',
   'lib/session',
-  'views/mixins/oauth-mixin'
+  'views/mixins/service-mixin'
 ],
-function (_, p, SignInView, Session, OAuthMixin) {
+function (_, p, SignInView, Session, ServiceMixin) {
   var View = SignInView.extend({
     className: 'sign-in oauth-sign-in',
 
@@ -50,7 +50,7 @@ function (_, p, SignInView, Session, OAuthMixin) {
     }
   });
 
-  _.extend(View.prototype, OAuthMixin);
+  _.extend(View.prototype, ServiceMixin);
 
   return View;
 });

--- a/app/scripts/views/oauth_sign_up.js
+++ b/app/scripts/views/oauth_sign_up.js
@@ -10,9 +10,9 @@ define([
   'views/base',
   'views/sign_up',
   'lib/session',
-  'views/mixins/oauth-mixin'
+  'views/mixins/service-mixin'
 ],
-function (_, p, BaseView, SignUpView, Session, OAuthMixin) {
+function (_, p, BaseView, SignUpView, Session, ServiceMixin) {
   var View = SignUpView.extend({
     className: 'sign-up oauth-sign-up',
 
@@ -45,7 +45,7 @@ function (_, p, BaseView, SignUpView, Session, OAuthMixin) {
     }
   });
 
-  _.extend(View.prototype, OAuthMixin);
+  _.extend(View.prototype, ServiceMixin);
 
   return View;
 });

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -19,10 +19,10 @@ define([
   'lib/session',
   'lib/xss',
   'lib/strings',
-  'views/mixins/oauth-mixin',
+  'views/mixins/service-mixin',
   'views/marketing_snippet'
 ],
-function (_, BaseView, FormView, Template, Session, Xss, Strings, OAuthMixin, MarketingSnippet) {
+function (_, BaseView, FormView, Template, Session, Xss, Strings, ServiceMixin, MarketingSnippet) {
 
   var View = BaseView.extend({
     template: Template,
@@ -39,7 +39,7 @@ function (_, BaseView, FormView, Template, Session, Xss, Strings, OAuthMixin, Ma
         // We're continuing an OAuth flow from the same browser
         this.setupOAuth(Session.oauth);
         return this.setServiceInfo();
-      } else if (this.isOAuth()) {
+      } else if (this.hasService()) {
         // We're continuing an OAuth flow in a different browser
         this.setupOAuth();
         return this.setServiceInfo();
@@ -90,7 +90,7 @@ function (_, BaseView, FormView, Template, Session, Xss, Strings, OAuthMixin, Ma
     submit: function () {
       if (this.isOAuthSameBrowser()) {
         return this.finishOAuthFlow();
-      } else if (this.isOAuth()) {
+      } else if (this.hasService()) {
         return this.oAuthRedirectWithError();
       }
     },
@@ -100,7 +100,7 @@ function (_, BaseView, FormView, Template, Session, Xss, Strings, OAuthMixin, Ma
     }
   });
 
-  _.extend(View.prototype, OAuthMixin);
+  _.extend(View.prototype, ServiceMixin);
 
   return View;
 });

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -11,9 +11,9 @@ define([
   'stache!templates/reset_password',
   'lib/session',
   'lib/auth-errors',
-  'views/mixins/oauth-mixin'
+  'views/mixins/service-mixin'
 ],
-function (_, BaseView, FormView, Template, Session, AuthErrors, OAuthMixin) {
+function (_, BaseView, FormView, Template, Session, AuthErrors, ServiceMixin) {
   var t = BaseView.t;
 
   var View = FormView.extend({
@@ -86,7 +86,7 @@ function (_, BaseView, FormView, Template, Session, AuthErrors, OAuthMixin) {
     }
   });
 
-  _.extend(View.prototype, OAuthMixin);
+  _.extend(View.prototype, ServiceMixin);
 
   return View;
 });

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -98,7 +98,7 @@ function (chai, View, Session, WindowMock) {
               //assert.equal(view.$('#redirectTo').length, 1);
               //var html = view.$('section').text();
               //assert.include(html, 'Firefox Sync');
-              //assert.ok(view.isOAuth());
+              //assert.ok(view.hasService());
               //assert.notOk(view.isOAuthSameBrowser());
             //});
       //});
@@ -118,7 +118,7 @@ function (chai, View, Session, WindowMock) {
 
         //return view.render()
             //.then(function () {
-              //assert.ok(view.isOAuth());
+              //assert.ok(view.hasService());
               //assert.ok(view.isOAuthSameBrowser());
 
               //assert.equal(view.$('#redirectTo').length, 1);


### PR DESCRIPTION
Fixes #1298.
