### PR TITLE
fix(client): Only add `autocomplete=off` when in sync or to text fields acting as passwords.

### DIFF
--- a/app/scripts/templates/change_password.mustache
+++ b/app/scripts/templates/change_password.mustache
@@ -13,7 +13,7 @@
       </p>
       <div class="input-row password-row">
         <label class="label-helper"></label>
-        <input type="password" class="password" id="old_password" placeholder="{{#t}}Old password{{/t}}" pattern=".{8,}" autofocus required autocomplete="off" />
+        <input type="password" class="password" id="old_password" placeholder="{{#t}}Old password{{/t}}" pattern=".{8,}" autofocus required {{#isPasswordAutoCompleteDisabled}}autocomplete="off"{{/isPasswordAutoCompleteDisabled}} />
 
         <input id="show-old-password" type="checkbox" class="show-password" aria-controls="old_password" tabindex="-1" data-novalue />
         <label for="show-old-password" class="show-password-label">
@@ -23,7 +23,7 @@
 
       <div class="input-row password-row">
         <label class="label-helper"></label>
-        <input type="password" class="password tooltip-below" id="new_password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" required autocomplete="off" />
+        <input type="password" class="password tooltip-below" id="new_password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" required {{#isPasswordAutoCompleteDisabled}}autocomplete="off"{{/isPasswordAutoCompleteDisabled}} />
 
         <input id="show-new-password" type="checkbox" class="show-password" aria-controls="new_password" tabindex="-1" data-novalue />
         <label for="show-new-password" class="show-password-label">

--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -41,7 +41,7 @@
     <form novalidate>
       <div class="input-row password-row">
         <label class="label-helper"></label>
-        <input type="password" class="password" id="password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" autofocus required autocomplete="off" />
+        <input type="password" class="password" id="password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" autofocus required {{#isPasswordAutoCompleteDisabled}}autocomplete="off"{{/isPasswordAutoCompleteDisabled}} />
 
         <input id="show-password" type="checkbox" class="show-password" aria-controls="password" tabindex="-1" data-novalue />
         <label for="show-password" class="show-password-label">
@@ -51,7 +51,7 @@
 
       <div class="input-row password-row">
         <label class="label-helper"></label>
-        <input type="password" class="password tooltip-below" id="vpassword" placeholder="{{#t}}Repeat password{{/t}}" pattern=".{8,}" required autocomplete="off" />
+        <input type="password" class="password tooltip-below" id="vpassword" placeholder="{{#t}}Repeat password{{/t}}" pattern=".{8,}" required {{#isPasswordAutoCompleteDisabled}}autocomplete="off"{{/isPasswordAutoCompleteDisabled}} />
 
         <input id="show-vpassword" type="checkbox" class="show-password" aria-controls="vpassword" tabindex="-1" data-novalue />
         <label for="show-vpassword" class="show-password-label">

--- a/app/scripts/templates/delete_account.mustache
+++ b/app/scripts/templates/delete_account.mustache
@@ -11,6 +11,9 @@
       <p class="prefill">{{ email }}</p>
 
       <div class="input-row password-row">
+        <!-- add the autocomplete=false attribute - the user is 
+             deleting the account, they most likely don't want 
+             the password saved. -->
         <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required autofocus autocomplete="off" />
 
         <input id="show-password" type="checkbox" class="show-password" aria-controls="password" tabindex="-1" data-novalue />

--- a/app/scripts/templates/force_auth.mustache
+++ b/app/scripts/templates/force_auth.mustache
@@ -16,7 +16,7 @@
       <p class="prefill">{{ email }}</p>
 
       <div class="input-row password-row">
-        <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" value="{{ password }}" required {{#email}}autofocus{{/email}} autocomplete="off" />
+        <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" value="{{ password }}" required {{#email}}autofocus{{/email}} {{#isPasswordAutoCompleteDisabled}}autocomplete="off"{{/isPasswordAutoCompleteDisabled}} />
 
         <input id="show-password" type="checkbox" class="show-password" aria-controls="password" tabindex="-1" data-novalue />
         <label for="show-password" class="show-password-label">

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -30,7 +30,7 @@
             <input type="hidden" class="email" value="{{ email }}" />
 
             <div class="input-row password-row">
-              <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autocomplete="off" autofocus />
+              <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required {{#isPasswordAutoCompleteDisabled}}autocomplete="off"{{/isPasswordAutoCompleteDisabled}} autofocus />
 
               <input id="show-password" type="checkbox" class="show-password" aria-controls="password" tabindex="-1" data-novalue />
               <label for="show-password" class="show-password-label">
@@ -69,7 +69,7 @@
         </div>
 
         <div class="input-row password-row">
-          <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required {{#email}}autofocus{{/email}} autocomplete="off" />
+          <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required {{#email}}autofocus{{/email}} {{#isPasswordAutoCompleteDisabled}}autocomplete="off"{{/isPasswordAutoCompleteDisabled}} />
 
           <input id="show-password" type="checkbox" class="show-password" aria-controls="password" tabindex="-1" data-novalue />
           <label for="show-password" class="show-password-label">

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -26,7 +26,7 @@
       </div>
 
       <div class="input-row password-row">
-        <input id="password" type="password" class="password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autocomplete="off" {{#shouldFocusPassword}}autofocus{{/shouldFocusPassword}} />
+        <input id="password" type="password" class="password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required {{#isPasswordAutoCompleteDisabled}}autocomplete="off"{{/isPasswordAutoCompleteDisabled}} {{#shouldFocusPassword}}autofocus{{/shouldFocusPassword}} />
         <input id="show-password" type="checkbox" class="show-password" aria-controls="password" tabindex="-1" data-novalue />
         <label for="show-password" class="show-password-label">
           {{#t}}Show{{/t}}

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -15,8 +15,13 @@
     <div class="input-row">
       <input type="email" id="email" />
     </div>
-    <div class="input-row">
-      <input type="password" id="password" />
+    <div class="input-row password-row">
+      <input type="password" class="password" id="password" pattern=".{8,}" required />
+      <input id="show-password" type="checkbox" class="show-password" aria-controls="password" data-novalue />
+    </div>
+    <div class="input-row password-row">
+      <input type="password" class="password" id="vpassword" pattern=".{8,}" required />
+      <input id="show-password" type="checkbox" class="show-password" aria-controls="vpassword" data-novalue />
     </div>
     <div class="input-row">
       <span class="label-helper"></span>

--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -30,6 +30,12 @@ function (_, BaseView, FormView, Template, PasswordMixin, FloatingPlaceholderMix
       'change .show-password': 'onPasswordVisibilityChange'
     },
 
+    context: function () {
+      return {
+        isPasswordAutoCompleteDisabled: this.isPasswordAutoCompleteDisabled()
+      };
+    },
+
     afterRender: function () {
       this.initializePlaceholderFields();
     },

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -85,6 +85,7 @@ function (_, BaseView, FormView, Template, PasswordMixin,
 
       // damaged and expired links have special messages.
       return {
+        isPasswordAutoCompleteDisabled: this.isPasswordAutoCompleteDisabled(),
         isLinkDamaged: ! doesLinkValidate,
         isLinkExpired: isLinkExpired,
         isLinkValid: doesLinkValidate && ! isLinkExpired

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -42,7 +42,8 @@ function (p, BaseView, FormView, SignInView, Template, Session) {
       return {
         email: email,
         password: this._prefillPassword,
-        fatalError: fatalError
+        fatalError: fatalError,
+        isPasswordAutoCompleteDisabled: this.isPasswordAutoCompleteDisabled()
       };
     },
 

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -38,8 +38,8 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin,
                     suggestedAccount.get('email') : this.prefillEmail;
 
       return {
-        service: this.relier.get('service'),
         serviceName: this.relier.get('serviceName'),
+        isPasswordAutoCompleteDisabled: this.isPasswordAutoCompleteDisabled(),
         email: email,
         suggestedAccount: hasSuggestedAccount,
         chooserAskForPassword: this._suggestedAccountAskPassword(suggestedAccount),

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -105,13 +105,13 @@ function (_, p, BaseView, FormView, Template, Session, AuthErrors,
         this._bouncedEmail, email, Session.prefillPassword);
 
       return {
-        service: this.relier.get('service'),
         serviceName: this.relier.get('serviceName'),
+        isSync: this.relier.isSync(),
+        isCustomizeSyncChecked: this.relier.isCustomizeSyncChecked(),
+        isPasswordAutoCompleteDisabled: this.isPasswordAutoCompleteDisabled(),
         email: email,
         password: Session.prefillPassword,
         year: Session.prefillYear || 'none',
-        isSync: this.relier.isSync(),
-        isCustomizeSyncChecked: this.relier.isCustomizeSyncChecked(),
         shouldFocusEmail: autofocusEl === 'email',
         shouldFocusPassword: autofocusEl === 'password',
         shouldFocusYear: autofocusEl === 'year',

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -24,7 +24,7 @@ define([
   '../../mocks/window',
   '../../lib/helpers'
 ],
-function (chai, jQuery, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
+function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
           AuthErrors, FxaClient, Relier, User, Template, DOMEventMock, RouterMock,
           WindowMock, TestHelpers) {
   var requiresFocus = TestHelpers.requiresFocus;
@@ -78,7 +78,7 @@ function (chai, jQuery, sinon, BaseView, p, Translator, EphemeralMessages, Metri
 
       return view.render()
           .then(function () {
-            jQuery('#container').append(view.el);
+            $('#container').html(view.el);
           });
     });
 
@@ -87,7 +87,7 @@ function (chai, jQuery, sinon, BaseView, p, Translator, EphemeralMessages, Metri
 
       if (view) {
         view.destroy();
-        jQuery('#container').empty();
+        $('#container').empty();
       }
 
       view = router = windowMock = metrics = null;
@@ -96,7 +96,7 @@ function (chai, jQuery, sinon, BaseView, p, Translator, EphemeralMessages, Metri
     describe('render', function () {
       it('renders the template without attaching it to the body', function () {
         // render is called in beforeEach
-        assert.ok(jQuery('#focusMe').length);
+        assert.ok($('#focusMe').length);
       });
 
       it('updates the page title with the embedded h1 and h2 tags', function () {
@@ -236,17 +236,17 @@ function (chai, jQuery, sinon, BaseView, p, Translator, EphemeralMessages, Metri
 
     describe('afterVisible', function () {
       afterEach(function () {
-        jQuery('html').removeClass('no-touch');
+        $('html').removeClass('no-touch');
       });
 
       it('focuses descendent element containing `autofocus` if html has `no-touch` class', function (done) {
         requiresFocus(function () {
-          jQuery('html').addClass('no-touch');
+          $('html').addClass('no-touch');
           // wekbit fails unless focusing another element first.
-          jQuery('#otherElement').focus();
+          $('#otherElement').focus();
 
           var handlerCalled = false;
-          jQuery('#focusMe').on('focus', function () {
+          $('#focusMe').on('focus', function () {
             handlerCalled = true;
           });
 
@@ -264,7 +264,7 @@ function (chai, jQuery, sinon, BaseView, p, Translator, EphemeralMessages, Metri
       it('does not focus descendent element containing `autofocus` if html does not have `no-touch` class', function (done) {
         requiresFocus(function () {
           var handlerCalled = false;
-          jQuery('#focusMe').on('focus', function () {
+          $('#focusMe').on('focus', function () {
             handlerCalled = true;
           });
 

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -202,21 +202,6 @@ function (chai, sinon, p, AuthErrors, Metrics, FxaClient, InterTabChannel,
       });
     });
 
-    describe('updatePasswordVisibility', function () {
-      it('pw field set to text when clicked', function () {
-        $('.show-password').click();
-        assert.equal($('#password').attr('type'), 'text');
-        assert.equal($('#vpassword').attr('type'), 'text');
-      });
-
-      it('pw field set to password when clicked again', function () {
-        $('.show-password').click();
-        $('.show-password').click();
-        assert.equal($('#password').attr('type'), PASSWORD);
-        assert.equal($('#vpassword').attr('type'), PASSWORD);
-      });
-    });
-
     describe('isValid', function () {
       it('returns true if password & vpassword valid and the same', function () {
         view.$('#password').val(PASSWORD);

--- a/app/tests/spec/views/mixins/password-mixin.js
+++ b/app/tests/spec/views/mixins/password-mixin.js
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'jquery',
+  'chai',
+  'sinon',
+  'backbone',
+  'underscore',
+  'views/mixins/password-mixin',
+  'views/base',
+  'models/reliers/relier',
+  'stache!templates/test_template'
+], function ($, chai, sinon, Backbone, _, PasswordMixin, BaseView, Relier, TestTemplate) {
+  var assert = chai.assert;
+
+  var PasswordView = BaseView.extend({
+    template: TestTemplate,
+    events: {
+      'change .show-password': 'onPasswordVisibilityChange'
+    }
+  });
+  _.extend(PasswordView.prototype, PasswordMixin);
+
+  describe('views/mixins/password-mixin', function () {
+    var view;
+    var relier;
+
+    beforeEach(function () {
+      relier = new Relier();
+
+      view = new PasswordView({
+        relier: relier
+      });
+
+      return view.render()
+        .then(function () {
+          $('#container').html(view.el);
+        });
+    });
+
+    afterEach(function () {
+      $('#container').empty();
+    });
+
+    describe('setPasswordVisibilityFromButton', function () {
+      it('sets the password field to type=text if button is checked', function () {
+        view.$('#show-password').attr('checked', 'checked');
+        view.setPasswordVisibilityFromButton('#show-password');
+        assert.equal(view.$('#password').attr('type'), 'text');
+        assert.equal(view.$('#password').attr('autocomplete'), 'off');
+      });
+
+      it('sets the password field to type=password if button is unchecked', function () {
+        view.$('#show-password').removeAttr('checked');
+        view.setPasswordVisibilityFromButton('#show-password');
+        assert.equal(view.$('#password').attr('type'), 'password');
+        assert.isUndefined(view.$('#password').attr('autocomplete'));
+      });
+
+      it('always sets the `autocomplete=off` attribute if the relier is sync', function () {
+        // sync users should never be allowed to save their password. If they
+        // were, it would end in this weird situation where sync users ask to
+        // save their sync password to sync before sync is setup.
+
+        sinon.stub(relier, 'isSync', function () {
+          return true;
+        });
+
+        view.$('#show-password').removeAttr('checked');
+        view.setPasswordVisibilityFromButton('#show-password');
+        assert.equal(view.$('#password').attr('type'), 'password');
+        assert.equal(view.$('#password').attr('autocomplete'), 'off');
+      });
+    });
+
+    describe('clicking on the show button', function () {
+      it('pw field set to text when clicked', function () {
+        view.$('.show-password').click();
+        assert.equal(view.$('#password').attr('type'), 'text');
+        assert.equal(view.$('#password').attr('autocomplete'), 'off');
+        assert.equal(view.$('#vpassword').attr('type'), 'text');
+        assert.equal(view.$('#vpassword').attr('autocomplete'), 'off');
+      });
+
+      it('pw field set to password when clicked again', function () {
+        view.$('.show-password').click();
+        view.$('.show-password').click();
+        assert.equal(view.$('#password').attr('type'), 'password');
+        assert.equal(view.$('#password').attr('autocomplete'), null);
+        assert.equal($('#vpassword').attr('type'), 'password');
+        assert.equal($('#vpassword').attr('autocomplete'), null);
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -138,19 +138,6 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
           });
     });
 
-    describe('updatePasswordVisibility', function () {
-      it('pw field set to text when clicked', function () {
-        $('.show-password').click();
-        assert.equal($('.password').attr('type'), 'text');
-      });
-
-      it('pw field set to password when clicked again', function () {
-        $('.show-password').click();
-        $('.show-password').click();
-        assert.equal($('.password').attr('type'), 'password');
-      });
-    });
-
     describe('isValid', function () {
       it('returns true if both email and password are valid', function () {
         view.$('[type=email]').val('testuser@testuser.com');

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -105,7 +105,7 @@ function (chai, _, $, moment, sinon, p, View, Session, AuthErrors, Metrics,
 
       return view.render()
           .then(function () {
-            $('#container').append(view.el);
+            $('#container').html(view.el);
           });
     });
 
@@ -624,19 +624,6 @@ function (chai, _, $, moment, sinon, p, View, Session, AuthErrors, Metrics,
           });
       });
 
-    });
-
-    describe('updatePasswordVisibility', function () {
-      it('pw field set to text when clicked', function () {
-        $('.show-password').click();
-        assert.equal($('.password').attr('type'), 'text');
-      });
-
-      it('pw field set to password when clicked again', function () {
-        $('.show-password').click();
-        $('.show-password').click();
-        assert.equal($('[type=password]').attr('type'), 'password');
-      });
     });
 
     describe('_isUserOldEnough', function () {

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -72,6 +72,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/floating-placeholder-mixin',
     '../tests/spec/views/mixins/timer-mixin',
     '../tests/spec/views/mixins/service-mixin',
+    '../tests/spec/views/mixins/password-mixin',
     '../tests/spec/models/user',
     '../tests/spec/models/account',
     '../tests/spec/models/reliers/base',

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -27,6 +27,7 @@ define([
   './functional/back_button_after_start',
   './functional/cookies_disabled',
   './functional/fonts',
+  './functional/password_visibility',
   './functional/avatar'
 ], function () {
   'use strict';

--- a/tests/functional/password_visibility.js
+++ b/tests/functional/password_visibility.js
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'require',
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, require, FunctionalHelpers) {
+  'use strict';
+
+  var config = intern.config;
+  var SIGNIN_URL = config.fxaContentRoot + 'signin';
+  var SYNC_SIGNIN_URL = config.fxaContentRoot + 'signin?service=sync&context=fx_desktop_v1';
+
+  registerSuite({
+    name: 'password visibility',
+
+    beforeEach: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    teardown: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'toggle show password for normal RP': function () {
+      this.get('remote').get(require.toUrl(SIGNIN_URL))
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        .findByCssSelector('#password')
+          .click()
+          .type('password')
+        .end()
+
+        // turn it into a text field
+        .findByCssSelector('.show-password-label')
+          .click()
+        .end()
+
+        .findByCssSelector('#password')
+          .getAttribute('type')
+          .then(function (typeValue) {
+            assert.equal(typeValue, 'text');
+          })
+
+          .getAttribute('autocomplete')
+          .then(function (autocompleteValue) {
+            assert.equal(autocompleteValue, 'off');
+          })
+        .end()
+
+        // turn it back into a password field
+        .findByCssSelector('.show-password-label')
+          .click()
+        .end()
+
+        .findByCssSelector('#password')
+          .getAttribute('type')
+          .then(function (typeValue) {
+            assert.equal(typeValue, 'password');
+          })
+
+          .getAttribute('autocomplete')
+          .then(function (autocompleteValue) {
+            assert.isNull(autocompleteValue);
+          })
+        .end();
+    },
+
+    'toggle show password for Sync': function () {
+      this.get('remote').get(require.toUrl(SYNC_SIGNIN_URL))
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        .findByCssSelector('#password')
+          .click()
+          .type('password')
+        .end()
+
+        // turn it into a text field
+        .findByCssSelector('.show-password-label')
+          .click()
+        .end()
+
+        .findByCssSelector('#password')
+          .getAttribute('type')
+          .then(function (typeValue) {
+            assert.equal(typeValue, 'text');
+          })
+
+          .getAttribute('autocomplete')
+          .then(function (autocompleteValue) {
+            assert.equal(autocompleteValue, 'off');
+          })
+        .end()
+
+        // turn it back into a password field
+        .findByCssSelector('.show-password-label')
+          .click()
+        .end()
+
+        .findByCssSelector('#password')
+          .getAttribute('type')
+          .then(function (typeValue) {
+            assert.equal(typeValue, 'password');
+          })
+
+          .getAttribute('autocomplete')
+          .then(function (autocompleteValue) {
+            assert.equal(autocompleteValue, 'off');
+          })
+        .end();
+    }
+  });
+});


### PR DESCRIPTION
fixes #1788
