### PR TITLE
chore(metrics): Change the event separator from `:` to `.`.

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -118,7 +118,7 @@ define([
       var self = this;
       this._inactivityFlushTimeout =
           setTimeout(function () {
-            self.logEvent('inactivity:flush');
+            self.logEvent('inactivity.flush');
             self.flush();
           }, this._inactivityFlushMs);
     },
@@ -172,10 +172,10 @@ define([
         data: JSON.stringify(data)
       }))
       .then(function () {
-        self.trigger('flush:success', data);
+        self.trigger('flush.success', data);
         return data;
       }, function(jqXHR) {
-        self.trigger('flush:error');
+        self.trigger('flush.error');
         throw jqXHR.statusText;
       });
     },
@@ -208,14 +208,14 @@ define([
      * Convert an error to an identifier
      */
     errorToId: function (err, errors) {
-      return 'error:' + errors.toCode(err);
+      return 'error.' + errors.toCode(err);
     },
 
     /**
      * Convert a pathname from a URL to an identifier
      */
     pathToId: function (path) {
-      return 'screen:' + Url.pathToScreenName(path);
+      return 'screen.' + Url.pathToScreenName(path);
     },
 
     /**

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -36,7 +36,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
       } catch(e) {
         // This is an invalid link. Abort and show an error message
         // before doing any more checks.
-        this.logEvent('complete_reset_password:link_damaged');
+        this.logEvent('complete_reset_password.link_damaged');
         return true;
       }
 
@@ -48,7 +48,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
       if (! this._doesLinkValidate()) {
         // One or more parameters fails validation. Abort and show an
         // error message before doing any more checks.
-        this.logEvent('complete_reset_password:link_damaged');
+        this.logEvent('complete_reset_password.link_damaged');
         return true;
       }
 
@@ -57,7 +57,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
         .then(function (isComplete) {
           self._isLinkExpired = isComplete;
           if (isComplete) {
-            self.logEvent('complete_reset_password:link_expired');
+            self.logEvent('complete_reset_password.link_expired');
           }
           return true;
         });

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -29,7 +29,7 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, R
         this.importSearchParam('uid');
         this.importSearchParam('code');
       } catch(e) {
-        this.logEvent('complete_sign_up:link_damaged');
+        this.logEvent('complete_sign_up.link_damaged');
         // This is an invalid link. Abort and show an error message
         // before doing any more checks.
         return true;
@@ -43,7 +43,7 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, R
       if (! this._doesLinkValidate()) {
         // One or more parameters fails validation. Abort and show an
         // error message before doing any more checks.
-        this.logEvent('complete_sign_up:link_damaged');
+        this.logEvent('complete_sign_up.link_damaged');
         return true;
       }
 
@@ -56,12 +56,12 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, R
           .then(null, function (err) {
             if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
               self._isLinkExpired = true;
-              self.logEvent('complete_sign_up:link_expired');
+              self.logEvent('complete_sign_up.link_expired');
             } else if (AuthErrors.is(err, 'INVALID_VERIFICATION_CODE') ||
                 AuthErrors.is(err, 'INVALID_PARAMETER')) {
               // These errors show a link damaged screen
               self._isLinkDamaged = true;
-              self.logEvent('complete_sign_up:link_damaged');
+              self.logEvent('complete_sign_up.link_damaged');
             } else {
               // all other errors show the standard error box.
               self._error = self.translateError(err);
@@ -97,7 +97,7 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, R
     submit: function () {
       var self = this;
 
-      self.logEvent('complete_sign_up:resend');
+      self.logEvent('complete_sign_up.resend');
       return this.fxaClient.signUpResend()
               .then(function () {
                 self.displaySuccess();

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -68,7 +68,7 @@ function (_, FormView, BaseView, Template, Session, AuthErrors, ResendMixin) {
     submit: function () {
       var self = this;
 
-      self.logEvent('confirm:resend');
+      self.logEvent('confirm.resend');
       return this.fxaClient.signUpResend()
               .then(function () {
                 self.displaySuccess();

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -83,7 +83,7 @@ function (_, ConfirmView, BaseView, Template, Session, Constants, AuthErrors, Se
     submit: function () {
       var self = this;
 
-      self.logEvent('confirm_reset_password:resend');
+      self.logEvent('confirm_reset_password.resend');
       return this.fxaClient.passwordResetResend()
               .then(function () {
                 self.displaySuccess();

--- a/app/scripts/views/mixins/resend-mixin.js
+++ b/app/scripts/views/mixins/resend-mixin.js
@@ -43,7 +43,7 @@ define([
       var self = this;
       // Hide the button after 4 attempts. Redisplay button after a delay.
       if (self._attemptedSubmits === 4) {
-        self.logEvent(self.className + ':too_many_attempts');
+        self.logEvent(self.className + '.too_many_attempts');
         self.$('#resend').hide();
         self.setTimeout(function () {
           self._attemptedSubmits = 0;

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -76,7 +76,7 @@ function (_, BaseView, FormView, Template, Session, AuthErrors, ServiceMixin) {
             err.forceMessage = t('Unknown account. <a href="/signup">Sign up</a>');
             return self.displayErrorUnsafe(err);
           } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
-            self.logEvent('login:canceled');
+            self.logEvent('login.canceled');
             // if user canceled login, just stop
             return;
           }

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -121,7 +121,7 @@ function (_, p, BaseView, FormView, SignInTemplate, Constants, Session, Password
           if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
             return self._suggestSignUp(err);
           } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
-            self.logEvent('login:canceled');
+            self.logEvent('login.canceled');
             // if user canceled login, just stop
             return;
           }

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -199,7 +199,7 @@ function (_, p, BaseView, FormView, Template, Session, PasswordMixin, AuthErrors
         if (AuthErrors.is(err, 'ACCOUNT_ALREADY_EXISTS')) {
           return self._suggestSignIn(err);
         } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
-          self.logEvent('login:canceled');
+          self.logEvent('login.canceled');
           // if user canceled login, just stop
           return;
         } else if (self._preVerifyToken && AuthErrors.is(err, 'INVALID_VERIFICATION_CODE')) {

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -138,7 +138,7 @@ function (chai, $, Metrics, WindowMock) {
         metrics.logEvent('event20');
 
         var filteredData = metrics.getFilteredData();
-        metrics.on('flush:success', function () {
+        metrics.on('flush.success', function () {
           var parsedSentData = JSON.parse(sentData);
 
           // `duration` fields are different if the above `getFilteredData`
@@ -180,7 +180,7 @@ function (chai, $, Metrics, WindowMock) {
         metrics.events.clear();
         metrics.logEvent('event-is-autoflushed');
 
-        metrics.on('flush:success', function (sentData) {
+        metrics.on('flush.success', function (sentData) {
           assert.equal(sentData.events[0].type, 'event-is-autoflushed');
           done();
         });

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -119,8 +119,8 @@ function (chai, _, Backbone, Router, SignInView, SignUpView, ReadyView, Session,
             .then(function () {
               assert.ok($('#fxa-signup-header').length);
 
-              assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen:signin'));
-              assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen:signup'));
+              assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen.signin'));
+              assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen.signup'));
             });
       });
     });
@@ -210,7 +210,7 @@ function (chai, _, Backbone, Router, SignInView, SignUpView, ReadyView, Session,
         return router.showView(view)
           .then(function () {
             assert.equal(metrics.getFilteredData().events.length, 1);
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen:signup_complete'));
+            assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen.signup_complete'));
           });
       });
     });

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -71,7 +71,7 @@ function (chai, p, AuthErrors, Metrics, FxaClient, View, RouterMock, WindowMock,
       it('shows form if token, code and email are all present', function () {
         return view.render()
             .then(function () {
-              testEventNotLogged('complete_reset_password:link_expired');
+              testEventNotLogged('complete_reset_password.link_expired');
               assert.ok(view.$('#fxa-complete-reset-password-header').length);
             });
       });
@@ -80,7 +80,7 @@ function (chai, p, AuthErrors, Metrics, FxaClient, View, RouterMock, WindowMock,
         windowMock.location.search = '?code=faea&email=testuser@testuser.com';
         return view.render()
             .then(function () {
-              testEventLogged('complete_reset_password:link_damaged');
+              testEventLogged('complete_reset_password.link_damaged');
             })
             .then(function () {
               assert.ok(view.$('#fxa-reset-link-damaged-header').length);
@@ -91,7 +91,7 @@ function (chai, p, AuthErrors, Metrics, FxaClient, View, RouterMock, WindowMock,
         windowMock.location.search = '?token=feed&email=testuser@testuser.com';
         return view.render()
             .then(function () {
-              testEventLogged('complete_reset_password:link_damaged');
+              testEventLogged('complete_reset_password.link_damaged');
             })
             .then(function () {
               assert.ok(view.$('#fxa-reset-link-damaged-header').length);
@@ -102,7 +102,7 @@ function (chai, p, AuthErrors, Metrics, FxaClient, View, RouterMock, WindowMock,
         windowMock.location.search = '?token=feed&code=dea0fae1abc2fab3bed4dec5eec6ace7';
         return view.render()
             .then(function () {
-              testEventLogged('complete_reset_password:link_damaged');
+              testEventLogged('complete_reset_password.link_damaged');
             })
             .then(function () {
               assert.ok(view.$('#fxa-reset-link-damaged-header').length);
@@ -113,7 +113,7 @@ function (chai, p, AuthErrors, Metrics, FxaClient, View, RouterMock, WindowMock,
         isPasswordResetComplete = true;
         return view.render()
             .then(function () {
-              testEventLogged('complete_reset_password:link_expired');
+              testEventLogged('complete_reset_password.link_expired');
             })
             .then(function () {
               assert.ok(view.$('#fxa-reset-link-expired-header').length);

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -83,7 +83,7 @@ function (chai, p, View, AuthErrors, Metrics, Constants, FxaClient, RouterMock, 
       it('shows an error if uid is not available on the URL', function () {
         return testShowsDamagedScreen('?code=' + validCode)
             .then(function () {
-              testEventLogged('complete_sign_up:link_damaged');
+              testEventLogged('complete_sign_up.link_damaged');
             })
             .then(function () {
               assert.isFalse(view.fxaClient.verifyCode.called);
@@ -93,7 +93,7 @@ function (chai, p, View, AuthErrors, Metrics, Constants, FxaClient, RouterMock, 
       it('shows an error if code is not available on the URL', function () {
         return testShowsDamagedScreen('?uid=' + validUid)
             .then(function () {
-              testEventLogged('complete_sign_up:link_damaged');
+              testEventLogged('complete_sign_up.link_damaged');
             })
             .then(function () {
               assert.isFalse(view.fxaClient.verifyCode.called);
@@ -104,7 +104,7 @@ function (chai, p, View, AuthErrors, Metrics, Constants, FxaClient, RouterMock, 
         verificationError = AuthErrors.toError('INVALID_PARAMETER', 'code');
         return testShowsDamagedScreen()
             .then(function () {
-              testEventLogged('complete_sign_up:link_damaged');
+              testEventLogged('complete_sign_up.link_damaged');
             })
             .then(function () {
               assert.isTrue(view.fxaClient.verifyCode.called);
@@ -115,7 +115,7 @@ function (chai, p, View, AuthErrors, Metrics, Constants, FxaClient, RouterMock, 
         verificationError = AuthErrors.toError('UNKNOWN_ACCOUNT', 'who are you?');
         return testShowsExpiredScreen()
             .then(function () {
-              testEventLogged('complete_sign_up:link_expired');
+              testEventLogged('complete_sign_up.link_expired');
             })
             .then(function () {
               assert.isTrue(view.fxaClient.verifyCode.called);

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -74,7 +74,7 @@ function (chai, p, Session, AuthErrors, Metrics, FxaClient, View, RouterMock, Te
               .then(function () {
                 assert.isTrue(view.$('.success').is(':visible'));
                 assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                  'confirm:resend'));
+                                  'confirm.resend'));
               });
 
       });
@@ -91,7 +91,7 @@ function (chai, p, Session, AuthErrors, Metrics, FxaClient, View, RouterMock, Te
                 assert.equal(routerMock.page, 'signup');
 
                 assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                  'confirm:resend'));
+                                  'confirm.resend'));
               });
       });
 
@@ -156,9 +156,9 @@ function (chai, p, Session, AuthErrors, Metrics, FxaClient, View, RouterMock, Te
                 assert.equal(view.$('#resend:visible').length, 0);
 
                 assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                  'confirm:resend'));
+                                  'confirm.resend'));
                 assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                  'confirm:too_many_attempts'));
+                                  'confirm.too_many_attempts'));
               });
       });
     });

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -181,7 +181,7 @@ function (chai, p, AuthErrors, View, Session, Metrics, FxaClient, RouterMock, Wi
                 assert.equal(routerMock.page, 'reset_password');
 
                 assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                  'confirm_reset_password:resend'));
+                                  'confirm_reset_password.resend'));
               });
       });
 

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -138,7 +138,7 @@ function (chai, p, Session, AuthErrors, Metrics, FxaClient, View, WindowMock, Ro
                     assert.isFalse(view.isErrorVisible());
 
                     assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                      'login:canceled'));
+                                      'login.canceled'));
                   });
       });
     });

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -173,7 +173,7 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient, Translator,
             assert.isFalse(view.isErrorVisible());
 
             assert.isTrue(TestHelpers.isEventLogged(metrics,
-                              'login:canceled'));
+                              'login.canceled'));
           });
       });
 

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -383,7 +383,7 @@ function (chai, _, $, p, View, Session, AuthErrors, Metrics, FxaClient, Translat
             assert.isFalse(view.isErrorVisible());
 
             assert.isTrue(TestHelpers.isEventLogged(metrics,
-                              'login:canceled'));
+                              'login.canceled'));
           });
       });
 


### PR DESCRIPTION
`:` is a special symbol for Kibana, using it here causes queries to be needelessly complex.

For you, @kparlante!

fixes #1601
