### PR TITLE
feat(metrics): Report distinct metrics codes for missing and invalid emails

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -58,7 +58,8 @@ function () {
     DIFFERENT_EMAIL_REQUIRED: 1019,
     DIFFERENT_EMAIL_REQUIRED_FIREFOX_DOMAIN: 1020,
     CHANNEL_TIMEOUT: 1021,
-    ILLEGAL_IFRAME_PARENT: 1022
+    ILLEGAL_IFRAME_PARENT: 1022,
+    INVALID_EMAIL: 1023
   };
 
   var CODE_TO_MESSAGES = {
@@ -105,7 +106,8 @@ function () {
     1019: t('Valid email required'),
     1020: t('Enter a valid email address. firefox.com does not offer email.'),
     1021: t('Unexpected error'),
-    1022: t('Firefox Accounts can only be placed into an IFRAME on approved sites')
+    1022: t('Firefox Accounts can only be placed into an IFRAME on approved sites'),
+    1023: t('Valid email required')
   };
 
   return {

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -358,7 +358,15 @@ function (_, $, p, Validate, AuthErrors, BaseView, Tooltip,
     },
 
     showEmailValidationError: function (el) {
-      return this.showValidationError(el, AuthErrors.toError('EMAIL_REQUIRED'));
+      var value = this.getElementValue(el);
+      var err = value && value.length ?
+                  // if the email element has any length, but is marked
+                  // as invalid, it's invalid.
+                  AuthErrors.toError('INVALID_EMAIL') :
+                  // email has no length, it's missing.
+                  AuthErrors.toError('EMAIL_REQUIRED');
+
+      return this.showValidationError(el, err);
     },
 
     /**

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -480,14 +480,27 @@ function (chai, sinon, $, p, FormView, Template, Constants, Metrics, AuthErrors,
         assert.isFalse(view.showValidationError.called);
       });
 
-      it('shows when an email is invalid', function () {
-        view.$('input[type="email"]').val('a');
-        sinon.spy(view, 'showValidationError');
+      it('shows correct error when an email is missing', function () {
+        view.$('input[type="email"]').val('');
+        sinon.stub(view, 'showValidationError', function (el, err) {
+          assert.ok(el);
+          assert.isTrue(AuthErrors.is(err, 'EMAIL_REQUIRED'));
+        });
         view.showValidationErrors();
         assert.isTrue(view.showValidationError.called);
       });
 
-      it('shows when a password is invalid', function () {
+      it('shows correct error when an email is invalid', function () {
+        view.$('input[type="email"]').val('a');
+        sinon.stub(view, 'showValidationError', function (el, err) {
+          assert.ok(el);
+          assert.isTrue(AuthErrors.is(err, 'INVALID_EMAIL'));
+        });
+        view.showValidationErrors();
+        assert.isTrue(view.showValidationError.called);
+      });
+
+      it('shows correct error when a password is invalid', function () {
         view.$('input[type="password"]').val('');
         sinon.spy(view, 'showValidationError');
         view.showValidationErrors();


### PR DESCRIPTION
@kparlante - how does this look for you?
- Missing: `error.<screen>.auth.1011`
- Invalid: `error.<screen>.auth.1023`

fixes #1814
