### PR TITLE
fix(test): Fix the 'Unexpected error' flash in the sign_in tests.

### DIFF
--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -148,6 +148,37 @@ define([
         .end();
     },
 
+    'open /reset_password from /signin with partial email': function () {
+      var self = this;
+      email = 'partial';
+
+      return self.get('remote')
+        .get(require.toUrl(SIGNIN_PAGE_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+
+        .findByCssSelector('input[type=email]')
+          .click()
+          .clearValue()
+          .type(email)
+        .end()
+
+        .findByCssSelector('a[href="/reset_password"]')
+          .click()
+        .end()
+
+        .findById('fxa-reset-password-header')
+        .end()
+
+        .findByCssSelector('input[type=email]')
+          .getAttribute('value')
+          .then(function (resultText) {
+            // check the email address was written
+            assert.equal(resultText, email);
+          })
+        .end();
+    },
+
+
     'enter an email with leading whitespace': function () {
       return fillOutResetPassword(this, '   ' + email)
         .findById('fxa-confirm-reset-password-header')

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -45,15 +45,9 @@ define([
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });
-      var self = this;
       return client.signUp(email, PASSWORD)
         .then(function (result) {
           accountData = result;
-          return result;
-        })
-        .then(function () {
-          // clear localStorage to avoid pollution from other tests.
-          return FunctionalHelpers.clearBrowserState(self);
         });
     },
 
@@ -161,59 +155,18 @@ define([
       return verifyUser(email, 0)
         .then(function () {
           return fillOutSignIn(self, email, '  ' + PASSWORD)
+
             // success is seeing the error message.
-            .findByClassName('error')
-            .end();
+           .then(FunctionalHelpers.visibleByQSA('.error'))
+           .end()
+
+           .findByCssSelector('.error')
+             .getVisibleText()
+             .then(function (text) {
+               assert.isTrue(/password/i.test(text));
+             })
+           .end();
         });
-    },
-
-    'click `forgot password?` link with no email redirects to /forgot_password': function () {
-      var self = this;
-
-      return self.get('remote')
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
-
-        .findByCssSelector('input[type=email]')
-          .click()
-          .clearValue()
-        .end()
-
-        .findByCssSelector('a[href="/reset_password"]')
-          .click()
-        .end()
-
-        .findById('fxa-reset-password-header');
-    },
-
-    'click `forgot password?` link with invalid email redirects to /forgot_password and prefills partial email': function () {
-      var self = this;
-      email = 'partial';
-
-      return self.get('remote')
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
-
-        .findByCssSelector('input[type=email]')
-          .click()
-          .clearValue()
-          .type(email)
-        .end()
-
-        .findByCssSelector('a[href="/reset_password"]')
-          .click()
-        .end()
-
-        .findById('fxa-reset-password-header')
-        .end()
-
-        .findByCssSelector('input[type=email]')
-          .getAttribute('value')
-          .then(function (resultText) {
-            // check the email address was written
-            assert.equal(resultText, email);
-          })
-        .end();
     },
 
     'visiting the pp links saves information for return': function () {


### PR DESCRIPTION
fix(test): Fix the 'Unexpected error' flash in the sign_in tests.

In `sign in verified with password that incorrectly has leading whitespace`,
the call to `FunctionalHelpers.visibleByQSA` was incorrectly made inside
of a function passed to a .then. This caused the tests to move on before
the tooltip was visible, which ultimately caused the test to complete
before the signin XHR request was complete. Selenium would start to unload
the page, which aborted the outstanding XHR request, which caused the `Unexpected error` message.

Fixed the call to `FunctionalHelpers.visibleByQSA` as well as ensure
the expected error message is displayed.

Finally, moved a couple of reset password related tests to reset_password.js

fixes #1875
