### PR TITLE
refactor(client): Extract form decorators into their own modules.

### DIFF
--- a/app/scripts/views/decorators/allow_only_one_submit.js
+++ b/app/scripts/views/decorators/allow_only_one_submit.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Function decorator to only allow one form submission.
+ *
+ * Requires the invokeHandler function.
+ */
+
+'use strict';
+
+define([
+  'lib/promise'
+],
+function (p) {
+  function allowOnlyOneSubmit(handler) {
+    return function () {
+      var self = this;
+      var args = arguments;
+
+      if (self._isSubmitting) {
+        return p()
+          .then(function () {
+            // already submitting, get outta here.
+            throw new Error('submit already in progress');
+          });
+      }
+
+      self._isSubmitting = true;
+      return p()
+          .then(function () {
+            return self.invokeHandler(handler, args);
+          })
+          .then(function (value) {
+            self._isSubmitting = false;
+            return value;
+          }, function (err) {
+            self._isSubmitting = false;
+            throw err;
+          });
+    };
+  }
+
+  return allowOnlyOneSubmit;
+});

--- a/app/scripts/views/decorators/button_progress_indicator.js
+++ b/app/scripts/views/decorators/button_progress_indicator.js
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Function decorator to show a button progress indicator during
+ * asynchronous operations.
+ *
+ * Progress indicator is removed whenever the handler completes, unless
+ * the handler returns a value that that contains `pageNavigation: true`.
+ *
+ * Requires the invokeHandler function.
+ */
+
+'use strict';
+
+define([
+  'lib/promise',
+  'views/button_progress_indicator'
+],
+function (p, ButtonProgressIndicator) {
+
+  function showButtonProgressIndicator(handler, _el) {
+    var el = _el || 'button[type=submit]';
+
+    return function () {
+      var self = this;
+      var args = arguments;
+
+      var buttonProgressIndicator = getButtonProgressIndicator.call(self);
+      buttonProgressIndicator.start(self.$(el));
+
+      return p()
+          .then(function () {
+            return self.invokeHandler(handler, args);
+          })
+          .then(function (value) {
+            // Stop the progress indicator unless the page is navigating
+            if (! (value && value.pageNavigation)) {
+              buttonProgressIndicator.done();
+            }
+            return value;
+          }, function(err) {
+            buttonProgressIndicator.done();
+            throw err;
+          });
+    };
+  }
+
+  function getButtonProgressIndicator() {
+    /*jshint validthis: true*/
+    var self = this;
+    if (! self._buttonProgressIndicator) {
+      self._buttonProgressIndicator = new ButtonProgressIndicator();
+      self.trackSubview(self._buttonProgressIndicator);
+    }
+
+    return self._buttonProgressIndicator;
+  }
+
+  return showButtonProgressIndicator;
+});

--- a/app/scripts/views/decorators/notify_delayed_request.js
+++ b/app/scripts/views/decorators/notify_delayed_request.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Function decorator to show a notice when requests take
+ * longer than expected
+ */
+'use strict';
+
+define([
+  'lib/promise',
+  'lib/auth-errors'
+],
+function (p, AuthErrors) {
+  function notifyDelayedRequest(handler) {
+    return function () {
+      var self = this;
+      var args = arguments;
+      var workingText;
+
+      self.clearTimeout(self._workingTimeout);
+
+      self._workingTimeout = self.setTimeout(function () {
+        var err = AuthErrors.toError('WORKING');
+        workingText = self.displayError(err);
+      }, self.LONGER_THAN_EXPECTED);
+
+      return p()
+          .then(function () {
+            return self.invokeHandler(handler, args);
+          })
+          .then(function (value) {
+            self.clearTimeout(self._workingTimeout);
+            if (workingText === self.$('.error').text()) {
+              self.hideError();
+            }
+            return value;
+          }, function(err) {
+            self.clearTimeout(self._workingTimeout);
+            throw err;
+          });
+    };
+  }
+
+  return notifyDelayedRequest;
+});


### PR DESCRIPTION
The goal here is to extract the decorators from `form.js` so they can be used elsewhere (like in the service-mixin [here](https://github.com/mozilla/fxa-content-server/pull/1437#discussion-diff-15283468R87)). I'm not 100% sold on this, but it does remove a lot of extra, non-essential code from `form.js`
