### PR TITLE
refactor(client): Share code between auth-errors.js and oauth-errors.js.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -91,6 +91,9 @@ function () {
   };
 
   return {
+    ERROR_TO_CODE: ERROR_TO_CODE,
+    CODE_TO_MESSAGES: CODE_TO_MESSAGES,
+
     /**
      * Convert an error, a numeric code or string type to a message
      */
@@ -117,7 +120,7 @@ function () {
         code = this.toCode('SERVICE_UNAVAILABLE');
       }
 
-      return CODE_TO_MESSAGES[code] || err;
+      return this.CODE_TO_MESSAGES[code] || err;
     },
 
     /**
@@ -150,7 +153,7 @@ function () {
      * Convert an error or a text type from ERROR_TO_CODE to a numeric code
      */
     toCode: function (type) {
-      return type.errno || ERROR_TO_CODE[type] || type;
+      return type.errno || this.ERROR_TO_CODE[type] || type;
     },
 
     /**

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -7,8 +7,10 @@
 'use strict';
 
 define([
+  'underscore',
+  'lib/auth-errors'
 ],
-function () {
+function (_, AuthErrors) {
   var t = function (msg) {
     return msg;
   };
@@ -32,69 +34,8 @@ function () {
     109: t('Invalid request signature')
   };
 
-  return {
-    /**
-     * Convert an error, a numeric code or string type to a message
-     */
-    toMessage: function (err) {
-      var code;
-
-      if (typeof err === 'number') {
-        code = err;
-      // error from backend
-      } else if (err && typeof err.errno === 'number') {
-        code = err.errno;
-      // error from backend that only has a message. Print the message.
-      } else if (err && err.message) {
-        return err.message;
-      // probably a string. Try to convert it.
-      } else if (err && err.length) {
-        code = this.toCode(err);
-      } else {
-        // if there is no error, no error message, and no code,
-        // assume no response from the backend and
-        // the service is unavailable.
-        code = this.toCode('SERVICE_UNAVAILABLE');
-      }
-
-      return CODE_TO_MESSAGES[code] || err;
-    },
-
-    /**
-     * Fetch the translation context out of the server error.
-     */
-    toContext: function (err) {
-      // For data returned by backend, see
-      // https://github.com/mozilla/fxa-auth-server/blob/master/error.js
-      try {
-        if (this.is(err, 'INVALID_PARAMETER')) {
-          return {
-            param: err.validation.keys
-          };
-        }
-      } catch (e) {
-        // handle invalid/unexpected data from the backend.
-        if (window.console && console.error) {
-          console.error('Error in oauth-errors.js->toContext: %s', String(e));
-        }
-      }
-
-      return {};
-    },
-
-    /**
-     * Convert a text type from ERROR_TO_CODE to a numeric code
-     */
-    toCode: function (type) {
-      return ERROR_TO_CODE[type];
-    },
-
-    /**
-     * Check if an error is of the given type
-     */
-    is: function (error, type) {
-      var code = this.toCode(type);
-      return error.errno === code;
-    }
-  };
+  return _.extend({}, AuthErrors, {
+    ERROR_TO_CODE: ERROR_TO_CODE,
+    CODE_TO_MESSAGES: CODE_TO_MESSAGES
+  });
 });

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -58,6 +58,7 @@ function (Translator, Session) {
     '../tests/spec/lib/router',
     '../tests/spec/lib/strings',
     '../tests/spec/lib/auth-errors',
+    '../tests/spec/lib/oauth-errors',
     '../tests/spec/lib/app-start',
     '../tests/spec/lib/validate',
     '../tests/spec/lib/service-name',

--- a/app/tests/spec/lib/oauth-errors.js
+++ b/app/tests/spec/lib/oauth-errors.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'lib/oauth-errors'
+],
+function (chai, OAuthErrors) {
+  'use strict';
+
+  /*global describe, it*/
+  var assert = chai.assert;
+
+  describe('lib/oauth-errors', function () {
+    describe('toMessage', function () {
+      it('converts a code to a message', function () {
+        assert.equal(OAuthErrors.toMessage(101), 'Unknown client');
+      });
+
+      it('converts a string type to a message', function () {
+        assert.equal(
+            OAuthErrors.toMessage('UNKNOWN_CLIENT'), 'Unknown client');
+      });
+
+      it('converts an error from the backend containing an errno to a message', function () {
+        assert.equal(
+          OAuthErrors.toMessage({
+            errno: 101
+          }), 'Unknown client');
+      });
+
+      it('converts an error from the backend containing a message to a message', function () {
+        assert.equal(
+          OAuthErrors.toMessage({
+            message: 'this has no errno'
+          }), 'this has no errno');
+      });
+    });
+
+    describe('toCode', function () {
+      it('returns the errno from an error object', function () {
+        var err = OAuthErrors.toError('UNKNOWN_CLIENT', 'dunno');
+        assert.equal(OAuthErrors.toCode(err), 101);
+      });
+
+      it('converts a string type to a numeric code, if valid code', function () {
+        assert.equal(OAuthErrors.toCode('UNKNOWN_CLIENT'), 101);
+      });
+
+      it('returns the string if an invalid code', function () {
+        assert.equal(OAuthErrors.toCode('this is an invalid code'), 'this is an invalid code');
+      });
+    });
+
+    describe('is', function () {
+      it('checks if an error returned from the server is of a given type',
+          function () {
+        assert.isTrue(OAuthErrors.is({ errno: 101 }, 'UNKNOWN_CLIENT'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Each object keeps a reference to the error value tables to use, allowing for code to be shared.
- Add some basic tests for oauth-errors.js to ensure things work as expected.
