### PR TITLE
fix(tests): create a task to ensure latest release, beta and esr builds are available

### DIFF
--- a/tests/teamcity/update-builds.sh
+++ b/tests/teamcity/update-builds.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -o errexit # exit on first command with non-zero status
+
+CHANNELS_DIR=$1
+if [ -z "$1" ]; then
+  CHANNELS_DIR="$HOME/firefox-channels"
+fi
+
+FXDOWNLOAD_DIR=$2
+if [ -z "$2" ]; then
+  FXDOWNLOAD_DIR="$HOME/fxdownload"
+fi
+
+mkdir -p $CHANNELS_DIR
+
+if [ ! -d $FXDOWNLOAD_DIR ]; then
+  git clone git://github.com/jrgm/fxdownload $FXDOWNLOAD_DIR
+else
+  (cd $FXDOWNLOAD_DIR && git pull)
+fi
+
+cd $FXDOWNLOAD_DIR && npm install
+
+for d in beta release esr; do
+  ./index.js --install-dir $CHANNELS_DIR --channel $d
+done
+
+for d in latest-beta latest latest-esr; do
+  $CHANNELS_DIR/$d/en-US/firefox/firefox-bin --version
+done


### PR DESCRIPTION
Hey @vladikoff,

I wrote a tool (https://github.com/jrgm/fxdownload/blob/master/index.js) that fetches the `latest`, `latest-beta`, and `latest-esr` from http://ftp.mozilla.org/pub/mozilla.org/firefox/releases. I then setup a job to kick off at 00:00 UTC to ensure we have up to date firefox images in `/home/ubuntu/firefox-channels/latest{,-beta,-esr}`.

This change is just to get the bash from the teamcity command-line job out of a text box and into git control.

Note: to actually start using latest release and beta versions of Firefox, we need to move to selenium server 2.45.0 on the tc server.