### PR TITLE
tests(fix): wait for XHR to set the display on the error div

### DIFF
--- a/tests/functional/cookies_disabled.js
+++ b/tests/functional/cookies_disabled.js
@@ -6,8 +6,9 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require'
-], function (intern, registerSuite, assert, require) {
+  'require',
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, require, FunctionalHelpers) {
   'use strict';
 
   // there is no way to disable cookies using wd. Add `disable_cookies`
@@ -38,6 +39,7 @@ define([
         .end()
 
         // show an error message after second try
+        .then(FunctionalHelpers.visibleByQSA('#stage .error'))
         .findByCssSelector('#stage .error').isDisplayed()
         .then(function (isDisplayed) {
           assert.equal(isDisplayed, true);


### PR DESCRIPTION
@vladikoff - I realize that waitForVisibleByCssSelector is deprecated in leadfoot, so what is the correct way (if it exists) to handle this case: an element exists in the DOM but is only displayed after an XHR returns. 

The way it is right now, `.findByCssSelector('#stage .error').isDisplayed()` wins the race over `.findById('submit-btn').click()` and the test incorrectly fails when run on a remote server.

If there's a better pattern to use, let me know and I'll update the PR. Thanks.
