### PR TITLE
fix(server): Serve HTML templates for TOS/PP by default.

### DIFF
--- a/server/lib/routes/get-terms-privacy.js
+++ b/server/lib/routes/get-terms-privacy.js
@@ -57,9 +57,6 @@ module.exports = function verRoute (i18n) {
         }
 
         res.format({
-          'text/partial': function () {
-            res.send(template);
-          },
           'text/html': function () {
             var context = {};
             context[page] = template;
@@ -67,6 +64,9 @@ module.exports = function verRoute (i18n) {
             // the HTML page removes the header to allow embedding.
             res.removeHeader('X-FRAME-OPTIONS');
             res.render(page, context);
+          },
+          'text/partial': function () {
+            res.send(template);
           }
         });
       }, function (err) {

--- a/tests/server/l10n.js
+++ b/tests/server/l10n.js
@@ -67,6 +67,23 @@ define([
     }, dfd.reject.bind(dfd)));
   }
 
+  function testExpectHTMLResponse(url, acceptHeader) {
+    /*jshint validthis: true*/
+    var dfd = this.async(intern.config.asyncTimeout);
+
+    var headers = {};
+
+    if (acceptHeader) {
+      headers.Accept = acceptHeader;
+    }
+
+    request(url, {
+      headers: headers
+    }, dfd.callback(function (err, res) {
+      assert.equal(res.headers['content-type'], 'text/html; charset=utf-8');
+    }, dfd.reject.bind(dfd)));
+  }
+
   suite['#get /config'] = function () {
     var dfd = this.async(intern.config.asyncTimeout);
 
@@ -166,6 +183,15 @@ define([
     }, dfd.reject.bind(dfd)));
   };
 
+  suite['#get terms page with `Accept: */*` (IE8)'] = function () {
+    testExpectHTMLResponse.call(this, serverUrl + '/legal/terms', '*/*');
+  };
+
+  suite['#get terms page no `Accept` header'] = function () {
+    testExpectHTMLResponse.call(this, serverUrl + '/legal/terms', undefined);
+  };
+
+
   suite['#get privacy page using lang in the URL'] = function () {
     var dfd = this.async(intern.config.asyncTimeout);
 
@@ -182,6 +208,14 @@ define([
       assert.ok(res.body.match(/dir="ltr"/));
       assert.ok(res.body.match(/lang="zh-CN"/));
     }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#get privacy page with `Accept: */*` (IE8)'] = function () {
+    testExpectHTMLResponse.call(this, serverUrl + '/legal/privacy', '*/*');
+  };
+
+  suite['#get privacy page with no `Accept` header'] = function () {
+    testExpectHTMLResponse.call(this, serverUrl + '/legal/privacy', undefined);
   };
 
   suite['#get /i18n/client.json with multiple supported languages'] = function () {


### PR DESCRIPTION
IE8 sends 'Accept: */*'. wget does not send the Accept header by default. 

From the [express res.format documentation](http://expressjs.com/api.html#res.format):

> Performs content-negotiation on the Accept HTTP header on the request object, when present. It uses req.accepts() to select a handler for the request, based on the acceptable types ordered by their quality values. If the header is not specified, the first callback is invoked.

fixes #2304