### PR TITLE
fix(avatars): proxy remote images to appease CSP and canvas restrictions

### DIFF
--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -69,11 +69,9 @@ function ($, _, FormView, Template, Session, AuthErrors) {
           var img = new Image();
           img.src = src;
           img.onload = function () {
-
-            require(['../bower_components/jquery-ui/ui/draggable'], function (ui) {
-              Session.set('cropImgWidth', img.width);
-              Session.set('cropImgHeight', img.height);
-
+            Session.set('cropImgWidth', img.width);
+            Session.set('cropImgHeight', img.height);
+            require(['../bower_components/jquery-ui/ui/draggable'], function () {
               self.navigate('settings/avatar/crop');
             });
           };

--- a/app/scripts/views/settings/avatar_url.js
+++ b/app/scripts/views/settings/avatar_url.js
@@ -12,6 +12,7 @@ define([
   'lib/auth-errors'
 ],
 function (_, FormView, Template, Session, AuthErrors) {
+  var PROXY_PATH = '/remote-image/';
 
   var View = FormView.extend({
     // user must be authenticated to see Settings
@@ -29,13 +30,16 @@ function (_, FormView, Template, Session, AuthErrors) {
     // Load the remote image into a canvas and prepare it for cropping
     submit: function () {
       var self = this;
-      var src = this.$('.url').val();
+      var src = PROXY_PATH + encodeURIComponent(this.$('.url').val());
       var img = new Image();
       img.src = src;
+
       img.onload = function () {
         Session.set('cropImgWidth', img.width);
         Session.set('cropImgHeight', img.height);
-        self.navigate('settings/avatar/crop');
+        require(['../bower_components/jquery-ui/ui/draggable'], function () {
+          self.navigate('settings/avatar/crop');
+        });
       };
       img.onerror = function () {
         self.navigate('settings/avatar', {

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -25,6 +25,7 @@ module.exports = function (config, templates, i18n) {
     require('./routes/get-terms-privacy')(i18n),
     require('./routes/get-config')(i18n),
     require('./routes/get-client.json')(i18n),
+    require('./routes/get-image-proxy')(),
     require('./routes/post-metrics')()
   ];
 

--- a/server/lib/routes/get-image-proxy.js
+++ b/server/lib/routes/get-image-proxy.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+var request = require('request');
+var logger = require('intel').getLogger('image.proxy');
+var config = require('../configuration');
+
+function proxy (req, res, next) {
+  var imgUrl = req.params.imageUrl;
+  // Restrict the proxy to requests from our own pages
+  if (!req.headers.referer || req.headers.referer.indexOf(config.get('public_url')) !== 0) {
+    return res.send(404);
+  }
+
+  logger.info('proxying image: %s', imgUrl);
+
+  request(imgUrl).pipe(res)
+    .on('error', function (e) {
+      logger.error('proxy error: %s', String(e));
+
+      res.send(404);
+    });
+};
+
+module.exports = function () {
+  var route = {};
+  route.method = 'get';
+  route.path = '/remote-image/:imageUrl';
+
+  route.process = proxy;
+
+  return route;
+}
+

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -19,6 +19,7 @@ define([
     'tests/server/l10n',
     'tests/server/metrics',
     'tests/server/metrics-collector-stderr',
+    'tests/server/image-proxy',
     'tests/server/proxy'
   ];
 

--- a/tests/server/image-proxy.js
+++ b/tests/server/image-proxy.js
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../server/lib/configuration',
+  'intern/dojo/node!request'
+], function (registerSuite, assert, config, request) {
+  'use strict';
+
+  var httpsUrl = config.get('public_url');
+  var imageUrl = 'http://upload.wikimedia.org/wikipedia/meta/b/be/Wikipedia-logo-v2_2x.png';
+
+  var suite = {
+    name: 'image proxy'
+  };
+
+  suite['#get remote image returns 404 on non-existent image'] = function () {
+    var dfd = this.async(1000);
+    var badImageUrl = 'http://example.com/does/no/exist.jpg';
+
+    request(httpsUrl + '/remote-image/' + encodeURIComponent(badImageUrl), {}, dfd.callback(function (err, res) {
+
+      assert.equal(res.statusCode, 404);
+
+    }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#get remote image returns 404 without referer header'] = function () {
+    var dfd = this.async(1000);
+
+    request(httpsUrl + '/remote-image/' + encodeURIComponent(imageUrl), {}, dfd.callback(function (err, res) {
+
+      assert.equal(res.statusCode, 404);
+
+    }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#get remote image returns 404 without invalid referer'] = function () {
+    var dfd = this.async(1000);
+
+    request(httpsUrl + '/remote-image/' + encodeURIComponent(imageUrl), {
+      headers: {
+        'Referer': 'http://example.com'
+      }
+    }, dfd.callback(function (err, res) {
+
+      assert.equal(res.statusCode, 404);
+
+    }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#get remote image with valid referer'] = function () {
+    var dfd = this.async(1000);
+
+    request(httpsUrl + '/remote-image/' + encodeURIComponent(imageUrl), {
+      headers: {
+        'Referer': httpsUrl
+      }
+    }, dfd.callback(function (err, res) {
+
+      assert.equal(res.statusCode, 200);
+
+    }, dfd.reject.bind(dfd)));
+  };
+
+  registerSuite(suite);
+});


### PR DESCRIPTION
This adds a proxy for remote images. This fixes the CSP restriction and also the canvas restriction that wouldn't let us export data of a remotely loaded image. The proxy checks to make sure the referer is from our content pages.

Fixes #1469.

@shane-tomlinson r?

@warner f?

@mostlygeek Should we have nginx handle this in production?
