### PR TITLE
chore(build): remove npm outdated command from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ install:
 
 # now run the tests!
 script:
-  - npm outdated --depth 0 # show old modules
   - grunt validate-shrinkwrap --force # check for vulnerable modules via nodesecurity.io
   - grunt lint
   - travis_retry npm run test-travis


### PR DESCRIPTION
Seems like this command is causing problems on travis. It has to ping npm for every module and will hang if npm is not responding.

@zaach r? 

sorry @pdehaan :(
