### PR TITLE
fix(css): Show links in TOS/PP text next to the original anchor text.

### DIFF
--- a/app/scripts/views/legal_copy.js
+++ b/app/scripts/views/legal_copy.js
@@ -33,6 +33,27 @@ function (Cocktail, xhr, BaseView, BackMixin) {
       })
       .then(function (template) {
         self.$('#legal-copy').html(template);
+
+        // data-visible-url is used to display the href in
+        // brackets next to the original text.
+        // Only show the href if the href is different from
+        // the text. See #2225.
+        //
+        // Links are only made visible from the main app. If
+        // the user browses directly to a TOS/PP page, the links
+        // are normal.
+        self.$el.addClass('show-visible-url');
+        self.$('a').each(function (index, element) {
+          element = $(element);
+
+          var href = element.attr('href');
+          var text = element.text();
+          // if the href is the same as the link text, don't convert.
+          if (href && href !== text) {
+            element.attr('data-visible-url', href);
+          }
+        });
+
         self.$('.hidden').removeClass('hidden');
 
         // Set a session cookie that informs the server

--- a/app/styles/modules/_legal.scss
+++ b/app/styles/modules/_legal.scss
@@ -57,7 +57,7 @@
 
   @include respond-to('trustedUI') {
     margin-bottom: 10px;
-    
+
     h2 {
       font-size: $base-font;
     }
@@ -71,5 +71,35 @@
   ul {
     margin-left: 0;
     padding-left: 20px;
+  }
+
+  .show-visible-url & {
+    // Links cannot be opened from the TOS/PP text when signing
+    // in to Sync on Fx for iOS. When signing in elsewhere, links
+    // replace the app. Yuck. Show the links href next to the link text.
+    // The href is fetched from the data-visible-url attribute instead of
+    // the href attribute because some links are the same as their
+    // text. In those cases, there is no point showing both.
+    //
+    // hrefs are only visible from the app, when the TOS/PP agreements
+    // are opened directly, the links display/act normally.
+    a[href^=http] {
+      // using text-decoration: underline underlines the ::after
+      // section as well, with no way to remove it.
+      // So, add a border to the entire element, then hide
+      // the border in the ::after using a border that is the same
+      // color as the background.
+      border-bottom: 1px dotted $text-color;
+      color: $text-color;
+      cursor: default;
+      pointer-events: none;
+      text-decoration: none;
+    }
+
+    a[data-visible-url^=http]:after,
+    a[data-visible-url^=http]::after {
+      border-bottom: 1px solid $content-background-color;
+      content: " [" attr(href) "] ";
+    }
   }
 }

--- a/app/tests/spec/views/pp.js
+++ b/app/tests/spec/views/pp.js
@@ -15,6 +15,11 @@ define([
 function (chai, sinon, View, p, WindowMock) {
   var assert = chai.assert;
 
+  var TEMPLATE_TEXT =
+    '<span id="fxa-pp-header"></span>' +
+      '<a id="data-visible-url-added" href="https://accounts.firefox.com">Firefox Accounts</a>' +
+      '<a id="data-visible-url-not-added" href="https://mozilla.org">https://mozilla.org</a>';
+
   describe('views/pp', function () {
     var view;
     var xhrMock;
@@ -23,7 +28,7 @@ function (chai, sinon, View, p, WindowMock) {
     beforeEach(function () {
       xhrMock = {
         ajax: function () {
-          return p('<span id="fxa-pp-header"></span>');
+          return p(TEMPLATE_TEXT);
         }
       };
 
@@ -86,6 +91,26 @@ function (chai, sinon, View, p, WindowMock) {
         .then(function () {
           assert.isTrue(xhrMock.ajax.called);
           assert.isTrue(view.isErrorVisible());
+        });
+    });
+
+    it('adds a `data-visible-url` to an anchor if the href and the text differ', function () {
+      return view.render()
+        .then(function () {
+          assert.equal(
+            view.$('#data-visible-url-added').attr('data-visible-url'),
+            'https://accounts.firefox.com'
+          );
+        });
+    });
+
+    it('does not add a `data-visible-url` to an anchor if the href is the same as the text', function () {
+      return view.render()
+        .then(function () {
+          assert.equal(
+            typeof view.$('#data-visible-url-not-added').attr('data-visible-url'),
+            'undefined'
+          );
         });
     });
   });

--- a/app/tests/spec/views/tos.js
+++ b/app/tests/spec/views/tos.js
@@ -15,6 +15,11 @@ define([
 function (chai, sinon, View, p, WindowMock) {
   var assert = chai.assert;
 
+  var TEMPLATE_TEXT =
+    '<span id="fxa-tos-header"></span>' +
+      '<a id="data-visible-url-added" href="https://accounts.firefox.com">Firefox Accounts</a>' +
+      '<a id="data-visible-url-not-added" href="https://mozilla.org">https://mozilla.org</a>';
+
   describe('views/tos', function () {
     var view;
     var xhrMock;
@@ -23,7 +28,7 @@ function (chai, sinon, View, p, WindowMock) {
     beforeEach(function () {
       xhrMock = {
         ajax: function () {
-          return p('<span id="fxa-tos-header"></span>');
+          return p(TEMPLATE_TEXT);
         }
       };
 
@@ -89,6 +94,26 @@ function (chai, sinon, View, p, WindowMock) {
         .then(function () {
           assert.isTrue(xhrMock.ajax.called);
           assert.isTrue(view.isErrorVisible());
+        });
+    });
+
+    it('adds a `data-visible-url` to an anchor if the href and the text differ', function () {
+      return view.render()
+        .then(function () {
+          assert.equal(
+            view.$('#data-visible-url-added').attr('data-visible-url'),
+            'https://accounts.firefox.com'
+          );
+        });
+    });
+
+    it('does not add a `data-visible-url` to an anchor if the href is the same as the text', function () {
+      return view.render()
+        .then(function () {
+          assert.equal(
+            typeof view.$('#data-visible-url-not-added').attr('data-visible-url'),
+            'undefined'
+          );
         });
     });
   });


### PR DESCRIPTION
When opening the TOS/PP text from the main app, links to external sites
show the link's href next to the link text.

e.g.:
Firefox Accounts [https://accounts.firefox.com]

fixes #1968
fixes #2225 