### PR TITLE
feat: Check for required OAuth parameters on startup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ app/scripts/processed
 
 ### Pre-processed error pages
 app/500.html
+app/502.html
 app/503.html
 
 ### Local configuration ###

--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -192,6 +192,32 @@ function (_, Errors) {
 
   return _.extend({}, Errors, {
     ERRORS: ERRORS,
-    NAMESPACE: 'auth'
+    NAMESPACE: 'auth',
+
+    /**
+     * Fetch the interpolation context out of the server error.
+     */
+    toInterpolationContext: function (err) {
+      // For data returned by backend, see
+      // https://github.com/mozilla/fxa-auth-server/blob/master/error.js
+      try {
+        if (this.is(err, 'INVALID_PARAMETER')) {
+          return {
+            param: err.validation.keys
+          };
+        } else if (this.is(err, 'MISSING_PARAMETER')) {
+          return {
+            param: err.param
+          };
+        }
+      } catch (e) {
+        // handle invalid/unexpected data from the backend.
+        if (window.console && console.error) {
+          console.error('Error in errors.js->toInterpolationContext: %s', String(e));
+        }
+      }
+
+      return {};
+    }
   });
 });

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -31,7 +31,8 @@ define([], function () {
     PROFILE_IMAGE_JPEG_QUALITY: 0.8,
     DEFAULT_PROFILE_IMAGE_MIME_TYPE: 'image/jpeg',
 
-    INTERNAL_ERROR_PAGE: '/500.html'
+    INTERNAL_ERROR_PAGE: '/500.html',
+    BAD_REQUEST_PAGE: '/400.html'
   };
 });
 

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -63,11 +63,37 @@ function (_, Errors) {
     USER_CANCELED_OAUTH_LOGIN: {
       errno: 1004,
       message: t('no message')
+    },
+    MISSING_PARAMETER: {
+      errno: 1005,
+      message: t('Missing OAuth parameter: %(param)s')
     }
   };
 
   return _.extend({}, Errors, {
     ERRORS: ERRORS,
-    NAMESPACE: 'oauth'
+    NAMESPACE: 'oauth',
+
+    /**
+     * Fetch the interpolation context out of the server error.
+     */
+    toInterpolationContext: function (err) {
+      // For data returned by backend, see
+      // https://github.com/mozilla/fxa-auth-server/blob/master/error.js
+      try {
+        if (this.is(err, 'MISSING_PARAMETER')) {
+          return {
+            param: err.param
+          };
+        }
+      } catch (e) {
+        // handle invalid/unexpected data from the backend.
+        if (window.console && console.error) {
+          console.error('Error in oauth-errors.js->toInterpolationContext: %s', String(e));
+        }
+      }
+
+      return {};
+    }
   });
 });

--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -13,9 +13,6 @@ function () {
 
   // temporary strings that can be extracted for the
   // l10n team to start translations.
-  // TODO - remove this string when the update to #1801 which removes the click
-  // from the confirm page and this is an actual error message.
-  t('Your verification email was just returned. Mistyped email?');
 
   // Intended for email marketing opt-in
   // Should be removed in favor of #992 and #993 when implemented

--- a/app/scripts/lib/url.js
+++ b/app/scripts/lib/url.js
@@ -44,6 +44,21 @@ function (_) {
       var terms = searchParams(str);
 
       return terms[name];
+    },
+
+    objToSearchString: function (obj) {
+      var params = [];
+      for (var paramName in obj) {
+        var paramValue = obj[paramName];
+        if (typeof paramValue !== 'undefined') {
+          params.push(paramName + '=' + encodeURIComponent(paramValue));
+        }
+      }
+
+      if (! params.length) {
+        return '';
+      }
+      return '?' + params.join('&');
     }
   };
 });

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -65,6 +65,19 @@ function (_, Backbone, $, p, AuthErrors,
     return translated;
   }
 
