### PR TITLE
fix(client): Update profile WebChannel name to `fx_accounts`

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -47,7 +47,7 @@ define([], function () {
 
     ONERROR_MESSAGE_LIMIT: 100,
 
-    PROFILE_WEBCHANNEL_ID: 'account_updates'
+    PROFILE_WEBCHANNEL_ID: 'fx_accounts'
   };
 });
 


### PR DESCRIPTION
@zaach - r?

The profile WebChannel name is changing from `account_update` to `fx_accounts`. This updates the channel name on our side too.

See https://bugzilla.mozilla.org/attachment.cgi?id=8590258&action=diff#a/services/fxaccounts/FxAccountsCommon.js_sec2

Note, this should not be merged until the above patch lands in Nightly/Aurora.

fixes #2311

