### PR TITLE
feat(metrics): Add screen width and height to the metrics.

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -40,7 +40,8 @@ define([
     'lang',
     'marketingLink',
     'marketingType',
-    'marketingClicked'
+    'marketingClicked',
+    'screen'
   ];
 
   var TEN_MINS_MS = 10 * 60 * 1000;

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -54,6 +54,8 @@ function (chai, Metrics, WindowMock) {
         assert.isTrue(filteredData.hasOwnProperty('context'));
         assert.isTrue(filteredData.hasOwnProperty('service'));
         assert.isTrue(filteredData.hasOwnProperty('lang'));
+        assert.equal(filteredData.screen.width, window.screen.width);
+        assert.equal(filteredData.screen.height, window.screen.height);
       });
     });
 

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "requirejs-mustache": "https://github.com/jfparadis/requirejs-mustache.git#5fb8c0a3e8560526e8f9617a689e2924a8532d0a",
     "requirejs-text": "2.0.10",
     "sinon": "http://sinonjs.org/releases/sinon-1.7.1.js",
-    "speed-trap": "0.0.4",
+    "speed-trap": "0.0.5",
     "tos-pp": "https://github.com/mozilla/legal-docs.git",
     "underscore": "1.5.2"
   },

--- a/server/lib/metrics-collector-stderr.js
+++ b/server/lib/metrics-collector-stderr.js
@@ -68,6 +68,19 @@ function addEvents(loggableEvent, event) {
   }
 }
 
+function addScreenSize(loggableEvent, event) {
+  if (! event.screen) {
+    return;
+  }
+
+  if (event.screen.width) {
+    loggableEvent['screen.width'] = event.screen.width;
+  }
+
+  if (event.screen.height) {
+    loggableEvent['screen.height'] = event.screen.height;
+  }
+}
 
 function toLoggableEvent(event) {
   var loggableEvent = {};
@@ -95,6 +108,7 @@ function toLoggableEvent(event) {
 
   addNavigationTiming(loggableEvent, event);
   addEvents(loggableEvent, event);
+  addScreenSize(loggableEvent, event);
 
 
   return loggableEvent;

--- a/tests/server/metrics-collector-stderr.js
+++ b/tests/server/metrics-collector-stderr.js
@@ -54,6 +54,9 @@ define([
       assert.equal(loggedMetrics.marketingType, 'survey');
       assert.equal(loggedMetrics.marketingLink, 'http://mzl.la/1oV7jUy');
       assert.isFalse(loggedMetrics.marketingClicked);
+
+      assert.equal(loggedMetrics['screen.width'], 1680);
+      assert.equal(loggedMetrics['screen.height'], 1050);
     });
 
     metricsCollector.write({
@@ -78,7 +81,11 @@ define([
       context: 'fx_desktop_v1',
       marketingType: 'survey',
       marketingLink: 'http://mzl.la/1oV7jUy',
-      marketingClicked: false
+      marketingClicked: false,
+      screen: {
+        width: 1680,
+        height: 1050
+      }
     });
   };
 


### PR DESCRIPTION
- width reported as `screen.width` in the logs.
- height reported as `screen.height` in the logs.

fixes #1373 

@kparlante - this is for you!
