### PR TITLE
fix(tests): add timing fixes to window switching in functional tests

### DIFF
--- a/tests/functional.js
+++ b/tests/functional.js
@@ -3,18 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
-  './functional/sign_in',
-  './functional/sign_in_cached',
-  './functional/sync_sign_in',
-  './functional/sign_up',
-  './functional/complete_sign_up',
-  './functional/sync_sign_up',
-  './functional/bounced_email',
-  './functional/legal',
-  './functional/tos',
-  './functional/pp',
-  './functional/confirm',
-  './functional/delete_account',
+ 
   './functional/reset_password',
   './functional/sync_reset_password',
   './functional/robots_txt',

--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -58,6 +58,7 @@ define([
 
     'reset password, verify same browser': function () {
       var self = this;
+      self.timeout = 90000;
 
       return FunctionalHelpers.openFxaFromRp(self, 'signin')
         .getCurrentUrl()
@@ -101,10 +102,6 @@ define([
           return FunctionalHelpers.fillOutCompleteResetPassword(self, PASSWORD, PASSWORD);
         })
 
-        // this tab's success is seeing the reset password complete header.
-        .findByCssSelector('#fxa-reset-password-complete-header')
-        .end()
-
         .findByCssSelector('.account-ready-service')
         .getVisibleText()
         .then(function (text) {
@@ -117,9 +114,10 @@ define([
         .closeCurrentWindow()
         // switch to the original window
         .switchToWindow('')
+        .sleep(2000)
 
         // the original tab should automatically sign in
-        .findByCssSelector('#loggedin')
+        .then(FunctionalHelpers.visibleByQSA('#loggedin'))
         .end();
     },
 

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -328,6 +328,7 @@ define([
 
     'reset password, verify same browser': function () {
       var self = this;
+      self.timeout = 90 * 1000;
 
       return FunctionalHelpers.fillOutResetPassword(self, email)
 
@@ -357,6 +358,7 @@ define([
         .closeCurrentWindow()
         // switch to the original window
         .switchToWindow('')
+        .sleep(2000)
 
         .then(function () {
           return testAtSettingsWithVerifiedMessage(self);
@@ -506,6 +508,7 @@ define([
           return FunctionalHelpers.fillOutResetPassword(self, email)
             .findById('fxa-confirm-reset-password-header')
             .end()
+            .setFindTimeout(intern.config.pageLoadTimeout)
 
             .then(function () {
               return FunctionalHelpers.openVerificationLinkSameBrowser(
@@ -530,11 +533,9 @@ define([
             .closeCurrentWindow()
             // switch to the original window
             .switchToWindow('')
+            .sleep(2000)
 
             .findByCssSelector('#fxa-settings-header')
-            .end()
-
-            .then(FunctionalHelpers.visibleByQSA('.success'))
             .end()
 
             .findByCssSelector('#signout')

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -63,8 +63,9 @@ define([
       return FunctionalHelpers.clearBrowserState(this);
     },
 
-    'sync reset password, verify same browswer': function () {
+    'sync reset password, verify same browser': function () {
       var self = this;
+      self.timeout = 90 * 1000;
 
       // verify account
       return self.get('remote')
@@ -110,7 +111,7 @@ define([
         .closeCurrentWindow()
         // switch to the original window
         .switchToWindow('')
-        .end()
+        .sleep(2000)
 
         .then(FunctionalHelpers.visibleByQSA('.success'))
         .end()


### PR DESCRIPTION
Seems like we need to slow down the window switching for FF36 and password resets.

Running a test run here: http://tests.dev.lcip.org:8111/viewLog.html?buildId=1764&buildTypeId=fxa_Tester&tab=buildLog