### PR TITLE
Removed home button from legal pages

### DIFF
--- a/server/templates/pages/src/privacy.html
+++ b/server/templates/pages/src/privacy.html
@@ -38,10 +38,6 @@
               <article id="legal-copy">
                 {{{ privacy }}}
               </article>
-
-              <div class="button-row">
-                <a href="/" id="fxa-pp-home" class="button">{{#t}}Home{{/t}}</a>
-              </div>
             </section>
           </div>
         </div>

--- a/server/templates/pages/src/terms.html
+++ b/server/templates/pages/src/terms.html
@@ -38,10 +38,6 @@
               <article id="legal-copy">
                 {{{ terms }}}
               </article>
-
-              <div class="button-row">
-                <a href="/" id="fxa-tos-home" class="button">{{#t}}Home{{/t}}</a>
-              </div>
             </section>
           </div>
         </div>


### PR DESCRIPTION
The home button that appears on the legal pages upon direct navigation causes problems on FxOS and Fennec since you can end up in an FxA web flow after visiting the privacy policy or terms of service. We decided it's easier to remove the home button all together, rather than to add browser sniffing, since these primary consumers of this page don't want it.

Fixes #1709.

@zaach @shane-tomlinson r?
