### PR TITLE
style(tooltip): wrap tooltip text

### DIFF
--- a/app/scripts/views/tooltip.js
+++ b/app/scripts/views/tooltip.js
@@ -12,6 +12,8 @@ define([
   'views/base'
 ], function (_, $, BaseView) {
   var displayedTooltip;
+  var PADDING_BELOW_TOOLTIP_PX = 2;
+  var PADDING_ABOVE_TOOLTIP_PX = 4;
 
   var Tooltip = BaseView.extend({
     tagName: 'aside',
@@ -39,10 +41,10 @@ define([
       }
       displayedTooltip = this;
 
-      this.setPosition();
-
       var tooltipContainer = this.invalidEl.closest('.input-row,.select-row-wrapper');
       this.$el.appendTo(tooltipContainer);
+
+      this.setPosition();
 
       this.bindDOMEvents();
     },
@@ -67,9 +69,12 @@ define([
       if (invalidEl.hasClass('tooltip-below')) {
         tooltipEl.addClass('tooltip-below fade-up-tt');
         tooltipEl.css({
-          top: invalidEl.outerHeight() + 4  // magic number alert.
+          top: invalidEl.outerHeight() + PADDING_ABOVE_TOOLTIP_PX
         });
       } else {
+        tooltipEl.css({
+          top: -tooltipEl.outerHeight() - PADDING_BELOW_TOOLTIP_PX
+        });
         tooltipEl.addClass('fade-down-tt');
       }
     },

--- a/app/styles/_general.scss
+++ b/app/styles/_general.scss
@@ -290,7 +290,6 @@ strong.email {
   padding: 5px 12px;
   position: absolute;
   top: -32px;
-  white-space: nowrap;
   z-index: 5;
 }
 
@@ -303,20 +302,12 @@ strong.email {
   left: 12px;
   position: absolute;
   text-indent: -999px;
-  top: 21px;
+  bottom: -8px;
   transform: rotate(45deg);
   white-space: nowrap;
   width: 16px;
   // The z-index must be -1 or else the caret is displayed on top of the tooltip text
   z-index: -1;
-}
-
-//RTL languages need adjusted caret position
-html[dir='rtl'] {
-  .tooltip:before,
-  .tooltip::before {
-    top: 19px;
-  }
 }
 
 /**

--- a/app/styles/_media_queries.scss
+++ b/app/styles/_media_queries.scss
@@ -274,6 +274,10 @@ only screen and (orientation:landscape) and (min-width:481px) and (max-height:48
   #legal-footer {
     margin: 0;
   }
+
+  .tooltip {
+    font-size: $small-font;
+  }
 }
 
 @media only screen and (max-height:568px) {


### PR DESCRIPTION
Fixes #1784. Tooltips now wrap; no longer extending past the content container even if the screen is wide enough.

@johngruen You got time for a review?
