### PR TITLE
fix(client): Auto-focus the password field on the /delete_account page.

### DIFF
--- a/app/scripts/templates/delete_account.mustache
+++ b/app/scripts/templates/delete_account.mustache
@@ -11,7 +11,7 @@
       <p class="prefill">{{ email }}</p>
 
       <div class="input-row password-row">
-        <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required autocomplete="off" />
+        <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required autofocus autocomplete="off" />
 
         <input id="show-password" type="checkbox" class="show-password" aria-controls="password" tabindex="-1" data-novalue />
         <label for="show-password" class="show-password-label">


### PR DESCRIPTION
fixes #1672
