### PR TITLE
fix(client): Allow leading/trailing whitespace on email addresses

### DIFF
--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -298,7 +298,7 @@ function (_, $, p, Validate, AuthErrors, BaseView, Tooltip,
       var value = this.$(el).val();
 
       if (value && this.getElementType(el) === 'email') {
-        value = value.trim();
+        value = $.trim(value);
       }
 
       return value;

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -446,7 +446,7 @@ function (chai, $, p, FormView, Template, Constants, Metrics, AuthErrors,
     });
 
     describe('getElementValue', function () {
-      it('gets an element\'s value', function () {
+      it('gets an element\'s value, does not trim by default', function () {
         var elementVal = 'this is the value of an element ';
         $('#required').val(elementVal);
         assert.equal(view.getElementValue('#required'), elementVal);
@@ -455,7 +455,13 @@ function (chai, $, p, FormView, Template, Constants, Metrics, AuthErrors,
       it('trims the value of an email element', function () {
         var elementVal = '   testuser@testuser.com ';
         $('#email').val(elementVal);
-        assert.equal(view.getElementValue('#email'), elementVal.trim());
+        assert.equal(view.getElementValue('#email'), $.trim(elementVal));
+      });
+
+      it('does not trim the value of a password element', function () {
+        var elementVal = '  password  ';
+        $('#password').val(elementVal);
+        assert.equal(view.getElementValue('#password'), elementVal);
       });
     });
   });

--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -262,7 +262,6 @@ define([
         // uh oh, user must verify their account.
         .then(FunctionalHelpers.visibleByQSA('#resend'))
         .findById('resend')
-          .moveMouseTo()
           .click()
         .end()
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -18,6 +18,8 @@ define([
   var CONTENT_SERVER = config.fxaContentRoot;
   var OAUTH_APP = config.fxaOauthApp;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
+  var SIGNIN_URL = config.fxaContentRoot + 'signin';
+  var SIGNUP_URL = config.fxaContentRoot + 'signup';
 
   function clearBrowserState(context, options) {
     options = options || {};
@@ -245,6 +247,59 @@ define([
       .end();
   }
 
+  function fillOutSignIn(context, email, password) {
+    return context.get('remote')
+      .get(require.toUrl(SIGNIN_URL))
+      .setFindTimeout(intern.config.pageLoadTimeout)
+      .findByCssSelector('form input.email')
+        .click()
+        .clearValue()
+        .type(email)
+      .end()
+
+      .findByCssSelector('form input.password')
+        .click()
+        .clearValue()
+        .type(password)
+      .end()
+
+      .findByCssSelector('button[type="submit"]')
+        .click()
+      .end();
+  }
+
+  function fillOutSignUp(context, email, password, year) {
+    return context.get('remote')
+      .get(require.toUrl(SIGNUP_URL))
+      .setFindTimeout(intern.config.pageLoadTimeout)
+
+      .findByCssSelector('form input.email')
+        .click()
+        .clearValue()
+        .type(email)
+      .end()
+
+      .findByCssSelector('form input.password')
+        .click()
+        .clearValue()
+        .type(password)
+      .end()
+
+      .findByCssSelector('#fxa-age-year')
+        .click()
+      .end()
+
+      .findById('fxa-' + year)
+        .pressMouseButton()
+        .releaseMouseButton()
+        .click()
+      .end()
+
+      .findByCssSelector('button[type="submit"]')
+        .click()
+      .end();
+  }
+
   return {
     clearBrowserState: clearBrowserState,
     clearSessionStorage: clearSessionStorage,
@@ -255,6 +310,9 @@ define([
     openVerificationLinkSameBrowser: openVerificationLinkSameBrowser,
     openVerificationLinkDifferentBrowser: openVerificationLinkDifferentBrowser,
     openPasswordResetLinkDifferentBrowser: openPasswordResetLinkDifferentBrowser,
-    openFxaFromRp: openFxaFromRp
+    openFxaFromRp: openFxaFromRp,
+
+    fillOutSignIn: fillOutSignIn,
+    fillOutSignUp: fillOutSignUp
   };
 });

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -383,7 +383,6 @@ define([
         // The error area shows a link to /signup
         .then(FunctionalHelpers.visibleByQSA('.error a[href="/signup"]'))
         .findByCssSelector('.error a[href="/signup"]')
-          .moveMouseTo()
           .click()
         .end()
 

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -33,22 +33,7 @@ define([
   }
 
   function fillOutSignIn(context, email, password) {
-    return context.get('remote')
-      .get(require.toUrl(PAGE_URL))
-      .setFindTimeout(intern.config.pageLoadTimeout)
-      .findByCssSelector('form input.email')
-        .click()
-        .type(email)
-      .end()
-
-      .findByCssSelector('form input.password')
-        .click()
-        .type(password)
-      .end()
-
-      .findByCssSelector('button[type="submit"]')
-        .click()
-      .end();
+    return FunctionalHelpers.fillOutSignIn(context, email, password);
   }
 
   registerSuite({
@@ -77,9 +62,6 @@ define([
     },
 
     teardown: function () {
-      // clear localStorage to avoid polluting other tests.
-      // Without the clear, /signup tests fail because of the info stored
-      // in prefillEmail
       return FunctionalHelpers.clearBrowserState(this);
     },
 
@@ -131,7 +113,6 @@ define([
         // The error area shows a link to /signup
         .then(FunctionalHelpers.visibleByQSA('.error a[href="/signup"]'))
         .findByCssSelector('.error a[href="/signup"]')
-          .moveMouseTo()
           .click()
         .end()
 
@@ -171,6 +152,17 @@ define([
           return fillOutSignIn(self, email + '   ', PASSWORD)
             // success is seeing the sign-in-complete screen.
             .findById('fxa-settings-header')
+            .end();
+        });
+    },
+
+    'sign in verified with password that incorrectly has leading whitespace': function () {
+      var self = this;
+      return verifyUser(email, 0)
+        .then(function () {
+          return fillOutSignIn(self, email, '  ' + PASSWORD)
+            // success is seeing the error message.
+            .findByClassName('error')
             .end();
         });
     },


### PR DESCRIPTION
@zaach - mind reviewing?

This is comprised of 2 commits, the first fixes the leading/trailing space on email problem, the second standardizes the parameter name for an element to `el` instead of a mix of `el`, `which` and `selector`.

fixes #519 
