### PR TITLE
feat(docker): Dockerfile and README update for basic docker development workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:trusty
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs npm git libgmp3-dev
+RUN ln -sf /usr/bin/nodejs /usr/local/bin/node
+
+RUN useradd --home-dir /opt/fxa fxa
+USER fxa
+
+WORKDIR /opt/fxa
+
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ It will listen on <http://127.0.0.1:3030> by default.
 Note: If you have issues with `npm install` please update to npm 2.0+ using `npm install -g npm@2` 
 ([Issue #1594](https://github.com/mozilla/fxa-content-server/issues/1594))
 
+## Docker Based Development
+
+To run the content server via Docker, three steps are required:
+
+    $ docker build --rm -t mozilla/fxa_content_server .
+    $ docker run --rm -v $PWD:/opt/fxa mozilla/fxa_content_server npm install
+    $ docker run -it --rm -v $PWD:/opt/fxa --net=host mozilla/fxa_content_server
+
+This method shares the codebase into the running container so that you can install npm and various modules required by package.json. It then runs FxA content server in a container, while allowing you to use your IDE of choice from your normal desktop environment to develop code.
+
+Be sure to copy server/config/local.json-dist to server/config/local.json per usual before the final docker invocation to run the service.
+
+Note to boot2docker users: you must edit your server/config/local.json to use the correct IP of your boot2docker VM. Check with the command: `boot2docker ip`
+
+ Then replace the public_url IP address in local.json that reads: "public_url": "http://127.0.0.1:3030" with the IP that you noted above. It should be something like 192.168.59.103.
+
+To stop the container, first try CTRL+C. If that does not work, run `docker ps |grep fxa_content_server` to get the hexadecimal Container ID (the first column of output). Run `docker stop nnnnnnnnnnnn` where the nnnn part is the Container ID.
+
 ## Testing
 
 #### Prerequisites:
@@ -58,8 +76,6 @@ To run tests locally with Selenium:
 npm test
 ```
 
-## Configuration
-
 To change the default auth server edit `server/config/*.json` on your deployed instance.
 
 ```json
@@ -67,6 +83,8 @@ To change the default auth server edit `server/config/*.json` on your deployed i
   "fxaccount_url": "http://your.auth.server.here.org"
 }
 ```
+
+**Note that testing with Selenium via Docker does *not* work at present, so all testing must be carried out via your normal operating system's npm & Java tooling.**
 
 ## Grunt Commands
 


### PR DESCRIPTION
I've added a dockerfile and some instructions to README.md explaining how to use Docker to develop and run the content server. I've also set it up so that the container runs Firefox with Selenium for testing. It allows for development with an IDE underneath a running container as one would normally work. This means changes and running the verifier are mostly transparent to normal development. If there are any questions feel free to ask here or in IRC.
