### PR TITLE
fix(styles): Hide the top-right Mozilla link if signing into Sync on Fx for iOS

### DIFF
--- a/app/scripts/vendor/env-test.js
+++ b/app/scripts/vendor/env-test.js
@@ -81,4 +81,11 @@
   if (isStyleAllowed(style)) {
     docElement.className += (' ' + style);
   }
+
+  /**
+   * Check if the user is signing in to Sync on Firefox for iOS. User agent sniff. Yuck.
+   */
+  if (/FxiOS/.test(navigator.userAgent) && parseQueryParams().service === 'sync') {
+    docElement.className += ' fx-ios-sync';
+  }
 }());

--- a/app/styles/modules/_branding.scss
+++ b/app/styles/modules/_branding.scss
@@ -66,7 +66,9 @@
     display: none;
   }
 
-  .chromeless & {
+  // Links to external sites cannot be opened when signing in
+  // to Sync on Firefox for iOS
+  .chromeless &, .fx-ios-sync & {
     display: none;
   }
 }


### PR DESCRIPTION
@vladikoff - could you review this?

* Do something gross and UA sniff if the browser is Fx for iOS and service=sync. If so, add the 'fx-ios-sync' class to the HTML element. If 'fx-ios-sync' is on the HTML element, do not show the Mozilla link.

fixes #2226