### PR TITLE
fix(avatars): prevent flicker when loading avatars on settings pages

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -24,6 +24,7 @@ define([
     sessionTokenContext: undefined,
     accessToken: undefined,
     verified: undefined,
+    profileImageUrl: undefined,
     lastLogin: undefined
   };
 

--- a/app/scripts/templates/settings/avatar.mustache
+++ b/app/scripts/templates/settings/avatar.mustache
@@ -4,7 +4,7 @@
   </header>
 
   <section>
-    <p class="avatar-wrapper with-default">
+    <p class="avatar-wrapper">
     </p>
 
     <div class="error"></div>

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -42,16 +42,38 @@ define([
         wrapperClass = '.avatar-wrapper';
       }
 
+      // If the account doesn't have a profile image URL cached it
+      // probably doesn't have one, so show the default image immediately
+      // while we check for a real image
+      if (! account.has('profileImageUrl')) {
+        self.$(wrapperClass).addClass('with-default');
+      }
+
       return this._fetchProfileImage(account)
         .then(function (result) {
           if (result && result.avatar) {
             self.$(wrapperClass).append(new Image());
             self.$(wrapperClass + ' img').attr('src', result.avatar);
+            self.$(wrapperClass).removeClass('with-default');
+          } else {
+            self.$(wrapperClass).addClass('with-default');
           }
           return result;
         }, function () {
           // Ignore errors; the default image will be shown.
+          self.$(wrapperClass).addClass('with-default');
         });
+    },
+
+    // Cache the profile image URL in localStorage whenever it changes
+    // TODO: issue #2095 send broadcast
+    updateAvatarUrl: function (url) {
+      if (! url && url !== null) {
+        return;
+      }
+      var account = this.getSignedInAccount();
+      account.set('profileImageUrl', url);
+      this.user.setAccount(account);
     }
   };
 });

--- a/app/scripts/views/mixins/settings-mixin.js
+++ b/app/scripts/views/mixins/settings-mixin.js
@@ -34,6 +34,5 @@ define([
         self.user.clearSignedInAccount();
       }
     }
-
   };
 });

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -11,13 +11,14 @@ define([
   'views/form',
   'views/progress_indicator',
   'views/mixins/settings-mixin',
+  'views/mixins/avatar-mixin',
   'stache!templates/settings/avatar_camera',
   'lib/constants',
   'lib/promise',
   'lib/auth-errors'
 ],
 function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
-    SettingsMixin, Template, Constants, p, AuthErrors) {
+    SettingsMixin, AvatarMixin, Template, Constants, p, AuthErrors) {
   // a blank 1x1 png
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
 
@@ -152,6 +153,7 @@ function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
           self.stream.stop();
           delete self.stream;
 
+          self.updateAvatarUrl(result.url);
           self.navigate('settings');
           return result;
         });
@@ -209,7 +211,7 @@ function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
     }
   });
 
