### PR TITLE
fix(styles): Ensure the year of birth select box uses Clear Sans.

### DIFF
--- a/app/styles/_general.scss
+++ b/app/styles/_general.scss
@@ -531,6 +531,7 @@ label:focus ~ .input-help-focused {
   }
 
   select {
+    @include font();
     // autoprefixer does not handle appearance, see https://github.com/ai/autoprefixer/issues/205
     -moz-appearance: none;
     -webkit-appearance: none;


### PR DESCRIPTION
@johngruen - could you review this? You are my SASS sensei.

The `.select-row select` style declaration did not include the "fonts()" mixin which is required to override the system set fonts.

fixes #1707
