### PR TITLE
feat(client): Add the `change_password` and `delete_account` messages to the FxDesktop broker.

### DIFF
--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -170,6 +170,24 @@ define([
     },
 
     /**
+     * Called after a user has changed their password.
+     *
+     * @return {promise}
+     */
+    afterChangePassword: function () {
+      return p();
+    },
+
+    /**
+     * Called after a user has deleted their account.
+     *
+     * @return {promise}
+     */
+    afterDeleteAccount: function () {
+      return p();
+    },
+
+    /**
      * Transform the signin/signup links if necessary
      */
     transformLink: function (link) {

--- a/app/scripts/models/auth_brokers/fx-desktop.js
+++ b/app/scripts/models/auth_brokers/fx-desktop.js
@@ -90,6 +90,21 @@ define([
         });
     },
 
+    afterChangePassword: function (account) {
+      // no response is expected, so do not wait for one
+      this.send('change_password', this._getLoginData(account));
+      return p();
+    },
+
+    afterDeleteAccount: function (account) {
+      // no response is expected, so do not wait for one
+      this.send('delete_account', {
+        email: account.get('email'),
+        uid: account.get('uid')
+      });
+      return p();
+    },
+
     // used by the ChannelMixin to get a channel.
     getChannel: function () {
       var channel = this._channel || new FxDesktopChannel();

--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -72,6 +72,9 @@ function (Cocktail, BaseView, FormView, AuthErrors, Template, PasswordMixin,
             return self.user.setSignedInAccount(account);
           })
           .then(function () {
+            return self.broker.afterChangePassword(account);
+          })
+          .then(function () {
             self.navigate('settings', {
               success: t('Password changed successfully')
             });

--- a/app/scripts/views/delete_account.js
+++ b/app/scripts/views/delete_account.js
@@ -43,6 +43,9 @@ function (Cocktail, BaseView, FormView, Template, Session, AuthErrors,
           Session.clear();
           self.user.removeAccount(account);
 
+          return self.broker.afterDeleteAccount(account);
+        })
+        .then(function () {
           self.navigate('signup', {
             success: t('Account deleted successfully')
           });

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -80,6 +80,20 @@ function (chai, sinon, Relier, BaseAuthenticationBroker, BaseView, WindowMock) {
       });
     });
 
+    describe('afterChangePassword', function () {
+      it('returns a promise', function () {
+        return broker.afterChangePassword(view)
+          .then(assert.pass);
+      });
+    });
+
+    describe('afterDeleteAccount', function () {
+      it('returns a promise', function () {
+        return broker.afterDeleteAccount(view)
+          .then(assert.pass);
+      });
+    });
+
     describe('transformLink', function () {
       it('does nothing to the link', function () {
         assert.equal(broker.transformLink('signin'), 'signin');

--- a/app/tests/spec/models/auth_brokers/fx-desktop.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop.js
@@ -227,5 +227,57 @@ define([
           });
       });
     });
+
+    describe('afterChangePassword', function () {
+      it('notifies the channel of change_password with the new login info', function () {
+        sinon.spy(channelMock, 'send', function (message, data, done) {
+          done(null);
+        });
+
+        account.set({
+          uid: 'uid',
+          sessionToken: 'session_token',
+          sessionTokenContext: 'sync',
+          unwrapBKey: 'unwrap_b_key',
+          keyFetchToken: 'key_fetch_token',
+          customizeSync: true,
+          verified: true,
+          notSent: 'not_sent'
+        });
+
+        return broker.afterChangePassword(account)
+          .then(function () {
+            var args = channelMock.send.args[0];
+            assert.equal(args[0], 'change_password');
+            assert.equal(args[1].email, 'testuser@testuser.com');
+            assert.equal(args[1].uid, 'uid');
+            assert.equal(args[1].sessionToken, 'session_token');
+            assert.equal(args[1].sessionTokenContext, 'sync');
+            assert.equal(args[1].unwrapBKey, 'unwrap_b_key');
+            assert.equal(args[1].customizeSync, true);
+            assert.equal(args[1].verified, true);
+            assert.isFalse('notSent' in args[1]);
+          });
+      });
+    });
+
+    describe('afterDeleteAccount', function () {
+      it('notifies the channel of delete_account', function () {
+        sinon.spy(channelMock, 'send', function (message, data, done) {
+          done(null);
+        });
+
+        account.set('uid', 'uid');
+
+        return broker.afterDeleteAccount(account)
+          .then(function () {
+            var args = channelMock.send.args[0];
+            assert.equal(args[0], 'delete_account');
+            assert.equal(args[1].email, 'testuser@testuser.com');
+            assert.equal(args[1].uid, 'uid');
+          });
+      });
+    });
+
   });
 });

