### PR TITLE
Create verification info models, views fetch data from models instead of URL.

### DIFF
--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -32,6 +32,7 @@ define([
       return p()
         .then(function () {
           self._isForceAuth = self._isForceAuthUrl();
+          self.importBooleanSearchParam('automatedBrowser');
         });
     },
 
@@ -186,6 +187,13 @@ define([
     _isForceAuthUrl: function () {
       var pathname = this.window.location.pathname;
       return pathname === '/force_auth' || pathname === '/oauth/force_auth';
+    },
+
+    /**
+     * Is the browser being automated? Set to true for selenium tests.
+     */
+    isAutomatedBrowser: function () {
+      return !! this.get('automatedBrowser');
     }
   });
 

--- a/app/scripts/models/verification/account-unlock.js
+++ b/app/scripts/models/verification/account-unlock.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+/**
+ * A model to hold account unlock verification data
+ */
+
+'use strict';
+
+define([
+  './base',
+  'lib/validate'
+], function (VerificationInfo, Validate) {
+
+  return VerificationInfo.extend({
+    defaults: {
+      uid: null,
+      code: null
+    },
+
+    validation: {
+      uid: Validate.isUidValid,
+      code: Validate.isCodeValid
+    }
+  });
+});
+

--- a/app/scripts/models/verification/base.js
+++ b/app/scripts/models/verification/base.js
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A model to hold verification data. Verification data is imported from
+ * the URL's query parameters and is cleaned up to remove whitespace on
+ * initialization.
+ *
+ * Subclasses should override the `defaults` and `validation`
+ * hashes. The `validation` hash contains the same keys as the `defaults`
+ * whose values are validation functions.
+ */
+
+'use strict';
+
+define([
+  'backbone',
+  'underscore'
+], function (Backbone, _) {
+
+  var VerificationInfo = Backbone.Model.extend({
+    initialize: function (options) {
+      Backbone.Model.prototype.initialize.call(this, options);
+
+      // clean up any whitespace that was probably added by an MUA.
+      _.each(this.defaults, function (value, key) {
+        if (this.has(key)) {
+          var cleanedValue = this.get(key).replace(/ /g, '');
+          if (cleanedValue) {
+            this.set(key, cleanedValue);
+          } else {
+            this.unset(key);
+          }
+        }
+      }, this);
+    },
+
+    /**
+     * Check if the model is valid.
+     *
+     * @method isValid
+     * @returns `false` if a `validationError` is set, or if `validate` either throws or returns false. `true` otherwise.
+     */
+    isValid: function () {
+      var isValid;
+
+      if (this.isDamaged()) {
+        return false;
+      }
+
+      try {
+        // super's isValid throws if invalid.
+        isValid = Backbone.Model.prototype.isValid.call(this);
+      } catch (e) {
+        isValid = false;
+      }
+
+      return isValid;
+    },
+
+
+    /**
+     * Validate the data model using the validators defined
+     * in the `validation` hash. Called automatically by
+     * `isValid`.
+     *
+     * @method validate
+     */
+    validate: function (attributes) {
+      _.each(this.validation, function (validator, key) {
+        if (! validator(attributes[key])) {
+          throw new Error('invalid ' + key);
+        }
+      });
+    },
+
+    /**
+     * Mark the verification info as expired.
+     * @method markExpired
+     */
+    markExpired: function () {
+      this._isExpired = true;
+    },
+
+    /**
+     * Check if the verification info is expired
+     *
+     * @method isExpired
+     * @returns {Boolen} `true` if expired, `false` otw.
+     */
+    isExpired: function () {
+      return !! this._isExpired;
+    },
+
+    /**
+     * Mark the verification info as damaged. This will cause `isValid` to
+     * return `false`.
+     * @method markDamaged
+     */
+    markDamaged: function () {
+      this._isDamaged = true;
+    },
+
+    /**
+     * Check if the verification info is damaged
+     *
+     * @method isDamaged
+     * @returns {Boolen} `true` if damaged, `false` otw.
+     */
+    isDamaged: function () {
+      return !! this._isDamaged;
+    }
+  });
+
+  return VerificationInfo;
+});
+

--- a/app/scripts/models/verification/reset-password.js
+++ b/app/scripts/models/verification/reset-password.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A model to hold reset password verification data
+ */
+
+'use strict';
+
+define([
+  './base',
+  'lib/validate'
+], function (VerificationInfo, Validate) {
+
+  return VerificationInfo.extend({
+    defaults: {
+      token: null,
+      code: null,
+      email: null
+    },
+
+    validation: {
+      token: Validate.isTokenValid,
+      code: Validate.isCodeValid,
+      email: Validate.isEmailValid
+    }
+  });
+});
+

--- a/app/scripts/models/verification/sign-up.js
+++ b/app/scripts/models/verification/sign-up.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A model to hold sign up verification data
+ */
+
+'use strict';
+
+define([
+  './base',
+  'lib/validate'
+], function (VerificationInfo, Validate) {
+
+  return VerificationInfo.extend({
+    defaults: {
+      uid: null,
+      code: null
+    },
+
+    validation: {
+      uid: Validate.isUidValid,
+      code: Validate.isCodeValid
+    }
+  });
+});
+

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -11,14 +11,13 @@ define([
   'jquery',
   'lib/promise',
   'lib/auth-errors',
-  'lib/url',
   'lib/strings',
   'lib/ephemeral-messages',
   'lib/null-metrics',
   'views/mixins/timer-mixin'
 ],
 function (Cocktail, _, Backbone, $, p, AuthErrors,
-      Url, Strings, EphemeralMessages, NullMetrics, TimerMixin) {
+      Strings, EphemeralMessages, NullMetrics, TimerMixin) {
   var DEFAULT_TITLE = window.document.title;
   var EPHEMERAL_MESSAGE_ANIMATION_MS = 150;
 
@@ -105,8 +104,6 @@ function (Cocktail, _, Backbone, $, p, AuthErrors,
 
       this.fxaClient = options.fxaClient;
       this._canGoBack = options.canGoBack;
-
-      this.automatedBrowser = !!this.searchParam('automatedBrowser');
 
       Backbone.View.call(this, options);
 
@@ -631,25 +628,6 @@ function (Cocktail, _, Backbone, $, p, AuthErrors,
         }
 
         return handler.apply(this, args);
-      }
-    },
-
-    /**
-     * Fetch a search parameter from this.window.location.search
-     */
-    searchParam: function (itemName) {
-      return Url.searchParam(itemName, this.window.location.search);
-    },
-
-    /**
-     * Import an item from the URL search parameters into the current context
-     */
-    importSearchParam: function (itemName) {
-      this[itemName] = this.searchParam(itemName);
-
-      if (! this[itemName]) {
-        var err = Strings.interpolate(t('missing search parameter: %(itemName)s'), { itemName: itemName });
-        throw new Error(err);
       }
     },
 

--- a/app/scripts/views/complete_account_unlock.js
+++ b/app/scripts/views/complete_account_unlock.js
@@ -6,49 +6,37 @@
 
 define([
   'views/form',
-  'views/base',
   'stache!templates/complete_account_unlock',
   'lib/auth-errors',
-  'lib/validate'
+  'lib/url',
+  'models/verification/account-unlock'
 ],
-function (FormView, BaseView, CompleteAccountUnlockTemplate, AuthErrors,
-    Validate) {
-
-  function isLinkValid(uid, code) {
-    return Validate.isUidValid(uid) && Validate.isCodeValid(code);
-  }
+function (FormView, CompleteAccountUnlockTemplate, AuthErrors,
+    Url, VerificationInfo) {
 
   var CompleteAccountUnlockView = FormView.extend({
     template: CompleteAccountUnlockTemplate,
     className: 'complete_account_unlock',
 
+    initialize: function () {
+      var searchParams = Url.searchParams(this.window.location.search);
+      this._verificationInfo = new VerificationInfo(searchParams);
+    },
+
     beforeRender: function () {
-      try {
-        this.importSearchParam('uid');
-        this.importSearchParam('code');
-      } catch(e) {
-        this._isLinkDamaged = true;
-        this.logError(AuthErrors.toError('DAMAGED_VERIFICATION_LINK'));
-        // This is an invalid link. Abort and show an error message
-        // before doing any more checks.
-        return true;
-      }
-
-      // Remove any spaces that are probably due to a MUA adding
-      // line breaks in the middle of the link.
-      this.uid = this.uid.replace(/ /g, '');
-      this.code = this.code.replace(/ /g, '');
-
-      if (! isLinkValid(this.uid, this.code)) {
+      var self = this;
+      var verificationInfo = self._verificationInfo;
+      if (! verificationInfo.isValid()) {
         // One or more parameters fails validation. Abort and show an
         // error message before doing any more checks.
-        this._isLinkDamaged = true;
-        this.logError(AuthErrors.toError('DAMAGED_VERIFICATION_LINK'));
+        self.logError(AuthErrors.toError('DAMAGED_VERIFICATION_LINK'));
         return true;
       }
 
-      var self = this;
-      return this.fxaClient.completeAccountUnlock(this.uid, this.code)
+      var uid = verificationInfo.get('uid');
+      var code = verificationInfo.get('code');
+
+      return this.fxaClient.completeAccountUnlock(uid, code)
         .then(function () {
           self.logScreenEvent('verification.success');
           self.navigate('account_unlock_complete');
@@ -56,26 +44,30 @@ function (FormView, BaseView, CompleteAccountUnlockTemplate, AuthErrors,
         })
         .fail(function (err) {
           if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
-            self._isLinkExpired = true;
-            self.logError(AuthErrors.toError('EXPIRED_VERIFICATION_LINK'));
-          } else if (AuthErrors.is(err, 'INVALID_VERIFICATION_CODE') ||
+            verificationInfo.markExpired();
+            err = AuthErrors.toError('EXPIRED_VERIFICATION_LINK');
+          } else if (
+              AuthErrors.is(err, 'INVALID_VERIFICATION_CODE') ||
               AuthErrors.is(err, 'INVALID_PARAMETER')) {
-            // These errors show a link damaged screen
-            self._isLinkDamaged = true;
-            self.logError(AuthErrors.toError('DAMAGED_VERIFICATION_LINK'));
+            // These server says the verification code or any parameter is
+            // invalid. The entire link is damaged.
+            verificationInfo.markDamaged();
+            err = AuthErrors.toError('DAMAGED_VERIFICATION_LINK');
           } else {
             // all other errors show the standard error box.
             self._error = self.translateError(err);
           }
+
+          self.logError(err);
           return true;
         });
     },
 
     context: function () {
+      var verificationInfo = this._verificationInfo;
       return {
-        isLinkDamaged: this._isLinkDamaged,
-        isLinkExpired: this._isLinkExpired,
-
+        isLinkDamaged: ! verificationInfo.isValid(),
+        isLinkExpired: verificationInfo.isExpired(),
         error: this._error
       };
     }

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -46,7 +46,7 @@ function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
       self.streaming = false;
 
 
-      if (self.automatedBrowser) {
+      if (self.broker.isAutomatedBrowser()) {
         var ARTIFICIAL_DELAY = 3000; // 3 seconds
         // mock some things out for automated browser testing
         self.streaming = true;
@@ -180,7 +180,7 @@ function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
       var pos = this.centeredPos(w, h, minValue);
 
       var dataSrc = this.video[0];
-      if (this.automatedBrowser) {
+      if (this.broker.isAutomatedBrowser()) {
         dataSrc = new Image();
         dataSrc.src = pngSrc;
       }

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -63,7 +63,7 @@ function ($, _, Cocktail, FormView, AvatarMixin, SettingsMixin, Template,
     filePicker: function () {
       var self = this;
       // skip the file picker if this is an automater browser
-      if (self.automatedBrowser) {
+      if (self.broker.isAutomatedBrowser()) {
         setTimeout(function () {
           require(['draggable', 'touch-punch'], function () {
             var cropImg = new CropperImage();

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -33,7 +33,7 @@ function (p, _, Cocktail, FormView, SettingsMixin, AvatarMixin, Template,
       var data = this.ephemeralData() || {};
       this._cropImg = data.cropImg;
 
-      if (! this._cropImg && this.automatedBrowser) {
+      if (! this._cropImg && this.broker.isAutomatedBrowser()) {
         this._cropImg = new CropperImage();
       }
     },
@@ -71,7 +71,7 @@ function (p, _, Cocktail, FormView, SettingsMixin, AvatarMixin, Template,
       } catch (e) {
         // settings_common functional tests visit this page directly so draggable
         // won't be preloaded. Ignore errors about that– they don't matter.
-        if (this.automatedBrowser && e.message.indexOf('draggable') !== -1) {
+        if (this.broker.isAutomatedBrowser() && e.message.indexOf('draggable') !== -1) {
           return;
         }
 

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -61,7 +61,7 @@ function ($, _, md5, Cocktail, FormView, SettingsMixin, AvatarMixin,
 
     gravatarUrl: function () {
       var hashedEmail = this.hashedEmail();
-      if (this.automatedBrowser) {
+      if (this.broker.isAutomatedBrowser()) {
         // Don't return a 404 so we can test the success flow
         return GRAVATAR_URL + hashedEmail + '?s=' + DISPLAY_LENGTH;
       }

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -96,7 +96,7 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
                   AuthErrors.toError('SIGNUP_EMAIL_BOUNCE'));
       }
 
-      if (this.automatedBrowser) {
+      if (this.broker.isAutomatedBrowser()) {
         // helps avoid 'focus' issues with Firefox Selenium Driver
         // See https://code.google.com/p/selenium/issues/detail?id=157
         this.$el.find('input[type=password]').click(function () {

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -99,6 +99,20 @@ function (chai, sinon, Relier, BaseAuthenticationBroker, BaseView, WindowMock) {
           });
       });
     });
+
+    describe('isAutomatedBrowser', function () {
+      it('returns `false` by default', function () {
+        assert.isFalse(broker.isAutomatedBrowser());
+      });
+
+      it('returns `true` if the URL contains `isAutomatedBrowser=true`', function () {
+        windowMock.location.search = '?automatedBrowser=true';
+        return broker.fetch()
+          .then(function () {
+            assert.isTrue(broker.isAutomatedBrowser());
+          });
+      });
+    });
   });
 });
 

--- a/app/tests/spec/models/verification/base.js
+++ b/app/tests/spec/models/verification/base.js
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'chai',
+  'sinon',
+  'models/verification/base'
+], function (chai, sinon, BaseModel) {
+  var assert = chai.assert;
+
+  var Model = BaseModel.extend({
+    defaults: {
+      uid: null,
+      code: null
+    },
+
+    validate: function (attributes) {
+      if (attributes.uid === null || attributes.code === null) {
+        throw new Error('invalid');
+      }
+    }
+  });
+
+  describe('models/verification/base', function () {
+    describe('initialization cleanup', function () {
+      it('removes whitespace in values', function () {
+        var model = new Model({
+          uid: 'dead beef ',
+          code: ' fad fade'
+        });
+
+        assert.equal(model.get('uid'), 'deadbeef');
+        assert.equal(model.get('code'), 'fadfade');
+      });
+
+      it('removes empty values', function () {
+        var model = new Model({
+          uid: '  ',
+          code: ''
+        });
+
+        assert.isFalse(model.has('uid'));
+        assert.isFalse(model.has('code'));
+      });
+    });
+
+
+    describe('isValid', function () {
+      it('returns false if model is marked as damaged', function () {
+        var model = new Model({
+          uid: 'hi',
+          code: 'ho'
+        });
+        model.markDamaged();
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns false if `validate` explodes', function () {
+        var model = new Model({
+          uid: 'hi',
+          code: null
+        });
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns true otherwise', function () {
+        var model = new Model({
+          uid: 'hi',
+          code: 'ho'
+        });
+        assert.isTrue(model.isValid());
+      });
+    });
+
+    describe('markExpired/isExpired', function () {
+      it('marks the link as expired', function () {
+        var model = new Model({
+          uid: 'hi',
+          code: 'ho'
+        });
+
+        assert.isFalse(model.isExpired());
+        model.markExpired();
+        assert.isTrue(model.isExpired());
+      });
+    });
+
+    describe('markDamaged/isDamaged', function () {
+      it('marks the link as damaged', function () {
+        var model = new Model({
+          uid: 'hi',
+          code: 'ho'
+        });
+
+        assert.isFalse(model.isDamaged());
+        model.markDamaged();
+        assert.isTrue(model.isDamaged());
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/models/verification/reset-password.js
+++ b/app/tests/spec/models/verification/reset-password.js
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'chai',
+  'sinon',
+  'lib/constants',
+  'models/verification/reset-password',
+  '../../../lib/helpers'
+], function (chai, sinon, Constants, Model, TestHelpers) {
+  var assert = chai.assert;
+
+  describe('models/verification/reset-password', function () {
+    var invalidCode = TestHelpers.createRandomHexString(Constants.CODE_LENGTH + 1);
+    var validCode = TestHelpers.createRandomHexString(Constants.CODE_LENGTH);
+    var invalidToken = TestHelpers.createRandomHexString(Constants.UID_LENGTH + 1);
+    var validToken = TestHelpers.createRandomHexString(Constants.UID_LENGTH);
+    var validEmail = 'testuser@testuser.com';
+    var invalidEmail = 'invalid';
+
+    describe('isValid', function () {
+      it('returns false if token is missing', function () {
+        var model = new Model({
+          code: validCode,
+          email: validEmail
+        });
+
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns false if token is invalid', function () {
+        var model = new Model({
+          token: invalidToken,
+          code: validCode,
+          email: validEmail
+        });
+
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns false if code is missing', function () {
+        var model = new Model({
+          token: validToken,
+          email: validEmail
+        });
+
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns false if code is invalid', function () {
+        var model = new Model({
+          token: validToken,
+          code: invalidCode,
+          email: validEmail
+        });
+
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns false if email is missing', function () {
+        var model = new Model({
+          token: validToken,
+          code: validCode
+        });
+
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns false if email is invalid', function () {
+        var model = new Model({
+          token: validToken,
+          code: validCode,
+          email: invalidEmail
+        });
+
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns true otherwise', function () {
+        var model = new Model({
+          token: validToken,
+          code: validCode,
+          email: validEmail
+        });
+
+        assert.isTrue(model.isValid());
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/models/verification/sign-up.js
+++ b/app/tests/spec/models/verification/sign-up.js
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'chai',
+  'sinon',
+  'lib/constants',
+  'models/verification/sign-up',
+  '../../../lib/helpers'
+], function (chai, sinon, Constants, Model, TestHelpers) {
+  var assert = chai.assert;
+
+  describe('models/verification/sign-up', function () {
+    var invalidCode = TestHelpers.createRandomHexString(Constants.CODE_LENGTH + 1);
+    var validCode = TestHelpers.createRandomHexString(Constants.CODE_LENGTH);
+    var invalidUid = TestHelpers.createRandomHexString(Constants.UID_LENGTH + 1);
+    var validUid = TestHelpers.createRandomHexString(Constants.UID_LENGTH);
+
+    describe('isValid', function () {
+      it('returns false if uid is missing', function () {
+        var model = new Model({
+          code: validCode
+        });
+
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns false if uid is invalid', function () {
+        var model = new Model({
+          uid: invalidUid,
+          code: validCode
+        });
+
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns false if code is missing', function () {
+        var model = new Model({
+          uid: validUid
+        });
+
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns false if code is invalid', function () {
+        var model = new Model({
+          uid: validUid,
+          code: invalidCode
+        });
+
+        assert.isFalse(model.isValid());
+      });
+
+      it('returns true otherwise', function () {
+        var model = new Model({
+          uid: validUid,
+          code: validCode
+        });
+
+        assert.isTrue(model.isValid());
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -496,39 +496,6 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
       });
     });
 
-    describe('searchParam', function () {
-      it('gets an item from the url\'s search parameters, if available', function () {
-        windowMock.location.search = '?item=value';
-
-        var value = view.searchParam('item');
-        assert.equal(value, 'value');
-      });
-
-      it('returns `undefined` if search parameter is not available', function () {
-        var value = view.searchParam('non-existent');
-        assert.isUndefined(value);
-      });
-    });
-
-    describe('importSearchParam', function () {
-      it('imports an item from the url\'s search parameters, if available', function () {
-        windowMock.location.search = '?item=value';
-
-        view.importSearchParam('item');
-        assert.equal(view.item, 'value');
-      });
-
-      it('throws an error if search parameter is not available', function () {
-        var err;
-        try {
-          view.importSearchParam('non-existent');
-        } catch(e) {
-          err = e;
-        }
-        assert.ok(err);
-      });
-    });
-
     describe('logEvent', function () {
       it('logs an event to the event stream', function () {
         view.logEvent('event1');

--- a/app/tests/spec/views/settings/avatar_camera.js
+++ b/app/tests/spec/views/settings/avatar_camera.js
@@ -17,10 +17,11 @@ define([
   '../../../mocks/profile',
   'models/user',
   'models/reliers/relier',
+  'models/auth_brokers/base',
   'lib/promise'
 ],
 function (chai, _, $, sinon, View, RouterMock, WindowMock, CanvasMock,
-    ProfileMock, User, Relier, p) {
+    ProfileMock, User, Relier, AuthBroker, p) {
   var assert = chai.assert;
 
   describe('views/settings/avatar/camera', function () {
@@ -31,18 +32,23 @@ function (chai, _, $, sinon, View, RouterMock, WindowMock, CanvasMock,
     var user;
     var account;
     var relier;
+    var broker;
 
     beforeEach(function () {
       routerMock = new RouterMock();
       windowMock = new WindowMock();
       user = new User();
       relier = new Relier();
+      broker = new AuthBroker({
+        relier: relier
+      });
 
       view = new View({
         router: routerMock,
         user: user,
         window: windowMock,
-        relier: relier
+        relier: relier,
+        broker: broker
       });
 
       account = user.initAccount({
@@ -144,6 +150,7 @@ function (chai, _, $, sinon, View, RouterMock, WindowMock, CanvasMock,
           user: user,
           window: windowMock,
           relier: relier,
+          broker: broker,
           displayLength: 240,
           exportLength: 600
         });

--- a/app/tests/spec/views/settings/avatar_crop.js
+++ b/app/tests/spec/views/settings/avatar_crop.js
@@ -17,13 +17,15 @@ define([
   'models/user',
   'models/cropper-image',
   'models/reliers/relier',
+  'models/auth_brokers/base',
   'lib/promise',
   'lib/constants',
   'lib/ephemeral-messages',
   'lib/auth-errors'
 ],
-function (chai, _, $, ui, sinon, View, RouterMock, ProfileMock, User, CropperImage,
-    Relier, p, Constants, EphemeralMessages, AuthErrors) {
+function (chai, _, $, ui, sinon, View, RouterMock, ProfileMock, User,
+    CropperImage, Relier, AuthBroker, p, Constants, EphemeralMessages,
+    AuthErrors) {
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
 
@@ -35,18 +37,23 @@ function (chai, _, $, ui, sinon, View, RouterMock, ProfileMock, User, CropperIma
     var user;
     var account;
     var relier;
+    var broker;
 
     beforeEach(function () {
       routerMock = new RouterMock();
       user = new User();
       ephemeralMessages = new EphemeralMessages();
       relier = new Relier();
+      broker = new AuthBroker({
+        relier: relier
+      });
 
       view = new View({
         user: user,
         ephemeralMessages: ephemeralMessages,
         router: routerMock,
-        relier: relier
+        relier: relier,
+        broker: broker
       });
     });
 

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -97,7 +97,10 @@ function (Translator, Session) {
     '../tests/spec/models/auth_brokers/web-channel',
     '../tests/spec/models/auth_brokers/redirect',
     '../tests/spec/models/auth_brokers/oauth',
-    '../tests/spec/models/auth_brokers/iframe'
+    '../tests/spec/models/auth_brokers/iframe',
+    '../tests/spec/models/verification/base',
+    '../tests/spec/models/verification/sign-up',
+    '../tests/spec/models/verification/reset-password'
   ];
 
   /*global mocha */

--- a/tests/functional/complete_sign_up.js
+++ b/tests/functional/complete_sign_up.js
@@ -68,7 +68,10 @@ define([
         // a successful user is immediately redirected to the
         // sign-up-complete page.
         .findById('fxa-verification-link-damaged-header')
-        .end();
+        .end()
+
+        .then(FunctionalHelpers.noSuchElement(this, '#fxa-verification-link-expired-header'));
+
     },
 
     'open verification link with server reported bad code': function () {
@@ -151,22 +154,18 @@ define([
     'open expired email verification link': function () {
       var url = PAGE_URL_ROOT + '?uid=' + uid + '&code=' + code;
 
-      return this.get('remote')
+      var self = this;
+      return self.get('remote')
         .get(require.toUrl(url))
 
         .findById('fxa-verification-link-expired-header')
         .end()
 
+        .then(FunctionalHelpers.noSuchElement(self, '#fxa-verification-link-damaged-header'))
+
         // Give resend time to show up
         .setFindTimeout(200)
-        .findById('resend')
-        .then(function () {
-          assert.fail('resend link should not be present');
-        }, function (err) {
-          assert.strictEqual(err.name, 'NoSuchElement');
-          return true;
-        })
-        .end();
+        .then(FunctionalHelpers.noSuchElement(self, '#resend'));
     }
   });
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -180,6 +180,28 @@ define([
     }, [ selector ], timeout);
   }
 
+  function noSuchElement(context, selector) {
+    return function () {
+      return context.get('remote')
+        .setFindTimeout(0)
+
+        .findByCssSelector(selector)
+          .then(function () {
+            throw new Error(selector + ' should not be present');
+          }, function (err) {
+            if (/NoSuchElement/.test(String(err))) {
+              // swallow the error
+              return;
+            }
+
+            throw err;
+          })
+        .end()
+
+        .setFindTimeout(config.pageLoadTimeout);
+    };
+  }
+
   function getVerificationLink(user, index) {
     if (/@/.test(user)) {
       user = TestHelpers.emailToUser(user);
@@ -494,6 +516,7 @@ define([
     clearBrowserState: clearBrowserState,
     clearSessionStorage: clearSessionStorage,
     visibleByQSA: visibleByQSA,
+    noSuchElement: noSuchElement,
     pollUntil: pollUntil,
     getVerificationLink: getVerificationLink,
     getVerificationHeaders: getVerificationHeaders,

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -270,7 +270,9 @@ define([
           var malformedToken = createRandomHexString(token.length - 1);
           return openCompleteResetPassword(self, email, malformedToken, code)
             .findById('fxa-reset-link-damaged-header')
-            .end();
+            .end()
+
+            .then(FunctionalHelpers.noSuchElement(self, '#fxa-reset-link-expired-header'));
         });
     },
 
@@ -281,7 +283,9 @@ define([
           var invalidToken = createRandomHexString(token.length);
           return openCompleteResetPassword(self, email, invalidToken, code)
             .findById('fxa-reset-link-expired-header')
-            .end();
+            .end()
+
+            .then(FunctionalHelpers.noSuchElement(self, '#fxa-reset-link-damaged-header'));
         });
     },
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -402,7 +402,7 @@ define([
       var CORRECTED_EMAIL = 'something@gmail.com';
 
       return this.get('remote')
-        .get(require.toUrl(PAGE_URL + '?mailcheck=1&automatedBrowser=1'))
+        .get(require.toUrl(PAGE_URL + '?mailcheck=1&automatedBrowser=true'))
         .findByCssSelector('input[type=email]')
         .type(BAD_EMAIL)
         .click()


### PR DESCRIPTION
Builds on #2124 and should be reviewed afterwards.

Made of 2 commits:
>  refactor(client): Extract email verification info into their own models.
>
> * Add models/verification/* with base, reset-password and sign-up.
> * Each model knows how to validate its data.
> * Data validation removed from the individual views.
>
> issue #2026

and

> Import "automatedBrowser" from the relier instead of from the search parameters.
>
> With this PR, views no longer directly import data from the URL! Woot!
>
> fixes #2026

@zaach and @vladikoff - could you check this PR out?