### PR TITLE
fix(client): getUserMedia check for avatar change.

### DIFF
--- a/app/scripts/head/startup-styles.js
+++ b/app/scripts/head/startup-styles.js
@@ -80,6 +80,7 @@
       this.addIframeStyles();
       this.addSearchParamStyles();
       this.addFxiOSSyncStyles();
+      this.addGetUserMediaStyles();
     },
 
     addTouchEventStyles: function () {
@@ -129,6 +130,14 @@
       var isSync = this._getQueryParam('service') === 'sync';
       if (this.environment.isFxiOS() && isSync) {
         this._addClass('fx-ios-sync');
+      }
+    },
+
+    addGetUserMediaStyles: function () {
+      if (this.environment.hasGetUserMedia()) {
+        this._addClass('getusermedia');
+      } else {
+        this._addClass('no-getusermedia');
       }
     }
   };

--- a/app/scripts/lib/environment.js
+++ b/app/scripts/lib/environment.js
@@ -29,6 +29,15 @@
   }
 
   Environment.prototype = {
+    hasGetUserMedia: function () {
+      var nav = this.window.navigator;
+
+      return !! (nav.getUserMedia ||
+                 nav.webkitGetUserMedia ||
+                 nav.mozGetUserMedia ||
+                 nav.msGetUserMedia);
+    },
+
     hasPasswordRevealer: function () {
       var document = this.window.document;
 

--- a/app/styles/modules/_avatar.scss
+++ b/app/styles/modules/_avatar.scss
@@ -163,3 +163,7 @@
     }
   }
 }
+
+.no-getusermedia #camera {
+  display: none;
+}

--- a/app/tests/spec/head/startup-styles.js
+++ b/app/tests/spec/head/startup-styles.js
@@ -153,6 +153,28 @@ define([
       });
     });
 
+    describe('addGetUserMediaStyles', function () {
+      it('adds `getusermedia` if UA supports getUserMedia', function () {
+        sinon.stub(environment, 'hasGetUserMedia', function () {
+          return true;
+        });
+
+        startupStyles.addGetUserMediaStyles();
+        assert.isTrue(/getusermedia/.test(startupStyles.getClassName()));
+        assert.isFalse(/no-getusermedia/.test(startupStyles.getClassName()));
+      });
+
+      it('adds `no-getusermedia` if UA does not support getUserMedia', function () {
+        sinon.stub(environment, 'hasGetUserMedia', function () {
+          return false;
+        });
+
+        startupStyles.addGetUserMediaStyles();
+        assert.isTrue(/no-getusermedia/.test(startupStyles.getClassName()));
+      });
+    });
+
+
     describe('initialize', function () {
       it('runs all the tests', function () {
         startupStyles.initialize();

--- a/app/tests/spec/lib/environment.js
+++ b/app/tests/spec/lib/environment.js
@@ -46,6 +46,42 @@ define([
       });
     });
 
+    describe('hasGetUserMedia', function () {
+      beforeEach(function () {
+        windowMock.navigator.getUserMedia = null;
+        delete windowMock.navigator.getUserMedia;
+      });
+
+
+      it('adds `getusermedia` if UA supports getUserMedia', function () {
+        windowMock.navigator.getUserMedia = sinon.spy();
+
+        assert.isTrue(environment.hasGetUserMedia());
+      });
+
+      it('adds `getusermedia` if UA supports webkitGetUserMedia', function () {
+        windowMock.navigator.webkitGetUserMedia = sinon.spy();
+
+        assert.isTrue(environment.hasGetUserMedia());
+      });
+
+      it('adds `getusermedia` if UA supports mozGetUserMedia', function () {
+        windowMock.navigator.mozGetUserMedia = sinon.spy();
+
+        assert.isTrue(environment.hasGetUserMedia());
+      });
+
+      it('adds `getusermedia` if UA supports msGetUserMedia', function () {
+        windowMock.navigator.msGetUserMedia = sinon.spy();
+
+        assert.isTrue(environment.hasGetUserMedia());
+      });
+
+      it('adds `no-getusermedia` if UA does not support getUserMedia', function () {
+        assert.isFalse(environment.hasGetUserMedia());
+      });
+    });
+
     describe('isFramed', function () {
       it('returns `true` if window is iframed', function () {
         windowMock.top = {};

--- a/app/tests/spec/views/settings/avatar_camera.js
+++ b/app/tests/spec/views/settings/avatar_camera.js
@@ -99,7 +99,7 @@ function (chai, _, $, sinon, View, RouterMock, WindowMock, CanvasMock,
         view.render()
           .then(function () {
             windowMock.on('stream', function () {
-              assert.isTrue(view._isErrorVisible);
+              assert.isTrue(view.isErrorVisible());
               done();
             });
           })
@@ -108,9 +108,12 @@ function (chai, _, $, sinon, View, RouterMock, WindowMock, CanvasMock,
 
       it('no browser support', function () {
         windowMock.navigator.getUserMedia = null;
+
+        sinon.spy(view, 'navigate');
+
         return view.render()
           .then(function () {
-            assert.isTrue(view._isErrorVisible);
+            assert.isTrue(view.navigate.calledWith('settings/avatar/change'));
           });
       });
 


### PR DESCRIPTION
Do not show the "camera" icon if the user agent does not support navigator.getUserMedia or any of the vendor specific variants.

fixes #2224