### PR TITLE
fix(test): check that signin is complete before proceeding

### DIFF
--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -173,6 +173,10 @@ define([
     'browse directly to page - no back button': function () {
       var self = this;
       return FunctionalHelpers.fillOutSignIn(this, email, FIRST_PASSWORD)
+        // check that signin is complete before proceeding
+        .findById('fxa-settings-header')
+        .end()
+        
         .get(require.toUrl(PAGE_URL))
 
         .findById('fxa-change-password-header')


### PR DESCRIPTION
Just need to wait until signin is complete; otherwise, loading the next page too early would result in an error and test failure.
