### PR TITLE
refactor(client): Remove global variables in fxa-client.js

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -32,6 +32,10 @@ function (_, Backbone, $, p, Session, AuthErrors, FxaClient, Url, Strings, Ephem
   // is passed in to the contstructor.
   var nullMetrics = new NullMetrics();
 
+  // Share one fxa client across all views. View can be initialized
+  // with an fxaClient for testing.
+  var fxaClient = new FxaClient();
+
   var BaseView = Backbone.View.extend({
     constructor: function (options) {
       options = options || {};
@@ -43,7 +47,7 @@ function (_, Backbone, $, p, Session, AuthErrors, FxaClient, Url, Strings, Ephem
       this.ephemeralMessages = options.ephemeralMessages || ephemeralMessages;
       this.metrics = options.metrics || nullMetrics;
 
-      this.fxaClient = new FxaClient();
+      this.fxaClient = options.fxaClient || fxaClient;
 
       Backbone.View.call(this, options);
     },

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -9,13 +9,12 @@ define([
   'views/form',
   'views/base',
   'stache!templates/complete_sign_up',
-  'lib/fxa-client',
   'lib/auth-errors',
   'lib/validate',
   'views/mixins/resend-mixin',
   'lib/session'
 ],
-function (_, FormView, BaseView, CompleteSignUpTemplate, FxaClient, AuthErrors, Validate, ResendMixin, Session) {
+function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, ResendMixin, Session) {
   var CompleteSignUpView = FormView.extend({
     template: CompleteSignUpTemplate,
     className: 'complete_sign_up',

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -40,10 +40,9 @@ require.config({
 require([
   'lib/translator',
   'lib/session',
-  'lib/fxa-client',
   '../tests/setup'
 ],
-function (Translator, Session, FxaClientWrapper) {
+function (Translator, Session) {
   'use strict';
 
   var tests = [
@@ -116,12 +115,10 @@ function (Translator, Session, FxaClientWrapper) {
      */
     beforeEach(function () {
       Session.testClear();
-      FxaClientWrapper.testClear();
     });
 
     afterEach(function () {
       Session.testClear();
-      FxaClientWrapper.testClear();
     });
 
     var runner = mocha.run();

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -13,6 +13,7 @@ define([
   'lib/ephemeral-messages',
   'lib/metrics',
   'lib/auth-errors',
+  'lib/fxa-client',
   'stache!templates/test_template',
   '../../mocks/dom-event',
   '../../mocks/router',
@@ -20,7 +21,7 @@ define([
   '../../lib/helpers'
 ],
 function (chai, jQuery, BaseView, Translator, EphemeralMessages, Metrics,
-          AuthErrors, Template, DOMEventMock, RouterMock, WindowMock,
+          AuthErrors, FxaClient, Template, DOMEventMock, RouterMock, WindowMock,
           TestHelpers) {
   var requiresFocus = TestHelpers.requiresFocus;
   var wrapAssertion = TestHelpers.wrapAssertion;
@@ -28,7 +29,7 @@ function (chai, jQuery, BaseView, Translator, EphemeralMessages, Metrics,
   var assert = chai.assert;
 
   describe('views/base', function () {
-    var view, router, windowMock, ephemeralMessages, translator, metrics;
+    var view, router, windowMock, ephemeralMessages, translator, metrics, fxaClient;
 
     beforeEach(function () {
       translator = new Translator('en-US', ['en-US']);
@@ -41,6 +42,7 @@ function (chai, jQuery, BaseView, Translator, EphemeralMessages, Metrics,
       windowMock = new WindowMock();
       ephemeralMessages = new EphemeralMessages();
       metrics = new Metrics();
+      fxaClient = new FxaClient();
 
       var View = BaseView.extend({
         template: Template
@@ -51,7 +53,8 @@ function (chai, jQuery, BaseView, Translator, EphemeralMessages, Metrics,
         router: router,
         window: windowMock,
         ephemeralMessages: ephemeralMessages,
-        metrics: metrics
+        metrics: metrics,
+        fxaClient: fxaClient
       });
 
       return view.render()

--- a/app/tests/spec/views/change_password.js
+++ b/app/tests/spec/views/change_password.js
@@ -10,22 +10,26 @@ define([
   'underscore',
   'jquery',
   'lib/auth-errors',
+  'lib/fxa-client',
   'views/change_password',
   '../../mocks/router',
   '../../lib/helpers',
   'lib/session'
 ],
-function (chai, _, $, AuthErrors, View, RouterMock, TestHelpers, Session) {
+function (chai, _, $, AuthErrors, FxaClient, View, RouterMock, TestHelpers, Session) {
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
 
   describe('views/change_password', function () {
-    var view, routerMock, email;
+    var view, routerMock, email, fxaClient;
 
     beforeEach(function () {
       routerMock = new RouterMock();
+      fxaClient = new FxaClient();
+
       view = new View({
-        router: routerMock
+        router: routerMock,
+        fxaClient: fxaClient
       });
     });
 

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -10,17 +10,18 @@ define([
   'p-promise',
   'lib/auth-errors',
   'lib/metrics',
+  'lib/fxa-client',
   'views/complete_reset_password',
   '../../mocks/router',
   '../../mocks/window',
   '../../lib/helpers'
 ],
-function (chai, p, AuthErrors, Metrics, View, RouterMock, WindowMock, TestHelpers) {
+function (chai, p, AuthErrors, Metrics, FxaClient, View, RouterMock, WindowMock, TestHelpers) {
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
 
   describe('views/complete_reset_password', function () {
-    var view, routerMock, windowMock, isPasswordResetComplete, metrics;
+    var view, routerMock, windowMock, isPasswordResetComplete, metrics, fxaClient;
 
     function testEventLogged(eventName) {
       assert.isTrue(TestHelpers.isEventLogged(metrics, eventName));
@@ -34,13 +35,15 @@ function (chai, p, AuthErrors, Metrics, View, RouterMock, WindowMock, TestHelper
       routerMock = new RouterMock();
       windowMock = new WindowMock();
       metrics = new Metrics();
+      fxaClient = new FxaClient();
 
       windowMock.location.search = '?code=dea0fae1abc2fab3bed4dec5eec6ace7&email=testuser@testuser.com&token=feed';
 
       view = new View({
         router: routerMock,
         window: windowMock,
-        metrics: metrics
+        metrics: metrics,
+        fxaClient: fxaClient
       });
 
       // mock in isPasswordResetComplete

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -12,15 +12,16 @@ define([
   'lib/auth-errors',
   'lib/metrics',
   'lib/constants',
+  'lib/fxa-client',
   '../../mocks/router',
   '../../mocks/window',
   '../../lib/helpers'
 ],
-function (chai, p, View, AuthErrors, Metrics, Constants, RouterMock, WindowMock, TestHelpers) {
+function (chai, p, View, AuthErrors, Metrics, Constants, FxaClient, RouterMock, WindowMock, TestHelpers) {
   var assert = chai.assert;
 
   describe('views/complete_sign_up', function () {
-    var view, routerMock, windowMock, verificationError, metrics;
+    var view, routerMock, windowMock, verificationError, metrics, fxaClient;
     var validCode = TestHelpers.createRandomHexString(Constants.CODE_LENGTH);
     var validUid = TestHelpers.createRandomHexString(Constants.UID_LENGTH);
 
@@ -48,11 +49,13 @@ function (chai, p, View, AuthErrors, Metrics, Constants, RouterMock, WindowMock,
       routerMock = new RouterMock();
       windowMock = new WindowMock();
       metrics = new Metrics();
+      fxaClient = new FxaClient();
 
       view = new View({
         router: routerMock,
         window: windowMock,
-        metrics: metrics
+        metrics: metrics,
+        fxaClient: fxaClient
       });
 
       verificationError = null;

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -8,27 +8,30 @@ define([
   'lib/session',
   'lib/auth-errors',
   'lib/metrics',
+  'lib/fxa-client',
   'views/confirm',
   '../../mocks/router',
   '../../lib/helpers'
 ],
-function (chai, p, Session, AuthErrors, Metrics, View, RouterMock, TestHelpers) {
+function (chai, p, Session, AuthErrors, Metrics, FxaClient, View, RouterMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
 
   describe('views/confirm', function () {
-    var view, routerMock, metrics;
+    var view, routerMock, metrics, fxaClient;
 
     beforeEach(function () {
       Session.set('sessionToken', 'fake session token');
 
       routerMock = new RouterMock();
       metrics = new Metrics();
+      fxaClient = new FxaClient();
 
       view = new View({
         router: routerMock,
-        metrics: metrics
+        metrics: metrics,
+        fxaClient: fxaClient
       });
 
       return view.render()

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -9,22 +9,24 @@ define([
   'views/confirm_reset_password',
   'lib/session',
   'lib/metrics',
+  'lib/fxa-client',
   '../../mocks/router',
   '../../mocks/window',
   '../../lib/helpers'
 ],
-function (chai, p, AuthErrors, View, Session, Metrics, RouterMock, WindowMock, TestHelpers) {
+function (chai, p, AuthErrors, View, Session, Metrics, FxaClient, RouterMock, WindowMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
 
   describe('views/confirm_reset_password', function () {
-    var view, routerMock, windowMock, metrics;
+    var view, routerMock, windowMock, metrics, fxaClient;
 
     beforeEach(function () {
       routerMock = new RouterMock();
       windowMock = new WindowMock();
       metrics = new Metrics();
+      fxaClient = new FxaClient();
 
       Session.set('passwordForgotToken', 'fake password reset token');
       Session.set('email', 'testuser@testuser.com');
@@ -32,7 +34,8 @@ function (chai, p, AuthErrors, View, Session, Metrics, RouterMock, WindowMock, T
       view = new View({
         router: routerMock,
         window: windowMock,
-        metrics: metrics
+        metrics: metrics,
+        fxaClient: fxaClient
       });
       return view.render()
             .then(function () {

--- a/app/tests/spec/views/delete_account.js
+++ b/app/tests/spec/views/delete_account.js
@@ -9,20 +9,24 @@ define([
   'chai',
   'jquery',
   'views/delete_account',
+  'lib/fxa-client',
   '../../mocks/router',
   '../../lib/helpers'
 ],
-function (chai, $, View, RouterMock, TestHelpers) {
+function (chai, $, View, FxaClient, RouterMock, TestHelpers) {
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
 
   describe('views/delete_account', function () {
-    var view, routerMock, email, password = 'password';
+    var view, routerMock, email, password = 'password', fxaClient;
 
     beforeEach(function () {
       routerMock = new RouterMock();
+      fxaClient = new FxaClient();
+
       view = new View({
-        router: routerMock
+        router: routerMock,
+        fxaClient: fxaClient
       });
     });
 

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -10,22 +10,28 @@ define([
   'jquery',
   'views/force_auth',
   'lib/session',
+  'lib/fxa-client',
   '../../mocks/window',
   '../../mocks/router'
 ],
-function (chai, $, View, Session, WindowMock, RouterMock) {
+function (chai, $, View, Session, FxaClient, WindowMock, RouterMock) {
   var assert = chai.assert;
 
   describe('/views/force_auth', function () {
     describe('missing email address', function () {
-      var view, windowMock;
+      var view, windowMock, fxaClient;
 
       beforeEach(function () {
         windowMock = new WindowMock();
         windowMock.location.search = '';
 
+        fxaClient = new FxaClient();
+
         Session.clear();
-        view = new View({ window: windowMock });
+        view = new View({
+          window: windowMock,
+          fxaClient: fxaClient
+        });
         return view.render()
             .then(function () {
               $('#container').html(view.el);

--- a/app/tests/spec/views/oauth_sign_in.js
+++ b/app/tests/spec/views/oauth_sign_in.js
@@ -19,7 +19,7 @@ function (chai, $, View, Session, FxaClient, WindowMock, RouterMock, TestHelpers
   var assert = chai.assert;
 
   describe('views/oauth_sign_in', function () {
-    var view, email, router, windowMock, CLIENT_ID, STATE, SCOPE, CLIENT_NAME, BASE_REDIRECT_URL;
+    var view, email, router, windowMock, CLIENT_ID, STATE, SCOPE, CLIENT_NAME, BASE_REDIRECT_URL, fxaClient;
 
     CLIENT_ID = 'dcdb5ae7add825d2';
     STATE = '123';
@@ -33,9 +33,13 @@ function (chai, $, View, Session, FxaClient, WindowMock, RouterMock, TestHelpers
       router = new RouterMock();
       windowMock = new WindowMock();
       windowMock.location.search = '?client_id=' + CLIENT_ID + '&state=' + STATE + '&scope=' + SCOPE;
+
+      fxaClient = new FxaClient();
+
       view = new View({
         router: router,
-        window: windowMock
+        window: windowMock,
+        fxaClient: fxaClient
       });
       view.render();
       $('#container').html(view.el);

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -18,7 +18,7 @@ function (chai, $, View, Session, FxaClient, WindowMock, RouterMock, TestHelpers
   var assert = chai.assert;
 
   describe('views/oauth_sign_up', function () {
-    var view, email, router, windowMock, CLIENT_ID, STATE, SCOPE, CLIENT_NAME, BASE_REDIRECT_URL;
+    var view, email, router, windowMock, CLIENT_ID, STATE, SCOPE, CLIENT_NAME, BASE_REDIRECT_URL, fxaClient;
 
     CLIENT_ID = 'dcdb5ae7add825d2';
     STATE = '123';
@@ -32,9 +32,13 @@ function (chai, $, View, Session, FxaClient, WindowMock, RouterMock, TestHelpers
       router = new RouterMock();
       windowMock = new WindowMock();
       windowMock.location.search = '?client_id=' + CLIENT_ID + '&state=' + STATE + '&scope=' + SCOPE + '&redirect_uri=' + encodeURIComponent(BASE_REDIRECT_URL);
+
+      fxaClient = new FxaClient();
+
       view = new View({
         router: router,
-        window: windowMock
+        window: windowMock,
+        fxaClient: fxaClient
       });
       view.render();
       $('#container').html(view.el);

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -9,20 +9,23 @@ define([
   'chai',
   'views/ready',
   'lib/session',
+  'lib/fxa-client',
   '../../mocks/window'
 ],
-function (chai, View, Session, WindowMock) {
+function (chai, View, Session, FxaClient, WindowMock) {
   var assert = chai.assert;
   //var redirectUri =  'https://sync.firefox.com';
 
   describe('views/ready', function () {
-    var view, windowMock;
+    var view, windowMock, fxaClient;
 
     function createView(surveyPercentage) {
       windowMock = new WindowMock();
+      fxaClient = new FxaClient();
 
       view = new View({
-        window: windowMock
+        window: windowMock,
+        fxaClient: fxaClient
       });
     }
 

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -11,25 +11,28 @@ define([
   'lib/session',
   'lib/auth-errors',
   'lib/metrics',
+  'lib/fxa-client',
   'views/reset_password',
   '../../mocks/window',
   '../../mocks/router',
   '../../lib/helpers'
 ],
-function (chai, p, Session, AuthErrors, Metrics, View, WindowMock, RouterMock, TestHelpers) {
+function (chai, p, Session, AuthErrors, Metrics, FxaClient, View, WindowMock, RouterMock, TestHelpers) {
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
 
   describe('views/reset_password', function () {
-    var view, router, metrics;
+    var view, router, metrics, fxaClient;
 
     beforeEach(function () {
       router = new RouterMock();
       metrics = new Metrics();
+      fxaClient = new FxaClient();
 
       view = new View({
         router: router,
-        metrics: metrics
+        metrics: metrics,
+        fxaClient: fxaClient
       });
       return view.render()
           .then(function () {

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -12,18 +12,22 @@ define([
   'views/settings',
   '../../mocks/router',
   'lib/session',
-  'lib/constants'
+  'lib/constants',
+  'lib/fxa-client'
 ],
-function (chai, _, $, View, RouterMock, Session, Constants) {
+function (chai, _, $, View, RouterMock, Session, Constants, FxaClient) {
   var assert = chai.assert;
 
   describe('views/settings', function () {
-    var view, routerMock, email;
+    var view, routerMock, email, fxaClient;
 
     beforeEach(function () {
       routerMock = new RouterMock();
+      fxaClient = new FxaClient();
+
       view = new View({
-        router: routerMock
+        router: routerMock,
+        fxaClient: fxaClient
       });
     });
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -13,16 +13,17 @@ define([
   'lib/session',
   'lib/auth-errors',
   'lib/metrics',
+  'lib/fxa-client',
   '../../mocks/window',
   '../../mocks/router',
   '../../lib/helpers'
 ],
-function (chai, $, p, View, Session, AuthErrors, Metrics, WindowMock, RouterMock, TestHelpers) {
+function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient, WindowMock, RouterMock, TestHelpers) {
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
 
   describe('views/sign_in', function () {
-    var view, email, routerMock, metrics, windowMock;
+    var view, email, routerMock, metrics, windowMock, fxaClient;
 
     beforeEach(function () {
       email = 'testuser.' + Math.random() + '@testuser.com';
@@ -32,11 +33,13 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, WindowMock, RouterMock
       routerMock = new RouterMock();
       windowMock = new WindowMock();
       metrics = new Metrics();
+      fxaClient = new FxaClient();
 
       view = new View({
         router: routerMock,
         metrics: metrics,
-        window: windowMock
+        window: windowMock,
+        fxaClient: fxaClient
       });
 
       return view.render()

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -14,11 +14,12 @@ define([
   'lib/session',
   'lib/auth-errors',
   'lib/metrics',
+  'lib/fxa-client',
   '../../mocks/router',
   '../../mocks/window',
   '../../lib/helpers'
 ],
-function (chai, _, $, p, View, Session, AuthErrors, Metrics, RouterMock, WindowMock, TestHelpers) {
+function (chai, _, $, p, View, Session, AuthErrors, Metrics, FxaClient, RouterMock, WindowMock, TestHelpers) {
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
 
@@ -40,7 +41,7 @@ function (chai, _, $, p, View, Session, AuthErrors, Metrics, RouterMock, WindowM
   }
 
   describe('views/sign_up', function () {
-    var view, router, email, metrics, windowMock;
+    var view, router, email, metrics, windowMock, fxaClient;
 
     beforeEach(function () {
       Session.clear();
@@ -50,11 +51,13 @@ function (chai, _, $, p, View, Session, AuthErrors, Metrics, RouterMock, WindowM
       router = new RouterMock();
       windowMock = new WindowMock();
       metrics = new Metrics();
+      fxaClient = new FxaClient();
 
       view = new View({
         router: router,
         metrics: metrics,
-        window: windowMock
+        window: windowMock,
+        fxaClient: fxaClient
       });
       return view.render()
           .then(function () {


### PR DESCRIPTION
- Replace the global variables in fxa-client.js with instance variables.
- All view tests create their own fxa-client to avoid cross test pollution.
- One fxa-client instance is shared across views for the application.

Work done as part of the evaluation of the amount of work to replace fxa-js-client with a mock for testing. (See #1356)

fixes #1304