+  /**
+   * Return the error module that produced the error, based on the error's
+   * namespace.
+   */
+  function getErrorModule(err) {
+    if (err && err.errorModule) {
+      return err.errorModule;
+    } else {
+      return AuthErrors;
+    }
+  }
+
+
   var BaseView = Backbone.View.extend({
     constructor: function (options) {
       options = options || {};
@@ -391,18 +404,6 @@ function (_, Backbone, $, p, AuthErrors,
     },
 
     /**
-     * Return the error module that produced the error, based on the error's
-     * namespace.
-     */
-    _errorContext: function (err) {
-      if (err && err.errorContext) {
-        return err.errorContext;
-      } else {
-        return AuthErrors;
-      }
-    },
-
-    /**
      * Display an error message.
      * @method translateError
      * @param {string} err - an error object
@@ -411,11 +412,8 @@ function (_, Backbone, $, p, AuthErrors,
      *   error text otw.
      */
     translateError: function (err) {
-      var errors = this._errorContext(err);
-
-      var msg = errors.toMessage(err);
-      var context = errors.toContext(err);
-      var translated = this.translator.get(msg, context);
+      var errors = getErrorModule(err);
+      var translated = errors.toInterpolatedMessage(err, this.translator);
 
       return translated;
     },
@@ -473,7 +471,7 @@ function (_, Backbone, $, p, AuthErrors,
     },
 
     _normalizeError: function (err) {
-      var errors = this._errorContext(err);
+      var errors = getErrorModule(err);
       if (! err) {
         // likely an error in logic, display an unexpected error to the
         // user and show a console trace to help us debug.

--- a/app/tests/spec/lib/auth-errors.js
+++ b/app/tests/spec/lib/auth-errors.js
@@ -82,10 +82,10 @@ function (chai, AuthErrors) {
       });
     });
 
-    describe('toContext', function () {
+    describe('toInterpolationContext', function () {
       it('returns the context from backend information for invalid parameter', function () {
         assert.deepEqual(
-          AuthErrors.toContext({
+          AuthErrors.toInterpolationContext({
             errno: 107,
             validation: {
               keys: 'uid'
@@ -95,7 +95,7 @@ function (chai, AuthErrors) {
 
       it('returns the context from backend information for missing parameter', function () {
         assert.deepEqual(
-          AuthErrors.toContext({
+          AuthErrors.toInterpolationContext({
             errno: 108,
             param: 'uid'
           }), { param: 'uid' });
@@ -103,7 +103,7 @@ function (chai, AuthErrors) {
 
       it('returns empty context for other errors', function () {
         assert.deepEqual(
-          AuthErrors.toContext({
+          AuthErrors.toInterpolationContext({
             errno: 109,
             validation: {
               keys: 'uid'

--- a/app/tests/spec/lib/url.js
+++ b/app/tests/spec/lib/url.js
@@ -48,6 +48,21 @@ function (chai, _, Url) {
           });
 
     });
+
+    describe('objToSearchString', function () {
+      it('includes all keys with values', function () {
+        var params = {
+          hasValue: 'value',
+          notIncluded: undefined
+        };
+
+        assert.equal(Url.objToSearchString(params), '?hasValue=value');
+      });
+
+      it('returns an empty string if no parameters are passed in', function () {
+        assert.equal(Url.objToSearchString({}), '');
+      });
+    });
   });
 });
 

--- a/grunttasks/copy.js
+++ b/grunttasks/copy.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
           flatten: true,
           cwd: '<%= yeoman.page_template_dist %>',
           dest: '<%= yeoman.app %>',
-          src: 'en_US/{500,503}.html'
+          src: 'en_US/{500,502,503}.html'
         }
       ]
     },

--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -7,6 +7,7 @@ var https = require('https');
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var path = require('path');
+var config = require('../lib/configuration');
 
 // This can't possibly be best way to librar-ify this module.
 var isMain = process.argv[1] === __filename;
@@ -29,7 +30,6 @@ var helmet = require('helmet');
 var express = require('express');
 var consolidate = require('consolidate');
 
-var config = require('../lib/configuration');
 var i18n = require('../lib/i18n')(config.get('i18n'));
 var templates = require('../lib/templates')(config.get('template_path'), i18n);
 var routes = require('../lib/routes')(config, templates, i18n);

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -7,6 +7,7 @@
 
 var logger = require('intel').getLogger('server.routes');
 
+
 /**
  * Each route has 3 attributes: method, path and process.
  * method is one of `GET`, `POST`, etc.
@@ -124,23 +125,44 @@ module.exports = function (config, templates, i18n) {
         res.json({result: 'ok'});
       });
 
-      app.get('/500.html', function (req, res) {
-        res.removeHeader('x-frame-options');
-        return res.render('500');
-      });
-
       app.get('/503.html', function (req, res) {
         res.removeHeader('x-frame-options');
         return res.render('503');
       });
-    }
 
-    // Add a route in dev mode to test 500 errors
-    if (config.get('env') === 'development') {
+      // Add a route in dev mode to test 500 errors
       app.get('/boom', function (req, res, next) {
         next(new Error('Uh oh!'));
       });
     }
+
+    // we always want to handle these so we can do some logging.
+    app.get('/400.html', function (req, res) {
+      res.removeHeader('x-frame-options');
+      logger.error('400.html', {
+        message: req.query.message,
+        errno: req.query.errno,
+        namespace: req.query.namespace,
+        context: req.query.context,
+        param: req.query.param,
+        client_id: req.query.client_id
+      });
+      return res.render('400', {
+        message: req.query.message
+      });
+    });
+
+    app.get('/500.html', function (req, res) {
+      res.removeHeader('x-frame-options');
+      logger.error('500.html', {
+        message: req.query.message,
+        errno: req.query.errno,
+        namespace: req.query.namespace,
+        context: req.query.context
+      });
+      return res.render('500');
+    });
+
   };
 
 };

--- a/server/templates/pages/src/400.html
+++ b/server/templates/pages/src/400.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" dir="{{ lang_dir }}" lang="{{ lang }}"> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>{{#t}}Firefox Accounts{{/t}}</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width">
+
+        <!-- build:css(.tmp) /styles/{{ locale }}.css -->
+        <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">
+        <link rel="stylesheet" href="/styles/fontello.css">
+        {{#if fontSupportDisabled}}
+        <link rel="stylesheet" href="/styles/system-font-main.css">
+        {{else}}
+        <link rel="stylesheet" href="/styles/fonts/{{ locale }}.css">
+        <link rel="stylesheet" href="/styles/main.css">
+        {{/if}}
+        <!-- endbuild -->
+    </head>
+    <body>
+        <div id="fox-logo" class="static"></div>
+        <div id="stage">
+            <div id="main-content">
+              <header>
+                <h1 id="fxa-400-header">{{#t}}Bad Request{{/t}}</h1>
+              </header>
+
+              <section>
+                {{#if message}}
+                  <div class="error visible">{{message}}</div>
+                {{/if}}
+              </section>
+            </div>
+        </div>
+
+        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
+    </body>
+</html>

--- a/server/templates/pages/src/502.html
+++ b/server/templates/pages/src/502.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" dir="{{ lang_dir }}" lang="{{ lang }}"> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>{{#t}}Firefox Accounts{{/t}}</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width">
+
+        <!-- build:css(.tmp) /styles/{{ locale }}.css -->
+        <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">
+        <link rel="stylesheet" href="/styles/fontello.css">
+        {{#if fontSupportDisabled}}
+        <link rel="stylesheet" href="/styles/system-font-main.css">
+        {{else}}
+        <link rel="stylesheet" href="/styles/fonts/{{ locale }}.css">
+        <link rel="stylesheet" href="/styles/main.css">
+        {{/if}}
+        <!-- endbuild -->
+    </head>
+    <body>
+        <div id="fox-logo" class="static"></div>
+        <div id="stage">
+          <div id="main-content">
+            <header>
+              <h1 id="fxa-502-header">{{#t}}502 Error{{/t}}</h1>
+            </header>
+
+            <section>
+              {{#t}}Oh dear, something went wrong there. We've been notified and will get working on a fix.{{/t}}
+            </section>
+
+            <div class="button-row">
+              <a href="/" class="button" id="fxa-502-home">{{#t}}Home{{/t}}</a>
+            </div>
+          </div>
+        </div>
+
+        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
+    </body>
+</html>

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -17,6 +17,7 @@ define([
   var config = intern.config;
   var OAUTH_APP = config.fxaOauthApp;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+  var SIGNIN_ROOT = config.fxaContentRoot + 'oauth/signin';
 
   var PASSWORD = 'password';
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
@@ -40,6 +41,24 @@ define([
         contentServer: true,
         '123done': true
       });
+    },
+
+    'with missing client_id': function () {
+      return this.get('remote').get(require.toUrl(SIGNIN_ROOT + '?scope=profile'))
+        .findByCssSelector('#fxa-400-header')
+        .end();
+    },
+
+    'with missing scope': function () {
+      return this.get('remote').get(require.toUrl(SIGNIN_ROOT + '?client_id=client_id'))
+        .findByCssSelector('#fxa-400-header')
+        .end();
+    },
+
+    'with invalid client_id': function () {
+      return this.get('remote').get(require.toUrl(SIGNIN_ROOT + '?client_id=invalid_client_id&scope=profile'))
+        .findByCssSelector('#fxa-400-header')
+        .end();
     },
 
     'verified': function () {
@@ -133,7 +152,10 @@ define([
         .findByCssSelector('#fxa-confirm-header')
 
         .then(function () {
-          return FunctionalHelpers.getVerificationLink(user, 0);
+          // get the second email, the first was sent on client.signUp w/
+          // preVerified: false above. The second email has the `service` and
+          // `resume` parameters.
+          return FunctionalHelpers.getVerificationLink(user, 1);
         })
         .then(function (verifyUrl) {
           return self.get('remote')

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -16,6 +16,7 @@ define([
   'use strict';
 
   var config = intern.config;
+  var SIGNUP_ROOT = config.fxaContentRoot + 'oauth/signup';
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
   var OLD_ENOUGH_YEAR = TOO_YOUNG_YEAR - 1;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
@@ -44,6 +45,24 @@ define([
         contentServer: true,
         '123done': true
       });
+    },
+
+    'with missing client_id': function () {
+      return this.get('remote').get(require.toUrl(SIGNUP_ROOT + '?scope=profile'))
+        .findByCssSelector('#fxa-400-header')
+        .end();
+    },
+
+    'with missing scope': function () {
+      return this.get('remote').get(require.toUrl(SIGNUP_ROOT + '?client_id=client_id'))
+        .findByCssSelector('#fxa-400-header')
+        .end();
+    },
+
+    'with invalid client_id': function () {
+      return this.get('remote').get(require.toUrl(SIGNUP_ROOT + '?client_id=invalid_client_id&scope=profile'))
+        .findByCssSelector('#fxa-400-header')
+        .end();
     },
 
     'signup, verify same browser': function () {

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -54,8 +54,8 @@ define([
   };
 
   if (config.get('are_dist_resources')) {
-    routes['/400.html'] = { statusCode: 200 };
     routes['/500.html'] = { statusCode: 200 };
+    routes['/502.html'] = { statusCode: 200 };
     routes['/503.html'] = { statusCode: 200 };
   }
 
@@ -73,8 +73,8 @@ define([
     '/legal/privacy',
     '/oauth/signin',
     '/oauth/signup',
-    '/400.html',
     '/500.html',
+    '/502.html',
     '/503.html'
   ];
 

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -54,6 +54,7 @@ define([
   };
 
   if (config.get('are_dist_resources')) {
+    routes['/400.html'] = { statusCode: 200 };
     routes['/500.html'] = { statusCode: 200 };
     routes['/503.html'] = { statusCode: 200 };
   }
@@ -72,6 +73,7 @@ define([
     '/legal/privacy',
     '/oauth/signin',
     '/oauth/signup',
+    '/400.html',
     '/500.html',
     '/503.html'
   ];


### PR DESCRIPTION
If either `scope` or `client_id` is missing/invalid, send the user to `/400.html` and show them an error message.

* Add the 400.html page.
* Check for required parameters in the OAuth relier.
* If the `client_id` is invalid, show the user `Unknown client`
* If app start detects an OAuth error, it redirects to /400.html with query parameters that can be used to log the error.
* Add server logging of parameters passed to /400.html and /500.html
* Try to simplify the error creation logic a bit.
* Move a lot of error unit tests from auth-errors.js to errors.js. Add more unit test coverage for the error creation logic.
* Add Url->objToSearchString.


Add a new OAuth error:
* 1005 - Missing parameter - it's `param` will be the missing parameter.

fixes #1740
fixes #1972 