### PR TITLE
feat(client): Add a `loaded` message for the fx-desktop and iframe brokers.

### DIFF
--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -61,6 +61,15 @@ define([
     },
 
     /**
+     * Called after the first screen is rendered. Can be used
+     * to notify the RP the system is loaded.
+     */
+    afterLoaded: function () {
+      return p();
+    },
+
+
+    /**
      * Called before sign in. Can be used to prevent sign in.
      */
     beforeSignIn: function () {

--- a/app/scripts/models/auth_brokers/fx-desktop.js
+++ b/app/scripts/models/auth_brokers/fx-desktop.js
@@ -30,6 +30,10 @@ define([
           this, options);
     },
 
+    afterLoaded: function () {
+      return this.send('loaded');
+    },
+
     beforeSignIn: function (email) {
       var self = this;
       // This will send a message over the channel to determine whether

--- a/app/scripts/models/auth_brokers/iframe.js
+++ b/app/scripts/models/auth_brokers/iframe.js
@@ -97,6 +97,10 @@ define([
 
     cancel: function () {
       return this.send('oauth_cancel');
+    },
+
+    afterLoaded: function () {
+      return this.send('loaded');
     }
   });
 

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -169,6 +169,8 @@ function (
     },
 
     showView: function (viewToShow) {
+      var isFirstView = ! this.currentView;
+
       if (this.currentView) {
         this.currentView.destroy();
       }
@@ -205,6 +207,13 @@ function (
           }
 
           self.$logo.css('opacity', 1);
+
+          if (isFirstView) {
+            // afterLoaded lets the RP know when the first screen has been
+            // loaded. It does not expect a response, so no error handler
+            // is attached and the promise is not returned.
+            self.broker.afterLoaded();
+          }
         })
         .fail(function (err) {
           // The router's navigate method doesn't set ephemeral messages,

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -31,6 +31,20 @@ function (chai, sinon, Relier, BaseAuthenticationBroker, BaseView, WindowMock) {
       });
     });
 
+    describe('afterLoaded', function () {
+      it('returns a promise', function () {
+        return broker.afterLoaded()
+          .then(assert.pass);
+      });
+    });
+
+    describe('cancel', function () {
+      it('returns a promise', function () {
+        return broker.cancel()
+          .then(assert.pass);
+      });
+    });
+
     describe('afterSignIn', function () {
       it('returns a promise', function () {
         return broker.afterSignIn(view)

--- a/app/tests/spec/models/auth_brokers/fx-desktop.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop.js
@@ -42,6 +42,21 @@ define([
       });
     });
 
+    describe('afterLoaded', function () {
+      it('sends a `loaded` message', function () {
+        sinon.stub(channelMock, 'send', function (message, data, done) {
+          if (message === 'loaded') {
+            done(null);
+          }
+        });
+
+        return broker.afterLoaded()
+          .then(function () {
+            assert.isTrue(channelMock.send.called);
+          });
+      });
+    });
+
     describe('beforeSignIn', function () {
       it('is happy if the user clicks `yes`', function () {
         sinon.stub(channelMock, 'send', function (message, data, done) {
@@ -50,7 +65,10 @@ define([
           }
         });
 
-        return broker.beforeSignIn('testuser@testuser.com');
+        return broker.beforeSignIn('testuser@testuser.com')
+          .then(function () {
+            assert.isTrue(channelMock.send.called);
+          });
       });
 
       it('throws a USER_CANCELED_LOGIN error if user rejects', function () {
@@ -61,10 +79,9 @@ define([
         });
 
         return broker.beforeSignIn('testuser@testuser.com')
-          .then(function () {
-            assert(false, 'should throw USER_CANCELED_LOGIN');
-          }, function (err) {
+          .then(assert.fail, function (err) {
             assert.isTrue(AuthErrors.is(err, 'USER_CANCELED_LOGIN'));
+            assert.isTrue(channelMock.send.called);
           });
       });
 
@@ -100,8 +117,10 @@ define([
           .then(function () {
             assert.equal(data.email, 'testuser@testuser.com');
             assert.isFalse(data.verifiedCanLinkAccount);
+            assert.isTrue(channelMock.send.called);
           });
       });
+
       it('sends a `login` message to the channel using current account data', function () {
         var data;
         sinon.stub(channelMock, 'send', function (message, _data, done) {
@@ -116,6 +135,7 @@ define([
           .then(function () {
             assert.equal(data.email, 'testuser@testuser.com');
             assert.isFalse(data.verifiedCanLinkAccount);
+            assert.isTrue(channelMock.send.called);
           });
       });
 
@@ -137,6 +157,7 @@ define([
           .then(function () {
             assert.equal(data.email, 'testuser@testuser.com');
             assert.isTrue(data.verifiedCanLinkAccount);
+            assert.isTrue(channelMock.send.called);
           });
       });
     });

--- a/app/tests/spec/models/auth_brokers/iframe.js
+++ b/app/tests/spec/models/auth_brokers/iframe.js
@@ -132,6 +132,16 @@ function (chai, sinon, $, IframeAuthenticationBroker, Relier, p, NullChannel,
           });
       });
     });
+
+    describe('afterLoaded', function () {
+      it('sends a `loaded` message', function () {
+        return broker.afterLoaded()
+          .then(function () {
+            assert.isTrue(channelMock.send.calledWith('loaded'));
+          });
+      });
+    });
+
   });
 });
 

--- a/tests/functional/lib/fx-desktop.js
+++ b/tests/functional/lib/fx-desktop.js
@@ -46,9 +46,12 @@ define([
       element.innerText = JSON.stringify(e.detail.data);
       document.body.appendChild(element);
 
-      sendMessageToFxa({
-        status: command
-      });
+      // loaded does not respond.
+      if (command !== 'loaded') {
+        sendMessageToFxa({
+          status: command
+        });
+      }
     });
 
     return true;
@@ -66,7 +69,6 @@ define([
         })
       .end();
   }
-
 
   return {
     listenForFxaCommands: listenForFxaCommands,


### PR DESCRIPTION
* An `afterLoaded` function is added to the brokers.
* The fx-desktop and iframe brokers send a `loaded` message to the RP.
* An RP that listens for this message knows the dialog is ready for display.

fixes #2066

for @ncalexan