### PR TITLE
refactor(client): Add a common base for tos/pp copy modules.

### DIFF
--- a/app/scripts/views/legal_copy.js
+++ b/app/scripts/views/legal_copy.js
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'cocktail',
+  'lib/xhr',
+  'views/base',
+  'views/mixins/back-mixin'
+],
+function (Cocktail, xhr, BaseView, BackMixin) {
+
+  // A view to fetch and render legal copy. Sub-classes must provide
+  // a `copyUrl` where the copy template can be fetched, as well a
+  // `fetchError`, which is an error to display if there is a
+  // problem fetching the copy template.
+
+  var View = BaseView.extend({
+    initialize: function (options) {
+      this._xhr = options.xhr || xhr;
+    },
+
+    afterRender: function () {
+      var self = this;
+      return self._xhr.ajax({
+        url: self.copyUrl,
+        accepts: {
+          text: 'text/partial'
+        },
+        dataType: 'text'
+      })
+      .then(function (template) {
+        self.$('#legal-copy').html(template);
+        self.$('.hidden').removeClass('hidden');
+
+        // Set a session cookie that informs the server
+        // the user can go back if they refresh the page.
+        // If the user can go back, the browser will not
+        // render the statically generated TOS/PP page,
+        // but will let the app render the page.
+        // The cookie is cleared whenever the user
+        // restarts the browser. See #2044
+        //
+        // The cookie is scoped to the page to avoid sending
+        // it on other requests, and to ensure the server
+        // only sends the user back to the app if the user in fact
+        // came from this page.
+        self.window.document.cookie = 'canGoBack=1; path=' + self.window.location.pathname;
+      })
+      .fail(function () {
+        self.displayError(self.fetchError);
+        self.$('.hidden').removeClass('hidden');
+      });
+    }
+  });
+
+  Cocktail.mixin(
+    View,
+    BackMixin
+  );
+
+  return View;
+});
+

