### PR TITLE
feat(client): Pass along a `service` and `reason` whenever signing a user in.

### DIFF
--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -63,9 +63,15 @@ function (Cocktail, BaseView, FormView, AuthErrors, Template, PasswordMixin,
             // prevents sync users from seeing the `sign out` button on the
             // settings screen.
 
-            return self.fxaClient.signIn(email, newPassword, self.relier, {
-              sessionTokenContext: account.get('sessionTokenContext')
-            });
+            return self.fxaClient.signIn(
+              email,
+              newPassword,
+              self.relier,
+              {
+                reason: self.fxaClient.SIGNIN_REASON.PASSWORD_CHANGE,
+                sessionTokenContext: account.get('sessionTokenContext')
+              }
+            );
           })
           .then(function (updatedSessionData) {
             account.set(updatedSessionData);

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -109,7 +109,14 @@ function (Cocktail, BaseView, FormView, Template, PasswordMixin,
       // from localStorage and go to town.
       return self.fxaClient.completePasswordReset(email, password, token, code)
         .then(function () {
-          return self.fxaClient.signIn(email, password, self.relier);
+          return self.fxaClient.signIn(
+            email,
+            password,
+            self.relier,
+            {
+              reason: self.fxaClient.SIGNIN_REASON.PASSWORD_RESET
+            }
+          );
         }).then(function (accountData) {
           var account = self.user.initAccount(accountData);
           self._interTabChannel.send('login', accountData);

--- a/app/scripts/views/confirm_account_unlock.js
+++ b/app/scripts/views/confirm_account_unlock.js
@@ -132,8 +132,15 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
       // the sign in will successfully complete. If they have not verified
       // their address, the sign in call will fail with the ACCOUNT_LOCKED
       // error, and we poll again.
-      return self.fxaClient.signIn(email, password, self.relier)
-        .then(null, function (err) {
+      return self.fxaClient.signIn(
+          email,
+          password,
+          self.relier,
+          {
+            reason: self.fxaClient.SIGNIN_REASON.ACCOUNT_UNLOCK
+          }
+        )
+        .fail(function (err) {
           if (AuthErrors.is(err, 'ACCOUNT_LOCKED')) {
             // user has not yet verified, poll again.
             var deferred = p.defer();

--- a/app/tests/spec/views/change_password.js
+++ b/app/tests/spec/views/change_password.js
@@ -222,7 +222,14 @@ function (chai, _, $, sinon, AuthErrors, FxaClient, Metrics, p,
               assert.isTrue(view.fxaClient.changePassword.calledWith(
                   EMAIL, oldPassword, newPassword));
               assert.isTrue(view.fxaClient.signIn.calledWith(
-                      EMAIL, newPassword, relier));
+                  EMAIL,
+                  newPassword,
+                  relier,
+                  {
+                    reason: view.fxaClient.SIGNIN_REASON.PASSWORD_CHANGE,
+                    sessionTokenContext: account.get('sessionTokenContext')
+                  }
+              ));
               assert.isTrue(user.setSignedInAccount.calledWith(account));
               assert.isTrue(broker.afterChangePassword.calledWith(account));
             });
@@ -254,8 +261,14 @@ function (chai, _, $, sinon, AuthErrors, FxaClient, Metrics, p,
           return view.submit()
               .then(function () {
                 assert.isTrue(view.fxaClient.signIn.calledWith(
-                    EMAIL, 'new_password', relier,
-                    { sessionTokenContext: 'foo' }));
+                    EMAIL,
+                    'new_password',
+                    relier,
+                    {
+                      reason: view.fxaClient.SIGNIN_REASON.PASSWORD_CHANGE,
+                      sessionTokenContext: 'foo'
+                    }
+                ));
                 assert.isTrue(user.setSignedInAccount.calledWith(account));
               });
         });

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -299,7 +299,13 @@ function (chai, sinon, p, AuthErrors, Metrics, FxaClient, InterTabChannel,
               assert.isTrue(fxaClient.completePasswordReset.calledWith(
                   EMAIL, PASSWORD, TOKEN, CODE));
               assert.isTrue(fxaClient.signIn.calledWith(
-                  EMAIL, PASSWORD, relier));
+                  EMAIL,
+                  PASSWORD,
+                  relier,
+                  {
+                    reason: view.fxaClient.SIGNIN_REASON.PASSWORD_RESET
+                  }
+              ));
               assert.equal(routerMock.page, 'reset_password_complete');
               assert.isTrue(broker.afterCompleteResetPassword.calledWith(account));
               assert.isTrue(loginSpy.called);
@@ -356,7 +362,13 @@ function (chai, sinon, p, AuthErrors, Metrics, FxaClient, InterTabChannel,
               assert.isTrue(fxaClient.completePasswordReset.calledWith(
                   EMAIL, PASSWORD, TOKEN, CODE));
               assert.isTrue(fxaClient.signIn.calledWith(
-                  EMAIL, PASSWORD, relier));
+                  EMAIL,
+                  PASSWORD,
+                  relier,
+                  {
+                    reason: view.fxaClient.SIGNIN_REASON.PASSWORD_RESET
+                  }
+              ));
               assert.notEqual(routerMock.page, 'reset_password_complete');
               assert.isTrue(broker.afterCompleteResetPassword.calledWith(account));
             });


### PR DESCRIPTION
feat(client): Pass along a `service` and `reason` whenever signing a user in.

Used for account notifications - if the user adds a new sync device, an email notification is sent.

`reason` can be one of:
* `signin`
* `password_check`
* `password_change`
* `password_reset`
* `account_unlock`

Used for account notifications - if the user adds a new sync device, an email notification is sent.

fixes #2128
fixes #2434

Link to:
https://github.com/mozilla/fxa-auth-mailer/pull/26
https://github.com/mozilla/fxa-js-client/pull/146
https://github.com/mozilla/fxa-auth-server/pull/876