### PR TITLE
refactor(client): Convert jQuery AJAX promises to Promises A+ promises.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -20,7 +20,7 @@
 define([
   'underscore',
   'backbone',
-  'p-promise',
+  'lib/promise',
   'router',
   'lib/constants',
   'lib/translator',

--- a/app/scripts/lib/assertion.js
+++ b/app/scripts/lib/assertion.js
@@ -5,7 +5,7 @@
 'use strict';
 
 define([
-  'p-promise',
+  'lib/promise',
   'vendor/jwcrypto',
   'lib/fxa-client'
 ],

--- a/app/scripts/lib/config-loader.js
+++ b/app/scripts/lib/config-loader.js
@@ -35,8 +35,6 @@ function (
         return p(this._config);
       }
 
-      var deferred = p.defer();
-
       // The content server sets no cookies of its own, and cannot check for
       // the existence of a session cookie. So, we send them a cookie
       // from the client to see if the backend receives it.
@@ -56,12 +54,11 @@ function (
       }
 
       var self = this;
-      $.getJSON('/config', function (config) {
-        self._config = config;
-        deferred.resolve(config);
-      });
-
-      return deferred.promise;
+      return p.jQueryXHR($.getJSON('/config'))
+          .then(function (config) {
+            self._config = config;
+            return config;
+          });
     },
 
     areCookiesEnabled: function (force) {

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -12,7 +12,7 @@ define([
   'underscore',
   'fxaClient',
   'jquery',
-  'p-promise',
+  'lib/promise',
   'lib/session',
   'lib/auth-errors',
   'lib/constants'
@@ -89,11 +89,10 @@ function (_, FxaClient, $, p, Session, AuthErrors, Constants) {
         return p(Session.config.fxaccountUrl);
       }
 
-      var defer = p.defer();
-      $.getJSON('/config', function (data) {
-        defer.resolve(data.fxaccountUrl);
-      });
-      return defer.promise;
+      return p.jQueryXHR($.getJSON('/config'))
+          .then(function (data) {
+            return data.fxaccountUrl;
+          });
     },
 
     /**

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -19,7 +19,7 @@ define([
   'backbone',
   'jquery',
   'speedTrap',
-  'p-promise',
+  'lib/promise',
   'lib/url'
 ], function (_, Backbone, $, speedTrap, p, Url) {
   'use strict';

--- a/app/scripts/lib/null-metrics.js
+++ b/app/scripts/lib/null-metrics.js
@@ -9,7 +9,7 @@
 
 define([
   'underscore',
-  'p-promise',
+  'lib/promise',
   'lib/metrics'
 ], function (_, p, Metrics) {
   'use strict';

--- a/app/scripts/lib/oauth-client.js
+++ b/app/scripts/lib/oauth-client.js
@@ -6,7 +6,7 @@
 
 define([
   'jquery',
-  'p-promise',
+  'lib/promise',
   'lib/session',
   'lib/config-loader'
 ],
@@ -49,16 +49,15 @@ function ($, p, Session, ConfigLoader) {
     // params = { assertion, client_id, redirect_uri, scope, state }
     getCode: function getCode(params) {
       return this._getOauthUrl().then(function (url) {
-        return $.post(url + GET_CODE, params);
+        return p.jQueryXHR($.post(url + GET_CODE, params));
       });
     },
 
     getClientInfo: function getClientInfo(id) {
       return this._getOauthUrl().then(function (url) {
-        return $.get(url + GET_CLIENT + id);
+        return p.jQueryXHR($.get(url + GET_CLIENT + id));
       });
     }
-
   };
 
   return OAuthClient;

--- a/app/scripts/lib/promise.js
+++ b/app/scripts/lib/promise.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// monkey patch p to be able to convert jQuery XHR promises to our promises.
+define([
+  'p-promise'
+], function (p) {
+  'use strict';
+
+  // for more background, read
+  // https://github.com/kriskowal/q/wiki/Coming-from-jQuery
+
+  p.jQueryXHR = function (jQueryDeferred) {
+    var defer = p.defer();
+
+    jQueryDeferred.then(function (data, textStatus, jqXHR) {
+      defer.resolve(data);
+    }, function (jqXHR, textStatus, errorThrown) {
+      defer.reject(jqXHR);
+    });
+
+    return defer.promise;
+  };
+
+  return p;
+});
+
+

--- a/app/scripts/lib/translator.js
+++ b/app/scripts/lib/translator.js
@@ -11,7 +11,7 @@
 define([
   'underscore',
   'jquery',
-  'p-promise',
+  'lib/promise',
   'lib/strings'
 ],
 function (_, $, p, Strings) {
@@ -27,31 +27,22 @@ function (_, $, p, Strings) {
 
     // Fetches our JSON translation file
     fetch: function () {
-      var defer = p.defer();
       var self = this;
 
-      $.getJSON('/i18n/client.json')
-        .done(function (data) {
-          // Only update the translations if some came back
-          // from the server. If the server sent no translations,
-          // english strings will be served.
-          if (data) {
-            self.translations = data;
-          }
-        })
-        .fail(function () {
-          // allow for 404's. `.get` will use the key for the translation
-          // if a value is not found in the translations table. This means
-          // English will be the fallback.
-          self.translations = {};
-        })
-        .always(function () {
-          // do not surface any errors, allow the app to load even
-          // if there are no translations for this locale.
-          defer.resolve();
-        });
-
-      return defer.promise;
+      return p.jQueryXHR($.getJSON('/i18n/client.json'))
+          .then(function (data) {
+            // Only update the translations if some came back
+            // from the server. If the server sent no translations,
+            // english strings will be served.
+            if (data) {
+              self.translations = data;
+            }
+          }, function () {
+            // allow for 404's. `.get` will use the key for the translation
+            // if a value is not found in the translations table. This means
+            // English will be the fallback.
+            self.translations = {};
+          });
     },
 
     /**

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -8,7 +8,7 @@ define([
   'underscore',
   'backbone',
   'jquery',
-  'p-promise',
+  'lib/promise',
   'lib/session',
   'lib/auth-errors',
   'lib/fxa-client',

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -5,7 +5,7 @@
 'use strict';
 
 define([
-  'p-promise',
+  'lib/promise',
   'views/base',
   'views/sign_in',
   'stache!templates/force_auth',

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -22,7 +22,7 @@
 define([
   'underscore',
   'jquery',
-  'p-promise',
+  'lib/promise',
   'lib/validate',
   'lib/auth-errors',
   'views/base',

--- a/app/scripts/views/oauth_sign_in.js
+++ b/app/scripts/views/oauth_sign_in.js
@@ -6,7 +6,7 @@
 
 define([
   'underscore',
-  'p-promise',
+  'lib/promise',
   'views/sign_in',
   'lib/session',
   'views/mixins/service-mixin'

--- a/app/scripts/views/oauth_sign_up.js
+++ b/app/scripts/views/oauth_sign_up.js
@@ -6,7 +6,7 @@
 
 define([
   'underscore',
-  'p-promise',
+  'lib/promise',
   'views/base',
   'views/sign_up',
   'lib/session',

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -6,7 +6,7 @@
 
 define([
   'underscore',
-  'p-promise',
+  'lib/promise',
   'views/base',
   'views/form',
   'stache!templates/sign_in',

--- a/app/tests/spec/lib/assertion.js
+++ b/app/tests/spec/lib/assertion.js
@@ -8,7 +8,7 @@
 define([
   'chai',
   'jquery',
-  'p-promise',
+  'lib/promise',
   'lib/session',
   'lib/constants',
   'lib/assertion',

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -5,7 +5,7 @@
 define([
   'chai',
   'jquery',
-  'p-promise',
+  'lib/promise',
   '../../mocks/channel',
   '../../lib/helpers',
   'lib/session',

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -7,7 +7,7 @@
 
 define([
   'chai',
-  'p-promise',
+  'lib/promise',
   'lib/auth-errors',
   'lib/metrics',
   'lib/fxa-client',

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -7,7 +7,7 @@
 
 define([
   'chai',
-  'p-promise',
+  'lib/promise',
   'views/complete_sign_up',
   'lib/auth-errors',
   'lib/metrics',

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -4,7 +4,7 @@
 
 define([
   'chai',
-  'p-promise',
+  'lib/promise',
   'lib/session',
   'lib/auth-errors',
   'lib/metrics',

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -4,7 +4,7 @@
 
 define([
   'chai',
-  'p-promise',
+  'lib/promise',
   'lib/auth-errors',
   'views/confirm_reset_password',
   'lib/session',

--- a/app/tests/spec/views/cookies_disabled.js
+++ b/app/tests/spec/views/cookies_disabled.js
@@ -8,7 +8,7 @@
 define([
   'jquery',
   'chai',
-  'p-promise',
+  'lib/promise',
   'views/cookies_disabled',
   '../../mocks/window'
 ],
@@ -24,8 +24,11 @@ function ($, chai, p, View, WindowMock) {
       // Going deep into the internals, which isn't great. Monkey patch
       // $.getJSON so that we do not have to actually make a request to
       // the backend and can control the return value.
-      $.getJSON = function (url, done) {
-        done(serverConfig);
+
+      $.getJSON = function (url) {
+        var deferred = jQuery.Deferred();
+        deferred.resolve(serverConfig);
+        return deferred.promise();
       };
 
       windowMock = new WindowMock();

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -8,7 +8,7 @@
 define([
   'chai',
   'jquery',
-  'p-promise',
+  'lib/promise',
   'views/form',
   'stache!templates/test_template',
   'lib/constants',

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -7,7 +7,7 @@
 
 define([
   'chai',
-  'p-promise',
+  'lib/promise',
   'lib/session',
   'lib/auth-errors',
   'lib/metrics',

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -8,7 +8,7 @@
 define([
   'chai',
   'jquery',
-  'p-promise',
+  'lib/promise',
   'views/sign_in',
   'lib/session',
   'lib/auth-errors',

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -9,7 +9,7 @@ define([
   'chai',
   'underscore',
   'jquery',
-  'p-promise',
+  'lib/promise',
   'views/sign_up',
   'lib/session',
   'lib/auth-errors',


### PR DESCRIPTION
jQuery AJAX promises are not Promises A+ compatible and can cause unexpected behavior. Monkey patch p to add a jQueryXHR function, and replace all references to 'p-promise' with 'lib/promise'.

fixes #1406
