### PR TITLE
fix(tests): Fix some places that race with an XHR response return

### DIFF
--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -260,7 +260,9 @@ define([
         .end()
 
         // uh oh, user must verify their account.
+        .then(FunctionalHelpers.visibleByQSA('#resend'))
         .findById('resend')
+          .moveMouseTo()
           .click()
         .end()
 

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -381,7 +381,9 @@ define([
         .end()
 
         // The error area shows a link to /signup
+        .then(FunctionalHelpers.visibleByQSA('.error a[href="/signup"]'))
         .findByCssSelector('.error a[href="/signup"]')
+          .moveMouseTo()
           .click()
         .end()
 

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -180,7 +180,9 @@ define([
         .end()
 
         // The error area shows a link to /signup
+        .then(FunctionalHelpers.visibleByQSA('.error a[href="/signup"]'))
         .findByCssSelector('.error a[href="/signup"]')
+          .moveMouseTo()
           .click()
         .end()
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -189,7 +189,9 @@ define([
             .end()
 
             // The error area shows a link to /signin
+            .then(FunctionalHelpers.visibleByQSA('.error a[href="/signin"]'))
             .findByCssSelector('.error a[href="/signin"]')
+              .moveMouseTo()
               .click()
             .end()
 


### PR DESCRIPTION
Notes: 
1. these call sites were found by continuous loops of tests on ubuntu, but have also been seen on travis.
2. the `moveMouseTo` calls are to address some cases where the test would fail with 'MoveTargetOutOfBounds: ... Element cannot be scrolled into view' because the element to be clicked was not in (or not fully in?) the viewport. (Not sure why leadfoot could not automatically do the scroll to element before clicking it, as a human would).
