### PR TITLE
refactor(client): Move interTabCommunication out of fxa-client into the views that need it.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -29,7 +29,6 @@ function (_, FxaClient, $, xhr, p, Session, AuthErrors, Constants) {
     this._client = options.client;
     this._signUpResendCount = 0;
     this._passwordResetResendCount = 0;
-    this._interTabChannel = options.interTabChannel;
   }
 
   FxaClientWrapper.prototype = {
@@ -97,7 +96,6 @@ function (_, FxaClient, $, xhr, p, Session, AuthErrors, Constants) {
     },
 
     _updateAccount: function (email, relier, user, accountData, options) {
-      var self = this;
       var sessionTokenContext = options.sessionTokenContext ||
                                   relier.get('context');
 
@@ -117,10 +115,6 @@ function (_, FxaClient, $, xhr, p, Session, AuthErrors, Constants) {
         updatedSessionData.unwrapBKey = accountData.unwrapBKey;
         updatedSessionData.keyFetchToken = accountData.keyFetchToken;
         updatedSessionData.customizeSync = options.customizeSync || false;
-      }
-
-      if (self._interTabChannel) {
-        self._interTabChannel.emit('login', updatedSessionData);
       }
 
       return user.setCurrentAccount(updatedSessionData)

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -21,6 +21,12 @@ function (_, BaseView, FormView, Template, PasswordMixin,
     template: Template,
     className: 'complete-reset-password',
 
+    initialize: function (options) {
+      options = options || {};
+
+      this._interTabChannel = options.interTabChannel;
+    },
+
     events: {
       'change .show-password': 'onPasswordVisibilityChange',
       'click #resend': BaseView.preventDefaultThen('resendResetEmail')
@@ -112,7 +118,10 @@ function (_, BaseView, FormView, Template, PasswordMixin,
       return self.fxaClient.completePasswordReset(email, password, token, code)
         .then(function () {
           return self.fxaClient.signIn(email, password, self.relier, self.user);
-        }).then(function () {
+        }).then(function (updatedSessionData) {
+          // See the above note about notifying the original tab.
+          self._interTabChannel.emit('login', updatedSessionData);
+
           self.logScreenEvent('verification.success');
           return self.broker.afterCompleteResetPassword();
         }).then(function (result) {


### PR DESCRIPTION
interTabCommunication crept into fxa-client. The interTabCommunication functionality is only really necessary in complete_reset_password, so it has been moved there.

fixes #1807
