### PR TITLE
fix(client): Fixed missing spinner on subsequent requests.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -48,7 +48,6 @@ function (_, Backbone, $, p, Session, AuthErrors,
   function displayError(displayStrategy, err) {
     /*jshint validthis: true*/
     this.hideSuccess();
-    this.$('.spinner').hide();
 
     err = this._normalizeError(err);
 


### PR DESCRIPTION
After much code spelunking I ended up with this worryingly obvious one line fix. I suspect this `.hide()` is left over from simpler times since `progress_indicator.js` is now concerned with the spinner. I tested Sign In, Sign Up, and Change Password. All seemed to now work correctly on multiple failed attempts.
