### PR TITLE
feat(metrics): Add the `migration` and `campaign` fields to the reported metrics.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -170,7 +170,7 @@ function (
         service: relier.get('service'),
         context: relier.get('context'),
         entrypoint: relier.get('entrypoint'),
-        isMigration: relier.get('isMigration'),
+        migration: relier.get('migration'),
         campaign: relier.get('campaign')
       });
       this._metrics.init();

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -37,7 +37,7 @@ define([
     'duration',
     'entrypoint',
     'events',
-    'isMigration',
+    'migration',
     'lang',
     'marketingClicked',
     'marketingLink',
@@ -71,7 +71,7 @@ define([
     this._lang = options.lang || 'unknown';
     this._context = options.context || 'web';
     this._entrypoint = options.entrypoint || 'none';
-    this._isMigration = options.isMigration || false;
+    this._migration = options.migration || 'none';
     this._service = options.service || 'none';
     this._campaign = options.campaign || 'none';
 
@@ -142,7 +142,7 @@ define([
         service: this._service,
         lang: this._lang,
         entrypoint: this._entrypoint,
-        isMigration: this._isMigration,
+        migration: this._migration,
         marketingType: this._marketingType || 'none',
         marketingLink: this._marketingLink || 'none',
         marketingClicked: this._marketingClicked || false,

--- a/app/scripts/models/reliers/fx-desktop.js
+++ b/app/scripts/models/reliers/fx-desktop.js
@@ -23,7 +23,7 @@ define([
       campaign: null,
       context: null,
       entrypoint: null,
-      isMigration: null
+      migration: null
     }),
 
     initialize: function (options) {
@@ -41,22 +41,14 @@ define([
             self.importSearchParam('context');
             self.importSearchParam('entrypoint');
             self.importSearchParam('campaign');
+            self.importSearchParam('migration');
 
-            self._setupIsMigration();
             self._setupServiceName();
           });
     },
 
     isFxDesktop: function () {
       return true;
-    },
-
-    _setupIsMigration: function () {
-      var self = this;
-      self.importSearchParam('isMigration');
-      if (self.get('isMigration') === 'true') {
-        self.set('isMigration', true);
-      }
     },
 
     _setupServiceName: function () {

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -31,7 +31,7 @@ function (chai, $, p, Metrics, AuthErrors, WindowMock, TestHelpers) {
         service: 'sync',
         context: 'fxa_desktop_v1',
         entrypoint: 'menupanel',
-        isMigration: true,
+        migration: 'sync1.5',
         campaign: 'fennec'
       });
       metrics.init();
@@ -64,7 +64,7 @@ function (chai, $, p, Metrics, AuthErrors, WindowMock, TestHelpers) {
         assert.equal(filteredData.service, 'sync');
         assert.equal(filteredData.lang, 'db_LB');
         assert.equal(filteredData.entrypoint, 'menupanel');
-        assert.isTrue(filteredData.isMigration);
+        assert.equal(filteredData.migration, 'sync1.5');
         assert.equal(filteredData.campaign, 'fennec');
 
         assert.equal(filteredData.screen.width, window.screen.width);

--- a/app/tests/spec/models/reliers/fx-desktop.js
+++ b/app/tests/spec/models/reliers/fx-desktop.js
@@ -34,7 +34,7 @@ define([
           campaign: 'fennec',
           context: 'fx_desktop_v1',
           entrypoint: 'menupanel',
-          isMigration: true,
+          migration: 'sync1.5',
           service: 'sync'
         });
 
@@ -43,7 +43,7 @@ define([
               assert.equal(relier.get('campaign'), 'fennec');
               assert.equal(relier.get('context'), 'fx_desktop_v1');
               assert.equal(relier.get('entrypoint'), 'menupanel');
-              assert.equal(relier.get('isMigration'), true);
+              assert.equal(relier.get('migration'), 'sync1.5');
               assert.equal(relier.get('service'), 'sync');
             });
       });

--- a/server/lib/metrics-collector-stderr.js
+++ b/server/lib/metrics-collector-stderr.js
@@ -102,7 +102,7 @@ function toLoggableEvent(event) {
     'context',
     'entrypoint',
     'service',
-    'isMigration',
+    'migration',
     'campaign',
     'marketingLink',
     'marketingType',

--- a/tests/server/metrics-collector-stderr.js
+++ b/tests/server/metrics-collector-stderr.js
@@ -66,7 +66,7 @@ define([
       assert.equal(loggedMetrics['screen.width'], 1680);
       assert.equal(loggedMetrics['screen.height'], 1050);
       assert.equal(loggedMetrics.entrypoint, 'menupanel');
-      assert.equal(loggedMetrics.isMigration, true);
+      assert.equal(loggedMetrics.migration, 'sync1.5');
       assert.equal(loggedMetrics.campaign, 'fennec');
     });
 
@@ -91,7 +91,7 @@ define([
       service: 'sync',
       context: 'fx_desktop_v1',
       entrypoint: 'menupanel',
-      isMigration: true,
+      migration: 'sync1.5',
       campaign: 'fennec',
       marketingType: 'survey',
       marketingLink: 'http://mzl.la/1oV7jUy',


### PR DESCRIPTION
@kparlante - what do you think?

Only reported for FxDesktop.

fixes #1906 
fixes #1792 
