### PR TITLE
fix(metrics): Log a screen once, childviews should not cause the parent to be lgoged.

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -162,6 +162,8 @@ function (
           self.$stage.html(viewToShow.el).css('display', 'block');
           viewToShow.afterVisible();
 
+          viewToShow.logScreen();
+
           // The user may be scrolled part way down the page
           // on screen transition. Force them to the top of the page.
           self.window.scrollTo(0, 0);

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -89,8 +89,6 @@ function (_, Backbone, $, p, Session, AuthErrors, FxaClient, Url, Strings, Ephem
     render: function () {
       var self = this;
 
-      self.logScreen();
-
       return p()
         .then(function () {
           return self.isUserAuthorized();


### PR DESCRIPTION
- Log a screen view from router.js so that child views do not cause the parent view to be logged.

fixes #1379
