### PR TITLE
fix(client & server): TOS/PP back button remains after page refresh.

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -127,8 +127,9 @@ function (
       this.notifications = options.notifications;
       this.able = options.able;
 
-      // back is only enabled after the first view is rendered.
-      this.canGoBack = false;
+      // back is enabled after the first view is rendered or
+      // if the user is re-starts the app.
+      this.canGoBack = this.window.sessionStorage.canGoBack || false;
 
       this._firstViewHasLoaded = false;
 
@@ -228,8 +229,9 @@ function (
             // is attached and the promise is not returned.
             self.broker.afterLoaded();
 
-            // back is enabled after the first view is rendered.
-            self.canGoBack = true;
+            // back is enabled after the first view is rendered or
+            // if the user is re-starts the app.
+            self.canGoBack = self.window.sessionStorage.canGoBack = true;
             self._firstViewHasLoaded = true;
           }
         })

--- a/app/scripts/views/pp.js
+++ b/app/scripts/views/pp.js
@@ -29,6 +29,20 @@ function (Cocktail, xhr, BaseView, Template, AuthErrors, BackMixin) {
       .then(function (template) {
         self.$('#legal-copy').html(template);
         self.$('.hidden').removeClass('hidden');
+
+        // Set a session cookie that informs the server
+        // the user can go back if they refresh the page.
+        // If the user can go back, the browser will not
+        // render the statically generated TOS/PP page,
+        // but will let the app render the page.
+        // The cookie is cleared whenever the user
+        // restarts the browser. See #2044
+        //
+        // The cookie is scoped to the page to avoid sending
+        // it on other requests, and to ensure the server
+        // only sends the user back to the app if the user in fact
+        // came from this page.
+        self.window.document.cookie = 'canGoBack=1; path=' + self.window.location.pathname;
       })
       .fail(function () {
         var err = AuthErrors.toError('COULD_NOT_GET_PP');

--- a/app/scripts/views/tos.js
+++ b/app/scripts/views/tos.js
@@ -29,6 +29,20 @@ function (Cocktail, xhr, BaseView, Template, AuthErrors, BackMixin) {
       .then(function (template) {
         self.$('#legal-copy').html(template);
         self.$('.hidden').removeClass('hidden');
+
+        // Set a session cookie that informs the server
+        // the user can go back if they refresh the page.
+        // If the user can go back, the browser will not
+        // render the statically generated TOS/PP page,
+        // but will let the app render the page.
+        // The cookie is cleared whenever the user
+        // restarts the browser. See #2044
+        //
+        // The cookie is scoped to the page to avoid sending
+        // it on other requests, and to ensure the server
+        // only sends the user back to the app if the user in fact
+        // came from this page.
+        self.window.document.cookie = 'canGoBack=1; path=' + self.window.location.pathname;
       })
       .fail(function () {
         var err = AuthErrors.toError('COULD_NOT_GET_TOS');

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -409,7 +409,27 @@ function (chai, sinon, _, Backbone, Router, SignInView, SignUpView, ReadyView,
         return router.createAndShowView(SignUpView, { canGoBack: false })
           .then(function () {
             assert.equal($('#fxa-signup-header').length, 1);
+            assert.isTrue(windowMock.sessionStorage.canGoBack);
           });
+      });
+    });
+
+    describe('canGoBack initial value', function () {
+      it('is `false` if sessionStorage.canGoBack is not set', function () {
+        assert.isFalse(router.canGoBack);
+      });
+
+      it('is `true` if sessionStorage.canGoBack is set', function () {
+        windowMock.sessionStorage.canGoBack = true;
+        router = new Router({
+          window: windowMock,
+          metrics: metrics,
+          relier: relier,
+          broker: broker,
+          user: user,
+          formPrefill: formPrefill
+        });
+        assert.isTrue(router.canGoBack);
       });
     });
   });

--- a/app/tests/spec/views/pp.js
+++ b/app/tests/spec/views/pp.js
@@ -8,16 +8,23 @@
 define([
   'chai',
   'sinon',
-  'views/pp'
+  'views/pp',
+  '../../mocks/window'
 ],
-function (chai, sinon, View) {
+function (chai, sinon, View, WindowMock) {
   var assert = chai.assert;
 
   describe('views/pp', function () {
     var view;
+    var windowMock;
 
     beforeEach(function () {
-      view = new View({});
+      windowMock = new WindowMock();
+      windowMock.location.pathname = '/legal/privacy';
+
+      view = new View({
+        window: windowMock
+      });
     });
 
     afterEach(function () {
@@ -34,6 +41,13 @@ function (chai, sinon, View) {
           .then(function () {
             assert.equal(view.$('#fxa-pp-back').length, 1);
           });
+    });
+
+    it('sets a cookie that lets the server correctly handle page refreshes', function () {
+      return view.render()
+        .then(function () {
+          assert.isTrue(/canGoBack=1; path=\/legal\/privacy/.test(windowMock.document.cookie));
+        });
     });
 
     it('Back button is not displayed if there is no page to go back to', function () {

--- a/app/tests/spec/views/tos.js
+++ b/app/tests/spec/views/tos.js
@@ -8,16 +8,23 @@
 define([
   'chai',
   'sinon',
-  'views/tos'
+  'views/tos',
+  '../../mocks/window'
 ],
-function (chai, sinon, View) {
+function (chai, sinon, View, WindowMock) {
   var assert = chai.assert;
 
   describe('views/tos', function () {
     var view;
+    var windowMock;
 
     beforeEach(function () {
-      view = new View({});
+      windowMock = new WindowMock();
+      windowMock.location.pathname = '/legal/terms';
+
+      view = new View({
+        window: windowMock
+      });
     });
 
     afterEach(function () {
@@ -34,6 +41,13 @@ function (chai, sinon, View) {
           .then(function () {
             assert.equal(view.$('#fxa-tos-back').length, 1);
           });
+    });
+
+    it('sets a cookie that lets the server correctly handle page refreshes', function () {
+      return view.render()
+        .then(function () {
+          assert.isTrue(/canGoBack=1; path=\/legal\/terms/.test(windowMock.document.cookie));
+        });
     });
 
     it('Back button is not displayed if there is no page to go back to', function () {

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -23,9 +23,9 @@ function isValidRoute(route) {
 module.exports = function (config, i18n) {
 
   var routes = [
+    require('./routes/get-terms-privacy')(i18n),
     require('./routes/get-index')(),
     require('./routes/get-ver.json'),
-    require('./routes/get-terms-privacy')(i18n),
     require('./routes/get-config')(i18n),
     require('./routes/get-client.json')(i18n),
     require('./routes/post-metrics')()

--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -180,12 +180,36 @@ define([
         .findByCssSelector('#fxa-settings-header')
         .end()
 
+        .execute(function () {
+          /* global sessionStorage */
+          sessionStorage.clear();
+        })
+
         .get(require.toUrl(PAGE_URL))
 
         .findByCssSelector('#fxa-change-password-header')
         .end()
 
         .then(Test.noElementById(self, 'back'));
+    },
+
+    'refresh the page - back button': function () {
+      return this.get('remote')
+        // check that signin is complete before proceeding
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+
+        .findById('change-password')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-change-password-header')
+        .end()
+
+        .refresh()
+
+        .findByCssSelector('#back')
+        .end();
     },
 
     'locked account, verify same browser': function () {

--- a/tests/functional/delete_account.js
+++ b/tests/functional/delete_account.js
@@ -110,12 +110,35 @@ define([
         .findById('fxa-settings-header')
         .end()
 
+        .execute(function () {
+          /* global sessionStorage */
+          sessionStorage.clear();
+        })
+
         // Go to delete account screen directly
         .get(require.toUrl(PAGE_URL))
         .findById('fxa-delete-account-header')
         .end()
 
         .then(Test.noElementById(self, 'back'));
+    },
+
+    'refresh the page, back button shown': function () {
+      return FunctionalHelpers.fillOutSignIn(this, email, PASSWORD)
+        .findById('fxa-settings-header')
+        .end()
+
+        .findById('delete-account')
+          .click()
+        .end()
+
+        .findById('fxa-delete-account-header')
+        .end()
+
+        .refresh()
+
+        .findById('back')
+        .end();
     },
 
     'locked account, verify same browser': function () {

--- a/tests/functional/pp.js
+++ b/tests/functional/pp.js
@@ -54,6 +54,26 @@ define([
         .end()
 
         .then(Test.noElementById(self, 'fxa-pp-back'));
+    },
+
+    'refresh, back button is available': function () {
+      return this.get('remote')
+
+        .get(require.toUrl(SIGNUP_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+        .findByCssSelector('#fxa-pp')
+          .click()
+        .end()
+
+        .refresh()
+
+        .findByCssSelector('#fxa-pp-back')
+          .click()
+        .end()
+
+        // success is going back to the signup
+        .findByCssSelector('#fxa-signup-header')
+        .end();
     }
   });
 });

--- a/tests/functional/tos.js
+++ b/tests/functional/tos.js
@@ -51,6 +51,26 @@ define([
         .end()
 
         .then(Test.noElementById(self, 'fxa-tos-back'));
+    },
+
+    'refresh, back button is available': function () {
+      return this.get('remote')
+
+        .get(require.toUrl(SIGNUP_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+        .findByCssSelector('#fxa-tos')
+          .click()
+        .end()
+
+        .refresh()
+
+        .findByCssSelector('#fxa-tos-back')
+          .click()
+        .end()
+
+        // success is going back to the signup
+        .findByCssSelector('#fxa-signup-header')
+        .end();
     }
   });
 });


### PR DESCRIPTION
@zaach or @vladikoff - r?

* "back" buttons are still available after the user refreshes the a page.
* If a user clicks on an external link from the TOS/PP text and then hits the browser's back button, show the "back" button is available.

fixes #2044

If this merges after #2330, it will need to be rebased.