### PR TITLE
refactor(client): Remove `language` from Session.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -93,7 +93,6 @@ function (
       this._config = config;
       this._configLoader.useConfig(config);
       Session.set('config', config);
-      Session.set('language', config.language);
 
       this._metrics = createMetrics(config.metricsSampleRate, {
         lang: config.language
@@ -101,7 +100,10 @@ function (
       this._metrics.init();
 
       if (! this._router) {
-        this._router = new Router({ metrics: this._metrics });
+        this._router = new Router({
+          metrics: this._metrics,
+          language: config.language
+        });
       }
       this._window.router = this._router;
     },

--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -15,15 +15,13 @@ define([
 
   // channel is initialized on app startup
   // and should not be saved to sessionStorage
-  var DO_NOT_PERSIST = ['channel', 'prefillPassword', 'prefillYear', 'error', 'language', 'service'];
+  var DO_NOT_PERSIST = ['channel', 'prefillPassword', 'prefillYear', 'error', 'service'];
 
   // channel should not be cleared from memory or else fxa-client.js
   // will blow up when sending the login message.
   // Don't clear service because the signup page needs that state
   //  even when user credentials are cleared.
-  // Don't clear `language`, this is set on startup based on the user's
-  // Accept-Language headers and does not change when user's sign in and out.
-  var DO_NOT_CLEAR = ['channel', 'context', 'service', 'config', 'language'];
+  var DO_NOT_CLEAR = ['channel', 'context', 'service', 'config'];
 
   // these keys will be persisted to localStorage so that they live between browser sessions
   var PERSIST_TO_LOCAL_STORAGE = ['email', 'sessionToken', 'sessionTokenContext', 'oauth'];

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -64,7 +64,8 @@ function (
       options = _.extend({
         metrics: this.metrics,
         window: this.window,
-        router: this
+        router: this,
+        language: this.language
       }, options || {});
 
       this.showView(new View(options));
@@ -103,6 +104,7 @@ function (
       this.window = options.window || window;
 
       this.metrics = options.metrics;
+      this.language = options.language;
 
       this.$stage = $('#stage');
 

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -31,6 +31,7 @@ function (_, BaseView, FormView, Template, Session, Xss, Strings, ServiceMixin, 
       options = options || {};
 
       this.type = options.type;
+      this.language = options.language;
     },
 
     beforeRender: function () {
@@ -77,7 +78,7 @@ function (_, BaseView, FormView, Template, Session, Xss, Strings, ServiceMixin, 
       var marketingSnippet = new MarketingSnippet({
         type: this.type,
         service: Session.service,
-        language: Session.language,
+        language: this.language,
         el: this.$('.marketing-area'),
         metrics: this.metrics
       });

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -36,13 +36,9 @@ function (chai, AppStart, Session, WindowMock, RouterMock, HistoryMock) {
     });
 
     describe('start', function () {
-      it('start starts the app', function () {
+      it('starts the app', function () {
         return appStart.startApp()
                     .then(function () {
-                      // language will be chosen by the backend depending
-                      // on the user's Accept-Language headers and could
-                      // be different for everybody.
-                      assert.ok(Session.language);
                       assert.ok(Session.config);
                       assert.ok(Session.channel);
 


### PR DESCRIPTION
In an effort to reduce the "God module" factor from Session, remove `language`. Pass language in as configuration to the only views that require it - ready.js and marketing-snippet.js

@zaach - there is no corresponding issue for this. Your refactor to remove "language" from fxa-client and the TOS/PP work made this refactor trivial to do.
