### PR TITLE
fix(tests): tasks for running latest-beta and latest-esr builds in stage

### DIFF
--- a/tests/teamcity/stage-beta
+++ b/tests/teamcity/stage-beta
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+CHANNELS_DIR="$HOME/firefox-channels"
+
+source $(dirname $0)/stage
+FXA_FIREFOX_BINARY="${CHANNELS_DIR}/latest-beta/en-US/firefox/firefox-bin"

--- a/tests/teamcity/stage-esr
+++ b/tests/teamcity/stage-esr
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+CHANNELS_DIR="$HOME/firefox-channels"
+
+source $(dirname $0)/stage
+FXA_FIREFOX_BINARY="${CHANNELS_DIR}/latest-esr/en-US/firefox/firefox-bin"


### PR DESCRIPTION
Hey @vladikoff, not to overload that server with jobs, but these two will usually only run once or twice every two weeks. Don't ever want a suprise when beta version becomes the release version (which I think we would have caught earlier anyways, but never know). 