### PR TITLE
Issue 1753 avatar nav link

### DIFF
--- a/app/scripts/templates/settings/avatar.mustache
+++ b/app/scripts/templates/settings/avatar.mustache
@@ -1,6 +1,5 @@
 <div id="main-content">
   <header>
-    <h3 id="fxa-settings-sub-header"><a href="/settings">{{#t}}Manage account{{/t}}</a> ›</h3>
     <h1 id="fxa-account-picture-header">{{#t}}Account picture{{/t}}</h1>
   </header>
 

--- a/app/scripts/templates/settings/avatar_camera.mustache
+++ b/app/scripts/templates/settings/avatar_camera.mustache
@@ -1,6 +1,5 @@
 <div id="main-content">
   <header>
-    <h3 id="fxa-settings-sub-header"><a href="/settings">{{#t}}Manage account{{/t}}</a> ›</h3>
     <h1 id="fxa-account-picture-header">{{#t}}Account picture{{/t}}</h1>
   </header>
 

--- a/app/scripts/templates/settings/avatar_change.mustache
+++ b/app/scripts/templates/settings/avatar_change.mustache
@@ -1,6 +1,5 @@
 <div id="main-content">
   <header>
-    <h3 id="fxa-settings-sub-header"><a href="/settings">{{#t}}Manage account{{/t}}</a> ›</h3>
     <h1 id="fxa-account-picture-header">{{#t}}Account picture{{/t}}</h1>
   </header>
 
@@ -27,5 +26,9 @@
       <a href="/settings/avatar/camera" id="camera"><span class="icon-camera-alt"></span>{{#t}}Camera{{/t}}</a>
       <a href="/settings/avatar/gravatar" id="gravatar"><span class="gravatar-logo"></span>{{#t}}Gravatar{{/t}}</a>
     </nav>
+
+    <p id="settings-home">
+      <a href="/settings">{{#t}}Home{{/t}}</a>
+    </p>
   </section>
 </div>

--- a/app/scripts/templates/settings/avatar_crop.mustache
+++ b/app/scripts/templates/settings/avatar_crop.mustache
@@ -1,6 +1,5 @@
 <div id="main-content">
   <header>
-    <h3 id="fxa-settings-sub-header"><a href="/settings">{{#t}}Manage account{{/t}}</a> ›</h3>
     <h1 id="fxa-account-picture-header">{{#t}}Account picture{{/t}}</h1>
   </header>
 

--- a/app/scripts/templates/settings/avatar_gravatar.mustache
+++ b/app/scripts/templates/settings/avatar_gravatar.mustache
@@ -1,6 +1,5 @@
 <div id="main-content">
   <header>
-    <h3 id="fxa-settings-sub-header"><a href="/settings">{{#t}}Manage account{{/t}}</a> ›</h3>
     <h1 id="fxa-account-picture-header">{{#t}}Account picture{{/t}}</h1>
   </header>
 

--- a/app/styles/_avatars.scss
+++ b/app/styles/_avatars.scss
@@ -64,9 +64,9 @@ a.avatar-wrapper {
 }
 
 #settings-home {
+  border-top: 1px solid $horizontal-rule-color;
   margin: 40px 0px -30px;
   padding: 25px;
-  border-top: 1px solid $horizontal-rule-color;
 
   a {
     font-size: $base-font;
@@ -107,14 +107,27 @@ a.avatar-wrapper {
   .gravatar-logo {
     background: image-url('gravatar.svg') no-repeat top center;
     background-size: contain;
-    display: inline-block;
-    height: 38.5px;
-    width: 38.5px;
+    /* This reduces the size of the gravatar logo to match the other icons */
+    font-size: 30px;
+
+    /* Mimic the style of the fontello icons */
+    &:before {
+      content: " ";
+      display: inline-block;
+      font-variant: normal;
+      line-height: 1em;
+      margin-left: 0.2em;
+      margin-right: 0.2em;
+      text-align: center;
+      text-decoration: inherit;
+      text-transform: none;
+      width: 1em;
+    }
   }
 
   nav {
-    margin: 0px -40px -40px -40px;
     padding: 20px;
+    margin: 0px -40px -40px -40px;
 
     a {
       background-color: $content-background-color;
@@ -123,9 +136,9 @@ a.avatar-wrapper {
       height: 80px;
       line-height: 1.1;
       margin: 5px;
+      min-width: 80px;
       padding: 11px;
       text-decoration: none;
-      width: 80px;
     }
 
     span {

--- a/app/styles/_avatars.scss
+++ b/app/styles/_avatars.scss
@@ -63,13 +63,13 @@ a.avatar-wrapper {
   color: transparent;
 }
 
-#fxa-settings-sub-header {
-  font-size: $medium-font;
-  font-weight: normal;
-  padding-bottom: 5px;
+#settings-home {
+  margin: 40px 0px -30px;
+  padding: 25px;
+  border-top: 1px solid $horizontal-rule-color;
 
   a {
-    font-size: 88%;
+    font-size: $base-font;
     text-decoration: none;
   }
 }
@@ -113,9 +113,7 @@ a.avatar-wrapper {
   }
 
   nav {
-    background-color: $html-background-color;
-    border-radius: $big-border-radius;
-    margin: 60px -40px -40px -40px;
+    margin: 0px -40px -40px -40px;
     padding: 20px;
 
     a {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -28,6 +28,7 @@ $success-background-color: #5fad47;
 $text-color: #424f59;
 $faint-text-color: #8a9ba8;
 $cropper-background-color: #000;
+$horizontal-rule-color: #e4e4e4;
 
 //Font-Size Variables
 $large-font: 24px;


### PR DESCRIPTION
The avatar change screen is looking fresh now. This makes the nav l10n friendly and removes that weird subheader nav from avatar pages.

![screen shot 2015-01-08 at 12 14 44 am](https://cloud.githubusercontent.com/assets/3903/5659710/fa55ef04-96cb-11e4-9a77-12507b8ac884.png)

Fixes #1753.
Fixes #1729.