### PR TITLE
feat(signup): suggest proper email spelling

### DIFF
--- a/app/scripts/lib/mailcheck.js
+++ b/app/scripts/lib/mailcheck.js
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// A ux utility to suggest correct spelling of email domains
+'use strict';
+
+define([
+  'views/tooltip',
+  'lib/url',
+  'mailcheck'
+],
+function (Tooltip, Url) {
+
+  var DOMAINS = [ // domains that get suggested, i.e gnail.com => gmail.com
+    'gmail.com', 'qq.com', 'yandex.ru', 'o2.pl', 'rambler.ru', 'googlemail.com', 't-online.de', 'mail.ru', 'web.de',
+    'sbcglobal.net', 'msn.com', 'me.com', 'aol.de', 'aol.com', 'seznam.cz', 'comcast.net', 'orange.fr',
+    'gmx.de', 'ymail.com', 'outlook.com', 'live.com', 'yahoo.com', 'yahoo.fr', 'yahoo.co.id'
+  ];
+  var SECOND_LEVEL_DOMAINS = [];
+  var TOP_LEVEL_DOMAINS = [ // TLD suggestion, i.e some.cpm => some.com
+    'com', 'net', 'org', 'ru', 'jp', 'de', 'fr', 'pl', 'es', 'co.uk', 'bg', 'co.id', 'cz'
+  ];
+  var MIN_CHARS = 5; // start suggesting email correction after MIN_CHARS
+  var SUGGEST_DIV_CLASS = 'tooltip-suggest';
+
+  function t(str, params, translator) {
+    return translator.interpolate(translator.get(str), params);
+  }
+
+  /**
+   * @param {Object} target DOM input node to target with mailcheck
+   * @param {Object} metrics Metrics logger
+   * @param {Object} translator Translator object passed by the view
+   * @param {String} queryParams Window query params
+   */
+  return function checkMailInput(target, metrics, translator, queryParams) {
+    var element = $(target);
+    var enabled = false;
+
+    // Url param flag 'mailcheck' to disable the feature unless the flag is set
+    if (Url.searchParam('mailcheck', queryParams) === '1') {
+      enabled = true;
+    }
+
+    if (element.val().length > MIN_CHARS && enabled) {
+      element.mailcheck({
+        domains: DOMAINS,
+        secondLevelDomains: SECOND_LEVEL_DOMAINS,
+        topLevelDomains: TOP_LEVEL_DOMAINS,
+        suggested: function (element, suggestion) {
+          // avoid suggesting empty or incomplete domains
+          var incompleteDomain = ! suggestion || ! suggestion.domain ||
+            suggestion.domain.indexOf('.') === -1;
+
+          if (incompleteDomain) {
+            return;
+          }
+
+          // user got a suggestion to check their email input
+          metrics.logEvent('tooltip.mailcheck-suggested');
+          var tooltip = new Tooltip({
+            message: t('Did you mean <span>%(domain)s</span>?', suggestion, translator),
+            invalidEl: target,
+            type: 'mailcheck',
+            extraClassNames: SUGGEST_DIV_CLASS,
+            dismissible: true
+          });
+
+          tooltip.render();
+
+          tooltip.$el.on('click', 'span', function () {
+            element.val(suggestion.full);
+            // the user has used the suggestion
+            metrics.logEvent('tooltip.mailcheck-used');
+            tooltip._destroy();
+          });
+        }
+      });
+    }
+  };
+});

