### PR TITLE
style(signup): reintroduce retina images in the select field after select-row hack

### DIFF
--- a/app/styles/_general.scss
+++ b/app/styles/_general.scss
@@ -508,6 +508,7 @@ label:focus ~ .input-help-focused {
 
 .select-row {
   background: $content-background-color image-url('ddarrow_inactive.png') 96% center no-repeat;
+  background-size: 10px 17px;
   border: 1px solid $input-row-border-color;
   border-radius: $big-border-radius;
   cursor: pointer;
@@ -537,15 +538,15 @@ label:focus ~ .input-help-focused {
       color: $input-text-color;
     }
 
-  &.disabled {
-     background: $content-background-color image-url('ddarrow_inactive.png') 96% center no-repeat;
-     border: 1px solid $input-row-border-color;
-     cursor: default;
+    &.disabled {
+       background: $content-background-color image-url('ddarrow_inactive.png') 96% center no-repeat;
+       border: 1px solid $input-row-border-color;
+       cursor: default;
 
-     select {
-      color: $input-placeholder-color;
-     }
-  }
+       select {
+        color: $input-placeholder-color;
+       }
+    }
   }
 
   select {

--- a/app/styles/_media_queries.scss
+++ b/app/styles/_media_queries.scss
@@ -320,11 +320,17 @@ only screen and (orientation:landscape) and (min-width:481px) and (max-height:48
     background-image: image-url('spinnerwhite@2x.png');
   }
 
-  .input-row select {
+  .input-row select,
+  .select-row,
+  .select-row.disabled:hover {
     background-image: image-url('ddarrow_inactive@2x.png');
   }
 
-  .input-row select:focus {
+  .input-row select:focus,
+  .input-row select:hover,
+  .input-row select:hover:active,
+  .select-row:hover,
+  .select-row.select-focus {
     background-image: image-url('ddarrow_active@2x.png');
   }
 


### PR DESCRIPTION
It looks like a regression was introduced when we began using `.select-row` to workaround
`select` styling issues in FF30. We lost our retina images! No longer.

Fixes #2120.

Before:
![screen shot 2015-02-19 at 1 26 11 pm](https://cloud.githubusercontent.com/assets/3903/6277179/42fab3d4-b841-11e4-915f-cbd6adda7172.png)

After:
![screen shot 2015-02-19 at 2 12 08 pm](https://cloud.githubusercontent.com/assets/3903/6277183/529af4ac-b841-11e4-8ef6-621b34afab95.png)

@vladikoff or @shane-tomlinson r?