--- a/app/scripts/views/pp.js
+++ b/app/scripts/views/pp.js
@@ -5,62 +5,22 @@
 'use strict';
 
 define([
-  'cocktail',
-  'lib/xhr',
-  'views/base',
+  'views/legal_copy',
   'stache!templates/pp',
-  'lib/auth-errors',
-  'views/mixins/back-mixin'
+  'lib/auth-errors'
 ],
-function (Cocktail, xhr, BaseView, Template, AuthErrors, BackMixin) {
-  var View = BaseView.extend({
+function (LegalCopyView, Template, AuthErrors) {
+  var View = LegalCopyView.extend({
     template: Template,
     className: 'pp',
-
-    afterRender: function () {
-      var self = this;
-      return xhr.ajax({
-        url: '/legal/privacy',
-        accepts: {
-          text: 'text/partial'
-        },
-        dataType: 'text'
-      })
-      .then(function (template) {
-        self.$('#legal-copy').html(template);
-        self.$('.hidden').removeClass('hidden');
-
-        // Set a session cookie that informs the server
-        // the user can go back if they refresh the page.
-        // If the user can go back, the browser will not
-        // render the statically generated TOS/PP page,
-        // but will let the app render the page.
-        // The cookie is cleared whenever the user
-        // restarts the browser. See #2044
-        //
-        // The cookie is scoped to the page to avoid sending
-        // it on other requests, and to ensure the server
-        // only sends the user back to the app if the user in fact
-        // came from this page.
-        self.window.document.cookie = 'canGoBack=1; path=' + self.window.location.pathname;
-      })
-      .fail(function () {
-        var err = AuthErrors.toError('COULD_NOT_GET_PP');
-        self.displayError(err);
-        self.$('.hidden').removeClass('hidden');
-      });
-    },
+    copyUrl: '/legal/privacy',
+    fetchError: AuthErrors.toError('COULD_NOT_GET_PP'),
 
     events: {
       'click #fxa-pp-back': 'back',
       'keyup #fxa-pp-back': 'backOnEnter'
     }
   });
-
-  Cocktail.mixin(
-    View,
-    BackMixin
-  );
 
   return View;
 });

--- a/app/scripts/views/tos.js
+++ b/app/scripts/views/tos.js
@@ -5,62 +5,22 @@
 'use strict';
 
 define([
-  'cocktail',
-  'lib/xhr',
-  'views/base',
+  'views/legal_copy',
   'stache!templates/tos',
-  'lib/auth-errors',
-  'views/mixins/back-mixin'
+  'lib/auth-errors'
 ],
-function (Cocktail, xhr, BaseView, Template, AuthErrors, BackMixin) {
-  var View = BaseView.extend({
+function (LegalCopyView, Template, AuthErrors) {
+  var View = LegalCopyView.extend({
     template: Template,
     className: 'tos',
-
-    afterRender: function () {
-      var self = this;
-      return xhr.ajax({
-        url: '/legal/terms',
-        accepts: {
-          text: 'text/partial'
-        },
-        dataType: 'text'
-      })
-      .then(function (template) {
-        self.$('#legal-copy').html(template);
-        self.$('.hidden').removeClass('hidden');
-
-        // Set a session cookie that informs the server
-        // the user can go back if they refresh the page.
-        // If the user can go back, the browser will not
-        // render the statically generated TOS/PP page,
-        // but will let the app render the page.
-        // The cookie is cleared whenever the user
-        // restarts the browser. See #2044
-        //
-        // The cookie is scoped to the page to avoid sending
-        // it on other requests, and to ensure the server
-        // only sends the user back to the app if the user in fact
-        // came from this page.
-        self.window.document.cookie = 'canGoBack=1; path=' + self.window.location.pathname;
-      })
-      .fail(function () {
-        var err = AuthErrors.toError('COULD_NOT_GET_TOS');
-        self.displayError(err);
-        self.$('.hidden').removeClass('hidden');
-      });
-    },
+    copyUrl: '/legal/terms',
+    fetchError: AuthErrors.toError('COULD_NOT_GET_TOS'),
 
     events: {
       'click #fxa-tos-back': 'back',
       'keyup #fxa-tos-back': 'backOnEnter'
     }
   });
-
-  Cocktail.mixin(
-    View,
-    BackMixin
-  );
 
   return View;
 });

--- a/app/tests/spec/views/pp.js
+++ b/app/tests/spec/views/pp.js
@@ -9,20 +9,29 @@ define([
   'chai',
   'sinon',
   'views/pp',
+  'lib/promise',
   '../../mocks/window'
 ],
-function (chai, sinon, View, WindowMock) {
+function (chai, sinon, View, p, WindowMock) {
   var assert = chai.assert;
 
   describe('views/pp', function () {
     var view;
+    var xhrMock;
     var windowMock;
 
     beforeEach(function () {
+      xhrMock = {
+        ajax: function () {
+          return p('<span id="fxa-pp-header"></span>');
+        }
+      };
+
       windowMock = new WindowMock();
       windowMock.location.pathname = '/legal/privacy';
 
       view = new View({
+        xhr: xhrMock,
         window: windowMock
       });
     });
@@ -38,9 +47,9 @@ function (chai, sinon, View, WindowMock) {
       });
 
       return view.render()
-          .then(function () {
-            assert.equal(view.$('#fxa-pp-back').length, 1);
-          });
+        .then(function () {
+          assert.equal(view.$('#fxa-pp-back').length, 1);
+        });
     });
 
     it('sets a cookie that lets the server correctly handle page refreshes', function () {
@@ -65,6 +74,18 @@ function (chai, sinon, View, WindowMock) {
       return view.render()
         .then(function () {
           assert.ok(view.$('#fxa-pp-header').length);
+        });
+    });
+
+    it('shows an error if fetch fails', function () {
+      sinon.stub(xhrMock, 'ajax', function () {
+        return p.reject(new Error('could not fetch resource'));
+      });
+
+      return view.render()
+        .then(function () {
+          assert.isTrue(xhrMock.ajax.called);
+          assert.isTrue(view.isErrorVisible());
         });
     });
   });


### PR DESCRIPTION
@zaach or @vladikoff - r?

LegalCopy is now the common base for the TOS/PP views. Subclasses must provide `copyUrl` and `fetchError`.

This module is to eliminate duplication across the two TOS/PP views, as well as to get ready for to convert links to inline text for #2225 

~~If this merges after #2331, it will need to be rebased.~~