### PR TITLE
fix(test): check for final state success after redirect

### DIFF
--- a/tests/functional/oauth_iframe.js
+++ b/tests/functional/oauth_iframe.js
@@ -205,7 +205,8 @@ define([
           return self.get('remote').get(require.toUrl(verificationLink));
         })
 
-        .findByCssSelector('#fxa-sign-up-complete-header')
+        // verification link is ultimately redirected back to 123done
+        .findByCssSelector('#loggedin')
         .end();
     },
 
@@ -395,7 +396,8 @@ define([
               self, PASSWORD, PASSWORD);
         })
 
-        .findByCssSelector('#fxa-reset-password-complete-header')
+        // verification link is ultimately redirected back to 123done
+        .findByCssSelector('#loggedin')
         .end();
     },
 


### PR DESCRIPTION
So, these two tests are currently flaky when run against stage, where there are multiple separate servers and a non-localhost database, so timing changes.

IIUC, the tests are trying to check for a state in a document that is pretty much immediately going to be destroyed on a redirect. I think this PR makes sense, in checking that after loading the verification url we wind up in the final logged-in to 123done.

@shane-tomlinson , @vladikoff, @zaach - thoughts, r?