### PR TITLE
feat(metrics): Add metrics for signup, preverified signup, signin, hide the resend button.

### DIFF
--- a/app/scripts/lib/url.js
+++ b/app/scripts/lib/url.js
@@ -51,6 +51,8 @@ function (_) {
       return path.replace(/^\//, '')
                 // strip trailing /
                 .replace(/\/$/, '')
+                // any other slashes get converted to '.'
+                .replace(/\//g, '.')
                 // search params can contain sensitive info
                 .replace(/\?.*/, '');
     }

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -436,6 +436,18 @@ function (_, Backbone, $, p, Session, AuthErrors,
       this.metrics.logEvent(eventName);
     },
 
+    /**
+     * Log an event with the screen name as a prefix
+     */
+    logScreenEvent: function (eventName) {
+      var event = Strings.interpolate('%(screenName)s.%(eventName)s', {
+        screenName: this.getScreenName(),
+        eventName: eventName
+      });
+
+      this.metrics.logEvent(event);
+    },
+
     hideError: function () {
       this.$('.error').slideUp(EPHEMERAL_MESSAGE_ANIMATION_MS);
       this._isErrorVisible = false;

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -90,7 +90,7 @@ function (_, FormView, BaseView, Template, Session, p, AuthErrors, ResendMixin,
     submit: function () {
       var self = this;
 
-      self.logEvent('confirm.resend');
+      self.logScreenEvent('resend');
       return self.fxaClient.signUpResend(self.relier)
               .then(function () {
                 self.displaySuccess();

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -14,10 +14,11 @@ define([
   'lib/session',
   'lib/constants',
   'lib/auth-errors',
+  'views/mixins/resend-mixin',
   'views/mixins/service-mixin'
 ],
 function (_, $, ConfirmView, BaseView, Template, p, Session, Constants,
-      AuthErrors, ServiceMixin) {
+      AuthErrors, ResendMixin, ServiceMixin) {
   var t = BaseView.t;
 
   var SESSION_UPDATE_TIMEOUT_MS = 10000;
@@ -240,7 +241,7 @@ function (_, $, ConfirmView, BaseView, Template, p, Session, Constants,
     submit: function () {
       var self = this;
 
-      self.logEvent('confirm_reset_password.resend');
+      self.logScreenEvent('resend');
       return self.fxaClient.passwordResetResend(self.relier)
               .then(function () {
                 self.displaySuccess();
@@ -261,7 +262,7 @@ function (_, $, ConfirmView, BaseView, Template, p, Session, Constants,
     }
   });
 
-  _.extend(View.prototype, ServiceMixin);
+  _.extend(View.prototype, ResendMixin, ServiceMixin);
 
   return View;
 });

--- a/app/scripts/views/mixins/resend-mixin.js
+++ b/app/scripts/views/mixins/resend-mixin.js
@@ -9,6 +9,7 @@
 define([
 ], function () {
   var SHOW_RESEND_IN_MS = 5 * 60 * 1000; // 5 minutes.
+  var TOO_MANY_ATTEMPTS = 4;
 
   return {
     _attemptedSubmits: 0,
@@ -42,8 +43,8 @@ define([
     _updateResendButton: function () {
       var self = this;
       // Hide the button after 4 attempts. Redisplay button after a delay.
-      if (self._attemptedSubmits === 4) {
-        self.logEvent(self.className + '.too_many_attempts');
+      if (self._attemptedSubmits === TOO_MANY_ATTEMPTS) {
+        self.logScreenEvent('too_many_attempts');
         self.$('#resend').hide();
         self.setTimeout(function () {
           self._attemptedSubmits = 0;

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -99,6 +99,7 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin, Auth
       })
       .then(function (accountData) {
         if (accountData.verified) {
+          self.logScreenEvent('success');
           return self.onSignInSuccess();
         } else {
           return self.onSignInUnverified();
@@ -108,7 +109,7 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin, Auth
         if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
           return self._suggestSignUp(err);
         } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
-          self.logEvent('login.canceled');
+          self.logScreenEvent('canceled');
           // if user canceled login, just stop
           return;
         }

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -221,6 +221,11 @@ function (_, p, BaseView, FormView, Template, Session, AuthErrors,
       var email = self.$('.email').val();
       var password = self.$('.password').val();
       var customizeSync = self.$('.customize-sync').is(':checked');
+      var preVerifyToken = self.relier.get('preVerifyToken');
+
+      if (preVerifyToken) {
+        self.logScreenEvent('preverified');
+      }
 
       return self.fxaClient.signUp(email, password, self.relier)
         .then(function () {
@@ -229,6 +234,13 @@ function (_, p, BaseView, FormView, Template, Session, AuthErrors,
             // already done in signUp, no need to do it again.
             verifiedCanLinkAccount: true
           });
+        }).then(function (accountData) {
+          if (preVerifyToken && accountData.verified) {
+            self.logScreenEvent('preverified.success');
+          }
+          self.logScreenEvent('success');
+
+          return accountData;
         })
         .then(_.bind(self.onSignUpSuccess, self))
         .then(null, function (err) {

--- a/app/tests/spec/lib/url.js
+++ b/app/tests/spec/lib/url.js
@@ -58,8 +58,8 @@ function (chai, _, Url) {
         assert.equal(Url.pathToScreenName('signup/'), 'signup');
       });
 
-      it('leaves middle / alone', function () {
-        assert.equal(Url.pathToScreenName('/legal/tos/'), 'legal/tos');
+      it('converts middle / to .', function () {
+        assert.equal(Url.pathToScreenName('/legal/tos/'), 'legal.tos');
       });
 
       it('strips search parameters', function () {

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -13,10 +13,11 @@ define([
   'views/confirm',
   'models/reliers/relier',
   '../../mocks/router',
+  '../../mocks/window',
   '../../lib/helpers'
 ],
 function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient, View,
-      Relier, RouterMock, TestHelpers) {
+      Relier, RouterMock, WindowMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -24,6 +25,7 @@ function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient, View,
   describe('views/confirm', function () {
     var view;
     var routerMock;
+    var windowMock;
     var metrics;
     var fxaClient;
     var relier;
@@ -32,12 +34,16 @@ function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient, View,
       Session.set('sessionToken', 'fake session token');
 
       routerMock = new RouterMock();
+      windowMock = new WindowMock();
+      windowMock.location.pathname = 'confirm';
+
       metrics = new Metrics();
       relier = new Relier();
       fxaClient = new FxaClient();
 
       view = new View({
         router: routerMock,
+        window: windowMock,
         metrics: metrics,
         fxaClient: fxaClient,
         relier: relier
@@ -150,7 +156,7 @@ function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient, View,
       it('debounces resend calls - submit on first and forth attempt', function () {
         var count = 0;
 
-        sinon.stub(view.fxaClient, 'signUpResend', function () {
+        sinon.stub(fxaClient, 'signUpResend', function () {
           count++;
           return p(true);
         });
@@ -193,6 +199,10 @@ function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient, View,
           // force at least one cycle through the poll
           count++;
           return p({ verified: count === 2 });
+        });
+
+        sinon.stub(view, 'setTimeout', function (callback) {
+          callback();
         });
 
         view.VERIFICATION_POLL_IN_MS = 100;

--- a/app/tests/spec/views/oauth_sign_in.js
+++ b/app/tests/spec/views/oauth_sign_in.js
@@ -12,13 +12,14 @@ define([
   'lib/session',
   'lib/fxa-client',
   'lib/promise',
+  'lib/metrics',
   'models/reliers/relier',
   '../../mocks/window',
   '../../mocks/router',
   '../../lib/helpers'
 ],
-function (chai, $, sinon, View, Session, FxaClient, p, Relier, WindowMock,
-      RouterMock, TestHelpers) {
+function (chai, $, sinon, View, Session, FxaClient, p, Metrics,
+      Relier, WindowMock, RouterMock, TestHelpers) {
   /*global describe, beforeEach, afterEach, it*/
   var assert = chai.assert;
 
@@ -29,6 +30,7 @@ function (chai, $, sinon, View, Session, FxaClient, p, Relier, WindowMock,
     var windowMock;
     var fxaClient;
     var relier;
+    var metrics;
 
     var CLIENT_ID = 'dcdb5ae7add825d2';
     var STATE = '123';
@@ -40,17 +42,20 @@ function (chai, $, sinon, View, Session, FxaClient, p, Relier, WindowMock,
       email = TestHelpers.createEmail();
       router = new RouterMock();
       windowMock = new WindowMock();
+      windowMock.location.pathname = 'oauth/signin';
       windowMock.location.search = '?client_id=' + CLIENT_ID + '&state=' + STATE + '&scope=' + SCOPE;
 
       relier = new Relier();
       relier.set('serviceName', CLIENT_NAME);
       fxaClient = new FxaClient();
+      metrics = new Metrics();
 
       view = new View({
         router: router,
         window: windowMock,
         fxaClient: fxaClient,
-        relier: relier
+        relier: relier,
+        metrics: metrics
       });
 
       return view.render()
@@ -102,6 +107,9 @@ function (chai, $, sinon, View, Session, FxaClient, p, Relier, WindowMock,
         return view.submit()
           .then(function () {
             assert.isTrue(view.finishOAuthFlow.called);
+
+            assert.isTrue(TestHelpers.isEventLogged(metrics,
+                              'oauth.signin.success'));
           });
       });
 

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -67,6 +67,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, AuthErrors,
       router = new RouterMock();
 
       windowMock = new WindowMock();
+      windowMock.location.pathname = 'oauth/signup';
       metrics = new Metrics();
       relier = new Relier({
         window: windowMock
@@ -147,6 +148,8 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, AuthErrors,
             assert.equal(Session.oauth.client_id, CLIENT_ID);
             assert.isTrue(fxaClient.signUp.calledWith(email, 'password'));
             assert.equal(router.page, 'confirm');
+            assert.isTrue(TestHelpers.isEventLogged(metrics,
+                              'oauth.signup.success'));
           });
       });
     });
@@ -176,9 +179,15 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, AuthErrors,
           return p(true);
         };
         return view.submit()
-            .then(function () {
-              assert.isTrue(isOAuthFlowFinished);
-            });
+          .then(function () {
+            assert.isTrue(isOAuthFlowFinished);
+            assert.isTrue(TestHelpers.isEventLogged(metrics,
+                              'oauth.signup.preverified'));
+            assert.isTrue(TestHelpers.isEventLogged(metrics,
+                              'oauth.signup.preverified.success'));
+            assert.isTrue(TestHelpers.isEventLogged(metrics,
+                              'oauth.signup.success'));
+          });
       });
 
       it('redirects to /confirm if pre-verification is not successful', function () {
@@ -201,9 +210,9 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, AuthErrors,
 
         fillOutSignUp(email, 'password', { year: nowYear - 14, context: view });
         return view.submit()
-            .then(function () {
-              assert.equal(router.page, 'confirm');
-            });
+          .then(function () {
+            assert.equal(router.page, 'confirm');
+          });
       });
     });
   });

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -41,6 +41,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
 
       routerMock = new RouterMock();
       windowMock = new WindowMock();
+      windowMock.location.pathname = 'signin';
       metrics = new Metrics();
       relier = new Relier();
       fxaClient = new FxaClient();
@@ -181,6 +182,8 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
         return view.submit()
           .then(function () {
             assert.equal(routerMock.page, 'settings');
+            assert.isTrue(TestHelpers.isEventLogged(metrics,
+                              'signin.success'));
           });
       });
 
@@ -196,7 +199,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
             assert.isFalse(view.isErrorVisible());
 
             assert.isTrue(TestHelpers.isEventLogged(metrics,
-                              'login.canceled'));
+                              'signin.canceled'));
           });
       });
 


### PR DESCRIPTION
@kparlante - can you see if this is a bit closer to what you were looking for?

@nchapman or @zaach - could one of you do a pass over this as well?

feat(metrics): Add metrics for signup, preverified signup, signin, hide the resend button.

Add:
- signin.success- for a user who signs in successfully.
- signup.preverified - for users who attempt to sign up with a preVerifyToken
- signup.preverified.success- users who successfully sign up with a preVerifyToken
- signup.success - users who successfully initiate a signup.
- oauth.signin.success- for an OAuth user who signs in successfully.
- oauth.signup.preverified - for an OAuth user who attempts to sign up with a preVerifyToken
- oauth.signup.preverified.success- for OAuth users who successfully sign up with a preVerifyToken
- oauth.signup.success - for OAuth users who successfully initiate a signup.
- confirm_reset_password.resend - users who attempt to resend the password reset email.
- confirm_reset_password.too_many_attempts - when we hide the "Resend" button for password reset users who have tried too many attempts.

Also:
- Hook up the debounce code to the password reset.
- Add a base.js->logScreenEvent that logs an event using the screen name as the prefix.
- Change `/` in screen names to `.`
  - `screen:legal/tos` => `screen:legal.tos`
  - `screen:legal/pp` => `screen:legal.pp`
  - `screen:oauth/signup` => `screen:oauth.signup`
  - `screen:oauth/signin` => `screen:oauth.signin`

issue #1559
fixes #1147
