### PR TITLE
fix(client): If a relier wants keys, give them keys.

### DIFF
--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -273,6 +273,12 @@ function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
         return true;
       }
 
+      // If the relier wants keys, then the user must authenticate
+      // and the password must be requested.
+      if (this.relier.wantsKeys()) {
+        return true;
+      }
+
       // We need to ask the user again for their password unless the credentials came from Sync.
       // Otherwise they aren't able to "fully" log out. Only Sync has a clear path to disconnect/log out
       // your account that invalidates your sessionToken.

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -549,6 +549,32 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
           });
       });
 
+      it('asks for the password if the relier wants keys', function () {
+        sinon.stub(relier, 'wantsKeys', function () {
+          return true;
+        });
+
+        var account = user.initAccount({
+          sessionToken: 'abc123',
+          email: 'a@a.com',
+          sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+          verified: true,
+          accessToken: 'foo'
+        });
+
+        sinon.stub(view, 'getAccount', function () {
+          return account;
+        });
+
+        relier.set('service', 'Firefox Hello');
+
+        return view.render()
+          .then(function () {
+            assert.equal($('.email')[0].type, 'hidden', 'should not show email input');
+            assert.ok($('.password').length, 'should show password input');
+          });
+      });
+
       it('does not ask for password right away if service is not sync', function () {
         var account = user.initAccount({
           sessionToken: 'abc123',


### PR DESCRIPTION
@vladikoff and @rfk - r?

* If a relier wants keys, the user must enter their password so that user keys can be fetched from the auth server and then converted to relier usable keys.

fixes #2356 