### PR TITLE
fix(client): Allow Fx18 to use the iframe flow.

### DIFF
--- a/app/scripts/models/auth_brokers/iframe.js
+++ b/app/scripts/models/auth_brokers/iframe.js
@@ -27,10 +27,15 @@ define([
   function getExpectedParentOrigin(relier) {
     // redirectUri comes from the oauthClient's getClientInfo, which is
     // populated on app start before the broker.
+    // The URL API is only supported by new browsers, a workaround is used.
     var anchor = document.createElement('a');
-    anchor.href = relier.get('redirectUri');
 
-    return anchor.origin;
+    // Fx 18 (& FxOS 1.*) do not support anchor.origin. Build the origin
+    // out of the protocol and host.
+    // Use setAttibute instead of a direct set or else Fx18 does not
+    // update anchor.protocol & anchor.host.
+    anchor.setAttribute('href', relier.get('redirectUri'));
+    return anchor.protocol + '//' + anchor.host;
   }
 
   function checkOriginAllowedToIframe() {


### PR DESCRIPTION
Fx18 had two problems:
1) anchor.origin is not available and must be built from anchor.protocol and anchor.host.
2) anchor.protocol and anchor.host are only updated if the anchor's href is set via `anchor.setAttribute(href, ...`.

fixes #1969

![screen shot 2014-12-10 at 11 39 15](https://cloud.githubusercontent.com/assets/848085/5375476/7237cdce-8062-11e4-8dc3-6b67665d717c.png)
