### PR TITLE
fix(l10n): sv is no longer maintained, switch to sv-SE

### DIFF
--- a/server/config/production-locales.json
+++ b/server/config/production-locales.json
@@ -37,7 +37,7 @@
       "sq",
       "sr",
       "sr-LATN",
-      "sv",
+      "sv-SE",
       "tr",
       "uk",
       "zh-CN",


### PR DESCRIPTION
@zaach - is this all that is needed? `grep` revealed nothing in puppet-config that looks like it needs updated.

fixes #1773