### PR TITLE
reenabling the shrinkwrap validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ install:
 
 # now run the tests!
 script:
+  - npm outdated --depth 0 # show old modules
+  - grunt validate-shrinkwrap --force # check for vulnerable modules via nodesecurity.io
   - grunt lint
   - npm run test-server
   - travis_retry npm run test-travis


### PR DESCRIPTION
Reverts the change in 7157ec44f8f8459866ca34e8567de3b6152e5fa8 (#1522) by using the `--force` flag to give us an exit code of 0.

Also adds a handy table of outdated modules (via `npm outdated`), which can be somewhat useful.

Fixes #1524
