### PR TITLE
fix(client): Extract the COPPA datepicker logic into its own module.

### DIFF
--- a/app/scripts/templates/partial/coppa-date-picker.mustache
+++ b/app/scripts/templates/partial/coppa-date-picker.mustache
@@ -1,0 +1,56 @@
+      <div class="select-row-wrapper" id="year-picker">
+        <div class="select-row">
+          <select id="fxa-age-year" {{#shouldFocusYear}}autofocus{{/shouldFocusYear}}>
+            <option id="fxa-none" value="none">{{#t}}Year of birth{{/t}}</option>
+            <option id="fxa-1990" value="1990">{{#t}}1990 or earlier{{/t}}</option>
+            <option id="fxa-1991" value="1991">{{#t}}1991{{/t}}</option>
+            <option id="fxa-1992" value="1992">{{#t}}1992{{/t}}</option>
+            <option id="fxa-1993" value="1993">{{#t}}1993{{/t}}</option>
+            <option id="fxa-1994" value="1994">{{#t}}1994{{/t}}</option>
+            <option id="fxa-1995" value="1995">{{#t}}1995{{/t}}</option>
+            <option id="fxa-1996" value="1996">{{#t}}1996{{/t}}</option>
+            <option id="fxa-1997" value="1997">{{#t}}1997{{/t}}</option>
+            <option id="fxa-1998" value="1998">{{#t}}1998{{/t}}</option>
+            <option id="fxa-1999" value="1999">{{#t}}1999{{/t}}</option>
+            <option id="fxa-2000" value="2000">{{#t}}2000{{/t}}</option>
+            <option id="fxa-2001" value="2001">{{#t}}2001{{/t}}</option>
+            <option id="fxa-2002" value="2002">{{#t}}2002{{/t}}</option>
+            <option id="fxa-2003" value="2003">{{#t}}2003{{/t}}</option>
+            <option id="fxa-2004" value="2004">{{#t}}2004{{/t}}</option>
+            <option id="fxa-2005" value="2005">{{#t}}2005{{/t}}</option>
+            <option id="fxa-2006" value="2006">{{#t}}2006{{/t}}</option>
+            <option id="fxa-2007" value="2007">{{#t}}2007{{/t}}</option>
+
+          </select>
+        </div>
+      </div>
+
+      <div class="select-row-wrapper hidden" id="month-date-picker">
+
+        <div class="select-row half-width">
+          <select id="fxa-age-month">
+            <option id="fxa-month-none" value="none">{{#t}}Month{{/t}}</option>
+            <option id="fxa-month-0" value="0">{{#t}}January{{/t}}</option>
+            <option id="fxa-month-1" value="1">{{#t}}February{{/t}}</option>
+            <option id="fxa-month-2" value="2">{{#t}}March{{/t}}</option>
+            <option id="fxa-month-3" value="3">{{#t}}April{{/t}}</option
+            <option id="fxa-month-4" value="4">{{#t}}May{{/t}}</option>
+            <option id="fxa-month-5" value="5">{{#t}}June{{/t}}</option>
+            <option id="fxa-month-6" value="6">{{#t}}July{{/t}}</option>
+            <option id="fxa-month-7" value="7">{{#t}}August{{/t}}</option>
+            <option id="fxa-month-8" value="8">{{#t}}September{{/t}}</option>
+            <option id="fxa-month-9" value="9">{{#t}}October{{/t}}</option>
+            <option id="fxa-month-10" value="10">{{#t}}November{{/t}}</option>
+            <option id="fxa-month-11" value="11">{{#t}}December{{/t}}</option>
+          </select>
+        </div>
+
+        <div class="select-row half-width disabled">
+          <select id="fxa-age-date" disabled="true">
+            <option id="fxa-day-none" value="none">{{#t}}Day{{/t}}</option>
+          </select>
+        </div>
+
+      </div>
+
+

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -35,59 +35,7 @@
 
       </div>
 
-      <div class="select-row-wrapper" id="year-picker">
-        <div class="select-row">
-          <select id="fxa-age-year" {{#shouldFocusYear}}autofocus{{/shouldFocusYear}}>
-            <option id="fxa-none" value="none">{{#t}}Year of birth{{/t}}</option>
-            <option id="fxa-1990" value="1990">{{#t}}1990 or earlier{{/t}}</option>
-            <option id="fxa-1991" value="1991">{{#t}}1991{{/t}}</option>
-            <option id="fxa-1992" value="1992">{{#t}}1992{{/t}}</option>
-            <option id="fxa-1993" value="1993">{{#t}}1993{{/t}}</option>
-            <option id="fxa-1994" value="1994">{{#t}}1994{{/t}}</option>
-            <option id="fxa-1995" value="1995">{{#t}}1995{{/t}}</option>
-            <option id="fxa-1996" value="1996">{{#t}}1996{{/t}}</option>
-            <option id="fxa-1997" value="1997">{{#t}}1997{{/t}}</option>
-            <option id="fxa-1998" value="1998">{{#t}}1998{{/t}}</option>
-            <option id="fxa-1999" value="1999">{{#t}}1999{{/t}}</option>
-            <option id="fxa-2000" value="2000">{{#t}}2000{{/t}}</option>
-            <option id="fxa-2001" value="2001">{{#t}}2001{{/t}}</option>
-            <option id="fxa-2002" value="2002">{{#t}}2002{{/t}}</option>
-            <option id="fxa-2003" value="2003">{{#t}}2003{{/t}}</option>
-            <option id="fxa-2004" value="2004">{{#t}}2004{{/t}}</option>
-            <option id="fxa-2005" value="2005">{{#t}}2005{{/t}}</option>
-            <option id="fxa-2006" value="2006">{{#t}}2006{{/t}}</option>
-            <option id="fxa-2007" value="2007">{{#t}}2007{{/t}}</option>
-
-          </select>
-        </div>
-      </div>
-
-      <div class="select-row-wrapper hidden" id="month-date-picker">
-
-        <div class="select-row half-width">
-          <select id="fxa-age-month">
-            <option id="fxa-month-none" value="none">{{#t}}Month{{/t}}</option>
-            <option id="fxa-month-0" value="0">{{#t}}January{{/t}}</option>
-            <option id="fxa-month-1" value="1">{{#t}}February{{/t}}</option>
-            <option id="fxa-month-2" value="2">{{#t}}March{{/t}}</option>
-            <option id="fxa-month-3" value="3">{{#t}}April{{/t}}</option
-            <option id="fxa-month-4" value="4">{{#t}}May{{/t}}</option>
-            <option id="fxa-month-5" value="5">{{#t}}June{{/t}}</option>
-            <option id="fxa-month-6" value="6">{{#t}}July{{/t}}</option>
-            <option id="fxa-month-7" value="7">{{#t}}August{{/t}}</option>
-            <option id="fxa-month-8" value="8">{{#t}}September{{/t}}</option>
-            <option id="fxa-month-9" value="9">{{#t}}October{{/t}}</option>
-            <option id="fxa-month-10" value="10">{{#t}}November{{/t}}</option>
-            <option id="fxa-month-11" value="11">{{#t}}December{{/t}}</option>
-          </select>
-        </div>
-
-        <div class="select-row half-width disabled">
-          <select id="fxa-age-date" disabled="true">
-            <option id="fxa-day-none" value="none">{{#t}}Day{{/t}}</option>
-          </select>
-        </div>
-
+      <div id="coppa">
       </div>
 
       <div class="privacy-links">

--- a/app/scripts/views/coppa/coppa-date-picker.js
+++ b/app/scripts/views/coppa/coppa-date-picker.js
@@ -1,0 +1,258 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'views/form',
+  'stache!templates/partial/coppa-date-picker',
+  'lib/strings',
+  'lib/auth-errors',
+  'lib/promise'
+], function (FormView, Template, Strings, AuthErrors, p) {
+  var now = new Date();
+  var CUTOFF_AGE = {
+    year: now.getFullYear() - 13,
+    month: now.getMonth(),
+    date: now.getDate()
+  };
+
+  var View = FormView.extend({
+
+    template: Template,
+    className: 'coppa-date-picker',
+
+    initialize: function (options) {
+      options = options || {};
+
+      this._formPrefill = options.formPrefill;
+      this._shouldFocus = options.shouldFocus;
+    },
+
+    events: {
+      'keydown #fxa-age-year': 'submitOnEnter',
+      'keydown #fxa-age-month': 'submitOnEnter',
+      'keydown #fxa-age-date': 'submitOnEnter',
+      'change #fxa-age-year': 'onUserYearSelect',
+      'change #fxa-age-month': 'onUserMonthSelect',
+
+      // handles select-row hack (issue 822)
+      'focus select': 'onSelectFocus',
+      'blur select': 'onSelectBlur',
+      'change select': 'onSelectChange'
+    },
+
+    /**
+     * Called by the parent view to determine if the user is old enough.
+     * @method isUserOldEnough
+     * @param {Object} [userAge] - hash with `year`, `month`, and `date`. Used
+     * for testing.
+     * @return {Boolean} true if user is old enough, false otw.
+     */
+    isUserOldEnough: function (userAge) {
+      userAge = userAge || this._getSelectedUserAge();
+      if (userAge.year < CUTOFF_AGE.year) {
+        return true;
+      } else if (userAge.year === CUTOFF_AGE.year &&
+                 userAge.month < CUTOFF_AGE.month) {
+        return true;
+      }
+
+      return (userAge.year === CUTOFF_AGE.year &&
+                 userAge.month === CUTOFF_AGE.month &&
+                 userAge.date <= CUTOFF_AGE.date);
+    },
+
+    /**
+     * Called by the parent view to determine if the COPPA form is valid
+     *
+     * @method isValidEnd
+     */
+    isValidEnd: function () {
+      if (! this._validateYear()) {
+        return false;
+      }
+
+      if (this._getYear() === CUTOFF_AGE.year) {
+        return this._validateMonthAndDate();
+      }
+
+      return true;
+    },
+
+    /**
+     * Called by the parent view to show any validation errors.
+     *
+     * @method showValidationErrorsEnd
+     */
+    showValidationErrorsEnd: function () {
+      if (! this._validateYear()) {
+        this.addInvalidRow('#fxa-age-year');
+
+        this.showValidationError('#fxa-age-year',
+                AuthErrors.toError('YEAR_OF_BIRTH_REQUIRED'));
+      } else if (this._getYear() === CUTOFF_AGE.year &&
+               ! this._validateMonthAndDate()) {
+        this.addInvalidRow('#fxa-age-month, #fxa-age-date');
+
+        this.showValidationError('#fxa-age-month',
+                AuthErrors.toError('BIRTHDAY_REQUIRED'));
+      }
+    },
+
+    context: function () {
+      return {
+        shouldFocusYear: !! this._shouldFocus
+      };
+    },
+
+    render: function () {
+      var self = this;
+      return p()
+        .then(function () {
+          self.$el.html(self.template(self.getContext()));
+          self._selectPrefillYear();
+        });
+    },
+
+    onSelectFocus: function (event) {
+      this.addSelectFocus(event.target);
+    },
+
+    onSelectBlur: function (event) {
+      this.removeSelectFocus(event.target);
+    },
+
+    onSelectChange: function (event) {
+      this.removeInvalidRow(event.target);
+    },
+
+    addSelectFocus: function (element) {
+      $(element).parent().addClass('select-focus');
+    },
+
+    removeSelectFocus: function (element) {
+      $(element).parent().removeClass('select-focus');
+    },
+
+    addInvalidRow: function (element) {
+      $(element).parent().addClass('invalid-row');
+    },
+
+    removeInvalidRow: function (element) {
+      $(element).parent().removeClass('invalid-row');
+    },
+
+    beforeDestroy: function () {
+      this._formPrefill.set('year', this.$('#fxa-age-year').val());
+    },
+
+    submitOnEnter: function (event) {
+      if (event.which === 13) {
+        this.trigger('submit');
+      }
+    },
+
+    _getSelectedUserAge: function () {
+      var self = this;
+      return {
+        year: self._getYear(),
+        month: self._getMonth(),
+        date: self._getDate()
+      };
+    },
+
+    _validateYear: function () {
+      return ! isNaN(this._getYear());
+    },
+
+    _validateMonthAndDate: function () {
+      return ! (isNaN(this._getMonth()) || isNaN(this._getDate()));
+    },
+
+    _getYear: function () {
+      return parseInt(this.$('#fxa-age-year').val(), 10);
+    },
+
+    _getMonth: function () {
+      return parseInt(this.$('#fxa-age-month').val(), 10);
+    },
+
+    _getDate: function () {
+      return parseInt(this.$('#fxa-age-date').val(), 10);
+    },
+
+    onUserYearSelect: function () {
+      if (this._getYear() === CUTOFF_AGE.year) {
+        this._toggleDatePicker();
+      }
+    },
+
+    onUserMonthSelect: function () {
+      var datePickerEl = this.$('#fxa-age-date');
+      var selectedYear = this._getYear();
+      var selectedMonth = this._getMonth();
+      var selectedDate = this._getDate();
+
+      if (isNaN(selectedMonth)) {
+        this._disableDatePicker(datePickerEl);
+      } else {
+        this._enableDatePicker(datePickerEl);
+      }
+
+      var daysInMonth = this._daysInMonth(selectedYear, selectedMonth);
+      this._updateDatePickerValues(datePickerEl, daysInMonth);
+
+      if (this._isValidDateForMonth(selectedDate, daysInMonth)) {
+        datePickerEl.val(selectedDate);
+      }
+    },
+
+    //if the user changes from march to february (or similar),
+    //we need to reset out-of-bounds dates, or keep in-bounds dates
+    _isValidDateForMonth: function (date, daysInMonth) {
+      return (! isNaN(date)) && date <= daysInMonth;
+    },
+
+    _disableDatePicker: function (datePickerEl) {
+      datePickerEl.attr('disabled', 'true');
+      datePickerEl.parent().addClass('disabled');
+    },
+
+    _enableDatePicker: function (datePickerEl) {
+      datePickerEl.removeAttr('disabled');
+      datePickerEl.parent().removeClass('disabled');
+    },
+
+    _updateDatePickerValues: function (datePickerEl, days) {
+      var defaultValue = datePickerEl.children(':eq(0)');
+      datePickerEl.empty();
+      datePickerEl.append(defaultValue);
+      for (var i = 1; i <= days; i++) {
+        var optionHtml = Strings.interpolate(
+          '<option id="fxa-day-%s" value="%s">%s</option>', [i, i, i]);
+        datePickerEl.append(optionHtml);
+      }
+    },
+
+    _daysInMonth: function (year, month) {
+      return new Date(year, month + 1, 0).getDate();
+    },
+
+    _toggleDatePicker: function () {
+      this.$('#year-picker').addClass('hidden');
+      this.$('#month-date-picker').removeClass('hidden');
+      this.focus('#fxa-age-month');
+    },
+
+    _selectPrefillYear: function () {
+      var prefillYear = this._formPrefill.get('year');
+      if (prefillYear) {
+        this.$('#fxa-' + prefillYear).attr('selected', 'selected');
+      }
+    }
+  });
+
+  return View;
+});

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -16,10 +16,11 @@ define([
   'lib/strings',
   'lib/mailcheck',
   'views/mixins/password-mixin',
-  'views/mixins/service-mixin'
+  'views/mixins/service-mixin',
+  'views/coppa/coppa-date-picker'
 ],
 function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
-      Strings, mailcheck, PasswordMixin, ServiceMixin) {
+      Strings, mailcheck, PasswordMixin, ServiceMixin, CoppaDatePicker) {
   var t = BaseView.t;
 
   function selectAutoFocusEl(bouncedEmail, email, password) {
@@ -30,15 +31,8 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
     } else if (! password) {
       return 'password';
     }
-    return 'year';
+    return null;
   }
-
-  var now = new Date();
-  var CUTOFF_AGE = {
-    year: now.getFullYear() - 13,
-    month: now.getMonth(),
-    date: now.getDate()
-  };
 
   var View = FormView.extend({
     template: Template,
@@ -48,6 +42,7 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
       options = options || {};
 
       this._formPrefill = options.formPrefill;
+      this._coppa = options.coppa;
     },
 
     beforeRender: function () {
@@ -62,27 +57,38 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
       return FormView.prototype.beforeRender.call(this);
     },
 
-    afterRender: function () {
-      this._addSelectRowBehavior();
-      this._selectPrefillYear();
+    _createCoppaView: function () {
+      var self = this;
 
-      this.transformLinks();
+      if (self._coppa) {
+        return p();
+      }
 
-      return FormView.prototype.afterRender.call(this);
+      var autofocusEl = this._selectAutoFocusEl();
+      var coppaDatePicker = new CoppaDatePicker({
+        el: self.$('#coppa'),
+        screenName: self.getScreenName(),
+        formPrefill: self._formPrefill,
+        shouldFocus: autofocusEl === null
+      });
+
+      return coppaDatePicker.render()
+        .then(function () {
+          self.trackSubview(coppaDatePicker);
+          coppaDatePicker.on('submit', self.validateAndSubmit.bind(self));
+
+          self._coppa = coppaDatePicker;
+        });
     },
 
-    // handles select-row hack (issue 822)
-    _addSelectRowBehavior: function () {
-      var select = this.$el.find('.select-row select');
-      select.focus(function (){
-        $(this).parent().addClass('select-focus');
-      });
-      select.blur(function (){
-        select.parent().removeClass('select-focus');
-      });
-      select.change(function (){
-        select.parent().removeClass('invalid-row');
-      });
+    afterRender: function () {
+      var self = this;
+      self._createCoppaView()
+        .then(function () {
+          self.transformLinks();
+
+          return FormView.prototype.afterRender.call(self);
+        });
     },
 
     afterVisible: function () {
@@ -103,11 +109,6 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
     },
 
     events: {
-      'keydown #fxa-age-year': 'submitOnEnter',
-      'keydown #fxa-age-month': 'submitOnEnter',
-      'keydown #fxa-age-date': 'submitOnEnter',
-      'change #fxa-age-year': 'onUserYearSelect',
-      'change #fxa-age-month': 'onUserMonthSelect',
       'blur input.email': 'suggestEmail'
     },
 
@@ -118,14 +119,18 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
       return this._formPrefill.get('email') || this.relier.get('email');
     },
 
+    _selectAutoFocusEl: function () {
+      var prefillEmail = this.getPrefillEmail();
+      var prefillPassword = this._formPrefill.get('password');
+
+      return selectAutoFocusEl(
+            this._bouncedEmail, prefillEmail, prefillPassword);
+    },
+
     context: function () {
       var prefillEmail = this.getPrefillEmail();
-      var formPrefill = this._formPrefill;
-      var prefillPassword = formPrefill.get('password');
-      var prefillYear = formPrefill.get('year') || 'none';
-
-      var autofocusEl = selectAutoFocusEl(
-            this._bouncedEmail, prefillEmail, prefillPassword);
+      var prefillPassword = this._formPrefill.get('password');
+      var autofocusEl = this._selectAutoFocusEl();
 
       var relier = this.relier;
       return {
@@ -135,10 +140,8 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
         isPasswordAutoCompleteDisabled: this.isPasswordAutoCompleteDisabled(),
         email: prefillEmail,
         password: prefillPassword,
-        year: prefillYear,
         shouldFocusEmail: autofocusEl === 'email',
         shouldFocusPassword: autofocusEl === 'password',
-        shouldFocusYear: autofocusEl === 'year',
         error: this.error
       };
     },
@@ -147,13 +150,6 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
       var formPrefill = this._formPrefill;
       formPrefill.set('email', this.getElementValue('.email'));
       formPrefill.set('password', this.getElementValue('.password'));
-      formPrefill.set('year', this.$('#fxa-age-year').val());
-    },
-
-    submitOnEnter: function (event) {
-      if (event.which === 13) {
-        this.validateAndSubmit();
-      }
     },
 
     isValidEnd: function () {
@@ -165,12 +161,8 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
         return false;
       }
 
-      if (! this._validateYear()) {
+      if (! this._coppa.isValid()) {
         return false;
-      }
-
-      if (this._getYear() === CUTOFF_AGE.year) {
-        return this._validateMonthAndDate();
       }
 
       return FormView.prototype.isValidEnd.call(this);
@@ -183,21 +175,8 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
       } else if (this._isEmailFirefoxDomain()) {
         this.showValidationError('input[type=email]',
                 AuthErrors.toError('DIFFERENT_EMAIL_REQUIRED_FIREFOX_DOMAIN'));
-      } else if (! this._validateYear()) {
-        //next two lines deal with ff30's select list regression
-        var selectYearRow = $('#fxa-age-year').parent();
-        selectYearRow.addClass('invalid-row');
-
-        this.showValidationError('#fxa-age-year',
-                AuthErrors.toError('YEAR_OF_BIRTH_REQUIRED'));
-      } else if (this._getYear() === CUTOFF_AGE.year &&
-               ! this._validateMonthAndDate()) {
-        var selectMonthDateRow =
-              this.$('#fxa-age-month, #fxa-age-date').parent();
-        selectMonthDateRow.addClass('invalid-row');
-
-        this.showValidationError('#fxa-age-month',
-                AuthErrors.toError('BIRTHDAY_REQUIRED'));
+      } else {
+        this._coppa.showValidationErrors();
       }
     },
 
@@ -222,47 +201,8 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
              (this.getElementValue('input[type=email]') === this._bouncedEmail));
     },
 
-    _getSelectedUserAge: function () {
-      var self = this;
-      return {
-        year: self._getYear(),
-        month: self._getMonth(),
-        date: self._getDate()
-      };
-    },
-
-    _validateYear: function () {
-      return ! isNaN(this._getYear());
-    },
-
-    _validateMonthAndDate: function () {
-      return ! (isNaN(this._getMonth()) || isNaN(this._getDate()));
-    },
-
-    _getYear: function () {
-      return parseInt(this.$('#fxa-age-year').val(), 10);
-    },
-
-    _getMonth: function () {
-      return parseInt(this.$('#fxa-age-month').val(), 10);
-    },
-
-    _getDate: function () {
-      return parseInt(this.$('#fxa-age-date').val(), 10);
-    },
-
-    _isUserOldEnough: function (userAge) {
-      userAge = userAge || this._getSelectedUserAge();
-      if (userAge.year < CUTOFF_AGE.year) {
-        return true;
-      } else if (userAge.year === CUTOFF_AGE.year &&
-                 userAge.month < CUTOFF_AGE.month) {
-        return true;
-      }
-
-      return (userAge.year === CUTOFF_AGE.year &&
-                 userAge.month === CUTOFF_AGE.month &&
-                 userAge.date <= CUTOFF_AGE.date);
+    _isUserOldEnough: function () {
+      return this._coppa.isUserOldEnough();
     },
 
     _isEmailFirefoxDomain: function () {
@@ -341,69 +281,6 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
         });
     },
 
-    onUserYearSelect: function () {
-      if (this._getYear() === CUTOFF_AGE.year) {
-        this._toggleDatePicker();
-      }
-    },
-
-    onUserMonthSelect: function () {
-      var datePickerEl = this.$('#fxa-age-date');
-      var selectedYear = this._getYear();
-      var selectedMonth = this._getMonth();
-      var selectedDate = this._getDate();
-
-      if (isNaN(selectedMonth)) {
-        this._disableDatePicker(datePickerEl);
-      } else {
-        this._enableDatePicker(datePickerEl);
-      }
-
-      var daysInMonth = this._daysInMonth(selectedYear, selectedMonth);
-      this._updateDatePickerValues(datePickerEl, daysInMonth);
-
-      if (this._isValidDateForMonth(selectedDate, daysInMonth)) {
-        datePickerEl.val(selectedDate);
-      }
-    },
-
-    //if the user changes from march to february (or similar),
-    //we need to reset out-of-bounds dates, or keep in-bounds dates
-    _isValidDateForMonth: function (date, daysInMonth) {
-      return (! isNaN(date)) && date <= daysInMonth;
-    },
-
-    _disableDatePicker: function (datePickerEl) {
-      datePickerEl.attr('disabled', 'true');
-      datePickerEl.parent().addClass('disabled');
-    },
-
-    _enableDatePicker: function (datePickerEl) {
-      datePickerEl.removeAttr('disabled');
-      datePickerEl.parent().removeClass('disabled');
-    },
-
-    _updateDatePickerValues: function (datePickerEl, days) {
-      var defaultValue = datePickerEl.children(':eq(0)');
-      datePickerEl.empty();
-      datePickerEl.append(defaultValue);
-      for (var i = 1; i <= days; i++) {
-        var optionHtml = Strings.interpolate(
-          '<option id="fxa-day-%s" value="%s">%s</option>', [i, i, i]);
-        datePickerEl.append(optionHtml);
-      }
-    },
-
-    _daysInMonth: function (year, month) {
-      return new Date(year, month + 1, 0).getDate();
-    },
-
-    _toggleDatePicker: function () {
-      this.$('#year-picker').addClass('hidden');
-      this.$('#month-date-picker').removeClass('hidden');
-      this.focus('#fxa-age-month');
-    },
-
     onSignUpSuccess: function (account) {
       var self = this;
       if (account.get('verified')) {
@@ -426,13 +303,6 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
     _suggestSignIn: function (err) {
       err.forceMessage = t('Account already exists. <a href="/signin">Sign in</a>');
       return this.displayErrorUnsafe(err);
-    },
-
-    _selectPrefillYear: function () {
-      var prefillYear = this._formPrefill.get('year');
-      if (prefillYear) {
-        this.$('#fxa-' + prefillYear).attr('selected', 'selected');
-      }
     }
   });
 

--- a/app/tests/spec/views/coppa/coppa-date-picker.js
+++ b/app/tests/spec/views/coppa/coppa-date-picker.js
@@ -1,0 +1,261 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'chai',
+  'underscore',
+  'jquery',
+  'moment',
+  'sinon',
+  'lib/auth-errors',
+  'lib/promise',
+  'views/coppa/coppa-date-picker',
+  'models/form-prefill'
+],
+function (chai, _, $, moment, sinon, p, AuthErrors, View, FormPrefill) {
+  var assert = chai.assert;
+
+  var DEFAULT_YEAR = 1990;
+  var DEFAULT_MONTH = 1;
+  var DEFAULT_DATE = 1;
+
+  function fillOutDatePicker (year, month, date, context) {
+    if (year !== null) {
+      $('#fxa-age-year').val(year);
+      $('#fxa-age-year').change();
+    }
+
+    if (month !== null) {
+      $('#fxa-age-month').val(month);
+      $('#fxa-age-month').change();
+    }
+
+    if (date !== null) {
+      $('#fxa-age-date').val(date);
+      $('#fxa-age-date').change();
+    }
+
+    if (context.enableSubmitIfValid) {
+      context.enableSubmitIfValid();
+    }
+  }
+
+  describe('views/coppa/coppa-date-picker', function () {
+    var view;
+    var formPrefill;
+
+    function createView() {
+      view = new View({
+        screenName: 'signup',
+        formPrefill: formPrefill
+      });
+    }
+
+    beforeEach(function () {
+
+      formPrefill = new FormPrefill();
+
+      createView();
+
+      return view.render()
+        .then(function () {
+          $('#container').html(view.el);
+        });
+    });
+
+    afterEach(function () {
+      view.remove();
+      view.destroy();
+
+      view = null;
+    });
+
+    describe('render', function () {
+      it('prefills year if stored in formPrefill (user comes from signup with existing account)', function () {
+        formPrefill.set('year', '1990');
+
+        createView();
+
+        return view.render()
+          .then(function () {
+            assert.ok(view.$('#fxa-1990').is(':selected'));
+          });
+      });
+    });
+
+    describe('isValid', function () {
+      it('returns true if year, month, and date are all valid', function () {
+        fillOutDatePicker(DEFAULT_YEAR, DEFAULT_MONTH, DEFAULT_DATE, view);
+
+        assert.isTrue(view.isValid());
+      });
+
+      it('returns false if no year selected', function () {
+        fillOutDatePicker(null, DEFAULT_MONTH, DEFAULT_DATE, view);
+
+        assert.isFalse(view.isValid());
+      });
+
+      it('returns false if no month selected and needs to be checked', function () {
+        var year = moment().subtract(13, 'years').year();
+        fillOutDatePicker(year, null, DEFAULT_DATE, view);
+
+        assert.isFalse(view.isValid());
+      });
+
+      it('returns false if no date selected and needs to be checked', function () {
+        var year = moment().subtract(13, 'years').year();
+        var month = moment().subtract(13, 'years').month();
+        fillOutDatePicker(year, month, null, view);
+
+        assert.isFalse(view.isValid());
+      });
+    });
+
+    describe('showValidationErrors', function () {
+      it('shows an error if no year is selected', function () {
+        fillOutDatePicker(null, DEFAULT_MONTH, DEFAULT_DATE, view);
+
+        sinon.spy(view, 'showValidationError');
+
+        view.showValidationErrors();
+        assert.isTrue(view.showValidationError.called);
+      });
+
+      it('shows an error if no month is selected and should be', function () {
+        var year = moment().subtract(13, 'years').year();
+        fillOutDatePicker(year, null, DEFAULT_DATE, view);
+
+        sinon.spy(view, 'showValidationError');
+
+        view.showValidationErrors();
+        assert.isTrue(view.showValidationError.called);
+      });
+
+      it('shows an error if no date is selected and should be', function () {
+        var year = moment().subtract(13, 'years').year();
+        var month = moment().subtract(13, 'years').month();
+        fillOutDatePicker(year, month, null, view);
+
+        sinon.spy(view, 'showValidationError');
+
+        view.showValidationErrors();
+        assert.isTrue(view.showValidationError.called);
+      });
+    });
+
+    describe('submitOnEnter', function () {
+      function testEnterKeyTriggersSubmit(element, done) {
+        view.on('submit', function () {
+          done();
+        });
+
+        // submit using the enter key
+        var e = jQuery.Event('keydown', { which: 13 });
+        $(element).trigger(e);
+      }
+
+      it('submits form if user presses enter on the year', function (done) {
+        testEnterKeyTriggersSubmit('#fxa-age-year', done);
+      });
+
+      it('submits form if user presses enter on the month', function (done) {
+        testEnterKeyTriggersSubmit('#fxa-age-month', done);
+      });
+
+      it('submits form if user presses enter on the day', function (done) {
+        testEnterKeyTriggersSubmit('#fxa-age-date', done);
+      });
+    });
+
+    describe('isUserOldEnough', function () {
+      it('returns true if user is 14 year old', function () {
+        var ageToCheck = moment().subtract(14, 'years');
+        assert.isTrue(view.isUserOldEnough({
+          year: ageToCheck.year(),
+          month: ageToCheck.month(),
+          date: ageToCheck.date()
+        }));
+      });
+
+      it('returns true if user is 13 years + 1 days old', function () {
+        var ageToCheck = moment().subtract(13, 'years').subtract(1, 'days');
+        assert.isTrue(view.isUserOldEnough({
+          year: ageToCheck.year(),
+          month: ageToCheck.month(),
+          date: ageToCheck.date()
+        }));
+      });
+
+      it('returns true if user is 13 years and 29 days old', function () {
+        var ageToCheck = moment().subtract(13, 'years').subtract(29, 'days');
+        assert.isTrue(view.isUserOldEnough({
+          year: ageToCheck.year(),
+          month: ageToCheck.month(),
+          date: ageToCheck.date()
+        }));
+      });
+
+      it('returns true if user is 13 years and 1 month old', function () {
+        var ageToCheck = moment().subtract(13, 'years').subtract(1, 'months');
+        assert.isTrue(view.isUserOldEnough({
+          year: ageToCheck.year(),
+          month: ageToCheck.month(),
+          date: ageToCheck.date()
+        }));
+      });
+
+      it('returns true if user is 13 years old today - HOORAY!', function () {
+        var ageToCheck = moment().subtract(13, 'years');
+        assert.isTrue(view.isUserOldEnough({
+          year: ageToCheck.year(),
+          month: ageToCheck.month(),
+          date: ageToCheck.date()
+        }));
+      });
+
+      it ('returns false if user is 13 years - 1 day old - wait until tomorrow', function () {
+        var ageToCheck = moment().subtract(13, 'years').add(1, 'days');
+        assert.isFalse(view.isUserOldEnough({
+          year: ageToCheck.year(),
+          month: ageToCheck.month(),
+          date: ageToCheck.date()
+        }));
+      });
+
+      it('returns false if user is 13 years - 1 month old - wait another month', function () {
+        var ageToCheck = moment().subtract(13, 'years').add(1, 'months');
+        assert.isFalse(view.isUserOldEnough({
+          year: ageToCheck.year(),
+          month: ageToCheck.month(),
+          date: ageToCheck.date()
+        }));
+      });
+
+      it('returns false if user is 12 years old - wait another year', function () {
+        var ageToCheck = moment().subtract(12, 'years');
+        assert.isFalse(view.isUserOldEnough({
+          year: ageToCheck.year(),
+          month: ageToCheck.month(),
+          date: ageToCheck.date()
+        }));
+      });
+    });
+
+    describe('destroy', function () {
+      it('saves the form info to formPrefill', function () {
+        view.$('#fxa-age-year').val('1990');
+
+        view.destroy();
+
+        assert.equal(formPrefill.get('year'), '1990');
+      });
+    });
+  });
+});
+
+

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -75,6 +75,7 @@ function (Translator, Session) {
     '../tests/spec/views/marketing_snippet',
     '../tests/spec/views/cannot_create_account',
     '../tests/spec/views/close_button',
+    '../tests/spec/views/coppa/coppa-date-picker',
     '../tests/spec/views/mixins/floating-placeholder-mixin',
     '../tests/spec/views/mixins/timer-mixin',
     '../tests/spec/views/mixins/service-mixin',


### PR DESCRIPTION
This is to prepare for AB testing. Alternative COPPA date pickers are going
to be tested, so each COPPA date picker must be encapsulated.

fixes #1977

This is for @johngruen, but could use review from @zaach or @vladikoff.