### PR TITLE
fix(client): autofocus the password field on /oauth/signin if the user already has a session.

### DIFF
--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -33,7 +33,7 @@
             <input type="hidden" class="email" value="{{ email }}" />
 
             <div class="input-row password-row">
-              <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autocomplete="off" />
+              <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autocomplete="off" autofocus />
 
               <input id="show-password" type="checkbox" class="show-password" aria-controls="password" tabindex="-1" data-novalue />
               <label for="show-password" class="show-password-label">


### PR DESCRIPTION
fixes #1679
