### PR TITLE
feat(test): Add more functional tests!

### DIFF
--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -56,7 +56,7 @@ define([
         });
     },
 
-    'oauth reset password, verify same browser': function () {
+    'reset password, verify same browser': function () {
       var self = this;
 
       return FunctionalHelpers.openFxaFromRp(self, 'signin')
@@ -79,14 +79,9 @@ define([
         .findById('fxa-reset-password-header')
         .end()
 
-        .findByCssSelector('input[type=email]')
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
 
         .findById('fxa-confirm-reset-password-header')
         .end()
@@ -96,23 +91,15 @@ define([
                       self, email, 0);
         })
 
-        // Complete the password reset in the new tab
+        // Complete the reset password in the new tab
         .switchToWindow('newwindow')
 
         .findById('fxa-complete-reset-password-header')
         .end()
 
-        .findByCssSelector('#password')
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('#vpassword')
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('button[type=submit]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutCompleteResetPassword(self, PASSWORD, PASSWORD);
+        })
 
         // this tab's success is seeing the reset password complete header.
         .findByCssSelector('#fxa-reset-password-complete-header')
@@ -136,7 +123,77 @@ define([
         .end();
     },
 
-    'oauth reset password, verify in a different browser, from the original tab\'s P.O.V.': function () {
+    'reset password, verify same browser with original tab closed': function () {
+      var self = this;
+
+      return FunctionalHelpers.openFxaFromRp(self, 'signin')
+
+        .findByCssSelector('.reset-password')
+          .click()
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
+
+        .findByCssSelector('#fxa-confirm-reset-password-header')
+        .end()
+
+        // user browses to another site.
+        .then(FunctionalHelpers.openExternalSite(self))
+
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkSameBrowser(
+                      self, email, 0);
+        })
+
+        .switchToWindow('newwindow')
+
+        .then(function () {
+          return FunctionalHelpers.fillOutCompleteResetPassword(
+              self, PASSWORD, PASSWORD);
+        })
+
+        .findByCssSelector('#fxa-reset-password-complete-header')
+        .end()
+
+        // switch to the original window
+        .closeCurrentWindow()
+        .switchToWindow('');
+    },
+
+    'reset password, verify same browser by replacing the original tab': function () {
+      var self = this;
+
+      return FunctionalHelpers.openFxaFromRp(self, 'signin')
+        .findByCssSelector('.reset-password')
+          .click()
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
+
+        .findByCssSelector('#fxa-confirm-reset-password-header')
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.getVerificationLink(email, 0);
+        })
+        .then(function (verificationLink) {
+          return self.get('remote').get(require.toUrl(verificationLink));
+        })
+
+        .then(function () {
+          return FunctionalHelpers.fillOutCompleteResetPassword(
+              self, PASSWORD, PASSWORD);
+        })
+
+        .findByCssSelector('#fxa-reset-password-complete-header')
+        .end();
+    },
+
+    'reset password, verify in a different browser, from the original tab\'s P.O.V.': function () {
       var self = this;
 
       return FunctionalHelpers.openFxaFromRp(self, 'signin')
@@ -147,14 +204,9 @@ define([
         .findById('fxa-reset-password-header')
         .end()
 
-        .findByCssSelector('input[type=email]')
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
 
         .findById('fxa-confirm-reset-password-header')
         .end()
@@ -167,6 +219,9 @@ define([
         // user verified in a new browser, they have to enter
         // their updated credentials in the original tab.
         .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        .then(FunctionalHelpers.visibleByQSA('.success'))
         .end()
 
         .findByCssSelector('#password')
@@ -182,7 +237,7 @@ define([
         .end();
     },
 
-    'oauth reset password, verify in a different browser, from the new browser\'s P.O.V.': function () {
+    'reset password, verify in a different browser, from the new browser\'s P.O.V.': function () {
       var self = this;
 
       return FunctionalHelpers.openFxaFromRp(self, 'signin')
@@ -193,14 +248,9 @@ define([
         .findById('fxa-reset-password-header')
         .end()
 
-        .findByCssSelector('input[type=email]')
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
 
         .findById('fxa-confirm-reset-password-header')
         .then(function () {
@@ -222,19 +272,9 @@ define([
         .findById('fxa-complete-reset-password-header')
         .end()
 
-        .findByCssSelector('form input#password')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('form input#vpassword')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-        .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutCompleteResetPassword(self, PASSWORD, PASSWORD);
+        })
 
         .findById('fxa-reset-password-complete-header')
         .end()

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -17,6 +17,7 @@ define([
 
   var config = intern.config;
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
+  var OLD_ENOUGH_YEAR = TOO_YOUNG_YEAR - 1;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
 
   var PASSWORD = 'password';
@@ -59,29 +60,9 @@ define([
         })
         .end()
 
-        .findByCssSelector('form input.email')
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('form input.password')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('#fxa-age-year')
-          .click()
-        .end()
-
-        .findById('fxa-' + (TOO_YOUNG_YEAR - 1))
-          .pressMouseButton()
-          .releaseMouseButton()
-          .click()
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR);
+        })
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -105,11 +86,67 @@ define([
         })
         .end()
 
-        .closeCurrentWindow()
         // switch to the original window
+        .closeCurrentWindow()
         .switchToWindow('')
 
         .findByCssSelector('#loggedin')
+        .end();
+    },
+
+
+    'signup, verify same browser with original tab closed': function () {
+      var self = this;
+
+      return FunctionalHelpers.openFxaFromRp(self, 'signup')
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR);
+        })
+
+        .findByCssSelector('#fxa-confirm-header')
+        .end()
+
+        // user browses to another site.
+        .switchToFrame(null)
+
+        .then(FunctionalHelpers.openExternalSite(self))
+
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkSameBrowser(
+                      self, email, 0);
+        })
+
+        .switchToWindow('newwindow')
+
+        .findByCssSelector('#fxa-sign-up-complete-header')
+        .end()
+
+        // switch to the original window
+        .closeCurrentWindow()
+        .switchToWindow('');
+    },
+
+    'signup, verify same browser by replacing the original tab': function () {
+      var self = this;
+
+      return FunctionalHelpers.openFxaFromRp(self, 'signup')
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR);
+        })
+
+        .findByCssSelector('#fxa-confirm-header')
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.getVerificationLink(email, 0);
+        })
+        .then(function (verificationLink) {
+          return self.get('remote').get(require.toUrl(verificationLink));
+        })
+
+        .findByCssSelector('#fxa-sign-up-complete-header')
         .end();
     },
 
