### PR TITLE
temporary workaround for travis failure; checkout an earlier version of fxa-auth-server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 # copy over the configuration that can be used to start the server.
   - cp server/config/local.json-dist server/config/local.json
 # install the resources necessary for the auth server.
-  - git clone git://github.com/mozilla/fxa-auth-server.git --depth 1
+  - git clone git://github.com/mozilla/fxa-auth-server.git
   - cd fxa-auth-server
   - git checkout a44b4ad
   - npm install --silent


### PR DESCRIPTION
This is just offered as a workaround so the travis build of fxa-content-server works again, and a better solution is worked out. This just checks out fxa-auth-server as of last Friday for running the content server tests.

/cc @shane-tomlinson since you'll be up in an hour or so and this would matter most to you overnight(PDT).
