### PR TITLE
fix(signin): improve the "use different account" flow

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -12,6 +12,7 @@ define([
   'views/sign_in',
   'views/oauth_sign_in',
   'views/force_auth',
+  'views/use_different',
   'views/sign_up',
   'views/oauth_sign_up',
   'views/confirm',
@@ -44,6 +45,7 @@ function (
   SignInView,
   OAuthSignInView,
   ForceAuthView,
+  UseDifferentView,
   SignUpView,
   OAuthSignUpView,
   ConfirmView,
@@ -115,6 +117,7 @@ function (
       'complete_reset_password(/)': showView(CompleteResetPasswordView),
       'reset_password_complete(/)': showView(ReadyView, { type: 'reset_password' }),
       'force_auth(/)': showView(ForceAuthView),
+      'use_different(/)': showView(UseDifferentView),
       'cookies_disabled(/)': showView(CookiesDisabledView),
       'clear(/)': showView(ClearStorageView),
       'unexpected_error(/)': showView(UnexpectedErrorView)

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -37,11 +37,13 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin, Auth
       // want the last used email.
       this.prefillEmail = Session.prefillEmail || this.searchParam('email');
 
+      var suggestedUser = this._suggestedUser();
+
       return {
         service: this.relier.get('service'),
         serviceName: this.relier.get('serviceName'),
         email: this.prefillEmail,
-        suggestedUser: this._suggestedUser(),
+        suggestedUser: suggestedUser,
         chooserAskForPassword: this._suggestedUserAskPassword(),
         password: Session.prefillPassword,
         error: this.error
@@ -95,24 +97,24 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin, Auth
           p.reject();
         }
       })
-        .then(function (accountData) {
-          if (accountData.verified) {
-            return self.onSignInSuccess();
-          } else {
-            return self.onSignInUnverified();
-          }
-        })
-        .then(null, function (err) {
-          if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
-            return self._suggestSignUp(err);
-          } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
-            self.logEvent('login.canceled');
-            // if user canceled login, just stop
-            return;
-          }
-          // re-throw error, it will be handled at a lower level.
-          throw err;
-        });
+      .then(function (accountData) {
+        if (accountData.verified) {
+          return self.onSignInSuccess();
+        } else {
+          return self.onSignInUnverified();
+        }
+      })
+      .then(null, function (err) {
+        if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
+          return self._suggestSignUp(err);
+        } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
+          self.logEvent('login.canceled');
+          // if user canceled login, just stop
+          return;
+        }
+        // re-throw error, it will be handled at a lower level.
+        throw err;
+      });
     },
 
     onSignInSuccess: function () {
@@ -176,11 +178,10 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin, Auth
     }),
 
     /**
-     * Render to a basic sign in view, used with "Use a different account" button
+     * Navigate to a clear sign in form, used with "Use a different account" button
      */
     useDifferentAccount: BaseView.preventDefaultThen(function () {
-      this.skipUserSuggestion = true;
-      return this.render();
+      this.navigate('use_different');
     }),
 
     /**
@@ -206,9 +207,7 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin, Auth
         // confirm that session token and email are present
         cachedSessionToken && cachedEmail &&
         // prefilled email must be the same or absent
-        (this.prefillEmail === cachedEmail || ! this.prefillEmail) &&
-        // must not be manually disabled
-        ! this.skipUserSuggestion
+        (this.prefillEmail === cachedEmail || ! this.prefillEmail)
       ) {
         return {
           email: cachedEmail,

--- a/app/scripts/views/use_different.js
+++ b/app/scripts/views/use_different.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'views/sign_in',
+  'stache!templates/sign_in'
+],
+function (SignInView, Template) {
+
+  var View = SignInView.extend({
+    template: Template,
+    className: 'use-different',
+
+    context: function () {
+      return {
+        error: this.error
+      };
+    }
+
+  });
+
+  return View;
+});

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -286,7 +286,7 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient,
     });
 
     describe('useLoggedInAccount', function () {
-      it('shows an error if session is expired', function (done) {
+      it('shows an error if session is expired', function () {
         Session.set('cachedCredentials', {
           sessionToken: 'abc123',
           email: 'a@a.com'
@@ -300,12 +300,10 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient,
             // show password input
             assert.ok(view.$('#password').length);
             assert.equal(view.$('.error').text(), 'Session expired. Sign in to continue.');
-            done();
-          })
-          .fail(done);
+          });
       });
 
-      it('signs in with a valid session', function (done) {
+      it('signs in with a valid session', function () {
         Session.set('cachedCredentials', {
           sessionToken: 'abc123',
           email: 'a@a.com'
@@ -319,14 +317,12 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient,
           .then(function () {
             assert.notOk(view._isErrorVisible);
             assert.equal(view.$('.error').text(), '');
-            done();
-          })
-          .fail(done);
+          });
       });
     });
 
     describe('useDifferentAccount', function () {
-      it('can switch to signin with the useDifferentAccount button', function (done) {
+      it('can switch to signin with the useDifferentAccount button', function () {
         Session.set('cachedCredentials', {
           sessionToken: 'abc123',
           email: 'a@a.com'
@@ -335,11 +331,8 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient,
         return view.useLoggedInAccount()
           .then(function () {
             $('.use-different').click();
-            assert.ok($('.email').length, 'should show email input');
-            assert.ok($('.password').length, 'should show password input');
-            done();
-          })
-          .fail(done);
+            assert.equal(routerMock.page, 'use_different', 'should navigate to use_different');
+          });
       });
     });
 

--- a/app/tests/spec/views/use_different.js
+++ b/app/tests/spec/views/use_different.js
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'chai',
+  'jquery',
+  'views/use_different',
+  'lib/session',
+  'lib/fxa-client',
+  'models/reliers/relier',
+  '../../mocks/window'
+],
+function (chai, $, View, Session, FxaClient, Relier, WindowMock) {
+  var assert = chai.assert;
+
+  describe('/views/use_different', function () {
+    describe('missing email address', function () {
+      var view;
+      var windowMock;
+      var fxaClient;
+      var relier;
+
+      beforeEach(function () {
+        windowMock = new WindowMock();
+        windowMock.location.search = '';
+
+        relier = new Relier();
+        fxaClient = new FxaClient({
+          relier: relier
+        });
+
+        Session.clear();
+        view = new View({
+          window: windowMock,
+          fxaClient: fxaClient,
+          relier: relier
+        });
+        return view.render()
+            .then(function () {
+              $('#container').html(view.el);
+            });
+      });
+
+      afterEach(function () {
+        view.remove();
+        view.destroy();
+        windowMock = view = null;
+      });
+
+      describe('render', function () {
+        it('does not prefill email and password if stored in Session', function () {
+          Session.set('prefillEmail', 'testuser@testuser.com');
+          Session.set('prefillPassword', 'prefilled password');
+          return view.render()
+              .then(function () {
+                assert.ok($('#fxa-signin-header').length);
+                assert.equal(view.$('[type=email]').val(), '');
+                assert.equal(view.$('[type=password]').val(), '');
+              });
+        });
+      });
+
+    });
+  });
+});
+
+

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -44,6 +44,7 @@ function (Translator, Session) {
     '../tests/spec/views/oauth_sign_in',
     '../tests/spec/views/oauth_sign_up',
     '../tests/spec/views/force_auth',
+    '../tests/spec/views/use_different',
     '../tests/spec/views/settings',
     '../tests/spec/views/settings/avatar',
     '../tests/spec/views/settings/avatar_change',

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -91,6 +91,7 @@ module.exports = function (config, templates, i18n) {
       '/reset_password_complete',
       '/delete_account',
       '/force_auth',
+      '/use_different',
       '/oauth/signin',
       '/oauth/signup',
       '/cookies_disabled',

--- a/tests/functional/pages.js
+++ b/tests/functional/pages.js
@@ -46,6 +46,7 @@ define([
     'complete_reset_password',
     'reset_password_complete',
     'force_auth',
+    'use_different',
     'delete_account',
     'non_existent',
     'cookies_disabled',

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -218,8 +218,12 @@ define([
         .click()
         .end()
 
+        // the form should not be prefilled
         .findByCssSelector('form input.email')
-        .clearValue()
+        .getAttribute('value')
+        .then(function (val) {
+          assert.equal(val, '');
+        })
         .click()
         .type(email2)
         .end()
@@ -246,7 +250,7 @@ define([
         .findByCssSelector('form input.email')
         .end()
 
-        .refresh()
+        .get(require.toUrl(PAGE_SIGNIN))
 
         .findByCssSelector('.use-different')
         .end();
@@ -482,7 +486,7 @@ define([
         .findByCssSelector('form input.email')
         .end()
 
-        .refresh()
+        .get(require.toUrl(PAGE_SIGNIN))
 
         .findByCssSelector('.use-different')
         .end();
@@ -517,7 +521,6 @@ define([
         .end()
 
         .findByCssSelector('form input.email')
-        .clearValue()
         .click()
         .type(email2)
         .end()

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -49,6 +49,7 @@ define([
     '/reset_password_complete': { statusCode: 200 },
     '/delete_account': { statusCode: 200 },
     '/force_auth': { statusCode: 200 },
+    '/use_different': { statusCode: 200 },
     '/ver.json': { statusCode: 200, headerAccept: 'application/json' },
     '/cookies_disabled': { statusCode: 200 }
   };


### PR DESCRIPTION
Fixes #1721.

This creates a new route to indicate that the user wanted to use a different account and keep that intent between refreshes.

@shane-tomlinson r?
