### PR TITLE
fix(client): Opt in to the iframe broker.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -399,7 +399,7 @@ function (
           .then(function (startPage) {
             // The IFrame cannot use pushState or else a page transition
             // would cause the parent frame to redirect.
-            var usePushState = ! self._isIframe();
+            var usePushState = ! self._isInAnIframe();
 
             if (! usePushState) {
               // If pushState cannot be used, Backbone falls back to using
@@ -453,8 +453,16 @@ function (
                   Session.oauth && Session.oauth.webChannelId));
     },
 
-    _isIframe: function () {
+    _isInAnIframe: function () {
       return this._window !== this._window.top;
+    },
+
+    _isIframeContext: function () {
+      return this._searchParam('context') === Constants.IFRAME_CONTEXT;
+    },
+
+    _isIframe: function () {
+      return this._isInAnIframe() && this._isIframeContext();
     },
 
     _isOAuth: function () {

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -15,6 +15,8 @@ define([], function () {
     FX_DESKTOP_CONTEXT: 'fx_desktop_v1',
     FX_DESKTOP_SYNC: 'sync',
 
+    IFRAME_CONTEXT: 'iframe',
+
     SIGNUP_RESEND_MAX_TRIES: 3,
     PASSWORD_RESET_RESEND_MAX_TRIES: 3,
     RESET_PASSWORD_POLL_INTERVAL: 2000,


### PR DESCRIPTION
* Only use the iframe flow if in an iframe and `context=iframe` is set on the query parameters.
* Add a bunch of tests to check that the correct brokers are created on startup.

fixes #2150

Depends on https://github.com/mozilla/fxa-relier-client/pull/47, the test 123done must be updated with a built version from that branch.