### PR TITLE
feat(build): Adding htmllint Grunt task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 node_js:
   - "0.10"
+
 addons:
   firefox: "29.0"
+
 env:
   global:
     - DISABLE_ROUTE_LOGGING=true
@@ -40,5 +42,7 @@ install:
 script:
   - grunt validate-shrinkwrap --force # check for vulnerable modules via nodesecurity.io
   - grunt lint
+  - grunt build &> /dev/null
+  - grunt htmllint:en_US
   - travis_retry npm run test-travis
   - travis_retry npm run test-server

--- a/grunttasks/htmllint.js
+++ b/grunttasks/htmllint.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (grunt) {
+  'use strict';
+
+  grunt.config('htmllint', {
+    options: {
+      ignore: [
+        'Bad value “X-UA-Compatible” for attribute “http-equiv” on XHTML element “meta”.',
+        'Duplicate ID “-”.',
+        'Text run is not in Unicode Normalization Form C.',
+        'The first occurrence of ID “-” was here.'
+      ]
+    },
+
+    all: [
+      '<%= yeoman.app %>/**/*.{html,mustache}',
+      '!<%= yeoman.app %>/bower_components/**',
+      '<%= yeoman.page_template_dist %>/**/*.html',
+      '!<%= yeoman.page_template_dist %>/it_CH/*.html',
+      '!<%= yeoman.page_template_dist %>/{privacy,terms}/*.html'
+    ],
+
+    en_US: [
+      '<%= yeoman.app %>/**/*.{html,mustache}',
+      '!<%= yeoman.app %>/bower_components/**',
+      '<%= yeoman.page_template_dist %>/en_US/*.html'
+    ]
+  });
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,7 +1,255 @@
 {
   "name": "fxa-content-server",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "dependencies": {
+    "awsbox": {
+      "version": "0.7.0",
+      "from": "awsbox@0.7.0",
+      "resolved": "https://registry.npmjs.org/awsbox/-/awsbox-0.7.0.tgz",
+      "dependencies": {
+        "awssum-amazon-ec2": {
+          "version": "1.5.0",
+          "from": "awssum-amazon-ec2@>=1.3.2",
+          "resolved": "https://registry.npmjs.org/awssum-amazon-ec2/-/awssum-amazon-ec2-1.5.0.tgz",
+          "dependencies": {
+            "data2xml": {
+              "version": "0.8.1",
+              "from": "data2xml@0.8.x",
+              "resolved": "https://registry.npmjs.org/data2xml/-/data2xml-0.8.1.tgz"
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "dateformat": {
+              "version": "1.0.4-1.2.3",
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
+            }
+          }
+        },
+        "awssum-amazon-route53": {
+          "version": "1.2.0",
+          "from": "awssum-amazon-route53@1.x",
+          "resolved": "https://registry.npmjs.org/awssum-amazon-route53/-/awssum-amazon-route53-1.2.0.tgz",
+          "dependencies": {
+            "fmt": {
+              "version": "0.4.0",
+              "from": "fmt@0.4.x",
+              "resolved": "https://registry.npmjs.org/fmt/-/fmt-0.4.0.tgz"
+            },
+            "data2xml": {
+              "version": "0.8.1",
+              "from": "data2xml@0.8.x",
+              "resolved": "https://registry.npmjs.org/data2xml/-/data2xml-0.8.1.tgz"
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "dateformat": {
+              "version": "1.0.4-1.2.3",
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
+            }
+          }
+        },
+        "nice-route53": {
+          "version": "0.3.4",
+          "from": "nice-route53@0.3.4",
+          "resolved": "https://registry.npmjs.org/nice-route53/-/nice-route53-0.3.4.tgz",
+          "dependencies": {
+            "awssum-amazon-route53": {
+              "version": "1.0.3",
+              "from": "awssum-amazon-route53@1.0.x",
+              "resolved": "https://registry.npmjs.org/awssum-amazon-route53/-/awssum-amazon-route53-1.0.3.tgz",
+              "dependencies": {
+                "fmt": {
+                  "version": "0.4.0",
+                  "from": "fmt@0.4.x",
+                  "resolved": "https://registry.npmjs.org/fmt/-/fmt-0.4.0.tgz"
+                },
+                "data2xml": {
+                  "version": "0.8.1",
+                  "from": "data2xml@0.8.x",
+                  "resolved": "https://registry.npmjs.org/data2xml/-/data2xml-0.8.1.tgz"
+                },
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "underscore@1.4.x",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                },
+                "dateformat": {
+                  "version": "1.0.4-1.2.3",
+                  "from": "dateformat@1.0.4-1.2.3",
+                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "async@0.2.x",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "JSONSelect": {
+          "version": "0.4.0",
+          "from": "JSONSelect@0.4.0",
+          "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz"
+        },
+        "temp": {
+          "version": "0.4.0",
+          "from": "temp@0.4.0",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz"
+        },
+        "xml2js": {
+          "version": "0.1.13",
+          "from": "xml2js@0.1.13",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.13.tgz",
+          "dependencies": {
+            "sax": {
+              "version": "0.6.0",
+              "from": "sax@>=0.1.1",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.0.tgz"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.3.1",
+          "from": "optimist@0.3.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            }
+          }
+        },
+        "urlparse": {
+          "version": "0.0.1",
+          "from": "urlparse@0.0.1",
+          "resolved": "https://registry.npmjs.org/urlparse/-/urlparse-0.0.1.tgz"
+        },
+        "relative-date": {
+          "version": "1.1.1",
+          "from": "relative-date@1.1.1",
+          "resolved": "https://registry.npmjs.org/relative-date/-/relative-date-1.1.1.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@~0.6.0-1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "awssum": {
+          "version": "1.1.0",
+          "from": "awssum@1.1.0",
+          "resolved": "https://registry.npmjs.org/awssum/-/awssum-1.1.0.tgz",
+          "dependencies": {
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "xml2js": {
+              "version": "0.2.8",
+              "from": "xml2js@0.2.x",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+              "dependencies": {
+                "sax": {
+                  "version": "0.5.8",
+                  "from": "sax@0.5.x",
+                  "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "awssum-amazon": {
+          "version": "1.1.0",
+          "from": "awssum-amazon@1.1.0",
+          "resolved": "https://registry.npmjs.org/awssum-amazon/-/awssum-amazon-1.1.0.tgz",
+          "dependencies": {
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@1.4.x",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "dateformat": {
+              "version": "1.0.4-1.2.3",
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
+            }
+          }
+        },
+        "read-package-json": {
+          "version": "1.1.9",
+          "from": "read-package-json@~1.1.3",
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.1.9.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@~3.2.1",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "normalize-package-data": {
+              "version": "0.2.13",
+              "from": "normalize-package-data@^0.2.13",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-0.2.13.tgz",
+              "dependencies": {
+                "github-url-from-git": {
+                  "version": "1.1.1",
+                  "from": "github-url-from-git@~1.1.1",
+                  "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.1.1.tgz"
+                },
+                "github-url-from-username-repo": {
+                  "version": "0.1.0",
+                  "from": "github-url-from-username-repo@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-0.1.0.tgz"
+                },
+                "semver": {
+                  "version": "2.3.2",
+                  "from": "semver@2",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@2",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            }
+          }
+        }
+      }
+    },
     "bluebird": {
       "version": "2.2.2",
       "from": "bluebird@2.2.2",
@@ -367,9 +615,9 @@
               }
             },
             "readable-stream": {
-              "version": "1.1.13-1",
+              "version": "1.1.13",
               "from": "readable-stream@~1.1.8",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
@@ -382,9 +630,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
-                  "version": "0.10.25-1",
+                  "version": "0.10.31",
                   "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
@@ -402,7 +650,7 @@
         },
         "fstream": {
           "version": "0.1.31",
-          "from": "fstream@~0.1.28",
+          "from": "fstream@~0.1.22",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
           "dependencies": {
             "inherits": {
@@ -438,12 +686,12 @@
         },
         "glob": {
           "version": "4.0.5",
-          "from": "glob@~4.0.0",
+          "from": "glob@~4.0.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.5.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
@@ -467,7 +715,7 @@
         },
         "graceful-fs": {
           "version": "3.0.2",
-          "from": "graceful-fs@~3.0.2",
+          "from": "graceful-fs@~3.0.1",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
         },
         "inquirer": {
@@ -718,7 +966,7 @@
                 },
                 "mute-stream": {
                   "version": "0.0.4",
-                  "from": "mute-stream@~0.0.4",
+                  "from": "mute-stream@0.0.4",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                 },
                 "readline2": {
@@ -751,9 +999,9 @@
                   }
                 },
                 "rx": {
-                  "version": "2.3.4",
+                  "version": "2.3.9",
                   "from": "rx@^2.2.27",
-                  "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.4.tgz"
+                  "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.9.tgz"
                 },
                 "through": {
                   "version": "2.3.4",
@@ -821,13 +1069,58 @@
               }
             },
             "request": {
-              "version": "2.40.0",
+              "version": "2.42.0",
               "from": "request@^2.40.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
               "dependencies": {
+                "bl": {
+                  "version": "0.9.1",
+                  "from": "bl@~0.9.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.31",
+                      "from": "readable-stream@~1.0.26",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.6.0",
+                  "from": "caseless@~0.6.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@~0.5.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
                 "qs": {
-                  "version": "1.0.2",
-                  "from": "qs@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
+                  "version": "1.2.2",
+                  "from": "qs@~1.2.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
@@ -839,15 +1132,15 @@
                   "from": "mime-types@~1.0.1",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
-                "forever-agent": {
-                  "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-                },
                 "node-uuid": {
                   "version": "1.4.1",
                   "from": "node-uuid@~1.4.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "form-data": {
                   "version": "0.1.4",
@@ -873,11 +1166,6 @@
                     }
                   }
                 },
-                "tunnel-agent": {
-                  "version": "0.4.0",
-                  "from": "tunnel-agent@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
-                },
                 "http-signature": {
                   "version": "0.10.0",
                   "from": "http-signature@~0.10.0",
@@ -901,9 +1189,9 @@
                   }
                 },
                 "oauth-sign": {
-                  "version": "0.3.0",
-                  "from": "oauth-sign@~0.3.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                  "version": "0.4.0",
+                  "from": "oauth-sign@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
@@ -975,7 +1263,7 @@
         },
         "lru-cache": {
           "version": "2.5.0",
-          "from": "lru-cache@2",
+          "from": "lru-cache@~2.5.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
         },
         "mout": {
@@ -1254,7 +1542,7 @@
           "dependencies": {
             "configstore": {
               "version": "0.3.1",
-              "from": "configstore@^0.3.0",
+              "from": "configstore@^0.3.1",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.1.tgz",
               "dependencies": {
                 "js-yaml": {
@@ -1326,9 +1614,9 @@
                       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-0.1.1.tgz",
                       "dependencies": {
                         "npmconf": {
-                          "version": "2.0.5",
+                          "version": "2.0.8",
                           "from": "npmconf@^2.0.1",
-                          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.5.tgz",
+                          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.8.tgz",
                           "dependencies": {
                             "config-chain": {
                               "version": "1.1.8",
@@ -1344,7 +1632,7 @@
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@2",
+                              "from": "inherits@~2.0.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "ini": {
@@ -1409,9 +1697,9 @@
       "resolved": "https://registry.npmjs.org/connect-cachify/-/connect-cachify-0.0.17.tgz",
       "dependencies": {
         "underscore": {
-          "version": "1.6.0",
+          "version": "1.7.0",
           "from": "underscore@>=1.3.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
         }
       }
     },
@@ -1448,6 +1736,7 @@
             "jsonlint": {
               "version": "1.6.0",
               "from": "jsonlint@1.6.0",
+              "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.0",
@@ -1521,6 +1810,210 @@
         }
       }
     },
+    "coveralls": {
+      "version": "2.11.1",
+      "from": "coveralls@2.11.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.1.tgz",
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.0.1",
+          "from": "js-yaml@3.0.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.1.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.15",
+              "from": "argparse@~ 0.1.11",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "underscore@~1.4.3",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@^2.3.3",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@~ 1.0.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "lcov-parse": {
+          "version": "0.0.6",
+          "from": "lcov-parse@0.0.6",
+          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz"
+        },
+        "log-driver": {
+          "version": "1.2.4",
+          "from": "log-driver@1.2.4",
+          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.4.tgz"
+        },
+        "request": {
+          "version": "2.36.0",
+          "from": "request@2.36.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "0.6.6",
+              "from": "qs@~0.6.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@~5.0.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@~1.2.9",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@~0.5.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.1",
+              "from": "node-uuid@~1.4.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.1",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
+                }
+              }
+            },
+            "form-data": {
+              "version": "0.1.4",
+              "from": "form-data@~0.1.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.5",
+                  "from": "combined-stream@~0.0.4",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@~0.9.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@~0.4.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
+            "http-signature": {
+              "version": "0.10.0",
+              "from": "http-signature@~0.10.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.2",
+                  "from": "assert-plus@0.1.2",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.2",
+                  "from": "ctype@0.5.2",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.3.0",
+              "from": "oauth-sign@~0.3.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+            },
+            "hawk": {
+              "version": "1.0.0",
+              "from": "hawk@~1.0.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "hoek@0.9.x",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "boom@0.4.x",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "cryptiles@0.2.x",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "sntp@0.2.x",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@~0.5.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "execSync": {
+      "version": "1.0.1-pre",
+      "from": "execSync@1.0.1-pre",
+      "resolved": "https://registry.npmjs.org/execSync/-/execSync-1.0.1-pre.tgz",
+      "dependencies": {
+        "temp": {
+          "version": "0.5.1",
+          "from": "temp@~0.5.1",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.5.1.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.1.4",
+              "from": "rimraf@~2.1.4",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "from": "graceful-fs@~1",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "express": {
       "version": "3.16.0",
       "from": "express@3.16.0",
@@ -1547,9 +2040,9 @@
               "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
             },
             "body-parser": {
-              "version": "1.6.5",
+              "version": "1.6.7",
               "from": "body-parser@~1.6.0",
-              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.5.tgz",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.7.tgz",
               "dependencies": {
                 "iconv-lite": {
                   "version": "0.4.4",
@@ -1569,9 +2062,9 @@
                   }
                 },
                 "qs": {
-                  "version": "1.2.2",
-                  "from": "qs@1.2.2",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+                  "version": "2.2.2",
+                  "from": "qs@2.2.2",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.2.tgz"
                 },
                 "raw-body": {
                   "version": "1.3.0",
@@ -1647,40 +2140,47 @@
               }
             },
             "csurf": {
-              "version": "1.4.0",
+              "version": "1.4.1",
               "from": "csurf@~1.4.0",
-              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.4.1.tgz",
               "dependencies": {
-                "csrf-tokens": {
-                  "version": "2.0.0",
-                  "from": "csrf-tokens@~2.0.0",
-                  "resolved": "https://registry.npmjs.org/csrf-tokens/-/csrf-tokens-2.0.0.tgz",
+                "csrf": {
+                  "version": "2.0.1",
+                  "from": "csrf@~2.0.1",
+                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.1.tgz",
                   "dependencies": {
                     "rndm": {
                       "version": "1.0.0",
-                      "from": "rndm@1",
+                      "from": "rndm@~1.0.0",
                       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.0.0.tgz"
                     },
                     "scmp": {
                       "version": "0.0.3",
-                      "from": "scmp@~0.0.3",
+                      "from": "scmp@0.0.3",
                       "resolved": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz"
                     },
                     "uid-safe": {
                       "version": "1.0.1",
-                      "from": "uid-safe@1",
+                      "from": "uid-safe@~1.0.1",
                       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                       "dependencies": {
                         "mz": {
-                          "version": "1.0.0",
+                          "version": "1.0.1",
                           "from": "mz@1",
-                          "resolved": "https://registry.npmjs.org/mz/-/mz-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/mz/-/mz-1.0.1.tgz",
+                          "dependencies": {
+                            "native-or-bluebird": {
+                              "version": "1.1.1",
+                              "from": "native-or-bluebird@1",
+                              "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.1.tgz"
+                            }
+                          }
                         }
                       }
                     },
                     "base64-url": {
                       "version": "1.0.0",
-                      "from": "base64-url@1",
+                      "from": "base64-url@1.0.0",
                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.0.0.tgz"
                     }
                   }
@@ -1712,9 +2212,9 @@
               }
             },
             "express-session": {
-              "version": "1.7.5",
+              "version": "1.7.6",
               "from": "express-session@~1.7.4",
-              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.7.5.tgz",
+              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.7.6.tgz",
               "dependencies": {
                 "on-headers": {
                   "version": "1.0.0",
@@ -1728,13 +2228,20 @@
                 },
                 "uid-safe": {
                   "version": "1.0.1",
-                  "from": "uid-safe@1",
+                  "from": "uid-safe@~1.0.1",
                   "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                   "dependencies": {
                     "mz": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "mz@1",
-                      "resolved": "https://registry.npmjs.org/mz/-/mz-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/mz/-/mz-1.0.1.tgz",
+                      "dependencies": {
+                        "native-or-bluebird": {
+                          "version": "1.1.1",
+                          "from": "native-or-bluebird@1",
+                          "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.1.tgz"
+                        }
+                      }
                     },
                     "base64-url": {
                       "version": "1.0.0",
@@ -1745,7 +2252,8 @@
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "utils-merge@1.0.0"
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 }
               }
             },
@@ -1796,9 +2304,9 @@
               "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.1.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.1.13-1",
+                  "version": "1.1.13",
                   "from": "readable-stream@~1.1.9",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
@@ -1811,13 +2319,13 @@
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
-                      "version": "0.10.25-1",
+                      "version": "0.10.31",
                       "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -1836,7 +2344,7 @@
             },
             "qs": {
               "version": "1.0.2",
-              "from": "qs@~1.0.0",
+              "from": "qs@1.0.2",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
             },
             "response-time": {
@@ -1884,9 +2392,9 @@
               }
             },
             "serve-static": {
-              "version": "1.5.3",
+              "version": "1.5.4",
               "from": "serve-static@~1.5.0",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.3.tgz",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.4.tgz",
               "dependencies": {
                 "parseurl": {
                   "version": "1.3.0",
@@ -1894,9 +2402,9 @@
                   "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
                 },
                 "send": {
-                  "version": "0.8.3",
-                  "from": "send@0.8.3",
-                  "resolved": "https://registry.npmjs.org/send/-/send-0.8.3.tgz",
+                  "version": "0.8.5",
+                  "from": "send@0.8.5",
+                  "resolved": "https://registry.npmjs.org/send/-/send-0.8.5.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.3",
@@ -1929,7 +2437,8 @@
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "utils-merge@1.0.0"
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 }
               }
             },
@@ -1971,7 +2480,7 @@
         },
         "debug": {
           "version": "1.0.4",
-          "from": "debug@*",
+          "from": "debug@1.0.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
@@ -2042,7 +2551,7 @@
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@~1.2.9",
+              "from": "mime@1.2.11",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "ms": {
@@ -2076,6 +2585,298 @@
           "version": "0.0.2",
           "from": "merge-descriptors@0.0.2",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+        }
+      }
+    },
+    "firefox-profile": {
+      "version": "0.3.3",
+      "from": "firefox-profile@0.3.3",
+      "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.3.tgz",
+      "dependencies": {
+        "jetpack-id": {
+          "version": "0.0.4",
+          "from": "jetpack-id@0.0.4",
+          "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz"
+        },
+        "adm-zip": {
+          "version": "0.4.4",
+          "from": "adm-zip@~0.4.3",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+        },
+        "archiver": {
+          "version": "0.10.1",
+          "from": "archiver@~0.10",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.10.1.tgz",
+          "dependencies": {
+            "buffer-crc32": {
+              "version": "0.2.3",
+              "from": "buffer-crc32@~0.2.1",
+              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.31",
+              "from": "readable-stream@~1.0.26",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "0.4.5",
+              "from": "tar-stream@~0.4.0",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.5.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.1",
+                  "from": "bl@^0.9.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.1.tgz"
+                },
+                "end-of-stream": {
+                  "version": "1.0.0",
+                  "from": "end-of-stream@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.0",
+                      "from": "once@~1.3.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.0.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@^4.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "zip-stream": {
+              "version": "0.3.7",
+              "from": "zip-stream@~0.3.0",
+              "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.3.7.tgz",
+              "dependencies": {
+                "crc32-stream": {
+                  "version": "0.2.0",
+                  "from": "crc32-stream@~0.2.0",
+                  "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.2.0.tgz"
+                },
+                "debug": {
+                  "version": "1.0.4",
+                  "from": "debug@~1.0.2",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                },
+                "deflate-crc32-stream": {
+                  "version": "0.1.2",
+                  "from": "deflate-crc32-stream@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/deflate-crc32-stream/-/deflate-crc32-stream-0.1.2.tgz"
+                }
+              }
+            },
+            "file-utils": {
+              "version": "0.2.1",
+              "from": "file-utils@~0.2.0",
+              "resolved": "https://registry.npmjs.org/file-utils/-/file-utils-0.2.1.tgz",
+              "dependencies": {
+                "findup-sync": {
+                  "version": "0.1.3",
+                  "from": "findup-sync@~0.1.2",
+                  "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz"
+                },
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@~3.2.6",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "iconv-lite": {
+                  "version": "0.4.4",
+                  "from": "iconv-lite@~0.4.3",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+                },
+                "isbinaryfile": {
+                  "version": "2.0.1",
+                  "from": "isbinaryfile@~2.0.1",
+                  "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@~0.2.12",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@~2.2.2",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "async": {
+          "version": "0.9.0",
+          "from": "async@~0.9.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+        },
+        "fs-extra": {
+          "version": "0.10.0",
+          "from": "fs-extra@~0.10.x",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.10.0.tgz",
+          "dependencies": {
+            "ncp": {
+              "version": "0.5.1",
+              "from": "ncp@^0.5.1",
+              "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz"
+            },
+            "jsonfile": {
+              "version": "1.2.0",
+              "from": "jsonfile@^1.2.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.2.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@^2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            }
+          }
+        },
+        "lazystream": {
+          "version": "0.1.0",
+          "from": "lazystream@~0.1.0",
+          "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.31",
+              "from": "readable-stream@~1.0.2",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@~2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "node-uuid": {
+          "version": "1.4.1",
+          "from": "node-uuid@~1.4.1",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+        },
+        "wrench": {
+          "version": "1.5.8",
+          "from": "wrench@~1.5.1",
+          "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
+        },
+        "xml2js": {
+          "version": "0.4.4",
+          "from": "xml2js@~0.4.0",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
+          "dependencies": {
+            "sax": {
+              "version": "0.6.0",
+              "from": "sax@0.6.x",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.0.tgz"
+            },
+            "xmlbuilder": {
+              "version": "2.4.3",
+              "from": "xmlbuilder@>=1.0.0",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.3.tgz",
+              "dependencies": {
+                "lodash-node": {
+                  "version": "2.4.1",
+                  "from": "lodash-node@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "ini": {
+          "version": "1.2.1",
+          "from": "ini@~1.2.1",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.2.1.tgz"
         }
       }
     },
@@ -2300,9 +3101,9 @@
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-2.2.0.tgz",
           "dependencies": {
             "caniuse-db": {
-              "version": "1.0.20140816",
+              "version": "1.0.20140903",
               "from": "caniuse-db@^1.0.20140727",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.20140816.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.20140903.tgz"
             },
             "fs-extra": {
               "version": "0.10.0",
@@ -2359,7 +3160,7 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@^0.5.0",
+          "from": "chalk@~0.5.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2379,7 +3180,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -2391,7 +3192,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -2402,6 +3203,420 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
+        }
+      }
+    },
+    "grunt-blanket-mocha": {
+      "version": "0.4.1",
+      "from": "grunt-blanket-mocha@0.4.1",
+      "resolved": "https://registry.npmjs.org/grunt-blanket-mocha/-/grunt-blanket-mocha-0.4.1.tgz",
+      "dependencies": {
+        "blanket": {
+          "version": "1.1.6",
+          "from": "blanket@~1.1.6",
+          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@~1.0.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            },
+            "falafel": {
+              "version": "0.1.6",
+              "from": "falafel@~0.1.6",
+              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "from": "xtend@~2.1.1",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "dependencies": {
+                "object-keys": {
+                  "version": "0.4.0",
+                  "from": "object-keys@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "grunt-lib-phantomjs": {
+          "version": "0.4.0",
+          "from": "grunt-lib-phantomjs@~0.4.0",
+          "resolved": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.4.0.tgz",
+          "dependencies": {
+            "eventemitter2": {
+              "version": "0.4.14",
+              "from": "eventemitter2@~0.4.9",
+              "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+            },
+            "semver": {
+              "version": "1.0.14",
+              "from": "semver@~1.0.14",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-1.0.14.tgz"
+            },
+            "temporary": {
+              "version": "0.0.8",
+              "from": "temporary@~0.0.4",
+              "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
+              "dependencies": {
+                "package": {
+                  "version": "1.0.1",
+                  "from": "package@>= 1.0.0 < 1.2.0",
+                  "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz"
+                }
+              }
+            },
+            "phantomjs": {
+              "version": "1.9.7-15",
+              "from": "phantomjs@~1.9.0-1",
+              "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.7-15.tgz",
+              "dependencies": {
+                "adm-zip": {
+                  "version": "0.2.1",
+                  "from": "adm-zip@0.2.1",
+                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.2.1.tgz"
+                },
+                "kew": {
+                  "version": "0.1.7",
+                  "from": "kew@~0.1.7",
+                  "resolved": "https://registry.npmjs.org/kew/-/kew-0.1.7.tgz"
+                },
+                "ncp": {
+                  "version": "0.4.2",
+                  "from": "ncp@0.4.2",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+                },
+                "npmconf": {
+                  "version": "0.0.24",
+                  "from": "npmconf@0.0.24",
+                  "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-0.0.24.tgz",
+                  "dependencies": {
+                    "config-chain": {
+                      "version": "1.1.8",
+                      "from": "config-chain@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+                      "dependencies": {
+                        "proto-list": {
+                          "version": "1.2.3",
+                          "from": "proto-list@~1.2.1",
+                          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "1.0.0",
+                      "from": "inherits@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                    },
+                    "once": {
+                      "version": "1.1.1",
+                      "from": "once@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                    },
+                    "osenv": {
+                      "version": "0.0.3",
+                      "from": "osenv@0.0.3",
+                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+                    },
+                    "nopt": {
+                      "version": "2.2.1",
+                      "from": "nopt@2",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.5",
+                          "from": "abbrev@1",
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "1.1.4",
+                      "from": "semver@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
+                    },
+                    "ini": {
+                      "version": "1.1.0",
+                      "from": "ini@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@0.3.5",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "progress": {
+                  "version": "1.1.8",
+                  "from": "progress@^1.1.5",
+                  "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+                },
+                "request": {
+                  "version": "2.36.0",
+                  "from": "request@2.36.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
+                  "dependencies": {
+                    "qs": {
+                      "version": "0.6.6",
+                      "from": "qs@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "from": "json-stringify-safe@~5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@~1.2.9",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.1",
+                      "from": "node-uuid@~1.4.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "0.12.1",
+                      "from": "tough-cookie@>=0.12.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.3.1",
+                          "from": "punycode@>=0.2.0",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "form-data": {
+                      "version": "0.1.4",
+                      "from": "form-data@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.5",
+                          "from": "combined-stream@~0.0.4",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "async": {
+                          "version": "0.9.0",
+                          "from": "async@~0.9.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.0",
+                      "from": "tunnel-agent@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.0",
+                      "from": "http-signature@~0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.2",
+                          "from": "assert-plus@0.1.2",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.2",
+                          "from": "ctype@0.5.2",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.3.0",
+                      "from": "oauth-sign@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "1.0.0",
+                      "from": "hawk@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.x",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@0.4.x",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@0.2.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@0.2.x",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    }
+                  }
+                },
+                "request-progress": {
+                  "version": "0.3.1",
+                  "from": "request-progress@^0.3.1",
+                  "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+                  "dependencies": {
+                    "throttleit": {
+                      "version": "0.0.2",
+                      "from": "throttleit@~0.0.2",
+                      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@~2.2.2",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "which": {
+                  "version": "1.0.5",
+                  "from": "which@~1.0.5",
+                  "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mocha": {
+          "version": "1.14.0",
+          "from": "mocha@~1.14.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.14.0.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "2.0.0",
+              "from": "commander@2.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
+            },
+            "growl": {
+              "version": "1.7.0",
+              "from": "growl@1.7.x",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
+            },
+            "jade": {
+              "version": "0.26.3",
+              "from": "jade@0.26.3",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@0.6.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.0",
+                  "from": "mkdirp@0.3.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                }
+              }
+            },
+            "diff": {
+              "version": "1.0.7",
+              "from": "diff@1.0.7",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
+            },
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@*",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@0.3.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "glob": {
+              "version": "3.2.3",
+              "from": "glob@3.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@~0.2.11",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "from": "graceful-fs@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.3.0",
+          "from": "lodash@~2.3.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.3.0.tgz"
+        }
+      }
+    },
+    "grunt-bump": {
+      "version": "0.0.15",
+      "from": "grunt-bump@0.0.15",
+      "resolved": "https://registry.npmjs.org/grunt-bump/-/grunt-bump-0.0.15.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "2.3.2",
+          "from": "semver@~2.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
         }
       }
     },
@@ -2424,7 +3639,7 @@
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@~0.1.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
@@ -2588,7 +3803,7 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@^0.5.0",
+          "from": "chalk@~0.5.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2608,7 +3823,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -2620,7 +3835,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -2651,6 +3866,25 @@
       "from": "grunt-contrib-copy@0.5.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz"
     },
+    "grunt-contrib-csslint": {
+      "version": "0.2.0",
+      "from": "grunt-contrib-csslint@0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-csslint/-/grunt-contrib-csslint-0.2.0.tgz",
+      "dependencies": {
+        "csslint": {
+          "version": "0.10.0",
+          "from": "csslint@~0.10.0",
+          "resolved": "https://registry.npmjs.org/csslint/-/csslint-0.10.0.tgz",
+          "dependencies": {
+            "parserlib": {
+              "version": "0.2.5",
+              "from": "parserlib@~0.2.2",
+              "resolved": "https://registry.npmjs.org/parserlib/-/parserlib-0.2.5.tgz"
+            }
+          }
+        }
+      }
+    },
     "grunt-contrib-cssmin": {
       "version": "0.10.0",
       "from": "grunt-contrib-cssmin@0.10.0",
@@ -2679,9 +3913,9 @@
           }
         },
         "clean-css": {
-          "version": "2.2.13",
+          "version": "2.2.15",
           "from": "clean-css@~2.2.0",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.13.tgz",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.15.tgz",
           "dependencies": {
             "commander": {
               "version": "2.2.0",
@@ -2697,7 +3931,7 @@
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@~0.5.1",
+              "from": "chalk@^0.5.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
@@ -2717,7 +3951,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0",
+                      "from": "ansi-regex@^0.2.1",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -2767,9 +4001,9 @@
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
-                      "version": "1.1.13-1",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
@@ -2782,9 +4016,9 @@
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
-                          "version": "0.10.25-1",
+                          "version": "0.10.31",
                           "from": "string_decoder@~0.10.x",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     }
@@ -2841,19 +4075,19 @@
           }
         },
         "html-minifier": {
-          "version": "0.6.6",
+          "version": "0.6.8",
           "from": "html-minifier@~0.6.0",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.6.tgz",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.8.tgz",
           "dependencies": {
             "change-case": {
-              "version": "2.1.3",
+              "version": "2.1.5",
               "from": "change-case@2.1.x",
-              "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.5.tgz",
               "dependencies": {
                 "camel-case": {
-                  "version": "1.0.1",
+                  "version": "1.0.2",
                   "from": "camel-case@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.0.2.tgz"
                 },
                 "constant-case": {
                   "version": "1.0.0",
@@ -2861,9 +4095,9 @@
                   "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.0.0.tgz"
                 },
                 "dot-case": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "dot-case@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.0.1.tgz"
                 },
                 "is-lower-case": {
                   "version": "1.0.0",
@@ -2871,9 +4105,9 @@
                   "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.0.0.tgz"
                 },
                 "is-upper-case": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "is-upper-case@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.0.1.tgz"
                 },
                 "lower-case": {
                   "version": "1.0.2",
@@ -2881,9 +4115,9 @@
                   "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.0.2.tgz"
                 },
                 "param-case": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "param-case@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.0.1.tgz"
                 },
                 "pascal-case": {
                   "version": "1.0.0",
@@ -2891,29 +4125,29 @@
                   "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.0.0.tgz"
                 },
                 "path-case": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "path-case@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.0.1.tgz"
                 },
                 "sentence-case": {
-                  "version": "1.0.1",
+                  "version": "1.0.3",
                   "from": "sentence-case@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.0.3.tgz"
                 },
                 "snake-case": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "snake-case@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.0.1.tgz"
                 },
                 "swap-case": {
-                  "version": "1.0.1",
+                  "version": "1.0.2",
                   "from": "swap-case@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.0.2.tgz"
                 },
                 "title-case": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "title-case@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.0.1.tgz"
                 },
                 "upper-case": {
                   "version": "1.0.3",
@@ -2928,9 +4162,9 @@
               }
             },
             "clean-css": {
-              "version": "2.2.13",
+              "version": "2.2.15",
               "from": "clean-css@2.2.x",
-              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.13.tgz",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.15.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.2.0",
@@ -2940,13 +4174,13 @@
               }
             },
             "cli": {
-              "version": "0.6.3",
+              "version": "0.6.4",
               "from": "cli@0.6.x",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.3.tgz",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.4.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@~3.2.9",
+                  "from": "glob@~ 3.2.1",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
@@ -3020,6 +4254,11 @@
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 }
               }
+            },
+            "relateurl": {
+              "version": "0.2.5",
+              "from": "relateurl@0.2.x",
+              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.5.tgz"
             }
           }
         },
@@ -3030,6 +4269,1929 @@
         }
       }
     },
+    "grunt-contrib-imagemin": {
+      "version": "0.8.0",
+      "from": "grunt-contrib-imagemin@git://github.com/vladikoff/grunt-contrib-imagemin#keepOldImage",
+      "resolved": "git://github.com/vladikoff/grunt-contrib-imagemin#52a42a834527a669e3ff4e7638a104e25ce545bf",
+      "dependencies": {
+        "async": {
+          "version": "0.7.0",
+          "from": "async@^0.7.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.7.0.tgz"
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@^0.5.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@^1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.1",
+              "from": "escape-string-regexp@^1.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@^0.1.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@^0.3.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@^0.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "imagemin": {
+          "version": "0.4.9",
+          "from": "imagemin@^0.4.7",
+          "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-0.4.9.tgz",
+          "dependencies": {
+            "fs-extra": {
+              "version": "0.10.0",
+              "from": "fs-extra@^0.10.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.10.0.tgz",
+              "dependencies": {
+                "ncp": {
+                  "version": "0.5.1",
+                  "from": "ncp@^0.5.1",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz"
+                },
+                "jsonfile": {
+                  "version": "1.2.0",
+                  "from": "jsonfile@^1.2.0",
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.2.0.tgz"
+                }
+              }
+            },
+            "image-type": {
+              "version": "0.1.4",
+              "from": "image-type@^0.1.4",
+              "resolved": "https://registry.npmjs.org/image-type/-/image-type-0.1.4.tgz",
+              "dependencies": {
+                "is-bmp": {
+                  "version": "0.1.1",
+                  "from": "is-bmp@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/is-bmp/-/is-bmp-0.1.1.tgz"
+                },
+                "is-gif": {
+                  "version": "0.1.1",
+                  "from": "is-gif@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/is-gif/-/is-gif-0.1.1.tgz"
+                },
+                "is-jpg": {
+                  "version": "0.1.2",
+                  "from": "is-jpg@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-0.1.2.tgz"
+                },
+                "is-jxr": {
+                  "version": "0.1.1",
+                  "from": "is-jxr@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/is-jxr/-/is-jxr-0.1.1.tgz"
+                },
+                "is-png": {
+                  "version": "0.1.1",
+                  "from": "is-png@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/is-png/-/is-png-0.1.1.tgz"
+                },
+                "is-psd": {
+                  "version": "0.1.1",
+                  "from": "is-psd@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/is-psd/-/is-psd-0.1.1.tgz"
+                },
+                "is-tif": {
+                  "version": "0.1.1",
+                  "from": "is-tif@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/is-tif/-/is-tif-0.1.1.tgz"
+                },
+                "is-webp": {
+                  "version": "0.1.1",
+                  "from": "is-webp@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/is-webp/-/is-webp-0.1.1.tgz"
+                },
+                "read-chunk": {
+                  "version": "0.1.0",
+                  "from": "read-chunk@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-0.1.0.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@^3.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.5",
+                  "from": "abbrev@1",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@^2.2.6",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "stat-mode": {
+              "version": "0.2.0",
+              "from": "stat-mode@^0.2.0",
+              "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.0.tgz"
+            },
+            "tempfile": {
+              "version": "0.1.3",
+              "from": "tempfile@^0.1.3",
+              "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
+              "dependencies": {
+                "uuid": {
+                  "version": "1.4.1",
+                  "from": "uuid@~1.4.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
+                }
+              }
+            },
+            "ware": {
+              "version": "0.3.0",
+              "from": "ware@^0.3.0",
+              "resolved": "https://registry.npmjs.org/ware/-/ware-0.3.0.tgz"
+            },
+            "imagemin-gifsicle": {
+              "version": "0.1.1",
+              "from": "imagemin-gifsicle@^0.1.1",
+              "resolved": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-0.1.1.tgz",
+              "dependencies": {
+                "exec-buffer": {
+                  "version": "0.1.1",
+                  "from": "exec-buffer@^0.1.1",
+                  "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-0.1.1.tgz"
+                },
+                "gifsicle": {
+                  "version": "0.1.7",
+                  "from": "gifsicle@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/gifsicle/-/gifsicle-0.1.7.tgz",
+                  "dependencies": {
+                    "bin-build": {
+                      "version": "0.1.1",
+                      "from": "bin-build@^0.1.0",
+                      "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-0.1.1.tgz",
+                      "dependencies": {
+                        "download": {
+                          "version": "0.1.19",
+                          "from": "download@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/download/-/download-0.1.19.tgz",
+                          "dependencies": {
+                            "decompress": {
+                              "version": "0.2.5",
+                              "from": "decompress@^0.2.5",
+                              "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.5.tgz",
+                              "dependencies": {
+                                "adm-zip": {
+                                  "version": "0.4.4",
+                                  "from": "adm-zip@^0.4.3",
+                                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                                },
+                                "ext-name": {
+                                  "version": "1.0.1",
+                                  "from": "ext-name@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-1.0.1.tgz",
+                                  "dependencies": {
+                                    "ext-list": {
+                                      "version": "0.2.0",
+                                      "from": "ext-list@^0.2.0",
+                                      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
+                                      "dependencies": {
+                                        "got": {
+                                          "version": "0.2.0",
+                                          "from": "got@^0.2.0",
+                                          "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
+                                          "dependencies": {
+                                            "object-assign": {
+                                              "version": "0.3.1",
+                                              "from": "object-assign@^0.3.0",
+                                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "underscore.string": {
+                                      "version": "2.3.3",
+                                      "from": "underscore.string@~2.3.3",
+                                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                                    }
+                                  }
+                                },
+                                "stream-combiner": {
+                                  "version": "0.0.4",
+                                  "from": "stream-combiner@^0.0.4",
+                                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                                  "dependencies": {
+                                    "duplexer": {
+                                      "version": "0.1.1",
+                                      "from": "duplexer@~0.1.1",
+                                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "tar": {
+                                  "version": "0.1.20",
+                                  "from": "tar@^0.1.18",
+                                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                                  "dependencies": {
+                                    "block-stream": {
+                                      "version": "0.0.7",
+                                      "from": "block-stream@*",
+                                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                    },
+                                    "fstream": {
+                                      "version": "0.1.31",
+                                      "from": "fstream@~0.1.28",
+                                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "3.0.2",
+                                          "from": "graceful-fs@~3.0.2",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                        },
+                                        "mkdirp": {
+                                          "version": "0.5.0",
+                                          "from": "mkdirp@0.5",
+                                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                                          "dependencies": {
+                                            "minimist": {
+                                              "version": "0.0.8",
+                                              "from": "minimist@0.0.8",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@2",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "0.1.3",
+                              "from": "each-async@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "0.1.0",
+                              "from": "get-stdin@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
+                            },
+                            "get-urls": {
+                              "version": "0.1.2",
+                              "from": "get-urls@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.3.5",
+                              "from": "mkdirp@^0.3.5",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                            },
+                            "nopt": {
+                              "version": "2.2.1",
+                              "from": "nopt@^2.2.0",
+                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.5",
+                                  "from": "abbrev@1",
+                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "0.4.2",
+                              "from": "through2@^0.4.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.31",
+                                  "from": "readable-stream@~1.0.17",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@2",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "2.1.2",
+                                  "from": "xtend@~2.1.1",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                                  "dependencies": {
+                                    "object-keys": {
+                                      "version": "0.4.0",
+                                      "from": "object-keys@~0.4.0",
+                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "bin-wrapper": {
+                      "version": "0.3.4",
+                      "from": "bin-wrapper@^0.3.0",
+                      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-0.3.4.tgz",
+                      "dependencies": {
+                        "bin-check": {
+                          "version": "0.1.5",
+                          "from": "bin-check@^0.1.0",
+                          "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-0.1.5.tgz",
+                          "dependencies": {
+                            "executable": {
+                              "version": "0.1.3",
+                              "from": "executable@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/executable/-/executable-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "download": {
+                          "version": "0.1.19",
+                          "from": "download@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/download/-/download-0.1.19.tgz",
+                          "dependencies": {
+                            "decompress": {
+                              "version": "0.2.5",
+                              "from": "decompress@^0.2.5",
+                              "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.5.tgz",
+                              "dependencies": {
+                                "adm-zip": {
+                                  "version": "0.4.4",
+                                  "from": "adm-zip@^0.4.3",
+                                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                                },
+                                "ext-name": {
+                                  "version": "1.0.1",
+                                  "from": "ext-name@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-1.0.1.tgz",
+                                  "dependencies": {
+                                    "ext-list": {
+                                      "version": "0.2.0",
+                                      "from": "ext-list@^0.2.0",
+                                      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
+                                      "dependencies": {
+                                        "got": {
+                                          "version": "0.2.0",
+                                          "from": "got@^0.2.0",
+                                          "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
+                                          "dependencies": {
+                                            "object-assign": {
+                                              "version": "0.3.1",
+                                              "from": "object-assign@^0.3.0",
+                                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "underscore.string": {
+                                      "version": "2.3.3",
+                                      "from": "underscore.string@~2.3.3",
+                                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                                    }
+                                  }
+                                },
+                                "stream-combiner": {
+                                  "version": "0.0.4",
+                                  "from": "stream-combiner@^0.0.4",
+                                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                                  "dependencies": {
+                                    "duplexer": {
+                                      "version": "0.1.1",
+                                      "from": "duplexer@~0.1.1",
+                                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "tar": {
+                                  "version": "0.1.20",
+                                  "from": "tar@^0.1.18",
+                                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                                  "dependencies": {
+                                    "block-stream": {
+                                      "version": "0.0.7",
+                                      "from": "block-stream@*",
+                                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                    },
+                                    "fstream": {
+                                      "version": "0.1.31",
+                                      "from": "fstream@~0.1.28",
+                                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "3.0.2",
+                                          "from": "graceful-fs@~3.0.2",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                        },
+                                        "mkdirp": {
+                                          "version": "0.5.0",
+                                          "from": "mkdirp@0.5",
+                                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                                          "dependencies": {
+                                            "minimist": {
+                                              "version": "0.0.8",
+                                              "from": "minimist@0.0.8",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@2",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "0.1.3",
+                              "from": "each-async@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "0.1.0",
+                              "from": "get-stdin@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
+                            },
+                            "get-urls": {
+                              "version": "0.1.2",
+                              "from": "get-urls@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.3.5",
+                              "from": "mkdirp@^0.3.5",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                            },
+                            "nopt": {
+                              "version": "2.2.1",
+                              "from": "nopt@^2.2.0",
+                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.5",
+                                  "from": "abbrev@1",
+                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "0.4.2",
+                              "from": "through2@^0.4.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.31",
+                                  "from": "readable-stream@~1.0.17",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "2.1.2",
+                                  "from": "xtend@~2.1.1",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                                  "dependencies": {
+                                    "object-keys": {
+                                      "version": "0.4.0",
+                                      "from": "object-keys@~0.4.0",
+                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "find-file": {
+                          "version": "0.1.4",
+                          "from": "find-file@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/find-file/-/find-file-0.1.4.tgz"
+                        }
+                      }
+                    },
+                    "log-symbols": {
+                      "version": "1.0.0",
+                      "from": "log-symbols@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "imagemin-jpegtran": {
+              "version": "0.1.0",
+              "from": "imagemin-jpegtran@^0.1.0",
+              "resolved": "https://registry.npmjs.org/imagemin-jpegtran/-/imagemin-jpegtran-0.1.0.tgz",
+              "dependencies": {
+                "jpegtran-bin": {
+                  "version": "0.2.8",
+                  "from": "jpegtran-bin@^0.2.6",
+                  "resolved": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-0.2.8.tgz",
+                  "dependencies": {
+                    "bin-build": {
+                      "version": "0.1.1",
+                      "from": "bin-build@^0.1.0",
+                      "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-0.1.1.tgz",
+                      "dependencies": {
+                        "download": {
+                          "version": "0.1.19",
+                          "from": "download@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/download/-/download-0.1.19.tgz",
+                          "dependencies": {
+                            "decompress": {
+                              "version": "0.2.5",
+                              "from": "decompress@^0.2.5",
+                              "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.5.tgz",
+                              "dependencies": {
+                                "adm-zip": {
+                                  "version": "0.4.4",
+                                  "from": "adm-zip@^0.4.3",
+                                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                                },
+                                "ext-name": {
+                                  "version": "1.0.1",
+                                  "from": "ext-name@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-1.0.1.tgz",
+                                  "dependencies": {
+                                    "ext-list": {
+                                      "version": "0.2.0",
+                                      "from": "ext-list@^0.2.0",
+                                      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
+                                      "dependencies": {
+                                        "got": {
+                                          "version": "0.2.0",
+                                          "from": "got@^0.2.0",
+                                          "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
+                                          "dependencies": {
+                                            "object-assign": {
+                                              "version": "0.3.1",
+                                              "from": "object-assign@^0.3.0",
+                                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "underscore.string": {
+                                      "version": "2.3.3",
+                                      "from": "underscore.string@~2.3.3",
+                                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                                    }
+                                  }
+                                },
+                                "stream-combiner": {
+                                  "version": "0.0.4",
+                                  "from": "stream-combiner@^0.0.4",
+                                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                                  "dependencies": {
+                                    "duplexer": {
+                                      "version": "0.1.1",
+                                      "from": "duplexer@~0.1.1",
+                                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "tar": {
+                                  "version": "0.1.20",
+                                  "from": "tar@^0.1.18",
+                                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                                  "dependencies": {
+                                    "block-stream": {
+                                      "version": "0.0.7",
+                                      "from": "block-stream@*",
+                                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                    },
+                                    "fstream": {
+                                      "version": "0.1.31",
+                                      "from": "fstream@~0.1.28",
+                                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "3.0.2",
+                                          "from": "graceful-fs@~3.0.2",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                        },
+                                        "mkdirp": {
+                                          "version": "0.5.0",
+                                          "from": "mkdirp@0.5",
+                                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                                          "dependencies": {
+                                            "minimist": {
+                                              "version": "0.0.8",
+                                              "from": "minimist@0.0.8",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@2",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "0.1.3",
+                              "from": "each-async@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "0.1.0",
+                              "from": "get-stdin@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
+                            },
+                            "get-urls": {
+                              "version": "0.1.2",
+                              "from": "get-urls@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.3.5",
+                              "from": "mkdirp@^0.3.5",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                            },
+                            "nopt": {
+                              "version": "2.2.1",
+                              "from": "nopt@^2.2.0",
+                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.5",
+                                  "from": "abbrev@1",
+                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "0.4.2",
+                              "from": "through2@^0.4.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.31",
+                                  "from": "readable-stream@~1.0.17",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "2.1.2",
+                                  "from": "xtend@~2.1.1",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                                  "dependencies": {
+                                    "object-keys": {
+                                      "version": "0.4.0",
+                                      "from": "object-keys@~0.4.0",
+                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "bin-wrapper": {
+                      "version": "0.3.4",
+                      "from": "bin-wrapper@^0.3.0",
+                      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-0.3.4.tgz",
+                      "dependencies": {
+                        "bin-check": {
+                          "version": "0.1.5",
+                          "from": "bin-check@^0.1.0",
+                          "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-0.1.5.tgz",
+                          "dependencies": {
+                            "executable": {
+                              "version": "0.1.3",
+                              "from": "executable@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/executable/-/executable-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "download": {
+                          "version": "0.1.19",
+                          "from": "download@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/download/-/download-0.1.19.tgz",
+                          "dependencies": {
+                            "decompress": {
+                              "version": "0.2.5",
+                              "from": "decompress@^0.2.5",
+                              "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.5.tgz",
+                              "dependencies": {
+                                "adm-zip": {
+                                  "version": "0.4.4",
+                                  "from": "adm-zip@^0.4.3",
+                                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                                },
+                                "ext-name": {
+                                  "version": "1.0.1",
+                                  "from": "ext-name@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-1.0.1.tgz",
+                                  "dependencies": {
+                                    "ext-list": {
+                                      "version": "0.2.0",
+                                      "from": "ext-list@^0.2.0",
+                                      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
+                                      "dependencies": {
+                                        "got": {
+                                          "version": "0.2.0",
+                                          "from": "got@^0.2.0",
+                                          "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
+                                          "dependencies": {
+                                            "object-assign": {
+                                              "version": "0.3.1",
+                                              "from": "object-assign@^0.3.0",
+                                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "underscore.string": {
+                                      "version": "2.3.3",
+                                      "from": "underscore.string@~2.3.3",
+                                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                                    }
+                                  }
+                                },
+                                "stream-combiner": {
+                                  "version": "0.0.4",
+                                  "from": "stream-combiner@^0.0.4",
+                                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                                  "dependencies": {
+                                    "duplexer": {
+                                      "version": "0.1.1",
+                                      "from": "duplexer@~0.1.1",
+                                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "tar": {
+                                  "version": "0.1.20",
+                                  "from": "tar@^0.1.18",
+                                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                                  "dependencies": {
+                                    "block-stream": {
+                                      "version": "0.0.7",
+                                      "from": "block-stream@*",
+                                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                    },
+                                    "fstream": {
+                                      "version": "0.1.31",
+                                      "from": "fstream@~0.1.28",
+                                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "3.0.2",
+                                          "from": "graceful-fs@~3.0.2",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                        },
+                                        "mkdirp": {
+                                          "version": "0.5.0",
+                                          "from": "mkdirp@0.5",
+                                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                                          "dependencies": {
+                                            "minimist": {
+                                              "version": "0.0.8",
+                                              "from": "minimist@0.0.8",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@2",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "0.1.3",
+                              "from": "each-async@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "0.1.0",
+                              "from": "get-stdin@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
+                            },
+                            "get-urls": {
+                              "version": "0.1.2",
+                              "from": "get-urls@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.3.5",
+                              "from": "mkdirp@^0.3.5",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                            },
+                            "nopt": {
+                              "version": "2.2.1",
+                              "from": "nopt@^2.2.0",
+                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.5",
+                                  "from": "abbrev@1",
+                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "0.4.2",
+                              "from": "through2@^0.4.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.31",
+                                  "from": "readable-stream@~1.0.17",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "2.1.2",
+                                  "from": "xtend@~2.1.1",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                                  "dependencies": {
+                                    "object-keys": {
+                                      "version": "0.4.0",
+                                      "from": "object-keys@~0.4.0",
+                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "find-file": {
+                          "version": "0.1.4",
+                          "from": "find-file@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/find-file/-/find-file-0.1.4.tgz"
+                        }
+                      }
+                    },
+                    "log-symbols": {
+                      "version": "1.0.0",
+                      "from": "log-symbols@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "imagemin-optipng": {
+              "version": "0.1.0",
+              "from": "imagemin-optipng@^0.1.0",
+              "resolved": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-0.1.0.tgz",
+              "dependencies": {
+                "optipng-bin": {
+                  "version": "0.3.11",
+                  "from": "optipng-bin@^0.3.3",
+                  "resolved": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-0.3.11.tgz",
+                  "dependencies": {
+                    "bin-build": {
+                      "version": "0.1.1",
+                      "from": "bin-build@^0.1.0",
+                      "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-0.1.1.tgz",
+                      "dependencies": {
+                        "download": {
+                          "version": "0.1.19",
+                          "from": "download@^0.1.16",
+                          "resolved": "https://registry.npmjs.org/download/-/download-0.1.19.tgz",
+                          "dependencies": {
+                            "decompress": {
+                              "version": "0.2.5",
+                              "from": "decompress@^0.2.5",
+                              "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.5.tgz",
+                              "dependencies": {
+                                "adm-zip": {
+                                  "version": "0.4.4",
+                                  "from": "adm-zip@^0.4.3",
+                                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                                },
+                                "ext-name": {
+                                  "version": "1.0.1",
+                                  "from": "ext-name@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-1.0.1.tgz",
+                                  "dependencies": {
+                                    "ext-list": {
+                                      "version": "0.2.0",
+                                      "from": "ext-list@^0.2.0",
+                                      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
+                                      "dependencies": {
+                                        "got": {
+                                          "version": "0.2.0",
+                                          "from": "got@^0.2.0",
+                                          "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
+                                          "dependencies": {
+                                            "object-assign": {
+                                              "version": "0.3.1",
+                                              "from": "object-assign@^0.3.0",
+                                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "underscore.string": {
+                                      "version": "2.3.3",
+                                      "from": "underscore.string@~2.3.3",
+                                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                                    }
+                                  }
+                                },
+                                "stream-combiner": {
+                                  "version": "0.0.4",
+                                  "from": "stream-combiner@^0.0.4",
+                                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                                  "dependencies": {
+                                    "duplexer": {
+                                      "version": "0.1.1",
+                                      "from": "duplexer@~0.1.1",
+                                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "tar": {
+                                  "version": "0.1.20",
+                                  "from": "tar@^0.1.18",
+                                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                                  "dependencies": {
+                                    "block-stream": {
+                                      "version": "0.0.7",
+                                      "from": "block-stream@*",
+                                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                    },
+                                    "fstream": {
+                                      "version": "0.1.31",
+                                      "from": "fstream@~0.1.28",
+                                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "3.0.2",
+                                          "from": "graceful-fs@~3.0.2",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                        },
+                                        "mkdirp": {
+                                          "version": "0.5.0",
+                                          "from": "mkdirp@0.5",
+                                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                                          "dependencies": {
+                                            "minimist": {
+                                              "version": "0.0.8",
+                                              "from": "minimist@0.0.8",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@2",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "0.1.3",
+                              "from": "each-async@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "0.1.0",
+                              "from": "get-stdin@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
+                            },
+                            "get-urls": {
+                              "version": "0.1.2",
+                              "from": "get-urls@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.3.5",
+                              "from": "mkdirp@^0.3.5",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                            },
+                            "nopt": {
+                              "version": "2.2.1",
+                              "from": "nopt@^2.2.0",
+                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.5",
+                                  "from": "abbrev@1",
+                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "0.4.2",
+                              "from": "through2@^0.4.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.31",
+                                  "from": "readable-stream@~1.0.17",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "2.1.2",
+                                  "from": "xtend@~2.1.1",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                                  "dependencies": {
+                                    "object-keys": {
+                                      "version": "0.4.0",
+                                      "from": "object-keys@~0.4.0",
+                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "bin-wrapper": {
+                      "version": "0.3.4",
+                      "from": "bin-wrapper@^0.3.0",
+                      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-0.3.4.tgz",
+                      "dependencies": {
+                        "bin-check": {
+                          "version": "0.1.5",
+                          "from": "bin-check@^0.1.0",
+                          "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-0.1.5.tgz",
+                          "dependencies": {
+                            "executable": {
+                              "version": "0.1.3",
+                              "from": "executable@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/executable/-/executable-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "download": {
+                          "version": "0.1.19",
+                          "from": "download@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/download/-/download-0.1.19.tgz",
+                          "dependencies": {
+                            "decompress": {
+                              "version": "0.2.5",
+                              "from": "decompress@^0.2.5",
+                              "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.5.tgz",
+                              "dependencies": {
+                                "adm-zip": {
+                                  "version": "0.4.4",
+                                  "from": "adm-zip@^0.4.3",
+                                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                                },
+                                "ext-name": {
+                                  "version": "1.0.1",
+                                  "from": "ext-name@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-1.0.1.tgz",
+                                  "dependencies": {
+                                    "ext-list": {
+                                      "version": "0.2.0",
+                                      "from": "ext-list@^0.2.0",
+                                      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
+                                      "dependencies": {
+                                        "got": {
+                                          "version": "0.2.0",
+                                          "from": "got@^0.2.0",
+                                          "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
+                                          "dependencies": {
+                                            "object-assign": {
+                                              "version": "0.3.1",
+                                              "from": "object-assign@^0.3.0",
+                                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "underscore.string": {
+                                      "version": "2.3.3",
+                                      "from": "underscore.string@~2.3.3",
+                                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                                    }
+                                  }
+                                },
+                                "stream-combiner": {
+                                  "version": "0.0.4",
+                                  "from": "stream-combiner@^0.0.4",
+                                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                                  "dependencies": {
+                                    "duplexer": {
+                                      "version": "0.1.1",
+                                      "from": "duplexer@~0.1.1",
+                                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "tar": {
+                                  "version": "0.1.20",
+                                  "from": "tar@^0.1.18",
+                                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                                  "dependencies": {
+                                    "block-stream": {
+                                      "version": "0.0.7",
+                                      "from": "block-stream@*",
+                                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                    },
+                                    "fstream": {
+                                      "version": "0.1.31",
+                                      "from": "fstream@~0.1.28",
+                                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "3.0.2",
+                                          "from": "graceful-fs@~3.0.2",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                        },
+                                        "mkdirp": {
+                                          "version": "0.5.0",
+                                          "from": "mkdirp@0.5",
+                                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                                          "dependencies": {
+                                            "minimist": {
+                                              "version": "0.0.8",
+                                              "from": "minimist@0.0.8",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@2",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "0.1.3",
+                              "from": "each-async@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "0.1.0",
+                              "from": "get-stdin@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
+                            },
+                            "get-urls": {
+                              "version": "0.1.2",
+                              "from": "get-urls@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.3.5",
+                              "from": "mkdirp@^0.3.5",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                            },
+                            "nopt": {
+                              "version": "2.2.1",
+                              "from": "nopt@^2.2.0",
+                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.5",
+                                  "from": "abbrev@1",
+                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "0.4.2",
+                              "from": "through2@^0.4.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.31",
+                                  "from": "readable-stream@~1.0.17",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "2.1.2",
+                                  "from": "xtend@~2.1.1",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                                  "dependencies": {
+                                    "object-keys": {
+                                      "version": "0.4.0",
+                                      "from": "object-keys@~0.4.0",
+                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "find-file": {
+                          "version": "0.1.4",
+                          "from": "find-file@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/find-file/-/find-file-0.1.4.tgz"
+                        }
+                      }
+                    },
+                    "log-symbols": {
+                      "version": "1.0.0",
+                      "from": "log-symbols@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "imagemin-pngquant": {
+              "version": "0.1.3",
+              "from": "imagemin-pngquant@^0.1.2",
+              "resolved": "https://registry.npmjs.org/imagemin-pngquant/-/imagemin-pngquant-0.1.3.tgz",
+              "dependencies": {
+                "exec-buffer": {
+                  "version": "0.1.1",
+                  "from": "exec-buffer@^0.1.1",
+                  "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-0.1.1.tgz"
+                },
+                "pngquant-bin": {
+                  "version": "0.3.5",
+                  "from": "pngquant-bin@^0.3.0",
+                  "resolved": "https://registry.npmjs.org/pngquant-bin/-/pngquant-bin-0.3.5.tgz",
+                  "dependencies": {
+                    "bin-build": {
+                      "version": "0.1.1",
+                      "from": "bin-build@^0.1.0",
+                      "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-0.1.1.tgz",
+                      "dependencies": {
+                        "download": {
+                          "version": "0.1.19",
+                          "from": "download@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/download/-/download-0.1.19.tgz",
+                          "dependencies": {
+                            "decompress": {
+                              "version": "0.2.5",
+                              "from": "decompress@^0.2.5",
+                              "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.5.tgz",
+                              "dependencies": {
+                                "adm-zip": {
+                                  "version": "0.4.4",
+                                  "from": "adm-zip@^0.4.3",
+                                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                                },
+                                "ext-name": {
+                                  "version": "1.0.1",
+                                  "from": "ext-name@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-1.0.1.tgz",
+                                  "dependencies": {
+                                    "ext-list": {
+                                      "version": "0.2.0",
+                                      "from": "ext-list@^0.2.0",
+                                      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
+                                      "dependencies": {
+                                        "got": {
+                                          "version": "0.2.0",
+                                          "from": "got@^0.2.0",
+                                          "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
+                                          "dependencies": {
+                                            "object-assign": {
+                                              "version": "0.3.1",
+                                              "from": "object-assign@^0.3.0",
+                                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "underscore.string": {
+                                      "version": "2.3.3",
+                                      "from": "underscore.string@~2.3.3",
+                                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                                    }
+                                  }
+                                },
+                                "stream-combiner": {
+                                  "version": "0.0.4",
+                                  "from": "stream-combiner@^0.0.4",
+                                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                                  "dependencies": {
+                                    "duplexer": {
+                                      "version": "0.1.1",
+                                      "from": "duplexer@~0.1.1",
+                                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "tar": {
+                                  "version": "0.1.20",
+                                  "from": "tar@^0.1.18",
+                                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                                  "dependencies": {
+                                    "block-stream": {
+                                      "version": "0.0.7",
+                                      "from": "block-stream@*",
+                                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                    },
+                                    "fstream": {
+                                      "version": "0.1.31",
+                                      "from": "fstream@~0.1.28",
+                                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "3.0.2",
+                                          "from": "graceful-fs@~3.0.2",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                        },
+                                        "mkdirp": {
+                                          "version": "0.5.0",
+                                          "from": "mkdirp@0.5",
+                                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                                          "dependencies": {
+                                            "minimist": {
+                                              "version": "0.0.8",
+                                              "from": "minimist@0.0.8",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@2",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "0.1.3",
+                              "from": "each-async@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "0.1.0",
+                              "from": "get-stdin@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
+                            },
+                            "get-urls": {
+                              "version": "0.1.2",
+                              "from": "get-urls@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.3.5",
+                              "from": "mkdirp@0.3.5",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                            },
+                            "nopt": {
+                              "version": "2.2.1",
+                              "from": "nopt@^2.2.0",
+                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.5",
+                                  "from": "abbrev@1",
+                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "0.4.2",
+                              "from": "through2@^0.4.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.31",
+                                  "from": "readable-stream@~1.0.17",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "2.1.2",
+                                  "from": "xtend@~2.1.1",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                                  "dependencies": {
+                                    "object-keys": {
+                                      "version": "0.4.0",
+                                      "from": "object-keys@~0.4.0",
+                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "bin-wrapper": {
+                      "version": "0.3.4",
+                      "from": "bin-wrapper@^0.3.0",
+                      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-0.3.4.tgz",
+                      "dependencies": {
+                        "bin-check": {
+                          "version": "0.1.5",
+                          "from": "bin-check@^0.1.0",
+                          "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-0.1.5.tgz",
+                          "dependencies": {
+                            "executable": {
+                              "version": "0.1.3",
+                              "from": "executable@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/executable/-/executable-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "download": {
+                          "version": "0.1.19",
+                          "from": "download@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/download/-/download-0.1.19.tgz",
+                          "dependencies": {
+                            "decompress": {
+                              "version": "0.2.5",
+                              "from": "decompress@^0.2.5",
+                              "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.5.tgz",
+                              "dependencies": {
+                                "adm-zip": {
+                                  "version": "0.4.4",
+                                  "from": "adm-zip@^0.4.3",
+                                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                                },
+                                "ext-name": {
+                                  "version": "1.0.1",
+                                  "from": "ext-name@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-1.0.1.tgz",
+                                  "dependencies": {
+                                    "ext-list": {
+                                      "version": "0.2.0",
+                                      "from": "ext-list@^0.2.0",
+                                      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
+                                      "dependencies": {
+                                        "got": {
+                                          "version": "0.2.0",
+                                          "from": "got@^0.2.0",
+                                          "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
+                                          "dependencies": {
+                                            "object-assign": {
+                                              "version": "0.3.1",
+                                              "from": "object-assign@^0.3.0",
+                                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "underscore.string": {
+                                      "version": "2.3.3",
+                                      "from": "underscore.string@~2.3.3",
+                                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                                    }
+                                  }
+                                },
+                                "stream-combiner": {
+                                  "version": "0.0.4",
+                                  "from": "stream-combiner@^0.0.4",
+                                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                                  "dependencies": {
+                                    "duplexer": {
+                                      "version": "0.1.1",
+                                      "from": "duplexer@~0.1.1",
+                                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "tar": {
+                                  "version": "0.1.20",
+                                  "from": "tar@^0.1.18",
+                                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                                  "dependencies": {
+                                    "block-stream": {
+                                      "version": "0.0.7",
+                                      "from": "block-stream@*",
+                                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                    },
+                                    "fstream": {
+                                      "version": "0.1.31",
+                                      "from": "fstream@~0.1.28",
+                                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "3.0.2",
+                                          "from": "graceful-fs@~3.0.2",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                        },
+                                        "mkdirp": {
+                                          "version": "0.5.0",
+                                          "from": "mkdirp@0.5",
+                                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                                          "dependencies": {
+                                            "minimist": {
+                                              "version": "0.0.8",
+                                              "from": "minimist@0.0.8",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@2",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "0.1.3",
+                              "from": "each-async@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "0.1.0",
+                              "from": "get-stdin@^0.1.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
+                            },
+                            "get-urls": {
+                              "version": "0.1.2",
+                              "from": "get-urls@^0.1.1",
+                              "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-0.1.2.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.3.5",
+                              "from": "mkdirp@^0.3.5",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                            },
+                            "nopt": {
+                              "version": "2.2.1",
+                              "from": "nopt@^2.2.0",
+                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.5",
+                                  "from": "abbrev@1",
+                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "0.4.2",
+                              "from": "through2@^0.4.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.31",
+                                  "from": "readable-stream@~1.0.17",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "2.1.2",
+                                  "from": "xtend@~2.1.1",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                                  "dependencies": {
+                                    "object-keys": {
+                                      "version": "0.4.0",
+                                      "from": "object-keys@~0.4.0",
+                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "find-file": {
+                          "version": "0.1.4",
+                          "from": "find-file@^0.1.2",
+                          "resolved": "https://registry.npmjs.org/find-file/-/find-file-0.1.4.tgz"
+                        }
+                      }
+                    },
+                    "log-symbols": {
+                      "version": "1.0.0",
+                      "from": "log-symbols@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "imagemin-svgo": {
+              "version": "0.1.1",
+              "from": "imagemin-svgo@^0.1.0",
+              "resolved": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-0.1.1.tgz",
+              "dependencies": {
+                "is-svg": {
+                  "version": "0.1.2",
+                  "from": "is-svg@^0.1.1",
+                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-0.1.2.tgz"
+                },
+                "svgo": {
+                  "version": "0.4.5",
+                  "from": "svgo@^0.4.4",
+                  "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.4.5.tgz",
+                  "dependencies": {
+                    "sax": {
+                      "version": "0.6.0",
+                      "from": "sax@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.0.tgz"
+                    },
+                    "coa": {
+                      "version": "0.4.1",
+                      "from": "coa@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/coa/-/coa-0.4.1.tgz",
+                      "dependencies": {
+                        "q": {
+                          "version": "0.9.7",
+                          "from": "q@~0.9.6",
+                          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+                        }
+                      }
+                    },
+                    "js-yaml": {
+                      "version": "2.1.3",
+                      "from": "js-yaml@~2.1.0",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
+                      "dependencies": {
+                        "argparse": {
+                          "version": "0.1.15",
+                          "from": "argparse@~ 0.1.11",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+                          "dependencies": {
+                            "underscore": {
+                              "version": "1.4.4",
+                              "from": "underscore@~1.4.3",
+                              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                            },
+                            "underscore.string": {
+                              "version": "2.3.3",
+                              "from": "underscore.string@~2.3.1",
+                              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                            }
+                          }
+                        },
+                        "esprima": {
+                          "version": "1.0.4",
+                          "from": "esprima@~ 1.0.2",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                        }
+                      }
+                    },
+                    "colors": {
+                      "version": "0.6.2",
+                      "from": "colors@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+                    },
+                    "whet.extend": {
+                      "version": "0.9.9",
+                      "from": "whet.extend@~0.9.9",
+                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pretty-bytes": {
+          "version": "0.1.2",
+          "from": "pretty-bytes@^0.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz"
+        }
+      }
+    },
+    "grunt-contrib-jshint": {
+      "version": "0.10.0",
+      "from": "grunt-contrib-jshint@0.10.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
+      "dependencies": {
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@~0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        }
+      }
+    },
     "grunt-contrib-uglify": {
       "version": "0.5.1",
       "from": "grunt-contrib-uglify@0.5.1",
@@ -3037,7 +6199,7 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@^0.5.0",
+          "from": "chalk@~0.5.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -3083,7 +6245,7 @@
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@^2.4.1",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "maxmin": {
@@ -3117,9 +6279,9 @@
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
-                      "version": "1.1.13-1",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
@@ -3132,9 +6294,9 @@
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
-                          "version": "0.10.25-1",
+                          "version": "0.10.31",
                           "from": "string_decoder@~0.10.x",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     }
@@ -3204,6 +6366,924 @@
         }
       }
     },
+    "grunt-contrib-watch": {
+      "version": "0.6.1",
+      "from": "grunt-contrib-watch@0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "dependencies": {
+        "gaze": {
+          "version": "0.5.1",
+          "from": "gaze@~0.5.1",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+          "dependencies": {
+            "globule": {
+              "version": "0.1.0",
+              "from": "globule@~0.1.0",
+              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "1.0.1",
+                  "from": "lodash@~1.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.1.tgz"
+                },
+                "glob": {
+                  "version": "3.1.21",
+                  "from": "glob@~3.1.21",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@~1.2.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                    },
+                    "inherits": {
+                      "version": "1.0.0",
+                      "from": "inherits@1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@~0.2.11",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tiny-lr-fork": {
+          "version": "0.0.5",
+          "from": "tiny-lr-fork@0.0.5",
+          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "0.5.6",
+              "from": "qs@~0.5.2",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+            },
+            "faye-websocket": {
+              "version": "0.4.4",
+              "from": "faye-websocket@~0.4.3",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
+            },
+            "noptify": {
+              "version": "0.0.3",
+              "from": "noptify@~0.0.3",
+              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "2.0.0",
+                  "from": "nopt@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "from": "abbrev@1",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@~0.7.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@~2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "async@~0.2.9",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        }
+      }
+    },
+    "grunt-conventional-changelog": {
+      "version": "1.1.0",
+      "from": "grunt-conventional-changelog@1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-conventional-changelog/-/grunt-conventional-changelog-1.1.0.tgz",
+      "dependencies": {
+        "conventional-changelog": {
+          "version": "0.0.6",
+          "from": "conventional-changelog@0.0.6",
+          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.6.tgz",
+          "dependencies": {
+            "lodash.assign": {
+              "version": "2.4.1",
+              "from": "lodash.assign@~2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+              "dependencies": {
+                "lodash._basecreatecallback": {
+                  "version": "2.4.1",
+                  "from": "lodash._basecreatecallback@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash.bind": {
+                      "version": "2.4.1",
+                      "from": "lodash.bind@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._createwrapper": {
+                          "version": "2.4.1",
+                          "from": "lodash._createwrapper@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._basebind": {
+                              "version": "2.4.1",
+                              "from": "lodash._basebind@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._basecreate": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._basecreate@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                  "dependencies": {
+                                    "lodash._isnative": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._isnative@~2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                    },
+                                    "lodash.noop": {
+                                      "version": "2.4.1",
+                                      "from": "lodash.noop@~2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                    }
+                                  }
+                                },
+                                "lodash.isobject": {
+                                  "version": "2.4.1",
+                                  "from": "lodash.isobject@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash._basecreatewrapper": {
+                              "version": "2.4.1",
+                              "from": "lodash._basecreatewrapper@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._basecreate": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._basecreate@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                  "dependencies": {
+                                    "lodash._isnative": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._isnative@~2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                    },
+                                    "lodash.noop": {
+                                      "version": "2.4.1",
+                                      "from": "lodash.noop@~2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                    }
+                                  }
+                                },
+                                "lodash.isobject": {
+                                  "version": "2.4.1",
+                                  "from": "lodash.isobject@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.isfunction": {
+                              "version": "2.4.1",
+                              "from": "lodash.isfunction@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._slice": {
+                          "version": "2.4.1",
+                          "from": "lodash._slice@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.identity": {
+                      "version": "2.4.1",
+                      "from": "lodash.identity@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
+                    },
+                    "lodash._setbinddata": {
+                      "version": "2.4.1",
+                      "from": "lodash._setbinddata@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "lodash._isnative@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash.noop": {
+                          "version": "2.4.1",
+                          "from": "lodash.noop@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.support": {
+                      "version": "2.4.1",
+                      "from": "lodash.support@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "lodash._isnative@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "2.4.1",
+                  "from": "lodash.keys@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "from": "lodash.isobject@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+                    },
+                    "lodash._shimkeys": {
+                      "version": "2.4.1",
+                      "from": "lodash._shimkeys@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash._objecttypes": {
+                  "version": "2.4.1",
+                  "from": "lodash._objecttypes@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                }
+              }
+            },
+            "event-stream": {
+              "version": "3.1.7",
+              "from": "event-stream@~3.1.0",
+              "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
+              "dependencies": {
+                "through": {
+                  "version": "2.3.4",
+                  "from": "through@~2.3.1",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.4.tgz"
+                },
+                "duplexer": {
+                  "version": "0.1.1",
+                  "from": "duplexer@~0.1.1",
+                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                },
+                "from": {
+                  "version": "0.1.3",
+                  "from": "from@~0",
+                  "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+                },
+                "map-stream": {
+                  "version": "0.1.0",
+                  "from": "map-stream@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+                },
+                "pause-stream": {
+                  "version": "0.0.11",
+                  "from": "pause-stream@0.0.11",
+                  "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+                },
+                "split": {
+                  "version": "0.2.10",
+                  "from": "split@0.2",
+                  "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
+                },
+                "stream-combiner": {
+                  "version": "0.0.4",
+                  "from": "stream-combiner@~0.0.4",
+                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "grunt-copyright": {
+      "version": "0.1.0",
+      "from": "grunt-copyright@0.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
+    },
+    "grunt-html": {
+      "version": "1.4.0",
+      "from": "grunt-html@1.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-1.4.0.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "from": "chalk@0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "dependencies": {
+            "has-color": {
+              "version": "0.1.7",
+              "from": "has-color@~0.1.0",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+            },
+            "ansi-styles": {
+              "version": "1.0.0",
+              "from": "ansi-styles@~1.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "from": "strip-ansi@~0.1.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-jscs": {
+      "version": "0.6.2",
+      "from": "grunt-jscs@0.6.2",
+      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-0.6.2.tgz",
+      "dependencies": {
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@~0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "jscs": {
+          "version": "1.5.9",
+          "from": "jscs@~1.5.9",
+          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.5.9.tgz",
+          "dependencies": {
+            "colors": {
+              "version": "0.6.2",
+              "from": "colors@~0.6.2",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+            },
+            "commander": {
+              "version": "2.3.0",
+              "from": "commander@~2.3.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+            },
+            "esprima": {
+              "version": "1.2.2",
+              "from": "esprima@~1.2.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
+            },
+            "glob": {
+              "version": "4.0.5",
+              "from": "glob@~4.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.5.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.0",
+                  "from": "once@^1.3.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.0.tgz"
+                },
+                "graceful-fs": {
+                  "version": "3.0.2",
+                  "from": "graceful-fs@^3.0.2",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.4.0",
+              "from": "minimatch@~0.4.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "strip-json-comments": {
+              "version": "0.1.3",
+              "from": "strip-json-comments@~0.1.1",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+            },
+            "vow-fs": {
+              "version": "0.3.2",
+              "from": "vow-fs@~0.3.1",
+              "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.2.tgz",
+              "dependencies": {
+                "node-uuid": {
+                  "version": "1.4.0",
+                  "from": "node-uuid@1.4.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.0.tgz"
+                },
+                "vow": {
+                  "version": "0.4.4",
+                  "from": "vow@0.4.4",
+                  "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.4.tgz"
+                },
+                "vow-queue": {
+                  "version": "0.3.1",
+                  "from": "vow-queue@0.3.1",
+                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.3.1.tgz"
+                },
+                "glob": {
+                  "version": "3.2.8",
+                  "from": "glob@3.2.8",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.8.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@~0.2.11",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "xmlbuilder": {
+              "version": "2.3.0",
+              "from": "xmlbuilder@~2.3.0",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.3.0.tgz",
+              "dependencies": {
+                "lodash.assign": {
+                  "version": "2.4.1",
+                  "from": "lodash.assign@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._basecreatecallback": {
+                      "version": "2.4.1",
+                      "from": "lodash._basecreatecallback@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash.bind": {
+                          "version": "2.4.1",
+                          "from": "lodash.bind@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._createwrapper": {
+                              "version": "2.4.1",
+                              "from": "lodash._createwrapper@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._basebind": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._basebind@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                                  "dependencies": {
+                                    "lodash._basecreate": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._basecreate@~2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                      "dependencies": {
+                                        "lodash._isnative": {
+                                          "version": "2.4.1",
+                                          "from": "lodash._isnative@~2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                        },
+                                        "lodash.noop": {
+                                          "version": "2.4.1",
+                                          "from": "lodash.noop@~2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash._basecreatewrapper": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._basecreatewrapper@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                                  "dependencies": {
+                                    "lodash._basecreate": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._basecreate@~2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                      "dependencies": {
+                                        "lodash._isnative": {
+                                          "version": "2.4.1",
+                                          "from": "lodash._isnative@~2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                        },
+                                        "lodash.noop": {
+                                          "version": "2.4.1",
+                                          "from": "lodash.noop@~2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash._slice": {
+                              "version": "2.4.1",
+                              "from": "lodash._slice@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash.identity": {
+                          "version": "2.4.1",
+                          "from": "lodash.identity@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
+                        },
+                        "lodash._setbinddata": {
+                          "version": "2.4.1",
+                          "from": "lodash._setbinddata@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "from": "lodash._isnative@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                            },
+                            "lodash.noop": {
+                              "version": "2.4.1",
+                              "from": "lodash.noop@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash.support": {
+                          "version": "2.4.1",
+                          "from": "lodash.support@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "from": "lodash._isnative@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "2.4.1",
+                      "from": "lodash.keys@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "lodash._isnative@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash._shimkeys": {
+                          "version": "2.4.1",
+                          "from": "lodash._shimkeys@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.create": {
+                  "version": "2.4.1",
+                  "from": "lodash.create@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._basecreate": {
+                      "version": "2.4.1",
+                      "from": "lodash._basecreate@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "lodash._isnative@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash.noop": {
+                          "version": "2.4.1",
+                          "from": "lodash.noop@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.isobject": {
+                  "version": "2.4.1",
+                  "from": "lodash.isobject@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.isarray": {
+                  "version": "2.4.1",
+                  "from": "lodash.isarray@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.isfunction": {
+                  "version": "2.4.1",
+                  "from": "lodash.isfunction@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
+                },
+                "lodash.isempty": {
+                  "version": "2.4.1",
+                  "from": "lodash.isempty@~2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash.forown": {
+                      "version": "2.4.1",
+                      "from": "lodash.forown@~2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._basecreatecallback": {
+                          "version": "2.4.1",
+                          "from": "lodash._basecreatecallback@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash.bind": {
+                              "version": "2.4.1",
+                              "from": "lodash.bind@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._createwrapper": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._createwrapper@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                                  "dependencies": {
+                                    "lodash._basebind": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._basebind@~2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                                      "dependencies": {
+                                        "lodash._basecreate": {
+                                          "version": "2.4.1",
+                                          "from": "lodash._basecreate@~2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                          "dependencies": {
+                                            "lodash._isnative": {
+                                              "version": "2.4.1",
+                                              "from": "lodash._isnative@~2.4.1",
+                                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                            },
+                                            "lodash.noop": {
+                                              "version": "2.4.1",
+                                              "from": "lodash.noop@~2.4.1",
+                                              "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "lodash._basecreatewrapper": {
+                                      "version": "2.4.1",
+                                      "from": "lodash._basecreatewrapper@~2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                                      "dependencies": {
+                                        "lodash._basecreate": {
+                                          "version": "2.4.1",
+                                          "from": "lodash._basecreate@~2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                          "dependencies": {
+                                            "lodash._isnative": {
+                                              "version": "2.4.1",
+                                              "from": "lodash._isnative@~2.4.1",
+                                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                            },
+                                            "lodash.noop": {
+                                              "version": "2.4.1",
+                                              "from": "lodash.noop@~2.4.1",
+                                              "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash._slice": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._slice@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.identity": {
+                              "version": "2.4.1",
+                              "from": "lodash.identity@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
+                            },
+                            "lodash._setbinddata": {
+                              "version": "2.4.1",
+                              "from": "lodash._setbinddata@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._isnative@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                },
+                                "lodash.noop": {
+                                  "version": "2.4.1",
+                                  "from": "lodash.noop@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                }
+                              }
+                            },
+                            "lodash.support": {
+                              "version": "2.4.1",
+                              "from": "lodash.support@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._isnative@~2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.keys": {
+                          "version": "2.4.1",
+                          "from": "lodash.keys@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "from": "lodash._isnative@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                            },
+                            "lodash._shimkeys": {
+                              "version": "2.4.1",
+                              "from": "lodash._shimkeys@~2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@~2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@~0.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@^2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "vow": {
+          "version": "0.4.5",
+          "from": "vow@~0.4.1",
+          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.5.tgz"
+        }
+      }
+    },
+    "grunt-jsonlint": {
+      "version": "1.0.4",
+      "from": "grunt-jsonlint@1.0.4",
+      "resolved": "https://registry.npmjs.org/grunt-jsonlint/-/grunt-jsonlint-1.0.4.tgz",
+      "dependencies": {
+        "jsonlint": {
+          "version": "1.6.0",
+          "from": "jsonlint@1.6.0",
+          "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+          "dependencies": {
+            "nomnom": {
+              "version": "1.8.0",
+              "from": "nomnom@>= 1.5.x",
+              "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.0.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@~1.6.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                },
+                "chalk": {
+                  "version": "0.4.0",
+                  "from": "chalk@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                  "dependencies": {
+                    "has-color": {
+                      "version": "0.1.7",
+                      "from": "has-color@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "1.0.0",
+                      "from": "ansi-styles@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "0.1.1",
+                      "from": "strip-ansi@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "JSV": {
+              "version": "4.0.2",
+              "from": "JSV@>= 4.0.x",
+              "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
+            }
+          }
+        }
+      }
+    },
     "grunt-marked": {
       "version": "0.1.1",
       "from": "grunt-marked@0.1.1",
@@ -3226,6 +7306,52 @@
         }
       }
     },
+    "grunt-nsp-shrinkwrap": {
+      "version": "0.0.3",
+      "from": "grunt-nsp-shrinkwrap@0.0.3",
+      "resolved": "https://registry.npmjs.org/grunt-nsp-shrinkwrap/-/grunt-nsp-shrinkwrap-0.0.3.tgz",
+      "dependencies": {
+        "cli-color": {
+          "version": "0.2.3",
+          "from": "cli-color@^0.2.3",
+          "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+          "dependencies": {
+            "es5-ext": {
+              "version": "0.9.2",
+              "from": "es5-ext@~0.9.2",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
+            },
+            "memoizee": {
+              "version": "0.2.6",
+              "from": "memoizee@~0.2.5",
+              "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+              "dependencies": {
+                "event-emitter": {
+                  "version": "0.2.2",
+                  "from": "event-emitter@~0.2.2",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz"
+                },
+                "next-tick": {
+                  "version": "0.1.0",
+                  "from": "next-tick@0.1.x",
+                  "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@^0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@^0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        }
+      }
+    },
     "grunt-po2json": {
       "version": "0.2.0",
       "from": "grunt-po2json@git://github.com/shane-tomlinson/grunt-po2json.git#c1a7406",
@@ -3244,6 +7370,7 @@
             "nomnom": {
               "version": "1.5.2",
               "from": "nomnom@1.5.2",
+              "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
@@ -3260,6 +7387,7 @@
             "gettext-parser": {
               "version": "0.2.0",
               "from": "gettext-parser@~0.2.0",
+              "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.8",
@@ -3315,9 +7443,9 @@
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
                 },
                 "readable-stream": {
-                  "version": "1.1.13-1",
+                  "version": "1.1.13",
                   "from": "readable-stream@1.1",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
@@ -3330,9 +7458,9 @@
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
-                      "version": "0.10.25-1",
+                      "version": "0.10.31",
                       "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
@@ -3420,7 +7548,7 @@
       "dependencies": {
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@^0.4.0",
+          "from": "chalk@~0.4.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
@@ -3493,9 +7621,9 @@
                   "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
                 },
                 "debug": {
-                  "version": "1.0.4",
-                  "from": "debug@~1.0.2",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                  "version": "2.0.0",
+                  "from": "debug@*",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.6.2",
@@ -3636,6 +7764,64 @@
       "from": "grunt-text-replace@0.3.12",
       "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.3.12.tgz"
     },
+    "grunt-todo": {
+      "version": "0.4.0",
+      "from": "grunt-todo@0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-todo/-/grunt-todo-0.4.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@~0.5",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@^1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.1",
+              "from": "escape-string-regexp@^1.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@^0.1.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@^0.3.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@^0.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@~0.2",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        }
+      }
+    },
     "grunt-usemin": {
       "version": "2.3.0",
       "from": "grunt-usemin@2.3.0",
@@ -3672,7 +7858,7 @@
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.10",
+          "from": "async@~0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "lodash": {
@@ -3806,9 +7992,9 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.2.0.tgz",
       "dependencies": {
         "eventemitter3": {
-          "version": "0.1.2",
+          "version": "0.1.5",
           "from": "eventemitter3@*",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.5.tgz"
         }
       }
     },
@@ -3840,6 +8026,7 @@
             "gettext-parser": {
               "version": "0.2.0",
               "from": "gettext-parser@0.2.0",
+              "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.8",
@@ -3858,6 +8045,7 @@
             "nomnom": {
               "version": "1.5.2",
               "from": "nomnom@1.5.2",
+              "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
@@ -3874,6 +8062,7 @@
             "jade": {
               "version": "0.30.0",
               "from": "jade@0.30.0",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
               "dependencies": {
                 "commander": {
                   "version": "1.1.1",
@@ -4057,7 +8246,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -4069,7 +8258,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -4108,6 +8297,561 @@
         }
       }
     },
+    "intern-geezer": {
+      "version": "2.0.1",
+      "from": "intern-geezer@2.0.1",
+      "resolved": "https://registry.npmjs.org/intern-geezer/-/intern-geezer-2.0.1.tgz",
+      "dependencies": {
+        "istanbul": {
+          "version": "0.2.16",
+          "from": "istanbul@0.2.16",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.2.16.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.2.2",
+              "from": "esprima@1.2.x",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
+            },
+            "escodegen": {
+              "version": "1.3.3",
+              "from": "escodegen@1.3.x",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "1.0.0",
+                  "from": "esutils@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+                },
+                "estraverse": {
+                  "version": "1.5.1",
+                  "from": "estraverse@~1.5.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                },
+                "esprima": {
+                  "version": "1.1.1",
+                  "from": "esprima@~1.1.1",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@3.x",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
+            },
+            "fileset": {
+              "version": "0.1.5",
+              "from": "fileset@0.1.x",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.4.0",
+                  "from": "minimatch@0.x",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@3.x",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.5",
+              "from": "which@1.0.x",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "async@0.9.x",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@1.0.x",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.x",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "resolve": {
+              "version": "0.7.4",
+              "from": "resolve@0.7.x",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+            },
+            "js-yaml": {
+              "version": "3.2.1",
+              "from": "js-yaml@3.x",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.1.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "0.1.15",
+                  "from": "argparse@~ 0.1.11",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+                  "dependencies": {
+                    "underscore": {
+                      "version": "1.4.4",
+                      "from": "underscore@~1.4.3",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "underscore.string@~2.3.1",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@~ 1.0.2",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.1.33",
+          "from": "source-map@0.1.33",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        },
+        "dojo": {
+          "version": "1.9.3",
+          "from": "dojo@1.9.3",
+          "resolved": "https://registry.npmjs.org/dojo/-/dojo-1.9.3.tgz"
+        },
+        "leadfoot": {
+          "version": "1.0.1",
+          "from": "leadfoot@1.0.1",
+          "resolved": "https://registry.npmjs.org/leadfoot/-/leadfoot-1.0.1.tgz",
+          "dependencies": {
+            "dojo": {
+              "version": "2.0.0-alpha1",
+              "from": "dojo@2.0.0-alpha1",
+              "resolved": "https://registry.npmjs.org/dojo/-/dojo-2.0.0-alpha1.tgz"
+            }
+          }
+        },
+        "digdug": {
+          "version": "1.0.0",
+          "from": "digdug@1.0.0",
+          "resolved": "https://registry.npmjs.org/digdug/-/digdug-1.0.0.tgz",
+          "dependencies": {
+            "dojo": {
+              "version": "2.0.0-alpha1",
+              "from": "dojo@2.0.0-alpha1",
+              "resolved": "https://registry.npmjs.org/dojo/-/dojo-2.0.0-alpha1.tgz"
+            },
+            "decompress": {
+              "version": "0.2.3",
+              "from": "decompress@0.2.3",
+              "resolved": "https://registry.npmjs.org/decompress/-/decompress-0.2.3.tgz",
+              "dependencies": {
+                "adm-zip": {
+                  "version": "0.4.4",
+                  "from": "adm-zip@^0.4.3",
+                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                },
+                "extname": {
+                  "version": "0.1.5",
+                  "from": "extname@^0.1.1",
+                  "resolved": "https://registry.npmjs.org/extname/-/extname-0.1.5.tgz",
+                  "dependencies": {
+                    "ext-list": {
+                      "version": "0.2.0",
+                      "from": "ext-list@^0.2.0",
+                      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-0.2.0.tgz",
+                      "dependencies": {
+                        "got": {
+                          "version": "0.2.0",
+                          "from": "got@^0.2.0",
+                          "resolved": "https://registry.npmjs.org/got/-/got-0.2.0.tgz",
+                          "dependencies": {
+                            "object-assign": {
+                              "version": "0.3.1",
+                              "from": "object-assign@^0.3.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "underscore.string@~2.3.3",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "get-stdin": {
+                  "version": "0.1.0",
+                  "from": "get-stdin@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-0.1.0.tgz"
+                },
+                "map-key": {
+                  "version": "0.1.5",
+                  "from": "map-key@^0.1.1",
+                  "resolved": "https://registry.npmjs.org/map-key/-/map-key-0.1.5.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "2.4.1",
+                      "from": "lodash@^2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "underscore.string@~2.3.3",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@^0.3.5",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "nopt": {
+                  "version": "2.2.1",
+                  "from": "nopt@^2.2.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "from": "abbrev@1",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@^2.2.2",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "stream-combiner": {
+                  "version": "0.0.4",
+                  "from": "stream-combiner@^0.0.4",
+                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                  "dependencies": {
+                    "duplexer": {
+                      "version": "0.1.1",
+                      "from": "duplexer@~0.1.1",
+                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                    }
+                  }
+                },
+                "tar": {
+                  "version": "0.1.20",
+                  "from": "tar@^0.1.18",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.7",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                    },
+                    "fstream": {
+                      "version": "0.1.31",
+                      "from": "fstream@~0.1.28",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "3.0.2",
+                          "from": "graceful-fs@~3.0.2",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                        },
+                        "mkdirp": {
+                          "version": "0.5.0",
+                          "from": "mkdirp@0.5",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "tempfile": {
+                  "version": "0.1.3",
+                  "from": "tempfile@^0.1.2",
+                  "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-0.1.3.tgz",
+                  "dependencies": {
+                    "uuid": {
+                      "version": "1.4.1",
+                      "from": "uuid@~1.4.0",
+                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "jshint": {
+      "version": "2.5.3",
+      "from": "jshint@2.5.3",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.3.tgz",
+      "dependencies": {
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "shelljs@0.3.x",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "from": "underscore@1.6.x",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+        },
+        "cli": {
+          "version": "0.6.4",
+          "from": "cli@0.6.x",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.4.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@~ 3.2.1",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.4.0",
+          "from": "minimatch@0.x.x",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@~1.0.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "htmlparser2": {
+          "version": "3.7.3",
+          "from": "htmlparser2@3.7.x",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+          "dependencies": {
+            "domhandler": {
+              "version": "2.2.0",
+              "from": "domhandler@2.2",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.0.tgz"
+            },
+            "domutils": {
+              "version": "1.5.0",
+              "from": "domutils@1.5",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
+            },
+            "domelementtype": {
+              "version": "1.1.1",
+              "from": "domelementtype@1",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@1.1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@1.1.x",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@^0.1.4",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@0.1.x",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "strip-json-comments": {
+          "version": "0.1.3",
+          "from": "strip-json-comments@0.1.x",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+        }
+      }
+    },
+    "jshint-stylish": {
+      "version": "0.4.0",
+      "from": "jshint-stylish@0.4.0",
+      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-0.4.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@~0.5.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@^1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.1",
+              "from": "escape-string-regexp@^1.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@^0.1.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@^0.3.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@^0.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.0",
+          "from": "log-symbols@^1.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.0.tgz"
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@^0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        }
+      }
+    },
     "jsxgettext-recursive": {
       "version": "0.0.5",
       "from": "jsxgettext-recursive@0.0.5",
@@ -4126,9 +8870,9 @@
           }
         },
         "jsxgettext": {
-          "version": "0.4.9",
+          "version": "0.4.10",
           "from": "jsxgettext@^0.4.8",
-          "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.4.9.tgz",
+          "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.4.10.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.5.0",
@@ -4190,7 +8934,7 @@
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@0.3.x",
+                  "from": "mkdirp@^0.3.5",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 },
                 "transformers": {
@@ -4362,6 +9106,11 @@
                   }
                 }
               }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.1",
+              "from": "escape-string-regexp@1.0.1",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz"
             }
           }
         }
@@ -4468,6 +9217,148 @@
         }
       }
     },
+    "request": {
+      "version": "2.40.0",
+      "from": "request@2.40.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "1.0.2",
+          "from": "qs@~1.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.0",
+          "from": "json-stringify-safe@~5.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+        },
+        "mime-types": {
+          "version": "1.0.2",
+          "from": "mime-types@~1.0.1",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "from": "forever-agent@~0.5.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+        },
+        "node-uuid": {
+          "version": "1.4.1",
+          "from": "node-uuid@~1.4.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+        },
+        "tough-cookie": {
+          "version": "0.12.1",
+          "from": "tough-cookie@>=0.12.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.1",
+              "from": "punycode@>=0.2.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
+            }
+          }
+        },
+        "form-data": {
+          "version": "0.1.4",
+          "from": "form-data@~0.1.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+          "dependencies": {
+            "combined-stream": {
+              "version": "0.0.5",
+              "from": "combined-stream@~0.0.4",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@~1.2.11",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "async@~0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            }
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.0",
+          "from": "tunnel-agent@~0.4.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+        },
+        "http-signature": {
+          "version": "0.10.0",
+          "from": "http-signature@~0.10.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.2",
+              "from": "assert-plus@0.1.2",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+            },
+            "asn1": {
+              "version": "0.1.11",
+              "from": "asn1@0.1.11",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+            },
+            "ctype": {
+              "version": "0.5.2",
+              "from": "ctype@0.5.2",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.3.0",
+          "from": "oauth-sign@~0.3.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+        },
+        "hawk": {
+          "version": "1.1.1",
+          "from": "hawk@1.1.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+          "dependencies": {
+            "hoek": {
+              "version": "0.9.1",
+              "from": "hoek@0.9.x",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+            },
+            "boom": {
+              "version": "0.4.2",
+              "from": "boom@0.4.x",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+            },
+            "cryptiles": {
+              "version": "0.2.2",
+              "from": "cryptiles@0.2.x",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+            },
+            "sntp": {
+              "version": "0.2.4",
+              "from": "sntp@0.2.x",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+            }
+          }
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "from": "aws-sign2@~0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.4",
+          "from": "stringstream@~0.0.4",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+        }
+      }
+    },
     "time-grunt": {
       "version": "0.4.0",
       "from": "time-grunt@0.4.0",
@@ -4475,7 +9366,7 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@^0.5.1",
+          "from": "chalk@~0.5.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -4531,7 +9422,7 @@
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@^0.2.3",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "pretty-ms": {
@@ -4552,6 +9443,11 @@
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }
+    },
+    "xmlhttprequest": {
+      "version": "1.5.1",
+      "from": "xmlhttprequest@git://github.com/zaach/node-XMLHttpRequest.git#onerror",
+      "resolved": "git://github.com/zaach/node-XMLHttpRequest.git#3f904613b860b4438e65a31b7b82f09a4d2d64dd"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "grunt-contrib-watch": "0.6.1",
     "grunt-conventional-changelog": "1.1.0",
     "grunt-copyright": "0.1.0",
+    "grunt-html": "1.4.0",
     "grunt-jscs": "0.6.2",
     "grunt-jsonlint": "1.0.4",
     "grunt-nsp-shrinkwrap": "0.0.3",

--- a/server/bin/csp-violation-server.js
+++ b/server/bin/csp-violation-server.js
@@ -6,6 +6,7 @@
 
 var fs = require('fs');
 var https = require('https');
+
 // set up common formatting for all loggers
 var intel = require('intel');
 intel.basicConfig({


### PR DESCRIPTION
This isn't linked to any `default` or `lint` Grunt task since it adds 15-20s per build, but it's nice to keep around since it may catch some HTML markup issues in the future.

``` sh
$ grunt htmllint

Running "htmllint:all" (htmllint) task
>> 697 files lint free.

Done, without errors.


Execution Time (2014-07-24 19:11:53 UTC)
loading tasks   1.7s  ▇▇▇▇▇ 10%
htmllint:all   15.3s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 90%
Total 17s
```
