### PR TITLE
fix(test): Fix `test-latest` functional tests.

### DIFF
--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -50,13 +50,11 @@ define([
         })
         .then(function () {
           // clear localStorage to avoid polluting other tests.
-          return FunctionalHelpers.clearBrowserState(self);
+          return FunctionalHelpers.clearBrowserState(self, {
+            contentServer: true,
+            '123done': true
+          });
         });
-    },
-
-    teardown: function () {
-      // clear localStorage to avoid polluting other tests.
-      return FunctionalHelpers.clearBrowserState(this);
     },
 
     'oauth reset password': function () {
@@ -195,7 +193,10 @@ define([
             .then(function () {
               // clear all browser state, simulate opening in a new
               // browser
-              return FunctionalHelpers.clearBrowserState(self);
+              return FunctionalHelpers.clearBrowserState(self, {
+                contentServer: true,
+                '123done': true
+              });
             })
             .then(function () {
               return FunctionalHelpers.getVerificationLink(user, 1);

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -38,7 +38,10 @@ define([
       // clear localStorage to avoid polluting other tests.
       // Without the clear, /signup tests fail because of the info stored
       // in prefillEmail
-      return FunctionalHelpers.clearBrowserState(this);
+      return FunctionalHelpers.clearBrowserState(this, {
+        contentServer: true,
+        '123done': true
+      });
     },
 
     'basic signup, from first tab\'s perspective - tab should redirect to RP automatically': function () {
@@ -107,18 +110,6 @@ define([
         .end()
 
         .findByCssSelector('#loggedin')
-        .end()
-
-        .findByCssSelector('#logout')
-        .click()
-        .end()
-
-        .findByCssSelector('#loggedin')
-        .getVisibleText()
-        .then(function (text) {
-          // confirm logged out
-          assert.ok(text.length === 0);
-        })
         .end();
     },
 
@@ -242,7 +233,10 @@ define([
 
         .then(function () {
           // clear browser state to simulate opening link in a new browser
-          return FunctionalHelpers.clearBrowserState(self);
+          return FunctionalHelpers.clearBrowserState(self, {
+            contentServer: true,
+            '123done': true
+          });
         })
 
         .then(function () {

--- a/tests/functional/oauth_webchannel.js
+++ b/tests/functional/oauth_webchannel.js
@@ -37,11 +37,10 @@ define([
       email = TestHelpers.createEmail();
       user = TestHelpers.emailToUser(email);
 
-      return FunctionalHelpers.clearBrowserState(this);
-    },
-
-    teardown: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return FunctionalHelpers.clearBrowserState(this, {
+        contentServer: true,
+        '123done': true
+      });
     },
 
     'signin using an oauth app': function () {
@@ -76,7 +75,7 @@ define([
         .click()
         .end()
 
-        .findByCssSelector('form input.email')
+        .findByCssSelector('#fxa-signin-header')
         .end()
 
         .getCurrentUrl()
@@ -85,6 +84,9 @@ define([
             // add "&webChannelId=test" to the OAuth login url to signal that this is a WebChannel flow
             .get(require.toUrl(url + '&webChannelId=test'));
         })
+
+        .findByCssSelector('#fxa-signin-header')
+        .end()
 
         .execute(function (OAUTH_APP) {
           // this event will fire once the form is submitted below, helping it redirect to the application
@@ -132,6 +134,10 @@ define([
         .findByCssSelector('#splash .signup')
         .click()
         .end()
+
+        .findByCssSelector('#fxa-signup-header')
+        .end()
+
         .getCurrentUrl()
         .then(function (url) {
 
@@ -139,6 +145,10 @@ define([
             // add '&webChannelId=test' to the current url, which is the confirmation screen
             .get(require.toUrl(url + '&webChannelId=test'));
         })
+
+        .findByCssSelector('#fxa-signup-header')
+        .end()
+
         .execute(function (OAUTH_APP) {
           // this event will fire once the account is confirmed, helping it redirect to the application
           // if the window redirect does not happen then the sign in page will hang on the confirmation screen


### PR DESCRIPTION
@vladikoff - could you review this? 

Several problems:
- When running against remote servers, Selenium moves very quickly. Sometimes too quickly. It'll move on before the previous step is ready in many cases.
- The email index being searched for was not being passed to restmail, so it would return as long as one email existed.
- OAuth tests depended on each other
- Signing out of 123done was not done correctly and state would hang around.
- Clearing content server state was being done before the content server was loaded, which ended up in a 500 error.

What we do now:
- Simplify the OAuth sign in tests so there is no cross-test dependencies.
- In the OAuth sign in tests, use the FxaClient to pre-generate users. We are testing sign in, not sign up.
- Ensure the content server page is loaded before clearing its state.
- Ensure the user is logged out of 123done when clearing its state - do so by calling XHR requests directly.
- Ensure the index of the email we are waiting for makes it to restmail.

fixes #1690
