### PR TITLE
fix(l10n): use en as the default language instead of en-US

### DIFF
--- a/grunttasks/build.js
+++ b/grunttasks/build.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
     // with requirejs and usemin
     'l10n-generate-pages',
 
-    // use error pages from en_US as the static error pages
+    // use error pages from en as the static error pages
     'copy:error_pages',
 
     // prepares the configuration to transform specific blocks

--- a/grunttasks/copy.js
+++ b/grunttasks/copy.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
           flatten: true,
           cwd: '<%= yeoman.page_template_dist %>',
           dest: '<%= yeoman.app %>',
-          src: 'en_US/{500,502,503}.html'
+          src: 'en/{500,502,503}.html'
         }
       ]
     },

--- a/server/config/awsbox.json
+++ b/server/config/awsbox.json
@@ -6,7 +6,7 @@
   "page_template_subdirectory": "dist",
   "static_max_age" : 0,
   "i18n": {
-    "supportedLanguages": ["af", "an", "ar", "as", "ast", "be", "bg", "bn-BD", "bn-IN", "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "en-GB", "en-US", "en-ZA", "eo", "es", "es-AR", "es-CL", "es-MX", "et", "eu", "fa", "ff", "fi", "fr", "fy", "fy-NL", "ga", "ga-IE", "gd", "gl", "gu", "gu-IN", "he", "hi-IN", "hr", "ht", "hu", "hy-AM", "id", "is", "it", "it-CH", "ja", "kk", "km", "kn", "ko", "ku", "lij", "lt", "lv", "mai", "mk", "ml", "mr", "ms", "nb-NO", "ne-NP", "nl", "nn-NO", "or", "pa", "pa-IN", "pl", "pt", "pt-BR", "pt-PT", "rm", "ro", "ru", "si", "sk", "sl", "son", "sq", "sr", "sr-LATN", "sv", "sv-SE", "ta", "te", "th", "tr", "uk", "ur", "vi", "xh", "zh-CN", "zh-TW", "zu"]
+    "supportedLanguages": ["af", "an", "ar", "as", "ast", "be", "bg", "bn-BD", "bn-IN", "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "en-GB", "en-ZA", "eo", "es", "es-AR", "es-CL", "es-MX", "et", "eu", "fa", "ff", "fi", "fr", "fy", "fy-NL", "ga", "ga-IE", "gd", "gl", "gu", "gu-IN", "he", "hi-IN", "hr", "ht", "hu", "hy-AM", "id", "is", "it", "it-CH", "ja", "kk", "km", "kn", "ko", "ku", "lij", "lt", "lv", "mai", "mk", "ml", "mr", "ms", "nb-NO", "ne-NP", "nl", "nn-NO", "or", "pa", "pa-IN", "pl", "pt", "pt-BR", "pt-PT", "rm", "ro", "ru", "si", "sk", "sl", "son", "sq", "sr", "sr-LATN", "sv", "sv-SE", "ta", "te", "th", "tr", "uk", "ur", "vi", "xh", "zh-CN", "zh-TW", "zu"]
   },
   "metrics": {
     "sample_rate": 0

--- a/server/config/local.json-dist
+++ b/server/config/local.json-dist
@@ -16,7 +16,7 @@
   "use_https": false,
   "static_max_age" : 0,
   "i18n": {
-    "supportedLanguages": ["af", "an", "ar", "as", "ast", "az", "be", "bg", "bn-BD", "bn-IN", "br", "bs", "ca", "cs", "cy", "da", "de", "dsb", "el", "en-GB", "en-US", "en-ZA", "eo", "es", "es-AR", "es-CL", "es-MX", "et", "eu", "fa", "ff", "fi", "fr", "fy", "fy-NL", "ga", "ga-IE", "gd", "gl", "gu", "gu-IN", "he", "hi-IN", "hr", "hsb", "ht", "hu", "hy-AM", "id", "is", "it", "it-CH", "ja", "kk", "km", "kn", "ko", "ku", "lij", "lt", "lv", "mai", "mk", "ml", "mr", "ms", "nb-NO", "ne-NP", "nl", "nn-NO", "or", "pa", "pa-IN", "pl", "pt", "pt-BR", "pt-PT", "rm", "ro", "ru", "si", "sk", "sl", "son", "sq", "sr", "sr-LATN", "sv", "sv-SE", "ta", "te", "th", "tr", "uk", "ur", "vi", "xh", "zh-CN", "zh-TW", "zu"]
+    "supportedLanguages": ["af", "an", "ar", "as", "ast", "az", "be", "bg", "bn-BD", "bn-IN", "br", "bs", "ca", "cs", "cy", "da", "de", "dsb", "el", "en", "en-GB", "en-ZA", "eo", "es", "es-AR", "es-CL", "es-MX", "et", "eu", "fa", "ff", "fi", "fr", "fy", "fy-NL", "ga", "ga-IE", "gd", "gl", "gu", "gu-IN", "he", "hi-IN", "hr", "hsb", "ht", "hu", "hy-AM", "id", "is", "it", "it-CH", "ja", "kk", "km", "kn", "ko", "ku", "lij", "lt", "lv", "mai", "mk", "ml", "mr", "ms", "nb-NO", "ne-NP", "nl", "nn-NO", "or", "pa", "pa-IN", "pl", "pt", "pt-BR", "pt-PT", "rm", "ro", "ru", "si", "sk", "sl", "son", "sq", "sr", "sr-LATN", "sv", "sv-SE", "ta", "te", "th", "tr", "uk", "ur", "vi", "xh", "zh-CN", "zh-TW", "zu"]
   },
   "route_log_format": "dev_fxa",
   "logging": {

--- a/server/config/production-locales.json
+++ b/server/config/production-locales.json
@@ -7,7 +7,7 @@
       "da",
       "de",
       "dsb",
-      "en-US",
+      "en",
       "es",
       "es-AR",
       "es-CL",

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -182,11 +182,16 @@ var conf = module.exports = convict({
   i18n: {
     defaultLang: {
       format: String,
-      default: 'en-US'
+      default: 'en'
     },
     debugLang: {
       format: String,
       default: 'it-CH'
+    },
+    defaultLegalLang: {
+      doc: 'The default langauge to use for legal (tos, pp) templates',
+      format: String,
+      default: 'en-US'
     },
     supportedLanguages: {
       doc: 'List of languages this deployment should detect and display localized strings.',
@@ -195,7 +200,7 @@ var conf = module.exports = convict({
       // can build all the locales before config/production.json is written.
       default: [
         'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg', 'bn-BD', 'bn-IN', 'br',
-        'bs', 'ca', 'cs', 'cy', 'da', 'de', 'dsb', 'el', 'en-GB', 'en-US', 'en-ZA',
+        'bs', 'ca', 'cs', 'cy', 'da', 'de', 'dsb', 'el', 'en', 'en-GB', 'en-ZA',
         'eo', 'es', 'es-AR', 'es-CL', 'es-MX', 'et', 'eu', 'fa', 'ff', 'fi',
         'fr', 'fy', 'fy-NL', 'ga', 'ga-IE', 'gd', 'gl', 'gu', 'gu-IN', 'he',
         'hi-IN', 'hr', 'hsb', 'ht', 'hu', 'hy-AM', 'id', 'is', 'it', 'it-CH', 'ja',
@@ -303,6 +308,7 @@ if (conf.has('http_proxy.port')) {
 // Ensure that supportedLanguages includes defaultLang.
 var defaultLang = conf.get('i18n.defaultLang');
 var supportedLanguages = conf.get('i18n.supportedLanguages');
+
 if (supportedLanguages.indexOf(defaultLang) === -1) {
   throw new Error('Configuration error: defaultLang (' + defaultLang + ') is missing from supportedLanguages');
 }

--- a/server/lib/legal-templates.js
+++ b/server/lib/legal-templates.js
@@ -19,8 +19,8 @@ module.exports = function (i18n, root) {
   }
 
   var templateCache = {};
-  function getTemplate(type, lang, defaultLang) {
-    var DEFAULT_LOCALE = i18n.localeFrom(defaultLang);
+  function getTemplate(type, lang, defaultLang, defaultLegalLang) {
+    var DEFAULT_LOCALE = i18n.localeFrom(defaultLegalLang);
 
     // Filenames are normalized to locale, not language.
     var locale = i18n.localeFrom(lang);
@@ -37,6 +37,12 @@ module.exports = function (i18n, root) {
     fs.exists(templatePath, function (exists) {
       if (! exists) {
         var bestLang = i18n.bestLanguage(i18n.parseAcceptLanguage(lang));
+        // If bestLang resolves to the default lang, replace it with
+        // the default legal lang since they may differ. E.g. en-US
+        // is the legal default while en is the general default.
+        if (bestLang === defaultLang) {
+          bestLang = defaultLegalLang;
+        }
 
         if (locale === DEFAULT_LOCALE) {
           var err = new Error(type + ' missing `' + DEFAULT_LOCALE + '` template: ' + templatePath);

--- a/server/lib/routes/get-terms-privacy.js
+++ b/server/lib/routes/get-terms-privacy.js
@@ -30,6 +30,7 @@ var templates = require('../legal-templates');
 
 module.exports = function verRoute (i18n) {
   var DEFAULT_LANG = config.get('i18n.defaultLang');
+  var DEFAULT_LEGAL_LANG = config.get('i18n.defaultLegalLang');
 
   var getTemplate = templates(i18n, PAGE_TEMPLATE_DIRECTORY);
 
@@ -47,7 +48,7 @@ module.exports = function verRoute (i18n) {
     var lang = req.params[0] || req.lang;
     var page = req.params[1];
 
-    getTemplate(page, lang)
+    getTemplate(page, lang, DEFAULT_LANG, DEFAULT_LEGAL_LANG)
       .then(function (template) {
         if (! template) {
           logger.warn('%s->`%s` does not exist, redirecting to `%s`',

--- a/tests/functional/fonts.js
+++ b/tests/functional/fonts.js
@@ -19,7 +19,7 @@ define([
     setup: function () {
     },
 
-    'Uses Fira for en-US': function () {
+    'Uses Fira for en': function () {
 
       return this.get('remote')
         .get(require.toUrl(url))

--- a/tests/functional/pages.js
+++ b/tests/functional/pages.js
@@ -43,8 +43,8 @@ define([
     'invalid-locale/legal/terms',
     'invalid-locale/legal/privacy',
     // yay!
-    'en-US/legal/terms',
-    'en-US/legal/privacy',
+    'en/legal/terms',
+    'en/legal/privacy',
     'reset_password',
     'confirm_reset_password',
     'complete_reset_password',

--- a/tests/server/configuration.js
+++ b/tests/server/configuration.js
@@ -28,7 +28,7 @@ define([
         PATH: process.env.PATH,
         PORT: '3040',
         HTTP_PORT: '3090',
-        I18N_SUPPORTED_LANGUAGES: 'en-US,blah'
+        I18N_SUPPORTED_LANGUAGES: 'en,blah'
       }
     });
 

--- a/tests/server/l10n.js
+++ b/tests/server/l10n.js
@@ -94,13 +94,13 @@ define([
 
     request(serverUrl + '/config', {
       headers: {
-        'Accept-Language': 'en-us'
+        'Accept-Language': 'zh-cn'
       }
     }, dfd.callback(function (err, res) {
       assert.equal(res.statusCode, 200);
 
       var body = JSON.parse(res.body);
-      assert.equal(body.language, 'en-us');
+      assert.equal(body.language, 'zh-cn');
     }, dfd.reject.bind(dfd)));
   };
 
@@ -111,17 +111,17 @@ define([
 
       request(serverUrl + page, {
         headers: {
-          'Accept-Language': 'en-us',
+          'Accept-Language': 'en',
           'Accept': 'text/html'
         }
       }, dfd.callback(function (err, res) {
-        var re = /styles\/en_US\.css/;
+        var re = /styles\/en\.css/;
         if (intern.config.fxaProduction) {
-          re = /styles\/[a-f0-9]{0,8}\.en_US\.css/;
+          re = /styles\/[a-f0-9]{0,8}\.en\.css/;
         }
         assert.ok(res.body.match(re));
         assert.ok(res.body.match(/dir="ltr"/));
-        assert.ok(res.body.match(/lang="en-us"/i));
+        assert.ok(res.body.match(/lang="en"/i));
       }, dfd.reject.bind(dfd)));
     };
   });
@@ -190,6 +190,18 @@ define([
         'de');
   };
 
+  suite['#get /i18n/client.json with en,fr should use en'] = function () {
+    testClientJson.call(this,
+        'en,fr',
+        'en');
+  };
+
+  suite['#get /i18n/client.json with en-US,fr should use en'] = function () {
+    testClientJson.call(this,
+        'en-us,fr',
+        'en');
+  };
+
   suite['#get /i18n/client.json with lowercase language'] = function () {
     testClientJson.call(this, 'es-ar', 'es_AR');
   };
@@ -219,11 +231,11 @@ define([
   };
 
   suite['#get /i18n/client.json with unsupported language returns default locale'] = function () {
-    testClientJson.call(this, 'no-OP', 'en_US');
+    testClientJson.call(this, 'no-OP', 'en');
   };
 
   suite['#get /i18n/client.json with no locale returns default locale'] = function () {
-    testClientJson.call(this, null, 'en_US');
+    testClientJson.call(this, null, 'en');
   };
 
   registerSuite(suite);

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -68,7 +68,7 @@ define([
     routes['/boom'] = { statusCode: 500 };
     routes['/non_existent'] = { statusCode: 404 };
     routes['/legal/non_existent'] = { statusCode: 404 };
-    routes['/en-US/legal/non_existent'] = { statusCode: 404 };
+    routes['/en/legal/non_existent'] = { statusCode: 404 };
   }
 
   var iframeAllowedRoutes = [


### PR DESCRIPTION
This makes `en` the default language and disables `en-US`. This way, `en-US` will default to `en` *and* we won't have those weird bugs when `en` is the user's selected language. The legal docs are under `en_US` so I had to modify things a bit to handle the inconsistency there.

Fixes #2072.

@vladikoff or @shane-tomlinson r?