### PR TITLE
fix(hsts): force hsts headers and use milliseconds

### DIFF
--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -71,7 +71,8 @@ function makeApp() {
   app.use(helmet.xssFilter());
   app.use(helmet.hsts({
     maxAge: config.get('hsts_max_age'),
-    includeSubdomains: true
+    includeSubdomains: true,
+    force: true
   }));
   app.use(helmet.nosniff());
 

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -131,9 +131,9 @@ var conf = module.exports = convict({
     default: 10 * 60 * 1000 // 10 minutes
   },
   hsts_max_age: {
-    doc: 'Max age of the STS directive, in seconds',
-    format: Number,
-    default: 180 * 24 * 60 * 60            // 180 days
+    doc: 'Max age of the STS directive',
+    format: 'duration',
+    default: '180 days'
   },
   template_path: {
     doc: 'The location of server-rendered templates',

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -124,6 +124,7 @@ define([
     }
 
     assert.equal(headers['x-content-type-options'], 'nosniff');
+    assert.include(headers['strict-transport-security'], 'max-age=');
   }
 
 });


### PR DESCRIPTION
helmet API changes require us to set `force: true` or else the header won't show up. In addition, `max-age` uses milliseconds now.

Fixes #1614
