### PR TITLE
Hang the logo over the stage at 320px

### DIFF
--- a/app/styles/_media_queries.scss
+++ b/app/styles/_media_queries.scss
@@ -130,14 +130,6 @@ only screen and (orientation:landscape) and (min-width:481px) and (max-height:48
   }
 }
 
-@media only screen and (max-width: 320px) {
-  #main-content {
-    margin: 0 auto;
-    min-height: 0;
-    width: 94%;
-  }
-}
-
 //You know...for the trusted UI
 @media only screen and (max-width:319px) {
 


### PR DESCRIPTION
At 320px the logo is showing up above the stage. The 320px media query gets overridden at 319px so this is the only point that the logo doesn't line up right.

![screen shot 2014-09-05 at 10 41 03](https://cloud.githubusercontent.com/assets/211578/4322691/9aab109e-3f4a-11e4-8696-5d24560e2899.png)
Before

![screen shot 2014-09-05 at 10 41 41](https://cloud.githubusercontent.com/assets/211578/4322690/9aa9c87e-3f4a-11e4-955f-20362df51561.png)
After
