### PR TITLE
allow able control feature flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ locale/*/*/*.po
 
 ### Source maps
 *.map
+
+### Experiments
+experiments

--- a/app/scripts/lib/able.js
+++ b/app/scripts/lib/able.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* global able:true */
+
+'use strict';
+
+if (typeof able === 'undefined') {
+  window.able = {
+    subject: {},
+    choose: function () {},
+    report: function () { return []; }
+  };
+}

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -14,6 +14,8 @@
  * but can also be sent by calling metrics.flush();
  */
 
+ /* global able */
+
 define([
   'underscore',
   'backbone',
@@ -44,7 +46,8 @@ define([
     'referrer',
     'screen',
     'service',
-    'timers'
+    'timers',
+    'ab'
   ];
 
   var TEN_MINS_MS = 10 * 60 * 1000;
@@ -147,6 +150,7 @@ define([
       var unloadData = this._speedTrap.getUnload();
 
       var allData = _.extend({}, loadData, unloadData, {
+        ab: able.report(),
         context: this._context,
         service: this._service,
         lang: this._lang,

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -5,7 +5,8 @@
 'use strict';
 
 require([
-  './require_config'
+  './require_config',
+  './lib/able'
 ],
 function () {
   // Ensure config is loaded before trying to load any other scripts.

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/* global able */
+
 'use strict';
 
 define([
@@ -56,9 +58,8 @@ function (Cocktail, Session, FormView, BaseView, AvatarMixin,
     _isAvatarLinkVisible: function (email) {
       // For automated testing accounts, emails begin with "avatarAB-" and end with "restmail.net"
       var isTestAccount = /^avatarAB-.+@restmail\.net$/.test(email);
-      var isMozillaAccount = /@mozilla\.(?:com|org)$/.test(email);
 
-      return isTestAccount || isMozillaAccount;
+      return isTestAccount || able.choose('avatarLinkVisible', { email: email });
     },
 
     afterVisible: function () {

--- a/app/tests/spec/lib/able.js
+++ b/app/tests/spec/lib/able.js
@@ -57,7 +57,7 @@ function (chai, sinon, Able) {
       it('defers to window.able.report if available', function () {
         window.able = {
           report: function () {
-            return ['value']
+            return ['value'];
           }
         };
 

--- a/grunttasks/l10n-generate-pages.js
+++ b/grunttasks/l10n-generate-pages.js
@@ -92,7 +92,6 @@ module.exports = function (grunt) {
     var locale = i18n.localeFrom(language);
     var destRoot = path.join(templateDest, locale);
     var context = i18n.localizationContext(language);
-
     grunt.file.recurse(templateSrc,
                     function (srcPath, rootDir, subDir, fileName) {
                       var destPath = path.join(destRoot, (subDir || ''), fileName);

--- a/grunttasks/l10n-generate-pages.js
+++ b/grunttasks/l10n-generate-pages.js
@@ -92,6 +92,7 @@ module.exports = function (grunt) {
     var locale = i18n.localeFrom(language);
     var destRoot = path.join(templateDest, locale);
     var context = i18n.localizationContext(language);
+
     grunt.file.recurse(templateSrc,
                     function (srcPath, rootDir, subDir, fileName) {
                       var destPath = path.join(destRoot, (subDir || ''), fileName);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,232 +1,232 @@
 {
   "name": "fxa-content-server",
-  "version": "0.27.0",
+  "version": "0.32.0",
   "dependencies": {
     "bluebird": {
       "version": "2.2.2",
-      "from": "bluebird@2.2.2",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz"
     },
     "bower": {
       "version": "1.3.9",
-      "from": "bower@1.3.9",
+      "from": "https://registry.npmjs.org/bower/-/bower-1.3.9.tgz",
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.9.tgz",
       "dependencies": {
         "abbrev": {
           "version": "1.0.5",
-          "from": "abbrev@~1.0.4",
+          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
         },
         "archy": {
           "version": "0.0.2",
-          "from": "archy@0.0.2",
+          "from": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz"
         },
         "bower-config": {
           "version": "0.5.2",
-          "from": "bower-config@~0.5.2",
+          "from": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
           "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@~2.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "optimist": {
               "version": "0.6.1",
-              "from": "optimist@~0.6.0",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@~0.0.2",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@~0.0.1",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.0.3",
-              "from": "osenv@0.0.3",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
             }
           }
         },
         "bower-endpoint-parser": {
           "version": "0.2.2",
-          "from": "bower-endpoint-parser@~0.2.2",
+          "from": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
         },
         "bower-json": {
           "version": "0.4.0",
-          "from": "bower-json@~0.4.0",
+          "from": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
           "dependencies": {
             "deep-extend": {
               "version": "0.2.11",
-              "from": "deep-extend@~0.2.5",
+              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@~2.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "intersect": {
               "version": "0.0.3",
-              "from": "intersect@~0.0.3",
+              "from": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
             }
           }
         },
         "bower-logger": {
           "version": "0.2.2",
-          "from": "bower-logger@~0.2.2",
+          "from": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
         },
         "bower-registry-client": {
           "version": "0.2.1",
-          "from": "bower-registry-client@~0.2.0",
+          "from": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.1.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.8",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@~2.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "lru-cache": {
               "version": "2.3.1",
-              "from": "lru-cache@~2.3.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
             },
             "request": {
               "version": "2.27.0",
-              "from": "request@~2.27.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
               "dependencies": {
                 "qs": {
                   "version": "0.6.6",
-                  "from": "qs@~0.6.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.3.0",
-                  "from": "tunnel-agent@~0.3.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.0",
-                  "from": "http-signature@~0.10.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.2",
-                      "from": "assert-plus@0.1.2",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.2",
-                      "from": "ctype@0.5.2",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
                     }
                   }
                 },
                 "hawk": {
                   "version": "1.0.0",
-                  "from": "hawk@~1.0.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@0.9.x",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@0.4.x",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@0.2.x",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@0.2.x",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign": {
                   "version": "0.3.0",
-                  "from": "aws-sign@~0.3.0",
+                  "from": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.3.0",
-                  "from": "oauth-sign@~0.3.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
                 },
                 "cookie-jar": {
                   "version": "0.3.0",
-                  "from": "cookie-jar@~0.3.0",
+                  "from": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "node-uuid@~1.4.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@~1.2.9",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "form-data": {
                   "version": "0.1.4",
-                  "from": "form-data@~0.1.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@~0.0.4",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     },
                     "async": {
                       "version": "0.9.0",
-                      "from": "async@~0.9.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                     }
                   }
@@ -235,237 +235,237 @@
             },
             "request-replay": {
               "version": "0.2.0",
-              "from": "request-replay@~0.2.0",
+              "from": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@0.3.x",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             }
           }
         },
         "cardinal": {
           "version": "0.4.4",
-          "from": "cardinal@~0.4.0",
+          "from": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
           "dependencies": {
             "redeyed": {
               "version": "0.4.4",
-              "from": "redeyed@~0.4.0",
+              "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
               "dependencies": {
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@~1.0.4",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
             },
             "ansicolors": {
               "version": "0.2.1",
-              "from": "ansicolors@~0.2.1",
+              "from": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
             }
           }
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "chmodr": {
           "version": "0.1.0",
-          "from": "chmodr@~0.1.0",
+          "from": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
         },
         "decompress-zip": {
           "version": "0.0.6",
-          "from": "decompress-zip@0.0.6",
+          "from": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.6.tgz",
           "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.6.tgz",
           "dependencies": {
             "mkpath": {
               "version": "0.1.0",
-              "from": "mkpath@~0.1.0",
+              "from": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
             },
             "binary": {
               "version": "0.3.0",
-              "from": "binary@~0.3.0",
+              "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
               "dependencies": {
                 "chainsaw": {
                   "version": "0.1.0",
-                  "from": "chainsaw@~0.1.0",
+                  "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.3.9",
-                      "from": "traverse@>=0.3.0 <0.4",
+                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                     }
                   }
                 },
                 "buffers": {
                   "version": "0.1.1",
-                  "from": "buffers@~0.1.1",
+                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                 }
               }
             },
             "touch": {
               "version": "0.0.2",
-              "from": "touch@0.0.2",
+              "from": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "1.0.10",
-                  "from": "nopt@~1.0.10",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@~1.1.8",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "nopt": {
               "version": "2.2.1",
-              "from": "nopt@~2.2.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz"
             }
           }
         },
         "fstream": {
           "version": "0.1.31",
-          "from": "fstream@~0.1.22",
+          "from": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "fstream-ignore": {
           "version": "0.0.6",
-          "from": "fstream-ignore@0.0.6",
+          "from": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.6.tgz",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.6.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@~0.2.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@~1.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "glob": {
           "version": "4.0.6",
-          "from": "glob@~4.0.0",
+          "from": "glob@>=4.0.0 <4.1.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@^1.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.1",
-              "from": "once@^1.3.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -474,93 +474,93 @@
         },
         "graceful-fs": {
           "version": "3.0.5",
-          "from": "graceful-fs@^3.0.1",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
         },
         "inquirer": {
           "version": "0.5.1",
-          "from": "inquirer@~0.5.1",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.5.1.tgz",
           "dependencies": {
             "async": {
               "version": "0.8.0",
-              "from": "async@~0.8.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.8.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz"
             },
             "cli-color": {
               "version": "0.3.2",
-              "from": "cli-color@~0.3.2",
+              "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
               "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "d@~0.1.1",
+                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.4",
-                  "from": "es5-ext@~0.10.2",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.4.tgz",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.4.tgz",
                   "dependencies": {
                     "es6-iterator": {
                       "version": "0.1.2",
-                      "from": "es6-iterator@~0.1.1",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
                     },
                     "es6-symbol": {
                       "version": "0.1.1",
-                      "from": "es6-symbol@0.1.x",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                     }
                   }
                 },
                 "memoizee": {
                   "version": "0.3.8",
-                  "from": "memoizee@0.3.x",
+                  "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
                   "dependencies": {
                     "es6-weak-map": {
                       "version": "0.1.2",
-                      "from": "es6-weak-map@~0.1.2",
+                      "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
                       "dependencies": {
                         "es6-iterator": {
                           "version": "0.1.2",
-                          "from": "es6-iterator@~0.1.1",
+                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
                         },
                         "es6-symbol": {
                           "version": "0.1.1",
-                          "from": "es6-symbol@0.1.x",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                         }
                       }
                     },
                     "event-emitter": {
                       "version": "0.3.1",
-                      "from": "event-emitter@~0.3.1",
+                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.1.tgz"
                     },
                     "lru-queue": {
                       "version": "0.1.0",
-                      "from": "lru-queue@0.1",
+                      "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                     },
                     "next-tick": {
                       "version": "0.2.2",
-                      "from": "next-tick@~0.2.2",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                     }
                   }
                 },
                 "timers-ext": {
                   "version": "0.1.0",
-                  "from": "timers-ext@0.1.x",
+                  "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                   "dependencies": {
                     "next-tick": {
                       "version": "0.2.2",
-                      "from": "next-tick@~0.2.2",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                     }
                   }
@@ -569,42 +569,42 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "mute-stream": {
               "version": "0.0.4",
-              "from": "mute-stream@~0.0.4",
+              "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
             },
             "readline2": {
               "version": "0.1.0",
-              "from": "readline2@~0.1.0",
+              "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.0.tgz"
             },
             "through": {
               "version": "2.3.6",
-              "from": "through@~2.3.4",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
             },
             "chalk": {
               "version": "0.4.0",
-              "from": "chalk@~0.4.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
               "dependencies": {
                 "has-color": {
                   "version": "0.1.7",
-                  "from": "has-color@~0.1.0",
+                  "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                 },
                 "ansi-styles": {
                   "version": "1.0.0",
-                  "from": "ansi-styles@~1.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                 },
                 "strip-ansi": {
                   "version": "0.1.1",
-                  "from": "strip-ansi@~0.1.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                 }
               }
@@ -613,139 +613,139 @@
         },
         "insight": {
           "version": "0.4.3",
-          "from": "insight@~0.4.1",
+          "from": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
           "resolved": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
           "dependencies": {
             "async": {
               "version": "0.9.0",
-              "from": "async@^0.9.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "configstore": {
               "version": "0.3.1",
-              "from": "configstore@^0.3.1",
+              "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.1.tgz",
               "dependencies": {
                 "js-yaml": {
                   "version": "3.0.2",
-                  "from": "js-yaml@~3.0.1",
+                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "0.1.16",
-                      "from": "argparse@~ 0.1.11",
+                      "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                       "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                       "dependencies": {
                         "underscore": {
                           "version": "1.7.0",
-                          "from": "underscore@~1.7.0",
+                          "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                         },
                         "underscore.string": {
                           "version": "2.4.0",
-                          "from": "underscore.string@~2.4.0",
+                          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "esprima@~ 1.0.2",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "0.3.1",
-                  "from": "object-assign@~0.3.1",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
                 },
                 "uuid": {
                   "version": "1.4.2",
-                  "from": "uuid@~1.4.1",
+                  "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz"
                 }
               }
             },
             "inquirer": {
               "version": "0.6.0",
-              "from": "inquirer@^0.6.0",
+              "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
               "dependencies": {
                 "cli-color": {
                   "version": "0.3.2",
-                  "from": "cli-color@~0.3.2",
+                  "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "d@~0.1.1",
+                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.4",
-                      "from": "es5-ext@~0.10.2",
+                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.4.tgz",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.4.tgz",
                       "dependencies": {
                         "es6-iterator": {
                           "version": "0.1.2",
-                          "from": "es6-iterator@~0.1.1",
+                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
                         },
                         "es6-symbol": {
                           "version": "0.1.1",
-                          "from": "es6-symbol@0.1.x",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                         }
                       }
                     },
                     "memoizee": {
                       "version": "0.3.8",
-                      "from": "memoizee@0.3.x",
+                      "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
                       "dependencies": {
                         "es6-weak-map": {
                           "version": "0.1.2",
-                          "from": "es6-weak-map@~0.1.2",
+                          "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
                           "dependencies": {
                             "es6-iterator": {
                               "version": "0.1.2",
-                              "from": "es6-iterator@~0.1.1",
+                              "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
                             },
                             "es6-symbol": {
                               "version": "0.1.1",
-                              "from": "es6-symbol@0.1.x",
+                              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                             }
                           }
                         },
                         "event-emitter": {
                           "version": "0.3.1",
-                          "from": "event-emitter@~0.3.1",
+                          "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.1.tgz"
                         },
                         "lru-queue": {
                           "version": "0.1.0",
-                          "from": "lru-queue@0.1",
+                          "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                         },
                         "next-tick": {
                           "version": "0.2.2",
-                          "from": "next-tick@~0.2.2",
+                          "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                         }
                       }
                     },
                     "timers-ext": {
                       "version": "0.1.0",
-                      "from": "timers-ext@0.1.x",
+                      "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                       "dependencies": {
                         "next-tick": {
                           "version": "0.2.2",
-                          "from": "next-tick@~0.2.2",
+                          "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                         }
                       }
@@ -754,37 +754,37 @@
                 },
                 "lodash": {
                   "version": "2.4.1",
-                  "from": "lodash@~2.4.1",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 },
                 "mute-stream": {
                   "version": "0.0.4",
-                  "from": "mute-stream@0.0.4",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                 },
                 "readline2": {
                   "version": "0.1.0",
-                  "from": "readline2@~0.1.0",
+                  "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.0.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@~0.4.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@~0.1.0",
+                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@~1.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@~0.1.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -793,46 +793,46 @@
                 },
                 "rx": {
                   "version": "2.3.22",
-                  "from": "rx@^2.2.27",
+                  "from": "https://registry.npmjs.org/rx/-/rx-2.3.22.tgz",
                   "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.22.tgz"
                 },
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@~2.3.4",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
                 }
               }
             },
             "lodash.debounce": {
               "version": "2.4.1",
-              "from": "lodash.debounce@^2.4.1",
+              "from": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
               "dependencies": {
                 "lodash.isfunction": {
                   "version": "2.4.1",
-                  "from": "lodash.isfunction@~2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
                 },
                 "lodash.isobject": {
                   "version": "2.4.1",
-                  "from": "lodash.isobject@~2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                   "dependencies": {
                     "lodash._objecttypes": {
                       "version": "2.4.1",
-                      "from": "lodash._objecttypes@~2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                     }
                   }
                 },
                 "lodash.now": {
                   "version": "2.4.1",
-                  "from": "lodash.now@~2.4.1",
+                  "from": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "2.4.1",
-                      "from": "lodash._isnative@~2.4.1",
+                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     }
                   }
@@ -841,59 +841,59 @@
             },
             "object-assign": {
               "version": "1.0.0",
-              "from": "object-assign@^1.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
             },
             "os-name": {
               "version": "1.0.1",
-              "from": "os-name@^1.0.0",
+              "from": "https://registry.npmjs.org/os-name/-/os-name-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "1.1.0",
-                  "from": "minimist@^1.1.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
                 },
                 "osx-release": {
                   "version": "1.0.0",
-                  "from": "osx-release@^1.0.0",
+                  "from": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz"
                 }
               }
             },
             "request": {
               "version": "2.51.0",
-              "from": "request@^2.40.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.3",
-                  "from": "bl@~0.9.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@~1.0.26",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -902,27 +902,27 @@
                 },
                 "caseless": {
                   "version": "0.8.0",
-                  "from": "caseless@~0.8.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@~0.2.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.4",
-                      "from": "mime-types@~2.0.3",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.3.1",
-                          "from": "mime-db@~1.3.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz"
                         }
                       }
@@ -931,101 +931,101 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@~5.0.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "mime-types@~1.0.1",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.2",
-                  "from": "node-uuid@~1.4.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@~2.3.1",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "tunnel-agent@~0.4.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.0",
-                  "from": "http-signature@~0.10.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.2",
-                      "from": "assert-plus@0.1.2",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.2",
-                      "from": "ctype@0.5.2",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.5.0",
-                  "from": "oauth-sign@~0.5.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "hawk@1.1.1",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@0.9.x",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@0.4.x",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@0.2.x",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@0.2.x",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@~0.0.5",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
@@ -1034,12 +1034,12 @@
             },
             "tough-cookie": {
               "version": "0.12.1",
-              "from": "tough-cookie@^0.12.1",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "punycode@>=0.2.0",
+                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 }
               }
@@ -1048,69 +1048,69 @@
         },
         "is-root": {
           "version": "0.1.0",
-          "from": "is-root@~0.1.0",
+          "from": "https://registry.npmjs.org/is-root/-/is-root-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/is-root/-/is-root-0.1.0.tgz"
         },
         "junk": {
           "version": "0.3.0",
-          "from": "junk@~0.3.0",
+          "from": "https://registry.npmjs.org/junk/-/junk-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/junk/-/junk-0.3.0.tgz"
         },
         "lockfile": {
           "version": "0.4.3",
-          "from": "lockfile@~0.4.2",
+          "from": "https://registry.npmjs.org/lockfile/-/lockfile-0.4.3.tgz",
           "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-0.4.3.tgz"
         },
         "lru-cache": {
           "version": "2.5.0",
-          "from": "lru-cache@~2.5.0",
+          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
         },
         "mout": {
           "version": "0.9.1",
-          "from": "mout@~0.9.1",
+          "from": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz",
           "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
         },
         "nopt": {
           "version": "3.0.1",
-          "from": "nopt@~3.0.0",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
         },
         "opn": {
           "version": "0.1.2",
-          "from": "opn@~0.1.1",
+          "from": "https://registry.npmjs.org/opn/-/opn-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/opn/-/opn-0.1.2.tgz"
         },
         "osenv": {
           "version": "0.1.0",
-          "from": "osenv@~0.1.0",
+          "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
         },
         "p-throttler": {
           "version": "0.0.1",
-          "from": "p-throttler@0.0.1",
+          "from": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.0.1.tgz",
           "dependencies": {
             "q": {
               "version": "0.9.7",
-              "from": "q@~0.9.2",
+              "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
               "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
             }
           }
         },
         "promptly": {
           "version": "0.2.0",
-          "from": "promptly@~0.2.0",
+          "from": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
           "dependencies": {
             "read": {
               "version": "1.0.5",
-              "from": "read@~1.0.4",
+              "from": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.4",
-                  "from": "mute-stream@~0.0.4",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                 }
               }
@@ -1119,328 +1119,328 @@
         },
         "q": {
           "version": "1.0.1",
-          "from": "q@~1.0.1",
+          "from": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
         },
         "request": {
           "version": "2.36.0",
-          "from": "request@~2.36.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
           "dependencies": {
             "qs": {
               "version": "0.6.6",
-              "from": "qs@~0.6.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "json-stringify-safe@~5.0.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@~1.2.9",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@~0.5.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "node-uuid@~1.4.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
             },
             "tough-cookie": {
               "version": "0.12.1",
-              "from": "tough-cookie@>=0.12.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "punycode@>=0.2.0",
+                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 }
               }
             },
             "form-data": {
               "version": "0.1.4",
-              "from": "form-data@~0.1.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@~0.0.4",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@~0.9.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@~0.4.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "http-signature": {
               "version": "0.10.0",
-              "from": "http-signature@~0.10.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.2",
-                  "from": "assert-plus@0.1.2",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.2",
-                  "from": "ctype@0.5.2",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.3.0",
-              "from": "oauth-sign@~0.3.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
             },
             "hawk": {
               "version": "1.0.0",
-              "from": "hawk@~1.0.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "hoek@0.9.x",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "boom@0.4.x",
+                  "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "cryptiles@0.2.x",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "sntp@0.2.x",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@~0.5.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             }
           }
         },
         "request-progress": {
           "version": "0.3.1",
-          "from": "request-progress@~0.3.0",
+          "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
           "dependencies": {
             "throttleit": {
               "version": "0.0.2",
-              "from": "throttleit@~0.0.2",
+              "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
             }
           }
         },
         "retry": {
           "version": "0.6.1",
-          "from": "retry@~0.6.0",
+          "from": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@^2.2.8",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "semver": {
           "version": "2.3.2",
-          "from": "semver@~2.3.0",
+          "from": "semver@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
         },
         "shell-quote": {
           "version": "1.4.2",
-          "from": "shell-quote@~1.4.1",
+          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.2.tgz",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.2.tgz",
           "dependencies": {
             "jsonify": {
               "version": "0.0.0",
-              "from": "jsonify@~0.0.0",
+              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             },
             "array-filter": {
               "version": "0.0.1",
-              "from": "array-filter@~0.0.0",
+              "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
             },
             "array-reduce": {
               "version": "0.0.0",
-              "from": "array-reduce@~0.0.0",
+              "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
             },
             "array-map": {
               "version": "0.0.0",
-              "from": "array-map@~0.0.0",
+              "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
             }
           }
         },
         "stringify-object": {
           "version": "0.2.1",
-          "from": "stringify-object@~0.2.0",
+          "from": "https://registry.npmjs.org/stringify-object/-/stringify-object-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-0.2.1.tgz"
         },
         "tar": {
           "version": "0.1.20",
-          "from": "tar@~0.1.17",
+          "from": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
           "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
           "dependencies": {
             "block-stream": {
               "version": "0.0.7",
-              "from": "block-stream@*",
+              "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "tmp": {
           "version": "0.0.23",
-          "from": "tmp@0.0.23",
+          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
         },
         "update-notifier": {
           "version": "0.2.2",
-          "from": "update-notifier@~0.2.0",
+          "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.2.tgz",
           "dependencies": {
             "configstore": {
               "version": "0.3.1",
-              "from": "configstore@^0.3.1",
+              "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.1.tgz",
               "dependencies": {
                 "js-yaml": {
                   "version": "3.0.2",
-                  "from": "js-yaml@~3.0.1",
+                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "0.1.16",
-                      "from": "argparse@~ 0.1.11",
+                      "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                       "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
                       "dependencies": {
                         "underscore": {
                           "version": "1.7.0",
-                          "from": "underscore@~1.7.0",
+                          "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                         },
                         "underscore.string": {
                           "version": "2.4.0",
-                          "from": "underscore.string@~2.4.0",
+                          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
                           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "esprima@~ 1.0.2",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "0.3.1",
-                  "from": "object-assign@~0.3.1",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
                 },
                 "uuid": {
                   "version": "1.4.2",
-                  "from": "uuid@~1.4.1",
+                  "from": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz"
                 }
               }
             },
             "is-npm": {
               "version": "1.0.0",
-              "from": "is-npm@^1.0.0",
+              "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
             },
             "latest-version": {
               "version": "1.0.0",
-              "from": "latest-version@^1.0.0",
+              "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
               "dependencies": {
                 "package-json": {
                   "version": "1.0.1",
-                  "from": "package-json@^1.0.0",
+                  "from": "https://registry.npmjs.org/package-json/-/package-json-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.0.1.tgz",
                   "dependencies": {
                     "got": {
                       "version": "1.2.2",
-                      "from": "got@^1.0.1",
+                      "from": "https://registry.npmjs.org/got/-/got-1.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/got/-/got-1.2.2.tgz",
                       "dependencies": {
                         "object-assign": {
                           "version": "1.0.0",
-                          "from": "object-assign@^1.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
                         }
                       }
                     },
                     "registry-url": {
                       "version": "2.0.0",
-                      "from": "registry-url@^2.0.0",
+                      "from": "https://registry.npmjs.org/registry-url/-/registry-url-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-2.0.0.tgz",
                       "dependencies": {
                         "rc": {
                           "version": "0.5.4",
-                          "from": "rc@^0.5.1",
+                          "from": "https://registry.npmjs.org/rc/-/rc-0.5.4.tgz",
                           "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.4.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.10",
-                              "from": "minimist@~0.0.7",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                             },
                             "deep-extend": {
                               "version": "0.2.11",
-                              "from": "deep-extend@~0.2.5",
+                              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
                               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                             },
                             "strip-json-comments": {
                               "version": "0.1.3",
-                              "from": "strip-json-comments@0.1.x",
+                              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                             },
                             "ini": {
                               "version": "1.1.0",
-                              "from": "ini@~1.1.0",
+                              "from": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
                             }
                           }
@@ -1453,29 +1453,29 @@
             },
             "semver-diff": {
               "version": "2.0.0",
-              "from": "semver-diff@^2.0.0",
+              "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
               "dependencies": {
                 "semver": {
                   "version": "4.1.1",
-                  "from": "semver@^4.0.0",
+                  "from": "https://registry.npmjs.org/semver/-/semver-4.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.1.1.tgz"
                 }
               }
             },
             "string-length": {
               "version": "1.0.0",
-              "from": "string-length@^1.0.0",
+              "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
               "dependencies": {
                 "strip-ansi": {
                   "version": "2.0.0",
-                  "from": "strip-ansi@^2.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.0",
-                      "from": "ansi-regex@^1.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
                     }
                   }
@@ -1486,86 +1486,86 @@
         },
         "which": {
           "version": "1.0.8",
-          "from": "which@~1.0.5",
+          "from": "https://registry.npmjs.org/which/-/which-1.0.8.tgz",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
         }
       }
     },
     "connect-cachify": {
       "version": "0.0.17",
-      "from": "connect-cachify@0.0.17",
+      "from": "https://registry.npmjs.org/connect-cachify/-/connect-cachify-0.0.17.tgz",
       "resolved": "https://registry.npmjs.org/connect-cachify/-/connect-cachify-0.0.17.tgz",
       "dependencies": {
         "underscore": {
           "version": "1.7.0",
-          "from": "underscore@>=1.3.1",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
         }
       }
     },
     "connect-fonts-clearsans": {
       "version": "0.0.1",
-      "from": "connect-fonts-clearsans@0.0.1",
+      "from": "https://registry.npmjs.org/connect-fonts-clearsans/-/connect-fonts-clearsans-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/connect-fonts-clearsans/-/connect-fonts-clearsans-0.0.1.tgz"
     },
     "connect-fonts-firasans": {
       "version": "0.0.4",
-      "from": "connect-fonts-firasans@0.0.4",
+      "from": "https://registry.npmjs.org/connect-fonts-firasans/-/connect-fonts-firasans-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/connect-fonts-firasans/-/connect-fonts-firasans-0.0.4.tgz"
     },
     "connect-restreamer": {
       "version": "1.0.0",
-      "from": "connect-restreamer@1.0.0",
+      "from": "https://registry.npmjs.org/connect-restreamer/-/connect-restreamer-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/connect-restreamer/-/connect-restreamer-1.0.0.tgz"
     },
     "consolidate": {
       "version": "0.10.0",
-      "from": "consolidate@0.10.0",
+      "from": "https://registry.npmjs.org/consolidate/-/consolidate-0.10.0.tgz",
       "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.10.0.tgz"
     },
     "convict": {
       "version": "0.6.0",
-      "from": "convict@0.6.0",
+      "from": "https://registry.npmjs.org/convict/-/convict-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/convict/-/convict-0.6.0.tgz",
       "dependencies": {
         "cjson": {
           "version": "0.3.0",
-          "from": "cjson@0.3.0",
+          "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
           "dependencies": {
             "jsonlint": {
               "version": "1.6.0",
-              "from": "jsonlint@1.6.0",
+              "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
                 "nomnom": {
                   "version": "1.8.1",
-                  "from": "nomnom@>= 1.5.x",
+                  "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@~1.6.0",
+                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
                       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
-                      "from": "chalk@~0.4.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@~0.1.0",
+                          "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@~1.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@~0.1.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
@@ -1574,7 +1574,7 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>= 4.0.x",
+                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
@@ -1583,149 +1583,149 @@
         },
         "depd": {
           "version": "1.0.0",
-          "from": "depd@1.0.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "moment": {
           "version": "2.8.3",
-          "from": "moment@2.8.3",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@0.6.1",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "validator": {
           "version": "3.22.1",
-          "from": "validator@3.22.1",
+          "from": "https://registry.npmjs.org/validator/-/validator-3.22.1.tgz",
           "resolved": "https://registry.npmjs.org/validator/-/validator-3.22.1.tgz"
         }
       }
     },
     "express": {
       "version": "3.17.1",
-      "from": "express@3.17.1",
+      "from": "https://registry.npmjs.org/express/-/express-3.17.1.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-3.17.1.tgz",
       "dependencies": {
         "basic-auth": {
           "version": "1.0.0",
-          "from": "basic-auth@1.0.0",
+          "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
         },
         "buffer-crc32": {
           "version": "0.2.3",
-          "from": "buffer-crc32@0.2.3",
+          "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
         },
         "connect": {
           "version": "2.26.0",
-          "from": "connect@2.26.0",
+          "from": "https://registry.npmjs.org/connect/-/connect-2.26.0.tgz",
           "resolved": "https://registry.npmjs.org/connect/-/connect-2.26.0.tgz",
           "dependencies": {
             "basic-auth-connect": {
               "version": "1.0.0",
-              "from": "basic-auth-connect@1.0.0",
+              "from": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
             },
             "body-parser": {
               "version": "1.8.4",
-              "from": "body-parser@~1.8.1",
+              "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
               "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
               "dependencies": {
                 "depd": {
                   "version": "0.4.5",
-                  "from": "depd@0.4.5",
+                  "from": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
                 },
                 "iconv-lite": {
                   "version": "0.4.4",
-                  "from": "iconv-lite@0.4.4",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
                 },
                 "on-finished": {
                   "version": "2.1.0",
-                  "from": "on-finished@2.1.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.0.5",
-                      "from": "ee-first@1.0.5",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "2.2.4",
-                  "from": "qs@2.2.4",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz"
                 },
                 "raw-body": {
                   "version": "1.3.0",
-                  "from": "raw-body@1.3.0",
+                  "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
                 }
               }
             },
             "bytes": {
               "version": "1.0.0",
-              "from": "bytes@1.0.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
             },
             "cookie-parser": {
               "version": "1.3.3",
-              "from": "cookie-parser@~1.3.3",
+              "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.3.tgz"
             },
             "compression": {
               "version": "1.1.2",
-              "from": "compression@~1.1.0",
+              "from": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@~1.1.3",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.4",
-                      "from": "mime-types@~2.0.4",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.3.1",
-                          "from": "mime-db@~1.3.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
                 },
                 "compressible": {
                   "version": "2.0.1",
-                  "from": "compressible@~2.0.1",
+                  "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.1.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.4.0",
-                      "from": "mime-db@1.x",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.4.0.tgz"
                     }
                   }
@@ -1734,59 +1734,59 @@
             },
             "connect-timeout": {
               "version": "1.3.0",
-              "from": "connect-timeout@~1.3.0",
+              "from": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "csurf": {
               "version": "1.6.3",
-              "from": "csurf@~1.6.1",
+              "from": "https://registry.npmjs.org/csurf/-/csurf-1.6.3.tgz",
               "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.6.3.tgz",
               "dependencies": {
                 "csrf": {
                   "version": "2.0.2",
-                  "from": "csrf@~2.0.2",
+                  "from": "https://registry.npmjs.org/csrf/-/csrf-2.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.2.tgz",
                   "dependencies": {
                     "rndm": {
                       "version": "1.0.0",
-                      "from": "rndm@~1.0.0",
+                      "from": "https://registry.npmjs.org/rndm/-/rndm-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.0.0.tgz"
                     },
                     "scmp": {
                       "version": "1.0.0",
-                      "from": "scmp@1.0.0",
+                      "from": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
                     },
                     "uid-safe": {
                       "version": "1.0.1",
-                      "from": "uid-safe@~1.0.1",
+                      "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                       "dependencies": {
                         "mz": {
                           "version": "1.2.0",
-                          "from": "mz@1",
+                          "from": "https://registry.npmjs.org/mz/-/mz-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/mz/-/mz-1.2.0.tgz",
                           "dependencies": {
                             "native-or-bluebird": {
                               "version": "1.1.2",
-                              "from": "native-or-bluebird@1",
+                              "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
                             },
                             "thenify": {
                               "version": "2.0.0",
-                              "from": "thenify@2",
+                              "from": "https://registry.npmjs.org/thenify/-/thenify-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/thenify/-/thenify-2.0.0.tgz"
                             },
                             "thenify-all": {
                               "version": "1.1.0",
-                              "from": "thenify-all@1",
+                              "from": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.1.0.tgz"
                             }
                           }
@@ -1795,24 +1795,24 @@
                     },
                     "base64-url": {
                       "version": "1.0.0",
-                      "from": "base64-url@1.0.0",
+                      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.0.0.tgz"
                     }
                   }
                 },
                 "http-errors": {
                   "version": "1.2.8",
-                  "from": "http-errors@~1.2.7",
+                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "statuses": {
                       "version": "1.2.0",
-                      "from": "statuses@1",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.0.tgz"
                     }
                   }
@@ -1821,29 +1821,29 @@
             },
             "errorhandler": {
               "version": "1.2.3",
-              "from": "errorhandler@~1.2.0",
+              "from": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.3.tgz",
               "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.3.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@~1.1.3",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.4",
-                      "from": "mime-types@~2.0.4",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.3.1",
-                          "from": "mime-db@~1.3.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
@@ -1852,88 +1852,88 @@
             },
             "express-session": {
               "version": "1.8.2",
-              "from": "express-session@~1.8.1",
+              "from": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
               "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
               "dependencies": {
                 "crc": {
                   "version": "3.0.0",
-                  "from": "crc@3.0.0",
+                  "from": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
                 },
                 "depd": {
                   "version": "0.4.5",
-                  "from": "depd@0.4.5",
+                  "from": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
                 },
                 "uid-safe": {
                   "version": "1.0.1",
-                  "from": "uid-safe@1.0.1",
+                  "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                   "dependencies": {
                     "mz": {
                       "version": "1.2.0",
-                      "from": "mz@1",
+                      "from": "https://registry.npmjs.org/mz/-/mz-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/mz/-/mz-1.2.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
                           "version": "1.1.2",
-                          "from": "native-or-bluebird@1",
+                          "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
                         },
                         "thenify": {
                           "version": "2.0.0",
-                          "from": "thenify@2",
+                          "from": "https://registry.npmjs.org/thenify/-/thenify-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/thenify/-/thenify-2.0.0.tgz"
                         },
                         "thenify-all": {
                           "version": "1.1.0",
-                          "from": "thenify-all@1",
+                          "from": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.1.0.tgz"
                         }
                       }
                     },
                     "base64-url": {
                       "version": "1.0.0",
-                      "from": "base64-url@1",
+                      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.0.0.tgz"
                     }
                   }
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
+                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 }
               }
             },
             "finalhandler": {
               "version": "0.2.0",
-              "from": "finalhandler@0.2.0",
+              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz"
             },
             "method-override": {
               "version": "2.2.0",
-              "from": "method-override@~2.2.0",
+              "from": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz"
             },
             "morgan": {
               "version": "1.3.2",
-              "from": "morgan@~1.3.0",
+              "from": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
               "dependencies": {
                 "depd": {
                   "version": "0.4.5",
-                  "from": "depd@0.4.5",
+                  "from": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
                 },
                 "on-finished": {
                   "version": "2.1.0",
-                  "from": "on-finished@2.1.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.0.5",
-                      "from": "ee-first@1.0.5",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                     }
                   }
@@ -1942,168 +1942,168 @@
             },
             "multiparty": {
               "version": "3.3.2",
-              "from": "multiparty@3.3.2",
+              "from": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
               "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@~1.1.9",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "stream-counter": {
                   "version": "0.2.0",
-                  "from": "stream-counter@~0.2.0",
+                  "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
                 }
               }
             },
             "on-headers": {
               "version": "1.0.0",
-              "from": "on-headers@~1.0.0",
+              "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
             },
             "qs": {
               "version": "2.2.3",
-              "from": "qs@2.2.3",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.2.3.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.3.tgz"
             },
             "response-time": {
               "version": "2.0.1",
-              "from": "response-time@~2.0.1",
+              "from": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz"
             },
             "serve-favicon": {
               "version": "2.1.7",
-              "from": "serve-favicon@~2.1.3",
+              "from": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
               "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
               "dependencies": {
                 "etag": {
                   "version": "1.5.1",
-                  "from": "etag@~1.5.0",
+                  "from": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
                   "dependencies": {
                     "crc": {
                       "version": "3.2.1",
-                      "from": "crc@3.2.1",
+                      "from": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
                     }
                   }
                 },
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "serve-index": {
               "version": "1.2.1",
-              "from": "serve-index@~1.2.1",
+              "from": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@~1.1.0",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.4",
-                      "from": "mime-types@~2.0.4",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.3.1",
-                          "from": "mime-db@~1.3.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
                 },
                 "batch": {
                   "version": "0.5.1",
-                  "from": "batch@0.5.1",
+                  "from": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz"
                 }
               }
             },
             "serve-static": {
               "version": "1.6.4",
-              "from": "serve-static@~1.6.1",
+              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.4.tgz",
               "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.4.tgz",
               "dependencies": {
                 "send": {
                   "version": "0.9.3",
-                  "from": "send@0.9.3",
+                  "from": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
                   "dependencies": {
                     "depd": {
                       "version": "0.4.5",
-                      "from": "depd@0.4.5",
+                      "from": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
                     },
                     "destroy": {
                       "version": "1.0.3",
-                      "from": "destroy@1.0.3",
+                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
                     },
                     "etag": {
                       "version": "1.4.0",
-                      "from": "etag@~1.4.0",
+                      "from": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
                       "dependencies": {
                         "crc": {
                           "version": "3.0.0",
-                          "from": "crc@3.0.0",
+                          "from": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.2.11",
-                      "from": "mime@1.2.11",
+                      "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                     },
                     "ms": {
                       "version": "0.6.2",
-                      "from": "ms@0.6.2",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                     },
                     "on-finished": {
                       "version": "2.1.0",
-                      "from": "on-finished@2.1.0",
+                      "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                       "dependencies": {
                         "ee-first": {
                           "version": "1.0.5",
-                          "from": "ee-first@1.0.5",
+                          "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                         }
                       }
@@ -2112,24 +2112,24 @@
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
+                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 }
               }
             },
             "type-is": {
               "version": "1.5.4",
-              "from": "type-is@~1.5.1",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.5.4.tgz",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.4.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.0.4",
-                  "from": "mime-types@~2.0.4",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.4.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.3.1",
-                      "from": "mime-db@~1.3.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.3.1.tgz"
                     }
                   }
@@ -2138,132 +2138,132 @@
             },
             "vhost": {
               "version": "3.0.0",
-              "from": "vhost@~3.0.0",
+              "from": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz"
             },
             "pause": {
               "version": "0.0.1",
-              "from": "pause@0.0.1",
+              "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
             }
           }
         },
         "commander": {
           "version": "1.3.2",
-          "from": "commander@1.3.2",
+          "from": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
           "dependencies": {
             "keypress": {
               "version": "0.1.0",
-              "from": "keypress@0.1.x",
+              "from": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
             }
           }
         },
         "cookie-signature": {
           "version": "1.0.5",
-          "from": "cookie-signature@1.0.5",
+          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
         },
         "debug": {
           "version": "2.0.0",
-          "from": "debug@~2.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "depd": {
           "version": "0.4.4",
-          "from": "depd@0.4.4",
+          "from": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz"
         },
         "escape-html": {
           "version": "1.0.1",
-          "from": "escape-html@1.0.1",
+          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "fresh": {
           "version": "0.2.4",
-          "from": "fresh@0.2.4",
+          "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
         },
         "media-typer": {
           "version": "0.3.0",
-          "from": "media-typer@0.3.0",
+          "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
         },
         "methods": {
           "version": "1.1.0",
-          "from": "methods@1.1.0",
+          "from": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
         },
         "parseurl": {
           "version": "1.3.0",
-          "from": "parseurl@~1.3.0",
+          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
         },
         "proxy-addr": {
           "version": "1.0.1",
-          "from": "proxy-addr@1.0.1",
+          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
           "dependencies": {
             "ipaddr.js": {
               "version": "0.1.2",
-              "from": "ipaddr.js@0.1.2",
+              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
             }
           }
         },
         "range-parser": {
           "version": "1.0.2",
-          "from": "range-parser@~1.0.2",
+          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
         },
         "send": {
           "version": "0.9.1",
-          "from": "send@0.9.1",
+          "from": "https://registry.npmjs.org/send/-/send-0.9.1.tgz",
           "resolved": "https://registry.npmjs.org/send/-/send-0.9.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.3",
-              "from": "destroy@1.0.3",
+              "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
             },
             "etag": {
               "version": "1.3.1",
-              "from": "etag@~1.3.0",
+              "from": "https://registry.npmjs.org/etag/-/etag-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/etag/-/etag-1.3.1.tgz",
               "dependencies": {
                 "crc": {
                   "version": "3.0.0",
-                  "from": "crc@3.0.0",
+                  "from": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@1.2.11",
+              "from": "mime@>=1.2.11 <1.3.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             },
             "on-finished": {
               "version": "2.1.0",
-              "from": "on-finished@2.1.0",
+              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.0.5",
-                  "from": "ee-first@1.0.5",
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                 }
               }
@@ -2272,277 +2272,2759 @@
         },
         "vary": {
           "version": "1.0.0",
-          "from": "vary@~1.0.0",
+          "from": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
         },
         "cookie": {
           "version": "0.1.2",
-          "from": "cookie@0.1.2",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
         },
         "merge-descriptors": {
           "version": "0.0.2",
-          "from": "merge-descriptors@0.0.2",
+          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
         }
       }
     },
-    "grunt": {
-      "version": "0.4.5",
-      "from": "grunt@0.4.5",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+    "express-able": {
+      "version": "0.2.0",
+      "from": "express-able@0.2.0",
+      "resolved": "https://registry.npmjs.org/express-able/-/express-able-0.2.0.tgz",
       "dependencies": {
-        "async": {
-          "version": "0.1.22",
-          "from": "async@~0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
-        },
-        "coffee-script": {
-          "version": "1.3.3",
-          "from": "coffee-script@~1.3.3",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
-        },
-        "colors": {
-          "version": "0.6.2",
-          "from": "colors@~0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
-        },
-        "dateformat": {
-          "version": "1.0.2-1.2.3",
-          "from": "dateformat@1.0.2-1.2.3",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
-        },
-        "eventemitter2": {
-          "version": "0.4.14",
-          "from": "eventemitter2@~0.4.13",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
-        },
-        "findup-sync": {
-          "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+        "able": {
+          "version": "0.2.0",
+          "from": "able@0.2.0",
+          "resolved": "https://registry.npmjs.org/able/-/able-0.2.0.tgz",
           "dependencies": {
-            "glob": {
-              "version": "3.2.11",
-              "from": "glob@~3.2.9",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+            "abatar": {
+              "version": "0.2.6",
+              "from": "abatar@0.2.6",
+              "resolved": "https://registry.npmjs.org/abatar/-/abatar-0.2.6.tgz",
               "dependencies": {
+                "browserify": {
+                  "version": "8.0.3",
+                  "from": "browserify@8.0.3",
+                  "resolved": "https://registry.npmjs.org/browserify/-/browserify-8.0.3.tgz",
+                  "dependencies": {
+                    "JSONStream": {
+                      "version": "0.8.4",
+                      "from": "JSONStream@>=0.8.3 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+                      "dependencies": {
+                        "jsonparse": {
+                          "version": "0.0.5",
+                          "from": "jsonparse@0.0.5",
+                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                        },
+                        "through": {
+                          "version": "2.3.6",
+                          "from": "through@>=2.2.7 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                        }
+                      }
+                    },
+                    "assert": {
+                      "version": "1.1.2",
+                      "from": "assert@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
+                    },
+                    "browser-pack": {
+                      "version": "3.2.0",
+                      "from": "browser-pack@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
+                      "dependencies": {
+                        "combine-source-map": {
+                          "version": "0.3.0",
+                          "from": "combine-source-map@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                          "dependencies": {
+                            "inline-source-map": {
+                              "version": "0.3.1",
+                              "from": "inline-source-map@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                              "dependencies": {
+                                "source-map": {
+                                  "version": "0.3.0",
+                                  "from": "source-map@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                                  "dependencies": {
+                                    "amdefine": {
+                                      "version": "0.1.0",
+                                      "from": "amdefine@>=0.0.4",
+                                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "convert-source-map": {
+                              "version": "0.3.5",
+                              "from": "convert-source-map@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                            },
+                            "source-map": {
+                              "version": "0.1.43",
+                              "from": "source-map@>=0.1.31 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                              "dependencies": {
+                                "amdefine": {
+                                  "version": "0.1.0",
+                                  "from": "amdefine@>=0.0.4",
+                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "0.5.1",
+                          "from": "through2@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+                        }
+                      }
+                    },
+                    "browser-resolve": {
+                      "version": "1.8.0",
+                      "from": "browser-resolve@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.0.tgz",
+                      "dependencies": {
+                        "resolve": {
+                          "version": "1.1.5",
+                          "from": "resolve@1.1.5",
+                          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz"
+                        }
+                      }
+                    },
+                    "browserify-zlib": {
+                      "version": "0.1.4",
+                      "from": "browserify-zlib@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                      "dependencies": {
+                        "pako": {
+                          "version": "0.2.5",
+                          "from": "pako@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
+                        }
+                      }
+                    },
+                    "buffer": {
+                      "version": "3.1.0",
+                      "from": "buffer@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.0.tgz",
+                      "dependencies": {
+                        "base64-js": {
+                          "version": "0.0.8",
+                          "from": "base64-js@0.0.8",
+                          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+                        },
+                        "ieee754": {
+                          "version": "1.1.4",
+                          "from": "ieee754@>=1.1.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+                        },
+                        "is-array": {
+                          "version": "1.0.1",
+                          "from": "is-array@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "builtins": {
+                      "version": "0.0.7",
+                      "from": "builtins@>=0.0.3 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+                    },
+                    "commondir": {
+                      "version": "0.0.1",
+                      "from": "commondir@0.0.1",
+                      "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
+                    },
+                    "concat-stream": {
+                      "version": "1.4.7",
+                      "from": "concat-stream@>=1.4.1 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+                      "dependencies": {
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "console-browserify": {
+                      "version": "1.1.0",
+                      "from": "console-browserify@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                      "dependencies": {
+                        "date-now": {
+                          "version": "0.1.4",
+                          "from": "date-now@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                        }
+                      }
+                    },
+                    "constants-browserify": {
+                      "version": "0.0.1",
+                      "from": "constants-browserify@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+                    },
+                    "crypto-browserify": {
+                      "version": "3.9.13",
+                      "from": "crypto-browserify@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
+                      "dependencies": {
+                        "browserify-aes": {
+                          "version": "1.0.0",
+                          "from": "browserify-aes@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
+                        },
+                        "browserify-sign": {
+                          "version": "2.8.0",
+                          "from": "browserify-sign@2.8.0",
+                          "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+                          "dependencies": {
+                            "bn.js": {
+                              "version": "1.3.0",
+                              "from": "bn.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                            },
+                            "browserify-rsa": {
+                              "version": "1.1.1",
+                              "from": "browserify-rsa@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+                            },
+                            "elliptic": {
+                              "version": "1.0.1",
+                              "from": "elliptic@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                              "dependencies": {
+                                "brorand": {
+                                  "version": "1.0.5",
+                                  "from": "brorand@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                                },
+                                "hash.js": {
+                                  "version": "1.0.2",
+                                  "from": "hash.js@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "parse-asn1": {
+                              "version": "2.0.0",
+                              "from": "parse-asn1@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                              "dependencies": {
+                                "asn1.js": {
+                                  "version": "1.0.3",
+                                  "from": "asn1.js@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                                  "dependencies": {
+                                    "minimalistic-assert": {
+                                      "version": "1.0.0",
+                                      "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "asn1.js-rfc3280": {
+                                  "version": "1.0.0",
+                                  "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
+                                },
+                                "pemstrip": {
+                                  "version": "0.0.1",
+                                  "from": "pemstrip@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "create-ecdh": {
+                          "version": "2.0.0",
+                          "from": "create-ecdh@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
+                          "dependencies": {
+                            "bn.js": {
+                              "version": "1.3.0",
+                              "from": "bn.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                            },
+                            "elliptic": {
+                              "version": "1.0.1",
+                              "from": "elliptic@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                              "dependencies": {
+                                "brorand": {
+                                  "version": "1.0.5",
+                                  "from": "brorand@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                                },
+                                "hash.js": {
+                                  "version": "1.0.2",
+                                  "from": "hash.js@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "create-hash": {
+                          "version": "1.1.0",
+                          "from": "create-hash@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
+                          "dependencies": {
+                            "ripemd160": {
+                              "version": "1.0.0",
+                              "from": "ripemd160@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
+                            },
+                            "sha.js": {
+                              "version": "2.3.6",
+                              "from": "sha.js@>=2.3.6 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
+                            }
+                          }
+                        },
+                        "create-hmac": {
+                          "version": "1.1.3",
+                          "from": "create-hmac@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
+                        },
+                        "diffie-hellman": {
+                          "version": "3.0.1",
+                          "from": "diffie-hellman@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+                          "dependencies": {
+                            "bn.js": {
+                              "version": "1.3.0",
+                              "from": "bn.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                            },
+                            "miller-rabin": {
+                              "version": "1.1.5",
+                              "from": "miller-rabin@>=1.1.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                              "dependencies": {
+                                "brorand": {
+                                  "version": "1.0.5",
+                                  "from": "brorand@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "pbkdf2-compat": {
+                          "version": "3.0.2",
+                          "from": "pbkdf2-compat@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
+                        },
+                        "public-encrypt": {
+                          "version": "2.0.0",
+                          "from": "public-encrypt@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+                          "dependencies": {
+                            "bn.js": {
+                              "version": "1.3.0",
+                              "from": "bn.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                            },
+                            "browserify-rsa": {
+                              "version": "2.0.0",
+                              "from": "browserify-rsa@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+                            },
+                            "parse-asn1": {
+                              "version": "3.0.0",
+                              "from": "parse-asn1@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                              "dependencies": {
+                                "asn1.js": {
+                                  "version": "1.0.3",
+                                  "from": "asn1.js@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                                  "dependencies": {
+                                    "minimalistic-assert": {
+                                      "version": "1.0.0",
+                                      "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "randombytes": {
+                          "version": "2.0.1",
+                          "from": "randombytes@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "deep-equal": {
+                      "version": "0.2.2",
+                      "from": "deep-equal@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
+                    },
+                    "defined": {
+                      "version": "0.0.0",
+                      "from": "defined@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+                    },
+                    "deps-sort": {
+                      "version": "1.3.5",
+                      "from": "deps-sort@>=1.3.5 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.2.0",
+                          "from": "minimist@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+                        },
+                        "through2": {
+                          "version": "0.5.1",
+                          "from": "through2@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+                        }
+                      }
+                    },
+                    "domain-browser": {
+                      "version": "1.1.4",
+                      "from": "domain-browser@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+                    },
+                    "duplexer2": {
+                      "version": "0.0.2",
+                      "from": "duplexer2@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "events": {
+                      "version": "1.0.2",
+                      "from": "events@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+                    },
+                    "glob": {
+                      "version": "4.5.2",
+                      "from": "glob@>=4.0.5 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.2.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "2.0.3",
+                          "from": "minimatch@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.3.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.0",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "http-browserify": {
+                      "version": "1.7.0",
+                      "from": "http-browserify@>=1.4.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+                      "dependencies": {
+                        "Base64": {
+                          "version": "0.2.1",
+                          "from": "Base64@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "https-browserify": {
+                      "version": "0.0.0",
+                      "from": "https-browserify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "insert-module-globals": {
+                      "version": "6.2.1",
+                      "from": "insert-module-globals@>=6.2.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
+                      "dependencies": {
+                        "JSONStream": {
+                          "version": "0.7.4",
+                          "from": "JSONStream@>=0.7.1 <0.8.0",
+                          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                          "dependencies": {
+                            "jsonparse": {
+                              "version": "0.0.5",
+                              "from": "jsonparse@0.0.5",
+                              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "combine-source-map": {
+                          "version": "0.3.0",
+                          "from": "combine-source-map@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                          "dependencies": {
+                            "inline-source-map": {
+                              "version": "0.3.1",
+                              "from": "inline-source-map@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                              "dependencies": {
+                                "source-map": {
+                                  "version": "0.3.0",
+                                  "from": "source-map@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                                  "dependencies": {
+                                    "amdefine": {
+                                      "version": "0.1.0",
+                                      "from": "amdefine@>=0.0.4",
+                                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "convert-source-map": {
+                              "version": "0.3.5",
+                              "from": "convert-source-map@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                            },
+                            "source-map": {
+                              "version": "0.1.43",
+                              "from": "source-map@>=0.1.31 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                              "dependencies": {
+                                "amdefine": {
+                                  "version": "0.1.0",
+                                  "from": "amdefine@>=0.0.4",
+                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lexical-scope": {
+                          "version": "1.1.0",
+                          "from": "lexical-scope@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+                          "dependencies": {
+                            "astw": {
+                              "version": "1.1.0",
+                              "from": "astw@>=1.1.0 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                              "dependencies": {
+                                "esprima-fb": {
+                                  "version": "3001.1.0-dev-harmony-fb",
+                                  "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "process": {
+                          "version": "0.6.0",
+                          "from": "process@>=0.6.0 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
+                        },
+                        "through": {
+                          "version": "2.3.6",
+                          "from": "through@>=2.3.4 <2.4.0",
+                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                        }
+                      }
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "labeled-stream-splicer": {
+                      "version": "1.0.2",
+                      "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+                      "dependencies": {
+                        "stream-splicer": {
+                          "version": "1.3.1",
+                          "from": "stream-splicer@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.1.13",
+                              "from": "readable-stream@>=1.1.13-1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "readable-wrap": {
+                              "version": "1.0.0",
+                              "from": "readable-wrap@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
+                            },
+                            "indexof": {
+                              "version": "0.0.1",
+                              "from": "indexof@0.0.1",
+                              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "module-deps": {
+                      "version": "3.7.2",
+                      "from": "module-deps@>=3.6.3 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.2.tgz",
+                      "dependencies": {
+                        "JSONStream": {
+                          "version": "0.7.4",
+                          "from": "JSONStream@>=0.7.1 <0.8.0",
+                          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                          "dependencies": {
+                            "jsonparse": {
+                              "version": "0.0.5",
+                              "from": "jsonparse@0.0.5",
+                              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                            },
+                            "through": {
+                              "version": "2.3.6",
+                              "from": "through@>=2.2.7 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                            }
+                          }
+                        },
+                        "detective": {
+                          "version": "4.0.0",
+                          "from": "detective@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
+                          "dependencies": {
+                            "acorn": {
+                              "version": "0.9.0",
+                              "from": "acorn@>=0.9.0 <0.10.0",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                            },
+                            "escodegen": {
+                              "version": "1.6.1",
+                              "from": "escodegen@>=1.4.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                              "dependencies": {
+                                "estraverse": {
+                                  "version": "1.9.3",
+                                  "from": "estraverse@>=1.9.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                                },
+                                "esutils": {
+                                  "version": "1.1.6",
+                                  "from": "esutils@>=1.1.6 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                                },
+                                "esprima": {
+                                  "version": "1.2.5",
+                                  "from": "esprima@>=1.2.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                                },
+                                "optionator": {
+                                  "version": "0.5.0",
+                                  "from": "optionator@>=0.5.0 <0.6.0",
+                                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                                  "dependencies": {
+                                    "prelude-ls": {
+                                      "version": "1.1.1",
+                                      "from": "prelude-ls@>=1.1.1 <1.2.0",
+                                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                                    },
+                                    "deep-is": {
+                                      "version": "0.1.3",
+                                      "from": "deep-is@>=0.1.2 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                                    },
+                                    "wordwrap": {
+                                      "version": "0.0.2",
+                                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                    },
+                                    "type-check": {
+                                      "version": "0.3.1",
+                                      "from": "type-check@>=0.3.1 <0.4.0",
+                                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                                    },
+                                    "levn": {
+                                      "version": "0.2.5",
+                                      "from": "levn@>=0.2.5 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                                    },
+                                    "fast-levenshtein": {
+                                      "version": "1.0.6",
+                                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                                    }
+                                  }
+                                },
+                                "source-map": {
+                                  "version": "0.1.43",
+                                  "from": "source-map@>=0.1.40 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                                  "dependencies": {
+                                    "amdefine": {
+                                      "version": "0.1.0",
+                                      "from": "amdefine@>=0.0.4",
+                                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "0.2.0",
+                          "from": "minimist@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+                        },
+                        "parents": {
+                          "version": "1.0.1",
+                          "from": "parents@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+                          "dependencies": {
+                            "path-platform": {
+                              "version": "0.11.15",
+                              "from": "path-platform@>=0.11.15 <0.12.0",
+                              "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
+                            }
+                          }
+                        },
+                        "resolve": {
+                          "version": "1.1.5",
+                          "from": "resolve@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz"
+                        },
+                        "stream-combiner2": {
+                          "version": "1.0.2",
+                          "from": "stream-combiner2@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+                          "dependencies": {
+                            "through2": {
+                              "version": "0.5.1",
+                              "from": "through2@>=0.5.1 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                              "dependencies": {
+                                "xtend": {
+                                  "version": "3.0.0",
+                                  "from": "xtend@>=3.0.0 <3.1.0",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "subarg": {
+                          "version": "0.0.1",
+                          "from": "subarg@0.0.1",
+                          "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "minimist@>=0.0.7 <0.1.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "0.4.2",
+                          "from": "through2@>=0.4.1 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                          "dependencies": {
+                            "xtend": {
+                              "version": "2.1.2",
+                              "from": "xtend@>=2.1.1 <2.2.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                              "dependencies": {
+                                "object-keys": {
+                                  "version": "0.4.0",
+                                  "from": "object-keys@>=0.4.0 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    },
+                    "os-browserify": {
+                      "version": "0.1.2",
+                      "from": "os-browserify@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+                    },
+                    "parents": {
+                      "version": "0.0.3",
+                      "from": "parents@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+                      "dependencies": {
+                        "path-platform": {
+                          "version": "0.0.1",
+                          "from": "path-platform@>=0.0.1 <0.0.2",
+                          "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-browserify": {
+                      "version": "0.0.0",
+                      "from": "path-browserify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+                    },
+                    "process": {
+                      "version": "0.8.0",
+                      "from": "process@>=0.8.0 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/process/-/process-0.8.0.tgz"
+                    },
+                    "punycode": {
+                      "version": "1.2.4",
+                      "from": "punycode@>=1.2.3 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+                    },
+                    "querystring-es3": {
+                      "version": "0.2.1",
+                      "from": "querystring-es3@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.33-1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "resolve": {
+                      "version": "0.7.4",
+                      "from": "resolve@>=0.7.1 <0.8.0",
+                      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+                    },
+                    "shallow-copy": {
+                      "version": "0.0.1",
+                      "from": "shallow-copy@0.0.1",
+                      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+                    },
+                    "shasum": {
+                      "version": "1.0.1",
+                      "from": "shasum@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
+                      "dependencies": {
+                        "json-stable-stringify": {
+                          "version": "0.0.1",
+                          "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                          "dependencies": {
+                            "jsonify": {
+                              "version": "0.0.0",
+                              "from": "jsonify@>=0.0.0 <0.1.0",
+                              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                            }
+                          }
+                        },
+                        "sha.js": {
+                          "version": "2.3.6",
+                          "from": "sha.js@>=2.3.0 <2.4.0",
+                          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
+                        }
+                      }
+                    },
+                    "shell-quote": {
+                      "version": "0.0.1",
+                      "from": "shell-quote@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
+                    },
+                    "stream-browserify": {
+                      "version": "1.0.0",
+                      "from": "stream-browserify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "subarg": {
+                      "version": "1.0.0",
+                      "from": "subarg@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.1.1",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "syntax-error": {
+                      "version": "1.1.2",
+                      "from": "syntax-error@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+                      "dependencies": {
+                        "acorn": {
+                          "version": "0.9.0",
+                          "from": "acorn@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                        }
+                      }
+                    },
+                    "through2": {
+                      "version": "1.1.1",
+                      "from": "through2@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@>=4.0.0 <4.1.0-0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    },
+                    "timers-browserify": {
+                      "version": "1.4.0",
+                      "from": "timers-browserify@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
+                      "dependencies": {
+                        "process": {
+                          "version": "0.10.1",
+                          "from": "process@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
+                        }
+                      }
+                    },
+                    "tty-browserify": {
+                      "version": "0.0.0",
+                      "from": "tty-browserify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+                    },
+                    "umd": {
+                      "version": "2.1.0",
+                      "from": "umd@>=2.1.0 <2.2.0",
+                      "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
+                      "dependencies": {
+                        "rfile": {
+                          "version": "1.0.0",
+                          "from": "rfile@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            },
+                            "resolve": {
+                              "version": "0.3.1",
+                              "from": "resolve@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
+                            }
+                          }
+                        },
+                        "ruglify": {
+                          "version": "1.0.0",
+                          "from": "ruglify@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+                          "dependencies": {
+                            "uglify-js": {
+                              "version": "2.2.5",
+                              "from": "uglify-js@>=2.2.0 <2.3.0",
+                              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                              "dependencies": {
+                                "source-map": {
+                                  "version": "0.1.43",
+                                  "from": "source-map@>=0.1.7 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                                  "dependencies": {
+                                    "amdefine": {
+                                      "version": "0.1.0",
+                                      "from": "amdefine@>=0.0.4",
+                                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                    }
+                                  }
+                                },
+                                "optimist": {
+                                  "version": "0.3.7",
+                                  "from": "optimist@>=0.3.5 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                                  "dependencies": {
+                                    "wordwrap": {
+                                      "version": "0.0.2",
+                                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "through": {
+                          "version": "2.3.6",
+                          "from": "through@>=2.3.4 <2.4.0",
+                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                        }
+                      }
+                    },
+                    "url": {
+                      "version": "0.10.3",
+                      "from": "url@>=0.10.1 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.3.2",
+                          "from": "punycode@1.3.2",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                        },
+                        "querystring": {
+                          "version": "0.2.0",
+                          "from": "querystring@0.2.0",
+                          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "util": {
+                      "version": "0.10.3",
+                      "from": "util@>=0.10.1 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+                    },
+                    "vm-browserify": {
+                      "version": "0.0.4",
+                      "from": "vm-browserify@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+                      "dependencies": {
+                        "indexof": {
+                          "version": "0.0.1",
+                          "from": "indexof@0.0.1",
+                          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "from": "xtend@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                },
+                "js-sha1": {
+                  "version": "0.2.0",
+                  "from": "js-sha1@0.2.0",
+                  "resolved": "https://registry.npmjs.org/js-sha1/-/js-sha1-0.2.0.tgz"
+                }
+              }
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "async@0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "boom": {
+              "version": "2.6.1",
+              "from": "boom@2.6.1",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.11.1",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
+                }
+              }
+            },
+            "browserify": {
+              "version": "9.0.3",
+              "from": "browserify@9.0.3",
+              "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "0.10.0",
+                  "from": "JSONStream@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "0.0.5",
+                      "from": "jsonparse@0.0.5",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.6",
+                      "from": "through@>=2.2.7 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                    }
+                  }
+                },
+                "assert": {
+                  "version": "1.3.0",
+                  "from": "assert@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+                },
+                "browser-pack": {
+                  "version": "4.0.1",
+                  "from": "browser-pack@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
+                  "dependencies": {
+                    "JSONStream": {
+                      "version": "0.8.4",
+                      "from": "JSONStream@>=0.8.4 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+                      "dependencies": {
+                        "jsonparse": {
+                          "version": "0.0.5",
+                          "from": "jsonparse@0.0.5",
+                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                        },
+                        "through": {
+                          "version": "2.3.6",
+                          "from": "through@>=2.2.7 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                        }
+                      }
+                    },
+                    "combine-source-map": {
+                      "version": "0.3.0",
+                      "from": "combine-source-map@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                      "dependencies": {
+                        "inline-source-map": {
+                          "version": "0.3.1",
+                          "from": "inline-source-map@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                          "dependencies": {
+                            "source-map": {
+                              "version": "0.3.0",
+                              "from": "source-map@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                              "dependencies": {
+                                "amdefine": {
+                                  "version": "0.1.0",
+                                  "from": "amdefine@>=0.0.4",
+                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "convert-source-map": {
+                          "version": "0.3.5",
+                          "from": "convert-source-map@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                        },
+                        "source-map": {
+                          "version": "0.1.43",
+                          "from": "source-map@>=0.1.31 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "0.1.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "through2": {
+                      "version": "0.5.1",
+                      "from": "through2@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@>=1.0.17 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "umd": {
+                      "version": "3.0.0",
+                      "from": "umd@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
+                    }
+                  }
+                },
+                "browser-resolve": {
+                  "version": "1.8.0",
+                  "from": "browser-resolve@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.0.tgz"
+                },
+                "browserify-zlib": {
+                  "version": "0.1.4",
+                  "from": "browserify-zlib@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                  "dependencies": {
+                    "pako": {
+                      "version": "0.2.5",
+                      "from": "pako@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
+                    }
+                  }
+                },
+                "buffer": {
+                  "version": "3.1.0",
+                  "from": "buffer@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.0.tgz",
+                  "dependencies": {
+                    "base64-js": {
+                      "version": "0.0.8",
+                      "from": "base64-js@0.0.8",
+                      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+                    },
+                    "ieee754": {
+                      "version": "1.1.4",
+                      "from": "ieee754@>=1.1.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+                    },
+                    "is-array": {
+                      "version": "1.0.1",
+                      "from": "is-array@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+                    }
+                  }
+                },
+                "builtins": {
+                  "version": "0.0.7",
+                  "from": "builtins@>=0.0.3 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+                },
+                "commondir": {
+                  "version": "0.0.1",
+                  "from": "commondir@0.0.1",
+                  "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
+                },
+                "concat-stream": {
+                  "version": "1.4.7",
+                  "from": "concat-stream@>=1.4.1 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+                  "dependencies": {
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    }
+                  }
+                },
+                "console-browserify": {
+                  "version": "1.1.0",
+                  "from": "console-browserify@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                  "dependencies": {
+                    "date-now": {
+                      "version": "0.1.4",
+                      "from": "date-now@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                    }
+                  }
+                },
+                "constants-browserify": {
+                  "version": "0.0.1",
+                  "from": "constants-browserify@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+                },
+                "crypto-browserify": {
+                  "version": "3.9.13",
+                  "from": "crypto-browserify@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
+                  "dependencies": {
+                    "browserify-aes": {
+                      "version": "1.0.0",
+                      "from": "browserify-aes@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
+                    },
+                    "browserify-sign": {
+                      "version": "2.8.0",
+                      "from": "browserify-sign@2.8.0",
+                      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "1.3.0",
+                          "from": "bn.js@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                        },
+                        "browserify-rsa": {
+                          "version": "1.1.1",
+                          "from": "browserify-rsa@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+                        },
+                        "elliptic": {
+                          "version": "1.0.1",
+                          "from": "elliptic@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                          "dependencies": {
+                            "brorand": {
+                              "version": "1.0.5",
+                              "from": "brorand@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                            },
+                            "hash.js": {
+                              "version": "1.0.2",
+                              "from": "hash.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "parse-asn1": {
+                          "version": "2.0.0",
+                          "from": "parse-asn1@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                          "dependencies": {
+                            "asn1.js": {
+                              "version": "1.0.3",
+                              "from": "asn1.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                              "dependencies": {
+                                "minimalistic-assert": {
+                                  "version": "1.0.0",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "asn1.js-rfc3280": {
+                              "version": "1.0.0",
+                              "from": "asn1.js-rfc3280@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
+                            },
+                            "pemstrip": {
+                              "version": "0.0.1",
+                              "from": "pemstrip@0.0.1",
+                              "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "create-ecdh": {
+                      "version": "2.0.0",
+                      "from": "create-ecdh@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "1.3.0",
+                          "from": "bn.js@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                        },
+                        "elliptic": {
+                          "version": "1.0.1",
+                          "from": "elliptic@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz",
+                          "dependencies": {
+                            "brorand": {
+                              "version": "1.0.5",
+                              "from": "brorand@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                            },
+                            "hash.js": {
+                              "version": "1.0.2",
+                              "from": "hash.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "create-hash": {
+                      "version": "1.1.0",
+                      "from": "create-hash@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
+                      "dependencies": {
+                        "ripemd160": {
+                          "version": "1.0.0",
+                          "from": "ripemd160@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
+                        },
+                        "sha.js": {
+                          "version": "2.3.6",
+                          "from": "sha.js@>=2.3.6 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
+                        }
+                      }
+                    },
+                    "create-hmac": {
+                      "version": "1.1.3",
+                      "from": "create-hmac@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
+                    },
+                    "diffie-hellman": {
+                      "version": "3.0.1",
+                      "from": "diffie-hellman@>=3.0.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "1.3.0",
+                          "from": "bn.js@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                        },
+                        "miller-rabin": {
+                          "version": "1.1.5",
+                          "from": "miller-rabin@>=1.1.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                          "dependencies": {
+                            "brorand": {
+                              "version": "1.0.5",
+                              "from": "brorand@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pbkdf2-compat": {
+                      "version": "3.0.2",
+                      "from": "pbkdf2-compat@>=3.0.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
+                    },
+                    "public-encrypt": {
+                      "version": "2.0.0",
+                      "from": "public-encrypt@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "1.3.0",
+                          "from": "bn.js@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+                        },
+                        "browserify-rsa": {
+                          "version": "2.0.0",
+                          "from": "browserify-rsa@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+                        },
+                        "parse-asn1": {
+                          "version": "3.0.0",
+                          "from": "parse-asn1@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                          "dependencies": {
+                            "asn1.js": {
+                              "version": "1.0.3",
+                              "from": "asn1.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                              "dependencies": {
+                                "minimalistic-assert": {
+                                  "version": "1.0.0",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "randombytes": {
+                      "version": "2.0.1",
+                      "from": "randombytes@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
+                    }
+                  }
+                },
+                "deep-equal": {
+                  "version": "1.0.0",
+                  "from": "deep-equal@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+                },
+                "defined": {
+                  "version": "0.0.0",
+                  "from": "defined@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+                },
+                "deps-sort": {
+                  "version": "1.3.5",
+                  "from": "deps-sort@>=1.3.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+                  "dependencies": {
+                    "JSONStream": {
+                      "version": "0.8.4",
+                      "from": "JSONStream@>=0.8.4 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+                      "dependencies": {
+                        "jsonparse": {
+                          "version": "0.0.5",
+                          "from": "jsonparse@0.0.5",
+                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                        },
+                        "through": {
+                          "version": "2.3.6",
+                          "from": "through@>=2.2.7 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "0.2.0",
+                      "from": "minimist@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+                    },
+                    "through2": {
+                      "version": "0.5.1",
+                      "from": "through2@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@>=1.0.17 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "domain-browser": {
+                  "version": "1.1.4",
+                  "from": "domain-browser@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+                },
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+                },
+                "events": {
+                  "version": "1.0.2",
+                  "from": "events@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+                },
+                "glob": {
+                  "version": "4.5.2",
+                  "from": "glob@>=4.0.5 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.2.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.3",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.3.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "has": {
+                  "version": "1.0.0",
+                  "from": "has@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
+                },
+                "http-browserify": {
+                  "version": "1.7.0",
+                  "from": "http-browserify@>=1.4.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+                  "dependencies": {
+                    "Base64": {
+                      "version": "0.2.1",
+                      "from": "Base64@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                    }
+                  }
+                },
+                "https-browserify": {
+                  "version": "0.0.0",
+                  "from": "https-browserify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+                },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "insert-module-globals": {
+                  "version": "6.2.1",
+                  "from": "insert-module-globals@>=6.2.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
+                  "dependencies": {
+                    "JSONStream": {
+                      "version": "0.7.4",
+                      "from": "JSONStream@>=0.7.1 <0.8.0",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                      "dependencies": {
+                        "jsonparse": {
+                          "version": "0.0.5",
+                          "from": "jsonparse@0.0.5",
+                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "combine-source-map": {
+                      "version": "0.3.0",
+                      "from": "combine-source-map@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                      "dependencies": {
+                        "inline-source-map": {
+                          "version": "0.3.1",
+                          "from": "inline-source-map@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                          "dependencies": {
+                            "source-map": {
+                              "version": "0.3.0",
+                              "from": "source-map@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                              "dependencies": {
+                                "amdefine": {
+                                  "version": "0.1.0",
+                                  "from": "amdefine@>=0.0.4",
+                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "convert-source-map": {
+                          "version": "0.3.5",
+                          "from": "convert-source-map@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                        },
+                        "source-map": {
+                          "version": "0.1.43",
+                          "from": "source-map@>=0.1.31 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "0.1.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lexical-scope": {
+                      "version": "1.1.0",
+                      "from": "lexical-scope@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+                      "dependencies": {
+                        "astw": {
+                          "version": "1.1.0",
+                          "from": "astw@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                          "dependencies": {
+                            "esprima-fb": {
+                              "version": "3001.1.0-dev-harmony-fb",
+                              "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "process": {
+                      "version": "0.6.0",
+                      "from": "process@>=0.6.0 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.6",
+                      "from": "through@>=2.3.4 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                    }
+                  }
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "labeled-stream-splicer": {
+                  "version": "1.0.2",
+                  "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+                  "dependencies": {
+                    "stream-splicer": {
+                      "version": "1.3.1",
+                      "from": "stream-splicer@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+                      "dependencies": {
+                        "readable-wrap": {
+                          "version": "1.0.0",
+                          "from": "readable-wrap@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
+                        },
+                        "indexof": {
+                          "version": "0.0.1",
+                          "from": "indexof@0.0.1",
+                          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "module-deps": {
+                  "version": "3.7.2",
+                  "from": "module-deps@>=3.6.3 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.2.tgz",
+                  "dependencies": {
+                    "JSONStream": {
+                      "version": "0.7.4",
+                      "from": "JSONStream@>=0.7.1 <0.8.0",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                      "dependencies": {
+                        "jsonparse": {
+                          "version": "0.0.5",
+                          "from": "jsonparse@0.0.5",
+                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                        },
+                        "through": {
+                          "version": "2.3.6",
+                          "from": "through@>=2.2.7 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                        }
+                      }
+                    },
+                    "detective": {
+                      "version": "4.0.0",
+                      "from": "detective@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
+                      "dependencies": {
+                        "acorn": {
+                          "version": "0.9.0",
+                          "from": "acorn@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                        },
+                        "escodegen": {
+                          "version": "1.6.1",
+                          "from": "escodegen@>=1.4.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                          "dependencies": {
+                            "estraverse": {
+                              "version": "1.9.3",
+                              "from": "estraverse@>=1.9.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                            },
+                            "esutils": {
+                              "version": "1.1.6",
+                              "from": "esutils@>=1.1.6 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                            },
+                            "esprima": {
+                              "version": "1.2.5",
+                              "from": "esprima@>=1.2.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                            },
+                            "optionator": {
+                              "version": "0.5.0",
+                              "from": "optionator@>=0.5.0 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                              "dependencies": {
+                                "prelude-ls": {
+                                  "version": "1.1.1",
+                                  "from": "prelude-ls@>=1.1.1 <1.2.0",
+                                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                                },
+                                "deep-is": {
+                                  "version": "0.1.3",
+                                  "from": "deep-is@>=0.1.2 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                },
+                                "type-check": {
+                                  "version": "0.3.1",
+                                  "from": "type-check@>=0.3.1 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                                },
+                                "levn": {
+                                  "version": "0.2.5",
+                                  "from": "levn@>=0.2.5 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                                },
+                                "fast-levenshtein": {
+                                  "version": "1.0.6",
+                                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                                }
+                              }
+                            },
+                            "source-map": {
+                              "version": "0.1.43",
+                              "from": "source-map@>=0.1.40 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                              "dependencies": {
+                                "amdefine": {
+                                  "version": "0.1.0",
+                                  "from": "amdefine@>=0.0.4",
+                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "0.2.0",
+                      "from": "minimist@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+                    },
+                    "stream-combiner2": {
+                      "version": "1.0.2",
+                      "from": "stream-combiner2@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+                      "dependencies": {
+                        "through2": {
+                          "version": "0.5.1",
+                          "from": "through2@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@>=1.0.17 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "xtend": {
+                              "version": "3.0.0",
+                              "from": "xtend@>=3.0.0 <3.1.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "subarg": {
+                      "version": "0.0.1",
+                      "from": "subarg@0.0.1",
+                      "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.10",
+                          "from": "minimist@>=0.0.7 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                        }
+                      }
+                    },
+                    "through2": {
+                      "version": "0.4.2",
+                      "from": "through2@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@>=1.0.17 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "2.1.2",
+                          "from": "xtend@>=2.1.1 <2.2.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                          "dependencies": {
+                            "object-keys": {
+                              "version": "0.4.0",
+                              "from": "object-keys@>=0.4.0 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                },
+                "os-browserify": {
+                  "version": "0.1.2",
+                  "from": "os-browserify@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+                },
+                "parents": {
+                  "version": "1.0.1",
+                  "from": "parents@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+                  "dependencies": {
+                    "path-platform": {
+                      "version": "0.11.15",
+                      "from": "path-platform@>=0.11.15 <0.12.0",
+                      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
+                    }
+                  }
+                },
+                "path-browserify": {
+                  "version": "0.0.0",
+                  "from": "path-browserify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+                },
+                "process": {
+                  "version": "0.10.1",
+                  "from": "process@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
+                },
+                "punycode": {
+                  "version": "1.2.4",
+                  "from": "punycode@>=1.2.3 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+                },
+                "querystring-es3": {
+                  "version": "0.2.1",
+                  "from": "querystring-es3@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.13 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                },
+                "resolve": {
+                  "version": "1.1.5",
+                  "from": "resolve@>=1.1.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.5.tgz"
+                },
+                "shallow-copy": {
+                  "version": "0.0.1",
+                  "from": "shallow-copy@0.0.1",
+                  "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+                },
+                "shasum": {
+                  "version": "1.0.1",
+                  "from": "shasum@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
+                  "dependencies": {
+                    "json-stable-stringify": {
+                      "version": "0.0.1",
+                      "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                      "dependencies": {
+                        "jsonify": {
+                          "version": "0.0.0",
+                          "from": "jsonify@>=0.0.0 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                        }
+                      }
+                    },
+                    "sha.js": {
+                      "version": "2.3.6",
+                      "from": "sha.js@>=2.3.0 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
+                    }
+                  }
+                },
+                "shell-quote": {
+                  "version": "0.0.1",
+                  "from": "shell-quote@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
+                },
+                "stream-browserify": {
+                  "version": "1.0.0",
+                  "from": "stream-browserify@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "subarg": {
+                  "version": "1.0.0",
+                  "from": "subarg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    }
+                  }
+                },
+                "syntax-error": {
+                  "version": "1.1.2",
+                  "from": "syntax-error@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+                  "dependencies": {
+                    "acorn": {
+                      "version": "0.9.0",
+                      "from": "acorn@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "1.1.1",
+                  "from": "through2@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+                  "dependencies": {
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                },
+                "timers-browserify": {
+                  "version": "1.4.0",
+                  "from": "timers-browserify@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
+                },
+                "tty-browserify": {
+                  "version": "0.0.0",
+                  "from": "tty-browserify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+                },
+                "url": {
+                  "version": "0.10.3",
+                  "from": "url@>=0.10.1 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@1.3.2",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    },
+                    "querystring": {
+                      "version": "0.2.0",
+                      "from": "querystring@0.2.0",
+                      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                    }
+                  }
+                },
+                "util": {
+                  "version": "0.10.3",
+                  "from": "util@>=0.10.1 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+                },
+                "vm-browserify": {
+                  "version": "0.0.4",
+                  "from": "vm-browserify@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+                  "dependencies": {
+                    "indexof": {
+                      "version": "0.0.1",
+                      "from": "indexof@0.0.1",
+                      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "3.0.0",
+                  "from": "xtend@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                }
+              }
+            },
+            "convict": {
+              "version": "0.6.1",
+              "from": "convict@0.6.1",
+              "resolved": "https://registry.npmjs.org/convict/-/convict-0.6.1.tgz",
+              "dependencies": {
+                "cjson": {
+                  "version": "0.3.0",
+                  "from": "cjson@0.3.0",
+                  "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+                  "dependencies": {
+                    "jsonlint": {
+                      "version": "1.6.0",
+                      "from": "jsonlint@1.6.0",
+                      "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+                      "dependencies": {
+                        "nomnom": {
+                          "version": "1.8.1",
+                          "from": "nomnom@>=1.5.0",
+                          "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                          "dependencies": {
+                            "underscore": {
+                              "version": "1.6.0",
+                              "from": "underscore@>=1.6.0 <1.7.0",
+                              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                            },
+                            "chalk": {
+                              "version": "0.4.0",
+                              "from": "chalk@>=0.4.0 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                              "dependencies": {
+                                "has-color": {
+                                  "version": "0.1.7",
+                                  "from": "has-color@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                                },
+                                "ansi-styles": {
+                                  "version": "1.0.0",
+                                  "from": "ansi-styles@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                                },
+                                "strip-ansi": {
+                                  "version": "0.1.1",
+                                  "from": "strip-ansi@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "JSV": {
+                          "version": "4.0.2",
+                          "from": "JSV@>=4.0.0",
+                          "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "depd": {
+                  "version": "1.0.0",
+                  "from": "depd@1.0.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+                },
+                "moment": {
+                  "version": "2.8.4",
+                  "from": "moment@2.8.4",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@0.6.1",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                },
+                "validator": {
+                  "version": "3.26.0",
+                  "from": "validator@3.26.0",
+                  "resolved": "https://registry.npmjs.org/validator/-/validator-3.26.0.tgz"
+                }
+              }
+            },
+            "github-url-to-object": {
+              "version": "1.4.2",
+              "from": "github-url-to-object@1.4.2",
+              "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-1.4.2.tgz",
+              "dependencies": {
+                "is-url": {
+                  "version": "1.2.0",
+                  "from": "is-url@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.0.tgz"
+                }
+              }
+            },
+            "glob": {
+              "version": "5.0.2",
+              "from": "glob@5.0.2",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.2.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "0.3.0",
-                  "from": "minimatch@0.3",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "version": "2.0.3",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.3.tgz",
                   "dependencies": {
-                    "lru-cache": {
-                      "version": "2.5.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
-            "lodash": {
-              "version": "2.4.1",
-              "from": "lodash@~2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-            }
-          }
-        },
-        "glob": {
-          "version": "3.1.21",
-          "from": "glob@~3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-            },
-            "inherits": {
-              "version": "1.0.0",
-              "from": "inherits@1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-            }
-          }
-        },
-        "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@~0.2.3",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        },
-        "iconv-lite": {
-          "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "from": "minimatch@~0.2.12",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "dependencies": {
-            "lru-cache": {
-              "version": "2.5.0",
-              "from": "lru-cache@2",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-            },
-            "sigmund": {
-              "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
-            }
-          }
-        },
-        "nopt": {
-          "version": "1.0.10",
-          "from": "nopt@~1.0.10",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.5",
-              "from": "abbrev@1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-            }
-          }
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "from": "rimraf@~2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-        },
-        "lodash": {
-          "version": "0.9.2",
-          "from": "lodash@~0.9.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
-        },
-        "underscore.string": {
-          "version": "2.2.1",
-          "from": "underscore.string@~2.2.1",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
-        },
-        "which": {
-          "version": "1.0.8",
-          "from": "which@~1.0.5",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
-        },
-        "js-yaml": {
-          "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-          "dependencies": {
-            "argparse": {
-              "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+            "hapi": {
+              "version": "8.3.1",
+              "from": "hapi@8.3.1",
+              "resolved": "https://registry.npmjs.org/hapi/-/hapi-8.3.1.tgz",
               "dependencies": {
-                "underscore": {
-                  "version": "1.7.0",
-                  "from": "underscore@~1.7.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                "accept": {
+                  "version": "1.0.0",
+                  "from": "accept@1.0.0",
+                  "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz"
                 },
-                "underscore.string": {
-                  "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                "ammo": {
+                  "version": "1.0.0",
+                  "from": "ammo@1.0.0",
+                  "resolved": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz"
+                },
+                "call": {
+                  "version": "2.0.1",
+                  "from": "call@2.0.1",
+                  "resolved": "https://registry.npmjs.org/call/-/call-2.0.1.tgz"
+                },
+                "catbox": {
+                  "version": "4.2.1",
+                  "from": "catbox@4.2.1",
+                  "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.2.1.tgz",
+                  "dependencies": {
+                    "joi": {
+                      "version": "5.1.0",
+                      "from": "joi@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                      "dependencies": {
+                        "isemail": {
+                          "version": "1.1.1",
+                          "from": "isemail@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
+                        },
+                        "moment": {
+                          "version": "2.9.0",
+                          "from": "moment@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "catbox-memory": {
+                  "version": "1.1.1",
+                  "from": "catbox-memory@1.1.1",
+                  "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.4",
+                  "from": "cryptiles@2.0.4",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                },
+                "h2o2": {
+                  "version": "4.0.0",
+                  "from": "h2o2@4.0.0",
+                  "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.0.tgz",
+                  "dependencies": {
+                    "joi": {
+                      "version": "5.1.0",
+                      "from": "joi@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                      "dependencies": {
+                        "isemail": {
+                          "version": "1.1.1",
+                          "from": "isemail@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
+                        },
+                        "moment": {
+                          "version": "2.9.0",
+                          "from": "moment@2.9.0",
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "heavy": {
+                  "version": "3.0.0",
+                  "from": "heavy@3.0.0",
+                  "resolved": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
+                  "dependencies": {
+                    "joi": {
+                      "version": "5.1.0",
+                      "from": "joi@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                      "dependencies": {
+                        "isemail": {
+                          "version": "1.1.1",
+                          "from": "isemail@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
+                        },
+                        "moment": {
+                          "version": "2.9.0",
+                          "from": "moment@2.9.0",
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "hoek": {
+                  "version": "2.11.1",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
+                },
+                "inert": {
+                  "version": "2.1.4",
+                  "from": "inert@2.1.4",
+                  "resolved": "https://registry.npmjs.org/inert/-/inert-2.1.4.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2.5.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    }
+                  }
+                },
+                "iron": {
+                  "version": "2.1.2",
+                  "from": "iron@2.1.2",
+                  "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz"
+                },
+                "items": {
+                  "version": "1.1.0",
+                  "from": "items@1.1.0",
+                  "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
+                },
+                "joi": {
+                  "version": "6.0.5",
+                  "from": "joi@6.0.5",
+                  "resolved": "https://registry.npmjs.org/joi/-/joi-6.0.5.tgz",
+                  "dependencies": {
+                    "isemail": {
+                      "version": "1.1.1",
+                      "from": "isemail@1.1.1",
+                      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
+                    },
+                    "moment": {
+                      "version": "2.9.0",
+                      "from": "moment@2.9.0",
+                      "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
+                    }
+                  }
+                },
+                "kilt": {
+                  "version": "1.1.1",
+                  "from": "kilt@1.1.1",
+                  "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
+                },
+                "mimos": {
+                  "version": "2.0.2",
+                  "from": "mimos@2.0.2",
+                  "resolved": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.7.0",
+                      "from": "mime-db@1.7.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                    }
+                  }
+                },
+                "peekaboo": {
+                  "version": "1.0.0",
+                  "from": "peekaboo@1.0.0",
+                  "resolved": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@2.3.3",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "shot": {
+                  "version": "1.4.2",
+                  "from": "shot@1.4.2",
+                  "resolved": "https://registry.npmjs.org/shot/-/shot-1.4.2.tgz"
+                },
+                "statehood": {
+                  "version": "2.0.0",
+                  "from": "statehood@2.0.0",
+                  "resolved": "https://registry.npmjs.org/statehood/-/statehood-2.0.0.tgz",
+                  "dependencies": {
+                    "joi": {
+                      "version": "5.1.0",
+                      "from": "joi@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                      "dependencies": {
+                        "isemail": {
+                          "version": "1.1.1",
+                          "from": "isemail@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
+                        },
+                        "moment": {
+                          "version": "2.9.0",
+                          "from": "moment@2.9.0",
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "subtext": {
+                  "version": "1.0.2",
+                  "from": "subtext@1.0.2",
+                  "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
+                  "dependencies": {
+                    "content": {
+                      "version": "1.0.1",
+                      "from": "content@1.0.1",
+                      "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz"
+                    },
+                    "pez": {
+                      "version": "1.0.0",
+                      "from": "pez@1.0.0",
+                      "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+                      "dependencies": {
+                        "b64": {
+                          "version": "2.0.0",
+                          "from": "b64@2.0.0",
+                          "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz"
+                        },
+                        "nigel": {
+                          "version": "1.0.1",
+                          "from": "nigel@1.0.1",
+                          "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                          "dependencies": {
+                            "vise": {
+                              "version": "1.0.0",
+                              "from": "vise@1.0.0",
+                              "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "topo": {
+                  "version": "1.0.2",
+                  "from": "topo@1.0.2",
+                  "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
+                },
+                "vision": {
+                  "version": "2.0.0",
+                  "from": "vision@2.0.0",
+                  "resolved": "https://registry.npmjs.org/vision/-/vision-2.0.0.tgz",
+                  "dependencies": {
+                    "joi": {
+                      "version": "5.1.0",
+                      "from": "joi@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                      "dependencies": {
+                        "isemail": {
+                          "version": "1.1.1",
+                          "from": "isemail@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
+                        },
+                        "moment": {
+                          "version": "2.9.0",
+                          "from": "moment@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "wreck": {
+                  "version": "5.2.0",
+                  "from": "wreck@5.2.0",
+                  "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.2.0.tgz"
                 }
               }
             },
-            "esprima": {
-              "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-            }
-          }
-        },
-        "exit": {
-          "version": "0.1.2",
-          "from": "exit@~0.1.1",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-        },
-        "getobject": {
-          "version": "0.1.0",
-          "from": "getobject@~0.1.0",
-          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
-        },
-        "grunt-legacy-util": {
-          "version": "0.2.0",
-          "from": "grunt-legacy-util@~0.2.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
-        },
-        "grunt-legacy-log": {
-          "version": "0.1.1",
-          "from": "grunt-legacy-log@~0.1.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "2.4.1",
-              "from": "lodash@~2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-            },
-            "underscore.string": {
-              "version": "2.3.3",
-              "from": "underscore.string@~2.3.3",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-autoprefixer": {
-      "version": "1.0.0",
-      "from": "grunt-autoprefixer@1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-1.0.0.tgz",
-      "dependencies": {
-        "autoprefixer": {
-          "version": "2.2.0",
-          "from": "autoprefixer@^2.1.0",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-2.2.0.tgz",
-          "dependencies": {
-            "caniuse-db": {
-              "version": "1.0.30000036",
-              "from": "caniuse-db@^1.0.20140727",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000036.tgz"
-            },
-            "fs-extra": {
-              "version": "0.10.0",
-              "from": "fs-extra@~0.10.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.10.0.tgz",
+            "hapi-fxa-oauth": {
+              "version": "2.0.1",
+              "from": "hapi-fxa-oauth@2.0.1",
+              "resolved": "https://registry.npmjs.org/hapi-fxa-oauth/-/hapi-fxa-oauth-2.0.1.tgz",
               "dependencies": {
-                "ncp": {
-                  "version": "0.5.1",
-                  "from": "ncp@^0.5.1",
-                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz"
+                "poolee": {
+                  "version": "0.4.15",
+                  "from": "poolee@0.4.15",
+                  "resolved": "https://registry.npmjs.org/poolee/-/poolee-0.4.15.tgz",
+                  "dependencies": {
+                    "keep-alive-agent": {
+                      "version": "0.0.1",
+                      "from": "keep-alive-agent@0.0.1",
+                      "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mozlog": {
+              "version": "1.0.3",
+              "from": "mozlog@1.0.3",
+              "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-1.0.3.tgz",
+              "dependencies": {
+                "intel": {
+                  "version": "1.0.0",
+                  "from": "intel@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "0.5.1",
+                      "from": "chalk@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "1.1.0",
+                          "from": "ansi-styles@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "0.1.0",
+                          "from": "has-ansi@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "0.2.1",
+                              "from": "ansi-regex@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "0.3.0",
+                          "from": "strip-ansi@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "0.2.1",
+                              "from": "ansi-regex@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "0.2.0",
+                          "from": "supports-color@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "dbug": {
+                      "version": "0.4.2",
+                      "from": "dbug@>=0.4.2 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
+                    },
+                    "stack-trace": {
+                      "version": "0.0.9",
+                      "from": "stack-trace@>=0.0.9 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+                    },
+                    "strftime": {
+                      "version": "0.8.4",
+                      "from": "strftime@>=0.8.2 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.4.tgz"
+                    },
+                    "symbol": {
+                      "version": "0.2.1",
+                      "from": "symbol@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
+                    },
+                    "utcstring": {
+                      "version": "0.1.0",
+                      "from": "utcstring@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
+                    }
+                  }
                 },
-                "jsonfile": {
+                "merge": {
                   "version": "1.2.0",
-                  "from": "jsonfile@^1.2.0",
-                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.2.0.tgz"
-                },
-                "rimraf": {
-                  "version": "2.2.8",
-                  "from": "rimraf@^2.2.8",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                  "from": "merge@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
                 }
               }
             },
-            "postcss": {
-              "version": "2.1.2",
-              "from": "postcss@~2.1.0",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-2.1.2.tgz",
+            "uglify-js": {
+              "version": "2.4.17",
+              "from": "uglify-js@2.4.17",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.17.tgz",
               "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
                 "source-map": {
-                  "version": "0.1.41",
-                  "from": "source-map@~0.1.38",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
@@ -2551,113 +5033,85 @@
                     }
                   }
                 },
-                "js-base64": {
-                  "version": "2.1.5",
-                  "from": "js-base64@~2.1.5",
-                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.5.tgz"
+                "yargs": {
+                  "version": "1.3.3",
+                  "from": "yargs@>=1.3.3 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 }
               }
             }
           }
         },
-        "diff": {
-          "version": "1.0.8",
-          "from": "diff@~1.0.8",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "from": "chalk@~0.5",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
+        "parseurl": {
+          "version": "1.3.0",
+          "from": "parseurl@1.3.0",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
         }
       }
     },
-    "grunt-cli": {
-      "version": "0.1.13",
-      "from": "grunt-cli@0.1.13",
-      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+    "grunt": {
+      "version": "0.4.5",
+      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
-        "nopt": {
-          "version": "1.0.10",
-          "from": "nopt@~1.0.10",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.5",
-              "from": "abbrev@1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-            }
-          }
+        "async": {
+          "version": "0.1.22",
+          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.0-1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+        },
+        "eventemitter2": {
+          "version": "0.4.14",
+          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.0",
+          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -2666,36 +5120,349 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+        },
+        "which": {
+          "version": "1.0.8",
+          "from": "https://registry.npmjs.org/which/-/which-1.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "from": "argparse@>=0.1.11 <0.2.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-autoprefixer": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-1.0.0.tgz",
+      "dependencies": {
+        "autoprefixer": {
+          "version": "2.2.0",
+          "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-2.2.0.tgz",
+          "dependencies": {
+            "caniuse-db": {
+              "version": "1.0.30000036",
+              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000036.tgz",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000036.tgz"
+            },
+            "fs-extra": {
+              "version": "0.10.0",
+              "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.10.0.tgz",
+              "dependencies": {
+                "ncp": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz"
+                },
+                "jsonfile": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.2.0.tgz"
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                }
+              }
+            },
+            "postcss": {
+              "version": "2.1.2",
+              "from": "https://registry.npmjs.org/postcss/-/postcss-2.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-2.1.2.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.41",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "js-base64": {
+                  "version": "2.1.5",
+                  "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "diff": {
+          "version": "1.0.8",
+          "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-cli": {
+      "version": "0.1.13",
+      "from": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "0.3.1",
-          "from": "resolve@~0.3.1",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
         }
       }
     },
     "grunt-concurrent": {
       "version": "0.5.0",
-      "from": "grunt-concurrent@0.5.0",
+      "from": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-0.5.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.10",
+          "from": "async@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "pad-stdio": {
           "version": "0.1.1",
-          "from": "pad-stdio@^0.1.0",
+          "from": "https://registry.npmjs.org/pad-stdio/-/pad-stdio-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/pad-stdio/-/pad-stdio-0.1.1.tgz",
           "dependencies": {
             "lpad": {
               "version": "0.2.1",
-              "from": "lpad@^0.2.0",
+              "from": "https://registry.npmjs.org/lpad/-/lpad-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/lpad/-/lpad-0.2.1.tgz"
             }
           }
@@ -2704,17 +5471,17 @@
     },
     "grunt-connect-fonts": {
       "version": "0.0.5",
-      "from": "grunt-connect-fonts@0.0.5",
+      "from": "https://registry.npmjs.org/grunt-connect-fonts/-/grunt-connect-fonts-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/grunt-connect-fonts/-/grunt-connect-fonts-0.0.5.tgz",
       "dependencies": {
         "connect-fonts": {
           "version": "2.0.2",
-          "from": "connect-fonts@2.0.2",
+          "from": "https://registry.npmjs.org/connect-fonts/-/connect-fonts-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/connect-fonts/-/connect-fonts-2.0.2.tgz",
           "dependencies": {
             "filed": {
               "version": "0.1.0",
-              "from": "filed@0.1.0",
+              "from": "https://registry.npmjs.org/filed/-/filed-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/filed/-/filed-0.1.0.tgz"
             },
             "node-font-face-generator": {
@@ -2734,7 +5501,7 @@
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.2.4",
-                      "from": "lru-cache@2.2.4",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
                     }
                   }
@@ -2748,22 +5515,22 @@
             },
             "oppressor": {
               "version": "0.0.1",
-              "from": "oppressor@0.0.1",
+              "from": "https://registry.npmjs.org/oppressor/-/oppressor-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/oppressor/-/oppressor-0.0.1.tgz",
               "dependencies": {
                 "through": {
                   "version": "0.1.4",
-                  "from": "through@0.1.4",
+                  "from": "https://registry.npmjs.org/through/-/through-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-0.1.4.tgz"
                 },
                 "response-stream": {
                   "version": "0.0.0",
-                  "from": "response-stream@0.0.0",
+                  "from": "https://registry.npmjs.org/response-stream/-/response-stream-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/response-stream/-/response-stream-0.0.0.tgz"
                 },
                 "negotiator": {
                   "version": "0.2.6",
-                  "from": "negotiator@0.2.6",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.6.tgz"
                 }
               }
@@ -2779,75 +5546,75 @@
     },
     "grunt-contrib-clean": {
       "version": "0.6.0",
-      "from": "grunt-contrib-clean@0.6.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.1",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
     },
     "grunt-contrib-concat": {
       "version": "0.5.0",
-      "from": "grunt-contrib-concat@0.5.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.5.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "source-map": {
           "version": "0.1.41",
-          "from": "source-map@~0.1.36",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
@@ -2856,132 +5623,132 @@
     },
     "grunt-contrib-copy": {
       "version": "0.5.0",
-      "from": "grunt-contrib-copy@0.5.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz"
     },
     "grunt-contrib-cssmin": {
       "version": "0.10.0",
-      "from": "grunt-contrib-cssmin@0.10.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.10.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.10.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0",
+              "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "clean-css": {
           "version": "2.2.22",
-          "from": "clean-css@~2.2.0",
+          "from": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.22.tgz",
           "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.22.tgz",
           "dependencies": {
             "commander": {
               "version": "2.2.0",
-              "from": "commander@2.2.x",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
             }
           }
         },
         "maxmin": {
           "version": "0.2.2",
-          "from": "maxmin@^0.2.0",
+          "from": "https://registry.npmjs.org/maxmin/-/maxmin-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-0.2.2.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@^0.5.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@^1.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "figures": {
               "version": "1.3.5",
-              "from": "figures@^1.0.1",
+              "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "gzip-size": {
               "version": "0.2.0",
-              "from": "gzip-size@^0.2.0",
+              "from": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.2.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.4.7",
-                  "from": "concat-stream@^1.4.1",
+                  "from": "concat-stream@>=1.4.6 <2.0.0",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@~0.0.5",
+                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@~1.1.9",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -2991,7 +5758,7 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
@@ -3000,12 +5767,12 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "browserify-zlib@^0.1.4",
+                  "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
                       "version": "0.2.5",
-                      "from": "pako@~0.2.0",
+                      "from": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
                     }
                   }
@@ -3014,7 +5781,7 @@
             },
             "pretty-bytes": {
               "version": "0.1.2",
-              "from": "pretty-bytes@^0.1.0",
+              "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz"
             }
           }
@@ -3023,158 +5790,158 @@
     },
     "grunt-contrib-htmlmin": {
       "version": "0.3.0",
-      "from": "grunt-contrib-htmlmin@0.3.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-htmlmin/-/grunt-contrib-htmlmin-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-htmlmin/-/grunt-contrib-htmlmin-0.3.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@~0.4.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0",
+              "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "html-minifier": {
           "version": "0.6.9",
-          "from": "html-minifier@~0.6.0",
+          "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
           "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
           "dependencies": {
             "change-case": {
               "version": "2.1.6",
-              "from": "change-case@2.1.x",
+              "from": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
               "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
               "dependencies": {
                 "camel-case": {
                   "version": "1.0.2",
-                  "from": "camel-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.0.2.tgz"
                 },
                 "constant-case": {
                   "version": "1.0.0",
-                  "from": "constant-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.0.0.tgz"
                 },
                 "dot-case": {
                   "version": "1.0.1",
-                  "from": "dot-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.0.1.tgz"
                 },
                 "is-lower-case": {
                   "version": "1.0.0",
-                  "from": "is-lower-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.0.0.tgz"
                 },
                 "is-upper-case": {
                   "version": "1.0.1",
-                  "from": "is-upper-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.0.1.tgz"
                 },
                 "lower-case": {
                   "version": "1.0.2",
-                  "from": "lower-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.0.2.tgz"
                 },
                 "param-case": {
                   "version": "1.0.1",
-                  "from": "param-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/param-case/-/param-case-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.0.1.tgz"
                 },
                 "pascal-case": {
                   "version": "1.0.0",
-                  "from": "pascal-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.0.0.tgz"
                 },
                 "path-case": {
                   "version": "1.0.1",
-                  "from": "path-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/path-case/-/path-case-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.0.1.tgz"
                 },
                 "sentence-case": {
                   "version": "1.1.0",
-                  "from": "sentence-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.0.tgz"
                 },
                 "snake-case": {
                   "version": "1.0.1",
-                  "from": "snake-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.0.1.tgz"
                 },
                 "swap-case": {
                   "version": "1.0.2",
-                  "from": "swap-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.0.2.tgz"
                 },
                 "title-case": {
                   "version": "1.0.1",
-                  "from": "title-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/title-case/-/title-case-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.0.1.tgz"
                 },
                 "upper-case": {
                   "version": "1.0.3",
-                  "from": "upper-case@^1.0.0",
+                  "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.0.3.tgz"
                 },
                 "upper-case-first": {
                   "version": "1.0.1",
-                  "from": "upper-case-first@^1.0.0",
+                  "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.0.1.tgz"
                 }
               }
             },
             "clean-css": {
               "version": "2.2.22",
-              "from": "clean-css@2.2.x",
+              "from": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.22.tgz",
               "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.22.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.2.0",
-                  "from": "commander@2.2.x",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
                 }
               }
             },
             "cli": {
               "version": "0.6.5",
-              "from": "cli@0.6.x",
+              "from": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
               "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.5.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@~ 3.2.1",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@0.3",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
@@ -3183,170 +5950,170 @@
                 },
                 "exit": {
                   "version": "0.1.2",
-                  "from": "exit@0.1.2",
+                  "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.4.16",
-              "from": "uglify-js@2.4.x",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@~0.2.6",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.34",
-                  "from": "source-map@0.1.34",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 },
                 "optimist": {
                   "version": "0.3.7",
-                  "from": "optimist@~0.3.5",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@~0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@~1.0.0",
+                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 }
               }
             },
             "relateurl": {
               "version": "0.2.6",
-              "from": "relateurl@0.2.x",
+              "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz",
               "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
             }
           }
         },
         "pretty-bytes": {
           "version": "0.1.2",
-          "from": "pretty-bytes@~0.1.0",
+          "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz"
         }
       }
     },
     "grunt-contrib-uglify": {
       "version": "0.5.1",
-      "from": "grunt-contrib-uglify@0.5.1",
+      "from": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.5.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@^2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "maxmin": {
           "version": "0.2.2",
-          "from": "maxmin@^0.2.0",
+          "from": "https://registry.npmjs.org/maxmin/-/maxmin-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-0.2.2.tgz",
           "dependencies": {
             "figures": {
               "version": "1.3.5",
-              "from": "figures@^1.0.1",
+              "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "gzip-size": {
               "version": "0.2.0",
-              "from": "gzip-size@^0.2.0",
+              "from": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.2.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.4.7",
-                  "from": "concat-stream@^1.4.1",
+                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@~0.0.5",
+                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@~1.1.9",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
@@ -3355,12 +6122,12 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "browserify-zlib@^0.1.4",
+                  "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
                       "version": "0.2.5",
-                      "from": "pako@~0.2.0",
+                      "from": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
                     }
                   }
@@ -3369,48 +6136,48 @@
             },
             "pretty-bytes": {
               "version": "0.1.2",
-              "from": "pretty-bytes@^0.1.0",
+              "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.4.16",
-          "from": "uglify-js@^2.4.0",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.6",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.34",
-              "from": "source-map@0.1.34",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             },
             "optimist": {
               "version": "0.3.7",
-              "from": "optimist@~0.3.5",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@~0.0.2",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@~1.0.0",
+              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             }
           }
@@ -3419,69 +6186,69 @@
     },
     "grunt-marked": {
       "version": "0.1.1",
-      "from": "grunt-marked@0.1.1",
+      "from": "https://registry.npmjs.org/grunt-marked/-/grunt-marked-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-marked/-/grunt-marked-0.1.1.tgz",
       "dependencies": {
         "marked": {
           "version": "0.3.2",
-          "from": "marked@~0.3.1",
+          "from": "https://registry.npmjs.org/marked/-/marked-0.3.2.tgz",
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.2.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9",
+          "from": "async@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "highlight.js": {
           "version": "8.0.0",
-          "from": "highlight.js@~8.0.0",
+          "from": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.0.0.tgz",
           "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.0.0.tgz"
         }
       }
     },
     "grunt-po2json": {
       "version": "0.2.0",
-      "from": "grunt-po2json@git://github.com/shane-tomlinson/grunt-po2json.git#c1a7406",
+      "from": "../../../../var/folders/y3/9qwwh1cx789d53l9l5c2lv380000gn/T/npm-3157-989161d1/git-cache-ec2c0b1e5bc9/c1a7406a0ba518612e80bfdffd450ab589dfd86d",
       "resolved": "git://github.com/shane-tomlinson/grunt-po2json.git#c1a7406a0ba518612e80bfdffd450ab589dfd86d",
       "dependencies": {
         "po2json": {
           "version": "0.3.2",
-          "from": "po2json@*",
+          "from": "https://registry.npmjs.org/po2json/-/po2json-0.3.2.tgz",
           "resolved": "https://registry.npmjs.org/po2json/-/po2json-0.3.2.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "nomnom": {
               "version": "1.8.0",
-              "from": "nomnom@1.8.0",
+              "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.0.tgz",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.0.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "underscore@~1.6.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 },
                 "chalk": {
                   "version": "0.4.0",
-                  "from": "chalk@~0.4.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                   "dependencies": {
                     "has-color": {
                       "version": "0.1.7",
-                      "from": "has-color@~0.1.0",
+                      "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
                       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                     },
                     "ansi-styles": {
                       "version": "1.0.0",
-                      "from": "ansi-styles@~1.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                     },
                     "strip-ansi": {
                       "version": "0.1.1",
-                      "from": "strip-ansi@~0.1.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                     }
                   }
@@ -3490,17 +6257,17 @@
             },
             "gettext-parser": {
               "version": "0.2.0",
-              "from": "gettext-parser@~0.2.0",
+              "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.11",
-                  "from": "encoding@~0.1",
+                  "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.5",
-                      "from": "iconv-lite@~0.4.4",
+                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
                     }
                   }
@@ -3513,62 +6280,62 @@
     },
     "grunt-requirejs": {
       "version": "0.4.2",
-      "from": "grunt-requirejs@0.4.2",
+      "from": "https://registry.npmjs.org/grunt-requirejs/-/grunt-requirejs-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/grunt-requirejs/-/grunt-requirejs-0.4.2.tgz",
       "dependencies": {
         "requirejs": {
           "version": "2.1.15",
-          "from": "requirejs@2.1.x",
+          "from": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.15.tgz",
           "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.15.tgz"
         },
         "cheerio": {
           "version": "0.13.1",
-          "from": "cheerio@0.13.x",
+          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
           "dependencies": {
             "htmlparser2": {
               "version": "3.4.0",
-              "from": "htmlparser2@~3.4.0",
+              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.1",
-                  "from": "domhandler@2.2",
+                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
                   "version": "1.3.0",
-                  "from": "domutils@1.3",
+                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz"
                 },
                 "domelementtype": {
                   "version": "1.1.3",
-                  "from": "domelementtype@1",
+                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@1.1",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -3577,32 +6344,32 @@
             },
             "underscore": {
               "version": "1.5.2",
-              "from": "underscore@~1.5",
+              "from": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "entities@0.x",
+              "from": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             },
             "CSSselect": {
               "version": "0.4.1",
-              "from": "CSSselect@~0.4.0",
+              "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "dependencies": {
                 "CSSwhat": {
                   "version": "0.4.7",
-                  "from": "CSSwhat@0.4",
+                  "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
                   "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                 },
                 "domutils": {
                   "version": "1.4.3",
-                  "from": "domutils@1.4",
+                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "domelementtype@1",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     }
                   }
@@ -3613,205 +6380,205 @@
         },
         "almond": {
           "version": "0.2.9",
-          "from": "almond@0.2.x",
+          "from": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz",
           "resolved": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz"
         },
         "gzip-js": {
           "version": "0.3.2",
-          "from": "gzip-js@0.3.x",
+          "from": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
           "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
           "dependencies": {
             "crc32": {
               "version": "0.2.2",
-              "from": "crc32@>= 0.2.2",
+              "from": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
               "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
             },
             "deflate-js": {
               "version": "0.2.3",
-              "from": "deflate-js@>= 0.2.2",
+              "from": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz",
               "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz"
             }
           }
         },
         "q": {
           "version": "0.8.12",
-          "from": "q@0.8.x",
+          "from": "https://registry.npmjs.org/q/-/q-0.8.12.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz"
         }
       }
     },
     "grunt-rev": {
       "version": "0.1.0",
-      "from": "grunt-rev@0.1.0",
+      "from": "https://registry.npmjs.org/grunt-rev/-/grunt-rev-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-rev/-/grunt-rev-0.1.0.tgz"
     },
     "grunt-sass": {
       "version": "0.14.0",
-      "from": "grunt-sass@0.14.0",
+      "from": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.14.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.14.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@^0.4.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "dependencies": {
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@~0.1.0",
+              "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "ansi-styles": {
               "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
             },
             "strip-ansi": {
               "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
             }
           }
         },
         "each-async": {
           "version": "0.1.3",
-          "from": "each-async@^0.1.2",
+          "from": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
         },
         "node-sass": {
           "version": "0.9.6",
-          "from": "node-sass@^0.9.0",
+          "from": "https://registry.npmjs.org/node-sass/-/node-sass-0.9.6.tgz",
           "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-0.9.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@~0.5.1",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@^1.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "mocha": {
               "version": "1.21.5",
-              "from": "mocha@~1.21.4",
+              "from": "https://registry.npmjs.org/mocha/-/mocha-1.21.5.tgz",
               "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.21.5.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.3.0",
-                  "from": "commander@2.3.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
                 },
                 "debug": {
                   "version": "2.0.0",
-                  "from": "debug@2.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.6.2",
-                      "from": "ms@0.6.2",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                     }
                   }
                 },
                 "diff": {
                   "version": "1.0.8",
-                  "from": "diff@1.0.8",
+                  "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@1.0.2",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "glob": {
                   "version": "3.2.3",
-                  "from": "glob@3.2.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
                   "dependencies": {
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@2",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@~1.0.0",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
                     },
                     "graceful-fs": {
                       "version": "2.0.3",
-                      "from": "graceful-fs@~2.0.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "growl": {
                   "version": "1.8.1",
-                  "from": "growl@1.8.1",
+                  "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
                 },
                 "jade": {
                   "version": "0.26.3",
-                  "from": "jade@0.26.3",
+                  "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
                   "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "0.6.1",
-                      "from": "commander@0.6.1",
+                      "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                     },
                     "mkdirp": {
                       "version": "0.3.0",
-                      "from": "mkdirp@0.3.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
                     }
                   }
@@ -3820,49 +6587,49 @@
             },
             "nan": {
               "version": "1.3.0",
-              "from": "nan@~1.3.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
             },
             "node-watch": {
               "version": "0.3.4",
-              "from": "node-watch@~0.3.4",
+              "from": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz",
               "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz"
             },
             "object-assign": {
               "version": "1.0.0",
-              "from": "object-assign@~1.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
             },
             "shelljs": {
               "version": "0.3.0",
-              "from": "shelljs@~0.3.0",
+              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
             },
             "sinon": {
               "version": "1.10.3",
-              "from": "sinon@~1.10.3",
+              "from": "https://registry.npmjs.org/sinon/-/sinon-1.10.3.tgz",
               "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.10.3.tgz",
               "dependencies": {
                 "formatio": {
                   "version": "1.0.2",
-                  "from": "formatio@~1.0",
+                  "from": "https://registry.npmjs.org/formatio/-/formatio-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.0.2.tgz",
                   "dependencies": {
                     "samsam": {
                       "version": "1.1.2",
-                      "from": "samsam@~1.1",
+                      "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
                     }
                   }
                 },
                 "util": {
                   "version": "0.10.3",
-                  "from": "util@>=0.10.3 <1",
+                  "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
                   "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -3871,114 +6638,114 @@
             },
             "node-sass-middleware": {
               "version": "0.3.1",
-              "from": "node-sass-middleware@~0.3.0",
+              "from": "https://registry.npmjs.org/node-sass-middleware/-/node-sass-middleware-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/node-sass-middleware/-/node-sass-middleware-0.3.1.tgz"
             },
             "yargs": {
               "version": "1.3.3",
-              "from": "yargs@~1.3.1",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
             },
             "get-stdin": {
               "version": "3.0.2",
-              "from": "get-stdin@~3.0.0",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
             }
           }
         },
         "object-assign": {
           "version": "0.3.1",
-          "from": "object-assign@^0.3.1",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
         }
       }
     },
     "grunt-text-replace": {
       "version": "0.3.12",
-      "from": "grunt-text-replace@0.3.12",
+      "from": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.3.12.tgz",
       "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.3.12.tgz"
     },
     "grunt-usemin": {
       "version": "2.3.0",
-      "from": "grunt-usemin@2.3.0",
+      "from": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-2.3.0.tgz",
       "dependencies": {
         "debug": {
           "version": "1.0.4",
-          "from": "debug@~1.0.1",
+          "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         }
       }
     },
     "grunt-z-schema": {
       "version": "0.1.0",
-      "from": "grunt-z-schema@0.1.0",
+      "from": "https://registry.npmjs.org/grunt-z-schema/-/grunt-z-schema-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-z-schema/-/grunt-z-schema-0.1.0.tgz",
       "dependencies": {
         "z-schema": {
           "version": "2.4.10",
-          "from": "z-schema@~2.4.3",
+          "from": "https://registry.npmjs.org/z-schema/-/z-schema-2.4.10.tgz",
           "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-2.4.10.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9",
+          "from": "async@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         }
       }
     },
     "handlebars": {
       "version": "1.3.0",
-      "from": "handlebars@1.3.0",
+      "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
       "dependencies": {
         "optimist": {
           "version": "0.3.7",
-          "from": "optimist@~0.3",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.3.6",
-          "from": "uglify-js@~2.3",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.6",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.41",
-              "from": "source-map@~0.1.7",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -3989,99 +6756,99 @@
     },
     "helmet": {
       "version": "0.4.0",
-      "from": "helmet@0.4.0",
+      "from": "https://registry.npmjs.org/helmet/-/helmet-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-0.4.0.tgz",
       "dependencies": {
         "camelize": {
           "version": "1.0.0",
-          "from": "camelize@1.0.x",
+          "from": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz"
         },
         "connect": {
           "version": "3.0.2",
-          "from": "connect@3.0.x",
+          "from": "https://registry.npmjs.org/connect/-/connect-3.0.2.tgz",
           "resolved": "https://registry.npmjs.org/connect/-/connect-3.0.2.tgz",
           "dependencies": {
             "debug": {
               "version": "1.0.3",
-              "from": "debug@1.0.3",
+              "from": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "finalhandler": {
               "version": "0.0.2",
-              "from": "finalhandler@0.0.2",
+              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.2.tgz",
               "dependencies": {
                 "debug": {
                   "version": "1.0.2",
-                  "from": "debug@1.0.2",
+                  "from": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.6.2",
-                      "from": "ms@0.6.2",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                     }
                   }
                 },
                 "escape-html": {
                   "version": "1.0.1",
-                  "from": "escape-html@1.0.1",
+                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 }
               }
             },
             "parseurl": {
               "version": "1.1.3",
-              "from": "parseurl@~1.1.3",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.3.tgz"
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
+              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             }
           }
         },
         "platform": {
           "version": "1.2.0",
-          "from": "platform@1.2.x",
+          "from": "https://registry.npmjs.org/platform/-/platform-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/platform/-/platform-1.2.0.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@1.6.x",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
     },
     "http-proxy": {
       "version": "1.2.0",
-      "from": "http-proxy@1.2.0",
+      "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.2.0.tgz",
       "dependencies": {
         "eventemitter3": {
           "version": "0.1.6",
-          "from": "eventemitter3@*",
+          "from": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
         }
       }
     },
     "i18n-abide": {
       "version": "0.0.22",
-      "from": "i18n-abide@0.0.22",
+      "from": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.22.tgz",
       "resolved": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.22.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@0.1.22",
+          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "gobbledygook": {
@@ -4091,27 +6858,27 @@
         },
         "jsxgettext": {
           "version": "0.3.9",
-          "from": "jsxgettext@0.3.9",
+          "from": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.3.9.tgz",
           "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.3.9.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.4.2",
-              "from": "acorn@0.4.2",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.4.2.tgz"
             },
             "gettext-parser": {
               "version": "0.2.0",
-              "from": "gettext-parser@0.2.0",
+              "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.11",
-                  "from": "encoding@~0.1",
+                  "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.5",
-                      "from": "iconv-lite@~0.4.4",
+                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
                     }
                   }
@@ -4120,102 +6887,102 @@
             },
             "nomnom": {
               "version": "1.5.2",
-              "from": "nomnom@1.5.2",
+              "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
-                  "from": "underscore@1.1.x",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                 },
                 "colors": {
                   "version": "0.5.1",
-                  "from": "colors@0.5.x",
+                  "from": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                 }
               }
             },
             "jade": {
               "version": "0.30.0",
-              "from": "jade@0.30.0",
+              "from": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
               "resolved": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
               "dependencies": {
                 "commander": {
                   "version": "1.1.1",
-                  "from": "commander@~1.1.1",
+                  "from": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                   "dependencies": {
                     "keypress": {
                       "version": "0.1.0",
-                      "from": "keypress@0.1.x",
+                      "from": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@0.3.x",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 },
                 "transformers": {
                   "version": "2.0.1",
-                  "from": "transformers@~2.0.1",
+                  "from": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                   "dependencies": {
                     "promise": {
                       "version": "2.0.0",
-                      "from": "promise@~2.0",
+                      "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                       "dependencies": {
                         "is-promise": {
                           "version": "1.0.1",
-                          "from": "is-promise@~1",
+                          "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                         }
                       }
                     },
                     "css": {
                       "version": "1.0.8",
-                      "from": "css@~1.0.8",
+                      "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                       "dependencies": {
                         "css-parse": {
                           "version": "1.0.4",
-                          "from": "css-parse@1.0.4",
+                          "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                         },
                         "css-stringify": {
                           "version": "1.0.5",
-                          "from": "css-stringify@1.0.5",
+                          "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                         }
                       }
                     },
                     "uglify-js": {
                       "version": "2.2.5",
-                      "from": "uglify-js@~2.2.5",
+                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.41",
-                          "from": "source-map@~0.1.7",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
                         },
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "optimist@~0.3.5",
+                          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "wordwrap@~0.0.2",
+                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
@@ -4226,37 +6993,37 @@
                 },
                 "character-parser": {
                   "version": "1.0.2",
-                  "from": "character-parser@~1.0.0",
+                  "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
                 },
                 "monocle": {
                   "version": "0.1.50",
-                  "from": "monocle@~0.1.46",
+                  "from": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                   "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                   "dependencies": {
                     "readdirp": {
                       "version": "0.2.5",
-                      "from": "readdirp@~0.2.3",
+                      "from": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                       "dependencies": {
                         "minimatch": {
                           "version": "2.0.1",
-                          "from": "minimatch@>=0.2.4",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.0",
-                              "from": "brace-expansion@^1.0.0",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.2.0",
-                                  "from": "balanced-match@^0.2.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
@@ -4273,29 +7040,29 @@
         },
         "optimist": {
           "version": "0.3.4",
-          "from": "optimist@0.3.4",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.4.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.4.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "plist": {
           "version": "0.4.3",
-          "from": "plist@0.4.3",
+          "from": "https://registry.npmjs.org/plist/-/plist-0.4.3.tgz",
           "resolved": "https://registry.npmjs.org/plist/-/plist-0.4.3.tgz",
           "dependencies": {
             "xmlbuilder": {
               "version": "0.4.3",
-              "from": "xmlbuilder@0.4.x",
+              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz"
             },
             "xmldom": {
               "version": "0.1.19",
-              "from": "xmldom@0.1.x",
+              "from": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
               "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
             }
           }
@@ -4304,44 +7071,44 @@
     },
     "jsxgettext-recursive": {
       "version": "0.0.5",
-      "from": "jsxgettext-recursive@0.0.5",
+      "from": "https://registry.npmjs.org/jsxgettext-recursive/-/jsxgettext-recursive-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/jsxgettext-recursive/-/jsxgettext-recursive-0.0.5.tgz",
       "dependencies": {
         "walk": {
           "version": "2.3.4",
-          "from": "walk@^2.3.1",
+          "from": "https://registry.npmjs.org/walk/-/walk-2.3.4.tgz",
           "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.4.tgz",
           "dependencies": {
             "foreachasync": {
               "version": "3.0.0",
-              "from": "foreachasync@3.x",
+              "from": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
             }
           }
         },
         "jsxgettext": {
           "version": "0.4.10",
-          "from": "jsxgettext@^0.4.8",
+          "from": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.4.10.tgz",
           "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.4.10.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.5.0",
-              "from": "acorn@~0.5.0",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.5.0.tgz"
             },
             "gettext-parser": {
               "version": "0.2.0",
-              "from": "gettext-parser@0.2.0",
+              "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.11",
-                  "from": "encoding@~0.1",
+                  "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.11.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.5",
-                      "from": "iconv-lite@~0.4.4",
+                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
                     }
                   }
@@ -4350,102 +7117,102 @@
             },
             "nomnom": {
               "version": "1.5.2",
-              "from": "nomnom@1.5.2",
+              "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
-                  "from": "underscore@1.1.x",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                 },
                 "colors": {
                   "version": "0.5.1",
-                  "from": "colors@0.5.x",
+                  "from": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                 }
               }
             },
             "jade": {
               "version": "0.30.0",
-              "from": "jade@0.30.0",
+              "from": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
               "resolved": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
               "dependencies": {
                 "commander": {
                   "version": "1.1.1",
-                  "from": "commander@~1.1.1",
+                  "from": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                   "dependencies": {
                     "keypress": {
                       "version": "0.1.0",
-                      "from": "keypress@0.1.x",
+                      "from": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@0.3.x",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 },
                 "transformers": {
                   "version": "2.0.1",
-                  "from": "transformers@~2.0.1",
+                  "from": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                   "dependencies": {
                     "promise": {
                       "version": "2.0.0",
-                      "from": "promise@~2.0",
+                      "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                       "dependencies": {
                         "is-promise": {
                           "version": "1.0.1",
-                          "from": "is-promise@~1",
+                          "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                         }
                       }
                     },
                     "css": {
                       "version": "1.0.8",
-                      "from": "css@~1.0.8",
+                      "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                       "dependencies": {
                         "css-parse": {
                           "version": "1.0.4",
-                          "from": "css-parse@1.0.4",
+                          "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                         },
                         "css-stringify": {
                           "version": "1.0.5",
-                          "from": "css-stringify@1.0.5",
+                          "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                         }
                       }
                     },
                     "uglify-js": {
                       "version": "2.2.5",
-                      "from": "uglify-js@~2.2.5",
+                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.41",
-                          "from": "source-map@~0.1.7",
+                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "0.1.0",
-                              "from": "amdefine@>=0.0.4",
+                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                             }
                           }
                         },
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "optimist@~0.3.5",
+                          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "wordwrap@~0.0.2",
+                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
@@ -4456,37 +7223,37 @@
                 },
                 "character-parser": {
                   "version": "1.0.2",
-                  "from": "character-parser@~1.0.0",
+                  "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
                 },
                 "monocle": {
                   "version": "0.1.50",
-                  "from": "monocle@~0.1.46",
+                  "from": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                   "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                   "dependencies": {
                     "readdirp": {
                       "version": "0.2.5",
-                      "from": "readdirp@~0.2.3",
+                      "from": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                       "dependencies": {
                         "minimatch": {
                           "version": "2.0.1",
-                          "from": "minimatch@>=0.2.4",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.0",
-                              "from": "brace-expansion@^1.0.0",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.2.0",
-                                  "from": "balanced-match@^0.2.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
@@ -4501,63 +7268,63 @@
             },
             "swig": {
               "version": "1.3.2",
-              "from": "swig@1.3.2",
+              "from": "https://registry.npmjs.org/swig/-/swig-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/swig/-/swig-1.3.2.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "2.4.16",
-                  "from": "uglify-js@~2.4",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@~0.2.6",
+                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "source-map": {
                       "version": "0.1.34",
-                      "from": "source-map@0.1.34",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
                     },
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "optimist@~0.3.5",
+                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@~0.0.2",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
-                      "from": "uglify-to-browserify@~1.0.0",
+                      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                     }
                   }
                 },
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "optimist@~0.6",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@~0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     },
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "minimist@~0.0.1",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
@@ -4566,7 +7333,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.1",
-              "from": "escape-string-regexp@1.0.1",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz"
             }
           }
@@ -4575,37 +7342,37 @@
     },
     "load-grunt-tasks": {
       "version": "0.6.0",
-      "from": "load-grunt-tasks@0.6.0",
+      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.6.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@^0.1.2",
+          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
@@ -4614,46 +7381,46 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             }
           }
         },
         "multimatch": {
           "version": "0.3.0",
-          "from": "multimatch@^0.3.0",
+          "from": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.3.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "0.1.0",
-              "from": "array-differ@^0.1.0",
+              "from": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-0.1.0.tgz"
             },
             "array-union": {
               "version": "0.1.0",
-              "from": "array-union@^0.1.0",
+              "from": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-0.1.0.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "0.1.1",
-                  "from": "array-uniq@^0.1.0",
+                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-0.1.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@^0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
@@ -4664,187 +7431,187 @@
     },
     "mkdirp": {
       "version": "0.5.0",
-      "from": "mkdirp@0.5.0",
+      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@0.0.8",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "mozlog": {
       "version": "1.0.1",
-      "from": "mozlog@1.0.1",
+      "from": "https://registry.npmjs.org/mozlog/-/mozlog-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-1.0.1.tgz",
       "dependencies": {
         "intel": {
           "version": "1.0.0",
-          "from": "intel@^1.0.0",
+          "from": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@~0.5.1",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.2",
-                  "from": "escape-string-regexp@^1.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "dbug@~0.4.2",
+              "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@~0.0.9",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.8.2",
-              "from": "strftime@~0.8.2",
+              "from": "https://registry.npmjs.org/strftime/-/strftime-0.8.2.tgz",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.2.tgz"
             },
             "symbol": {
               "version": "0.2.1",
-              "from": "symbol@~0.2.0",
+              "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "utcstring@~0.1.0",
+              "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "merge@^1.2.0",
+          "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
     },
     "time-grunt": {
       "version": "0.4.0",
-      "from": "time-grunt@0.4.0",
+      "from": "https://registry.npmjs.org/time-grunt/-/time-grunt-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-0.4.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@^0.5.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "date-time": {
           "version": "0.1.1",
-          "from": "date-time@^0.1.0",
+          "from": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz"
         },
         "figures": {
           "version": "1.3.5",
-          "from": "figures@^1.0.0",
+          "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@^0.2.3",
+          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "pretty-ms": {
           "version": "0.2.2",
-          "from": "pretty-ms@^0.2.2",
+          "from": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
           "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
           "dependencies": {
             "parse-ms": {
               "version": "0.1.2",
-              "from": "parse-ms@^0.1.0",
+              "from": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "consolidate": "0.10.0",
     "convict": "0.6.0",
     "express": "3.17.1",
+    "express-able": "0.2.0",
     "grunt": "0.4.5",
     "grunt-autoprefixer": "1.0.0",
     "grunt-cli": "0.1.13",

--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -83,6 +83,14 @@ function makeApp() {
   app.use(express.cookieParser());
   app.use(express.bodyParser());
 
+  var ableOptions = {
+    dir: config.get('experiments.dir'),
+    git: config.get('experiments.git'),
+    watch: config.get('experiments.watch'),
+    addRoutes: true
+  }
+
+  app.use(require('express-able')(ableOptions))
 
   routes(app);
 

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -264,7 +264,7 @@ var conf = module.exports = convict({
     },
     watch: {
       doc: 'poll the experiments git repo for changes',
-      default: true
+      default: false
     }
   }
 });

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -252,6 +252,20 @@ var conf = module.exports = convict({
   cert_path: {
     doc: 'The location of the SSL certificate in pem format',
     default: path.resolve(__dirname, '..', '..', 'cert.pem')
+  },
+  experiments: {
+    dir: {
+      doc: 'path to where experiments are stored',
+      default: path.resolve(__dirname, '..', '..', 'experiments')
+    },
+    git: {
+      doc: 'git url for experiments repo. set to empty to not pull',
+      default: 'git://github.com/mozilla/fxa-content-experiments.git#master'
+    },
+    watch: {
+      doc: 'poll the experiments git repo for changes',
+      default: true
+    }
   }
 });
 

--- a/server/lib/csp.js
+++ b/server/lib/csp.js
@@ -12,6 +12,7 @@ var config = require('./configuration');
 
 var cspMiddleware = helmet.csp({
                       'default-src': ['\'self\''],
+                      'script-src': ['\'self\''],
                       'connect-src': [
                         '\'self\'',
                         config.get('fxaccount_url'),

--- a/server/lib/csp.js
+++ b/server/lib/csp.js
@@ -12,7 +12,6 @@ var config = require('./configuration');
 
 var cspMiddleware = helmet.csp({
                       'default-src': ['\'self\''],
-                      'script-src': ['\'self\''],
                       'connect-src': [
                         '\'self\'',
                         config.get('fxaccount_url'),

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -55,6 +55,7 @@
              with a cache aware URL.
          -->
         <!--[if gt IE 9]><!-->
+        <script src="/experiments.bundle.js"></script>
         <script data-main="/scripts/main" src="/bower_components/requirejs/require.js"></script>
         <!--<![endif]-->
     </body>


### PR DESCRIPTION
@shane-tomlinson

Here's a draft of integrating able...

The one "oddity" that I'm not sure of is the code around adding the `ab_url` script tag to `index.html`. Originally I had the page render twice, once for localization at build time and once to pick up the ab_url from config at runtime, but this broke localhost and seemed silly. Instead I tried setting the url at the same time as localization. The advantage is it only needs to render once and doesn't break (but also doesn't really work) on localhost. The disadvantage is that the url is now set at build time, so changing it in the config later won't automatically change the url on restart, which *might* not be too big of an issue. The location of where `ab_url` gets set from is also in a weird place, `grunttasks/l10n-generate-pages.js`

I think everything else is pretty straightforward. The `able.js` stub fills in when there's no able server script, and just returns `undefined` for `choose`. I think the pattern there ought to be to inline the "code default" in that case like:

```js
// for instance
able.choose('greeting', { email: email }) || 'howdy!'
```