### PR TITLE
feat(client): Add "style=chromeless" flag which allows a chromesless styling.

### DIFF
--- a/app/scripts/vendor/env-test.js
+++ b/app/scripts/vendor/env-test.js
@@ -28,6 +28,37 @@
   // END MODERNIZR BASED CODE
 
   // Code below here is our own.
+
+  function parseQueryParams() {
+    var search = document.location.search.replace(/^\?/, '');
+    var paramPairs = search.split('&');
+    var params = {};
+
+    // Use old school for instead of Array.prototype.forEach because
+    // env-test still has to run in IE8 even if the rest of the
+    // app doesn't.
+    for (var i = 0; i < paramPairs.length; ++i) {
+      var paramPair = paramPairs[i].split('=');
+      params[paramPair[0]] = paramPair[1] || 'undefined';
+    }
+
+    return params;
+  }
+
+  function isStyleAllowed(style) {
+    var queryParams = parseQueryParams();
+    var service = queryParams.service;
+    var context = queryParams.context;
+
+    // The 'chromeless' style is only opened up
+    // to Sync when using an iframe.
+    if (style === 'chromeless') {
+      return (service === 'sync' && context === 'iframe');
+    }
+
+    return false;
+  }
+
   if (document.documentMode && document.documentMode >= 10) {
     docElement.className += ' reveal-pw';
   } else {
@@ -41,7 +72,17 @@
    * We also need to make sure that the iframe name is not 'remote', that is used by 'about:accounts'.
    */
   if (window.top && window.top !== window && window.name !== 'remote') {
-    var htmlElement = document.querySelector('html');
-    htmlElement.className += ' iframe';
+    docElement.className += ' iframe';
+  }
+
+  /**
+   * A relier can add the `style=x` query parameter to indicate
+   * an alternative styling should be used.
+   * Allowed styles:
+   *   * chromeless
+   */
+  var style = parseQueryParams().style;
+  if (isStyleAllowed(style)) {
+    docElement.className += (' ' + style);
   }
 }());

--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -15,6 +15,10 @@ html {
   @include respond-to('trustedUI') {
     background-color: $content-background-color;
   }
+
+  &.chromeless {
+    background-color: $chromeless-html-background-color;
+  }
 }
 
 body {
@@ -101,7 +105,7 @@ header {
         font-size: $medium-font;
         margin-top: 10px;
       }
-      
+
       @include respond-to('trustedUI') {
         font-size: $base-font;
         margin-top: 4px;
@@ -133,7 +137,7 @@ section p {
 
   &.prefill {
     word-wrap: break-word;
-    
+
     @include respond-to('reasonableUI') {
       margin-top: 24px;
     }

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -1,6 +1,6 @@
 // Apply styles to div injected by backbone, rather than to the stage itself.
 #main-content {
-  
+
   background: $content-background-color;
   text-align: center;
 
@@ -44,6 +44,12 @@
     top: 0;
     width: 250px;
   }
+
+  .chromeless & {
+    border: none;
+    box-shadow: none;
+  }
+
 }
 
 #stage {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -10,6 +10,7 @@ $error-background-color: #d63920;
 $info-background-color: #0095dd;
 $error-text-color: #d63920;
 $html-background-color: #f2f2f2;
+$chromeless-html-background-color: #fff;
 $input-border-color: #424f59;
 $input-text-color: #424f59;
 $input-placeholder-color: #8a9ba8;

--- a/app/styles/modules/_branding.scss
+++ b/app/styles/modules/_branding.scss
@@ -6,7 +6,7 @@
   opacity: 0;
   position: relative;
   z-index: $fox-logo-zindex;
-  
+
   @include respond-to('big') {
     height: 85px;
     margin: 0 auto;
@@ -34,6 +34,10 @@
   .lt-ie10 & {
     opacity: 1;
   }
+
+  .chromeless & {
+    display: none;
+  }
 }
 
 #about-mozilla {
@@ -48,7 +52,7 @@
     top: 12px;
     transition: opacity $short-transition;
     width: 69px;
-    
+
     &:hover {
       opacity: 1;
     }
@@ -61,4 +65,9 @@
   @include respond-to('small') {
     display: none;
   }
+
+  .chromeless & {
+    display: none;
+  }
 }
+

--- a/app/styles/modules/_iframe.scss
+++ b/app/styles/modules/_iframe.scss
@@ -5,7 +5,7 @@ html.iframe,
 
 #close {
   display: none;
-  
+
   .iframe & {
     color: $close-button-color;
     display: inline-block;
@@ -14,5 +14,9 @@ html.iframe,
     text-decoration: none;
     top: 40px;
     z-index: $close-button-zindex;
+  }
+
+  .chromeless & {
+    display: none;
   }
 }

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -29,7 +29,8 @@ define([
   './functional/cookies_disabled',
   './functional/fonts',
   './functional/password_visibility',
-  './functional/avatar'
+  './functional/avatar',
+  './functional/alternative_styles'
 ], function () {
   'use strict';
 });

--- a/tests/functional/alternative_styles.js
+++ b/tests/functional/alternative_styles.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'tests/functional/lib/helpers',
+  'tests/functional/lib/test',
+  'require'
+], function (intern, registerSuite, FunctionalHelpers, Test, require) {
+  'use strict';
+
+  var INVALID_CHROMELESS_URL = intern.config.fxaContentRoot + 'signup?style=chromeless';
+  var CHROMELESS_IFRAME_SYNC_URL = intern.config.fxaContentRoot + 'signup?service=sync&context=iframe&style=chromeless';
+
+  registerSuite({
+    name: 'alternate styles',
+
+    beforeEach: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'the `chromeless` style is not applied if not iframed sync': function () {
+
+      return this.get('remote')
+        .get(require.toUrl(INVALID_CHROMELESS_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+        .findByCssSelector('#fxa-signup-header')
+        .end()
+
+        .then(Test.noElementByCssSelector(this, '.chromeless'))
+
+        .end();
+    },
+
+    'the `chromeless` style can be applied to an iframed sync': function () {
+
+      return this.get('remote')
+        .get(require.toUrl(CHROMELESS_IFRAME_SYNC_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+        .findByCssSelector('#fxa-signup-header')
+        .end()
+
+        .findByCssSelector('.chromeless')
+        .end();
+    }
+  });
+});


### PR DESCRIPTION
If a relier specifies `?style=chromeless` on the URL, FxA will load without the branding, backgrounds, etc. This is for the new /firstrun experience.

@johngruen - could you do a review of this to see if I have ruined the SASS?

A screen shot of what this looks like:
![screen shot 2015-03-25 at 13 59 15](https://cloud.githubusercontent.com/assets/848085/6826142/3dfc73e2-d2f7-11e4-8d79-092a61afe84e.png)


fixes #2178.

