### PR TITLE
feat(client): Allow TLD only domain names in email addresses

### DIFF
--- a/app/scripts/lib/validate.js
+++ b/app/scripts/lib/validate.js
@@ -30,18 +30,17 @@ define([
 
       // Original regexp from:
       //  http://blog.gerv.net/2011/05/html5_email_address_regexp/
-      // Modified to require at least a 2 part tld and remove the
-      // length checks, which are done later.
+      // Modified to remove the length checks, which are done later.
       // IETF spec: http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
       // NOTE: this does *NOT* allow internationalized domain names.
-      return (/^[\w.!#$%&'*+\-\/=?\^`{|}~]+@[a-z\d][a-z\d\-]*(?:\.[a-z\d][a-z\d\-]*)+$/i).test(email) &&
+      return (/^[\w.!#$%&'*+\-\/=?\^`{|}~]+@[a-z\d][a-z\d\-]*(?:\.[a-z\d][a-z\d\-]*)*$/i).test(email) &&
              // total email allwed to be 256 bytes long
              email.length <= 256 &&
              // local side only allowed to be 64 bytes long
              1 <= localLength && localLength <= 64 &&
              // domain side allowed to be up to 255 bytes long which
              // doesn't make much sense unless the local side has 0 length;
-             3 <= domainLength && domainLength <= 255;
+             1 <= domainLength && domainLength <= 255;
     },
 
     /**

--- a/app/tests/spec/lib/validate.js
+++ b/app/tests/spec/lib/validate.js
@@ -22,8 +22,8 @@ function (chai, _, Validate, Constants, TestHelpers) {
         assert.isFalse(Validate.isEmailValid('a'));
       });
 
-      it('returns false for email without a one part domain', function () {
-        assert.isFalse(Validate.isEmailValid('a@b'));
+      it('returns true for email with a one part domain', function () {
+        assert.isTrue(Validate.isEmailValid('a@b'));
       });
 
       it('returns true for valid email', function () {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -211,11 +211,6 @@ function (chai, _, $, moment, sinon, p, View, Session, AuthErrors, Metrics,
         assert.isFalse(view.isValid());
       });
 
-      it('returns false if email contain one part TLD', function () {
-        fillOutSignUp('a@b', 'password', { context: view });
-        assert.isFalse(view.isValid());
-      });
-
       it('returns false if email is the same as the bounced email', function () {
         ephemeralMessages.set('bouncedEmail', 'testuser@testuser.com');
 
@@ -232,7 +227,12 @@ function (chai, _, $, moment, sinon, p, View, Session, AuthErrors, Metrics,
           });
       });
 
-      it('returns true if email contain two part TLD', function () {
+      it('returns true if email contains a one part TLD', function () {
+        fillOutSignUp('a@b', 'password', { context: view });
+        assert.isTrue(view.isValid());
+      });
+
+      it('returns true if email contains a two part TLD', function () {
         fillOutSignUp('a@b.c', 'password', { context: view });
         assert.isTrue(view.isValid());
       });
@@ -392,7 +392,7 @@ function (chai, _, $, moment, sinon, p, View, Session, AuthErrors, Metrics,
         view.on('validation_error', function (which, msg) {
           var err = AuthErrors.toError('DIFFERENT_EMAIL_REQUIRED_FIREFOX_DOMAIN');
           err.context = 'signup';
-          
+
           wrapAssertion(function () {
             assert.equal(msg, err.message);
             assert.isTrue(TestHelpers.isErrorLogged(metrics, err));


### PR DESCRIPTION
@zaach or @vladikoff - r?

The email `user@com` is a valid email according to the IETF RFC5321. Marketplace allows them. We should too.

http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1

fixes #1871
