### PR TITLE
fix(oauth): use the correct client_id for local oauth server

### DIFF
--- a/server/config/local.json-dist
+++ b/server/config/local.json-dist
@@ -3,6 +3,7 @@
   "api_proxy": {
     "enabled": true
   },
+  "oauth_client_id": "98e6508e88680e1a",
   "oauth_url": "http://127.0.0.1:9010",
   "profile_url": "http://127.0.0.1:1111",
   "profile_images_url": "http://127.0.0.1:1112",


### PR DESCRIPTION
When run locally, the oauth server uses this `client_id` for the `canGrant` privileged client. This will fix the oauth client when testing locally.

@vladikoff r?
