### PR TITLE
fix(test): Ensure requirejs configuration is loaded before any other scripts.

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -5,10 +5,12 @@
 'use strict';
 
 require([
-  './require_config',
-  './lib/app-start'
+  './require_config'
 ],
 function (RequireConfig, AppStart) {
-  var appStart = new AppStart();
-  appStart.startApp();
+  // Ensure config is loaded before trying to load any other scripts.
+  require(['./lib/app-start'], function (AppStart) {
+    var appStart = new AppStart();
+    appStart.startApp();
+  });
 });

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -3,10 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 require([
-  '../scripts/require_config',
-  './test_start'
+  '../scripts/require_config'
 ],
-function (RequireConfig, TestStart) {
+function (RequireConfig) {
   'use strict';
-  // don't need to do anything.
+  // Ensure config is loaded before trying to load any other scripts.
+  require(['../tests/test_start'], function () {
+    // nothing to do here.
+  });
 });


### PR DESCRIPTION
In main.js, both require_config and ./lib/app-start are requested at the same time. If app-start is loaded and parsed before require_config, then the shims for underscore and backbone are not defined.

fixes #1478