-  Cocktail.mixin(View, SettingsMixin);
+  Cocktail.mixin(View, SettingsMixin, AvatarMixin);
 
   return View;
 });

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -63,6 +63,7 @@ function ($, _, Cocktail, FormView, AvatarMixin, SettingsMixin, Template, AuthEr
       var self = this;
       return self.getSignedInAccount().deleteAvatar(self.avatarId)
         .then(function () {
+          self.updateAvatarUrl(null);
           self.navigate('settings');
         });
     },

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -10,14 +10,15 @@ define([
   'cocktail',
   'views/form',
   'views/mixins/settings-mixin',
+  'views/mixins/avatar-mixin',
   'stache!templates/settings/avatar_crop',
   'lib/constants',
   'lib/cropper',
   'lib/auth-errors',
   'models/cropper-image'
 ],
-function (p, _, Cocktail, FormView, SettingsMixin, Template, Constants, Cropper,
-    AuthErrors, CropperImage) {
+function (p, _, Cocktail, FormView, SettingsMixin, AvatarMixin, Template,
+    Constants, Cropper, AuthErrors, CropperImage) {
   var HORIZONTAL_GUTTER = 90;
   var VERTICAL_GUTTER = 0;
 
@@ -98,6 +99,7 @@ function (p, _, Cocktail, FormView, SettingsMixin, Template, Constants, Cropper,
           return self.getSignedInAccount().uploadAvatar(data);
         })
         .then(function (result) {
+          self.updateAvatarUrl(result.url);
           self.navigate('settings');
           return result;
         });
@@ -105,7 +107,7 @@ function (p, _, Cocktail, FormView, SettingsMixin, Template, Constants, Cropper,
 
   });
 
-  Cocktail.mixin(View, SettingsMixin);
+  Cocktail.mixin(View, SettingsMixin, AvatarMixin);
 
   return View;
 });

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -11,13 +11,14 @@ define([
   'cocktail',
   'views/form',
   'views/mixins/settings-mixin',
+  'views/mixins/avatar-mixin',
   'stache!templates/settings/avatar_gravatar',
   'lib/constants',
   'lib/image-loader',
   'views/decorators/progress_indicator'
 ],
-function ($, _, md5, Cocktail, FormView, SettingsMixin, Template,
-    Constants, ImageLoader, showProgressIndicator) {
+function ($, _, md5, Cocktail, FormView, SettingsMixin, AvatarMixin,
+    Template, Constants, ImageLoader, showProgressIndicator) {
 
   function t (s) { return s; }
 
@@ -79,6 +80,8 @@ function ($, _, md5, Cocktail, FormView, SettingsMixin, Template,
 
       return self.getSignedInAccount().postAvatar(url, true)
         .then(function (result) {
+          self.updateAvatarUrl(url);
+
           self.navigate('settings', {
             successUnsafe: t('Courtesy of <a href="https://www.gravatar.com">Gravatar</a>')
           });
@@ -87,7 +90,7 @@ function ($, _, md5, Cocktail, FormView, SettingsMixin, Template,
     }
   });
 
-  Cocktail.mixin(View, SettingsMixin);
+  Cocktail.mixin(View, SettingsMixin, AvatarMixin);
 
   return View;
 });

--- a/app/styles/_avatars.scss
+++ b/app/styles/_avatars.scss
@@ -14,8 +14,6 @@
     width: 120px;
     display: block;
     margin: 0 auto;
-    background: image-url('default-profile.svg') center;
-    background-repeat: no-repeat;
     img, a.change-avatar {
       height: 120px;
       width: 120px;
@@ -25,10 +23,6 @@
       position: absolute;
       bottom: 0px;
     }
-  }
-
-  &.with-default {
-    background: image-url('default-profile.svg') center;
   }
 
   img {
@@ -51,6 +45,11 @@
     border-radius: 50%;
     position: relative;
   }
+}
+
+.with-default {
+  background: image-url('default-profile.svg') center;
+  background-repeat: no-repeat;
 }
 
 p.change-avatar-text {

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'chai',
+  'backbone',
+  'sinon',
+  'underscore',
+  'views/mixins/avatar-mixin',
+  'views/base',
+  'models/reliers/relier',
+  'models/user',
+  'models/account'
+], function (Chai, Backbone, sinon, _, AvatarMixin, BaseView,
+    Relier, User, Account) {
+  var assert = Chai.assert;
+
+  var SettingsView = BaseView.extend({});
+
+  _.extend(SettingsView.prototype, AvatarMixin);
+
+  describe('views/mixins/avatar-mixin', function () {
+    var view;
+    var user;
+    var account;
+    var relier;
+
+    beforeEach(function () {
+      user = new User();
+      account = new Account();
+      relier = new Relier();
+      view = new SettingsView({
+        user: user,
+        relier: relier
+      });
+      sinon.stub(view, 'getSignedInAccount', function () {
+        return account;
+      });
+      sinon.stub(user, 'setAccount', function () { });
+    });
+
+    describe('updateAvatarUrl', function () {
+      it('returns when no avatar', function () {
+        view.updateAvatarUrl();
+        assert.isFalse(view.getSignedInAccount.called);
+      });
+
+      it('stores the url', function () {
+        view.updateAvatarUrl('url');
+        assert.equal(account.get('profileImageUrl'), 'url');
+        assert.isTrue(view.getSignedInAccount.called);
+        assert.isTrue(user.setAccount.calledWith(account));
+      });
+
+      it('deletes the url if null', function () {
+        view.updateAvatarUrl('url');
+        assert.isTrue(account.has('profileImageUrl'));
+        view.updateAvatarUrl(null);
+        assert.isFalse(account.has('profileImageUrl'));
+        assert.isTrue(user.setAccount.calledWith(account));
+      });
+    });
+
+  });
+});
+

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -193,6 +193,7 @@ function (chai, _, $, sinon, View, RouterMock, WindowMock, TestHelpers,
           })
           .then(function () {
             assert.equal(view.$('.avatar-wrapper img').length, 0);
+            assert.equal(view.$('.avatar-wrapper.with-default').length, 1);
           });
       });
 
