### PR TITLE
tests(sauce): adds custom proxyPort argument to the test runner.

### DIFF
--- a/tests/intern.js
+++ b/tests/intern.js
@@ -19,6 +19,7 @@ function (args, topic, firefoxProfile) {
   var fxaOauthApp = args.fxaOauthApp || 'http://127.0.0.1:8080/';
   var fxaProduction = !!args.fxaProduction;
   var fxaToken = args.fxaToken || 'http://';
+  var proxyPort = args.proxyPort || 9090;
 
   if (topic) {
     topic.subscribe('/suite/start', function (suite) {
@@ -28,10 +29,10 @@ function (args, topic, firefoxProfile) {
 
   var config = {
     // The port on which the instrumenting proxy will listen
-    proxyPort: 9090,
+    proxyPort: proxyPort,
 
     // A fully qualified URL to the Intern proxy
-    proxyUrl: 'http://127.0.0.1:9090/',
+    proxyUrl: 'http://127.0.0.1:' + proxyPort + '/',
 
     asyncTimeout: 5000, // milliseconds
 

--- a/tests/intern_sauce.js
+++ b/tests/intern_sauce.js
@@ -12,7 +12,27 @@ define([
   intern.tunnelOptions = {
     port: 4445,
     directDomains: [
-      'latest.dev.lcip.org'
+      'lcip.org',
+      'dev.lcip.org',
+
+      'latest.dev.lcip.org',
+      'oauth-latest.dev.lcip.org',
+      '123done-latest.dev.lcip.org',
+
+      'nightly.dev.lcip.org',
+      'oauth-nightly.dev.lcip.org',
+      '123done-nightly.dev.lcip.org',
+
+      'stable.dev.lcip.org',
+      'oauth-stable.dev.lcip.org',
+      '123done-stable.dev.lcip.org',
+
+      'mozaws.net',
+      'stage.mozaws.net',
+      'oauth.stage.mozaws.net',
+      'profile.stage.mozaws.net',
+      'api-accounts.stage.mozaws.net',
+      '123done-stage.mozaws.net'
     ],
     skipSslDomains: [
       'latest.dev.lcip.org'


### PR DESCRIPTION
adds domain exclusion for Sauce Labs tunnels.
