### PR TITLE
fix(legal): show home button on legal pages when loaded directly

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -156,12 +156,6 @@ function (
     showView: function (viewToShow) {
       if (this.currentView) {
         this.currentView.destroy();
-        Session.set('canGoBack', true);
-      } else {
-        // user can only go back if there is a screen to go back to.
-        // this is used for the TOS/PP pages where there is no
-        // back button if the user browses there directly.
-        Session.set('canGoBack', false);
       }
 
       this.currentView = viewToShow;

--- a/app/scripts/templates/pp.mustache
+++ b/app/scripts/templates/pp.mustache
@@ -10,10 +10,8 @@
     <article id="legal-copy">
     </article>
 
-    {{#canGoBack}}
     <div class="button-row">
       <button id="fxa-pp-back" class="back">{{#t}}Back{{/t}}</button>
     </div>
-    {{/canGoBack}}
   </section>
 </div>

--- a/app/scripts/templates/tos.mustache
+++ b/app/scripts/templates/tos.mustache
@@ -10,10 +10,8 @@
     <article id="legal-copy">
     </article>
 
-    {{#canGoBack}}
     <div class="button-row">
       <button id="fxa-tos-back" class="back">{{#t}}Back{{/t}}</button>
     </div>
-    {{/canGoBack}}
   </section>
 </div>

--- a/app/scripts/views/pp.js
+++ b/app/scripts/views/pp.js
@@ -12,16 +12,10 @@ define([
   'lib/session',
   'lib/auth-errors'
 ],
-function ($, BaseView, Template, p, Session, AuthErrors) {
+function ($, BaseView, Template, p, AuthErrors) {
   var View = BaseView.extend({
     template: Template,
     className: 'pp',
-
-    context: function () {
-      return {
-        canGoBack: Session.canGoBack
-      };
-    },
 
     afterRender: function () {
       var self = this;

--- a/app/scripts/views/tos.js
+++ b/app/scripts/views/tos.js
@@ -12,16 +12,10 @@ define([
   'lib/session',
   'lib/auth-errors'
 ],
-function ($, BaseView, Template, p, Session, AuthErrors) {
+function ($, BaseView, Template, p, AuthErrors) {
   var View = BaseView.extend({
     template: Template,
     className: 'tos',
-
-    context: function () {
-      return {
-        canGoBack: Session.canGoBack
-      };
-    },
 
     afterRender: function () {
       var self = this;

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -113,16 +113,11 @@ function (chai, _, Backbone, Router, SignInView, SignUpView, ReadyView, Session,
             .then(function () {
               assert.ok($('#fxa-signin-header').length);
 
-              // session was cleared in beforeEach, simulating a user
-              // visiting their first page. The user cannot go back.
-              assert.equal(Session.canGoBack, false);
               windowMock.location.pathname = '/signup';
               return router.showView(signUpView);
             })
             .then(function () {
               assert.ok($('#fxa-signup-header').length);
-              // if there is a back button, it can be shown now.
-              assert.equal(Session.canGoBack, true);
 
               assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen:signin'));
               assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen:signup'));

--- a/app/tests/spec/views/pp.js
+++ b/app/tests/spec/views/pp.js
@@ -25,8 +25,7 @@ function (chai, View, Session) {
       view.destroy();
     });
 
-    it('Back button displayed if Session.canGoBack is true', function () {
-      Session.set('canGoBack', true);
+    it('Back button is displayed', function () {
       return view.render()
           .then(function () {
             $('#container').html(view.el);
@@ -35,17 +34,7 @@ function (chai, View, Session) {
           });
     });
 
-    it('Back button not displayed if Session.canGoBack is false', function () {
-      Session.set('canGoBack', false);
-      return view.render()
-          .then(function () {
-            $('#container').html(view.el);
-
-            assert.equal($('#fxa-pp-back').length, 0);
-          });
-    });
-
-    it('fetches ?? translated text from the backend', function () {
+    it('fetches translated text from the backend', function () {
       return view.render()
         .then(function() {
           assert.ok(view.$('#fxa-pp-header').length);

--- a/app/tests/spec/views/tos.js
+++ b/app/tests/spec/views/tos.js
@@ -25,22 +25,11 @@ function (chai, View, Session) {
       view.destroy();
     });
 
-    it('Back button displayed if Session.canGoBack is true', function () {
-      Session.set('canGoBack', true);
+    it('Back button is displayed', function () {
       return view.render()
           .then(function () {
             $('#container').html(view.el);
             assert.ok($('#fxa-tos-back').length);
-          });
-    });
-
-    it('Back button not displayed if Session.canGoBack is false', function () {
-      Session.set('canGoBack', false);
-      return view.render()
-          .then(function () {
-            $('#container').html(view.el);
-
-            assert.equal($('#fxa-tos-back').length, 0);
           });
     });
 

--- a/server/templates/pages/src/privacy.html
+++ b/server/templates/pages/src/privacy.html
@@ -38,6 +38,10 @@
               <article id="legal-copy">
                 {{{ privacy }}}
               </article>
+
+              <div class="button-row">
+                <a href="/" id="fxa-pp-home" class="button">{{#t}}Home{{/t}}</a>
+              </div>
             </section>
           </div>
         </div>

--- a/server/templates/pages/src/terms.html
+++ b/server/templates/pages/src/terms.html
@@ -38,6 +38,10 @@
               <article id="legal-copy">
                 {{{ terms }}}
               </article>
+
+              <div class="button-row">
+                <a href="/" id="fxa-tos-home" class="button">{{#t}}Home{{/t}}</a>
+              </div>
             </section>
           </div>
         </div>

--- a/tests/functional/pp.js
+++ b/tests/functional/pp.js
@@ -6,14 +6,20 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
+  'tests/functional/lib/helpers',
   'require'
-], function (intern, registerSuite, assert, require) {
+], function (intern, registerSuite, assert, FunctionalHelpers, require) {
   'use strict';
 
   var PAGE_URL = intern.config.fxaContentRoot + 'signup';
+  var PP_URL = intern.config.fxaContentRoot + 'legal/privacy';
 
   registerSuite({
     name: 'pp',
+
+    beforeEach: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
 
     'start at signup': function () {
 
@@ -24,7 +30,7 @@ define([
           .click()
         .end()
 
-        // success is going to the TOS screen
+        // success is going to the Privacy screen
         .findById('fxa-pp-header')
         .end()
 
@@ -33,6 +39,24 @@ define([
         .end()
 
         // success is going back to the signup
+        .findById('fxa-signup-header')
+        .end();
+    },
+
+    'start at privacy': function () {
+
+      return this.get('remote')
+        .get(require.toUrl(PP_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+
+        .findById('fxa-pp-header')
+        .end()
+
+        .findById('fxa-pp-home')
+          .click()
+        .end()
+
+        // success is going home
         .findById('fxa-signup-header')
         .end();
     }

--- a/tests/functional/tos.js
+++ b/tests/functional/tos.js
@@ -6,19 +6,25 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
+  'tests/functional/lib/helpers',
   'require'
-], function (intern, registerSuite, assert, require) {
+], function (intern, registerSuite, assert, FunctionalHelpers, require) {
   'use strict';
 
-  var url = intern.config.fxaContentRoot + 'signup';
+  var PAGE_URL = intern.config.fxaContentRoot + 'signup';
+  var TOS_URL = intern.config.fxaContentRoot + 'legal/terms';
 
   registerSuite({
     name: 'tos',
 
+    beforeEach: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
     'start at signup': function () {
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(require.toUrl(PAGE_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('#fxa-tos')
           .click()
@@ -30,6 +36,24 @@ define([
 
         // success is going back to the signup
         .findByCssSelector('#fxa-signup-header')
+        .end();
+    },
+
+    'start at terms': function () {
+
+      return this.get('remote')
+        .get(require.toUrl(TOS_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+
+        .findById('fxa-tos-header')
+        .end()
+
+        .findById('fxa-tos-home')
+          .click()
+        .end()
+
+        // success is going home
+        .findById('fxa-signup-header')
         .end();
     }
   });


### PR DESCRIPTION
Closes #1445. Rips out `canGoBack` since we no longer need it.

cc @pdehaan 

@shane-tomlinson r?
