### PR TITLE
fix(tests): Fix the oauth_webchannel tests when run by themselves.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -9,9 +9,22 @@ define([
 ], function (intern, require, pollUntil) {
   'use strict';
 
+  var config = intern.config;
+  var CONTENT_SERVER = config.fxaContentRoot;
+
   function clearBrowserState(context) {
     // clear localStorage to avoid polluting other tests.
     return context.get('remote')
+      // always go to the content server so the browser state is cleared
+      .setFindTimeout(config.pageLoadTimeout)
+      .getCurrentUrl()
+      .then(function (url) {
+        // only load up the content server if we aren't
+        // already at the content server.
+        if (url.indexOf(CONTENT_SERVER) === -1) {
+          return context.get('remote').get(require.toUrl(CONTENT_SERVER));
+        }
+      })
       .execute(function () {
         try {
           /* global document, localStorage, sessionStorage */

--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -70,13 +70,7 @@ define([
         })
         .then(function () {
           // clear localStorage to avoid polluting other tests.
-          return self.get('remote')
-            // always go to the content server so the browser state is cleared
-            .get(require.toUrl(CONTENT_SERVER))
-            .setFindTimeout(intern.config.pageLoadTimeout)
-            .then(function () {
-              return FunctionalHelpers.clearBrowserState(self);
-            });
+          return FunctionalHelpers.clearBrowserState(self);
         });
     },
 

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -16,7 +16,6 @@ define([
   'use strict';
 
   var config = intern.config;
-  var CONTENT_SERVER = config.fxaContentRoot;
   var OAUTH_APP = config.fxaOauthApp;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
@@ -34,17 +33,10 @@ define([
     },
 
     beforeEach: function () {
-      var self = this;
       // clear localStorage to avoid polluting other tests.
       // Without the clear, /signup tests fail because of the info stored
       // in prefillEmail
-      return self.get('remote')
-        // always go to the content server so the browser state is cleared
-        .get(require.toUrl(CONTENT_SERVER))
-        .setFindTimeout(intern.config.pageLoadTimeout)
-        .then(function () {
-          return FunctionalHelpers.clearBrowserState(self);
-        });
+      return FunctionalHelpers.clearBrowserState(this);
     },
 
     'basic sign up': function () {

--- a/tests/functional/oauth_webchannel.js
+++ b/tests/functional/oauth_webchannel.js
@@ -76,10 +76,6 @@ define([
         .click()
         .end()
 
-        .findByCssSelector('.use-different')
-        .click()
-        .end()
-
         .findByCssSelector('form input.email')
         .end()
 
@@ -102,10 +98,6 @@ define([
 
           return true;
         }, [ OAUTH_APP ])
-
-        .findByCssSelector('.use-different')
-        .click()
-        .end()
 
         .findByCssSelector('form input.email')
         .clearValue()


### PR DESCRIPTION
@vladikoff - could you review this?

In beforeEach, FunctionalHelpers.clearBrowserState was being called before any page was loaded, meaning localStorage and sessionStorage were not being cleared for the content server. This has the side effect that the tests contained a subtle bug where they unknowingly depended on other tests to sign a user in.

The fix is to load the content server's page before running FunctionalHelpers.clearBrowserState.

fixes #1669 