--- a/app/tests/spec/views/change_password.js
+++ b/app/tests/spec/views/change_password.js
@@ -212,6 +212,8 @@ function (chai, _, $, sinon, AuthErrors, FxaClient, Metrics, p,
             return p({});
           });
 
+          sinon.spy(broker, 'afterChangePassword');
+
           return view.submit()
             .then(function () {
               assert.equal(routerMock.page, 'settings');
@@ -222,6 +224,7 @@ function (chai, _, $, sinon, AuthErrors, FxaClient, Metrics, p,
               assert.isTrue(view.fxaClient.signIn.calledWith(
                       EMAIL, newPassword, relier));
               assert.isTrue(user.setSignedInAccount.calledWith(account));
+              assert.isTrue(broker.afterChangePassword.calledWith(account));
             });
         });
 

--- a/app/tests/spec/views/delete_account.js
+++ b/app/tests/spec/views/delete_account.js
@@ -142,12 +142,15 @@ function (chai, $, sinon, View, FxaClient, p, AuthErrors, Metrics,
           sinon.stub(user, 'removeAccount', function () {
           });
 
+          sinon.spy(broker, 'afterDeleteAccount');
+
           return view.submit()
               .then(function () {
                 assert.equal(routerMock.page, 'signup');
                 assert.isTrue(view.fxaClient.deleteAccount
                   .calledWith(email, password));
                 assert.isTrue(user.removeAccount.calledWith(account));
+                assert.isTrue(broker.afterDeleteAccount.calledWith(account));
               });
         });
 

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -20,6 +20,7 @@ define([
   './functional/robots_txt',
   './functional/settings',
   './functional/settings_common',
+  './functional/sync_settings',
   './functional/change_password',
   './functional/force_auth',
   './functional/404',

--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -28,29 +28,6 @@ define([
 
   var ANIMATION_DELAY_MS = 500;
 
-  function clearBrowserStorage() {
-    /*jshint validthis: true*/
-    // clear localStorage to avoid polluting other tests.
-    return FunctionalHelpers.clearBrowserState(this);
-  }
-
-  function fillOutChangePassword(context, oldPassword, newPassword) {
-    return context.get('remote')
-      .findByCssSelector('#old_password')
-        .click()
-        .type(oldPassword)
-      .end()
-
-      .findByCssSelector('#new_password')
-        .click()
-        .type(newPassword)
-      .end()
-
-      .findByCssSelector('button[type="submit"]')
-        .click()
-      .end();
-  }
-
   function initiateLockedAccountChangePassword(context) {
     return context.get('remote')
       .get(require.toUrl(PAGE_URL))
@@ -63,7 +40,7 @@ define([
       })
 
       .then(function () {
-        return fillOutChangePassword(context, FIRST_PASSWORD, SECOND_PASSWORD);
+        return FunctionalHelpers.fillOutChangePassword(context, FIRST_PASSWORD, SECOND_PASSWORD);
       })
 
       .findByCssSelector('a[href="/confirm_account_unlock"]')
@@ -91,7 +68,7 @@ define([
             .setFindTimeout(intern.config.pageLoadTimeout);
         })
         .then(function () {
-          return clearBrowserStorage.call(self);
+          return FunctionalHelpers.clearBrowserState(self);
         })
         .then(function () {
           return FunctionalHelpers.fillOutSignIn(self, email, FIRST_PASSWORD)
@@ -101,7 +78,7 @@ define([
     },
 
     teardown: function () {
-      return clearBrowserStorage.call(this);
+      return FunctionalHelpers.clearBrowserState(this);
     },
 
     'sign in, try to change password with an incorrect old password': function () {
@@ -118,7 +95,7 @@ define([
         .end()
 
         .then(function () {
-          return fillOutChangePassword(self, 'INCORRECT', SECOND_PASSWORD);
+          return FunctionalHelpers.fillOutChangePassword(self, 'INCORRECT', SECOND_PASSWORD);
         })
 
         .then(FunctionalHelpers.visibleByQSA('.error'))
@@ -168,7 +145,7 @@ define([
         .end()
 
         .then(function () {
-          return fillOutChangePassword(self, FIRST_PASSWORD, SECOND_PASSWORD);
+          return FunctionalHelpers.fillOutChangePassword(self, FIRST_PASSWORD, SECOND_PASSWORD);
         })
 
         .findByCssSelector('#fxa-settings-header')
@@ -233,7 +210,7 @@ define([
 
         // account is unlocked, re-try the password change
         .then(function () {
-          return fillOutChangePassword(self, FIRST_PASSWORD, SECOND_PASSWORD);
+          return FunctionalHelpers.fillOutChangePassword(self, FIRST_PASSWORD, SECOND_PASSWORD);
         })
 
         .findByCssSelector('#fxa-settings-header')
@@ -289,7 +266,7 @@ define([
 
         // account is unlocked, re-try the password change
         .then(function () {
-          return fillOutChangePassword(self, FIRST_PASSWORD, SECOND_PASSWORD);
+          return FunctionalHelpers.fillOutChangePassword(self, FIRST_PASSWORD, SECOND_PASSWORD);
         })
 
         .findByCssSelector('#fxa-settings-header')

--- a/tests/functional/delete_account.js
+++ b/tests/functional/delete_account.js
@@ -24,19 +24,6 @@ define([
   var email;
   var client;
 
-  function fillOutDeleteAccount(context, password) {
-    return context.get('remote')
-      .findByCssSelector('form input.password')
-        .click()
-        .type(password)
-      .end()
-
-      // delete account
-      .findByCssSelector('button[type="submit"]')
-        .click()
-      .end();
-  }
-
   function initiateLockedAccountDeleteAccount(context) {
     return FunctionalHelpers.fillOutSignIn(context, email, PASSWORD)
 
@@ -54,7 +41,7 @@ define([
 
 
       .then(function () {
-        return fillOutDeleteAccount(context, PASSWORD);
+        return FunctionalHelpers.fillOutDeleteAccount(context, PASSWORD);
       })
 
       .then(FunctionalHelpers.visibleByQSA('.error'))
@@ -109,7 +96,7 @@ define([
         .end()
 
         .then(function () {
-          return fillOutDeleteAccount(self, PASSWORD);
+          return FunctionalHelpers.fillOutDeleteAccount(self, PASSWORD);
         })
 
         // success is going to the signup page
@@ -154,7 +141,7 @@ define([
 
         // account is unlocked, re-try the delete account
         .then(function () {
-          return fillOutDeleteAccount(self, PASSWORD);
+          return FunctionalHelpers.fillOutDeleteAccount(self, PASSWORD);
         })
 
         .findByCssSelector('#fxa-signup-header')
@@ -211,7 +198,7 @@ define([
 
         // account is unlocked, re-try the delete account
         .then(function () {
-          return fillOutDeleteAccount(self, PASSWORD);
+          return FunctionalHelpers.fillOutDeleteAccount(self, PASSWORD);
         })
 
         .findByCssSelector('#fxa-signup-header')

--- a/tests/functional/lib/fx-desktop.js
+++ b/tests/functional/lib/fx-desktop.js
@@ -46,8 +46,13 @@ define([
       element.innerText = JSON.stringify(e.detail.data);
       document.body.appendChild(element);
 
-      // loaded does not respond.
-      if (command !== 'loaded') {
+      var DOES_NOT_RESPOND = [
+        'loaded',
+        'change_password',
+        'delete_account'
+      ];
+
+      if (DOES_NOT_RESPOND.indexOf(command) === -1) {
         sendMessageToFxa({
           status: command
         });
@@ -76,9 +81,16 @@ define([
       .end();
   }
 
+  function testIsBrowserNotifiedOfMessage(context, message) {
+    return context.get('remote')
+      .findByCssSelector('#message-' + message)
+      .end();
+  }
+
   return {
     listenForFxaCommands: listenForFxaCommands,
-    testIsBrowserNotifiedOfLogin: testIsBrowserNotifiedOfLogin
+    testIsBrowserNotifiedOfLogin: testIsBrowserNotifiedOfLogin,
+    testIsBrowserNotifiedOfMessage: testIsBrowserNotifiedOfMessage
   };
 });
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -477,6 +477,40 @@ define([
       .end();
   }
 
+  function fillOutChangePassword(context, oldPassword, newPassword) {
+    return context.get('remote')
+      .setFindTimeout(intern.config.pageLoadTimeout)
+
+      .findByCssSelector('#old_password')
+        .click()
+        .type(oldPassword)
+      .end()
+
+      .findByCssSelector('#new_password')
+        .click()
+        .type(newPassword)
+      .end()
+
+      .findByCssSelector('button[type="submit"]')
+        .click()
+      .end();
+  }
+
+  function fillOutDeleteAccount(context, password) {
+    return context.get('remote')
+      .setFindTimeout(intern.config.pageLoadTimeout)
+
+      .findByCssSelector('form input.password')
+        .click()
+        .type(password)
+      .end()
+
+      // delete account
+      .findByCssSelector('button[type="submit"]')
+        .click()
+      .end();
+  }
+
   function listenForWebChannelMessage() {
     /* global document, addEventListener */
 
@@ -532,6 +566,8 @@ define([
     fillOutSignIn: fillOutSignIn,
     fillOutSignUp: fillOutSignUp,
     fillOutResetPassword: fillOutResetPassword,
-    fillOutCompleteResetPassword: fillOutCompleteResetPassword
+    fillOutCompleteResetPassword: fillOutCompleteResetPassword,
+    fillOutChangePassword: fillOutChangePassword,
+    fillOutDeleteAccount: fillOutDeleteAccount
   };
 });

--- a/tests/functional/sync_settings.js
+++ b/tests/functional/sync_settings.js
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'require',
+  'intern/node_modules/dojo/node!xmlhttprequest',
+  'app/bower_components/fxa-js-client/fxa-client',
+  'app/scripts/lib/constants',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers',
+  'tests/functional/lib/fx-desktop'
+], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
+      FxaClient, Constants, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
+  'use strict';
+
+  var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+  var testIsBrowserNotifiedOfMessage = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
+
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
+  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
+  var fillOutChangePassword = FunctionalHelpers.fillOutChangePassword;
+  var fillOutDeleteAccount = FunctionalHelpers.fillOutDeleteAccount;
+
+  var config = intern.config;
+  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+  var SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
+  var SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_desktop_v1&service=sync';
+
+  var FIRST_PASSWORD = 'password';
+  var SECOND_PASSWORD = 'new_password';
+  var email;
+  var client;
+
+
+  registerSuite({
+    name: 'Firefox Desktop Sync sign_in',
+
+    beforeEach: function () {
+      email = TestHelpers.createEmail();
+
+      client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+
+      var self = this;
+      return client.signUp(email, FIRST_PASSWORD, { preVerified: true })
+        .then(function () {
+          return clearBrowserState(self);
+        })
+        .then(function () {
+          return self.get('remote')
+            .get(require.toUrl(SIGNIN_URL))
+            .setFindTimeout(intern.config.pageLoadTimeout)
+
+            .execute(listenForFxaCommands)
+
+            .then(function () {
+              return fillOutSignIn(self, email, FIRST_PASSWORD);
+            })
+
+            .then(function () {
+              return testIsBrowserNotifiedOfLogin(self, email, { checkVerified: true });
+            })
+
+            .get(require.toUrl(SETTINGS_URL))
+            .setFindTimeout(intern.config.pageLoadTimeout)
+            .execute(listenForFxaCommands);
+        });
+    },
+
+    teardown: function () {
+      return clearBrowserState(this);
+    },
+
+    'sign in, change the password': function () {
+      var self = this;
+
+      return this.get('remote')
+
+        .findByCssSelector('#change-password')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-change-password-header')
+        .end()
+
+        .then(function () {
+          return fillOutChangePassword(self, FIRST_PASSWORD, SECOND_PASSWORD);
+        })
+
+        .then(function () {
+          return testIsBrowserNotifiedOfMessage(self, 'change_password');
+        });
+    },
+
+    'sign in, delete the account': function () {
+      var self = this;
+
+      return this.get('remote')
+
+        .findByCssSelector('#delete-account')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-delete-account-header')
+        .end()
+
+        .then(function () {
+          return fillOutDeleteAccount(self, FIRST_PASSWORD);
+        })
+
+        .then(function () {
+          return testIsBrowserNotifiedOfMessage(self, 'delete_account');
+        });
+    }
+  });
+});


### PR DESCRIPTION
@zaach or @vladikoff - r?

Requested by @ncalexan for Fx on iOS to enable the browser to react to these scenarios.

fixes #2152