### PR TITLE
fix(client): Fix CORS requests not being decoded for Fx<21

### DIFF
--- a/app/scripts/lib/config-loader.js
+++ b/app/scripts/lib/config-loader.js
@@ -8,13 +8,13 @@
 
 define([
   'underscore',
-  'jquery',
-  'p-promise',
+  'lib/xhr',
+  'lib/promise',
   'lib/url'
 ],
 function (
   _,
-  $,
+  xhr,
   p,
   Url
 ) {
@@ -54,7 +54,7 @@ function (
       }
 
       var self = this;
-      return p.jQueryXHR($.getJSON('/config'))
+      return xhr.getJSON('/config')
           .then(function (config) {
             self._config = config;
             return config;

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -12,13 +12,14 @@ define([
   'underscore',
   'fxaClient',
   'jquery',
+  'lib/xhr',
   'lib/promise',
   'lib/session',
   'lib/auth-errors',
   'lib/constants',
   'lib/channels'
 ],
-function (_, FxaClient, $, p, Session, AuthErrors, Constants, Channels) {
+function (_, FxaClient, $, xhr, p, Session, AuthErrors, Constants, Channels) {
   function trim(str) {
     return $.trim(str);
   }
@@ -80,7 +81,7 @@ function (_, FxaClient, $, p, Session, AuthErrors, Constants, Channels) {
         return p(Session.config.fxaccountUrl);
       }
 
-      return p.jQueryXHR($.getJSON('/config'))
+      return xhr.getJSON('/config')
           .then(function (data) {
             return data.fxaccountUrl;
           });

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -19,10 +19,11 @@ define([
   'backbone',
   'jquery',
   'speedTrap',
+  'lib/xhr',
   'lib/promise',
   'lib/url',
   'lib/strings'
-], function (_, Backbone, $, speedTrap, p, Url, Strings) {
+], function (_, Backbone, $, speedTrap, xhr, p, Url, Strings) {
   'use strict';
 
   // Speed trap is a singleton, convert it
@@ -54,7 +55,7 @@ define([
     // by default, send the metrics to the content server.
     this._collector = options.collector || '';
 
-    this._ajax = options.ajax || $.ajax;
+    this._ajax = options.ajax || xhr.ajax;
 
     this._speedTrap = new SpeedTrap();
     this._speedTrap.init();
@@ -166,13 +167,13 @@ define([
 
     _send: function (data, url, async) {
       var self = this;
-      return p.jQueryXHR(this._ajax({
+      return this._ajax({
         async: async !== false,
         type: 'POST',
         url: url,
         contentType: 'application/json',
         data: JSON.stringify(data)
-      }))
+      })
       .then(function () {
         self.trigger('flush.success', data);
         return data;

--- a/app/scripts/lib/oauth-client.js
+++ b/app/scripts/lib/oauth-client.js
@@ -5,13 +5,13 @@
 'use strict';
 
 define([
-  'jquery',
+  'lib/xhr',
   'lib/promise',
   'lib/session',
   'lib/config-loader',
   'lib/oauth-errors'
 ],
-function ($, p, Session, ConfigLoader, OAuthErrors) {
+function (xhr, p, Session, ConfigLoader, OAuthErrors) {
   var oauthUrl;
 
   var GET_CLIENT = '/v1/client/';
@@ -50,7 +50,7 @@ function ($, p, Session, ConfigLoader, OAuthErrors) {
     // params = { assertion, client_id, redirect_uri, scope, state }
     getCode: function getCode(params) {
       return this._getOauthUrl().then(function (url) {
-        return p.jQueryXHR($.post(url + GET_CODE, params))
+        return xhr.post(url + GET_CODE, params)
             .then(null, function (xhr) {
               var err = OAuthErrors.normalizeXHRError(xhr);
               throw err;
@@ -60,7 +60,7 @@ function ($, p, Session, ConfigLoader, OAuthErrors) {
 
     getClientInfo: function getClientInfo(id) {
       return this._getOauthUrl().then(function (url) {
-        return p.jQueryXHR($.get(url + GET_CLIENT + id))
+        return xhr.get(url + GET_CLIENT + id)
             .then(null, function (xhr) {
               var err = OAuthErrors.normalizeXHRError(xhr);
               throw err;

--- a/app/scripts/lib/profile-client.js
+++ b/app/scripts/lib/profile-client.js
@@ -5,16 +5,15 @@
 'use strict';
 
 define([
-  'jquery',
+  'lib/xhr',
   'underscore',
-  'lib/promise',
   'lib/session',
   'lib/config-loader',
   'lib/oauth-client',
   'lib/assertion',
   'lib/auth-errors'
 ],
-function ($, _, p, Session, ConfigLoader, OAuthClient, Assertion, AuthErrors) {
+function (xhr, _, Session, ConfigLoader, OAuthClient, Assertion, AuthErrors) {
 
   function ProfileClient(options) {
     this.profileUrl = options.profileUrl;
@@ -46,7 +45,7 @@ function ($, _, p, Session, ConfigLoader, OAuthClient, Assertion, AuthErrors) {
       request.processData = false;
     }
 
-    return p.jQueryXHR($.ajax(request))
+    return xhr.ajax(request)
       .then(function (result) {
         if (result.error) {
           throw ProfileErrors.toError(result);

--- a/app/scripts/lib/xhr.js
+++ b/app/scripts/lib/xhr.js
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A thin wrapper around jQuery's ajax functionality with two modifications:
+ *
+ * 1. All functions return a Promises/A+ compliant promise
+ * 2. The default dataType for `get` and `post` is `application/json` to fix
+ *    jQuery/Firefox < 21 not decoding CORS request headers unless the
+ *    dataType is set. `ajax` is a low level function and does not set
+ *    a default data type. See issue #1786.
+ */
+
+'use strict';
+
+define([
+  'jquery',
+  'lib/promise'
+], function ($, p) {
+  var DEFAULT_DATA_TYPE = 'json';
+
+  return {
+    /**
+     * Low level ajax functionality, does not set a default data type.
+     *
+     * @return {promise}
+     */
+    ajax: function (options) {
+      return p.jQueryXHR($.ajax(options));
+    },
+
+    /**
+     * GET request
+     *
+     * Sets a default dataType of 'json'
+     * @return {promise}
+     */
+    get: function (url, data, success, dataType) {
+      if (! dataType) {
+        dataType = DEFAULT_DATA_TYPE;
+      }
+
+      return p.jQueryXHR($.get(url, data, success, dataType));
+    },
+
+    /**
+     * POST request
+     *
+     * Sets a default dataType of 'json'
+     * @return {promise}
+     */
+    post: function (url, data, success, dataType) {
+      if (! dataType) {
+        dataType = DEFAULT_DATA_TYPE;
+      }
+
+      return p.jQueryXHR($.post(url, data, success, dataType));
+    },
+
+    /**
+     * GET JSON request
+     *
+     * @return {promise}
+     */
+    getJSON: function (url, data, success) {
+      return p.jQueryXHR($.getJSON(url, data, success));
+    }
+  };
+});
+
+

--- a/app/scripts/views/pp.js
+++ b/app/scripts/views/pp.js
@@ -5,27 +5,26 @@
 'use strict';
 
 define([
-  'jquery',
+  'lib/xhr',
   'views/base',
   'stache!templates/pp',
-  'lib/promise',
   'lib/session',
   'lib/auth-errors'
 ],
-function ($, BaseView, Template, p, AuthErrors) {
+function (xhr, BaseView, Template, AuthErrors) {
   var View = BaseView.extend({
     template: Template,
     className: 'pp',
 
     afterRender: function () {
       var self = this;
-      p.jQueryXHR($.ajax({
+      return xhr.ajax({
         url: '/legal/privacy',
         accepts: {
           text: 'text/partial'
         },
         dataType: 'text'
-      }))
+      })
       .then(function (template) {
         self.$('#legal-copy').html(template);
         self.$('.hidden').removeClass('hidden');

--- a/app/scripts/views/tos.js
+++ b/app/scripts/views/tos.js
@@ -5,27 +5,26 @@
 'use strict';
 
 define([
-  'jquery',
+  'lib/xhr',
   'views/base',
   'stache!templates/tos',
-  'lib/promise',
   'lib/session',
   'lib/auth-errors'
 ],
-function ($, BaseView, Template, p, AuthErrors) {
+function (xhr, BaseView, Template, AuthErrors) {
   var View = BaseView.extend({
     template: Template,
     className: 'tos',
 
     afterRender: function () {
       var self = this;
-      return p.jQueryXHR($.ajax({
+      return xhr.ajax({
         url: '/legal/terms',
         accepts: {
           text: 'text/partial'
         },
         dataType: 'text'
-      }))
+      })
       .then(function (template) {
         self.$('#legal-copy').html(template);
         self.$('.hidden').removeClass('hidden');

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -7,12 +7,13 @@
 define([
   'chai',
   'jquery',
+  'lib/promise',
   'lib/metrics',
   'lib/auth-errors',
   '../../mocks/window',
   '../../lib/helpers'
 ],
-function (chai, $, Metrics, AuthErrors, WindowMock, TestHelpers) {
+function (chai, $, p, Metrics, AuthErrors, WindowMock, TestHelpers) {
   'use strict';
 
   /*global describe, it*/
@@ -100,15 +101,11 @@ function (chai, $, Metrics, AuthErrors, WindowMock, TestHelpers) {
       function ajaxMock(options) {
         sentData = options.data;
 
-        var deferred = $.Deferred();
-
         if (serverError) {
-          deferred.reject({ statusText: serverError }, 'bad jiji', serverError);
-        } else {
-          deferred.resolve({});
+          return p.reject({ statusText: serverError });
         }
 
-        return deferred.promise();
+        return p({});
       }
 
       beforeEach(function () {

--- a/app/tests/spec/lib/xhr.js
+++ b/app/tests/spec/lib/xhr.js
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'chai',
+  'sinon',
+  'jquery',
+  'underscore',
+  'lib/xhr'
+],
+function (chai, sinon, $, _, xhr, undefined) {
+  var assert = chai.assert;
+
+  afterEach(function () {
+    var possiblyOverridden = ['ajax', 'get', 'post', 'getJSON'];
+    _.each(possiblyOverridden, function (funcNameToRestore) {
+      if ($[funcNameToRestore].restore) {
+        $[funcNameToRestore].restore();
+      }
+    });
+  });
+
+  describe('lib/xhr', function () {
+    describe('ajax', function () {
+      it('calls $.ajax', function () {
+        var deferred = $.Deferred();
+
+        sinon.stub($, 'ajax', function () {
+          return deferred.promise();
+        });
+
+        deferred.resolve('mocked_response');
+
+        return xhr.ajax({
+          url: '/fake_endpoint'
+        })
+        .then(function (resp) {
+          assert.equal(resp, 'mocked_response');
+          assert.isTrue($.ajax.calledWith({ url: '/fake_endpoint' }));
+        });
+      });
+    });
+
+    describe('get', function () {
+      it('calls $.get, sets the default dataType to `json`', function () {
+        var deferred = $.Deferred();
+
+        sinon.stub($, 'get', function () {
+          return deferred.promise();
+        });
+
+        deferred.resolve('mocked_response');
+
+        return xhr.get('/fake_endpoint')
+          .then(function (resp) {
+            assert.equal(resp, 'mocked_response');
+            assert.isTrue(
+                $.get.calledWith('/fake_endpoint', undefined, undefined, 'json'));
+          });
+      });
+
+      it('calls $.get with no changes if dataType is set', function () {
+        var deferred = $.Deferred();
+
+        sinon.stub($, 'get', function () {
+          return deferred.promise();
+        });
+
+        deferred.resolve('mocked_response');
+
+        return xhr.get('/fake_endpoint', { key: 'value' }, null, 'text')
+          .then(function (resp) {
+            assert.equal(resp, 'mocked_response');
+            assert.isTrue(
+                $.get.calledWith('/fake_endpoint', { key: 'value' }, null, 'text'));
+          });
+      });
+    });
+
+    describe('post', function () {
+      it('calls $.post, sets the default dataType to `json`', function () {
+        var deferred = $.Deferred();
+
+        sinon.stub($, 'post', function () {
+          return deferred.promise();
+        });
+
+        deferred.resolve('mocked_response');
+
+        return xhr.post('/fake_endpoint')
+          .then(function (resp) {
+            assert.equal(resp, 'mocked_response');
+            assert.isTrue(
+                $.post.calledWith('/fake_endpoint', undefined, undefined, 'json'));
+          });
+      });
+
+      it('calls $.post with no changes if dataType is set', function () {
+        var deferred = $.Deferred();
+
+        sinon.stub($, 'post', function () {
+          return deferred.promise();
+        });
+
+        deferred.resolve('mocked_response');
+
+        return xhr.post('/fake_endpoint', { key: 'value' }, null, 'text')
+          .then(function (resp) {
+            assert.equal(resp, 'mocked_response');
+            assert.isTrue(
+                $.post.calledWith('/fake_endpoint', { key: 'value' }, null, 'text'));
+          });
+      });
+    });
+
+    describe('getJSON', function () {
+      it('calls $.getJSON', function () {
+        var deferred = $.Deferred();
+
+        sinon.stub($, 'getJSON', function () {
+          return deferred.promise();
+        });
+
+        deferred.resolve({ key: 'value' });
+
+        return xhr.getJSON('/fake_endpoint')
+          .then(function (resp) {
+            assert.deepEqual(resp, { key: 'value' });
+            assert.isTrue($.getJSON.calledWith('/fake_endpoint'));
+          });
+      });
+    });
+  });
+});
+
+

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -36,6 +36,7 @@ function (Translator, Session) {
     '../tests/spec/lib/cropper',
     '../tests/spec/lib/image-loader',
     '../tests/spec/lib/resume-token',
+    '../tests/spec/lib/xhr',
     '../tests/spec/views/base',
     '../tests/spec/views/tooltip',
     '../tests/spec/views/form',


### PR DESCRIPTION
Fx < 21 has a problem where it returns an emtpy string when calling
xhr.getAllResponseHeaders() for CORS requests. jQuery uses the
'Content-Type' header to do smart decoding of content. Since jQuery
cannot get the correct type, it returns JSON content as text, causing the app
to blowup whenever trying use the returned data as an object.

We also have issues where jQuery does not return Promises/A+ compliant promises
from its XHR functionality. We convert between jQuery deferreds and promises wherever we 
make a request.

Instead of leaving these two problems to be solved on an ad-hoc basis, a simple
xhr wrapper library is created that surfaces the functions we make use of. All
functions return a Promises/A+ compatible promise. The default dataType is set
to JSON for `get` and `post` if not already specified. `ajax` is left alone so we do
not alter default low level functionality.

fixes #1786
