### PR TITLE
cleanup(client): Remove Session.error and DO_NOT_PERSIST list.

### DIFF
--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -12,9 +12,6 @@ define([
 ], function (_) {
   var NAMESPACE = '__fxa_session';
 
-  // and should not be saved to sessionStorage
-  var DO_NOT_PERSIST = ['error'];
-
   // these keys will be persisted to localStorage so that they live between browser sessions
   var PERSIST_TO_LOCAL_STORAGE = ['oauth'];
 
@@ -70,19 +67,16 @@ define([
     /**
      * Persist data to sessionStorage or localStorage
      * @method persist
-     * Note: items in DO_NOT_PERSIST are not saved to sessionStorage
      */
     persist: function () {
       // items on the blacklist do not get saved to sessionStorage.
       var toSaveToSessionStorage = {};
       var toSaveToLocalStorage = {};
       _.each(this, function (value, key) {
-        if (_.indexOf(DO_NOT_PERSIST, key) === -1) {
-          if (_.indexOf(PERSIST_TO_LOCAL_STORAGE, key) >= 0) {
-            toSaveToLocalStorage[key] = value;
-          } else {
-            toSaveToSessionStorage[key] = value;
-          }
+        if (_.indexOf(PERSIST_TO_LOCAL_STORAGE, key) >= 0) {
+          toSaveToLocalStorage[key] = value;
+        } else {
+          toSaveToSessionStorage[key] = value;
         }
       });
 

--- a/app/tests/spec/lib/session.js
+++ b/app/tests/spec/lib/session.js
@@ -89,14 +89,6 @@ function (chai, Session) {
         assert.equal(Session.key7, 'value7');
         assert.equal(Session.key8, 'value8');
       });
-
-      it('does not load up items in DO_NOT_PERSIST', function () {
-        Session.set('error', 'this is an error');
-        Session.persist();
-        Session.clear();
-        Session.load();
-        assert.isUndefined(Session.error);
-      });
     });
   });
 });


### PR DESCRIPTION
Session.error was the last item in the list. Since it's removed, the DO_NOT_PERSIST list is no longer needed.

fixes #2022