@@ -117,29 +154,9 @@ define([
       var self = this;
 
       return FunctionalHelpers.openFxaFromRp(self, 'signup')
-        .findByCssSelector('form input.email')
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('form input.password')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('#fxa-age-year')
-          .click()
-        .end()
-
-        .findById('fxa-' + (TOO_YOUNG_YEAR - 1))
-          .pressMouseButton()
-          .releaseMouseButton()
-          .click()
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR);
+        })
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -157,29 +174,9 @@ define([
       var self = this;
 
       return FunctionalHelpers.openFxaFromRp(self, 'signup')
-        .findByCssSelector('form input.email')
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('form input.password')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('#fxa-age-year')
-          .click()
-        .end()
-
-        .findById('fxa-' + (TOO_YOUNG_YEAR - 1))
-          .pressMouseButton()
-          .releaseMouseButton()
-          .click()
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR);
+        })
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -220,29 +217,9 @@ define([
       });
 
       return FunctionalHelpers.openFxaFromRp(self, 'signup')
-        .findByCssSelector('form input.email')
-          .click()
-          .type(bouncedEmail)
-        .end()
-
-        .findByCssSelector('form input.password')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('#fxa-age-year')
-          .click()
-        .end()
-
-        .findById('fxa-' + (TOO_YOUNG_YEAR - 1))
-          .pressMouseButton()
-          .releaseMouseButton()
-          .click()
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutSignUp(self, bouncedEmail, PASSWORD, OLD_ENOUGH_YEAR);
+        })
 
         .findById('fxa-confirm-header')
         .end()
