### PR TITLE
fix(client): Show the /force_auth error message on startup, if one exists.

### DIFF
--- a/app/scripts/templates/force_auth.mustache
+++ b/app/scripts/templates/force_auth.mustache
@@ -5,7 +5,7 @@
 
   <section>
     {{#fatalError}}
-      <div class="error">{{fatalError}}</div>
+      <div class="error visible">{{fatalError}}</div>
     {{/fatalError}}
     {{^fatalError}}
 


### PR DESCRIPTION
- `.error` elements are invisible by default. Add the `.visible` class.

fixes #1504
