### PR TITLE
fix(l10n): remove target=_blank from legal-docs

### DIFF
--- a/grunttasks/replace.js
+++ b/grunttasks/replace.js
@@ -18,6 +18,10 @@ module.exports = function (grunt) {
       }, {
         from: /^#\s.*?\n$/m,
         to: ''
+      }, {
+        // BEGONE, `target="_blank"`!
+        from: /target=["'].*?["']/g,
+        to: ''
       }]
     }
   });


### PR DESCRIPTION
Remove any `target=".*"` from the legal-docs. This was causing unwanted sadness on the B2G side.

Fixes #1592
