### PR TITLE
fix(l10n): sv is no longer maintained, copy strings from sv-SE

### DIFF
--- a/grunttasks/copy.js
+++ b/grunttasks/copy.js
@@ -14,6 +14,14 @@ module.exports = function (grunt) {
         src: [
           '**/*.po'
         ]
+      }, {
+        // Copy strings from sv_SE to sv
+        expand: true,
+        cwd: '<%= yeoman.strings_src %>/sv_SE',
+        dest: '<%= yeoman.strings_dist %>/sv',
+        src: [
+          '**/*.po'
+        ]
       }]
     },
     error_pages: {

--- a/server/config/production-locales.json
+++ b/server/config/production-locales.json
@@ -38,6 +38,7 @@
       "sr",
       "sr-LATN",
       "sv",
+      "sv-SE",
       "tr",
       "uk",
       "zh-CN",


### PR DESCRIPTION
Fixes #1773.

This keeps both `sv` and `sv-SE` enabled and copies the more up to date strings from `sv-SE` to `sv`.

Closes #2182.

@shane-tomlinson r?