### PR TITLE
chore(metrics): Round timestamps to the nearest hour instead of day.

### DIFF
--- a/server/lib/metrics-collector-stderr.js
+++ b/server/lib/metrics-collector-stderr.js
@@ -14,9 +14,9 @@ var OP = 'client.metrics';
 var VERSION = 1;
 
 function addTime(loggableEvent) {
-  // round the date to the nearest day.
+  // round the date to the nearest hour.
   var today = new Date();
-  today.setHours(0, 0, 0, 0);
+  today.setMinutes(0, 0, 0);
   loggableEvent.time = today.toISOString();
 }
 


### PR DESCRIPTION
- This allows us more granularity when querying the metrics DB, without sacraficing user privacy.

Another one for you, @kparlante!

fixes #1602
