### PR TITLE
feat(metrics): Log whether the user changes the password visibility.

### DIFF
--- a/app/scripts/views/mixins/password-mixin.js
+++ b/app/scripts/views/mixins/password-mixin.js
@@ -36,6 +36,7 @@ define([
         var passwordField = this.$('.password');
         if (isVisible) {
           passwordField.attr('type', 'text').attr('autocomplete', 'off');
+          this.logScreenEvent('password.visible');
         } else {
           passwordField.attr('type', 'password');
           if (this.isPasswordAutoCompleteDisabled()) {
@@ -43,6 +44,7 @@ define([
           } else {
             passwordField.removeAttr('autocomplete');
           }
+          this.logScreenEvent('password.hidden');
         }
       } catch(e) {
         // IE8 blows up when changing the type of the input field. Other

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -271,6 +271,10 @@ function (_, p, BaseView, FormView, Template, Session, AuthErrors,
         self.logScreenEvent('preverified');
       }
 
+      if (self.relier.isSync()) {
+        self.logScreenEvent('customizeSync.' + String(customizeSync));
+      }
+
       return self.broker.beforeSignIn(email)
         .then(function () {
           return self.fxaClient.signUp(

--- a/app/tests/spec/views/mixins/password-mixin.js
+++ b/app/tests/spec/views/mixins/password-mixin.js
@@ -10,11 +10,14 @@ define([
   'sinon',
   'backbone',
   'underscore',
+  'lib/metrics',
   'views/mixins/password-mixin',
   'views/base',
   'models/reliers/relier',
-  'stache!templates/test_template'
-], function ($, chai, sinon, Backbone, _, PasswordMixin, BaseView, Relier, TestTemplate) {
+  'stache!templates/test_template',
+  '../../../lib/helpers'
+], function ($, chai, sinon, Backbone, _, Metrics, PasswordMixin, BaseView,
+  Relier, TestTemplate, TestHelpers) {
   var assert = chai.assert;
 
   var PasswordView = BaseView.extend({
@@ -28,12 +31,16 @@ define([
   describe('views/mixins/password-mixin', function () {
     var view;
     var relier;
+    var metrics;
 
     beforeEach(function () {
       relier = new Relier();
+      metrics = new Metrics();
 
       view = new PasswordView({
-        relier: relier
+        relier: relier,
+        metrics: metrics,
+        screenName: 'password-screen'
       });
 
       return view.render()
@@ -93,6 +100,20 @@ define([
         assert.equal(view.$('#password').attr('autocomplete'), null);
         assert.equal($('#vpassword').attr('type'), 'password');
         assert.equal($('#vpassword').attr('autocomplete'), null);
+      });
+
+      it('logs whether the password is shown or hidden', function () {
+        view.$('.show-password').click();
+        assert.isTrue(TestHelpers.isEventLogged(metrics,
+                          'password-screen.password.visible'));
+        // the password has not been hidden yet.
+        assert.isFalse(TestHelpers.isEventLogged(metrics,
+                          'password-screen.password.hidden'));
+
+
+        view.$('.show-password').click();
+        assert.isTrue(TestHelpers.isEventLogged(metrics,
+                          'password-screen.password.hidden'));
       });
     });
   });


### PR DESCRIPTION
* screen_name.password.visible if the user shows the password.
* screen_name.password.hidden if the user hides the password.

@kparlante and @ryanfeeley - this is for you!

fixes #2064

----------------------

2nd commit!  More metrics!

feat(metrics): Add `signup.customizeSync.(true|false)` metrics.

If the relier is sync, report the `signup.customizeSync.(true|false)` metric. `true` if the `customize sync` box is checked, false otw.

fixes #2069
