### PR TITLE
refactor(cropper): pass crop image data around using ephemeral messages

### DIFF
--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -13,7 +13,7 @@ define([
   var NAMESPACE = '__fxa_session';
 
   // and should not be saved to sessionStorage
-  var DO_NOT_PERSIST = ['prefillPassword', 'prefillYear', 'error', 'cropImgWidth', 'cropImgHeight', 'cropImgSrc'];
+  var DO_NOT_PERSIST = ['prefillPassword', 'prefillYear', 'error'];
 
   var DO_NOT_CLEAR = ['config'];
 

--- a/app/scripts/models/cropper-image.js
+++ b/app/scripts/models/cropper-image.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This model abstracts images used by the cropper view
+
+'use strict';
+
+define([
+  'backbone'
+], function (Backbone) {
+  // a 1x1 jpeg
+  var jpegSrc = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsM' +
+                'DAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQE' +
+                'AAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISU' +
+                'pTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAA' +
+                'wEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5' +
+                'OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn' +
+                '6/9oADAMBAAIRAxEAPwD9/KKKKAP/2Q==';
+
+  var CropperImage = Backbone.Model.extend({
+    defaults: {
+      src: jpegSrc,
+      type: 'image/jpeg',
+      width: 1,
+      height: 1
+    }
+  });
+
+  return CropperImage;
+});

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -10,11 +10,10 @@ define([
   'views/form',
   'stache!templates/settings/avatar_crop',
   'lib/constants',
-  'lib/session',
   'lib/cropper',
   'lib/auth-errors'
 ],
-function (p, _, FormView, Template, Constants, Session, Cropper, AuthErrors) {
+function (p, _, FormView, Template, Constants, Cropper, AuthErrors) {
   var HORIZONTAL_GUTTER = 90;
   var VERTICAL_GUTTER = 0;
 
@@ -28,12 +27,12 @@ function (p, _, FormView, Template, Constants, Session, Cropper, AuthErrors) {
     initialize: function (options) {
       options = options || {};
 
-      this.imgSrc = Session.cropImgSrc;
-      this.imgType = Session.cropImgType;
+      var data = this.ephemeralData() || {};
+      this._cropImg = data.cropImg;
     },
 
     beforeRender: function () {
-      if (! this.imgSrc) {
+      if (! this._cropImg) {
         this.navigate('settings/avatar/change', {
           error: AuthErrors.toMessage('UNUSABLE_IMAGE')
         });
@@ -47,13 +46,14 @@ function (p, _, FormView, Template, Constants, Session, Cropper, AuthErrors) {
 
     afterVisible: function () {
       // Use pre-set dimensions if available
-      var width = Session.cropImgWidth;
-      var height = Session.cropImgHeight;
+      var width = this._cropImg.get('width');
+      var height = this._cropImg.get('height');
+      var src = this._cropImg.get('src');
 
       try {
         this.cropper = new Cropper({
           container: this.$('.cropper'),
-          src: this.imgSrc,
+          src: src,
           width: width,
           height: height,
           displayLength: Constants.PROFILE_IMAGE_DISPLAY_SIZE,
@@ -73,7 +73,7 @@ function (p, _, FormView, Template, Constants, Session, Cropper, AuthErrors) {
 
       this.cropper.toBlob(function (data) {
         defer.resolve(data);
-      }, this.imgType || Constants.DEFAULT_PROFILE_IMAGE_MIME_TYPE,
+      }, this._cropImg.get('type'),
       Constants.PROFILE_IMAGE_JPEG_QUALITY);
 
       return defer.promise;

--- a/app/tests/spec/lib/cropper.js
+++ b/app/tests/spec/lib/cropper.js
@@ -11,21 +11,32 @@ define([
   '../../mocks/router',
   '../../mocks/canvas',
   'lib/cropper',
-  'views/settings/avatar_crop'
+  'lib/ephemeral-messages',
+  'views/settings/avatar_crop',
+  'models/cropper-image'
 ],
-function (chai, jquery, RouterMock, CanvasMock, Cropper, View) {
+function (chai, jquery, RouterMock, CanvasMock, Cropper, EphemeralMessages,
+    View, CropperImage) {
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
 
   describe('lib/cropper', function () {
-    var view, routerMock;
+    var view;
+    var routerMock;
+    var ephemeralMessages;
 
     beforeEach(function () {
       routerMock = new RouterMock();
-      view = new View({
-        router: routerMock
+      ephemeralMessages = new EphemeralMessages();
+      ephemeralMessages.set('data', {
+        cropImg: new CropperImage({
+          src: pngSrc
+        })
       });
-      view.imgSrc = pngSrc;
+      view = new View({
+        router: routerMock,
+        ephemeralMessages: ephemeralMessages
+      });
       view.isUserAuthorized = function () {
         return true;
       };

--- a/app/tests/spec/views/settings/avatar_change.js
+++ b/app/tests/spec/views/settings/avatar_change.js
@@ -16,11 +16,10 @@ define([
   '../../../mocks/profile',
   'models/user',
   'lib/promise',
-  'lib/session',
   'lib/auth-errors'
 ],
 function (chai, _, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
-            User, p, Session, AuthErrors) {
+            User, p, AuthErrors) {
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
 
@@ -153,8 +152,9 @@ function (chai, _, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
 
               view.router.on('navigate', function () {
                 try {
+                  var cropImg = view.ephemeralMessages.get('data').cropImg;
                   assert.equal(routerMock.page, 'settings/avatar/crop');
-                  assert.equal(Session.cropImgSrc, pngSrc);
+                  assert.equal(cropImg.get('src'), pngSrc);
                   done();
                 } catch (e) {
                   return done(e);


### PR DESCRIPTION
This gets rid of `Session` in favor of passing ephemeral data between views for handling cropper images.

Fixes #1912.

@shane-tomlinson or @vladikoff r?
