### PR TITLE
fix(client): Do not display errors after window.beforeunload is triggerred.

### DIFF
--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -316,6 +316,15 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
         view.displayError();
         assert.equal(view.$('.error').html(), AuthErrors.toMessage('UNEXPECTED_ERROR'));
       });
+
+      it('does not log or display an error after window.beforeunload', function () {
+        view.$('.error').html('');
+
+        $(windowMock).trigger('beforeunload');
+        view.displayError(AuthErrors.toError('UNEXPECTED_ERROR'));
+
+        assert.equal(view.$('.error').html(), '');
+      });
     });
 
     describe('displayErrorUnsafe', function () {


### PR DESCRIPTION
@zaach, @jrgm - mind reviewing?

The error is most likely an aborted XHR request, and the user won't see any
message for long enough to make sense of or act on it anyways.

* `assign` was never used, so it has been removed.

Another approach is to only supress [err.errno === 999 && err.message === 'Timeout error'](https://github.com/mozilla/fxa-js-client/blob/master/client/lib/request.js#L86).

fixes #1901 