### PR TITLE
fix(signin): choosing to use a different account clears cached credentials

### DIFF
--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -286,7 +286,7 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient,
     });
 
     describe('useLoggedInAccount', function () {
-      it('shows an error if session is expired', function (done) {
+      it('shows an error if session is expired', function () {
         Session.set('cachedCredentials', {
           sessionToken: 'abc123',
           email: 'a@a.com'
@@ -300,12 +300,10 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient,
             // show password input
             assert.ok(view.$('#password').length);
             assert.equal(view.$('.error').text(), 'Session expired. Sign in to continue.');
-            done();
-          })
-          .fail(done);
+          });
       });
 
-      it('signs in with a valid session', function (done) {
+      it('signs in with a valid session', function () {
         Session.set('cachedCredentials', {
           sessionToken: 'abc123',
           email: 'a@a.com'
@@ -319,14 +317,12 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient,
           .then(function () {
             assert.notOk(view._isErrorVisible);
             assert.equal(view.$('.error').text(), '');
-            done();
-          })
-          .fail(done);
+          });
       });
     });
 
     describe('useDifferentAccount', function () {
-      it('can switch to signin with the useDifferentAccount button', function (done) {
+      it('can switch to signin with the useDifferentAccount button', function () {
         Session.set('cachedCredentials', {
           sessionToken: 'abc123',
           email: 'a@a.com'
@@ -334,12 +330,15 @@ function (chai, $, p, View, Session, AuthErrors, Metrics, FxaClient,
 
         return view.useLoggedInAccount()
           .then(function () {
-            $('.use-different').click();
+            assert.ok($('.use-different').length, 'has use different button');
+            return view.useDifferentAccount();
+          })
+          .then(function () {
             assert.ok($('.email').length, 'should show email input');
             assert.ok($('.password').length, 'should show password input');
-            done();
-          })
-          .fail(done);
+
+            assert.equal($('.email').val(), '', 'should have an empty email input');
+          });
       });
     });
 

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -218,8 +218,12 @@ define([
         .click()
         .end()
 
+        // the form should not be prefilled
         .findByCssSelector('form input.email')
-        .clearValue()
+        .getAttribute('value')
+        .then(function (val) {
+          assert.equal(val, '');
+        })
         .click()
         .type(email2)
         .end()
@@ -246,9 +250,13 @@ define([
         .findByCssSelector('form input.email')
         .end()
 
-        .refresh()
+        .get(require.toUrl(PAGE_SIGNIN))
 
-        .findByCssSelector('.use-different')
+        .findByCssSelector('form input.email')
+        .getAttribute('value')
+        .then(function (val) {
+          assert.equal(val, '');
+        })
         .end();
     },
     'sign in with cached credentials but with an expired session': function () {
@@ -480,15 +488,10 @@ define([
         .end()
 
         .findByCssSelector('form input.email')
-        .end()
-
-        .refresh()
-
-        .findByCssSelector('.use-different')
         .end();
     },
 
-    'sign in with desktop context then no context, desktop credentials should persist': function () {
+    'sign in with desktop context then no context, desktop credentials should not persist': function () {
       var self = this;
 
       return this.get('remote')
@@ -512,12 +515,12 @@ define([
         .click()
         .end()
 
+        // This will clear the desktop credentials
         .findByCssSelector('.use-different')
         .click()
         .end()
 
         .findByCssSelector('form input.email')
-        .clearValue()
         .click()
         .type(email2)
         .end()
@@ -546,7 +549,7 @@ define([
         .getVisibleText()
         .then(function (text) {
           // confirm prefilled email
-          assert.ok(text.indexOf(email) > -1);
+          assert.ok(text.indexOf(email) === -1);
         })
         .end()
 


### PR DESCRIPTION
Fixes #1721.

Alternative to #1752. This clears `Session` after the user chooses to select a different account.

@shane-tomlinson or @nchapman r?
