### PR TITLE
fix(test): Fix the account locked tests when run against latest.

### DIFF
--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -94,7 +94,9 @@ define([
           return clearBrowserStorage.call(self);
         })
         .then(function () {
-          return FunctionalHelpers.fillOutSignIn(self, email, FIRST_PASSWORD);
+          return FunctionalHelpers.fillOutSignIn(self, email, FIRST_PASSWORD)
+            .findByCssSelector('#fxa-settings-header')
+            .end();
         });
     },
 

--- a/tests/functional/delete_account.js
+++ b/tests/functional/delete_account.js
@@ -40,6 +40,9 @@ define([
   function initiateLockedAccountDeleteAccount(context) {
     return FunctionalHelpers.fillOutSignIn(context, email, PASSWORD)
 
+      .findByCssSelector('#fxa-settings-header')
+      .end()
+
       .get(require.toUrl(PAGE_URL))
 
       .findByCssSelector('#fxa-delete-account-header')


### PR DESCRIPTION
* The signin was not complete before attempts were made to visit the /settings page. Since the user was not signed in, they were booted back to /signin.

fixes #2215

@vladikoff - r?