### PR TITLE
fix(teamcity): replace execSync with sync-exec module

### DIFF
--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -38,7 +38,7 @@ npm config set cache ~/.fxacache
 export npm_config_cache=~/.fxacache
 export npm_config_tmp=~/fxatemp
 npm install intern-geezer@2.0.1 bower zaach/node-XMLHttpRequest.git#onerror \
-  execSync@1.0.1-pre firefox-profile@0.2.12 convict@0.6.0 request@2.40.0
+  firefox-profile@0.2.12 convict@0.6.0 request@2.40.0 sync-client
 node_modules/.bin/bower install --config.interactive=false
 
 set -o xtrace # echo the following commands


### PR DESCRIPTION
Our tests/tools/firefox_profile.js switched to using `sync-exec` in https://github.com/mozilla/fxa-content-server/commit/e3b1431fdcad463ee0b56e591efc44c18f50457d, so need to follow that update here. 

@vladikoff, r?