@@ -293,8 +270,8 @@ define([
         })
         .end()
 
-        .closeCurrentWindow()
         // switch to the original window
+        .closeCurrentWindow()
         .switchToWindow('')
 
         .findByCssSelector('#loggedin')

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -72,19 +72,14 @@ define([
         .setFindTimeout(intern.config.pageLoadTimeout)
         .execute(listenForFxaCommands)
 
-        .findById('fxa-reset-password-header')
+        .findByCssSelector('#fxa-reset-password-header')
         .end()
 
-        .findByCssSelector('input[type=email]')
-          .click()
-          .type(email)
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
 
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
-
-        .findById('fxa-confirm-reset-password-header')
+        .findByCssSelector('#fxa-confirm-reset-password-header')
         .end()
 
         .then(function () {
@@ -93,24 +88,15 @@ define([
         })
         .switchToWindow('newwindow')
 
-        .findById('fxa-complete-reset-password-header')
+        .findByCssSelector('#fxa-complete-reset-password-header')
         .end()
 
-        .findByCssSelector('form input#password')
-          .click()
-          .type(PASSWORD)
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutCompleteResetPassword(
+                    self, PASSWORD, PASSWORD);
+        })
 
-        .findByCssSelector('form input#vpassword')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
-
-        .findById('fxa-reset-password-complete-header')
+        .findByCssSelector('#fxa-reset-password-complete-header')
         .end()
 
         .findByCssSelector('.account-ready-service')
@@ -134,6 +120,76 @@ define([
         });
     },
 
+    'password reset, verify same browser with original tab closed': function () {
+      var self = this;
+
+      return self.get('remote')
+        .get(require.toUrl(PAGE_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+        .execute(listenForFxaCommands)
+
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
+
+        .findByCssSelector('#fxa-confirm-reset-password-header')
+        .end()
+
+        // user browses to another site.
+        .then(FunctionalHelpers.openExternalSite(self))
+
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkSameBrowser(
+                      self, email, 0);
+        })
+
+        .switchToWindow('newwindow')
+
+        .then(function () {
+          return FunctionalHelpers.fillOutCompleteResetPassword(
+              self, PASSWORD, PASSWORD);
+        })
+
+        .findByCssSelector('#fxa-reset-password-complete-header')
+        .end()
+
+        .closeCurrentWindow()
+        // switch to the original window
+        .switchToWindow('')
+        .end();
+    },
+
+    'password reset, verify same browser by replacing the original tab': function () {
+      var self = this;
+
+      return self.get('remote')
+        .get(require.toUrl(PAGE_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+        .execute(listenForFxaCommands)
+
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
+
+        .findByCssSelector('#fxa-confirm-reset-password-header')
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.getVerificationLink(email, 0);
+        })
+        .then(function (verificationLink) {
+          return self.get('remote').get(require.toUrl(verificationLink));
+        })
+
+        .then(function () {
+          return FunctionalHelpers.fillOutCompleteResetPassword(
+              self, PASSWORD, PASSWORD);
+        })
+
+        .findByCssSelector('#fxa-reset-password-complete-header')
+        .end();
+    },
+
     'reset password, verify different browser - from original tab\'s P.O.V.': function () {
       var self = this;
 
@@ -144,19 +200,16 @@ define([
         .execute(listenForFxaCommands)
 
 
-        .findById('fxa-reset-password-header')
+        .findByCssSelector('#fxa-reset-password-header')
         .end()
 
-        .findByCssSelector('input[type=email]')
-          .click()
-          .type(email)
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
+
+        .findByCssSelector('#fxa-confirm-reset-password-header')
         .end()
 
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
-
-        .findById('fxa-confirm-reset-password-header')
         .then(function () {
           return FunctionalHelpers.openPasswordResetLinkDifferentBrowser(
                       client, email, PASSWORD);
@@ -165,12 +218,12 @@ define([
         // for an unknown reason, it sometimes takes an exceptionally
         // long time to transition to the new screen.
 
-        // user verified in a new browser, they have to enter
-        // their updated credentials in the original tab.
-        .then(FunctionalHelpers.visibleByQSA('.success', 20000))
+        .findByCssSelector('#fxa-signin-header')
         .end()
 
-        .findByCssSelector('#fxa-signin-header')
+        // user verified in a new browser, they have to enter
+        // their updated credentials in the original tab.
+        .then(FunctionalHelpers.visibleByQSA('.success'))
         .end()
 
         .findByCssSelector('#password')
@@ -197,19 +250,14 @@ define([
         .execute(listenForFxaCommands)
 
 
-        .findById('fxa-reset-password-header')
+        .findByCssSelector('#fxa-reset-password-header')
         .end()
 
-        .findByCssSelector('input[type=email]')
-        .click()
-        .type(email)
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
 
-        .findByCssSelector('button[type="submit"]')
-        .click()
-        .end()
-
-        .findById('fxa-confirm-reset-password-header')
+        .findByCssSelector('#fxa-confirm-reset-password-header')
         .then(function () {
           // clear all browser state, simulate opening in a new
           // browser
@@ -223,24 +271,15 @@ define([
         })
         .end()
 
-        .findById('fxa-complete-reset-password-header')
+        .findByCssSelector('#fxa-complete-reset-password-header')
         .end()
 
-        .findByCssSelector('form input#password')
-        .click()
-        .type(PASSWORD)
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutCompleteResetPassword(
+                    self, PASSWORD, PASSWORD);
+        })
 
-        .findByCssSelector('form input#vpassword')
-        .click()
-        .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-        .click()
-        .end()
-
-        .findById('fxa-reset-password-complete-header')
+        .findByCssSelector('#fxa-reset-password-complete-header')
         .end()
 
         .findByCssSelector('.account-ready-service')

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -55,9 +55,6 @@ define([
           return result;
         })
         .then(function () {
-          return verifyUser(user, 0);
-        })
-        .then(function () {
           // clear localStorage to avoid pollution from other tests.
           return FunctionalHelpers.clearBrowserState(self);
         });
@@ -79,25 +76,38 @@ define([
             .findByCssSelector('#fxa-signin-header')
             .end()
 
-            .findByCssSelector('form input.email')
-              .click()
-              .type(email)
-            .end()
-
-            .findByCssSelector('form input.password')
-              .click()
-              .type(PASSWORD)
-            .end()
-
-            .findByCssSelector('button[type="submit"]')
-              .click()
-            .end()
+            .then(function () {
+              return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+            })
 
             .then(function () {
               return testIsBrowserNotifiedOfLogin(self, email);
             });
         });
-    }
+    },
 
+
+    'unverified': function () {
+      var self = this;
+
+      return self.get('remote')
+        .get(require.toUrl(PAGE_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+        .execute(listenForFxaCommands)
+
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+        })
+
+        .findByCssSelector('#fxa-confirm-header')
+        .end()
+
+        .then(function () {
+          return testIsBrowserNotifiedOfLogin(self, email);
+        });
+    }
   });
 });


### PR DESCRIPTION
@zaach or @vladikoff - r?
- Add functional tests to check users who verify by replacing the original tab, and users who verify by closing the original tab and open a new tab. This is for both OAuth and Sync, for sign up and reset password.
- Add a functional test for signing into sync with an unverified account

fixes #1935
issue #1816
issue #1936
issue #1938
issue #1940
