### PR TITLE
cleanup(client): Remove resetPasswordIfKnownValidEmail from views/sign_in.js

### DIFF
--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -61,7 +61,6 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin,
 
     events: {
       'change .show-password': 'onPasswordVisibilityChange',
-      'click a[href="/reset_password"]': 'resetPasswordIfKnownValidEmail',
       'click .use-logged-in': 'useLoggedInAccount',
       'click .use-different': 'useDifferentAccount'
     },
@@ -182,21 +181,10 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin,
         });
     },
 
-    onPasswordResetNavigate: function () {
-      this.navigate('reset_password');
-    },
-
     _suggestSignUp: function (err) {
       err.forceMessage = t('Unknown account. <a href="/signup">Sign up</a>');
       return this.displayErrorUnsafe(err);
     },
-
-    resetPasswordIfKnownValidEmail: BaseView.preventDefaultThen(function () {
-      var self = this;
-      return p().then(function () {
-        self.onPasswordResetNavigate();
-      });
-    }),
 
     /**
      * Used for the special "Sign In" button

--- a/app/tests/spec/views/oauth_sign_in.js
+++ b/app/tests/spec/views/oauth_sign_in.js
@@ -158,28 +158,7 @@ function (chai, $, sinon, View, Session, FxaClient, p, Metrics, OAuthRelier,
           });
       });
     });
-
-    describe('resetPasswordIfKnownValidEmail', function () {
-      it('goes to the reset_password page if user types a valid, known email', function () {
-        // the screen is rendered, we can take over from here.
-        $('.email').val(email);
-        return view.resetPasswordIfKnownValidEmail()
-          .then(function () {
-            assert.equal(router.page, 'reset_password');
-          });
-      });
-
-      it('goes to the reset_password screen if a blank email', function () {
-        // the screen is rendered, we can take over from here.
-        $('[type=email]').val('');
-        return view.resetPasswordIfKnownValidEmail()
-            .then(function () {
-              assert.ok(router.page, 'reset_password');
-            });
-      });
-    });
   });
-
 });
 
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -305,24 +305,6 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
       });
     });
 
-    describe('resetPasswordIfKnownValidEmail', function () {
-      it('goes to the reset_password screen if a blank email', function () {
-        $('[type=email]').val('');
-        return view.resetPasswordIfKnownValidEmail()
-            .then(function () {
-              assert.ok(routerMock.page, 'reset_password');
-            });
-      });
-
-      it('goes to the reset_password screen if an invalid email', function () {
-        $('[type=email]').val('partial');
-        return view.resetPasswordIfKnownValidEmail()
-            .then(function () {
-              assert.ok(routerMock.page, 'reset_password');
-            });
-      });
-    });
-
     describe('useLoggedInAccount', function () {
       it('shows an error if session is expired', function () {
 


### PR DESCRIPTION
The function is a left over artifact from a former time and is no longer needed.

fixes #2030