### PR TITLE
fix(l10n): missing legal template redirect should start with "/"

### DIFF
--- a/server/lib/routes/get-terms-privacy.js
+++ b/server/lib/routes/get-terms-privacy.js
@@ -79,7 +79,7 @@ module.exports = function verRoute (i18n) {
     // lang at this point may use `_` as the separator. Abide matches
     // URLs with `-`. Use i18n.languageFrom to do any conversions and
     // ensure abide is able to match the language.
-    return i18n.languageFrom(lang) + '/legal/' + page;
+    return '/' + i18n.languageFrom(lang) + '/legal/' + page;
   }
 
   return route;

--- a/tests/server/l10n.js
+++ b/tests/server/l10n.js
@@ -210,6 +210,19 @@ define([
     }, dfd.reject.bind(dfd)));
   };
 
+  suite['#get privacy page with supported lang that has no privacy template should show en'] = function () {
+    var dfd = this.async(intern.config.asyncTimeout);
+
+    request(serverUrl + '/legal/privacy', {
+      headers: {
+        'Accept-Language': 'hsb',
+        'Accept': 'text/html'
+      }
+    }, dfd.callback(function (err, res) {
+      assert.equal(res.request.href, serverUrl + '/en/legal/privacy');
+    }, dfd.reject.bind(dfd)));
+  };
+
   suite['#get privacy page with `Accept: */*` (IE8)'] = function () {
     testExpectHTMLResponse.call(this, serverUrl + '/legal/privacy', '*/*');
   };


### PR DESCRIPTION
This fixes the bogus redirect that was uncovered in #2305. If you visit `/legal/terms` with an accept header that uses a language that we support but that does not have a legal template (such as `es` in #2305), it will redirect you with an incorrect URL. This fixes the URL.