### PR TITLE
fix(client): OAuth/redirect users who paste the verification link into the original tab should be redirected to the RP.

### DIFF
--- a/app/scripts/models/auth_brokers/redirect.js
+++ b/app/scripts/models/auth_brokers/redirect.js
@@ -27,6 +27,76 @@ define([
 
           win.location.href = redirectTo;
         });
+    },
+
+    /**
+     * Sets a marker used to determine if this is the tab a user
+     * signed up or initiated a password reset in. If the user replaces
+     * the original tab with the verification tab, then the OAuth flow
+     * should complete and the user redirected to the RP.
+     */
+    setOriginalTabMarker: function () {
+      this.window.sessionStorage.setItem('originalTab', '1');
+    },
+
+    isOriginalTab: function () {
+      return !! this.window.sessionStorage.getItem('originalTab');
+    },
+
+    clearOriginalTabMarker: function () {
+      this.window.sessionStorage.removeItem('originalTab');
+    },
+
+    persist: function () {
+      // If the user replaces the current tab with the verification url,
+      // finish the OAuth flow.
+      var self = this;
+      return p().then(function () {
+        self.setOriginalTabMarker();
+        return OAuthAuthenticationBroker.prototype.persist.call(self);
+      });
+    },
+
+    finishOAuthFlow: function () {
+      var self = this;
+      return p().then(function () {
+        // There are no ill side effects if if the Original Tab Marker is
+        // cleared in the a tab other than the original. Always clear it just
+        // to make sure the bases are covered.
+        self.clearOriginalTabMarker();
+        return OAuthAuthenticationBroker.prototype.finishOAuthFlow.call(self);
+      });
+    },
+
+    afterCompleteSignUp: function () {
+      // The user may have replaced the original tab with the verification
+      // tab. If this is the case, send the OAuth result to the RP.
+      //
+      // The slight delay is to allow the functional tests time to bind
+      // event handlers before the flow completes.
+      var self = this;
+      return p().delay(100).then(function () {
+        if (self.isOriginalTab()) {
+          return self.finishOAuthFlow()
+            .then(function () {
+              return { halt: true };
+            });
+        }
+      });
+    },
+
+    afterCompleteResetPassword: function () {
+      // The user may have replaced the original tab with the verification
+      // tab. If this is the case, send the OAuth result to the RP.
+      var self = this;
+      return p().then(function () {
+        if (self.isOriginalTab()) {
+          return self.finishOAuthFlow()
+            .then(function () {
+              return { halt: true };
+            });
+        }
+      });
     }
   });
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -197,7 +197,20 @@ define([
       .then(function (verificationLink) {
         return context.get('remote')
           .execute(function (verificationLink, windowName) {
-            window.open(verificationLink, windowName);
+            var newWindow = window.open(verificationLink, windowName);
+
+            // from http://dev.w3.org/html5/webstorage/
+            // When a new top-level browsing context is created by a script in
+            // an existing browsing context, then the session storage area of
+            // the origin of that Document must be copied into the new
+            // browsing context when it is created. From that point on,
+            // however, the two session storage areas must be considered
+            // separate, not affecting each other in any way.
+            //
+            // We want to pretend this is a new tab that the user opened using
+            // CTRL-T, which does NOT copy sessionStorage over. Wipe
+            // sessionStorage in this new context;
+            newWindow.sessionStorage.clear();
 
             return true;
           }, [ verificationLink, windowName ]);

--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -189,7 +189,7 @@ define([
               self, PASSWORD, PASSWORD);
         })
 
-        .findByCssSelector('#fxa-reset-password-complete-header')
+        .findByCssSelector('#loggedin')
         .end();
     },
 

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -20,6 +20,7 @@ define([
 
   var PASSWORD = 'password';
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
+  var OLD_ENOUGH_YEAR = TOO_YOUNG_YEAR - 1;
   var user;
   var email;
 
@@ -49,20 +50,9 @@ define([
           return client.signUp(email, PASSWORD, { preVerified: true });
         })
 
-        .findByCssSelector('form input.email')
-          .clearValue()
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('form input.password')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+        })
 
         .findByCssSelector('#loggedin')
         .getCurrentUrl()
@@ -82,20 +72,9 @@ define([
         })
 
         // sign in with a verified account to cache credentials
-        .findByCssSelector('form input.email')
-          .clearValue()
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('form input.password')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+        })
 
         .findByCssSelector('#loggedin')
         .getCurrentUrl()
@@ -139,7 +118,7 @@ define([
         .end();
     },
 
-    'unverified': function () {
+    'unverified, acts like signup': function () {
       var self = this;
 
       return FunctionalHelpers.openFxaFromRp(self, 'signin')
@@ -147,20 +126,9 @@ define([
           return client.signUp(email, PASSWORD, { preVerified: false });
         })
 
-        .findByCssSelector('form input.email')
-          .clearValue()
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('form input.password')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+        })
 
         .findByCssSelector('#fxa-confirm-header')
 
@@ -169,14 +137,10 @@ define([
         })
         .then(function (verifyUrl) {
           return self.get('remote')
+            // user verifies in the same tab, so they are logged in to the RP.
             .get(require.toUrl(verifyUrl))
-            .findByCssSelector('.account-ready-service')
-            .getVisibleText()
-            .then(function (text) {
-              // user sees the name of the rp,
-              // but cannot redirect
-              assert.isTrue(/123done/i.test(text));
-            })
+
+            .findByCssSelector('#loggedin')
             .end();
         });
 
@@ -189,26 +153,9 @@ define([
         .end()
 
         // first, sign the user up to cache the login
-        .findByCssSelector('form input.email')
-          .clearValue()
-          .click()
-          .type(email)
-        .end()
-
-        .findByCssSelector('form input.password')
-          .click()
-          .type(PASSWORD)
-        .end()
-
-        .findById('fxa-' + (TOO_YOUNG_YEAR - 1))
-          .pressMouseButton()
-          .releaseMouseButton()
-          .click()
-        .end()
-
-        .findByCssSelector('button[type="submit"]')
-          .click()
-        .end()
+        .then(function () {
+          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR );
+        })
 
         .findByCssSelector('#fxa-confirm-header')
         .end()

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -94,7 +94,6 @@ define([
         .end();
     },
 
-
     'signup, verify same browser with original tab closed': function () {
       var self = this;
 
@@ -146,7 +145,7 @@ define([
           return self.get('remote').get(require.toUrl(verificationLink));
         })
 
-        .findByCssSelector('#fxa-sign-up-complete-header')
+        .findByCssSelector('#loggedin')
         .end();
     },
 


### PR DESCRIPTION
Save a bit to sessionStorage whenever the user signs up or initiates a password reset. When the verification tab opens, it looks for this bit. If the bit is set, that means the user overwrote the signup/reset password tab with the verification tab and the user should redirect to the RP when the OAuth flow completes. If the bit is not set, this is either another tab or another browser, and the user should _not_ go back to the RP.

fixes #1816
