### PR TITLE
feat(client): Give the relier the ability to overrule cached credentials...

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -32,7 +32,11 @@ define([], function () {
     DEFAULT_PROFILE_IMAGE_MIME_TYPE: 'image/jpeg',
 
     INTERNAL_ERROR_PAGE: '/500.html',
-    BAD_REQUEST_PAGE: '/400.html'
+    BAD_REQUEST_PAGE: '/400.html',
+
+    // A relier can indicate they do not want to allow
+    // cached credentials if they set email === 'blank'
+    DISALLOW_CACHED_CREDENTIALS: 'blank'
   };
 });
 

--- a/app/scripts/models/reliers/base.js
+++ b/app/scripts/models/reliers/base.js
@@ -55,6 +55,13 @@ define([
      */
     getResumeToken: function () {
       return null;
+    },
+
+    /**
+     * Indicates whether the relier allows cached credentials
+     */
+    allowCachedCredentials: function () {
+      return true;
     }
   });
 

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -19,7 +19,9 @@ define([
   var Relier = BaseRelier.extend({
     defaults: {
       service: null,
-      preVerifyToken: null
+      preVerifyToken: null,
+      email: null,
+      allowCachedCredentials: true
     },
 
     initialize: function (options) {
@@ -45,11 +47,19 @@ define([
     fetch: function () {
       var self = this;
       return p()
-          .then(function () {
-            self.importSearchParam('service');
-            self.importSearchParam('preVerifyToken');
+        .then(function () {
+          self.importSearchParam('service');
+          self.importSearchParam('preVerifyToken');
+
+          // A relier can indicate they do not want to allow
+          // cached credentials if they set email === 'blank'
+          if (self.getSearchParam('email') ===
+              Constants.DISALLOW_CACHED_CREDENTIALS) {
+            self.set('allowCachedCredentials', false);
+          } else {
             self.importSearchParam('email');
-          });
+          }
+        });
     },
 
     /**
@@ -57,6 +67,14 @@ define([
      */
     isSync: function () {
       return this.get('service') === Constants.FX_DESKTOP_SYNC;
+    },
+
+    /**
+     * Check if the relier allows cached credentials. A relier
+     * can set email=blank to indicate they do not.
+     */
+    allowCachedCredentials: function () {
+      return this.get('allowCachedCredentials');
     }
   });
 

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -33,7 +33,7 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin,
       // go to another screen, edit the email again, and come back here. We
       // want the last used email. Session.prefillEmail is not until after
       // the view initializes.
-      this.prefillEmail = Session.prefillEmail || this.searchParam('email');
+      this.prefillEmail = Session.prefillEmail || this.relier.get('email');
 
       this._account = this._suggestedAccount();
     },
@@ -242,6 +242,8 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin,
       var account = this.user.getChooserAccount();
 
       if (
+        // the relier can overrule cached creds.
+        this.relier.allowCachedCredentials() &&
         // confirm that session email is present
         account.get('email') && account.get('sessionToken') &&
         // prefilled email must be the same or absent

--- a/app/tests/spec/models/reliers/base.js
+++ b/app/tests/spec/models/reliers/base.js
@@ -53,6 +53,12 @@ define([
         assert.isNull(relier.getResumeToken());
       });
     });
+
+    describe('allowCachedCredentials', function () {
+      it('returns `true`', function () {
+        assert.isTrue(relier.allowCachedCredentials());
+      });
+    });
   });
 });
 

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -6,10 +6,11 @@
 
 define([
   'chai',
+  'lib/constants',
   'models/reliers/relier',
   '../../../mocks/window',
   '../../../lib/helpers'
-], function (chai, Relier, WindowMock, TestHelpers) {
+], function (chai, Constants, Relier, WindowMock, TestHelpers) {
   var assert = chai.assert;
 
   describe('models/reliers/relier', function () {
@@ -87,6 +88,40 @@ define([
       });
     });
 
+    describe('allowCachedCredentials', function () {
+      it('returns `true` if `email` not set', function () {
+        return relier.fetch()
+          .then(function () {
+            assert.isTrue(relier.allowCachedCredentials());
+          });
+      });
+
+      it('returns `true` if `email` is set to an email address', function () {
+        windowMock.location.search = TestHelpers.toSearchString({
+          email: 'testuser@testuser.com'
+        });
+
+        return relier.fetch()
+          .then(function () {
+            assert.isTrue(relier.allowCachedCredentials());
+          });
+      });
+
+      it('returns `false` if `email` is set to `blank`', function () {
+        windowMock.location.search = TestHelpers.toSearchString({
+          email: Constants.DISALLOW_CACHED_CREDENTIALS
+        });
+
+        return relier.fetch()
+          .then(function () {
+            assert.isFalse(relier.allowCachedCredentials());
+
+            // the email should not be set on the relier model
+            // if the specified email === blank
+            assert.isFalse(relier.has('email'));
+          });
+      });
+    });
   });
 });
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -126,8 +126,8 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
             });
       });
 
