### PR TITLE
fix(chrome): fix a "read-only" strict mode error in Chrome

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -198,7 +198,7 @@ function (
           // The router's navigate method doesn't set ephemeral messages,
           // so use the view's higher level navigate method.
           return viewToShow.navigate('unexpected_error', {
-            error: err && err.message
+            error: err
           });
         });
     },

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -392,7 +392,7 @@ function (_, Backbone, $, p, Session, AuthErrors,
       err.logged = true;
 
       if (typeof console !== 'undefined' && console) {
-        console.error(err.message || String(err));
+        console.error(err.message);
       }
 
       this.metrics.logError(err);
@@ -413,6 +413,10 @@ function (_, Backbone, $, p, Session, AuthErrors,
         if (this.window.console && this.window.console.trace) {
           this.window.console.trace();
         }
+      }
+
+      if (typeof err === 'string') {
+        err = new Error(err);
       }
 
       if (! err.context) {

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -70,7 +70,7 @@ function (_, canvasToBlob, FormView, ProgressIndicator, Template, Constants, p, 
                              nav.msGetUserMedia;
 
       if (! getUserMedia) {
-        this.displayError(AuthErrors.toCode('NO_CAMERA'));
+        this.displayError(AuthErrors.toError('NO_CAMERA'));
         return false;
       }
 
@@ -93,7 +93,7 @@ function (_, canvasToBlob, FormView, ProgressIndicator, Template, Constants, p, 
         },
         function () {
           self._avatarProgressIndicator.done();
-          self.displayError(AuthErrors.toCode('NO_CAMERA'));
+          self.displayError(AuthErrors.toError('NO_CAMERA'));
         }
       );
 

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -166,7 +166,7 @@ function (chai, _, Backbone, Router, SignInView, SignUpView, ReadyView,
 
         var navigate = view.navigate;
         view.navigate = function (url, options) {
-          assert.equal(options.error, 'boom');
+          assert.equal(options.error.message, 'boom');
           return navigate.call(this, url, options);
         };
 
@@ -184,7 +184,7 @@ function (chai, _, Backbone, Router, SignInView, SignUpView, ReadyView,
 
         var navigate = view.navigate;
         view.navigate = function (url, options) {
-          assert.equal(options.error, 'boom');
+          assert.equal(options.error.message, 'boom');
           return navigate.call(this, url, options);
         };
 
@@ -202,7 +202,7 @@ function (chai, _, Backbone, Router, SignInView, SignUpView, ReadyView,
 
         var navigate = view.navigate;
         view.navigate = function (url, options) {
-          assert.equal(options.error, 'boom');
+          assert.equal(options.error.message, 'boom');
           return navigate.call(this, url, options);
         };
 

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -464,6 +464,15 @@ function (chai, jQuery, sinon, BaseView, Translator, EphemeralMessages, Metrics,
         assert.isTrue(TestHelpers.isErrorLogged(metrics, err));
       });
 
+      it('can log a string as an error', function () {
+        view.metrics.events.clear();
+        view.logError('foo');
+        var err = new Error('foo');
+        err.context = view.getScreenName();
+
+        assert.isTrue(TestHelpers.isErrorLogged(metrics, err));
+      });
+
       it('prints a stack trace via console.trace to facilitate debugging if no error object is passed in', function () {
         view.metrics.events.clear();
         sinon.spy(view.window.console, 'trace');


### PR DESCRIPTION
A new version of Chrome doesn't like when when we assign values to read-only properties of string values. This normalizes all strings to an object. @vladikoff r?

![](http://v14d.com/i/5447fc3101c42.png)

Fixes #1794.
