### PR TITLE
feat(client): Allow the user to restart the signup flow on email bounce.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -53,7 +53,9 @@ function () {
     NO_CAMERA: 1014,
     URL_REQUIRED: 1015,
     BIRTHDAY_REQUIRED: 1016,
-    DESKTOP_CHANNEL_TIMEOUT: 1017
+    DESKTOP_CHANNEL_TIMEOUT: 1017,
+    SIGNUP_EMAIL_BOUNCE: 1018,
+    DIFFERENT_EMAIL_REQUIRED: 1019
   };
 
   var CODE_TO_MESSAGES = {
@@ -95,7 +97,9 @@ function () {
     1014: t('Could not initialize camera'),
     1015: t('Valid URL required'),
     1016: t('Valid birthday required'),
-    1017: t('Unexpected error')
+    1017: t('Unexpected error'),
+    1018: t('Your verification email was just returned. Mistyped email? <a href="/signup">Start over.</a>'),
+    1019: t('Valid email required')
   };
 
   return {

--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -13,8 +13,9 @@ function () {
 
   // temporary strings that can be extracted for the
   // l10n team to start translations.
-  // for use in #1801 when implemented.
-  t('Your verification email was just returned. Mistyped email? <a href="/signup">Start over.</a>');
+  // TODO - remove this string when the update to #1801 which removes the click
+  // from the confirm page and this is an actual error message.
+  t('Your verification email was just returned. Mistyped email?');
 
   // Intended for email marketing opt-in
   // Should be removed in favor of #992 and #993 when implemented

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -119,6 +119,7 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin,
               Session.set('oauth', oauthData);
             });
         }).then(function () {
+          self.logScreenEvent('verification.success');
           return self.broker.afterCompleteResetPassword();
         }).then(function (result) {
           if (! (result && result.halt)) {

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -50,6 +50,7 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, R
       var self = this;
       return this.fxaClient.verifyCode(this.uid, this.code)
           .then(function () {
+            self.logEvent('complete_sign_up.verification.success');
             return self.broker.afterCompleteSignUp();
           })
           .then(function (result) {

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -118,6 +118,7 @@ function (_, $, ConfirmView, BaseView, Template, p, Session, Constants,
         .then(function () {
           self._waitForConfirmation()
             .then(function (sessionInfo) {
+              self.logScreenEvent('verification.success');
               // The original window should finish the flow if the user
               // completes verification in the same browser and has sessionInfo
               // passed over from tab 2.

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -399,6 +399,41 @@ function (chai, $, sinon, p, testHelpers, Session, FxaClientWrapper,
       });
     });
 
+    describe('checkAccountExists', function () {
+      it('returns true if an account exists', function () {
+        sinon.stub(realClient, 'accountStatus', function () {
+          return p({ exists: true });
+        });
+
+        return client.checkAccountExists('uid')
+          .then(function (accountExists) {
+            assert.isTrue(accountExists);
+          });
+      });
+
+      it('returns false if an account does not exist', function () {
+        sinon.stub(realClient, 'accountStatus', function () {
+          return p({ exists: false });
+        });
+
+        return client.checkAccountExists('uid')
+          .then(function (accountExists) {
+            assert.isFalse(accountExists);
+          });
+      });
+
+      it('throws other errors from the auth server', function () {
+        sinon.stub(realClient, 'accountStatus', function () {
+          return p.reject(new Error('missing uid'));
+        });
+
+        return client.checkAccountExists()
+          .then(assert.fail, function (err) {
+            assert.equal(err.message, 'missing uid');
+          });
+      });
+    });
+
     describe('checkPassword', function () {
       it('returns error if password is incorrect', function () {
         email = trim(email);

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -50,6 +50,7 @@ function (chai, sinon, p, AuthErrors, Metrics, FxaClient, View, Relier,
     beforeEach(function () {
       routerMock = new RouterMock();
       windowMock = new WindowMock();
+      windowMock.location.pathname = 'complete_reset_password';
       metrics = new Metrics();
       relier = new Relier();
       broker = new Broker();
@@ -298,6 +299,8 @@ function (chai, sinon, p, AuthErrors, Metrics, FxaClient, View, Relier,
                   EMAIL, PASSWORD, relier));
               assert.equal(routerMock.page, 'reset_password_complete');
               assert.isTrue(broker.afterCompleteResetPassword.called);
+              assert.isTrue(TestHelpers.isEventLogged(
+                      metrics, 'complete_reset_password.verification.success'));
             });
       });
 

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -59,6 +59,7 @@ function (chai, sinon, p, View, AuthErrors, Metrics, Constants,
     beforeEach(function () {
       routerMock = new RouterMock();
       windowMock = new WindowMock();
+      windowMock.location.pathname = 'verify_email';
       metrics = new Metrics();
       relier = new Relier();
       broker = new Broker();
@@ -164,6 +165,8 @@ function (chai, sinon, p, View, AuthErrors, Metrics, Constants,
               assert.isTrue(view.fxaClient.verifyCode.called);
               assert.equal(routerMock.page, 'signup_complete');
               assert.isTrue(broker.afterCompleteSignUp.called);
+              assert.isTrue(TestHelpers.isEventLogged(
+                      metrics, 'complete_sign_up.verification.success'));
             });
       });
 

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -174,6 +174,8 @@ function (chai, sinon, p, AuthErrors, View, Session, Metrics,
         sinon.stub(view, 'navigate', function (url) {
           TestHelpers.wrapAssertion(function () {
             assert.equal(url, 'reset_password_complete');
+            assert.isTrue(TestHelpers.isEventLogged(
+                    metrics, 'confirm_reset_password.verification.success'));
           }, done);
         });
 

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -8,6 +8,7 @@ define([
   './functional/sign_up',
   './functional/complete_sign_up',
   './functional/sync_sign_up',
+  './functional/bounced_email',
   './functional/legal',
   './functional/tos',
   './functional/pp',

--- a/tests/functional/bounced_email.js
+++ b/tests/functional/bounced_email.js
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'intern/node_modules/dojo/node!xmlhttprequest',
+  'app/bower_components/fxa-js-client/fxa-client',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
+  'use strict';
+
+  var config = intern.config;
+  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+  var CUTOFF_YEAR = new Date().getFullYear() - 13;
+
+  var bouncedEmail;
+  var deliveredEmail;
+  var PASSWORD = '12345678';
+
+  registerSuite({
+    name: 'sign_up with an email that bounces',
+
+    beforeEach: function () {
+      bouncedEmail = TestHelpers.createEmail();
+      deliveredEmail = TestHelpers.createEmail();
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    teardown: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'sign up, bounce email, allow user to restart flow but force a different email': function () {
+      var client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+
+      return FunctionalHelpers.fillOutSignUp(this, bouncedEmail, PASSWORD, CUTOFF_YEAR - 1)
+        .findById('fxa-confirm-header')
+        .end()
+
+        .then(function () {
+          return client.accountDestroy(bouncedEmail, PASSWORD);
+        })
+
+        .then(FunctionalHelpers.visibleByQSA('.error a[href="/signup"]'))
+
+        .findByCssSelector('.error a[href="/signup"]')
+          .click()
+        .end()
+
+        .findById('fxa-signup-header')
+        .end()
+
+        // expect an error message to already be present on redirect
+        .then(FunctionalHelpers.visibleByQSA('.tooltip'))
+
+        // submit button should be disabled.
+        .findByCssSelector('button[type="submit"].disabled')
+        .end()
+
+        .findByCssSelector('input[type="email"]')
+          .clearValue()
+          .click()
+          .type(bouncedEmail)
+        .end()
+
+        // user must change the email address
+        .findByCssSelector('button[type="submit"].disabled')
+          .click()
+        .end()
+
+        // error message should still be around
+        .then(FunctionalHelpers.visibleByQSA('.tooltip'))
+
+        .findByCssSelector('input[type="email"]')
+          .clearValue()
+          .click()
+          .type(deliveredEmail)
+        .end()
+
+        .findByCssSelector('button[type="submit"]')
+          .click()
+        .end()
+
+        .findById('fxa-confirm-header')
+        .end();
+    }
+
+  });
+});

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -253,7 +253,7 @@ define([
       .getCurrentUrl()
       .then(function (currentUrl) {
         // only load the signin page if not already at a signin page.
-        if (currentUrl.indexOf('signin') === -1) {
+        if (currentUrl.indexOf(/\/signin[$?]/) === -1) {
           return context.get('remote')
             .get(require.toUrl(SIGNIN_URL))
             .setFindTimeout(intern.config.pageLoadTimeout);
@@ -282,7 +282,7 @@ define([
       .getCurrentUrl()
       .then(function (currentUrl) {
         // only load the signup page if not already at a signup page.
-        if (currentUrl.indexOf('signup') === -1) {
+        if (currentUrl.indexOf(/\/signup[$?]/) === -1) {
           return context.get('remote')
             .get(require.toUrl(SIGNUP_URL))
             .setFindTimeout(intern.config.pageLoadTimeout);
@@ -322,7 +322,7 @@ define([
       .then(function (currentUrl) {
         // only load the reset_password page if not already at
         // the reset_password page.
-        if (currentUrl.indexOf('reset_password') === -1) {
+        if (currentUrl.indexOf(/\/reset_password[$?]/) === -1) {
           return context.get('remote')
             .get(require.toUrl(RESET_PASSWORD_URL))
             .setFindTimeout(intern.config.pageLoadTimeout);


### PR DESCRIPTION
Add two new error codes:
- 1018 - SIGNUP_EMAIL_BOUNCE
- 1019 - DIFFERENT_EMAIL_REQUIRED

Additional work:
- Add functional tests/TODOS for the bounced email case.
- Be more specific when comparing the current URL against the expected URL. `fillOutSignUp` had an error where it would not redirect if the previous test finished at `/signup_complete`
- Add 4 new verification events that are added to the event stream when a user verifies their email address.
  - confirm.verification.success
  - complete_sign_up.verification.success
  - confirm_reset_password.verification.success
  - complete_reset_password.verification.success

fixes #1801
