### PR TITLE
fix(client): Ensure the spinner stays spinning after signin for Sync/OAuth.

### DIFF
--- a/app/scripts/views/decorators/progress_indicator.js
+++ b/app/scripts/views/decorators/progress_indicator.js
@@ -37,7 +37,7 @@ function (p, ProgressIndicator) {
           })
           .then(function (value) {
             // Stop the progress indicator unless the page is navigating
-            if (! (value && value.pageNavigation)) {
+            if (! (value && value.halt)) {
               progressIndicator.done();
             }
             return value;

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -122,6 +122,8 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin, Auth
           if (! (result && result.halt)) {
             self.navigate('settings');
           }
+
+          return result;
         });
     },
 


### PR DESCRIPTION
If the result of `submit` contains `halt: true`, the form is "halted" and the button spinner remains spinning.

Add a notion of "halt" to a form. I would like this to be called `disableForm`, but that name is already taken. If a form is halted, do now allow the fields to be modified, do not allow form submission.

Add a shed-load of unit tests for the form module.

fixes #1879
