### PR TITLE
fix(client): Redirect to `/settings` for direct access users who verify signup or password reset in the same browser.

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -142,6 +142,10 @@ define([
         });
     },
 
+    isAuthenticated: function () {
+      return this.has('sessionToken');
+    },
+
     toJSON: function () {
       return _.pick(this.attributes, ALLOWED_KEYS);
     },

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -142,8 +142,8 @@ define([
         });
     },
 
-    isAuthenticated: function () {
-      return this.has('sessionToken');
+    isSignedIn: function () {
+      return this._fxaClient.isSignedIn(this.get('sessionToken'));
     },
 
     toJSON: function () {

--- a/app/scripts/models/reliers/base.js
+++ b/app/scripts/models/reliers/base.js
@@ -22,6 +22,18 @@ define([
     },
 
     /**
+     * Check if the user visits FxA directly, without
+     * a relier.
+     *
+     * @returns {Boolean}
+     * `true` if the user visits FxA without using
+     * a relier
+     */
+    isDirectAccess: function () {
+      return ! this.has('service');
+    },
+
+    /**
      * Check if the relier is using the oauth flow
      */
     isOAuth: function () {

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -17,6 +17,7 @@ define([
 ],
 function (_, BaseView, FormView, Template, PasswordMixin,
       FloatingPlaceholderMixin, Validate, AuthErrors, ServiceMixin) {
+  var t = BaseView.t;
   var View = FormView.extend({
     template: Template,
     className: 'complete-reset-password',
@@ -135,7 +136,15 @@ function (_, BaseView, FormView, Template, PasswordMixin,
         })
         .then(function (result) {
           if (! (result && result.halt)) {
-            self.navigate('reset_password_complete');
+            // the user is definitively signed in here, otherwise this
+            // path would not be taken.
+            if (self.relier.isDirectAccess()) {
+              self.navigate('settings', {
+                success: t('Account verified')
+              });
+            } else {
+              self.navigate('reset_password_complete');
+            }
           }
         })
         .then(null, function (err) {

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -15,6 +15,8 @@ define([
   'views/mixins/resend-mixin'
 ],
 function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, p, ResendMixin) {
+  var t = BaseView.t;
+
   var CompleteSignUpView = FormView.extend({
     template: CompleteSignUpTemplate,
     className: 'complete_sign_up',
@@ -64,7 +66,14 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, p
           })
           .then(function (result) {
             if (! (result && result.halt)) {
-              self.navigate('signup_complete');
+              if (self.relier.isDirectAccess() &&
+                  self.getAccount().isAuthenticated()) {
+                self.navigate('settings', {
+                  success: t('Account verified')
+                });
+              } else {
+                self.navigate('signup_complete');
+              }
             }
             return false;
           })

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -16,6 +16,7 @@ define([
 ],
 function (_, FormView, BaseView, Template, p, AuthErrors,
     ResendMixin, ServiceMixin) {
+  var t = BaseView.t;
   var VERIFICATION_POLL_IN_MS = 4000; // 4 seconds
 
   var View = FormView.extend({
@@ -84,7 +85,14 @@ function (_, FormView, BaseView, Template, p, AuthErrors,
             })
             .then(function (result) {
               if (! (result && result.halt)) {
-                self.navigate('signup_complete');
+                // the user is definitely authenticated here.
+                if (self.relier.isDirectAccess()) {
+                  self.navigate('settings', {
+                    success: t('Account verified')
+                  });
+                } else {
+                  self.navigate('signup_complete');
+                }
               }
             }, function (err) {
               // The user's email may have bounced because it was invalid.

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -165,7 +165,14 @@ function (_, $, ConfirmView, BaseView, Template, p, Session, Constants,
           return self.broker.afterResetPasswordConfirmationPoll(account)
             .then(function (result) {
               if (! (result && result.halt)) {
-                self.navigate('reset_password_complete');
+                if (self.relier.isDirectAccess() &&
+                    account.isAuthenticated()) {
+                  self.navigate('settings', {
+                    success: t('Account verified')
+                  });
+                } else {
+                  self.navigate('reset_password_complete');
+                }
               }
             });
         });

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -164,15 +164,18 @@ function (_, $, ConfirmView, BaseView, Template, p, Session, Constants,
 
           return self.broker.afterResetPasswordConfirmationPoll(account)
             .then(function (result) {
-              if (! (result && result.halt)) {
-                if (self.relier.isDirectAccess() &&
-                    account.isAuthenticated()) {
-                  self.navigate('settings', {
-                    success: t('Account verified')
-                  });
-                } else {
-                  self.navigate('reset_password_complete');
-                }
+              if (result && result.halt) {
+                return;
+              }
+
+              if (self.relier.isDirectAccess()) {
+                // user is most definitely signed in since sessionInfo
+                // was passed in. Just ship direct access users to /settings
+                self.navigate('settings', {
+                  success: t('Account verified')
+                });
+              } else {
+                self.navigate('reset_password_complete');
               }
             });
         });

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -378,5 +378,38 @@ function (chai, sinon, p, Constants, Assertion, ProfileClient,
       });
     });
 
+    describe('isSignedIn', function () {
+      it('returns `false` if the model has no sessionToken', function () {
+        account.unset('sessionToken');
+        return account.isSignedIn()
+          .then(function (isSignedIn) {
+            assert.isFalse(isSignedIn);
+          });
+      });
+
+      it('returns `false` if the sessionToken is expired', function () {
+        account.set('sessionToken', 'exipred token');
+        sinon.stub(fxaClient, 'sessionStatus', function () {
+          return p.reject(AuthErrors.toError('INVALID_TOKEN'));
+        });
+
+        return account.isSignedIn()
+          .then(function (isSignedIn) {
+            assert.isFalse(isSignedIn);
+          });
+      });
+
+      it('returns `true` if the sessionToken is valid', function () {
+        account.set('sessionToken', 'valid token');
+        sinon.stub(fxaClient, 'sessionStatus', function () {
+          return p();
+        });
+
+        return account.isSignedIn()
+          .then(function (isSignedIn) {
+            assert.isTrue(isSignedIn);
+          });
+      });
+    });
   });
 });

--- a/app/tests/spec/models/reliers/base.js
+++ b/app/tests/spec/models/reliers/base.js
@@ -24,6 +24,17 @@ define([
       });
     });
 
+    describe('isDirectAccess', function () {
+      it('returns false if `service` is set', function () {
+        relier.set('service', 'serviceName');
+        assert.isFalse(relier.isDirectAccess());
+      });
+
+      it('returns true if `service` is unset', function () {
+        assert.isTrue(relier.isDirectAccess());
+      });
+    });
+
     describe('isOAuth', function () {
       it('returns `false`', function () {
         assert.isFalse(relier.isOAuth());

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -333,9 +333,9 @@ function (chai, sinon, p, AuthErrors, Metrics, FxaClient, InterTabChannel,
         });
 
         return view.validateAndSubmit()
-            .then(function () {
-              assert.equal(routerMock.page, 'settings');
-            });
+          .then(function () {
+            assert.equal(routerMock.page, 'settings');
+          });
       });
 
 

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -195,9 +195,12 @@ function (chai, sinon, p, View, AuthErrors, Metrics, Constants,
             });
       });
 
-      it('redirects to /signup_complete if verification successful and broker does not halt', function () {
+      it('non-direct-access redirects to /signup_complete access if verification successful and broker does not halt', function () {
         windowMock.location.search = '?code=' + validCode + '&uid=' + validUid;
         sinon.spy(broker, 'afterCompleteSignUp');
+        sinon.stub(relier, 'isDirectAccess', function () {
+          return false;
+        });
         initView();
         sinon.stub(view, 'getAccount', function () {
           return account;
@@ -209,6 +212,22 @@ function (chai, sinon, p, View, AuthErrors, Metrics, Constants,
               assert.isTrue(broker.afterCompleteSignUp.calledWith(account));
               assert.isTrue(TestHelpers.isEventLogged(
                       metrics, 'complete_sign_up.verification.success'));
+            });
+      });
+
+      it('direct-access redirects to /settings if verification successful and broker does not halt', function () {
+        windowMock.location.search = '?code=' + validCode + '&uid=' + validUid;
+        sinon.spy(broker, 'afterCompleteSignUp');
+        sinon.stub(relier, 'isDirectAccess', function () {
+          return true;
+        });
+        initView();
+        sinon.stub(view, 'getAccount', function () {
+          return account;
+        });
+        return view.render()
+            .then(function () {
+              assert.equal(routerMock.page, 'settings');
             });
       });
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -400,7 +400,9 @@ define([
 
   function fillOutCompleteResetPassword(context, password, vpassword) {
     return context.get('remote')
-      .findById('fxa-complete-reset-password-header')
+      .setFindTimeout(intern.config.pageLoadTimeout)
+
+      .findByCssSelector('#fxa-complete-reset-password-header')
       .end()
 
       .findByCssSelector('#password')
@@ -411,7 +413,7 @@ define([
         .type(vpassword)
       .end()
 
-      .findByCssSelector('button[type=submit]')
+      .findByCssSelector('button[type="submit"]')
         .click()
       .end();
   }


### PR DESCRIPTION
@zaach - mind reviewing? This is for @ryanfeeley.

The idea is that users who visit FxA directly (instead of via an RP of some sort) should be redirected to the `/settings` screen upon email verification, as long as the user is signed in.

* Add `isDirectAccess` to relier, which means user is visiting FxA directly.
* Add lots of functional tests.

fixes #1703
fixes #1939

https://docs.google.com/spreadsheets/d/16Uhb8vtGB_-krMbzaq0b3XYvTWePi_xgIElL7dquohA/ is updated with behavior.

