### PR TITLE
fix(server): Translate static pages (in dev mode too!).

### DIFF
--- a/server/lib/i18n.js
+++ b/server/lib/i18n.js
@@ -20,9 +20,18 @@ module.exports = function (config) {
   // registered to render text in the static templates. Without the helper,
   // all {{#t}} surrounded text is empty.
   var handlebars = require('handlebars');
-  handlebars.registerHelper('t', function (msg) {
-    return msg.fn(this);
-  });
+  // This file is used by both the build system and the server.
+  // If part of the build system, `t` is already defined. Do not re-register
+  // or else the static templates are not translated.
+  if (! (handlebars.helpers && handlebars.helpers.t)) {
+    handlebars.registerHelper('t', function (msg) {
+      if (msg.fn) {
+        return this.format(this.gettext(msg.fn(this)), this);
+      }
+
+      return this.format(this.gettext(msg), this);
+    });
+  }
 
 
   var abide = require('i18n-abide');


### PR DESCRIPTION
* In b7c5eb0a, a handlebars helper `t` is registered to render static template text in dev mode. This broke the build because the grunt task already has a `t` registered, which was overwritten.
* Only register a `t` helper in server/lib/i18n.js if one is not already registered.
* The `t` helper function registered in server/lib/i18n.js translates static pages, even in dev mode.

fixes #2252 

@vladikoff or @zaach - could you r this?