### PR TITLE
refactor(client): denodeify jwcrypto calls to reduce boilerplate.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "mocha": "1.18.2",
     "mustache": "0.7.3",
     "normalize-css": "2.1.3",
-    "p": "https://github.com/rkatic/p.git#5e9520f364789db476aad434e3da3b36e4ecc535",
+    "p": "https://github.com/rkatic/p.git#ce57958635f71376a4563ca1ae5820f6fbe1f956",
     "requirejs": "2.1.11",
     "requirejs-mustache": "https://github.com/jfparadis/requirejs-mustache.git#5fb8c0a3e8560526e8f9617a689e2924a8532d0a",
     "requirejs-text": "2.0.10",


### PR DESCRIPTION
@zaach - Mind reviewing? I was trying to figure out how to create JWTs and found a feature in P that could help us reduce boilerplate code when calling node-style callbacks. the P.denodeify function converts node-style callbacks to promise returning functions.