--- a/app/scripts/require_config.js
+++ b/app/scripts/require_config.js
@@ -21,6 +21,7 @@ require.config({
     md5: '../bower_components/JavaScript-MD5/js/md5',
     canvasToBlob: '../bower_components/blueimp-canvas-to-blob/js/canvas-to-blob',
     moment: '../bower_components/moment/moment',
+    mailcheck: '../bower_components/mailcheck/src/mailcheck',
     crosstab: 'vendor/crosstab'
   },
   config: {
@@ -57,6 +58,10 @@ require.config({
     },
     sjcl: {
       exports: 'sjcl'
+    },
+    mailcheck: {
+      deps: ['jquery'],
+      exports: 'mailcheck'
     }
   },
   stache: {

--- a/app/scripts/views/tooltip.js
+++ b/app/scripts/views/tooltip.js
@@ -18,10 +18,14 @@ define([
   var Tooltip = BaseView.extend({
     tagName: 'aside',
     className: 'tooltip',
+    // tracks the type of a tooltip, used for metrics purposes
+    type: 'generic',
 
     initialize: function (options) {
       options = options || {};
       this.message = options.message || '';
+      this.dismissible  = options.dismissible || false;
+      this.extraClassNames = options.extraClassNames || '';
 
       // the tooltip has to be attached to an element.
       // By default, the tooltip is displayed just above the
@@ -42,9 +46,15 @@ define([
       displayedTooltip = this;
 
       var tooltipContainer = this.invalidEl.closest('.input-row,.select-row-wrapper');
+
+      this.$el.addClass(this.extraClassNames);
       this.$el.appendTo(tooltipContainer);
 
       this.setPosition();
+
+      if (this.dismissible) {
+        this.$el.append('<span class="dismiss">&#10005;</span>');
+      }
 
       this.bindDOMEvents();
     },
@@ -89,6 +99,13 @@ define([
       invalidEl.one('keydown change', this._destroy);
       // handle selecting an option with the mouse for select elements
       invalidEl.find('option').one('click', this._destroy);
+
+      // destroy when dismissed
+      this.$el.find('.dismiss').one('click', function () {
+        var metricsEvent = 'tooltip.' + this.type + '-dismissed';
+        this.logEvent(metricsEvent);
+        this._destroy();
+      }.bind(this));
     }
   });
 

--- a/app/styles/_general.scss
+++ b/app/styles/_general.scss
@@ -313,6 +313,17 @@ strong.email {
   position: absolute;
   top: -32px;
   z-index: 5;
+  &.tooltip-suggest {
+    background: $info-background-color;
+    > span {
+      cursor: pointer;
+      text-decoration: underline;
+      &.dismiss {
+        margin-left: 5px;
+        text-decoration: none;
+      }
+    }
+  }
 }
 
 /* tooltip caret */
@@ -330,6 +341,11 @@ strong.email {
   width: 16px;
   // The z-index must be -1 or else the caret is displayed on top of the tooltip text
   z-index: -1;
+}
+
+.tooltip-suggest:before,
+.tooltip-suggest::before {
+  background: $info-background-color;
 }
 
 /**

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -7,6 +7,7 @@ $button-background-color: #0095dd;
 $button-background-disabled-color: #8a9ba8;
 $button-background-hover-color: #08c;
 $error-background-color: #d63920;
+$info-background-color: #0095dd;
 $error-text-color: #d63920;
 $html-background-color: #f2f2f2;
 $input-border-color: #424f59;

--- a/app/tests/spec/lib/mailcheck.js
+++ b/app/tests/spec/lib/mailcheck.js
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// test the metrics library
+
+define([
+  'sinon',
+  'chai',
+  'jquery',
+  'lib/promise',
+  'lib/mailcheck'
+],
+function (sinon, chai, $, p, mailcheck) {
+  'use strict';
+
+  /*global describe, it*/
+  var assert = chai.assert;
+  var MAILCHECK_ID = 'mailcheck-test';
+  var MAILCHECK_SELECTOR = '#' + MAILCHECK_ID;
+  var TOOLTIP_SELECTOR = '.tooltip-suggest';
+  var BAD_EMAIL = 'something@gnail.com';
+  var CORRECTED_EMAIL = 'something@gmail.com';
+  var RESULT_TEXT = 'Did you mean gmail.com?✕';
+
+  describe('lib/mailcheck', function () {
+    var mockTranslator = window.translator;
+    var mockParams = 'something=1&mailcheck=1';
+    var mockMetrics = {
+      logEvent: function () {
+      }
+    };
+    var metricsStub;
+
+    beforeEach(function () {
+      $('body').append('<div class="input-row test-input"><input type=text id="' + MAILCHECK_ID + '"/></div>');
+      metricsStub = sinon.stub(mockMetrics, 'logEvent', function () {
+      });
+    });
+
+    afterEach(function () {
+      $('.test-input').remove();
+      metricsStub.restore();
+    });
+
+    it('works with attached elements and changes values', function (done) {
+      $(MAILCHECK_SELECTOR).blur(function () {
+        mailcheck(MAILCHECK_SELECTOR, mockMetrics, mockTranslator, mockParams);
+      });
+
+      $(MAILCHECK_SELECTOR).val(BAD_EMAIL).blur();
+      assert.isTrue(mockMetrics.logEvent.calledOnce, 'called logEvent once');
+
+      // wait for tooltip
+      setTimeout(function () {
+        assert.equal($(TOOLTIP_SELECTOR).text(), RESULT_TEXT);
+        $(TOOLTIP_SELECTOR).find('span').first().click();
+        // email should be corrected
+        assert.equal($(MAILCHECK_SELECTOR).val(), CORRECTED_EMAIL);
+        assert.isTrue(mockMetrics.logEvent.calledTwice, 'called logEvent twice');
+        done();
+      }, 50);
+    });
+
+    it('works with attached elements and can be dismissed', function (done) {
+      $(MAILCHECK_SELECTOR).blur(function () {
+        mailcheck(MAILCHECK_SELECTOR, mockMetrics, mockTranslator, mockParams);
+      });
+
+      $(MAILCHECK_SELECTOR).val(BAD_EMAIL).blur();
+      assert.isTrue(mockMetrics.logEvent.calledOnce, 'called logEvent once');
+
+      // wait for tooltip
+      setTimeout(function () {
+        assert.equal($(TOOLTIP_SELECTOR).text(), RESULT_TEXT);
+        $(TOOLTIP_SELECTOR).find('span').eq(1).click();
+        // email should NOT be corrected
+        assert.equal($(MAILCHECK_SELECTOR).val(), BAD_EMAIL);
+        assert.isFalse(mockMetrics.logEvent.calledTwice, 'called logEvent twice');
+        done();
+      }, 50);
+    });
+
+    it('only works if enabled', function (done) {
+      var mockParams = '';
+
+      $(MAILCHECK_SELECTOR).blur(function () {
+        mailcheck(MAILCHECK_SELECTOR, mockMetrics, mockTranslator, mockParams);
+      });
+
+      $(MAILCHECK_SELECTOR).val(BAD_EMAIL).blur();
+
+      // wait for tooltip
+      setTimeout(function () {
+        // no tooltips
+        assert.equal($(TOOLTIP_SELECTOR).length, 0);
+        done();
+      }, 50);
+    });
+  });
+});

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -18,6 +18,7 @@ define([
   'lib/metrics',
   'lib/fxa-client',
   'lib/ephemeral-messages',
+  'lib/mailcheck',
   'models/reliers/fx-desktop',
   'models/auth_brokers/base',
   'models/user',
@@ -26,7 +27,7 @@ define([
   '../../lib/helpers'
 ],
 function (chai, _, $, moment, sinon, p, View, Session, AuthErrors, Metrics,
-      FxaClient, EphemeralMessages, Relier, Broker, User, FormPrefill,
+      FxaClient, EphemeralMessages, mailcheck, Relier, Broker, User, FormPrefill,
       RouterMock, TestHelpers) {
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
@@ -778,6 +779,21 @@ function (chai, _, $, moment, sinon, p, View, Session, AuthErrors, Metrics,
       });
     });
 
+    describe('suggestEmail', function () {
+      it('suggests emails via a tooltip', function (done) {
+        view.suggestEmail = function () {
+          mailcheck(view.$('.email'), metrics, translator, 'mailcheck=1');
+        };
+
+        view.$('.email').val('testuser@gnail.com');
+        view.suggestEmail();
+        // wait for tooltip
+        setTimeout(function () {
+          assert.equal($('.tooltip-suggest').text(), 'Did you mean gmail.com?✕');
+          done();
+        }, 50);
+      });
+    });
   });
 });
 

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -32,6 +32,7 @@ function (Translator, Session) {
     '../tests/spec/lib/service-name',
     '../tests/spec/lib/screen-info',
     '../tests/spec/lib/metrics',
+    '../tests/spec/lib/mailcheck',
     '../tests/spec/lib/null-metrics',
     '../tests/spec/lib/cropper',
     '../tests/spec/lib/image-loader',

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "jquery-ui": "1.11.0",
     "JavaScript-MD5": "1.1.0",
     "jquery-ui-touch-punch": "https://github.com/zaach/jquery-ui-touch-punch.git#89e5a9159494de37df1e09cccf9036dda5429830",
-    "blueimp-canvas-to-blob": "2.1.0"
+    "blueimp-canvas-to-blob": "2.1.0",
+    "mailcheck": "https://github.com/mailcheck/mailcheck.git#9fcf9c40da06f6769e5d702dd0fd1f33f36e55a6"
   },
   "devDependencies": {
     "moment": "2.8.3"

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -395,6 +395,35 @@ define([
 
     'visiting the tos links saves information for return': function () {
       return testRepopulateFields.call(this, '/legal/privacy', 'fxa-pp-header');
+    },
+
+    'use an email suggestion': function () {
+      var BAD_EMAIL = 'something@gnail.com';
+      var CORRECTED_EMAIL = 'something@gmail.com';
+
+      return this.get('remote')
+        .get(require.toUrl(PAGE_URL + '?mailcheck=1&automatedBrowser=1'))
+        .findByCssSelector('input[type=email]')
+        .type(BAD_EMAIL)
+        .click()
+        .end()
+
+        .findByCssSelector('input[type=password]')
+        .click()
+        .end()
+
+        .findByCssSelector('.tooltip-suggest > span:nth-child(1)')
+        .click()
+        .end()
+
+        .findByCssSelector('input[type=email]')
+        .getProperty('value')
+        .then(function (resultText) {
+          // check the email address was re-populated
+          assert.equal(resultText, CORRECTED_EMAIL);
+        })
+        .end();
+
     }
   });
 


### PR DESCRIPTION
Fixes #871.

TODO Action Items:
* [x] ~~Add Able to this~~ Param flag instead of able
* [x] Add metrics events (based on "show" password button)
* [x] Update the suggested list of emails to be more generic