### PR TITLE
fix(client): Do not attempt to re-focus an element that has been blurred before the refocus occurs.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -238,8 +238,19 @@ function (_, Backbone, $, p, Session, AuthErrors, FxaClient, Url, Strings, Ephem
           if (autofocusEl.is(':focus')) {
             return;
           }
+
           self.focus(autofocusEl);
-          self.setTimeout(attemptFocus, 50);
+
+          var focusTimeout = self.setTimeout(attemptFocus, 50);
+
+          // If the autofocusElement loses focus before we attempt to re-focus,
+          // then don't try to re-focus. This happens when using WebDriver
+          // (esp with ChromeDriver) where keys are typed at blazing speeds
+          // and then the script moves on to the next input before the focus
+          // attempt is made.
+          autofocusEl.one('blur', function () {
+            self.clearTimeout(focusTimeout);
+          });
         };
 
         attemptFocus();


### PR DESCRIPTION
@vladikoff - wanna r?

Fixes Selenium/ChromeDriver where an attempt is made to autofocus an element
after ChromeDriver has already moved on to the next element.

The timing was:
1) A new view was rendered, an autofocus element found.
2) The autofocus element was focused, a timer set to check for focus 50ms later.
3) In that 50ms, ChromeDriver would fill out the field, and move on to the next field.
4) The timer expired, and the view tried to re-focus the autofocus element.
5) ChromeDriver failed the test.

fixes #1329 (on a mac)
