### PR TITLE
chore(client): Wrap the ajax request in the metrics module.

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -163,26 +163,21 @@ define([
     },
 
     _send: function (data, url, async) {
-      var deferred = p.defer();
-
       var self = this;
-      this._ajax({
+      return p.jQueryXHR(this._ajax({
         async: async !== false,
         type: 'POST',
         url: url,
         contentType: 'application/json',
-        data: JSON.stringify(data),
-        error: function (jqXHR, textStatus, errorThrown) {
-          self.trigger('flush:error');
-          deferred.reject(errorThrown);
-        },
-        success: function () {
-          self.trigger('flush:success', data);
-          deferred.resolve(data);
-        }
+        data: JSON.stringify(data)
+      }))
+      .then(function () {
+        self.trigger('flush:success', data);
+        return data;
+      }, function(jqXHR) {
+        self.trigger('flush:error');
+        throw jqXHR.statusText;
       });
-
-      return deferred.promise;
     },
 
     /**

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -6,10 +6,11 @@
 
 define([
   'chai',
+  'jquery',
   'lib/metrics',
   '../../mocks/window'
 ],
-function (chai, Metrics, WindowMock) {
+function (chai, $, Metrics, WindowMock) {
   'use strict';
 
   /*global describe, it*/
@@ -94,11 +95,15 @@ function (chai, Metrics, WindowMock) {
       function ajaxMock(options) {
         sentData = options.data;
 
+        var deferred = $.Deferred();
+
         if (serverError) {
-          options.error({}, 'bad jiji', serverError);
+          deferred.reject({ statusText: serverError }, 'bad jiji', serverError);
         } else {
-          options.success();
+          deferred.resolve({});
         }
+
+        return deferred.promise();
       }
 
       beforeEach(function () {


### PR DESCRIPTION
@zaach - I've wrapped the ajax call, and use the statusText as the error (that's what jQuery does). Something about that doesn't seem quite right. Any suggestions?
