### PR TITLE
fix(client): Autofocus on /signup works again.

### DIFF
--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -80,6 +80,8 @@ function (_, p, BaseView, FormView, Template, Session, AuthErrors,
         this.showValidationError('input[type=email]',
                   AuthErrors.toError('DIFFERENT_EMAIL_REQUIRED'));
       }
+
+      return FormView.prototype.afterVisible.call(this);
     },
 
     events: {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -174,6 +174,21 @@ function (chai, _, $, moment, sinon, p, View, Session, AuthErrors, Metrics,
             assert.isTrue(view.showValidationError.called);
           });
       });
+
+      it('focuses the email element by default', function (done) {
+        $('html').addClass('no-touch');
+        TestHelpers.requiresFocus(function () {
+          view.render()
+            .then(function () {
+
+              view.$('input[type="email"]').one('focus', function () {
+                done();
+              });
+
+              view.afterVisible();
+            });
+        }, done);
+      });
     });
 
     describe('isValid', function () {


### PR DESCRIPTION
PR #1855(Handle bounced emails) introduced a regression that eliminated autofocus on the /signup page unless there was a bounced email.

fixes #1891
