### PR TITLE
chore(client): Whitelist allowed oauth parameters that can come from the URL.

### DIFF
--- a/app/scripts/lib/url.js
+++ b/app/scripts/lib/url.js
@@ -8,7 +8,7 @@
 define(['underscore'],
 function (_) {
 
-  function searchParams (str) {
+  function searchParams (str, whitelist) {
     var search = (str || window.location.search).replace(/^\?/, '');
     if (! search) {
       return {};
@@ -22,7 +22,20 @@ function (_) {
       terms[keyValue[0]] = decodeURIComponent(keyValue[1]);
     });
 
-    return terms;
+    if (! whitelist) {
+      return terms;
+    }
+
+    // whitelist is in effect.
+    var allowedTerms = {};
+
+    _.each(whitelist, function(allowedTerm) {
+      if (allowedTerm in terms) {
+        allowedTerms[allowedTerm] = terms[allowedTerm];
+      }
+    });
+
+    return allowedTerms;
   }
 
   return {

--- a/app/scripts/views/mixins/service-mixin.js
+++ b/app/scripts/views/mixins/service-mixin.js
@@ -33,8 +33,11 @@ define([
 
       this._oAuthClient = new OAuthClient();
 
-      if (!params) {
-        params = Url.searchParams(this.window.location.search);
+      if (! params) {
+        // params listed in:
+        // https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1authorization
+        params = Url.searchParams(this.window.location.search,
+                  ['client_id', 'redirect_uri', 'state', 'scope', 'action']);
       }
       this._oAuthParams = params;
 

--- a/app/tests/spec/lib/url.js
+++ b/app/tests/spec/lib/url.js
@@ -15,7 +15,7 @@ function (chai, _, Url) {
 
   describe('lib/url', function () {
     describe('searchParam', function () {
-      it('returns a parameter from window.location.serach, if it exists',
+      it('returns a parameter from window.location.search, if it exists',
           function() {
         assert.equal(Url.searchParam('color', '?color=green'), 'green');
       });
@@ -27,6 +27,26 @@ function (chai, _, Url) {
       it('does not throw if str override is not specified', function() {
         assert.isUndefined(Url.searchParam('animal'));
       });
+    });
+
+    describe('searchParams', function () {
+      var search = '?color=green&email=' + encodeURIComponent('testuser@testuser.com');
+
+      it('returns all parameters from window.location.search, if no whitelist specified',
+          function() {
+        var params = Url.searchParams(search);
+        assert.equal(params.color, 'green');
+        assert.equal(params.email, 'testuser@testuser.com');
+      });
+
+      it('only returns whitelisted parameters from window.location.search, if whitelist specified',
+          function() {
+        var params = Url.searchParams(search, ['color', 'notDefined']);
+        assert.equal(params.color, 'green');
+        assert.isFalse('email' in params);
+        assert.isFalse('notDefined' in params);
+      });
+
     });
 
     describe('pathToScreenName', function () {


### PR DESCRIPTION
- Add whitelist capabilities to Url.searchParams
- This is an effort to understand the OAuth flow better.
- List of parameters comes from https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1authorization
