### PR TITLE
feat(channels): broadcast messages across across all channels

### DIFF
--- a/app/scripts/lib/channels/inter-tab.js
+++ b/app/scripts/lib/channels/inter-tab.js
@@ -19,7 +19,7 @@ define([
   }
 
   InterTabChannel.prototype = {
-    emit: function (name, data) {
+    send: function (name, data) {
       // Sensitive data is sent across the channel and should only
       // be in localStorage if absolutely necessary. Only send
       // data if another tab is listening.

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -41,7 +41,9 @@ define([], function () {
     // cached credentials if they set email === 'blank'
     DISALLOW_CACHED_CREDENTIALS: 'blank',
 
-    ONERROR_MESSAGE_LIMIT: 100
+    ONERROR_MESSAGE_LIMIT: 100,
+
+    PROFILE_WEBCHANNEL_ID: 'account_updates'
   };
 });
 

--- a/app/scripts/models/auth_brokers/iframe.js
+++ b/app/scripts/models/auth_brokers/iframe.js
@@ -64,13 +64,6 @@ define([
 
     // used by the ChannelMixin to get a channel.
     getChannel: function () {
-      if (! this._channel) {
-        this._channel = new IframeChannel();
-        this._channel.init({
-          window: this.window
-        });
-      }
-
       return this._channel;
     },
 

--- a/app/scripts/models/notifications.js
+++ b/app/scripts/models/notifications.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * The notifier broadcasts messages across multiple channels (iframe, tabs, browsers, etc).
+ */
+
+'use strict';
+
+define([
+  'backbone',
+  'underscore'
+], function (Backbone, _) {
+
+  var EVENTS = {
+    PROFILE_CHANGE: 'profile:change'
+  };
+
+  var Notifications = Backbone.Model.extend({
+    defaults: {
+    },
+    initialize: function (options) {
+      options = options || {};
+      this._channels = [
+        options.tabChannel,
+        options.webChannel
+      ];
+      // The iframe channel only available when the content is framed, naturally.
+      if (options.iframeChannel) {
+        this._channels.push(options.iframeChannel);
+      }
+
+      this._listen(options.tabChannel);
+    },
+
+    broadcast: function (event, data) {
+      this._channels.forEach(function (channel) {
+        channel.send(event, data);
+      });
+    },
+
+    profileChanged: function (data) {
+      this.broadcast(EVENTS.PROFILE_CHANGE, data);
+    },
+
+    // Listen for notifications from other fxa tabs or frames
+    _listen: function (tabChannel) {
+      var self = this;
+      _.each(EVENTS, function (name) {
+        tabChannel.on(name, self._handleNotification.bind(self));
+      });
+    },
+
+    _handleNotification: function (message) {
+      this.trigger(message.event, message.data);
+    }
+  }, Backbone.Events);
+
+  return Notifications;
+});

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -120,6 +120,7 @@ function (
       this.user = options.user;
       this.interTabChannel = options.interTabChannel;
       this.formPrefill = options.formPrefill;
+      this.notifications = options.notifications;
 
       // back is only enabled after the first view is rendered.
       this.canGoBack = false;
@@ -173,7 +174,8 @@ function (
         user: this.user,
         window: this.window,
         screenName: this.fragmentToScreenName(Backbone.history.fragment),
-        formPrefill: this.formPrefill
+        formPrefill: this.formPrefill,
+        notifications: this.notifications
       }, options || {});
 
       return new View(viewOptions);

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -25,6 +25,8 @@ function (Cocktail, BaseView, FormView, Template, PasswordMixin,
     initialize: function (options) {
       options = options || {};
 
+      // We use the interTabChannel rather than notifications because we only
+      // want to send account data to other tabs– not listeners on all channels.
       this._interTabChannel = options.interTabChannel;
     },
 
@@ -121,7 +123,7 @@ function (Cocktail, BaseView, FormView, Template, PasswordMixin,
           return self.fxaClient.signIn(email, password, self.relier);
         }).then(function (accountData) {
           var account = self.user.initAccount(accountData);
-          self._interTabChannel.emit('login', accountData);
+          self._interTabChannel.send('login', accountData);
 
           return self.user.setSignedInAccount(account)
             .then(function () {

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -10,6 +10,10 @@ define([
 ], function () {
 
   return {
+    initialize: function (options) {
+      this.notifications = options.notifications;
+    },
+
     // Attempt to load a profile image from the profile server
     _fetchProfileImage: function (account) {
       var self = this;
@@ -74,6 +78,10 @@ define([
       var account = this.getSignedInAccount();
       account.set('profileImageUrl', url);
       this.user.setAccount(account);
+
+      this.notifications.profileChanged({
+        uid: account.get('uid')
+      });
     }
   };
 });

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -58,6 +58,15 @@ function (chai, sinon, AppStart, Session, Constants, p,
                     });
       });
 
+      it('starts the app in an iframe', function () {
+        windowMock.top = new WindowMock();
+        return appStart.startApp()
+                    .then(function () {
+                      assert.isTrue(appStart._isIframe());
+                      assert.ok(appStart._iframeChannel);
+                    });
+      });
+
       it('redirects to /cookies_disabled if localStorage is disabled', function () {
         appStart.useConfig({
           localStorageEnabled: false,

--- a/app/tests/spec/lib/channels/inter-tab.js
+++ b/app/tests/spec/lib/channels/inter-tab.js
@@ -27,26 +27,26 @@ define([
     afterEach(function () {
     });
 
-    describe('emit', function () {
-      it('does not emit a message if no other tab is ready', function () {
+    describe('send', function () {
+      it('does not send a message if no other tab is ready', function () {
         sinon.stub(crossTabMock.util, 'tabCount', function () {
           return 1;
         });
 
         sinon.spy(crossTabMock, 'broadcast');
 
-        interTabChannel.emit('message');
+        interTabChannel.send('message');
         assert.isFalse(crossTabMock.broadcast.called);
       });
 
-      it('emits a message if another tab is ready', function () {
+      it('send a message if another tab is ready', function () {
         sinon.stub(crossTabMock.util, 'tabCount', function () {
           return 2;
         });
 
         sinon.spy(crossTabMock, 'broadcast');
 
-        interTabChannel.emit('message');
+        interTabChannel.send('message');
         assert.isTrue(crossTabMock.broadcast.called);
       });
 
@@ -59,12 +59,12 @@ define([
           throw new Error('unsupported browser');
         });
 
-        interTabChannel.emit('message');
+        interTabChannel.send('message');
       });
     });
 
     describe('on', function () {
-      it('register a callback to be called when a message is emitted', function () {
+      it('register a callback to be called when a message is sent', function () {
         sinon.spy(crossTabMock.util.events, 'on');
         interTabChannel.on('message', function () {});
 
@@ -73,7 +73,7 @@ define([
     });
 
     describe('off', function () {
-      it('unregister a callback to be called when a message is emitted', function () {
+      it('unregister a callback to be called when a message is sent', function () {
         sinon.spy(crossTabMock.util.events, 'off');
         interTabChannel.off('message', function () {});
 

--- a/app/tests/spec/models/auth_brokers/iframe.js
+++ b/app/tests/spec/models/auth_brokers/iframe.js
@@ -107,12 +107,7 @@ function (chai, sinon, $, IframeAuthenticationBroker, Relier, p, NullChannel,
     });
 
     describe('getChannel', function () {
-      it('creates an IframeChannel', function () {
-        var broker = new IframeAuthenticationBroker({
-          windowMock: windowMock,
-          relier: relierMock
-        });
-
+      it('gets an IframeChannel', function () {
         var channel = broker.getChannel();
         assert.ok(channel);
       });

--- a/app/tests/spec/models/notifications.js
+++ b/app/tests/spec/models/notifications.js
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'chai',
+  'sinon',
+  'models/notifications',
+  'lib/promise',
+  'lib/channels/null'
+],
+function (chai, sinon, Notifications, p, NullChannel) {
+  var assert = chai.assert;
+
+  describe('models/notifications', function () {
+    var NOTIFICATION = 'profile:change';
+    var notifications;
+    var webChannelMock;
+    var tabChannelMock;
+    var iframeChannelMock;
+
+    beforeEach(function () {
+      webChannelMock = new NullChannel();
+      tabChannelMock = new NullChannel();
+      iframeChannelMock = new NullChannel();
+      sinon.spy(webChannelMock, 'send');
+      sinon.spy(tabChannelMock, 'send');
+      sinon.spy(iframeChannelMock, 'send');
+
+      sinon.spy(tabChannelMock, 'on');
+
+      notifications = new Notifications({
+        webChannel: webChannelMock,
+        tabChannel: tabChannelMock,
+        iframeChannel: iframeChannelMock
+      });
+    });
+
+    it('listens on initialization', function () {
+      assert.isTrue(tabChannelMock.on.called);
+      assert.equal(tabChannelMock.on.args[0][0], NOTIFICATION);
+    });
+
+    it('emits events received from other tabs', function (done) {
+      notifications.on(NOTIFICATION, function (data) {
+        try {
+          assert.equal(data.uid, '123');
+        } catch (e) {
+          return done(e);
+        }
+        done();
+      });
+      var message = {
+        event: NOTIFICATION,
+        data: { uid: '123' }
+      };
+      var callback = tabChannelMock.on.args[0][1];
+      // manually trigger the event callback
+      callback(message);
+    });
+
+    describe('broadcast', function () {
+      it('broabcasts to all channels', function () {
+        var ev = 'some event';
+        var data = { foo: 'bar' };
+
+        notifications.broadcast(ev, data);
+
+        assert.isTrue(webChannelMock.send.calledWith(ev, data));
+        assert.isTrue(tabChannelMock.send.calledWith(ev, data));
+        assert.isTrue(iframeChannelMock.send.calledWith(ev, data));
+      });
+
+      it('notifies profile image change', function () {
+        var ev = NOTIFICATION;
+        var data = { foo: 'bar' };
+
+        notifications.profileChanged(data);
+
+        assert.isTrue(webChannelMock.send.calledWith(ev, data));
+        assert.isTrue(tabChannelMock.send.calledWith(ev, data));
+        assert.isTrue(iframeChannelMock.send.calledWith(ev, data));
+      });
+    });
+
+  });
+});
+
+

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -197,7 +197,7 @@ function (chai, sinon, p, AuthErrors, View, Session, Metrics, EphemeralMessages,
         sinon.stub(fxaClient, 'isPasswordResetComplete', function () {
           // simulate the sessionToken being set in another tab.
           // simulate the login occurring in another tab.
-          interTabChannel.emit('login', {
+          interTabChannel.send('login', {
             sessionToken: 'sessiontoken'
           });
           return p(true);
@@ -234,7 +234,7 @@ function (chai, sinon, p, AuthErrors, View, Session, Metrics, EphemeralMessages,
         sinon.stub(fxaClient, 'isPasswordResetComplete', function () {
           // simulate the sessionToken being set in another tab.
           // simulate the login occurring in another tab.
-          interTabChannel.emit('login', {
+          interTabChannel.send('login', {
             sessionToken: 'sessiontoken'
           });
           return p(true);

--- a/app/tests/spec/views/settings/avatar_change.js
+++ b/app/tests/spec/views/settings/avatar_change.js
@@ -102,6 +102,8 @@ function (chai, _, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
           return p('');
         });
 
+        sinon.stub(view, 'updateAvatarUrl', function () { });
+
         return view.render()
           .then(function () {
             assert.equal(view.$('.avatar-wrapper img').length, 1);
@@ -110,7 +112,7 @@ function (chai, _, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
           .then(function () {
             assert.isTrue(profileClientMock.deleteAvatar.calledWith(
               accessToken, 'foo'));
-            assert.isNull(account.get('profileImageUrl'));
+            assert.isTrue(view.updateAvatarUrl.calledWith(null));
             assert.equal(routerMock.page, 'settings');
           });
       });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -81,6 +81,7 @@ function (Translator, Session) {
     '../tests/spec/models/user',
     '../tests/spec/models/account',
     '../tests/spec/models/form-prefill',
+    '../tests/spec/models/notifications',
     '../tests/spec/models/reliers/base',
     '../tests/spec/models/reliers/relier',
     '../tests/spec/models/reliers/oauth',

--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -29,6 +29,12 @@ define([
   var client;
   var emailAvatarAb;
 
+  function testIsBrowserNotifiedOfAvatarChange(context) {
+    return FunctionalHelpers.testIsBrowserNotified(context, 'profile:change', function (data) {
+      assert.ok(data.uid);
+    });
+  }
+
   function signUp(context, email) {
     return client.signUp(email, PASSWORD, { preVerified: true })
       .then(function () {
@@ -157,6 +163,8 @@ define([
         .findByCssSelector('img[src*="https://secure.gravatar.com"]')
         .end()
 
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
+
         .findById('submit-btn')
           .click()
         .end()
@@ -169,6 +177,8 @@ define([
             assert.ok(val, 'has success text');
           })
         .end()
+
+        .then(testIsBrowserNotifiedOfAvatarChange(this))
 
         //success is returning to the settings page
         .findById('fxa-settings-header')
@@ -245,9 +255,13 @@ define([
           .click()
         .end()
 
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
+
         .findById('submit-btn')
           .click()
         .end()
+
+        .then(testIsBrowserNotifiedOfAvatarChange(this))
 
         .findById('fxa-settings-header')
         //success is seeing the image loaded
@@ -300,9 +314,13 @@ define([
           .click()
         .end()
 
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
+
         .findById('submit-btn')
           .click()
         .end()
+
+        .then(testIsBrowserNotifiedOfAvatarChange(this))
 
         .findById('fxa-settings-header')
         //success is seeing the image loaded

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -443,6 +443,40 @@ define([
       .end();
   }
 
+  function listenForWebChannelMessage() {
+    /* global document, addEventListener */
+
+    // this event will fire once the account is confirmed, helping it
+    // redirect to the application. If the window redirect does not
+    // happen then the sign in page will hang on the confirmation screen
+    addEventListener('WebChannelMessageToChrome', function (e) {
+      var command = e.detail.message.command;
+      var data = e.detail.message.data;
+
+      var element = document.createElement('div');
+      element.setAttribute('id', 'message-' + command.replace(/:/g, '-'));
+      element.innerText = JSON.stringify(data);
+      document.body.appendChild(element);
+    });
+
+    return true;
+  }
+
+  function testIsBrowserNotified(context, command, cb) {
+    return function () {
+      return context.get('remote')
+        .findByCssSelector('#message-' + command.replace(/:/g, '-'))
+          .getProperty('innerText')
+          .then(function (innerText) {
+            var data = JSON.parse(innerText);
+            if (cb) {
+              cb(data);
+            }
+          })
+        .end();
+    };
+  }
+
   return {
     imageLoadedByQSA: imageLoadedByQSA,
     clearBrowserState: clearBrowserState,
@@ -456,6 +490,8 @@ define([
     openVerificationLinkDifferentBrowser: openVerificationLinkDifferentBrowser,
     openPasswordResetLinkDifferentBrowser: openPasswordResetLinkDifferentBrowser,
     openFxaFromRp: openFxaFromRp,
+    listenForWebChannelMessage: listenForWebChannelMessage,
+    testIsBrowserNotified: testIsBrowserNotified,
 
     fillOutSignIn: fillOutSignIn,
     fillOutSignUp: fillOutSignUp,

--- a/tests/functional/oauth_webchannel.js
+++ b/tests/functional/oauth_webchannel.js
@@ -26,7 +26,6 @@ define([
   var email;
   var client;
   var ANIMATION_DELAY_MS = 1000;
-  /* global document, addEventListener */
 
   /**
    * This suite tests the WebChannel functionality in the OAuth signin and
@@ -34,37 +33,13 @@ define([
    * finish OAuth flows
    */
 
-  function listenForWebChannelMessage() {
-    // this event will fire once the account is confirmed, helping it
-    // redirect to the application. If the window redirect does not
-    // happen then the sign in page will hang on the confirmation screen
-    addEventListener('WebChannelMessageToChrome', function (e) {
-      var command = e.detail.message.command;
-      var data = e.detail.message.data;
-
-      var element = document.createElement('div');
-      element.setAttribute('id', 'message-' + command);
-      element.innerText = JSON.stringify(data);
-      document.body.appendChild(element);
-    });
-
-    return true;
-  }
-
   function testIsBrowserNotifiedOfLogin(context, shouldCloseTab) {
-    return function () {
-      return context.get('remote')
-        .findByCssSelector('#message-oauth_complete')
-          .getProperty('innerText')
-          .then(function (innerText) {
-            var data = JSON.parse(innerText);
-            assert.ok(data.redirect);
-            assert.ok(data.code);
-            assert.ok(data.state);
-            assert.equal(data.closeWindow, shouldCloseTab);
-          })
-        .end();
-    };
+    return FunctionalHelpers.testIsBrowserNotified(context, 'oauth_complete', function (data) {
+      assert.ok(data.redirect);
+      assert.ok(data.code);
+      assert.ok(data.state);
+      assert.equal(data.closeWindow, shouldCloseTab);
+    });
   }
 
   function openFxaFromRp(context, page) {
@@ -114,7 +89,7 @@ define([
           return client.signUp(email, PASSWORD, { preVerified: true });
         })
 
-        .execute(listenForWebChannelMessage)
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
 
         .then(function () {
           return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
@@ -131,7 +106,7 @@ define([
       var self = this;
 
       return openFxaFromRp(self, 'signup')
-        .execute(listenForWebChannelMessage)
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
 
         .then(function () {
           return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR);
@@ -178,7 +153,7 @@ define([
         })
 
         .switchToWindow('newwindow')
-        .execute(listenForWebChannelMessage)
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
 
         .then(testIsBrowserNotifiedOfLogin(self, false))
 
@@ -207,7 +182,7 @@ define([
         })
         .then(function (verificationLink) {
           return self.get('remote').get(require.toUrl(verificationLink))
-            .execute(listenForWebChannelMessage);
+            .execute(FunctionalHelpers.listenForWebChannelMessage);
         })
 
         .then(testIsBrowserNotifiedOfLogin(self, false))
@@ -220,7 +195,7 @@ define([
       var self = this;
 
       return openFxaFromRp(self, 'signup')
-        .execute(listenForWebChannelMessage)
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
 
         .then(function () {
           return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR);
@@ -243,7 +218,7 @@ define([
       var self = this;
 
       return openFxaFromRp(self, 'signup')
-        .execute(listenForWebChannelMessage)
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
 
         .then(function () {
           return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR);
@@ -274,7 +249,7 @@ define([
       var self = this;
 
       return openFxaFromRp(self, 'signin')
-        .execute(listenForWebChannelMessage)
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
 
         .then(function () {
           return client.signUp(email, PASSWORD, { preVerified: true });
@@ -353,7 +328,7 @@ define([
         })
 
         .switchToWindow('newwindow')
-        .execute(listenForWebChannelMessage)
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
 
         .then(function () {
           return FunctionalHelpers.fillOutCompleteResetPassword(
@@ -396,7 +371,7 @@ define([
         })
         .then(function (verificationLink) {
           return self.get('remote').get(require.toUrl(verificationLink))
-            .execute(listenForWebChannelMessage);
+            .execute(FunctionalHelpers.listenForWebChannelMessage);
         })
 
         .then(function () {
@@ -415,7 +390,7 @@ define([
       var self = this;
 
       return openFxaFromRp(self, 'signin')
-        .execute(listenForWebChannelMessage)
+        .execute(FunctionalHelpers.listenForWebChannelMessage)
 
         .then(function () {
           return client.signUp(email, PASSWORD, { preVerified: true });


### PR DESCRIPTION
This adds an abstraction for broadcasting messages to all channels
that may be listening. It also broadcasts `profile_image_change` on
profile image changes.

Fixes #2095.