### PR TITLE
cleanup(test): Replace all homegrown email creation logic with `TestHelpers.createEmail()`

### DIFF
--- a/app/tests/spec/lib/assertion.js
+++ b/app/tests/spec/lib/assertion.js
@@ -8,6 +8,7 @@
 define([
   'chai',
   'jquery',
+  '../../lib/helpers',
   'lib/promise',
   'lib/session',
   'lib/constants',
@@ -19,7 +20,7 @@ define([
 // FxaClientWrapper is the object that is used in
 // fxa-content-server views. It wraps FxaClient to
 // take care of some app-specific housekeeping.
-function (chai, $, P,
+function (chai, $, TestHelpers, P,
               Session, Constants, Assertion, FxaClientWrapper, jwcrypto) {
   /*global beforeEach, afterEach, describe, it*/
   var assert = chai.assert;
@@ -35,7 +36,7 @@ function (chai, $, P,
       Session.clear();
       assertionLibrary = new Assertion();
       client = new FxaClientWrapper();
-      email = ' testuser' + Math.random() + '@testuser.com ';
+      email = ' ' + TestHelpers.createEmail() + ' ';
       return client.signUp(email, password, { preVerified: true });
     });
 

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -35,7 +35,7 @@ function (chai, $, sinon, p, ChannelMock, testHelpers,
   describe('lib/fxa-client', function () {
     beforeEach(function () {
       channelMock = new ChannelMock();
-      email = ' testuser' + Math.random() + '@testuser.com ';
+      email = ' ' + testHelpers.createEmail() + ' ';
 
       client = new FxaClientWrapper({
         channel: channelMock

--- a/app/tests/spec/views/change_password.js
+++ b/app/tests/spec/views/change_password.js
@@ -51,7 +51,7 @@ function (chai, _, $, AuthErrors, FxaClient, View, RouterMock, TestHelpers, Sess
 
     describe('with session', function () {
       beforeEach(function () {
-        email = 'testuser.' + Math.random() + '@testuser.com';
+        email = TestHelpers.createEmail();
 
         return view.fxaClient.signUp(email, 'password', {preVerified: true})
           .then(function () {
@@ -168,7 +168,7 @@ function (chai, _, $, AuthErrors, FxaClient, View, RouterMock, TestHelpers, Sess
         });
 
         it('shows the unverified user message if the user is unverified', function () {
-          email = 'testuser.' + Math.random() + '@testuser.com';
+          email = TestHelpers.createEmail();
 
           // create an unverified user, then change their password.
           return view.fxaClient.signUp(email, 'password')

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -155,7 +155,7 @@ function (chai, p, AuthErrors, View, Session, Metrics, FxaClient, RouterMock, Wi
 
     describe('submit', function () {
       it('resends the confirmation email, shows success message', function () {
-        var email = 'user' + Math.random() + '@testuser.com';
+        var email = TestHelpers.createEmail();
 
         return view.fxaClient.signUp(email, 'password')
               .then(function () {
@@ -203,7 +203,7 @@ function (chai, p, AuthErrors, View, Session, Metrics, FxaClient, RouterMock, Wi
 
     describe('validateAndSubmit', function () {
       it('only called after click on #resend', function () {
-        var email = 'user' + Math.random() + '@testuser.com';
+        var email = TestHelpers.createEmail();
 
         return view.fxaClient.signUp(email, 'password')
               .then(function () {

--- a/app/tests/spec/views/delete_account.js
+++ b/app/tests/spec/views/delete_account.js
@@ -48,7 +48,7 @@ function (chai, $, View, FxaClient, RouterMock, TestHelpers) {
 
     describe('with session', function () {
       beforeEach(function () {
-        email = 'testuser.' + Math.random() + '@testuser.com';
+        email = TestHelpers.createEmail();
 
         return view.fxaClient.signUp(email, 'password')
           .then(function () {

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -12,9 +12,10 @@ define([
   'lib/session',
   'lib/fxa-client',
   '../../mocks/window',
-  '../../mocks/router'
+  '../../mocks/router',
+  '../../lib/helpers'
 ],
-function (chai, $, View, Session, FxaClient, WindowMock, RouterMock) {
+function (chai, $, View, Session, FxaClient, WindowMock, RouterMock, TestHelpers) {
   var assert = chai.assert;
 
   describe('/views/force_auth', function () {
@@ -108,7 +109,7 @@ function (chai, $, View, Session, FxaClient, WindowMock, RouterMock) {
       var view, windowMock, router, email;
 
       beforeEach(function () {
-        email = 'testuser.' + Math.random() + '@testuser.com';
+        email = TestHelpers.createEmail();
         Session.set('prefillPassword', 'password');
 
         windowMock = new WindowMock();

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -96,7 +96,7 @@ function (chai, p, Session, AuthErrors, Metrics, FxaClient, View, WindowMock, Ro
 
     describe('submit with valid input', function () {
       it('submits the email address', function () {
-        var email = 'testuser.' + Math.random() + '@testuser.com';
+        var email = TestHelpers.createEmail();
         return view.fxaClient.signUp(email, 'password')
               .then(function () {
                 view.$('input[type=email]').val(email);
@@ -111,7 +111,7 @@ function (chai, p, Session, AuthErrors, Metrics, FxaClient, View, WindowMock, Ro
 
     describe('submit with unknown email address', function () {
       it('shows an error message', function () {
-        var email = 'unknown' + Math.random() + '@testuser.com';
+        var email = TestHelpers.createEmail();
         view.$('input[type=email]').val(email);
 
         return view.submit()

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -11,11 +11,12 @@ define([
   'jquery',
   'views/settings',
   '../../mocks/router',
+  '../../lib/helpers',
   'lib/session',
   'lib/constants',
   'lib/fxa-client'
 ],
-function (chai, _, $, View, RouterMock, Session, Constants, FxaClient) {
+function (chai, _, $, View, RouterMock, TestHelpers, Session, Constants, FxaClient) {
   var assert = chai.assert;
 
   describe('views/settings', function () {
@@ -49,7 +50,7 @@ function (chai, _, $, View, RouterMock, Session, Constants, FxaClient) {
 
     describe('with session', function () {
       beforeEach(function () {
-        email = 'testuser.' + Math.random() + '@testuser.com';
+        email = TestHelpers.createEmail();
 
         return view.fxaClient.signUp(email, 'password', { preVerified: true })
           .then(function() {

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -29,7 +29,7 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient, Translator,
     var view, email, routerMock, metrics, windowMock, fxaClient;
 
     beforeEach(function () {
-      email = 'testuser.' + Math.random() + '@testuser.com';
+      email = TestHelpers.createEmail();
 
       Session.clear();
 


### PR DESCRIPTION
This is for you, @pdehaan!

fixes #1608
