### PR TITLE
fix(client): Ensure console errors are displayed in Firefox on catastrophic startup error.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -135,9 +135,16 @@ function (
           self._metrics.logError(err);
         }
 
-        //Something terrible happened. Let's bail.
-        var redirectTo = self._getErrorPage(err);
-        self._window.location.href = redirectTo;
+        // this extra promise is to ensure the message is printed
+        // to the console in Firefox before redirecting. Without
+        // the delay, the console message is lost, even with
+        // persistent logs enabled. See #2183
+        return p()
+          .then(function () {
+            //Something terrible happened. Let's bail.
+            var redirectTo = self._getErrorPage(err);
+            self._window.location.href = redirectTo;
+          });
       });
     },
 


### PR DESCRIPTION
Do the redirect asynchronously after writing to the console to give the browser time to do the write.

fixes #2183

@zaach - could you have a quick look at this one?