### PR TITLE
fix(metrics): Convert all `_` in screen names to `-`.

### DIFF
--- a/app/scripts/lib/url.js
+++ b/app/scripts/lib/url.js
@@ -44,17 +44,6 @@ function (_) {
       var terms = searchParams(str);
 
       return terms[name];
-    },
-
-    pathToScreenName: function (path) {
-                // strip leading /
-      return path.replace(/^\//, '')
-                // strip trailing /
-                .replace(/\/$/, '')
-                // any other slashes get converted to '.'
-                .replace(/\//g, '.')
-                // search params can contain sensitive info
-                .replace(/\?.*/, '');
     }
   };
 });

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -83,7 +83,7 @@ function (
         router: this,
         user: this.user,
         window: this.window,
-        screenName: Backbone.history.fragment
+        screenName: this.fragmentToScreenName(Backbone.history.fragment)
       }, options || {});
 
       this.showView(new View(viewOptions));
@@ -232,6 +232,19 @@ function (
           self.navigate(url);
         }
       });
+    },
+
+    fragmentToScreenName: function (fragment) {
+                // strip leading /
+      return fragment.replace(/^\//, '')
+                // strip trailing /
+                .replace(/\/$/, '')
+                // any other slashes get converted to '.'
+                .replace(/\//g, '.')
+                // search params can contain sensitive info
+                .replace(/\?.*/, '')
+                // replace _ with -
+                .replace(/_/g, '-');
     }
   });
 

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -469,8 +469,7 @@ function (_, Backbone, $, p, AuthErrors,
     },
 
     getScreenName: function () {
-      var screenName = Url.pathToScreenName(this.screenName);
-      return screenName;
+      return this.screenName;
     },
 
     _normalizeError: function (err) {

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -126,7 +126,7 @@ function (chai, sinon, _, Backbone, Router, SignInView, SignUpView, ReadyView,
           relier: relier,
           router: router,
           broker: broker,
-          screenName: '/signin'
+          screenName: 'signin'
         });
         signUpView = new SignUpView({
           metrics: metrics,
@@ -135,7 +135,7 @@ function (chai, sinon, _, Backbone, Router, SignInView, SignUpView, ReadyView,
           relier: relier,
           router: router,
           broker: broker,
-          screenName: '/signup'
+          screenName: 'signup'
         });
       });
 
@@ -241,15 +241,41 @@ function (chai, sinon, _, Backbone, Router, SignInView, SignUpView, ReadyView,
           relier: relier,
           broker: broker,
           type: 'sign_up',
-          screenName: '/signup_complete'
+          screenName: 'signup-complete'
         });
 
         return router.showView(view)
           .then(function () {
             assert.equal(metrics.getFilteredData().events.length, 1);
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen.signup_complete'));
+            assert.isTrue(TestHelpers.isEventLogged(metrics,
+                'screen.signup-complete'));
           });
       });
+    });
+
+    describe('pathToScreenName', function () {
+      it('strips leading /', function () {
+        assert.equal(router.fragmentToScreenName('/signin'), 'signin');
+      });
+
+      it('strips trailing /', function () {
+        assert.equal(router.fragmentToScreenName('signup/'), 'signup');
+      });
+
+      it('converts middle / to .', function () {
+        assert.equal(router.fragmentToScreenName('/legal/tos/'), 'legal.tos');
+      });
+
+      it('converts _ to -', function () {
+        assert.equal(router.fragmentToScreenName('complete_sign_up'),
+            'complete-sign-up');
+      });
+
+      it('strips search parameters', function () {
+        assert.equal(router.fragmentToScreenName('complete_sign_up?email=testuser@testuser.com'),
+            'complete-sign-up');
+      });
+
     });
   });
 });

--- a/app/tests/spec/lib/url.js
+++ b/app/tests/spec/lib/url.js
@@ -48,24 +48,6 @@ function (chai, _, Url) {
           });
 
     });
-
-    describe('pathToScreenName', function () {
-      it('strips leading /', function () {
-        assert.equal(Url.pathToScreenName('/signin'), 'signin');
-      });
-
-      it('strips trailing /', function () {
-        assert.equal(Url.pathToScreenName('signup/'), 'signup');
-      });
-
-      it('converts middle / to .', function () {
-        assert.equal(Url.pathToScreenName('/legal/tos/'), 'legal.tos');
-      });
-
-      it('strips search parameters', function () {
-        assert.equal(Url.pathToScreenName('complete_sign_up?email=testuser@testuser.com'), 'complete_sign_up');
-      });
-    });
   });
 });
 

--- a/app/tests/spec/views/oauth_sign_in.js
+++ b/app/tests/spec/views/oauth_sign_in.js
@@ -83,7 +83,7 @@ function (chai, $, sinon, View, Session, FxaClient, p, Metrics, OAuthRelier,
         user: user,
         profileClient: profileClientMock,
         metrics: metrics,
-        screenName: 'oauth/signin'
+        screenName: 'oauth.signin'
       });
     }
 

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -114,7 +114,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, AuthErrors,
         user: user,
         assertionLibrary: assertionLibrary,
         oAuthClient: oAuthClient,
-        screenName: 'oauth/signup'
+        screenName: 'oauth.signup'
       });
 
       return view.render()


### PR DESCRIPTION
- Moved the screen name cleanup from lib/url.js to router.js, renamed fragmentToScreenName. The functionality makes more sense here.

@kparlante - this is for you!

fixes #1907
