### PR TITLE
fix(client): Show the back button for reset_password, even if an email is on the URL query string. Generalize whether the "back" button should be shown.

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -73,7 +73,7 @@ function (
     return function () {
       // passed in options block can override
       // default options.
-      options = _.extend({
+      var viewOptions = _.extend({
         metrics: this.metrics,
         window: this.window,
         router: this,
@@ -82,10 +82,14 @@ function (
         broker: this.broker,
         fxaClient: this.fxaClient,
         user: this.user,
-        interTabChannel: this.interTabChannel
+        interTabChannel: this.interTabChannel,
+        canGoBack: this.canGoBack
       }, options || {});
 
-      this.showView(new View(options));
+      this.showView(new View(viewOptions));
+
+      // back is enabled after the first view is rendered.
+      this.canGoBack = true;
     };
   }
 
@@ -133,6 +137,9 @@ function (
       this.fxaClient = options.fxaClient;
       this.user = options.user;
       this.interTabChannel = options.interTabChannel;
+
+      // back is only enabled after the first view is rendered.
+      this.canGoBack = false;
 
       this.$stage = $('#stage');
 

--- a/app/scripts/templates/change_password.mustache
+++ b/app/scripts/templates/change_password.mustache
@@ -38,8 +38,10 @@
       </div>
     </form>
 
-    <div class="links">
-      <a id="back" href="#">{{#t}}Back{{/t}}</a>
-    </div>
+    {{#canGoBack}}
+      <div class="links">
+        <a id="back" href="#">{{#t}}Back{{/t}}</a>
+      </div>
+    {{/canGoBack}}
   </section>
 </div>

--- a/app/scripts/templates/cookies_disabled.mustache
+++ b/app/scripts/templates/cookies_disabled.mustache
@@ -5,7 +5,7 @@
 
   <section>
     <div class="error"></div>
-    
+
     <p>
       {{#t}}Please enable cookies in your browser which are required by Firefox Accounts. Cookies are small pieces of data stored in your browser that provide functionality such as remembering you between sessions.{{/t}}
     </p>
@@ -13,6 +13,7 @@
     <p>
       <a href="https://support.mozilla.org/kb/cookies-information-websites-store-on-your-computer" target="_blank">{{#t}}Learn more{{/t}}</a>
     </p>
+
 
     <div class="button-row">
       <button id="submit-btn" type="submit">{{#t}}Try again{{/t}}</button>

--- a/app/scripts/templates/delete_account.mustache
+++ b/app/scripts/templates/delete_account.mustache
@@ -25,8 +25,10 @@
       </div>
     </form>
 
-    <div class="links">
-      <a href="#" id="back">{{#t}}Back{{/t}}</a>
-    </div>
+    {{#canGoBack}}
+      <div class="links">
+        <a href="#" id="back">{{#t}}Back{{/t}}</a>
+      </div>
+    {{/canGoBack}}
   </section>
 </div>

--- a/app/scripts/templates/pp.mustache
+++ b/app/scripts/templates/pp.mustache
@@ -10,8 +10,10 @@
     <article id="legal-copy">
     </article>
 
-    <div class="button-row">
-      <button id="fxa-pp-back" class="back">{{#t}}Back{{/t}}</button>
-    </div>
+    {{#canGoBack}}
+      <div class="button-row">
+        <button id="fxa-pp-back" class="back">{{#t}}Back{{/t}}</button>
+      </div>
+    {{/canGoBack}}
   </section>
 </div>

--- a/app/scripts/templates/reset_password.mustache
+++ b/app/scripts/templates/reset_password.mustache
@@ -22,10 +22,10 @@
       </div>
     </form>
 
-    {{#backEnabled}}
+    {{#canGoBack}}
       <div class="links">
         <a id="back" href="/signin">{{#t}}Back{{/t}}</a>
       </div>
-    {{/backEnabled}}
+    {{/canGoBack}}
   </section>
 </div>

--- a/app/scripts/templates/tos.mustache
+++ b/app/scripts/templates/tos.mustache
@@ -10,8 +10,10 @@
     <article id="legal-copy">
     </article>
 
-    <div class="button-row">
-      <button id="fxa-tos-back" class="back">{{#t}}Back{{/t}}</button>
-    </div>
+    {{#canGoBack}}
+      <div class="button-row">
+        <button id="fxa-tos-back" class="back">{{#t}}Back{{/t}}</button>
+      </div>
+    {{/canGoBack}}
   </section>
 </div>

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -81,6 +81,7 @@ function (_, Backbone, $, p, AuthErrors,
       this.user = options.user;
 
       this.fxaClient = options.fxaClient;
+      this._canGoBack = options.canGoBack;
 
       this.automatedBrowser = !!this.searchParam('automatedBrowser');
 
@@ -250,6 +251,7 @@ function (_, Backbone, $, p, AuthErrors,
       var ctx = this.context() || {};
 
       ctx.t = _.bind(this.translate, this);
+      ctx.canGoBack = this.canGoBack();
 
       return ctx;
     },
@@ -524,6 +526,13 @@ function (_, Backbone, $, p, AuthErrors,
       return !!this._isErrorVisible;
     },
 
+    /**
+     * Check if the back button should be shown.
+     */
+    canGoBack: function () {
+      return !! this._canGoBack;
+    },
+
     back: function (event) {
       if (event) {
         event.preventDefault();
@@ -534,7 +543,7 @@ function (_, Backbone, $, p, AuthErrors,
 
     backOnEnter: function (event) {
       if (event.which === ENTER_BUTTON_CODE) {
-        this.window.history.back();
+        this.back();
       }
     },
 

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -20,28 +20,13 @@ function (_, BaseView, FormView, Template, Session, AuthErrors, ServiceMixin) {
     template: Template,
     className: 'reset_password',
 
-    _isBackEnabled: function () {
-      /* If email is specified on the query param, user probably browsed
-       * directly to the page. No back for them.
-       * Users who visit `/force_auth?email=<xxx>` and
-       * click "forgot password" are sent to the
-       * "confirm your email" screen, skipping this step.
-       */
-      return !this._getQueryEmail();
-    },
-
-    _getQueryEmail: function () {
-      return this.searchParam('email');
-    },
-
     _getPrefillEmail: function () {
-      return this._getQueryEmail() || Session.prefillEmail || '';
+      return this.searchParam('email') || Session.prefillEmail || '';
     },
 
     context: function () {
       return {
-        email: this._getPrefillEmail(),
-        backEnabled: this._isBackEnabled()
+        email: this._getPrefillEmail()
       };
     },
 

--- a/app/tests/spec/views/cookies_disabled.js
+++ b/app/tests/spec/views/cookies_disabled.js
@@ -8,11 +8,12 @@
 define([
   'jquery',
   'chai',
+  'sinon',
   'lib/promise',
   'views/cookies_disabled',
   '../../mocks/window'
 ],
-function ($, chai, p, View, WindowMock) {
+function ($, chai, sinon, p, View, WindowMock) {
   var assert = chai.assert;
 
   describe('views/cookies_disabled', function () {
@@ -55,10 +56,14 @@ function ($, chai, p, View, WindowMock) {
     });
 
     describe('backIfCookiesEnabled', function () {
-      it('goes back in history if localStorage is enabled', function () {
+      it('goes back in history if localStorage is enabled and there is a page to go back to', function () {
         serverConfig = {
           localStorageEnabled: true
         };
+
+        sinon.stub(view, 'canGoBack', function () {
+          return true;
+        });
 
         return view.backIfCookiesEnabled()
           .then(function () {

--- a/app/tests/spec/views/pp.js
+++ b/app/tests/spec/views/pp.js
@@ -7,9 +7,10 @@
 
 define([
   'chai',
+  'sinon',
   'views/pp'
 ],
-function (chai, View) {
+function (chai, sinon, View) {
   var assert = chai.assert;
 
   describe('views/pp', function () {
@@ -24,12 +25,25 @@ function (chai, View) {
       view.destroy();
     });
 
-    it('Back button is displayed', function () {
+    it('Back button is displayed if there is a page to go back to', function () {
+      sinon.stub(view, 'canGoBack', function () {
+        return true;
+      });
+
       return view.render()
           .then(function () {
-            $('#container').html(view.el);
+            assert.equal(view.$('#fxa-pp-back').length, 1);
+          });
+    });
 
-            assert.ok($('#fxa-pp-back').length);
+    it('Back button is not displayed if there is no page to go back to', function () {
+      sinon.stub(view, 'canGoBack', function () {
+        return false;
+      });
+
+      return view.render()
+          .then(function () {
+            assert.equal(view.$('#fxa-pp-back').length, 0);
           });
     });
 

--- a/app/tests/spec/views/tos.js
+++ b/app/tests/spec/views/tos.js
@@ -7,9 +7,10 @@
 
 define([
   'chai',
+  'sinon',
   'views/tos'
 ],
-function (chai, View) {
+function (chai, sinon, View) {
   var assert = chai.assert;
 
   describe('views/tos', function () {
@@ -24,11 +25,25 @@ function (chai, View) {
       view.destroy();
     });
 
-    it('Back button is displayed', function () {
+    it('Back button is displayed if there is a page to go back to', function () {
+      sinon.stub(view, 'canGoBack', function () {
+        return true;
+      });
+
       return view.render()
           .then(function () {
-            $('#container').html(view.el);
-            assert.ok($('#fxa-tos-back').length);
+            assert.equal(view.$('#fxa-tos-back').length, 1);
+          });
+    });
+
+    it('Back button is not displayed if there is no page to go back to', function () {
+      sinon.stub(view, 'canGoBack', function () {
+        return false;
+      });
+
+      return view.render()
+          .then(function () {
+            assert.equal(view.$('#fxa-tos-back').length, 0);
           });
     });
 

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -14,6 +14,7 @@ define([
   './functional/tos',
   './functional/pp',
   './functional/confirm',
+  './functional/delete_account',
   './functional/reset_password',
   './functional/sync_reset_password',
   './functional/robots_txt',

--- a/tests/functional/delete_account.js
+++ b/tests/functional/delete_account.js
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'require',
+  'intern/node_modules/dojo/node!xmlhttprequest',
+  'app/bower_components/fxa-js-client/fxa-client',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers',
+  'tests/functional/lib/test'
+], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
+      FxaClient, TestHelpers, FunctionalHelpers, Test)  {
+  'use strict';
+
+  var config = intern.config;
+  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+  var PAGE_URL = config.fxaContentRoot + 'delete_account';
+
+  var PASSWORD = 'password';
+  var email;
+  var client;
+
+  registerSuite({
+    name: 'delete_account',
+
+    beforeEach: function () {
+      email = TestHelpers.createEmail();
+
+      client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+
+      var self = this;
+      return client.signUp(email, PASSWORD, { preVerified: true })
+        .then(function () {
+          return FunctionalHelpers.clearBrowserState(self);
+        });
+    },
+
+    teardown: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'sign in, delete account': function () {
+      return FunctionalHelpers.fillOutSignIn(this, email, PASSWORD)
+        .findById('fxa-settings-header')
+        .end()
+
+        // Go to delete account screen
+        .findById('delete-account')
+          .click()
+        .end()
+
+        // ensure the back button exists
+        .findById('back')
+        .end()
+
+        // success is going to the delete account page
+        .findById('fxa-delete-account-header')
+        .end()
+
+        .findByCssSelector('form input.password')
+          .click()
+          .type(PASSWORD)
+        .end()
+
+        // delete account
+        .findByCssSelector('button[type="submit"]')
+          .click()
+        .end()
+
+        // success is going to the signup page
+        .findById('fxa-signup-header')
+        .end();
+    },
+
+    'visit delete account directly - no back button': function () {
+      var self = this;
+      return FunctionalHelpers.fillOutSignIn(this, email, PASSWORD)
+        .findById('fxa-settings-header')
+        .end()
+
+        // Go to delete account screen directly
+        .get(require.toUrl(PAGE_URL))
+        .findById('fxa-delete-account-header')
+        .end()
+
+        .then(Test.noElementById(self, 'back'));
+    }
+
+  });
+});

--- a/tests/functional/lib/test.js
+++ b/tests/functional/lib/test.js
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Additional tests.
+ */
+
+define([
+  'intern',
+  'intern/chai!assert'
+], function (intern, assert) {
+  'use strict';
+
+  function noElementByCssSelector(context, selector) {
+    return function () {
+      return context.get('remote')
+        .setFindTimeout(0)
+
+        .findByCssSelector(selector)
+          .then(assert.fail, function (err) {
+            assert.isTrue(/NoSuchElement/.test(String(err)));
+          })
+        .end()
+
+        .setFindTimeout(intern.config.pageLoadTimeout);
+    };
+  }
+
+  function noElementById(context, id) {
+    return noElementByCssSelector(context, '#' + id);
+  }
+
+  return {
+    noElementByCssSelector: noElementByCssSelector,
+    noElementById: noElementById
+  };
+
+});
+
+

--- a/tests/functional/pp.js
+++ b/tests/functional/pp.js
@@ -7,11 +7,13 @@ define([
   'intern!object',
   'intern/chai!assert',
   'tests/functional/lib/helpers',
+  'tests/functional/lib/test',
   'require'
-], function (intern, registerSuite, assert, FunctionalHelpers, require) {
+], function (intern, registerSuite, assert, FunctionalHelpers, Test, require) {
   'use strict';
 
-  var PAGE_URL = intern.config.fxaContentRoot + 'signup';
+  var PAGE_URL = intern.config.fxaContentRoot + 'legal/privacy';
+  var SIGNUP_URL = intern.config.fxaContentRoot + 'signup';
 
   registerSuite({
     name: 'pp',
@@ -23,7 +25,7 @@ define([
     'start at signup': function () {
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(require.toUrl(SIGNUP_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findById('fxa-pp')
           .click()
@@ -40,6 +42,18 @@ define([
         // success is going back to the signup
         .findById('fxa-signup-header')
         .end();
+    },
+
+    'browse directly to page - no back button': function () {
+      var self = this;
+      return this.get('remote')
+        .get(require.toUrl(PAGE_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+
+        .findById('fxa-pp-header')
+        .end()
+
+        .then(Test.noElementById(self, 'fxa-pp-back'));
     }
   });
 });

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -11,8 +11,10 @@ define([
   'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/restmail',
   'tests/lib/helpers',
-  'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, restmail, TestHelpers, FunctionalHelpers) {
+  'tests/functional/lib/helpers',
+  'tests/functional/lib/test'
+], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
+      FxaClient, restmail, TestHelpers, FunctionalHelpers, Test) {
   'use strict';
 
   var config = intern.config;
@@ -128,6 +130,10 @@ define([
         .end()
 
         .findById('fxa-reset-password-header')
+        .end()
+
+        // ensure there is a back button
+        .findById('back')
         .end()
 
         // email should be pre-filled
@@ -383,8 +389,9 @@ define([
         });
     },
 
-    'open page with email on query params': function () {
+    'browse directly to page with email on query params': function () {
       var url = RESET_PAGE_URL + '?email=' + email;
+      var self = this;
       return this.get('remote')
         .get(require.toUrl(url))
         .setFindTimeout(intern.config.pageLoadTimeout)
@@ -395,6 +402,9 @@ define([
             assert.equal(resultText, email);
           })
         .end()
+
+        // ensure there is no back button when browsing directly to page
+        .then(Test.noElementById(self, 'fxa-tos-back'))
 
         .findByCssSelector('button[type="submit"]')
           .click()

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -136,50 +136,6 @@ define([
         });
     },
 
-    'sign in, delete account': function () {
-      return this.get('remote')
-        .get(require.toUrl(SIGNIN_URL))
-        .findByCssSelector('form input.email')
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('form input.password')
-          .click()
-          .type(FIRST_PASSWORD)
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
-
-        .findById('fxa-settings-header')
-        .end()
-
-        // Go to delete account screen
-        .findById('delete-account')
-          .click()
-        .end()
-
-        // success is going to the delete account page
-        .findById('fxa-delete-account-header')
-        .end()
-
-        .findByCssSelector('form input.password')
-          .click()
-          .type(FIRST_PASSWORD)
-        .end()
-
-        // delete account
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
-
-        // success is going to the signup page
-        .findById('fxa-signup-header')
-        .end();
-    },
-
     'visit settings page with an unknown uid parameter redirects to signin': function () {
       var self = this;
 

--- a/tests/functional/tos.js
+++ b/tests/functional/tos.js
@@ -7,11 +7,13 @@ define([
   'intern!object',
   'intern/chai!assert',
   'tests/functional/lib/helpers',
+  'tests/functional/lib/test',
   'require'
-], function (intern, registerSuite, assert, FunctionalHelpers, require) {
+], function (intern, registerSuite, assert, FunctionalHelpers, Test, require) {
   'use strict';
 
-  var PAGE_URL = intern.config.fxaContentRoot + 'signup';
+  var PAGE_URL = intern.config.fxaContentRoot + 'legal/terms';
+  var SIGNUP_URL = intern.config.fxaContentRoot + 'signup';
 
   registerSuite({
     name: 'tos',
@@ -23,7 +25,7 @@ define([
     'start at signup': function () {
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL))
+        .get(require.toUrl(SIGNUP_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .findByCssSelector('#fxa-tos')
           .click()
@@ -36,6 +38,19 @@ define([
         // success is going back to the signup
         .findByCssSelector('#fxa-signup-header')
         .end();
+    },
+
+    'browse directly to page - no back button': function () {
+      var self = this;
+      return this.get('remote')
+
+        .get(require.toUrl(PAGE_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+
+        .findById('fxa-tos-header')
+        .end()
+
+        .then(Test.noElementById(self, 'fxa-tos-back'));
     }
   });
 });


### PR DESCRIPTION
In `/reset_password`, the `email` query parameter was used as a proxy to indicate whether the user has directly browsed to the page. If the user directly browses to the page, the "back" button should not be shown.

Proxy checks are never a great idea. This update uses an explicit flag that says whether the user can go back, and this flag is passed to all views.

Logic:
- The first FxA view displayed cannot go back.
- Subsequent views can go back.

All views that have a back button only show the back button if the user can go back. If the user directly visits a page with a back button, the button will not be shown.

Another considered option:
Check if window.history.length > 1. If so, the user can go back. This was strange if users visited a page with a back button from an external site. A user could click "back" and go back to the previous site, not really expected.

Other work:
- Ensure there are functional tests for the existence/non-existence of the back button on pages that have them.
- Extract the delete_account related tests from settings into its own module.

fixes #1917
