### PR TITLE
 chore(tests): Replace calls to require.toUrl with FunctionalHelpers.toUrl, a function that makes adding query parameters to a URL more readable.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -83,7 +83,7 @@ function (_, Backbone, $, p, Session, AuthErrors,
       this.fxaClient = options.fxaClient;
       this.profileClient = options.profileClient;
 
-      this.automatedBrowser = !!this.searchParam('automatedBrowser');
+      this.automatedBrowser = this.searchParam('automatedBrowser') === 'true';
 
       Backbone.View.call(this, options);
     },

--- a/tests/functional/404.js
+++ b/tests/functional/404.js
@@ -6,8 +6,8 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require'
-], function (intern, registerSuite, assert, require) {
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   'use strict';
 
   var url = intern.config.fxaContentRoot + 'four-oh-four';
@@ -18,7 +18,7 @@ define([
     'visit an invalid page': function () {
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(FunctionalHelpers.toUrl(url))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findById('fxa-404-home')
           .click()

--- a/tests/functional/500.js
+++ b/tests/functional/500.js
@@ -6,8 +6,8 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require'
-], function (intern, registerSuite, assert, require) {
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   'use strict';
 
   var url = intern.config.fxaContentRoot + 'boom';
@@ -19,7 +19,7 @@ define([
       var expected = intern.config.fxaProduction ? 'fxa-404-home' : 'fxa-500-home';
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(FunctionalHelpers.toUrl(url))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findById(expected)
           .click()

--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -6,21 +6,25 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'app/scripts/lib/constants',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Constants, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, Constants, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
   var AVATAR_URL = config.fxaContentRoot + 'settings/avatar';
   var AVATAR_CHANGE_URL = config.fxaContentRoot + 'settings/avatar/change';
-  var AVATAR_CHANGE_URL_AUTOMATED = config.fxaContentRoot + 'settings/avatar/change?automatedBrowser=true';
+  var AVATAR_CHANGE_URL_AUTOMATED = toUrl(AVATAR_CHANGE_URL, {
+    query: {
+      automatedBrowser: true
+    }
+  });
 
   var PASSWORD = 'password';
   var email;
@@ -45,7 +49,7 @@ define([
         })
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(SIGNIN_URL))
+            .get(toUrl(SIGNIN_URL))
             // This will configure the timeout for the duration of this test suite
             .setFindTimeout(intern.config.pageLoadTimeout)
             .findByCssSelector('form input.email')
@@ -81,7 +85,7 @@ define([
         })
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(SIGNIN_URL))
+            .get(toUrl(SIGNIN_URL))
             .findByCssSelector('form input.email')
               .click()
               .type(email2)
@@ -99,7 +103,7 @@ define([
             .findById('fxa-confirm-header')
             .end()
 
-            .get(require.toUrl(AVATAR_URL))
+            .get(toUrl(AVATAR_URL))
 
             // success is going to the confirm page
             .findById('fxa-confirm-header')
@@ -109,7 +113,7 @@ define([
 
     'go to avatars then avatar change': function () {
       return this.get('remote')
-        .get(require.toUrl(AVATAR_URL))
+        .get(toUrl(AVATAR_URL))
 
         // go to change avatar
         .findById('change-avatar')
@@ -123,7 +127,7 @@ define([
 
     'visit gravatar with gravatar set': function () {
       return this.get('remote')
-        .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
+        .get(toUrl(AVATAR_CHANGE_URL_AUTOMATED))
 
         // go to change avatar
         .findById('gravatar')
@@ -157,7 +161,7 @@ define([
 
     'visit gravatar with gravatar set then cancel': function () {
       return this.get('remote')
-        .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
+        .get(toUrl(AVATAR_CHANGE_URL_AUTOMATED))
 
         // go to change avatar
         .findById('gravatar')
@@ -191,7 +195,7 @@ define([
     },
     'visit gravatar with no gravatar set': function () {
       return this.get('remote')
-        .get(require.toUrl(AVATAR_CHANGE_URL))
+        .get(toUrl(AVATAR_CHANGE_URL))
 
         // go to change avatar
         .findById('gravatar')
@@ -213,7 +217,7 @@ define([
 
     'attempt to use webcam for avatar': function () {
       return this.get('remote')
-        .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
+        .get(toUrl(AVATAR_CHANGE_URL_AUTOMATED))
 
         // go to change avatar
         .findById('camera')
@@ -231,7 +235,7 @@ define([
 
     'attempt to use webcam for avatar, then cancel': function () {
       return this.get('remote')
-        .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
+        .get(toUrl(AVATAR_CHANGE_URL_AUTOMATED))
 
         // go to change avatar
         .findById('camera')
@@ -249,7 +253,7 @@ define([
 
     'upload a profile image': function () {
       return this.get('remote')
-        .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
+        .get(toUrl(AVATAR_CHANGE_URL_AUTOMATED))
 
         // go to change avatar
         .findById('imageLoader')
@@ -286,7 +290,7 @@ define([
 
     'cancel uploading a profile image': function () {
       return this.get('remote')
-        .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
+        .get(toUrl(AVATAR_CHANGE_URL_AUTOMATED))
 
         // go to change avatar
         .findById('imageLoader')

--- a/tests/functional/back_button_after_start.js
+++ b/tests/functional/back_button_after_start.js
@@ -6,11 +6,12 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require'
-], function (intern, registerSuite, assert, require) {
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   'use strict';
 
-  var FROM_URL = 'http://example.com/';
+  var toUrl = FunctionalHelpers.toUrl;
+  var FROM_URL = toUrl('http://example.com/');
   var FXA_ROOT_URL = intern.config.fxaContentRoot;
 
   registerSuite({
@@ -18,8 +19,8 @@ define([
 
     'start at github, visit Fxa root, click `back` - should go back to example': function () {
       return this.get('remote')
-        .get(require.toUrl(FROM_URL))
-        .get(require.toUrl(FXA_ROOT_URL))
+        .get(FROM_URL)
+        .get(toUrl(FXA_ROOT_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findById('fxa-signup-header')
 

--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -6,15 +6,15 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
   var CHANGE_PASSWORD_URL = config.fxaContentRoot + 'change_password';
@@ -59,7 +59,7 @@ define([
 
     'sign in, try to change password with an incorrect old password': function () {
       return this.get('remote')
-        .get(require.toUrl(SIGNIN_URL))
+        .get(toUrl(SIGNIN_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('form input.email')
           .click()
@@ -133,7 +133,7 @@ define([
 
     'sign in, change password, sign in with new password': function () {
       return this.get('remote')
-        .get(require.toUrl(SIGNIN_URL))
+        .get(toUrl(SIGNIN_URL))
         .findByCssSelector('form input.email')
           .click()
           .type(email)
@@ -178,7 +178,7 @@ define([
           })
         .end()
 
-        .get(require.toUrl(SIGNIN_URL))
+        .get(toUrl(SIGNIN_URL))
 
         .findByCssSelector('.use-different')
           .click()
@@ -224,7 +224,7 @@ define([
 
     'sign in, change password screen, user must verifiy account': function () {
       return this.get('remote')
-        .get(require.toUrl(SIGNIN_URL))
+        .get(toUrl(SIGNIN_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('form input.email')
           .click()
@@ -244,7 +244,7 @@ define([
         .end()
 
         // unverified user browses directly to change password page.
-        .get(require.toUrl(CHANGE_PASSWORD_URL))
+        .get(toUrl(CHANGE_PASSWORD_URL))
         .findById('old_password')
           .click()
           .type(FIRST_PASSWORD)

--- a/tests/functional/complete_sign_up.js
+++ b/tests/functional/complete_sign_up.js
@@ -6,17 +6,17 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'app/scripts/lib/constants',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Constants, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, Constants, restmail, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
   var PAGE_URL_ROOT = config.fxaContentRoot + 'verify_email';
@@ -63,7 +63,7 @@ define([
 
       return this.get('remote')
         .setFindTimeout(intern.config.pageLoadTimeout)
-        .get(require.toUrl(url))
+        .get(toUrl(url))
 
         // a successful user is immediately redirected to the
         // sign-up-complete page.
@@ -77,7 +77,7 @@ define([
       var url = PAGE_URL_ROOT + '?uid=' + uid + '&code=' + code;
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
 
         // a successful user is immediately redirected to the
         // sign-up-complete page.
@@ -90,7 +90,7 @@ define([
       var url = PAGE_URL_ROOT + '?uid=' + uid + '&code=' + code;
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
 
         // a successful user is immediately redirected to the
         // sign-up-complete page.
@@ -103,7 +103,7 @@ define([
       var url = PAGE_URL_ROOT + '?uid=' + uid + '&code=' + code;
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
 
         // a successful user is immediately redirected to the
         // sign-up-complete page.
@@ -115,7 +115,7 @@ define([
       var url = PAGE_URL_ROOT + '?uid=' + uid + '&code=' + code;
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
 
         // a successful user is immediately redirected to the
         // sign-up-complete page.
@@ -152,7 +152,7 @@ define([
       var url = PAGE_URL_ROOT + '?uid=' + uid + '&code=' + code;
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
 
         .findById('fxa-verification-link-expired-header')
         .end()
@@ -199,7 +199,7 @@ define([
       return client.signUp(email, PASSWORD)
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(SIGNUP_PAGE_URL))
+            .get(toUrl(SIGNUP_PAGE_URL))
             .setFindTimeout(intern.config.pageLoadTimeout)
             .findById('fxa-signup-header')
             .end()
@@ -232,7 +232,7 @@ define([
             .findById('fxa-confirm-header')
             .end()
 
-            .get(require.toUrl(completeUrl))
+            .get(toUrl(completeUrl))
 
             .findById('fxa-verification-link-expired-header')
             .end()

--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -6,14 +6,14 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'intern/dojo/node!leadfoot/helpers/pollUntil'
-], function (intern, registerSuite, assert, require, TestHelpers, FunctionalHelpers, pollUntil) {
+], function (intern, registerSuite, assert, TestHelpers, FunctionalHelpers, pollUntil) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var CONFIRM_URL = config.fxaContentRoot + 'confirm';
   var SIGNUP_URL = config.fxaContentRoot + 'signup';
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
@@ -28,7 +28,7 @@ define([
 
     'visit confirmation screen without initiating sign up, user is redirected to /signup': function () {
       return this.get('remote')
-        .get(require.toUrl(CONFIRM_URL))
+        .get(toUrl(CONFIRM_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
 
         // user is immediately redirected to /signup if they have no
@@ -42,7 +42,7 @@ define([
       var password = '12345678';
 
       return this.get('remote')
-        .get(require.toUrl(SIGNUP_URL))
+        .get(toUrl(SIGNUP_URL))
         .findByCssSelector('form input.email')
           .click()
           .type(email)

--- a/tests/functional/cookies_disabled.js
+++ b/tests/functional/cookies_disabled.js
@@ -6,14 +6,14 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, FunctionalHelpers) {
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   'use strict';
 
   // there is no way to disable cookies using wd. Add `disable_cookies`
   // to the URL to synthesize cookies being disabled.
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var SIGNUP_COOKIES_DISABLED_URL = config.fxaContentRoot + 'signup?disable_local_storage=1';
   var SIGNUP_COOKIES_ENABLED_URL = config.fxaContentRoot + 'signup';
 
@@ -28,7 +28,7 @@ define([
 
     'visit signup page with localStorage disabled': function () {
       return this.get('remote')
-        .get(require.toUrl(SIGNUP_COOKIES_DISABLED_URL))
+        .get(toUrl(SIGNUP_COOKIES_DISABLED_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findById('fxa-cookies-disabled-header')
         .end()
@@ -48,13 +48,13 @@ define([
 
     'synthesize enabling cookies by visiting the sign up page, then cookies_disabled, then clicking "try again"': function () {
       return this.get('remote')
-        .get(require.toUrl(SIGNUP_COOKIES_ENABLED_URL))
+        .get(toUrl(SIGNUP_COOKIES_ENABLED_URL))
         // wd has no way of disabling/enabling cookies, so we have to
         // manually seed history.
         .findById('fxa-signup-header')
         .end()
 
-        .get(require.toUrl(COOKIES_DISABLED_URL))
+        .get(toUrl(COOKIES_DISABLED_URL))
 
         .findById('fxa-cookies-disabled-header')
         .end()
@@ -70,7 +70,7 @@ define([
 
     'visit verify page with localStorage disabled': function () {
       return this.get('remote')
-        .get(require.toUrl(VERIFY_COOKIES_DISABLED_URL))
+        .get(toUrl(VERIFY_COOKIES_DISABLED_URL))
 
         .findById('fxa-cookies-disabled-header')
         .end();

--- a/tests/functional/fonts.js
+++ b/tests/functional/fonts.js
@@ -6,12 +6,13 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require'
-], function (intern, registerSuite, assert, require) {
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   'use strict';
 
   var url = intern.config.fxaContentRoot + 'signin';
   var nonFiraUrl = intern.config.fxaContentRoot + 'zh-CN/legal/privacy';
+  var toUrl = FunctionalHelpers.toUrl;
 
   registerSuite({
     name: 'fonts',
@@ -22,7 +23,7 @@ define([
     'Uses Fira for en-US': function () {
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .setFindTimeout(intern.config.pageLoadTimeout)
 
         .findByCssSelector('#fxa-signin-header')
@@ -43,7 +44,7 @@ define([
     'Does not use Fira for non-supported locale': function () {
 
       return this.get('remote')
-        .get(require.toUrl(nonFiraUrl))
+        .get(toUrl(nonFiraUrl))
 
         .findByCssSelector('#fxa-pp-header')
           .getComputedStyle('font-family')

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -6,17 +6,17 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'intern/node_modules/dojo/Deferred',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Deferred, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, Deferred, restmail, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
   var FORCE_AUTH_URL = config.fxaContentRoot + 'force_auth';
@@ -57,7 +57,7 @@ define([
     'sign in via force-auth': function () {
       return this.get('remote')
         .setFindTimeout(intern.config.pageLoadTimeout)
-        .get(require.toUrl(FORCE_AUTH_URL + '?email=' + email))
+        .get(toUrl(FORCE_AUTH_URL + '?email=' + email))
         .findByCssSelector('form input.password')
           .click()
           .type(PASSWORD)
@@ -74,7 +74,7 @@ define([
     'forgot password flow via force-auth goes directly to confirm email screen': function () {
       return this.get('remote')
         .setFindTimeout(intern.config.pageLoadTimeout)
-        .get(require.toUrl(FORCE_AUTH_URL + '?email=' + email))
+        .get(toUrl(FORCE_AUTH_URL + '?email=' + email))
         .findByCssSelector('.reset-password')
           .click()
         .end()
@@ -108,7 +108,7 @@ define([
 
     return self.get('remote')
       .setFindTimeout(intern.config.pageLoadTimeout)
-      .get(require.toUrl(FORCE_AUTH_URL + '?email=' + email))
+      .get(toUrl(FORCE_AUTH_URL + '?email=' + email))
       .findByCssSelector('input[type=password]')
         .clearValue()
         .click()

--- a/tests/functional/legal.js
+++ b/tests/functional/legal.js
@@ -6,11 +6,12 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require'
-], function (intern, registerSuite, assert, require) {
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   'use strict';
 
   var url = intern.config.fxaContentRoot + 'legal';
+  var toUrl = FunctionalHelpers.toUrl;
 
   registerSuite({
     name: 'legal',
@@ -21,7 +22,7 @@ define([
     'start at legal page': function () {
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('a[href="/legal/terms"]')
           .click()
@@ -48,7 +49,7 @@ define([
     'start at terms page': function () {
 
       return this.get('remote')
-        .get(require.toUrl(url + '/terms'))
+        .get(toUrl(url + '/terms'))
 
         .findByCssSelector('#main-content')
         .end()
@@ -65,7 +66,7 @@ define([
     'start at privacy page': function () {
 
       return this.get('remote')
-        .get(require.toUrl(url + '/privacy'))
+        .get(toUrl(url + '/privacy'))
 
         .findByCssSelector('#main-content')
         .end()

--- a/tests/functional/mocha.js
+++ b/tests/functional/mocha.js
@@ -8,13 +8,14 @@ define([
   'intern/chai!assert',
   'intern/dojo/node!../../server/lib/configuration',
   'intern/dojo/Deferred',
-  'require',
+  'tests/functional/lib/helpers',
   'intern/node_modules/dojo/has!host-node?intern/node_modules/dojo/node!child_process'
-], function (intern, registerSuite, assert, config, Deferred, require, child_process) {
+], function (intern, registerSuite, assert, config, Deferred, FunctionalHelpers, child_process) {
   'use strict';
 
   /* global process */
   var travis = process && process.env.TRAVIS_COMMIT;
+  var toUrl = FunctionalHelpers.toUrl;
   var url = intern.config.fxaContentRoot + 'tests/index.html?coverage';
   if (travis) {
     url += '&travis=true';
@@ -32,7 +33,7 @@ define([
 
       return this.get('remote')
         .setFindTimeout(this.timeout)
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .refresh()
         // let the mocha reporter load up
         .sleep(MOCHA_LOADER_SLEEP)

--- a/tests/functional/oauth_preverified_sign_up.js
+++ b/tests/functional/oauth_preverified_sign_up.js
@@ -6,16 +6,16 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var CONTENT_SERVER = config.fxaContentRoot;
   var OAUTH_APP = config.fxaOauthApp;
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
@@ -39,7 +39,7 @@ define([
       // in prefillEmail
       return self.get('remote')
         // always go to the content server so the browser state is cleared
-        .get(require.toUrl(CONTENT_SERVER))
+        .get(toUrl(CONTENT_SERVER))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .then(function () {
           return FunctionalHelpers.clearBrowserState(self);
@@ -53,7 +53,7 @@ define([
                         'email=' + encodeURIComponent(email);
 
       return self.get('remote')
-        .get(require.toUrl(SIGNUP_URL))
+        .get(toUrl(SIGNUP_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
 
         .findByCssSelector('#fxa-signup-header')

--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -6,16 +6,16 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var OAUTH_APP = config.fxaOauthApp;
 
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
@@ -70,7 +70,7 @@ define([
         })
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(OAUTH_APP))
+            .get(toUrl(OAUTH_APP))
             .setFindTimeout(intern.config.pageLoadTimeout)
             .findByCssSelector('.signin')
             .click()
@@ -110,7 +110,7 @@ define([
               return FunctionalHelpers.getVerificationLink(user, 1);
             })
             .then(function (url) {
-              return self.get('remote').get(require.toUrl(url));
+              return self.get('remote').get(toUrl(url));
             })
             .end()
 
@@ -186,7 +186,7 @@ define([
         })
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(OAUTH_APP))
+            .get(toUrl(OAUTH_APP))
             .setFindTimeout(intern.config.pageLoadTimeout)
             .findByCssSelector('.signin')
             .click()
@@ -231,7 +231,7 @@ define([
               return FunctionalHelpers.getVerificationLink(user, 1);
             })
             .then(function (url) {
-              return self.get('remote').get(require.toUrl(url));
+              return self.get('remote').get(toUrl(url));
             })
             .end()
 

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -6,16 +6,16 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var CONTENT_SERVER = config.fxaContentRoot;
   var OAUTH_APP = config.fxaOauthApp;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
@@ -38,13 +38,13 @@ define([
 
       return self.get('remote')
         // always go to the content server so the browser state is cleared
-        .get(require.toUrl(CONTENT_SERVER))
+        .get(toUrl(CONTENT_SERVER))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .then(function () {
           return FunctionalHelpers.clearBrowserState(self);
         })
         // sign up, do not verify steps
-        .get(require.toUrl(OAUTH_APP))
+        .get(toUrl(OAUTH_APP))
         .findByCssSelector('#splash .signup')
         .click()
         .end()
@@ -85,13 +85,13 @@ define([
         .then(function (emails) {
 
           return self.get('remote')
-            .get(require.toUrl(emails[0].headers['x-link']))
+            .get(toUrl(emails[0].headers['x-link']))
 
             // wait for confirmation
             .findById('fxa-sign-up-complete-header')
             .end()
             // sign in with a verified account
-            .get(require.toUrl(OAUTH_APP))
+            .get(toUrl(OAUTH_APP))
             .findByCssSelector('#splash .signin')
             .click()
             .end()
@@ -168,13 +168,13 @@ define([
         .then(function (emails) {
 
           return self.get('remote')
-            .get(require.toUrl(emails[0].headers['x-link']))
+            .get(toUrl(emails[0].headers['x-link']))
 
             // wait for confirmation
             .findById('fxa-sign-up-complete-header')
             .end()
             // sign in with a verified account
-            .get(require.toUrl(OAUTH_APP))
+            .get(toUrl(OAUTH_APP))
             .findByCssSelector('#splash .signin')
             .click()
             .end()
@@ -230,7 +230,7 @@ define([
 
       return this.get('remote')
         // Step 2: Try to sign in, unverified
-        .get(require.toUrl(OAUTH_APP))
+        .get(toUrl(OAUTH_APP))
         .findByCssSelector('#splash .signin')
         .click()
         .end()
@@ -272,7 +272,7 @@ define([
             .then(function (emails) {
               var verifyUrl = emails[0].headers['x-link'];
               return self.get('remote')
-                .get(require.toUrl(verifyUrl))
+                .get(toUrl(verifyUrl))
                 .findByCssSelector('#redirectTo')
                 .click()
                 .end()
@@ -314,7 +314,7 @@ define([
     },
     'unverified with a cached login': function () {
       return this.get('remote')
-        .get(require.toUrl(OAUTH_APP))
+        .get(toUrl(OAUTH_APP))
         .findByCssSelector('#splash .signin')
         .click()
         .end()

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -6,16 +6,16 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var OAUTH_APP = config.fxaOauthApp;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
@@ -41,7 +41,7 @@ define([
       var self = this;
 
       return this.get('remote')
-        .get(require.toUrl(OAUTH_APP))
+        .get(toUrl(OAUTH_APP))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('.signup')
           .click()
@@ -91,7 +91,7 @@ define([
           return restmail(EMAIL_SERVER_ROOT + '/mail/' + user)
             .then(function (emails) {
               return self.get('remote')
-                .get(require.toUrl(emails[0].headers['x-link']));
+                .get(toUrl(emails[0].headers['x-link']));
             });
         })
         .end()
@@ -122,7 +122,7 @@ define([
       var self = this;
 
       return this.get('remote')
-        .get(require.toUrl(OAUTH_APP))
+        .get(toUrl(OAUTH_APP))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('.signup')
           .click()
@@ -175,7 +175,7 @@ define([
           return restmail(EMAIL_SERVER_ROOT + '/mail/' + user)
             .then(function (emails) {
               return self.get('remote')
-                .get(require.toUrl(emails[0].headers['x-link']));
+                .get(toUrl(emails[0].headers['x-link']));
             });
         })
         .end()

--- a/tests/functional/oauth_webchannel.js
+++ b/tests/functional/oauth_webchannel.js
@@ -6,16 +6,16 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var OAUTH_APP = config.fxaOauthApp;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
@@ -62,7 +62,7 @@ define([
             })
             .then(function (emails) {
               return self.get('remote')
-                .get(require.toUrl(emails[0].headers['x-link']));
+                .get(toUrl(emails[0].headers['x-link']));
             });
         })
 
@@ -71,7 +71,7 @@ define([
         .end()
 
         // sign in with a verified account via OAUTH_APP uri
-        .get(require.toUrl(OAUTH_APP))
+        .get(toUrl(OAUTH_APP))
         .findByCssSelector('#splash .signin')
         .click()
         .end()
@@ -83,7 +83,7 @@ define([
         .then(function (url) {
           return self.get('remote')
             // add "&webChannelId=test" to the OAuth login url to signal that this is a WebChannel flow
-            .get(require.toUrl(url + '&webChannelId=test'));
+            .get(toUrl(url + '&webChannelId=test'));
         })
 
         .execute(function (OAUTH_APP) {
@@ -127,7 +127,7 @@ define([
 
       return self.get('remote')
         // sign up, do not verify steps
-        .get(require.toUrl(OAUTH_APP))
+        .get(toUrl(OAUTH_APP))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('#splash .signup')
         .click()
@@ -137,7 +137,7 @@ define([
 
           return self.get('remote')
             // add '&webChannelId=test' to the current url, which is the confirmation screen
-            .get(require.toUrl(url + '&webChannelId=test'));
+            .get(toUrl(url + '&webChannelId=test'));
         })
         .execute(function (OAUTH_APP) {
           // this event will fire once the account is confirmed, helping it redirect to the application

--- a/tests/functional/pages.js
+++ b/tests/functional/pages.js
@@ -6,11 +6,12 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require'
-], function (intern, registerSuite, assert, require) {
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   'use strict';
 
   var url = intern.config.fxaContentRoot;
+  var toUrl = FunctionalHelpers.toUrl;
 
   var pages = [
     'v1/complete_reset_password',
@@ -60,7 +61,7 @@ define([
   var visitFn = function (path) {
     return function () {
       return this.get('remote')
-        .get(require.toUrl(url + path))
+        .get(toUrl(url + path))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('#stage header')
         .end();

--- a/tests/functional/pp.js
+++ b/tests/functional/pp.js
@@ -6,13 +6,13 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'tests/functional/lib/helpers',
-  'require'
-], function (intern, registerSuite, assert, FunctionalHelpers, require) {
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   'use strict';
 
   var PAGE_URL = intern.config.fxaContentRoot + 'signup';
   var PP_URL = intern.config.fxaContentRoot + 'legal/privacy';
+  var toUrl = FunctionalHelpers.toUrl;
 
   registerSuite({
     name: 'pp',
@@ -24,7 +24,7 @@ define([
     'start at signup': function () {
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findById('fxa-pp')
           .click()
@@ -46,7 +46,7 @@ define([
     'start at privacy': function () {
 
       return this.get('remote')
-        .get(require.toUrl(PP_URL))
+        .get(toUrl(PP_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
 
         .findById('fxa-pp-header')

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -6,17 +6,17 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'intern/node_modules/dojo/Deferred',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Deferred, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, Deferred, restmail, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
   var SIGNIN_PAGE_URL = config.fxaContentRoot + 'signin';
@@ -66,7 +66,7 @@ define([
 
     'visit confirmation screen without initiating reset_password, user is redirected to /reset_password': function () {
       return this.get('remote')
-        .get(require.toUrl(CONFIRM_PAGE_URL))
+        .get(toUrl(CONFIRM_PAGE_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
 
         // user is immediately redirected to /reset_password if they have no
@@ -77,7 +77,7 @@ define([
 
     'open /reset_password page from /signin': function () {
       return this.get('remote')
-        .get(require.toUrl(SIGNIN_PAGE_URL))
+        .get(toUrl(SIGNIN_PAGE_URL))
         .findByCssSelector('a[href="/reset_password"]')
           .click()
         .end()
@@ -97,7 +97,7 @@ define([
 
     'open confirm_reset_password page, click resend': function () {
       return this.get('remote')
-        .get(require.toUrl(CONFIRM_PAGE_URL))
+        .get(toUrl(CONFIRM_PAGE_URL))
         .findById('resend')
           .click()
         .end()
@@ -137,7 +137,7 @@ define([
       var url = COMPLETE_PAGE_URL_ROOT + '?code=' + code + '&email=' + encodeURIComponent(email);
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .findById('fxa-reset-link-damaged-header')
         .end();
     },
@@ -147,7 +147,7 @@ define([
       var url = COMPLETE_PAGE_URL_ROOT + '?token=' + malformedToken + '&code=' + code + '&email=' + encodeURIComponent(email);
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .findById('fxa-reset-link-damaged-header')
         .end();
     },
@@ -157,7 +157,7 @@ define([
       var url = COMPLETE_PAGE_URL_ROOT + '?token=' + invalidToken + '&code=' + code + '&email=' + encodeURIComponent(email);
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .findById('fxa-reset-link-expired-header')
         .end();
     },
@@ -166,7 +166,7 @@ define([
       var url = COMPLETE_PAGE_URL_ROOT + '?token=' + token + '&email=' + encodeURIComponent(email);
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .findById('fxa-reset-link-damaged-header')
         .end();
     },
@@ -176,7 +176,7 @@ define([
       var url = COMPLETE_PAGE_URL_ROOT + '?token=' + token + '&code=' + malformedCode + '&email=' + encodeURIComponent(email);
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .findById('fxa-reset-link-damaged-header')
         .end();
     },
@@ -185,7 +185,7 @@ define([
       var url = COMPLETE_PAGE_URL_ROOT + '?token=' + token + '&code=' + code;
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .findById('fxa-reset-link-damaged-header')
         .end();
     },
@@ -194,7 +194,7 @@ define([
       var url = COMPLETE_PAGE_URL_ROOT + '?token=' + token + '&code=' + code + '&email=invalidemail';
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .findById('fxa-reset-link-damaged-header')
         .end();
     },
@@ -203,7 +203,7 @@ define([
       var url = COMPLETE_PAGE_URL_ROOT + '?token=' + token + '&code=' + code + '&email=' + encodeURIComponent(email);
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .findByCssSelector('form input#password')
           .click()
           .type(PASSWORD)
@@ -250,7 +250,7 @@ define([
       var url = COMPLETE_PAGE_URL_ROOT + '?token=' + token + '&code=' + code + '&email=' + encodeURIComponent(email);
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('form input#password')
           .click()
@@ -274,7 +274,7 @@ define([
       var url = COMPLETE_PAGE_URL_ROOT + '?token=' + token + '&code=' + code + '&email=' + encodeURIComponent(email);
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .findById('fxa-reset-link-expired-header')
         .end()
 
@@ -302,7 +302,7 @@ define([
     'open page with email on query params': function () {
       var url = RESET_PAGE_URL + '?email=' + email;
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('form input.email')
           .getAttribute('value')
@@ -338,7 +338,7 @@ define([
 
     'page transitions after completion': function () {
       return this.get('remote')
-        .get(require.toUrl(RESET_PAGE_URL))
+        .get(toUrl(RESET_PAGE_URL))
         .findByCssSelector('form input.email')
           .click()
           .type(email)
@@ -369,7 +369,7 @@ define([
 
     'open /reset_password page, enter unknown email': function () {
       return this.get('remote')
-        .get(require.toUrl(RESET_PAGE_URL))
+        .get(toUrl(RESET_PAGE_URL))
         .findByCssSelector('input[type=email]')
           .click()
           .clearValue()

--- a/tests/functional/robots_txt.js
+++ b/tests/functional/robots_txt.js
@@ -6,11 +6,12 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require'
-], function (intern, registerSuite, assert, require) {
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   'use strict';
 
   var url = intern.config.fxaContentRoot + 'robots.txt';
+  var toUrl = FunctionalHelpers.toUrl;
 
   registerSuite({
     name: 'robots.txt',
@@ -18,7 +19,7 @@ define([
     'should disallow root': function () {
 
       return this.get('remote')
-        .get(require.toUrl(url))
+        .get(toUrl(url))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByTagName('body')
         .getVisibleText()

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -6,16 +6,17 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'app/scripts/lib/constants',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Constants, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, Constants, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
+
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
   var SETTINGS_URL = config.fxaContentRoot + 'settings';
@@ -49,7 +50,7 @@ define([
 
     'sign in, go to settings, sign out': function () {
       return this.get('remote')
-        .get(require.toUrl(SIGNIN_URL))
+        .get(toUrl(SIGNIN_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('form input.email')
           .click()
@@ -77,7 +78,7 @@ define([
 
     'sign in to desktop context, go to settings, no way to sign out': function () {
       return this.get('remote')
-        .get(require.toUrl(SIGNIN_URL + '?context=' + Constants.FX_DESKTOP_CONTEXT))
+        .get(toUrl(SIGNIN_URL + '?context=' + Constants.FX_DESKTOP_CONTEXT))
         .findByCssSelector('form input.email')
           .click()
           .type(email)
@@ -101,7 +102,7 @@ define([
           assert.equal(isDisplayed, true);
         })
 
-        .get(require.toUrl(SETTINGS_URL))
+        .get(toUrl(SETTINGS_URL))
         // make sure the sign out element doesn't exist
         .findById('signout')
           .then(assert.fail, assert.ok)
@@ -118,7 +119,7 @@ define([
         })
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(SETTINGS_URL))
+            .get(toUrl(SETTINGS_URL))
             // Expect to get redirected to sign in since the sessionToken is invalid
             .findById('fxa-signin-header')
             .end();
@@ -127,7 +128,7 @@ define([
 
     'sign in, delete account': function () {
       return this.get('remote')
-        .get(require.toUrl(SIGNIN_URL))
+        .get(toUrl(SIGNIN_URL))
         .findByCssSelector('form input.email')
           .click()
           .type(email)

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -6,16 +6,16 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
   var PAGE_URL = config.fxaContentRoot + 'signin';
@@ -59,7 +59,7 @@ define([
 
     'sign in unverified': function () {
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('form input.email')
           .click()
@@ -93,7 +93,7 @@ define([
         })
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(PAGE_URL))
+            .get(toUrl(PAGE_URL))
             .findByCssSelector('form input.email')
               .clearValue()
               .click()
@@ -125,7 +125,7 @@ define([
         })
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(PAGE_URL))
+            .get(toUrl(PAGE_URL))
             .findByCssSelector('form input.email')
               .clearValue()
               .click()
@@ -163,7 +163,7 @@ define([
       user = TestHelpers.emailToUser(email);
 
       return self.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .findByCssSelector('input[type=email]')
           .click()
           .clearValue()
@@ -207,7 +207,7 @@ define([
       var self = this;
 
       return self.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .findByCssSelector('input[type=email]')
           .click()
           .clearValue()
@@ -225,7 +225,7 @@ define([
       email = 'partial';
 
       return self.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .findByCssSelector('input[type=email]')
           .click()
           .clearValue()
@@ -264,7 +264,7 @@ define([
     var password = '12345678';
 
     return self.get('remote')
-      .get(require.toUrl(PAGE_URL))
+      .get(toUrl(PAGE_URL))
       .findByCssSelector('input[type=email]')
         .clearValue()
         .click()

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -6,28 +6,39 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'app/scripts/lib/constants'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers, Constants) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers, Constants) {
   'use strict';
 
   var FX_DESKTOP_CONTEXT = Constants.FX_DESKTOP_CONTEXT;
 
   var config = intern.config;
 
+  var toUrl = FunctionalHelpers.toUrl;
+
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
   // The automatedBrowser query param tells signin/up to stub parts of the flow
   // that require a functioning desktop channel
   var PAGE_SIGNIN = config.fxaContentRoot + 'signin';
-  var PAGE_SIGNIN_DESKTOP = PAGE_SIGNIN + '?context=' + FX_DESKTOP_CONTEXT;
+  var PAGE_SIGNIN_DESKTOP = toUrl(PAGE_SIGNIN, {
+    query: {
+      context: FX_DESKTOP_CONTEXT,
+      automatedBrowser: true
+    }
+  });
   var PAGE_SIGNUP = config.fxaContentRoot + 'signup';
-  var PAGE_SIGNUP_DESKTOP = config.fxaContentRoot + 'signup?context=' + FX_DESKTOP_CONTEXT;
+  var PAGE_SIGNUP_DESKTOP = toUrl(PAGE_SIGNUP, {
+    query: {
+      context: FX_DESKTOP_CONTEXT,
+      automatedBrowser: true
+    }
+  });
   var PAGE_SETTINGS = config.fxaContentRoot + 'settings';
 
 
@@ -78,7 +89,8 @@ define([
             .then(function (emails) {
 
               return self.get('remote')
-                .get(require.toUrl(emails[0].headers['x-link']))
+                .setFindTimeout(intern.config.pageLoadTimeout)
+                .get(toUrl(emails[0].headers['x-link']))
                 .findById('fxa-sign-up-complete-header')
                 .end();
             });
@@ -96,7 +108,7 @@ define([
             .then(function (emails) {
 
               return self.get('remote')
-                .get(require.toUrl(emails[0].headers['x-link']));
+                .get(toUrl(emails[0].headers['x-link']));
             });
         })
         .then(function () {
@@ -121,7 +133,7 @@ define([
       var self = this;
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_SIGNIN))
+        .get(toUrl(PAGE_SIGNIN))
         .findByCssSelector('form input.email')
         .click()
         .type(email)
@@ -144,7 +156,7 @@ define([
           return FunctionalHelpers.clearSessionStorage(self);
         })
 
-        .get(require.toUrl(PAGE_SIGNIN))
+        .get(toUrl(PAGE_SIGNIN))
 
         .findByCssSelector('form input.password')
         .click()
@@ -163,7 +175,7 @@ define([
       var self = this;
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_SIGNIN_DESKTOP))
+        .get(toUrl(PAGE_SIGNIN_DESKTOP))
         .findByCssSelector('form input.email')
         .click()
         .type(email)
@@ -193,7 +205,7 @@ define([
 
     'sign in once, use a different account': function () {
       return this.get('remote')
-        .get(require.toUrl(PAGE_SIGNIN))
+        .get(toUrl(PAGE_SIGNIN))
         .findByCssSelector('form input.email')
         .click()
         .type(email)
@@ -211,7 +223,7 @@ define([
         .findById('fxa-settings-header')
         .end()
 
-        .get(require.toUrl(PAGE_SIGNIN))
+        .get(toUrl(PAGE_SIGNIN))
 
         // testing to make sure "Use different account" button works
         .findByCssSelector('.use-different')
@@ -237,7 +249,7 @@ define([
         .end()
 
         // testing to make sure cached signin comes back after a refresh
-        .get(require.toUrl(PAGE_SIGNIN))
+        .get(toUrl(PAGE_SIGNIN))
 
         .findByCssSelector('.use-different')
         .click()
@@ -255,7 +267,7 @@ define([
       var self = this;
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_SIGNIN_DESKTOP))
+        .get(toUrl(PAGE_SIGNIN_DESKTOP))
         // signin normally, nothing in session yet
         .findByCssSelector('form input.email')
         .click()
@@ -321,7 +333,7 @@ define([
       var self = this;
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_SIGNUP_DESKTOP))
+        .get(toUrl(PAGE_SIGNUP_DESKTOP))
         .findByCssSelector('form input.email')
         .clearValue()
         .click()
@@ -355,7 +367,7 @@ define([
           return FunctionalHelpers.clearSessionStorage(self);
         })
 
-        .get(require.toUrl(PAGE_SIGNIN))
+        .get(toUrl(PAGE_SIGNIN))
 
         // cached login should still go to email confirmation screen for unverified accounts
         .findByCssSelector('.use-logged-in')
@@ -369,7 +381,7 @@ define([
       var email = TestHelpers.createEmail();
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_SIGNUP))
+        .get(toUrl(PAGE_SIGNUP))
         .findByCssSelector('form input.email')
         .clearValue()
         .click()
@@ -398,7 +410,7 @@ define([
         .findById('fxa-confirm-header')
         .end()
 
-        .get(require.toUrl(PAGE_SIGNIN))
+        .get(toUrl(PAGE_SIGNIN))
 
         // cached login should still go to email confirmation screen for unverified accounts
 
@@ -419,7 +431,7 @@ define([
       var self = this;
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_SIGNIN_DESKTOP))
+        .get(toUrl(PAGE_SIGNIN_DESKTOP))
         .findByCssSelector('form input.email')
         .click()
         .type(email)
@@ -465,7 +477,7 @@ define([
         })
 
         // testing to make sure cached signin comes back after a refresh
-        .get(require.toUrl(PAGE_SIGNIN))
+        .get(toUrl(PAGE_SIGNIN))
 
         .findByCssSelector('.prefill')
         .getVisibleText()
@@ -492,7 +504,7 @@ define([
       var self = this;
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_SIGNIN_DESKTOP))
+        .get(toUrl(PAGE_SIGNIN_DESKTOP))
         .findByCssSelector('form input.email')
         .click()
         .type(email)
@@ -540,7 +552,7 @@ define([
         })
 
         // testing to make sure cached signin comes back after a refresh
-        .get(require.toUrl(PAGE_SIGNIN))
+        .get(toUrl(PAGE_SIGNIN))
 
         .findByCssSelector('.prefill')
         .getVisibleText()

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -6,16 +6,16 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'intern/node_modules/dojo/node!leadfoot/helpers/pollUntil',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, pollUntil, FxaClient, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, pollUntil, FxaClient, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var PAGE_URL = config.fxaContentRoot + 'signup';
 
@@ -37,7 +37,7 @@ define([
       var password = '12345678';
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('form input.email')
           .click()
@@ -78,7 +78,7 @@ define([
       var password = '12345678';
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .findByCssSelector('form input.email')
           .click()
           .type(email)
@@ -125,7 +125,7 @@ define([
       var dateToSelect = now.getDate();
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .findByCssSelector('form input.email')
           .click()
           .type(email)
@@ -176,7 +176,7 @@ define([
       var dateToSelect = now.getDate();
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .findByCssSelector('form input.email')
           .click()
           .type(email)
@@ -230,7 +230,7 @@ define([
       var password = '12345678';
 
       return this.get('remote')
-        .get(require.toUrl(urlForSync))
+        .get(toUrl(urlForSync))
         .findByCssSelector('form input.email')
           .click()
           .type(email)
@@ -277,7 +277,7 @@ define([
       return client.signUp(email, password, { preVerified: true })
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(PAGE_URL))
+            .get(toUrl(PAGE_URL))
             .findByCssSelector('input[type=email]')
               .click()
               .clearValue()
@@ -341,7 +341,7 @@ define([
       return client.signUp(email, password)
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(PAGE_URL))
+            .get(toUrl(PAGE_URL))
             .findByCssSelector('input[type=email]')
               .click()
               .type(email)
@@ -394,7 +394,7 @@ define([
     var year = CUTOFF_YEAR - 1;
 
     return self.get('remote')
-      .get(require.toUrl(PAGE_URL))
+      .get(toUrl(PAGE_URL))
       .findByCssSelector('input[type=email]')
         .clearValue()
         .click()

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -6,16 +6,16 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var PAGE_URL = config.fxaContentRoot + 'reset_password?context=fx_desktop_v1&service=sync';
 
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
@@ -70,7 +70,7 @@ define([
         })
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(PAGE_URL))
+            .get(toUrl(PAGE_URL))
             .setFindTimeout(intern.config.pageLoadTimeout)
 
             .findById('fxa-reset-password-header')
@@ -90,7 +90,7 @@ define([
               return FunctionalHelpers.getVerificationLink(user, 1);
             })
             .then(function (url) {
-              return self.get('remote').get(require.toUrl(url));
+              return self.get('remote').get(toUrl(url));
             })
             .end()
 
@@ -135,7 +135,7 @@ define([
         })
         .then(function () {
           return self.get('remote')
-            .get(require.toUrl(PAGE_URL))
+            .get(toUrl(PAGE_URL))
             .setFindTimeout(intern.config.pageLoadTimeout)
 
             .findById('fxa-reset-password-header')
@@ -160,7 +160,7 @@ define([
               return FunctionalHelpers.getVerificationLink(user, 1);
             })
             .then(function (url) {
-              return self.get('remote').get(require.toUrl(url));
+              return self.get('remote').get(toUrl(url));
             })
             .end()
 

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -6,16 +6,16 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'intern/node_modules/dojo/node!leadfoot/helpers/pollUntil',
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, pollUntil, FxaClient, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, pollUntil, FxaClient, TestHelpers, FunctionalHelpers) {
   'use strict';
 
   var config = intern.config;
+  var toUrl = FunctionalHelpers.toUrl;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_desktop_v1&service=sync';
 
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
@@ -39,7 +39,7 @@ define([
       var self = this;
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('form input.email')
           .click()
@@ -102,7 +102,7 @@ define([
       var self = this;
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('form input.email')
           .click()

--- a/tests/functional/tos.js
+++ b/tests/functional/tos.js
@@ -6,13 +6,13 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'tests/functional/lib/helpers',
-  'require'
-], function (intern, registerSuite, assert, FunctionalHelpers, require) {
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   'use strict';
 
   var PAGE_URL = intern.config.fxaContentRoot + 'signup';
   var TOS_URL = intern.config.fxaContentRoot + 'legal/terms';
+  var toUrl = FunctionalHelpers.toUrl;
 
   registerSuite({
     name: 'tos',
@@ -24,7 +24,7 @@ define([
     'start at signup': function () {
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(toUrl(PAGE_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('#fxa-tos')
           .click()
@@ -42,7 +42,7 @@ define([
     'start at terms': function () {
 
       return this.get('remote')
-        .get(require.toUrl(TOS_URL))
+        .get(toUrl(TOS_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
 
         .findById('fxa-tos-header')


### PR DESCRIPTION
@zaach and @vladikoff - could you guys give this a review?

As part of the "broker" PR, I am using the "automatedBrowser=true" flag to ensure the tests don't stall. I went ahead and refactored the functional tests to always pass "automatedBrowser=true" when running the functional tests.

Is this sane?
