### PR TITLE
chore(tests): Set Functional test timeout to 30 seconds. Adds directDoma...

### DIFF
--- a/tests/intern.js
+++ b/tests/intern.js
@@ -50,7 +50,7 @@ define(['intern/lib/args', 'intern/node_modules/dojo/has!host-node?intern/node_m
       { browserName: 'firefox' }
     ],
 
-    pageLoadTimeout: 20000,
+    pageLoadTimeout: 30000,
 
     // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
     maxConcurrency: 3,

--- a/tests/intern_sauce.js
+++ b/tests/intern_sauce.js
@@ -10,7 +10,13 @@ define([
   // override the main config file and adjust it to suit Sauce Labs
   intern.tunnel = 'SauceLabsTunnel';
   intern.tunnelOptions = {
-    port: 4445
+    port: 4445,
+    directDomains: [
+      'lcip.org'
+    ],
+    skipSslDomains: [
+      'lcip.org'
+    ]
   };
   intern.functionalSuites = [ 'tests/functional', 'tests/functional_extra' ];
   intern.environments = [


### PR DESCRIPTION
...ins and skipSslDomains for the SauceLabs tunnel.

Ref https://docs.saucelabs.com/reference/sauce-connect/#command-line-options
Ref https://theintern.github.io/digdug/SauceLabsTunnel.html
