### PR TITLE
fix(client): Disable the sign up confirmation poll for Sync.

### DIFF
--- a/app/scripts/models/auth_brokers/fx-desktop.js
+++ b/app/scripts/models/auth_brokers/fx-desktop.js
@@ -66,11 +66,13 @@ define([
       // before the user has verified her email. This allows the user
       // to close the original tab or open the verification link in
       // the about:accounts tab and have Sync still successfully start.
-      return this._notifyRelierOfLogin(account);
-    },
-
-    afterSignUpConfirmationPoll: function () {
-      return p({ halt: true });
+      return this._notifyRelierOfLogin(account)
+        .then(function () {
+          // the browser is already polling, no need for the content server
+          // code to poll as well, otherwise two sets of polls are going on
+          // for the same user.
+          return { halt: true };
+        });
     },
 
     afterResetPasswordConfirmationPoll: function (account) {

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -72,7 +72,11 @@ function (_, FormView, BaseView, Template, p, AuthErrors,
         .then(function () {
           return self.broker.beforeSignUpConfirmationPoll(self.getAccount());
         })
-        .then(function () {
+        .then(function (result) {
+          if (result && result.halt) {
+            return;
+          }
+
           self._waitForConfirmation()
             .then(function () {
               self.logScreenEvent('verification.success');

--- a/app/tests/spec/models/auth_brokers/fx-desktop.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop.js
@@ -155,22 +155,14 @@ define([
     });
 
     describe('beforeSignUpConfirmationPoll', function () {
-      it('notifies the channel of login', function () {
+      it('notifies the channel of login, halts the flow', function () {
         sinon.stub(broker, '_notifyRelierOfLogin', function () {
           return p();
         });
 
         return broker.beforeSignUpConfirmationPoll(account)
-          .then(function () {
-            assert.isTrue(broker._notifyRelierOfLogin.calledWith(account));
-          });
-      });
-    });
-
-    describe('afterSignUpConfirmationPoll', function () {
-      it('halts', function () {
-        return broker.afterSignUpConfirmationPoll()
           .then(function (result) {
+            assert.isTrue(broker._notifyRelierOfLogin.calledWith(account));
             assert.isTrue(result.halt);
           });
       });


### PR DESCRIPTION
The browser already polls in the background. The content server takes no additional action once the poll is complete, meaning its poll is unnecessary. The double poll is causing strain on the servers.

This prevents the signup poll from ever happening for Sync.

fixes #2038