### PR TITLE
fix(client): Channel timeouts are informative, they no longer throw errors.

### DIFF
--- a/app/scripts/lib/channels/mixins/postmessage_receiver.js
+++ b/app/scripts/lib/channels/mixins/postmessage_receiver.js
@@ -10,10 +10,9 @@
  */
 
 define([
-  'underscore',
-  'lib/auth-errors'
-], function (_, AuthErrors) {
-  var DEFAULT_SEND_TIMEOUT_LENGTH_MS = 5000;
+  'underscore'
+], function (_) {
+  var DEFAULT_SEND_TIMEOUT_LENGTH_MS = 90 * 1000;
 
   function noOp() {
     // it's a noOp, nothing to do.
@@ -33,12 +32,11 @@ define([
     }
   }
 
-  function errorIfNoResponse(outstandingRequest) {
+  function setResponseTimeoutTimer(outstandingRequest) {
     /*jshint validthis: true*/
-    outstandingRequest.timeout = this.window.setTimeout(function () {
-      // only called if the request has not been responded to.
-      outstandingRequest.done(AuthErrors.toError('CHANNEL_TIMEOUT'));
-    }, this._sendTimeoutLength);
+    outstandingRequest.timeout = this.window.setTimeout(function (command) {
+      this.window.console.error('Response not received for: ' + command);
+    }.bind(this, outstandingRequest.command), this._sendTimeoutLength);
   }
 
   var PostMessageReceiverMixin = {
@@ -87,7 +85,7 @@ define([
         return done(e);
       }
 
-      errorIfNoResponse.call(this, outstanding);
+      setResponseTimeoutTimer.call(this, outstanding);
     },
 
     receiveMessage: function (event) {

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -58,7 +58,15 @@ function (_, Backbone, NullStorage) {
       }
     };
 
-    this.console = window.console;
+    // Create a console wrapper whose members can be safely
+    // stubbed in using sinon.
+    this.console = {
+      error: console.error.bind(console),
+      info: console.info.bind(console),
+      log: console.log.bind(console),
+      trace: console.trace.bind(console),
+      warn: console.warn.bind(console)
+    };
 
     this.localStorage = new NullStorage();
     this.sessionStorage = new NullStorage();

--- a/app/tests/spec/lib/channels/fx-desktop.js
+++ b/app/tests/spec/lib/channels/fx-desktop.js
@@ -10,13 +10,11 @@ define([
   'sinon',
   'lib/auth-errors',
   'lib/channels/fx-desktop',
-  '../../../mocks/window',
-  '../../../lib/helpers'
+  '../../../mocks/window'
 ],
-function (chai, sinon, AuthErrors, FxDesktopChannel, WindowMock, TestHelpers) {
+function (chai, sinon, AuthErrors, FxDesktopChannel, WindowMock) {
   var assert = chai.assert;
   var channel;
-  var wrapAssertion = TestHelpers.wrapAssertion;
 
   describe('lib/channel/fx-desktop', function () {
     var windowMock;
@@ -59,7 +57,7 @@ function (chai, sinon, AuthErrors, FxDesktopChannel, WindowMock, TestHelpers) {
       });
 
 
-      it('times out if browser does not respond', function (done) {
+      it('prints a message to the console if browser does not respond', function (done) {
         sinon.stub(parentMock, 'postMessage', function () {
         });
 
@@ -67,11 +65,11 @@ function (chai, sinon, AuthErrors, FxDesktopChannel, WindowMock, TestHelpers) {
           callback();
         });
 
-        channel.send('wait-for-response', {}, function (err) {
-          wrapAssertion(function () {
-            assert.isTrue(AuthErrors.is(err, 'CHANNEL_TIMEOUT'));
-          }, done);
+        sinon.stub(windowMock.console, 'error', function () {
+          done();
         });
+
+        channel.send('wait-for-response', {});
       });
 
       it('does not except on timeout if callback is not given', function (done) {

--- a/app/tests/spec/lib/channels/iframe.js
+++ b/app/tests/spec/lib/channels/iframe.js
@@ -68,7 +68,7 @@ function (chai, sinon, IFrameChannel, AuthErrors, WindowMock, TestHelpers) {
         channel.send('ping');
       });
 
-      it('times out if there is no response', function (done) {
+      it('prints a message to the console if there is no response', function (done) {
         // drop the message on the ground.
         sinon.stub(parentMock, 'postMessage', function () {
         });
@@ -77,11 +77,11 @@ function (chai, sinon, IFrameChannel, AuthErrors, WindowMock, TestHelpers) {
           callback();
         });
 
-        channel.send('ping', {}, function (err) {
-          TestHelpers.wrapAssertion(function () {
-            assert.isTrue(AuthErrors.is(err, 'CHANNEL_TIMEOUT'));
-          }, done);
+        sinon.stub(windowMock.console, 'error', function () {
+          done();
         });
+
+        channel.send('ping', {});
       });
 
       it('returns any errors in `dispatchCommand`', function (done) {


### PR DESCRIPTION
If a response is not received in 90 seconds, an error is logged to the console.

fixes #2146

This is for @ncalexan for the iOS effort.

@zaach or @vladikoff - r?