### PR TITLE
refactor(client): Simplify the error handling code.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -7,218 +7,191 @@
 'use strict';
 
 define([
+  'underscore',
+  'lib/errors'
 ],
-function () {
+function (_, Errors) {
   var t = function (msg) {
     return msg;
   };
 
-  var ERROR_TO_CODE = {
-    UNEXPECTED_ERROR: 999,
-    INVALID_TOKEN: 110,
-    INVALID_TIMESTAMP: 111,
-    INVALID_NONCE: 115,
-    ACCOUNT_ALREADY_EXISTS: 101,
-    UNKNOWN_ACCOUNT: 102,
-    INCORRECT_EMAIL_CASE: 120,
-    INCORRECT_PASSWORD: 103,
-    UNVERIFIED_ACCOUNT: 104,
-    INVALID_VERIFICATION_CODE: 105,
-    INVALID_JSON: 106,
-    INVALID_PARAMETER: 107,
-    MISSING_PARAMETER: 108,
-    INVALID_REQUEST_SIGNATURE: 109,
-    MISSING_CONTENT_LENGTH_HEADER: 112,
-    REQUEST_TOO_LARGE: 113,
-    THROTTLED: 114,
-    SERVER_BUSY: 201,
-    ENDPOINT_NOT_SUPPORTED: 116,
-
-    // local only error codes
-    SERVICE_UNAVAILABLE: 998,
-    USER_CANCELED_LOGIN: 1001,
-    SESSION_EXPIRED: 1002,
-
-    COOKIES_STILL_DISABLED: 1003,
-    PASSWORDS_DO_NOT_MATCH: 1004,
-    WORKING: 1005,
-    COULD_NOT_GET_PP: 1006,
-    COULD_NOT_GET_TOS: 1007,
-    PASSWORDS_MUST_BE_DIFFERENT: 1008,
-    PASSWORD_TOO_SHORT: 1009,
-    PASSWORD_REQUIRED: 1010,
-    EMAIL_REQUIRED: 1011,
-    YEAR_OF_BIRTH_REQUIRED: 1012,
-    UNUSABLE_IMAGE: 1013,
-    NO_CAMERA: 1014,
-    URL_REQUIRED: 1015,
-    BIRTHDAY_REQUIRED: 1016,
-    DESKTOP_CHANNEL_TIMEOUT: 1017,
-    SIGNUP_EMAIL_BOUNCE: 1018,
-    DIFFERENT_EMAIL_REQUIRED: 1019,
-    DIFFERENT_EMAIL_REQUIRED_FIREFOX_DOMAIN: 1020,
-    CHANNEL_TIMEOUT: 1021,
-    ILLEGAL_IFRAME_PARENT: 1022,
-    INVALID_EMAIL: 1023
-  };
-
-  var CODE_TO_MESSAGES = {
-    // errors returned by the auth server
-    999: t('Unexpected error'),
-    110: t('Invalid token'),
-    111: t('Invalid timestamp in request signature'),
-    115: t('Invalid nonce in request signature'),
-    101: t('Account already exists'),
-    102: t('Unknown account'),
-    120: t('Incorrect email case'),
-    103: t('Incorrect password'),
-    104: t('Unverified account'),
-    105: t('Invalid verification code'),
-    106: t('Invalid JSON in request body'),
-    107: t('Invalid parameter in request body: %(param)s'),
-    108: t('Missing parameter in request body: %(param)s'),
-    109: t('Invalid request signature'),
-    112: t('Missing content-length header'),
-    113: t('Request body too large'),
-    114: t('Attempt limit exceeded'),
-    201: t('Server busy, try again soon'),
-    116: t('This endpoint is no longer supported'),
-
-    // local only error messages
-    998: t('System unavailable, try again soon'),
-    1002: t('Session expired. Sign in to continue.'),
-    1003: t('Cookies are still disabled'),
-    1004: t('Passwords do not match'),
-    1005: t('Working…'),
-    1006: t('Could not get Privacy Notice'),
-    1007: t('Could not get Terms of Service'),
-    1008: t('Your new password must be different'),
-    1009: t('Must be at least 8 characters'),
-    1010: t('Valid password required'),
-    1011: t('Valid email required'),
-    1012: t('Year of birth required'),
-    1013: t('A usable image was not found'),
-    1014: t('Could not initialize camera'),
-    1015: t('Valid URL required'),
-    1016: t('Valid birthday required'),
-    1017: t('Unexpected error'),
-    1018: t('Your verification email was just returned. Mistyped email?'),
-    1019: t('Valid email required'),
-    1020: t('Enter a valid email address. firefox.com does not offer email.'),
-    1021: t('Unexpected error'),
-    1022: t('Firefox Accounts can only be placed into an IFRAME on approved sites'),
-    1023: t('Valid email required')
-  };
-
-  return {
-    ERROR_TO_CODE: ERROR_TO_CODE,
-    CODE_TO_MESSAGES: CODE_TO_MESSAGES,
-    NAMESPACE: 'auth',
-
-    /**
-     * Convert an error, a numeric code or string type to a message
-     */
-    toMessage: function (err) {
-      var code;
-
-      if (typeof err === 'number') {
-        code = err;
-      } else if (err && err.forceMessage) {
-        return err.forceMessage;
-      // error from backend
-      } else if (err && typeof err.errno === 'number') {
-        code = err.errno;
-      // error from backend that only has a message. Print the message.
-      } else if (err && err.message) {
-        return err.message;
-      // probably a string. Try to convert it.
-      } else if (err && err.length) {
-        code = this.toCode(err);
-      } else {
-        // if there is no error, no error message, and no code,
-        // assume no response from the backend and
-        // the service is unavailable.
-        code = this.toCode('SERVICE_UNAVAILABLE');
-      }
-
-      return this.CODE_TO_MESSAGES[code] || err;
+  var ERRORS = {
+    UNEXPECTED_ERROR: {
+      errno: 999,
+      message: t('Unexpected error')
     },
-
-    /**
-     * Fetch the translation context out of the server error.
-     */
-    toContext: function (err) {
-      // For data returned by backend, see
-      // https://github.com/mozilla/fxa-auth-server/blob/master/error.js
-      try {
-        if (this.is(err, 'INVALID_PARAMETER')) {
-          return {
-            param: err.validation.keys
-          };
-        } else if (this.is(err, 'MISSING_PARAMETER')) {
-          return {
-            param: err.param
-          };
-        }
-      } catch (e) {
-        // handle invalid/unexpected data from the backend.
-        if (window.console && console.error) {
-          console.error('Error in auth-errors.js->toContext: %s', String(e));
-        }
-      }
-
-      return {};
+    INVALID_TOKEN: {
+      errno: 110,
+      message: t('Invalid token')
     },
-
-    /**
-     * Convert an error or a text type from ERROR_TO_CODE to a numeric code
-     */
-    toCode: function (type) {
-      return type.errno || this.ERROR_TO_CODE[type] || type;
+    INVALID_TIMESTAMP: {
+      errno: 111,
+      message: t('Invalid timestamp in request signature')
     },
-
-    /**
-     * Synthesize an error of the given type
-     *
-     * @param {String || Number || Object} type
-     * @param {String} [context]
-     */
-    toError: function (type, context) {
-      var message = this.toMessage(type);
-
-      var err = new Error(message);
-      err.errno = this.toCode(type);
-      err.namespace = this.NAMESPACE;
-      err.message = message;
-      err.errorContext = this;
-
-      if (context) {
-        err.context = context;
-      }
-
-      return err;
+    INVALID_NONCE: {
+      errno: 115,
+      message: t('Invalid nonce in request signature')
     },
-
-    /**
-     * Check if an error is of the given type
-     */
-    is: function (error, type) {
-      var code = this.toCode(type);
-      return error.errno === code;
+    ACCOUNT_ALREADY_EXISTS: {
+      errno: 101,
+      message: t('Account already exists')
     },
-
-    normalizeXHRError: function (xhr) {
-      if (! xhr || xhr.status === 0) {
-        return this.toError('SERVICE_UNAVAILABLE');
-      }
-
-      var errObj = xhr.responseJSON;
-
-      if (! errObj) {
-        return this.toError('UNEXPECTED_ERROR');
-      }
-
-      return this.toError(errObj.errno);
+    UNKNOWN_ACCOUNT: {
+      errno: 102,
+      message: t('Unknown account')
+    },
+    INCORRECT_EMAIL_CASE: {
+      errno: 120,
+      message: t('Incorrect email case')
+    },
+    INCORRECT_PASSWORD: {
+      errno: 103,
+      message: t('Incorrect password')
+    },
+    UNVERIFIED_ACCOUNT: {
+      errno: 104,
+      message: t('Unverified account')
+    },
+    INVALID_VERIFICATION_CODE: {
+      errno: 105,
+      message: t('Invalid verification errno')
+    },
+    INVALID_JSON: {
+      errno: 106,
+      message: t('Invalid JSON in request body')
+    },
+    INVALID_PARAMETER: {
+      errno: 107,
+      message: t('Invalid parameter in request body: %(param)s')
+    },
+    MISSING_PARAMETER: {
+      errno: 108,
+      message: t('Missing parameter in request body: %(param)s')
+    },
+    INVALID_REQUEST_SIGNATURE: {
+      errno: 109,
+      message: t('Invalid request signature')
+    },
+    MISSING_CONTENT_LENGTH_HEADER: {
+      errno: 112,
+      message: t('Missing content-length header')
+    },
+    REQUEST_TOO_LARGE: {
+      errno: 113,
+      message: t('Request body too large')
+    },
+    THROTTLED: {
+      errno: 114,
+      message: t('Attempt limit exceeded')
+    },
+    SERVER_BUSY: {
+      errno: 201,
+      message: t('Server busy, try again soon')
+    },
+    ENDPOINT_NOT_SUPPORTED: {
+      errno: 116,
+      message: t('This endpoint is no longer supported')
+    },
+    SERVICE_UNAVAILABLE: {
+      errno: 998,
+      message: t('System unavailable, try again soon')
+    },
+    USER_CANCELED_LOGIN: {
+      errno: 1001,
+      message: t('no message')
+    },
+    SESSION_EXPIRED: {
+      errno: 1002,
+      message: t('Session expired. Sign in to continue.')
+    },
+    COOKIES_STILL_DISABLED: {
+      errno: 1003,
+      message: t('Cookies are still disabled')
+    },
+    PASSWORDS_DO_NOT_MATCH: {
+      errno: 1004,
+      message: t('Passwords do not match')
+    },
+    WORKING: {
+      errno: 1005,
+      message: t('Working…')
+    },
+    COULD_NOT_GET_PP: {
+      errno: 1006,
+      message: t('Could not get Privacy Notice')
+    },
+    COULD_NOT_GET_TOS: {
+      errno: 1007,
+      message: t('Could not get Terms of Service')
+    },
+    PASSWORDS_MUST_BE_DIFFERENT: {
+      errno: 1008,
+      message: t('Your new password must be different')
+    },
+    PASSWORD_TOO_SHORT: {
+      errno: 1009,
+      message: t('Must be at least 8 characters')
+    },
+    PASSWORD_REQUIRED: {
+      errno: 1010,
+      message: t('Valid password required')
+    },
+    EMAIL_REQUIRED: {
+      errno: 1011,
+      message: t('Valid email required')
+    },
+    YEAR_OF_BIRTH_REQUIRED: {
+      errno: 1012,
+      message: t('Year of birth required')
+    },
+    UNUSABLE_IMAGE: {
+      errno: 1013,
+      message: t('A usable image was not found')
+    },
+    NO_CAMERA: {
+      errno: 1014,
+      message: t('Could not initialize camera')
+    },
+    URL_REQUIRED: {
+      errno: 1015,
+      message: t('Valid URL required')
+    },
+    BIRTHDAY_REQUIRED: {
+      errno: 1016,
+      message: t('Valid birthday required')
+    },
+    DESKTOP_CHANNEL_TIMEOUT: {
+      errno: 1017,
+      message: t('Unexpected error')
+    },
+    SIGNUP_EMAIL_BOUNCE: {
+      errno: 1018,
+      message: t('Your verification email was just returned. Mistyped email?')
+    },
+    DIFFERENT_EMAIL_REQUIRED: {
+      errno: 1019,
+      message: t('Valid email required')
+    },
+    DIFFERENT_EMAIL_REQUIRED_FIREFOX_DOMAIN: {
+      errno: 1020,
+      message: t('Enter a valid email address. firefox.com does not offer email.')
+    },
+    CHANNEL_TIMEOUT: {
+      errno: 1021,
+      message: t('Unexpected error')
+    },
+    ILLEGAL_IFRAME_PARENT: {
+      errno: 1022,
+      message: t('Firefox Accounts can only be placed into an IFRAME on approved sites')
+    },
+    INVALID_EMAIL: {
+      errno: 1023,
+      message: t('Valid email required')
     }
   };
+
+  return _.extend({}, Errors, {
+    ERRORS: ERRORS,
+    NAMESPACE: 'auth'
+  });
 });

--- a/app/scripts/lib/errors.js
+++ b/app/scripts/lib/errors.js
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define(['underscore'], function (_) {
+  return {
+    /**
+     * Find an error in this.ERRORS. Searches by string, number,
+     * or if searchFor contains errno, the errno.
+     */
+    find: function (searchFor) {
+      var found;
+      if (typeof searchFor.errno === 'number') {
+        found = this.find(searchFor.errno);
+      } else if (typeof searchFor === 'number') {
+        found = _.find(this.ERRORS, function (value) {
+          return value.errno === searchFor;
+        });
+      } else if (typeof searchFor === 'string') {
+        found = this.ERRORS[searchFor];
+      }
+
+      return found;
+    },
+
+    /**
+     * Convert an error, a numeric code or string type to a message
+     */
+    toMessage: function (err) {
+      if (! err) {
+        // No error, assume no response from the backend and
+        // the service is unavailable.
+        return this.toMessage('SERVICE_UNAVAILABLE');
+      } else if (err.forceMessage) {
+        return err.forceMessage;
+      } else if (err.message) {
+        return err.message;
+      }
+
+      // try to convert error to something with an error message
+      var messageSource = this.find(err);
+      if (messageSource && messageSource.message) {
+        return messageSource.message;
+      }
+
+      // could not find an error with a message, return the original.
+      return err;
+    },
+
+    /**
+     * Fetch the translation context out of the server error.
+     */
+    toContext: function (err) {
+      // For data returned by backend, see
+      // https://github.com/mozilla/fxa-auth-server/blob/master/error.js
+      try {
+        if (this.is(err, 'INVALID_PARAMETER')) {
+          return {
+            param: err.validation.keys
+          };
+        } else if (this.is(err, 'MISSING_PARAMETER')) {
+          return {
+            param: err.param
+          };
+        }
+      } catch (e) {
+        // handle invalid/unexpected data from the backend.
+        if (window.console && console.error) {
+          console.error('Error in errors.js->toContext: %s', String(e));
+        }
+      }
+
+      return {};
+    },
+
+    /**
+     * Convert an error or a text type to a numeric code
+     */
+    toErrno: function (err) {
+      var errnoSource = this.find(err);
+      // try to find an error with an errno.
+      if (errnoSource && errnoSource.errno) {
+        return errnoSource.errno;
+      }
+
+      // could not find an error with an errno, return the original.
+      return err;
+    },
+
+    /**
+     * Synthesize an error of the given type
+     *
+     * @param {String || Number || Object} type
+     * @param {String} [context]
+     */
+    toError: function (type, context) {
+      var message = this.toMessage(type);
+      if (! message) {
+        message = this.toMessage('UNEXPECTED_ERROR');
+      }
+
+      var err = new Error(message);
+
+      err.message = message;
+      err.errno = this.toErrno(type);
+      err.namespace = this.NAMESPACE;
+      err.errorContext = this;
+
+      if (context) {
+        err.context = context;
+      }
+
+      return err;
+    },
+
+    /**
+     * Check if an error is of the given type
+     */
+    is: function (error, type) {
+      var code = this.toErrno(type);
+      return error.errno === code;
+    },
+
+    normalizeXHRError: function (xhr) {
+      if (! xhr || xhr.status === 0) {
+        return this.toError('SERVICE_UNAVAILABLE');
+      }
+
+      var errObj = xhr.responseJSON;
+
+      if (! errObj) {
+        return this.toError('UNEXPECTED_ERROR');
+      }
+
+      return this.toError(errObj.errno);
+    }
+  };
+});
+

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -8,51 +8,66 @@
 
 define([
   'underscore',
-  'lib/auth-errors'
+  'lib/errors'
 ],
-function (_, AuthErrors) {
+function (_, Errors) {
   var t = function (msg) {
     return msg;
   };
 
-  var ERROR_TO_CODE = {
-    UNKNOWN_CLIENT: 101,
-    INCORRECT_REDIRECT: 103,
-    INVALID_ASSERTION: 104,
-    INVALID_PARAMETER: 108,
-    INVALID_REQUEST_SIGNATURE: 109,
-
-    // local only errors.
-    SERVICE_UNAVAILABLE: 998,
-    UNEXPECTED_ERROR: 999,
-    TRY_AGAIN: 1000,
-    INVALID_RESULT: 1001,
-    INVALID_RESULT_REDIRECT: 1002,
-    INVALID_RESULT_CODE: 1003,
-
-    USER_CANCELED_OAUTH_LOGIN: 1004
+  var ERRORS = {
+    UNKNOWN_CLIENT: {
+      errno: 101,
+      message: t('Unknown client')
+    },
+    INCORRECT_REDIRECT: {
+      errno: 103,
+      message: t('Incorrect redirect_uri')
+    },
+    INVALID_ASSERTION: {
+      errno: 104,
+      message: t('Invalid assertion')
+    },
+    INVALID_PARAMETER: {
+      errno: 108,
+      message: t('Invalid parameter in request body: %(param)s')
+    },
+    INVALID_REQUEST_SIGNATURE: {
+      errno: 109,
+      message: t('Invalid request signature')
+    },
+    SERVICE_UNAVAILABLE: {
+      errno: 998,
+      message: t('System unavailable, try again soon')
+    },
+    UNEXPECTED_ERROR: {
+      errno: 999,
+      message: t('Unexpected error')
+    },
+    TRY_AGAIN: {
+      errno: 1000,
+      message: t('Something went wrong. Please close this tab and try again.')
+    },
+    INVALID_RESULT: {
+      errno: 1001,
+      message: t('Unexpected error')
+    },
+    INVALID_RESULT_REDIRECT: {
+      errno: 1002,
+      message: t('Unexpected error')
+    },
+    INVALID_RESULT_CODE: {
+      errno: 1003,
+      message: t('Unexpected error')
+    },
+    USER_CANCELED_OAUTH_LOGIN: {
+      errno: 1004,
+      message: t('no message')
+    }
   };
 
-  var CODE_TO_MESSAGES = {
-    // errors returned by the oauth server
-    101: t('Unknown client'),
-    103: t('Incorrect redirect_uri'),
-    104: t('Invalid assertion'),
-    108: t('Invalid parameter in request body: %(param)s'),
-    109: t('Invalid request signature'),
-
-    // local only errors.
-    998: t('System unavailable, try again soon'),
-    999: t('Unexpected error'),
-    1000: t('Something went wrong. Please close this tab and try again.'),
-    1001: t('Unexpected error'),
-    1002: t('Unexpected error'),
-    1003: t('Unexpected error')
-  };
-
-  return _.extend({}, AuthErrors, {
-    ERROR_TO_CODE: ERROR_TO_CODE,
-    CODE_TO_MESSAGES: CODE_TO_MESSAGES,
+  return _.extend({}, Errors, {
+    ERRORS: ERRORS,
     NAMESPACE: 'oauth'
   });
 });

--- a/app/scripts/lib/profile-client.js
+++ b/app/scripts/lib/profile-client.js
@@ -12,9 +12,9 @@ define([
   'lib/config-loader',
   'lib/oauth-client',
   'lib/assertion',
-  'lib/auth-errors'
+  'lib/profile-errors'
 ],
-function (xhr, _, ConfigLoader, OAuthClient, Assertion, AuthErrors) {
+function (xhr, _, ConfigLoader, OAuthClient, Assertion, ProfileErrors) {
 
   function ProfileClient(options) {
     options = options || {};
@@ -86,38 +86,7 @@ function (xhr, _, ConfigLoader, OAuthClient, Assertion, AuthErrors) {
     });
   };
 
-  var t = function (msg) {
-    return msg;
-  };
-
-  var ERROR_TO_CODE = {
-    UNAUTHORIZED: 100,
-    INVALID_PARAMETER: 101,
-    UNSUPPORTED_PROVIDER: 102,
-    IMAGE_PROCESSING_ERROR: 103,
-
-    // local only errors.
-    SERVICE_UNAVAILABLE: 998,
-    UNEXPECTED_ERROR: 999
-  };
-
-  var CODE_TO_MESSAGES = {
-    // errors returned by the profile server
-    100: t('Unauthorized'),
-    101: t('Invalid parameter in request body: %(param)s'),
-    102: t('Unsupported image provider'),
-    103: t('Image processing error'),
-
-    // local only errors.
-    998: t('System unavailable, try again soon'),
-    999: t('Unexpected error')
-  };
-
-  var ProfileErrors = ProfileClient.Errors = _.extend({}, AuthErrors, {
-    ERROR_TO_CODE: ERROR_TO_CODE,
-    CODE_TO_MESSAGES: CODE_TO_MESSAGES,
-    NAMESPACE: 'profile'
-  });
+  ProfileClient.Errors = ProfileErrors;
 
   return ProfileClient;
 });

--- a/app/scripts/lib/profile-errors.js
+++ b/app/scripts/lib/profile-errors.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'underscore',
+  'lib/errors'
+], function (_, Errors) {
+  var t = function (msg) {
+    return msg;
+  };
+
+  var ERRORS = {
+    UNAUTHORIZED: {
+      errno: 100,
+      message: t('Unauthorized')
+    },
+    INVALID_PARAMETER: {
+      errno: 101,
+      message: t('Invalid parameter in request body: %(param)s')
+    },
+    UNSUPPORTED_PROVIDER: {
+      errno: 102,
+      message: t('Unsupported image provider')
+    },
+    IMAGE_PROCESSING_ERROR: {
+      errno: 103,
+      message: t('Image processing error')
+    },
+    SERVICE_UNAVAILABLE: {
+      errno: 998,
+      message: t('System unavailable, try again soon')
+    },
+    UNEXPECTED_ERROR: {
+      errno: 999,
+      message: t('Unexpected error')
+    }
+  };
+
+  return _.extend({}, Errors, {
+    ERRORS: ERRORS,
+    NAMESPACE: 'profile'
+  });
+});

--- a/app/tests/spec/lib/auth-errors.js
+++ b/app/tests/spec/lib/auth-errors.js
@@ -112,18 +112,18 @@ function (chai, AuthErrors) {
       });
     });
 
-    describe('toCode', function () {
+    describe('toErrno', function () {
       it('returns the errno from an error object', function () {
         var err = AuthErrors.toError('INVALID_TOKEN', 'bad token, man');
-        assert.equal(AuthErrors.toCode(err), 110);
+        assert.equal(AuthErrors.toErrno(err), 110);
       });
 
       it('converts a string type to a numeric code, if valid code', function () {
-        assert.equal(AuthErrors.toCode('UNKNOWN_ACCOUNT'), 102);
+        assert.equal(AuthErrors.toErrno('UNKNOWN_ACCOUNT'), 102);
       });
 
       it('returns the string if an invalid code', function () {
-        assert.equal(AuthErrors.toCode('this is an invalid code'), 'this is an invalid code');
+        assert.equal(AuthErrors.toErrno('this is an invalid code'), 'this is an invalid code');
       });
     });
 
@@ -133,6 +133,24 @@ function (chai, AuthErrors) {
             assert.isTrue(AuthErrors.is({ errno: 102 }, 'UNKNOWN_ACCOUNT'));
             assert.isFalse(AuthErrors.is({ errno: 103 }, 'UNKNOWN_ACCOUNT'));
           });
+    });
+
+    describe('normalizeXHRError', function () {
+      it('converts a missing XHR request to a `SERVICE_UNAVAILABLE` error', function () {
+        assert.isTrue(AuthErrors.is(AuthErrors.normalizeXHRError(), 'SERVICE_UNAVAILABLE'));
+      });
+
+      it('converts an XHR request with `status=0` to a `SERVICE_UNAVAILABLE` error', function () {
+        assert.isTrue(AuthErrors.is(AuthErrors.normalizeXHRError({ status: 0 }), 'SERVICE_UNAVAILABLE'));
+      });
+
+      it('converts an XHR request with missing `responseJSON` to an `UNEXPECTED_ERROR` error', function () {
+        assert.isTrue(AuthErrors.is(AuthErrors.normalizeXHRError({ status: 200 }), 'UNEXPECTED_ERROR'));
+      });
+
+      it('converts an XHR request with `responseJSON` to an error`', function () {
+        assert.isTrue(AuthErrors.is(AuthErrors.normalizeXHRError({ status: 200, responseJSON: { errno: 201 }}), 'SERVER_BUSY'));
+      });
     });
   });
 });

--- a/app/tests/spec/lib/oauth-client.js
+++ b/app/tests/spec/lib/oauth-client.js
@@ -87,7 +87,7 @@ function (chai, $, testHelpers, sinon,
           server.respondWith('POST', OAUTH_URL + '/v1/authorization',
             [400, { 'Content-Type': 'application/json' },
               JSON.stringify({
-                errno: OAuthErrors.toCode('INCORRECT_REDIRECT'),
+                errno: OAuthErrors.toErrno('INCORRECT_REDIRECT'),
                 code: 400
               })]);
 
@@ -136,7 +136,7 @@ function (chai, $, testHelpers, sinon,
             server.respondWith('GET', OAUTH_URL + '/v1/client/' + clientId,
               [400, { 'Content-Type': 'application/json' },
                 JSON.stringify({
-                  errno: OAuthErrors.toCode('EXPIRED_CODE'),
+                  errno: OAuthErrors.toErrno('EXPIRED_CODE'),
                   code: 400
                 })]);
 
@@ -192,7 +192,7 @@ function (chai, $, testHelpers, sinon,
               server.respondWith('POST', OAUTH_URL + '/v1/authorization',
                 [400, { 'Content-Type': 'application/json' },
                   JSON.stringify({
-                    errno: OAuthErrors.toCode('INVALID_ASSERTION'),
+                    errno: OAuthErrors.toErrno('INVALID_ASSERTION'),
                     code: 400
                   })]);
 

--- a/app/tests/spec/lib/oauth-errors.js
+++ b/app/tests/spec/lib/oauth-errors.js
@@ -38,18 +38,18 @@ function (chai, OAuthErrors) {
       });
     });
 
-    describe('toCode', function () {
+    describe('toErrno', function () {
       it('returns the errno from an error object', function () {
         var err = OAuthErrors.toError('UNKNOWN_CLIENT', 'dunno');
-        assert.equal(OAuthErrors.toCode(err), 101);
+        assert.equal(OAuthErrors.toErrno(err), 101);
       });
 
       it('converts a string type to a numeric code, if valid code', function () {
-        assert.equal(OAuthErrors.toCode('UNKNOWN_CLIENT'), 101);
+        assert.equal(OAuthErrors.toErrno('UNKNOWN_CLIENT'), 101);
       });
 
       it('returns the string if an invalid code', function () {
-        assert.equal(OAuthErrors.toCode('this is an invalid code'), 'this is an invalid code');
+        assert.equal(OAuthErrors.toErrno('this is an invalid code'), 'this is an invalid code');
       });
     });
 


### PR DESCRIPTION
- Rename `code` to `errno` to be consistent with the backend.
- Use a single hash called ERRORS for each namespace. The hash contains both `errno` and `message`
- Extract `errors.js` from logic that was in `auth-errors.js`
- Extract `profile-errors.js` from logic in `profile-client.js`

fixes #1508 
