### PR TITLE
chore(tests): scripts for running on teamcity server

### DIFF
--- a/tests/teamcity/defaults.sh
+++ b/tests/teamcity/defaults.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 FXA_CONTENT_ROOT="https://latest.dev.lcip.org/"
 FXA_AUTH_ROOT="https://latest.dev.lcip.org/auth/v1"

--- a/tests/teamcity/defaults.sh
+++ b/tests/teamcity/defaults.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+FXA_CONTENT_ROOT="https://latest.dev.lcip.org/"
+FXA_AUTH_ROOT="https://latest.dev.lcip.org/auth/v1"
+FXA_OAUTH_APP_ROOT="https://123done-latest.dev.lcip.org/"
+FXA_FIREFOX_BINARY="/usr/bin/firefox"
+

--- a/tests/teamcity/latest
+++ b/tests/teamcity/latest
@@ -1,0 +1,3 @@
+FXA_CONTENT_ROOT="https://latest.dev.lcip.org/"
+FXA_AUTH_ROOT="https://latest.dev.lcip.org/auth/"
+FXA_OAUTH_APP_ROOT="https://123done-latest.dev.lcip.org/"

--- a/tests/teamcity/latest
+++ b/tests/teamcity/latest
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 FXA_CONTENT_ROOT="https://latest.dev.lcip.org/"
 FXA_AUTH_ROOT="https://latest.dev.lcip.org/auth/"
 FXA_OAUTH_APP_ROOT="https://123done-latest.dev.lcip.org/"

--- a/tests/teamcity/latest-ff18
+++ b/tests/teamcity/latest-ff18
@@ -1,2 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 source $(dirname $0)/latest
 FXA_FIREFOX_BINARY="/home/ubuntu/ff18/firefox/firefox-bin"

--- a/tests/teamcity/latest-ff18
+++ b/tests/teamcity/latest-ff18
@@ -1,0 +1,2 @@
+source $(dirname $0)/latest
+FXA_FIREFOX_BINARY="/home/ubuntu/ff18/firefox/firefox-bin"

--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 set -o nounset
 set -o errexit
 

--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+
+BASENAME=$(basename $0)
+DIRNAME=$(dirname $0)
+
+if [ "x$1" = "x" ]; then
+    echo "Usage: $0 test-name"
+    exit
+fi
+FXA_TEST_NAME=$1
+
+source $DIRNAME/defaults.sh
+source $DIRNAME/$FXA_TEST_NAME
+
+GIT_COMMIT=$(curl -s "$FXA_CONTENT_ROOT/ver.json" | jsawk  "return this.commit")
+
+echo "FXA_TEST_NAME      $FXA_TEST_NAME"
+echo "FXA_CONTENT_ROOT   $FXA_CONTENT_ROOT"
+echo "FXA_AUTH_ROOT      $FXA_AUTH_ROOT"
+echo "FXA_OAUTH_APP_ROOT $FXA_OAUTH_APP_ROOT"
+echo "FXA_FIREFOX_BINARY $FXA_FIREFOX_BINARY"
+echo "GIT_COMMIT         $GIT_COMMIT"
+
+rm -rf fxa-content-server-"$FXA_TEST_NAME"
+git clone https://github.com/mozilla/fxa-content-server.git -b master fxa-content-server-"$FXA_TEST_NAME"
+cd fxa-content-server-"$FXA_TEST_NAME"
+git checkout "$GIT_COMMIT"
+git show --summary
+
+npm config set cache ~/.fxacache
+export npm_config_cache=~/.fxacache
+export npm_config_tmp=~/fxatemp
+npm install intern-geezer@2.0.1 bower zaach/node-XMLHttpRequest.git#onerror \
+  execSync@1.0.1-pre firefox-profile@0.2.12 convict@0.6.0 request@2.40.0
+node_modules/.bin/bower install --config.interactive=false
+
+set -x
+./node_modules/.bin/intern-runner \
+    config="tests/intern_functional_full" \
+    fxaAuthRoot="$FXA_AUTH_ROOT" \
+    fxaContentRoot="$FXA_CONTENT_ROOT" \
+    fxaOauthApp="$FXA_OAUTH_APP_ROOT" \
+    fxaIframeOauthApp="${FXA_OAUTH_APP_ROOT}iframe" \
+    fxaEmailRoot="http://restmail.net" \
+    fxaProduction="true" \
+    firefoxBinary="$FXA_FIREFOX_BINARY"
+
+# && \
+# ./node_modules/.bin/intern-client \
+#   config=tests/intern_server \
+#   fxaAuthRoot="$FXA_AUTH_ROOT" \
+#   fxaContentRoot="$FXA_CONTENT_ROOT" \
+#   fxaOauthApp="$FXA_OAUTH_APP_ROOT" \
+#   fxaEmailRoot="http://restmail.net" \
+#   fxaProduction="true"

