### PR TITLE
fix(sync): correct a typo that voided the customize sync option

### DIFF
--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -275,7 +275,7 @@ function (_, p, BaseView, FormView, Template, Session, AuthErrors,
         .then(function () {
           return self.fxaClient.signUp(
                         email, password, self.relier, {
-                          cusomizeSync: customizeSync
+                          customizeSync: customizeSync
                         });
         }).then(function (accountData) {
           var account = self.user.initAccount(accountData);


### PR DESCRIPTION
This also updates the tests so that we assert `fxaClient.signUp` receives the correct `customizeSync` option and also tests that the broker receives the correct `customizeSync` value from `fxaClient.signUp`.

Fixes #2013.