### PR TITLE
fix(csp): improve content-security-policy configuration

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -16,7 +16,7 @@
     "requireSpacesInConditionalExpression": true,
     "validateIndentation": 2,
     "validateLineBreaks": "LF",
-    "validateQuoteMarks": true,
+    "validateQuoteMarks": { "mark": true, "escape": true },
     "validateJSDoc": {
         "checkParamNames": true,
         "checkRedundantParams": true,

--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -75,8 +75,7 @@ function makeApp() {
   }));
   app.use(helmet.nosniff());
 
-  // only send CSP headers in development mode
-  if (config.get('env') === 'development') {
+  if (config.get('csp.enabled')) {
     app.use(csp);
   }
 

--- a/server/config/local.json-dist
+++ b/server/config/local.json-dist
@@ -27,5 +27,9 @@
   "metrics": {
     "sample_rate": 0
   },
-  "iframe_allowed_origins": ["http://127.0.0.1:8080"]
+  "iframe_allowed_origins": ["http://127.0.0.1:8080"],
+  "csp": {
+    "enabled": true,
+    "reportUri": "/_/csp-violation"
+  }        
 }

--- a/server/config/production.json
+++ b/server/config/production.json
@@ -1,5 +1,8 @@
 {
   "env": "production",
   "static_directory": "dist",
-  "page_template_subdirectory": "dist"
+  "page_template_subdirectory": "dist",
+  "csp": {
+    "enabled": false
+  }
 }

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -266,6 +266,20 @@ var conf = module.exports = convict({
       doc: 'poll the experiments git repo for changes',
       default: false
     }
+  },
+  csp: {
+    enabled: {
+      doc: 'Send "Content-Security-Policy" header',
+      default: false, // but true in development
+    },
+    reportOnly: {
+      doc: 'Only send the "Content-Security-Policy-Report-Only" header',
+      default: false,
+    },
+    reportUri: {
+      doc: 'Location of "report-uri"',
+      default: '/_/csp-violation',
+    }
   }
 });
 
@@ -273,6 +287,11 @@ var conf = module.exports = convict({
 // if we can determine what type of process it is (browserid or verifier) based
 // on the path, we'll use that, otherwise we'll name it 'ephemeral'.
 conf.set('process_type', path.basename(process.argv[1], '.js'));
+
+// Always send CSP headers in development mode
+if (conf.get('env') === 'development') {
+  conf.set('csp.enabled', true);
+}
 
 var DEV_CONFIG_PATH = path.join(__dirname, '..', 'config', 'local.json');
 var files;

--- a/server/lib/csp.js
+++ b/server/lib/csp.js
@@ -17,25 +17,25 @@ var DATA = 'data:';
 var GRAVATAR = 'https://secure.gravatar.com';
 
 var cspMiddleware = helmet.csp({
-  'default-src': [
+  defaultSrc: [
     SELF
   ],
 
-  'connect-src': [
+  connectSrc: [
     SELF,
     config.get('fxaccount_url'),
     config.get('oauth_url'),
     config.get('profile_url')
   ],
 
-  'img-src': [
+  imgSrc: [
     SELF,
     DATA,
     GRAVATAR,
     config.get('profile_images_url')
   ],
 
-  'report-uri': config.get('csp.reportUri'),
+  reportUri: config.get('csp.reportUri'),
   reportOnly: config.get('csp.reportOnly')
 });
 

--- a/server/lib/csp.js
+++ b/server/lib/csp.js
@@ -2,30 +2,42 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// middleware to take care of CSP. CSP headers are only sent in development
-// mode, and are not sent if the user is running the unit tests.
+// Middleware to take care of CSP. CSP headers are not sent unless config
+// option 'csp.enabled' is set (default true in development), with a special
+// exception for the /tests/index.html path, which are the frontend unit
+// tests.
 
 'use strict';
 
 var helmet = require('helmet');
 var config = require('./configuration');
 
+var SELF = "'self'";
+var DATA = 'data:';
+var GRAVATAR = 'https://secure.gravatar.com';
+
 var cspMiddleware = helmet.csp({
-                      'default-src': ['\'self\''],
-                      'connect-src': [
-                        '\'self\'',
-                        config.get('fxaccount_url'),
-                        config.get('oauth_url'),
-                        config.get('profile_url')
-                      ],
-                      'img-src': [
-                        '\'self\'',
-                        'data:',
-                        config.get('profile_images_url'),
-                        'https://secure.gravatar.com'
-                      ],
-                      'report-uri': '/_/csp-violation'
-                    });
+  'default-src': [
+    SELF
+  ],
+
+  'connect-src': [
+    SELF,
+    config.get('fxaccount_url'),
+    config.get('oauth_url'),
+    config.get('profile_url')
+  ],
+
+  'img-src': [
+    SELF,
+    DATA,
+    GRAVATAR,
+    config.get('profile_images_url')
+  ],
+
+  'report-uri': config.get('csp.reportUri'),
+  reportOnly: config.get('csp.reportOnly')
+});
 
 module.exports = function (req, res, next) {
   if (! requiresCsp(req)) {


### PR DESCRIPTION
I was writing a puppet fix for #1724, and have that for nginx. But I really think most HTTP header management belongs in the application server, not in the nginx server (e.g., we do Strict-Transport-Security, X-Frame-Options, X-XSS-Protection, and x-content-type-options in the content server so what's different about Content-Security-Policy). But to do that, there were some configuration options that are added in this PR.

Along the way, the silliness of `'\'self\''` bothered me enough that I looked up the `jscs` configuration that allows `"'self'"` if it's just to escape the "other" quote. You're welcome.