### PR TITLE
feat(client): Add `signup` message for the iframe flow.

### DIFF
--- a/app/scripts/models/auth_brokers/iframe.js
+++ b/app/scripts/models/auth_brokers/iframe.js
@@ -101,6 +101,14 @@ define([
 
     afterLoaded: function () {
       return this.send('loaded');
+    },
+
+    beforeSignUpConfirmationPoll: function () {
+      // `signup` is used to notify reliers that the user
+      // has initiated a signup. It does not expect a response.
+      this.send('signup');
+
+      return p();
     }
   });
 

--- a/app/tests/spec/models/auth_brokers/iframe.js
+++ b/app/tests/spec/models/auth_brokers/iframe.js
@@ -142,6 +142,15 @@ function (chai, sinon, $, IframeAuthenticationBroker, Relier, p, NullChannel,
       });
     });
 
+    describe('beforeSignUpConfirmationPoll', function () {
+      it('sends a `signup` message', function () {
+        return broker.beforeSignUpConfirmationPoll()
+          .then(function () {
+            assert.isTrue(channelMock.send.calledWith('signup'));
+          });
+      });
+    });
+
   });
 });
 


### PR DESCRIPTION
@ckarlof - Can you provide feedback? For sync, we provide a "login" message, @jpetto requested something similar for the FxA firstrun experience. I am wondering if this exposes too much information in the general case, and whether this message should only be sent for whitelisted reliers?

* Requested by @jpetto for the new Firefox first run experience so they can add a screen transition once they know a user has signed up.

fixes #2091 