### PR TITLE
refactor(client): Use Cocktail to mix in the majority of mixins.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -5,6 +5,7 @@
 'use strict';
 
 define([
+  'cocktail',
   'underscore',
   'backbone',
   'jquery',
@@ -16,7 +17,7 @@ define([
   'lib/null-metrics',
   'views/mixins/timer-mixin'
 ],
-function (_, Backbone, $, p, AuthErrors,
+function (Cocktail, _, Backbone, $, p, AuthErrors,
       Url, Strings, EphemeralMessages, NullMetrics, TimerMixin) {
   var ENTER_BUTTON_CODE = 13;
   var DEFAULT_TITLE = window.document.title;
@@ -732,7 +733,10 @@ function (_, Backbone, $, p, AuthErrors,
 
   BaseView.t = t;
 
-  _.extend(BaseView.prototype, TimerMixin);
+  Cocktail.mixin(
+    BaseView,
+    TimerMixin
+  );
 
   return BaseView;
 });

--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -5,7 +5,7 @@
 'use strict';
 
 define([
-  'underscore',
+  'cocktail',
   'views/base',
   'views/form',
   'stache!templates/change_password',
@@ -14,7 +14,8 @@ define([
   'lib/auth-errors',
   'views/mixins/service-mixin'
 ],
-function (_, BaseView, FormView, Template, PasswordMixin, FloatingPlaceholderMixin, AuthErrors, ServiceMixin) {
+function (Cocktail, BaseView, FormView, Template, PasswordMixin,
+  FloatingPlaceholderMixin, AuthErrors, ServiceMixin) {
   var t = BaseView.t;
 
   var View = FormView.extend({
@@ -83,9 +84,12 @@ function (_, BaseView, FormView, Template, PasswordMixin, FloatingPlaceholderMix
 
   });
 
-  _.extend(View.prototype, PasswordMixin);
-  _.extend(View.prototype, FloatingPlaceholderMixin);
-  _.extend(View.prototype, ServiceMixin);
+  Cocktail.mixin(
+    View,
+    PasswordMixin,
+    FloatingPlaceholderMixin,
+    ServiceMixin
+  );
 
   return View;
 });

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -5,7 +5,7 @@
 'use strict';
 
 define([
-  'underscore',
+  'cocktail',
   'views/base',
   'views/form',
   'stache!templates/complete_reset_password',
@@ -15,7 +15,7 @@ define([
   'lib/auth-errors',
   'views/mixins/service-mixin'
 ],
-function (_, BaseView, FormView, Template, PasswordMixin,
+function (Cocktail, BaseView, FormView, Template, PasswordMixin,
       FloatingPlaceholderMixin, Validate, AuthErrors, ServiceMixin) {
   var t = BaseView.t;
   var View = FormView.extend({
@@ -184,9 +184,12 @@ function (_, BaseView, FormView, Template, PasswordMixin,
     }
   });
 
-  _.extend(View.prototype, PasswordMixin);
-  _.extend(View.prototype, ServiceMixin);
-  _.extend(View.prototype, FloatingPlaceholderMixin);
+  Cocktail.mixin(
+    View,
+    PasswordMixin,
+    ServiceMixin,
+    FloatingPlaceholderMixin
+  );
 
   return View;
 });

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -14,7 +14,8 @@ define([
   'lib/promise',
   'views/mixins/resend-mixin'
 ],
-function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, p, ResendMixin) {
+function (_, FormView, BaseView, CompleteSignUpTemplate,
+  AuthErrors, Validate, p, ResendMixin) {
   var t = BaseView.t;
 
   var CompleteSignUpView = FormView.extend({
@@ -162,7 +163,12 @@ function (_, FormView, BaseView, CompleteSignUpTemplate, AuthErrors, Validate, p
     }
   });
 
-  _.extend(CompleteSignUpView.prototype, ResendMixin);
+  _.extend(
+    CompleteSignUpView.prototype,
+    // ResendMixin overrides beforeSubmit and has unexpected behavior
+    // with Cocktail's collision handling.
+    ResendMixin
+  );
 
   return CompleteSignUpView;
 });

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -5,7 +5,7 @@
 'use strict';
 
 define([
-  'underscore',
+  'cocktail',
   'views/form',
   'views/base',
   'stache!templates/complete_sign_up',
@@ -14,7 +14,7 @@ define([
   'lib/promise',
   'views/mixins/resend-mixin'
 ],
-function (_, FormView, BaseView, CompleteSignUpTemplate,
+function (Cocktail, FormView, BaseView, CompleteSignUpTemplate,
   AuthErrors, Validate, p, ResendMixin) {
   var t = BaseView.t;
 
@@ -160,13 +160,15 @@ function (_, FormView, BaseView, CompleteSignUpTemplate,
                 // unexpected error, rethrow for display.
                 throw err;
               });
-    }
+    },
+
+    // The ResendMixin overrides beforeSubmit. Unless set to undefined,
+    // Cocktail runs both the original version and the overridden version.
+    beforeSubmit: undefined
   });
 
-  _.extend(
-    CompleteSignUpView.prototype,
-    // ResendMixin overrides beforeSubmit and has unexpected behavior
-    // with Cocktail's collision handling.
+  Cocktail.mixin(
+    CompleteSignUpView,
     ResendMixin
   );
 

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -149,21 +149,18 @@ function (Cocktail, _, FormView, BaseView, Template, p, AuthErrors,
           // unexpected error, rethrow for display.
           throw err;
         });
-    }
+    },
+
+    // The ResendMixin overrides beforeSubmit. Unless set to undefined,
+    // Cocktail runs both the original version and the overridden version.
+    beforeSubmit: undefined
   });
 
   Cocktail.mixin(
     View,
-    ServiceMixin
-  );
-
-  _.extend(
-    View.prototype,
-    // ResendMixin overrides beforeSubmit and has unexpected behavior
-    // with Cocktail's collision handling.
+    ServiceMixin,
     ResendMixin
   );
-
 
   return View;
 });

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -5,6 +5,7 @@
 'use strict';
 
 define([
+  'cocktail',
   'underscore',
   'views/form',
   'views/base',
@@ -14,7 +15,7 @@ define([
   'views/mixins/resend-mixin',
   'views/mixins/service-mixin'
 ],
-function (_, FormView, BaseView, Template, p, AuthErrors,
+function (Cocktail, _, FormView, BaseView, Template, p, AuthErrors,
     ResendMixin, ServiceMixin) {
   var t = BaseView.t;
   var VERIFICATION_POLL_IN_MS = 4000; // 4 seconds
@@ -151,7 +152,18 @@ function (_, FormView, BaseView, Template, p, AuthErrors,
     }
   });
 
-  _.extend(View.prototype, ResendMixin, ServiceMixin);
+  Cocktail.mixin(
+    View,
+    ServiceMixin
+  );
+
+  _.extend(
+    View.prototype,
+    // ResendMixin overrides beforeSubmit and has unexpected behavior
+    // with Cocktail's collision handling.
+    ResendMixin
+  );
+
 
   return View;
 });

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -5,6 +5,7 @@
 'use strict';
 
 define([
+  'cocktail',
   'underscore',
   'jquery',
   'views/confirm',
@@ -17,7 +18,7 @@ define([
   'views/mixins/resend-mixin',
   'views/mixins/service-mixin'
 ],
-function (_, $, ConfirmView, BaseView, Template, p, Session, Constants,
+function (Cocktail, _, $, ConfirmView, BaseView, Template, p, Session, Constants,
       AuthErrors, ResendMixin, ServiceMixin) {
   var t = BaseView.t;
 
@@ -272,7 +273,17 @@ function (_, $, ConfirmView, BaseView, Template, p, Session, Constants,
     }
   });
 
-  _.extend(View.prototype, ResendMixin, ServiceMixin);
+  Cocktail.mixin(
+    View,
+    ServiceMixin
+  );
+
+  _.extend(
+    View.prototype,
+    // ResendMixin overrides beforeSubmit and has unexpected behavior
+    // with Cocktail's collision handling.
+    ResendMixin
+  );
 
   return View;
 });

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -270,19 +270,17 @@ function (Cocktail, _, $, ConfirmView, BaseView, Template, p, Session, Constants
 
     savePrefillEmailForSignin: function () {
       Session.set('prefillEmail', this._email);
-    }
+    },
+
+    // The ResendMixin overrides beforeSubmit. Unless set to undefined,
+    // Cocktail runs both the original version and the overridden version.
+    beforeSubmit: undefined
   });
 
   Cocktail.mixin(
     View,
+    ResendMixin,
     ServiceMixin
-  );
-
-  _.extend(
-    View.prototype,
-    // ResendMixin overrides beforeSubmit and has unexpected behavior
-    // with Cocktail's collision handling.
-    ResendMixin
   );
 
   return View;

--- a/app/scripts/views/delete_account.js
+++ b/app/scripts/views/delete_account.js
@@ -5,7 +5,7 @@
 'use strict';
 
 define([
-  'underscore',
+  'cocktail',
   'views/base',
   'views/form',
   'stache!templates/delete_account',
@@ -13,7 +13,8 @@ define([
   'views/mixins/password-mixin',
   'views/mixins/service-mixin'
 ],
-function (_, BaseView, FormView, Template, Session, PasswordMixin, ServiceMixin) {
+function (Cocktail, BaseView, FormView, Template, Session,
+  PasswordMixin, ServiceMixin) {
   var t = BaseView.t;
 
   var View = FormView.extend({
@@ -51,8 +52,11 @@ function (_, BaseView, FormView, Template, Session, PasswordMixin, ServiceMixin)
     }
   });
 
-  _.extend(View.prototype, PasswordMixin);
-  _.extend(View.prototype, ServiceMixin);
+  Cocktail.mixin(
+    View,
+    PasswordMixin,
+    ServiceMixin
+  );
 
   return View;
 });

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -153,7 +153,7 @@ function (_, $, p, Validate, AuthErrors, BaseView, Tooltip,
      * @method validateAndSubmit
      * @return {promise}
      */
-    validateAndSubmit: allowOnlyOneSubmit(function () {
+    validateAndSubmit: allowOnlyOneSubmit(function validateAndSubmit () {
       var self = this;
 
       return p()

--- a/app/scripts/views/mixins/resend-mixin.js
+++ b/app/scripts/views/mixins/resend-mixin.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // helper functions for views with passwords. Meant to be mixed into views.
+// Note, this mixin overrides beforeSubmit and is incompatible with Cocktail.
 
 'use strict';
 

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -11,7 +11,7 @@
 'use strict';
 
 define([
-  'underscore',
+  'cocktail',
   'views/base',
   'stache!templates/ready',
   'lib/session',
@@ -22,7 +22,7 @@ define([
   'views/mixins/service-mixin',
   'views/marketing_snippet'
 ],
-function (_, BaseView, Template, Session, Xss, Strings,
+function (Cocktail, BaseView, Template, Session, Xss, Strings,
       AuthErrors, p, ServiceMixin, MarketingSnippet) {
 
   var View = BaseView.extend({
@@ -72,7 +72,10 @@ function (_, BaseView, Template, Session, Xss, Strings,
     }
   });
 
-  _.extend(View.prototype, ServiceMixin);
+  Cocktail.mixin(
+    View,
+    ServiceMixin
+  );
 
   return View;
 });

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -5,7 +5,7 @@
 'use strict';
 
 define([
-  'underscore',
+  'cocktail',
   'views/base',
   'views/form',
   'stache!templates/reset_password',
@@ -13,7 +13,8 @@ define([
   'lib/auth-errors',
   'views/mixins/service-mixin'
 ],
-function (_, BaseView, FormView, Template, Session, AuthErrors, ServiceMixin) {
+function (Cocktail, BaseView, FormView, Template, Session,
+  AuthErrors, ServiceMixin) {
   var t = BaseView.t;
 
   var View = FormView.extend({
@@ -76,7 +77,10 @@ function (_, BaseView, FormView, Template, Session, AuthErrors, ServiceMixin) {
     }
   });
 
-  _.extend(View.prototype, ServiceMixin);
+  Cocktail.mixin(
+    View,
+    ServiceMixin
+  );
 
   return View;
 });

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -5,7 +5,6 @@
 'use strict';
 
 define([
-  'underscore',
   'cocktail',
   'lib/session',
   'views/form',
@@ -14,7 +13,8 @@ define([
   'views/mixins/settings-mixin',
   'stache!templates/settings'
 ],
-function (_, Cocktail, Session, FormView, BaseView, AvatarMixin, SettingsMixin, Template) {
+function (Cocktail, Session, FormView, BaseView, AvatarMixin,
+  SettingsMixin, Template) {
   var t = BaseView.t;
 
   var View = FormView.extend({

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -5,7 +5,7 @@
 'use strict';
 
 define([
-  'underscore',
+  'cocktail',
   'lib/promise',
   'views/base',
   'views/form',
@@ -19,7 +19,7 @@ define([
   'views/decorators/allow_only_one_submit',
   'views/decorators/progress_indicator'
 ],
-function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin,
+function (Cocktail, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin,
       AuthErrors, Validate, ServiceMixin, AvatarMixin, allowOnlyOneSubmit,
       showProgressIndicator) {
   var t = BaseView.t;
@@ -271,9 +271,12 @@ function (_, p, BaseView, FormView, SignInTemplate, Session, PasswordMixin,
     }
   });
 
-  _.extend(View.prototype, PasswordMixin);
-  _.extend(View.prototype, ServiceMixin);
-  _.extend(View.prototype, AvatarMixin);
+  Cocktail.mixin(
+    View,
+    PasswordMixin,
+    ServiceMixin,
+    AvatarMixin
+  );
 
   return View;
 });

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -5,6 +5,7 @@
 'use strict';
 
 define([
+  'cocktail',
   'underscore',
   'lib/promise',
   'views/base',
@@ -16,7 +17,7 @@ define([
   'views/mixins/password-mixin',
   'views/mixins/service-mixin'
 ],
-function (_, p, BaseView, FormView, Template, Session, AuthErrors,
+function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
       Strings, PasswordMixin, ServiceMixin) {
   var t = BaseView.t;
 
@@ -406,8 +407,11 @@ function (_, p, BaseView, FormView, Template, Session, AuthErrors,
     }
   });
 
-  _.extend(View.prototype, PasswordMixin);
-  _.extend(View.prototype, ServiceMixin);
+  Cocktail.mixin(
+    View,
+    PasswordMixin,
+    ServiceMixin
+  );
 
   return View;
 });

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -381,25 +381,22 @@ function (chai, sinon, p, AuthErrors, View, Session, Metrics, EphemeralMessages,
       });
 
       it('debounces resend calls - submit on first and forth attempt', function () {
-        var count = 0;
-
         sinon.stub(fxaClient, 'passwordResetResend', function () {
-          count++;
           return p(true);
         });
 
         return view.validateAndSubmit()
               .then(function () {
-                assert.equal(count, 1);
+                assert.equal(fxaClient.passwordResetResend.callCount, 1);
                 return view.validateAndSubmit();
               }).then(function () {
-                assert.equal(count, 1);
+                assert.equal(fxaClient.passwordResetResend.callCount, 1);
                 return view.validateAndSubmit();
               }).then(function () {
-                assert.equal(count, 1);
+                assert.equal(fxaClient.passwordResetResend.callCount, 1);
                 return view.validateAndSubmit();
               }).then(function () {
-                assert.equal(count, 2);
+                assert.equal(fxaClient.passwordResetResend.callCount, 2);
                 assert.equal(view.$('#resend:visible').length, 0);
 
                 assert.isTrue(TestHelpers.isEventLogged(metrics,


### PR DESCRIPTION
@zaach - could you have a look at this? ~~Do you think there is an easy way to get around the `beforeSubmit` collision issue w/o too much ugliness? I'd like to have "one way to rule them all" if possible.~~

The ResendMixin overrides `beforeSubmit`. If a function name collision exists between a view and a mixin, Cocktail will first call the View's function, then the Mixin's function. This causes unexpected behavior. To get around this, Views that use the ResendMixin set their `beforeSubmit` function to `undefined`.

This is preparation work to extract common functionality/event handlers into mixins.