@@ -210,6 +211,7 @@ function (chai, _, $, sinon, View, RouterMock, WindowMock, TestHelpers,
           })
           .then(function () {
             assert.equal(view.$('.avatar-wrapper img').attr('src'), url);
+            assert.equal(view.$('.avatar-wrapper.with-default').length, 0);
           });
       });
 

--- a/app/tests/spec/views/settings/avatar_camera.js
+++ b/app/tests/spec/views/settings/avatar_camera.js
@@ -167,6 +167,10 @@ function (chai, _, $, sinon, View, RouterMock, WindowMock, CanvasMock,
           });
         });
 
+        sinon.stub(view, 'updateAvatarUrl', function () {
+          return p();
+        });
+
         view.render()
           .then(function () {
             view.canvas = new CanvasMock();
@@ -190,6 +194,7 @@ function (chai, _, $, sinon, View, RouterMock, WindowMock, CanvasMock,
                   assert.ok(! view.stream, 'stream is gone');
                   assert.equal(result.url, 'test');
                   assert.equal(result.id, 'foo');
+                  assert.isTrue(view.updateAvatarUrl.calledWith(result));
                 }, done);
 
               // check canvas drawImage args

--- a/app/tests/spec/views/settings/avatar_change.js
+++ b/app/tests/spec/views/settings/avatar_change.js
@@ -109,6 +109,7 @@ function (chai, _, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
               .then(function () {
                 assert.isTrue(profileClientMock.deleteAvatar.calledWith(
                   accessToken, 'foo'));
+                assert.isNull(account.get('profileImageUrl'));
                 assert.equal(routerMock.page, 'settings');
               });
           });

--- a/app/tests/spec/views/settings/avatar_crop.js
+++ b/app/tests/spec/views/settings/avatar_crop.js
@@ -120,6 +120,9 @@ function (chai, _, $, ui, sinon, View, RouterMock, ProfileMock, User, CropperIma
           sinon.stub(account, 'profileClient', function () {
             return p(profileClientMock);
           });
+          sinon.stub(view, 'updateAvatarUrl', function () {
+            return p();
+          });
         });
 
         it('has a cropper image', function () {
@@ -149,6 +152,7 @@ function (chai, _, $, ui, sinon, View, RouterMock, ProfileMock, User, CropperIma
               return view.submit();
             })
             .then(function (result) {
+              assert.isTrue(view.updateAvatarUrl.calledWith(result.url));
               assert.equal(result.url, 'test');
               assert.equal(result.id, 'foo');
               assert.equal(routerMock.page, 'settings');

--- a/app/tests/spec/views/settings/avatar_gravatar.js
+++ b/app/tests/spec/views/settings/avatar_gravatar.js
@@ -119,6 +119,11 @@ function (chai, _, $, sinon, View, RouterMock, ProfileMock, User,
           });
           view.automatedBrowser = true;
 
+          sinon.stub(view, 'updateAvatarUrl', function (result) {
+            assert.ok(result);
+            return p();
+          });
+
           return view.render()
             .then(function () {
               return view.submit();

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -74,6 +74,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/timer-mixin',
     '../tests/spec/views/mixins/service-mixin',
     '../tests/spec/views/mixins/password-mixin',
+    '../tests/spec/views/mixins/avatar-mixin',
     '../tests/spec/models/user',
     '../tests/spec/models/account',
     '../tests/spec/models/reliers/base',


### PR DESCRIPTION
There's currently a brief flash of the default profile image before your custom profile image is shown. This PR hides the default image unless it's needed.

Fixes #2105.

@shane-tomlinson or @vladikoff r?