### PR TITLE
fix(client): Go to the /cookies_disabled screen instead of the /500 screen if cookies are disabled.

### DIFF
--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -18,8 +18,9 @@ define([
   'lib/assertion',
   'lib/oauth-client',
   'models/account',
-  'lib/storage'
-], function (Backbone, _, p, Assertion, OAuthClient, Account, Storage) {
+  'lib/storage',
+  'lib/null-storage'
+], function (Backbone, _, p, Assertion, OAuthClient, Account, Storage, NullStorage) {
 
   var User = Backbone.Model.extend({
     initialize: function (options) {
@@ -29,7 +30,17 @@ define([
       this._profileClient = options.profileClient;
       this._fxaClient = options.fxaClient;
       this._assertion = options.assertion;
-      this._storage = options.storage || new Storage(localStorage);
+
+      this._storage = options.storage;
+      var win = options.window || window;
+      if (! this._storage) {
+        try {
+          this._storage = new Storage(win.localStorage);
+        } catch (e) {
+          // if cookies are disabled, accessing localStorage will blow up.
+          this._storage = new Storage(new NullStorage());
+        }
+      }
     },
 
     _accounts: function () {

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -6,9 +6,10 @@
 
 define([
   'underscore',
-  'backbone'
+  'backbone',
+  'lib/null-storage'
 ],
-function (_, Backbone) {
+function (_, Backbone, NullStorage) {
   'use strict';
 
   function WindowMock() {
@@ -58,6 +59,9 @@ function (_, Backbone) {
     };
 
     this.console = window.console;
+
+    this.localStorage = new NullStorage();
+    this.sessionStorage = new NullStorage();
   }
 
   _.extend(WindowMock.prototype, Backbone.Events, {

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -12,22 +12,43 @@ define([
   'lib/constants',
   'lib/session',
   'lib/fxa-client',
-  'models/user'
+  'models/user',
+  '../../mocks/window'
 ],
-function (chai, sinon, p, Constants, Session, FxaClient, User) {
+function (chai, sinon, p, Constants, Session, FxaClient, User, WindowMock) {
   var assert = chai.assert;
 
   describe('models/user', function () {
     var user;
     var fxaClientMock;
+    var windowMock;
 
     beforeEach(function () {
       fxaClientMock = new FxaClient();
-      user = new User();
+      windowMock = new WindowMock();
+      user = new User({
+        window: windowMock
+      });
     });
 
     afterEach(function () {
       user = null;
+    });
+
+    it('does not blow up if cookies are disabled', function () {
+      Object.defineProperty(windowMock, 'localStorage', {
+        get: function () {
+          throw new Error('The operation is insecure.');
+        }
+      });
+
+      try {
+        user = new User({
+          window: windowMock
+        });
+      } finally {
+        assert.ok(user);
+      }
     });
 
     it('creates an account', function () {


### PR DESCRIPTION
The User model was accessing localStorage directly which causes most browsers to except. If localStorage is disabled, create a Storage object with a NullStorage backing instead.

fixes #1919