--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -47,12 +47,3 @@ set -x
     fxaEmailRoot="http://restmail.net" \
     fxaProduction="true" \
     firefoxBinary="$FXA_FIREFOX_BINARY"
-
-# && \
-# ./node_modules/.bin/intern-client \
-#   config=tests/intern_server \
-#   fxaAuthRoot="$FXA_AUTH_ROOT" \
-#   fxaContentRoot="$FXA_CONTENT_ROOT" \
-#   fxaOauthApp="$FXA_OAUTH_APP_ROOT" \
-#   fxaEmailRoot="http://restmail.net" \
-#   fxaProduction="true"

--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 set -o nounset
-set -o errexit
+set -o errexit # exit on first command with non-zero status
 
 BASENAME=$(basename $0)
 DIRNAME=$(dirname $0)
@@ -41,7 +41,8 @@ npm install intern-geezer@2.0.1 bower zaach/node-XMLHttpRequest.git#onerror \
   execSync@1.0.1-pre firefox-profile@0.2.12 convict@0.6.0 request@2.40.0
 node_modules/.bin/bower install --config.interactive=false
 
-set -x
+set -o xtrace # echo the following commands
+
 ./node_modules/.bin/intern-runner \
     config="tests/intern_functional_full" \
     fxaAuthRoot="$FXA_AUTH_ROOT" \

--- a/tests/teamcity/stage
+++ b/tests/teamcity/stage
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 FXA_CONTENT_ROOT="https://accounts.stage.mozaws.net/"
 FXA_AUTH_ROOT="https://api-accounts.stage.mozaws.net/v1"
 FXA_OAUTH_APP_ROOT="https://123done-stage.dev.lcip.org/"

--- a/tests/teamcity/stage
+++ b/tests/teamcity/stage
@@ -1,0 +1,3 @@
+FXA_CONTENT_ROOT="https://accounts.stage.mozaws.net/"
+FXA_AUTH_ROOT="https://api-accounts.stage.mozaws.net/v1"
+FXA_OAUTH_APP_ROOT="https://123done-stage.dev.lcip.org/"

--- a/tests/teamcity/stage-ff18
+++ b/tests/teamcity/stage-ff18
@@ -1,2 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 source $(dirname $0)/stage
 FXA_FIREFOX_BINARY="/home/ubuntu/ff18/firefox/firefox-bin"

--- a/tests/teamcity/stage-ff18
+++ b/tests/teamcity/stage-ff18
@@ -1,0 +1,2 @@
+source $(dirname $0)/stage
+FXA_FIREFOX_BINARY="/home/ubuntu/ff18/firefox/firefox-bin"


### PR DESCRIPTION
Hey @vladikoff. I was looking at adding intern_server tests to these test runs and a FxBeta too, but in looking at the scripts in Teamcity, it seemed to me these scripts should be in version control which would also make it easier to read and update.

So, I came up with this way. Let me know what you think. I have this running the Stage test with this now:

```
if [ ! -d ./fxa-content-server-teamcity ]; then
  git clone https://github.com/jrgm/fxa-content-server.git -b teamcity-scripts fxa-content-server-teamcity
else
  (cd fxa-content-server-teamcity; git pull)
fi
./fxa-content-server-teamcity/tests/teamcity/run.sh stage
```
(Obviously, I'd change that to point the mozilla version later).

Let me know what you think.