### PR TITLE
fix(server): Ensure templates render text in dev mode.

### DIFF
--- a/server/lib/i18n.js
+++ b/server/lib/i18n.js
@@ -16,6 +16,15 @@
 
 module.exports = function (config) {
 
+  // this is perhaps a bit janky. In dev mode, a `t` helper needs to be
+  // registered to render text in the static templates. Without the helper,
+  // all {{#t}} surrounded text is empty.
+  var handlebars = require('handlebars');
+  handlebars.registerHelper('t', function (msg) {
+    return msg.fn(this);
+  });
+
+
   var abide = require('i18n-abide');
 
   // Convert the array to an object for faster lookups

--- a/tests/server/l10n.js
+++ b/tests/server/l10n.js
@@ -238,5 +238,19 @@ define([
     testClientJson.call(this, null, 'en');
   };
 
+  // this is a basic test to ensure the original strings are replaced
+  // in dev mode and the templates do not render without text.
+  suite['#get /503.html page - check text is rendered in dev mode'] = function () {
+    var dfd = this.async(intern.config.asyncTimeout);
+
+    request(serverUrl + '/503.html', {
+      headers: {
+        'Accept': 'text/html'
+      }
+    }, dfd.callback(function (err, res) {
+      assert.ok(res.body.match(/server busy/i));
+    }, dfd.reject.bind(dfd)));
+  };
+
   registerSuite(suite);
 });


### PR DESCRIPTION
Register a 't' helper that returns the English strings in dev mode.

fixes #2158
fixes #2090