### PR TITLE
refactor(client): FxaClient no longer takes a relier in its constructor.

### DIFF
--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -54,7 +54,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
             }
 
             return self.fxaClient.changePassword(
-                          email, oldPassword, newPassword);
+                     email, oldPassword, newPassword, self.relier);
           })
           .then(function () {
             self.navigate('settings', {
@@ -73,7 +73,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
     resendVerificationEmail: BaseView.preventDefaultThen(function () {
       var self = this;
 
-      return this.fxaClient.signUpResend()
+      return self.fxaClient.signUpResend(self.relier)
               .then(function () {
                 self.navigate('confirm');
               }, function (err) {

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -16,7 +16,8 @@ define([
   'lib/auth-errors',
   'views/mixins/service-mixin'
 ],
-function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlaceholderMixin, Validate, AuthErrors, ServiceMixin) {
+function (_, BaseView, FormView, Template, Session, PasswordMixin,
+      FloatingPlaceholderMixin, Validate, AuthErrors, ServiceMixin) {
   var View = FormView.extend({
     template: Template,
     className: 'complete_reset_password',
@@ -107,7 +108,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
       // completes in the original tab, it will fetch the sessionToken
       // from localStorage and go to town.
       return self.fxaClient.completePasswordReset(
-              self.email, password, self.token, self.code, {
+              self.email, password, self.token, self.code, self.relier, {
                 shouldSignIn: self._shouldSignIn()
               })
           .then(function () {
@@ -139,7 +140,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, FloatingPlace
 
     resendResetEmail: function () {
       var self = this;
-      return this.fxaClient.passwordReset(this.email)
+      return self.fxaClient.passwordReset(self.email, self.relier)
               .then(function () {
                 self.navigate('confirm_reset_password');
               }, function (err) {

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -98,7 +98,7 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, R
       var self = this;
 
       self.logEvent('complete_sign_up.resend');
-      return this.fxaClient.signUpResend()
+      return self.fxaClient.signUpResend(self.relier)
               .then(function () {
                 self.displaySuccess();
               }, function (err) {

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -91,7 +91,7 @@ function (_, FormView, BaseView, Template, Session, p, AuthErrors, ResendMixin,
       var self = this;
 
       self.logEvent('confirm.resend');
-      return this.fxaClient.signUpResend()
+      return self.fxaClient.signUpResend(self.relier)
               .then(function () {
                 self.displaySuccess();
               }, function (err) {

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -241,7 +241,7 @@ function (_, $, ConfirmView, BaseView, Template, p, Session, Constants,
       var self = this;
 
       self.logEvent('confirm_reset_password.resend');
-      return this.fxaClient.passwordResetResend()
+      return self.fxaClient.passwordResetResend(self.relier)
               .then(function () {
                 self.displaySuccess();
               }, function (err) {

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -82,7 +82,7 @@ function (p, BaseView, SignInView, Template, Session) {
 
         var email = Session.forceEmail;
         self._isSubmitting = true;
-        return self.fxaClient.passwordReset(email)
+        return self.fxaClient.passwordReset(email, self.relier)
                 .then(function () {
                   self._isSubmitting = false;
                   self.navigate('confirm_reset_password');

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -62,7 +62,7 @@ function (_, BaseView, FormView, Template, Session, AuthErrors, ServiceMixin) {
       var email = this.$('.email').val();
 
       var self = this;
-      return this.fxaClient.passwordReset(email)
+      return self.fxaClient.passwordReset(email, self.relier)
         .then(function () {
           self.navigate('confirm_reset_password');
         })

--- a/app/scripts/views/settings/avatar.js
+++ b/app/scripts/views/settings/avatar.js
@@ -45,7 +45,7 @@ function (_, FormView, Template, AuthErrors, Session) {
           }
         }, function (err) {
           if (AuthErrors.is(err, 'UNVERIFIED_ACCOUNT')) {
-            return self.fxaClient.signUpResend()
+            return self.fxaClient.signUpResend(self.relier)
               .then(function () {
                 self.navigate('confirm');
                 return false;

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -90,7 +90,7 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin, Auth
 
       return p().then(function () {
         if (credentials.password) {
-          return self.fxaClient.signIn(email, credentials.password);
+          return self.fxaClient.signIn(email, credentials.password, self.relier);
         } else if (credentials.sessionToken) {
           return self.fxaClient.recoveryEmailStatus(credentials.sessionToken);
         } else {
@@ -133,7 +133,7 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin, Auth
     onSignInUnverified: function () {
       var self = this;
 
-      return self.fxaClient.signUpResend()
+      return self.fxaClient.signUpResend(self.relier)
         .then(function () {
           self.navigate('confirm');
         });

--- a/app/tests/spec/lib/assertion.js
+++ b/app/tests/spec/lib/assertion.js
@@ -46,7 +46,12 @@ function (chai, $, TestHelpers, P,
         fxaClient: client
       });
       email = ' ' + TestHelpers.createEmail() + ' ';
-      return client.signUp(email, password, { preVerified: true });
+      return client.signUp(email, password, relier, {
+        preVerified: true
+      })
+      .then(function () {
+        return client.signIn(email, password, relier);
+      });
     });
 
     afterEach(function () {

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -54,9 +54,7 @@ function (chai, jQuery, sinon, BaseView, Translator, EphemeralMessages, Metrics,
       ephemeralMessages = new EphemeralMessages();
       metrics = new Metrics();
       relier = new Relier();
-      fxaClient = new FxaClient({
-        relier: relier
-      });
+      fxaClient = new FxaClient();
 
       var View = BaseView.extend({
         template: Template

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -271,9 +271,12 @@ function (chai, sinon, p, AuthErrors, View, Session, Metrics,
         });
 
         return view.submit()
-            .then(function () {
-              assert.isTrue(view.$('.success').is(':visible'));
-            });
+          .then(function () {
+            assert.isTrue(view.$('.success').is(':visible'));
+
+            assert.isTrue(fxaClient.passwordResetResend.calledWith(
+                relier));
+          });
       });
 
       it('redirects to `/reset_password` if the resend token is invalid', function () {

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -30,9 +30,7 @@ function (chai, sinon, View, Session, FxaClient, p, FxDesktopRelier,
       relier = new FxDesktopRelier({
         window: windowMock
       });
-      fxaClient = new FxaClient({
-        relier: relier
-      });
+      fxaClient = new FxaClient();
 
       view = new View({
         window: windowMock,

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -9,35 +9,35 @@ define([
   'chai',
   'underscore',
   'jquery',
+  'sinon',
   'views/settings',
   '../../mocks/router',
   '../../lib/helpers',
   'lib/session',
   'lib/constants',
   'lib/fxa-client',
+  'lib/promise',
   'models/reliers/relier'
 ],
-function (chai, _, $, View, RouterMock, TestHelpers, Session, Constants,
-      FxaClient, Relier) {
+function (chai, _, $, sinon, View, RouterMock, TestHelpers, Session, Constants,
+      FxaClient, p, Relier) {
   var assert = chai.assert;
 
   describe('views/settings', function () {
     var view;
     var routerMock;
-    var email;
     var fxaClient;
     var relier;
 
     beforeEach(function () {
       routerMock = new RouterMock();
       relier = new Relier();
-      fxaClient = new FxaClient({
-        relier: relier
-      });
+      fxaClient = new FxaClient();
 
       view = new View({
         router: routerMock,
-        fxaClient: fxaClient
+        fxaClient: fxaClient,
+        relier: relier
       });
     });
 
@@ -59,12 +59,12 @@ function (chai, _, $, View, RouterMock, TestHelpers, Session, Constants,
 
     describe('with session', function () {
       beforeEach(function () {
-        email = TestHelpers.createEmail();
+        sinon.stub(view.fxaClient, 'sessionStatus', function () {
+          return p(true);
+        });
+        Session.set('sessionToken', 'sessiontoken');
 
-        return view.fxaClient.signUp(email, 'password', { preVerified: true })
-          .then(function () {
-            return view.render();
-          })
+        return view.render()
           .then(function () {
             $('body').append(view.el);
           });

--- a/app/tests/spec/views/settings/avatar.js
+++ b/app/tests/spec/views/settings/avatar.js
@@ -17,10 +17,11 @@ define([
   'lib/promise',
   'lib/session',
   'lib/profile',
-  'lib/auth-errors'
+  'lib/auth-errors',
+  'models/reliers/relier'
 ],
 function (chai, _, $, sinon, View, RouterMock, ProfileMock, FxaClientMock,
-    p, Session, Profile, AuthErrors) {
+    p, Session, Profile, AuthErrors, Relier) {
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
   var IMG_URL = 'http://127.0.0.1:1112/avatar/example.jpg';
@@ -30,16 +31,19 @@ function (chai, _, $, sinon, View, RouterMock, ProfileMock, FxaClientMock,
     var routerMock;
     var profileClientMock;
     var fxaClientMock;
+    var relierMock;
 
     beforeEach(function () {
       routerMock = new RouterMock();
       profileClientMock = new ProfileMock();
       fxaClientMock = new FxaClientMock();
+      relierMock = new Relier();
 
       view = new View({
         router: routerMock,
         profileClient: profileClientMock,
-        fxaClient: fxaClientMock
+        fxaClient: fxaClientMock,
+        relier: relierMock
       });
     });
 
@@ -109,6 +113,7 @@ function (chai, _, $, sinon, View, RouterMock, ProfileMock, FxaClientMock,
         return view.render()
           .then(function () {
             assert.equal(routerMock.page, 'confirm');
+            assert.isTrue(fxaClientMock.signUpResend.calledWith(relierMock));
           });
       });
 

--- a/app/tests/spec/views/settings/avatar_url.js
+++ b/app/tests/spec/views/settings/avatar_url.js
@@ -49,9 +49,7 @@ function (chai, _, $, p, sinon, View, RouterMock, Session, Assertion,
     beforeEach(function () {
       routerMock = new RouterMock();
       relier = new Relier();
-      fxaClient = new FxaClient({
-        relier: relier
-      });
+      fxaClient = new FxaClient();
       view = new View({
         router: routerMock,
         fxaClient: fxaClient,


### PR DESCRIPTION
@ckarlof - This is the FxaClient without the relier passed in to the constructor. The core of this update was pretty easy, updating the tests was not. Since so many fxaClient.signUp calls has to be updated in the unit tests, I replaced most calls to the auth-server with sinon stubs.
- Instead of creating the FxaClient with a relier in its constructor, pass a relier instance to the functions that need it.
- Since we had to update any unit test that used fxaClient.signUp to pass in a relier, it was easy to update the tests to no longer touch the server.
- Increase the unit test coverage of fxa-client.js and complete_sign_up.js
- FxaClient.signUp no longer calls .signIn, the sign up view takes care of this.

Note, no functional tests were modified with this!

This is not a full fix for the issues listed in #1777, but contains probably the most difficult part.

issue #1777 
