### PR TITLE
fix(client): Use standard error formats for expired and damaged verification links.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -191,6 +191,14 @@ function (_, Errors) {
     FORCE_AUTH_EMAIL_REQUIRED: {
       errno: 1024,
       message: t('/force_auth requires an email')
+    },
+    EXPIRED_VERIFICATION_LINK: {
+      errno: 1025,
+      message: t('The link you clicked to verify your email is expired.')
+    },
+    DAMAGED_VERIFICATION_LINK: {
+      errno: 1026,
+      message: t('Verification link damaged')
     }
   };
 

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -44,7 +44,7 @@ function (Cocktail, BaseView, FormView, Template, PasswordMixin,
       } catch(e) {
         // This is an invalid link. Abort and show an error message
         // before doing any more checks.
-        this.logEvent('complete_reset_password.link_damaged');
+        this.logError(AuthErrors.toError('DAMAGED_VERIFICATION_LINK'));
         return true;
       }
 
@@ -56,7 +56,7 @@ function (Cocktail, BaseView, FormView, Template, PasswordMixin,
       if (! this._doesLinkValidate()) {
         // One or more parameters fails validation. Abort and show an
         // error message before doing any more checks.
-        this.logEvent('complete_reset_password.link_damaged');
+        this.logError(AuthErrors.toError('DAMAGED_VERIFICATION_LINK'));
         return true;
       }
 
@@ -65,7 +65,7 @@ function (Cocktail, BaseView, FormView, Template, PasswordMixin,
         .then(function (isComplete) {
           self._isLinkExpired = isComplete;
           if (isComplete) {
-            self.logEvent('complete_reset_password.link_expired');
+            self.logError(AuthErrors.toError('EXPIRED_VERIFICATION_LINK'));
           }
           return true;
         });
@@ -171,6 +171,7 @@ function (Cocktail, BaseView, FormView, Template, PasswordMixin,
 
     resendResetEmail: function () {
       var self = this;
+      self.logScreenEvent('resend');
       return self.fxaClient.passwordReset(self.email, self.relier)
               .then(function (result) {
                 self.navigate('confirm_reset_password', {

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -89,7 +89,15 @@ The event stream is a log of events and the time they occurred while the user is
 #### cannot_create_account
 #### change_password
 #### complete_reset_password
+* complete_reset_password.verification.success - email successfully verified.
+* complete_reset_password.resend - A verification email was resent after an expired link was opened.
+* error.complete_reset_password.auth.1025 - User clicked on an expired verification link.
+* error.complete_reset_password.auth.1026 - User clicked on a damaged verification link.
 #### complete_sign_up
+* complete_sign_up.verification.success - email successfully verified.
+* complete_sign_up.resend - A verification email was resent after an expired link was opened.
+* error.complete_sign_up.auth.1025 - User clicked on an expired verification link.
+* error.complete_sign_up.auth.1026 - User clicked on a damaged verification link.
 #### confirm
 #### confirm_reset_password
 #### cookies_disabled


### PR DESCRIPTION
@vladikoff - this is a breakout of the new error portion of #2125, and should be a bit easier to review. r?

<screen_name>.link_damaged and <screen_name>.link_expired were being used to indicate an invalid link. These have been converted to use the standard format from AuthErrors.

Two AuthError errors added:
* EXPIRED_VERIFICATION_LINK - 1025
* DAMAGED_VERIFICATION_LINK - 1026

In addition, not all error in complete_sign_up->beforeRender were logged. Now they are.

fixes #2206
fixes #2207