### PR TITLE
feat(metrics): Log which marketing material is shown to a user.

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -37,7 +37,10 @@ define([
     'events',
     'context',
     'service',
-    'lang'
+    'lang',
+    'marketingLink',
+    'marketingType',
+    'marketingClicked'
   ];
 
   var TEN_MINS_MS = 10 * 60 * 1000;
@@ -130,7 +133,10 @@ define([
       var allData = _.extend({
         context: this._context,
         service: this._service,
-        lang: this._lang
+        lang: this._lang,
+        marketingType: this._marketingType || 'none',
+        marketingLink: this._marketingLink || 'none',
+        marketingClicked: this._marketingClicked || false
       }, loadData, unloadData);
 
       return allData;
@@ -214,6 +220,21 @@ define([
      */
     pathToId: function (path) {
       return 'screen:' + Url.pathToScreenName(path);
+    },
+
+    /**
+     * Log which marketing snippet is shown to the user
+     */
+    logMarketingImpression: function (type, link) {
+      this._marketingType = type;
+      this._marketingLink = link;
+    },
+
+    /**
+     * Log whether the user clicked on the marketing link
+     */
+    logMarketingClick: function () {
+      this._marketingClicked = true;
     }
   });
 

--- a/app/scripts/templates/marketing_snippet.mustache
+++ b/app/scripts/templates/marketing_snippet.mustache
@@ -1,17 +1,17 @@
 {{#showSignUpMarketing}}
-  <aside class="marketing desktop image-snippet default">
+  <aside class="marketing desktop image-snippet default" data-marketing-type="android-sync">
     <div class="marketing-spacer">
       <span class="android-logo" />
       <span class="marketing-copy">{{#t}}Stay in sync on the go:{{/t}}</span>
-      <a href="http://mzl.la/KBozcn" target="_blank">{{#t}}Get Firefox for Android{{/t}}</a>
+      <a class="marketing-link" href="http://mzl.la/KBozcn" target="_blank">{{#t}}Get Firefox for Android{{/t}}</a>
     </div>
   </aside>
 {{/showSignUpMarketing}}
 
 {{#showSignUpSurvey}}
-  <aside class="marketing desktop text-snippet survey">
+  <aside class="marketing desktop text-snippet survey" data-marketing-type="survey">
       <span class="marketing-copy">We're making Firefox Accounts better for you.</span>
-      <a href="http://mzl.la/1oV7jUy" target="_blank">Help us by taking this quick survey.</a>
+      <a class="marketing-link" href="http://mzl.la/1oV7jUy" target="_blank">Help us by taking this quick survey.</a>
   </aside>
 {{/showSignUpSurvey}}
 

--- a/app/scripts/views/marketing_snippet.js
+++ b/app/scripts/views/marketing_snippet.js
@@ -46,6 +46,18 @@ define([
       };
     },
 
+    events: {
+      'click .marketing-link': '_logMarketingClick'
+    },
+
+    afterRender: function () {
+      var marketingType = this.$('[data-marketing-type]').attr('data-marketing-type');
+      var marketingLink = this.$('.marketing-link').attr('href');
+
+
+      this.metrics.logMarketingImpression(marketingType, marketingLink);
+    },
+
     _shouldShowSignUpMarketing: function () {
       var isSignUp = this._type === 'sign_up';
       var isSync = this._service === 'sync';
@@ -89,6 +101,10 @@ define([
       var isTabletFirefox = /Tablet/.test(ua) && /Firefox/.test(ua);
 
       return isMobileFirefox || isTabletFirefox;
+    },
+
+    _logMarketingClick: function () {
+      this.metrics.logMarketingClick();
     }
   });
 

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -80,7 +80,8 @@ function (_, BaseView, FormView, Template, Session, Xss, Strings, ServiceMixin, 
         type: this.type,
         service: Session.service,
         language: Session.language,
-        el: this.$('.marketing-area')
+        el: this.$('.marketing-area'),
+        metrics: this.metrics
       });
       this.trackSubview(marketingSnippet);
 

--- a/app/tests/spec/views/marketing_snippet.js
+++ b/app/tests/spec/views/marketing_snippet.js
@@ -8,16 +8,20 @@
 define([
   'chai',
   'views/marketing_snippet',
+  'lib/metrics',
   '../../mocks/window'
 ],
-function (chai, View, WindowMock) {
+function (chai, View, Metrics, WindowMock) {
   var assert = chai.assert;
 
   describe('views/marketing_snippet', function () {
-    var view, windowMock;
+    var view, windowMock, metrics;
 
     function createView(options) {
       options.window = windowMock;
+
+      metrics = new Metrics();
+      options.metrics = metrics;
 
       view = new View(options);
     }
@@ -145,6 +149,43 @@ function (chai, View, WindowMock) {
             });
       });
 
+      it('logs the marketing type and link', function () {
+        createView({
+          type: 'sign_up',
+          service: 'sync',
+          language: 'de',
+          surveyPercentage: 100
+        });
+
+        return view.render()
+            .then(function () {
+              var filteredData = metrics.getFilteredData();
+              assert.ok(filteredData.marketingType);
+              assert.ok(filteredData.marketingLink);
+              assert.isFalse(filteredData.marketingClicked);
+            });
+      });
+
+    });
+
+    describe('a click on the marketing material', function () {
+      it('is logged', function () {
+        createView({
+          type: 'sign_up',
+          service: 'sync',
+          language: 'de',
+          surveyPercentage: 100
+        });
+
+        return view.render()
+            .then(function () {
+              view.$('.marketing-link').click();
+            })
+            .then(function () {
+              var filteredData = metrics.getFilteredData();
+              assert.isTrue(filteredData.marketingClicked);
+            });
+      });
     });
   });
 });

--- a/server/lib/metrics-collector-stderr.js
+++ b/server/lib/metrics-collector-stderr.js
@@ -38,7 +38,7 @@ function addVersion(loggableEvent) {
 
 function copyFields(fields, to, from) {
   fields.forEach(function(field) {
-    to[field] = from[field] || 'unknown';
+    to[field] = from.hasOwnProperty(field) ? from[field] : 'unknown';
   });
 }
 
@@ -87,7 +87,10 @@ function toLoggableEvent(event) {
     'agent',
     'duration',
     'context',
-    'service'
+    'service',
+    'marketingLink',
+    'marketingType',
+    'marketingClicked'
   ], loggableEvent, event);
 
   addNavigationTiming(loggableEvent, event);

--- a/tests/server/metrics-collector-stderr.js
+++ b/tests/server/metrics-collector-stderr.js
@@ -50,6 +50,10 @@ define([
 
       assert.equal(loggedMetrics.service, 'sync');
       assert.equal(loggedMetrics.context, 'fx_desktop_v1');
+
+      assert.equal(loggedMetrics.marketingType, 'survey');
+      assert.equal(loggedMetrics.marketingLink, 'http://mzl.la/1oV7jUy');
+      assert.isFalse(loggedMetrics.marketingClicked);
     });
 
     metricsCollector.write({
@@ -71,7 +75,10 @@ define([
       'user-agent': 'Firefox 32.0',
       lang: 'db_LB',
       service: 'sync',
-      context: 'fx_desktop_v1'
+      context: 'fx_desktop_v1',
+      marketingType: 'survey',
+      marketingLink: 'http://mzl.la/1oV7jUy',
+      marketingClicked: false
     });
   };
 


### PR DESCRIPTION
Add `marketingType`, `marketingLink`, `marketingClicked`.
- `marketingType` is either `android-sync` or `survey`
- `marketingLink` is the URL that the user can click on.
- `marketingClicked` is whether the user clicked on the marketing.

fixes #1259

@kparlante - could you have a look at this to see what you think