-      it('prefills email with email from search parameter if Session.prefillEmail is not set', function () {
-        windowMock.location.search = '?email=' + encodeURIComponent('testuser@testuser.com');
+      it('prefills email with email from relier if Session.prefillEmail is not set', function () {
+        relier.set('email', 'testuser@testuser.com');
 
         initView();
         return view.render()
@@ -444,8 +444,8 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
           });
       });
 
-      it('does shows if there is the same email in query params', function () {
-        windowMock.location.search = '?email=a@a.com';
+      it('shows if there is the same email in relier', function () {
+        relier.set('email', 'a@a.com');
         var account = user.initAccount({
           sessionToken: 'abc123',
           email: 'a@a.com',
@@ -471,8 +471,8 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
           });
       });
 
-      it('does not show if there is an email in query params that does not match', function () {
-        windowMock.location.search = '?email=b@b.com';
+      it('does not show if there is an email in relier that does not match', function () {
+        relier.set('email', 'b@b.com');
         var account = user.initAccount({
           sessionToken: 'abc123',
           email: 'a@a.com',
@@ -489,6 +489,30 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
           .then(function () {
             assert.equal(view.$('.email')[0].type, 'email', 'should show email input');
             assert.ok(view.$('.password').length, 'should show password input');
+          });
+      });
+
+      it('does not show if the relier overrules cached credentials', function () {
+        sinon.stub(relier, 'allowCachedCredentials', function () {
+          return false;
+        });
+
+        relier.set('email', 'a@a.com');
+
+        sinon.stub(user, 'getChooserAccount', function () {
+          return user.initAccount({
+            sessionToken: 'abc123',
+            email: 'a@a.com',
+            sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+            verified: true,
+            accessToken: 'foo'
+          });
+        });
+
+        return view.render()
+          .then(function () {
+            assert.equal(view.$('input[type=email]').length, 1, 'should show email input');
+            assert.equal(view.$('input[type=password]').length, 1, 'should show password input');
           });
       });
     });

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -29,6 +29,7 @@ define([
   // that require a functioning desktop channel
   var PAGE_SIGNIN = config.fxaContentRoot + 'signin';
   var PAGE_SIGNIN_DESKTOP = PAGE_SIGNIN + '?context=' + FX_DESKTOP_CONTEXT;
+  var PAGE_SIGNIN_NO_CACHED_CREDS = PAGE_SIGNIN + '?email=blank';
   var PAGE_SIGNUP = config.fxaContentRoot + 'signup';
   var PAGE_SIGNUP_DESKTOP = config.fxaContentRoot + 'signup?context=' + FX_DESKTOP_CONTEXT;
   var PAGE_SETTINGS = config.fxaContentRoot + 'settings';
@@ -534,7 +535,55 @@ define([
 
         .findByCssSelector('.use-different')
         .end();
+    },
+
+    'overrule cached credentials': function () {
+      var self = this;
+
+      return this.get('remote')
+        .get(require.toUrl(PAGE_SIGNIN))
+        .findByCssSelector('form input.email')
+          .click()
+          .type(email)
+        .end()
+
+        .findByCssSelector('form input.password')
+          .click()
+          .type(PASSWORD)
+        .end()
+
+        .findByCssSelector('button[type="submit"]')
+          .click()
+        .end()
+
+        .findById('fxa-settings-header')
+        .end()
+
+        .then(function () {
+          // reset prefill and context
+          return FunctionalHelpers.clearSessionStorage(self);
+        })
+
+        .get(require.toUrl(PAGE_SIGNIN_NO_CACHED_CREDS))
+
+        .findByCssSelector('form input.email')
+          .click()
+          .type(email)
+        .end()
+
+        .findByCssSelector('form input.password')
+          .click()
+          .type(PASSWORD)
+        .end()
+
+        .findByCssSelector('button[type="submit"]')
+          .click()
+        .end()
+
+        .findById('fxa-settings-header')
+        .end();
     }
+
 
   });
 });


### PR DESCRIPTION
@zaach - could you have a look?

If a relier loads up with `email=blank`, cached credentials will not be used.

fixes #1950