### PR TITLE
cleanup(styles): Remove all references to `.input-row select`.

### DIFF
--- a/app/styles/_general.scss
+++ b/app/styles/_general.scss
@@ -375,18 +375,12 @@ html[dir='rtl'] {
   }
 
   button,
-  input,
-  select {
+  input {
     @include font();
   }
 
   input[type='email'],
   input[type='text'] {
-  }
-
-  select {
-    @include formElement();
-    padding: 0 $input-left-right-padding;
   }
 
   input::-webkit-input-placeholder,
@@ -396,47 +390,7 @@ html[dir='rtl'] {
     color: $input-placeholder-color;
   }
 
-  select {
-    // autoprefixer does not handle appearance, see https://github.com/ai/autoprefixer/issues/205
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    appearance: none;
-    background: $content-background-color image-url('ddarrow_inactive.png') 96% center;
-    background-repeat: no-repeat;
-    background-size: 10px 17px;
-    color: $input-placeholder-color;
-    height: auto;
-    outline: none;
-    padding: 10px $input-left-right-padding;
-    // Some hackery for Firefox since moz-appearance: none doesn't remove the arrow
-    text-indent: 0.01px;
-    text-overflow: '';
-    user-select: none;
-    width: 100%;
-
-    &:hover,
-    &:hover:active,
-    &:focus {
-      background-color: $html-background-color;
-      background-image: image-url('ddarrow_active.png');
-      transition-duration: $short-transition;
-      transition-property: all;
-    }
-
-    /**
-     * Firefox show a focus ring around the selected text.
-     * See issue https://github.com/mozilla/fxa-content-server/issues/459
-     * and the solution at:
-     * http://stackoverflow.com/questions/19468372/how-to-remove-dashed-border-of-select-box-in-firefox#answer-19468615
-     */
-    &:-moz-focusring {
-      color: transparent !important; /* !important must be added or else the browser ignores the request */
-      text-shadow: 0 0 0 $input-row-hover-border-color !important;
-    }
-  }
-
-  input:focus,
-  select:focus {
+  input:focus {
     border-color: $input-row-focus-border-color;
     transition-duration: $short-transition;
     transition-property: border-color;
@@ -447,17 +401,13 @@ html[dir='rtl'] {
   }
 
   input:hover,
-  select:hover,
-  &:hover input:hover,
-  &:hover select:hover {
+  &:hover input:hover {
     border-color: $input-row-hover-border-color;
     outline: none;
   }
 
   input:focus,
-  select:focus,
   &:hover input:focus,
-  &:hover select:focus,
   &:focus input {
     border-color: $input-row-focus-border-color;
     color: $text-color;
@@ -468,8 +418,7 @@ html[dir='rtl'] {
   input[type='email'].invalid,
   input[type='password'].invalid,
   input[type='text'].invalid ~ .show-password-label,
-  input[type='password'].invalid ~ .show-password-label,
-  select.invalid {
+  input[type='password'].invalid ~ .show-password-label {
     border-color: $error-background-color;
   }
 
@@ -648,10 +597,6 @@ button::-moz-focus-inner {
 }
 
 /* Custom rows */
-.input-row-month-day select {
-  width: 45%;
-}
-
 .description {
   font-size: $medium-font;
 }

--- a/app/styles/_media_queries.scss
+++ b/app/styles/_media_queries.scss
@@ -56,8 +56,7 @@ only screen and (orientation:landscape) and (min-width:481px) and (max-height:48
   html[dir='rtl'] {
     .input-row input[type='text'],
     .input-row input[type='email'],
-    .input-row input[type='password'],
-    .input-row select {
+    .input-row input[type='password'] {
       border-radius: $small-border-radius;
       font-size: $base-font + $media-adjustment;
       height: 40px;
@@ -320,15 +319,11 @@ only screen and (orientation:landscape) and (min-width:481px) and (max-height:48
     background-image: image-url('spinnerwhite@2x.png');
   }
 
-  .input-row select,
   .select-row,
   .select-row.disabled:hover {
     background-image: image-url('ddarrow_inactive@2x.png');
   }
 
-  .input-row select:focus,
-  .input-row select:hover,
-  .input-row select:hover:active,
   .select-row:hover,
   .select-row.select-focus {
     background-image: image-url('ddarrow_active@2x.png');


### PR DESCRIPTION
@zaach - could you review this? This is follow on for the arrow PR (#2121)

`.input-row select` was replaced by `.select-row select`.

fixes #2126 