### PR TITLE
fix(router): anchor event handler should handle event bubbling

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -254,7 +254,7 @@ function (
       event.preventDefault();
 
       // Remove leading slashes
-      var url = $(event.target).attr('href').replace(/^\//, '');
+      var url = $(event.currentTarget).attr('href').replace(/^\//, '');
 
       // Instruct Backbone to trigger routing events
       this.navigate(url);

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -311,7 +311,7 @@ function (chai, sinon, _, Backbone, Router, SignInView, SignUpView, ReadyView,
         $('#container').empty().append('<a href="/signup">Sign up</a>');
 
         event = $.Event('click');
-        event.target = $('a[href="/signup"]');
+        event.currentTarget = $('a[href="/signup"]');
       });
 
       function testNoNavigation() {

--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -239,8 +239,9 @@ define([
       return this.get('remote')
         .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
 
-        // go to change avatar
-        .findById('camera')
+        // go to change avatar - click the span inside the element
+        // to ensure the click handlers are hooked up properly.
+        .findByCssSelector('#camera span')
           .click()
         .end()
 


### PR DESCRIPTION
If you click on an element inside of an anchor, `event.target` won't be the anchor element, which breaks our handler.

@shane-tomlinson or @vladikoff r?

We should land this before we cut the train.