### PR TITLE
fix(avatars): set the correct OAuth client ID for fxa-dev environment

### DIFF
--- a/server/config/awsbox.json
+++ b/server/config/awsbox.json
@@ -1,6 +1,7 @@
 {
   "fxaccount_url": "https://api-accounts.dev.lcip.org",
   "oauth_url": "https://oauth.dev.lcip.org",
+  "oauth_client_id": "ea3ca969f8c6bb0d",
   "static_directory": "dist",
   "page_template_subdirectory": "dist",
   "static_max_age" : 0,


### PR DESCRIPTION
Fixes #1683.

@ckarlof r?
