### PR TITLE
feat: `/` can be framed by allowed reliers.

### DIFF
--- a/app/scripts/head/startup-styles.js
+++ b/app/scripts/head/startup-styles.js
@@ -103,11 +103,8 @@
       /**
        * The iframe'd OAuth flow needs special styling applied to it as
        * soon as possible so that it doesn't look terrible.
-       *
-       * Make sure that the iframe name is not 'remote'
-       * which is used by 'about:accounts'.
        */
-      if (this.environment.isFramed() && this.window.name !== 'remote') {
+      if (this.environment.isFramed()) {
         this._addClass('iframe');
       }
     },

--- a/app/scripts/lib/channels/iframe.js
+++ b/app/scripts/lib/channels/iframe.js
@@ -9,16 +9,6 @@
  *
  * An RPs origin must match the origin registered for the client_id
  * on the URL.
- *
- * When the channel is initialized, it sends a `ping` message
- * to the parent window. The parent window should respond with
- * a `ping` message. We do this to get a trusted origin for the
- * parent window, otherwise all we would have to use the `referrer`
- * header, which can be faked.
- *
- * When the `ping` response is received, the origin of the message is
- * checked against the origin registered for the client_id. If the origins
- * do not match, an ILLEGAL_IFRAME_PARENT error is thrown.
  */
 
 define([

--- a/app/scripts/lib/environment.js
+++ b/app/scripts/lib/environment.js
@@ -65,8 +65,9 @@
 
     isFramed: function () {
       var win = this.window;
-
-      return !! (win.top && win.top !== win);
+      // about:accounts places FxA into an iframe, but is not considered
+      // to use the iframe flow. about:accounts sets window.name = 'remote'
+      return !! (win.top && win.top !== win && win.name !== 'remote');
     },
 
     isFxiOS: function () {

--- a/app/scripts/lib/origin-check.js
+++ b/app/scripts/lib/origin-check.js
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Get a window's origin from a postMessage `message` event.
+ * This scheme is used instead of checking the referrer header or
+ * document.referrer because the referrer header can be disabled/spoofed.
+ * A postMessage event's origin is set by the browser and is trusted.
+ *
+ * A list of allowed origins are passed to getOrigin. If embedded
+ * in an oauth flow, the list will have a length of 1. If used for sync,
+ * the list can be >1. We do not know which parent we are talking to so
+ * must query all possible parents to figure out which parent is framing.
+ *
+ * The protocol is:
+ * Send a `{ command: 'ping' }` postMessage to all of the allowed origins.
+ * Wait for a `{ command: 'ping' }` postMessage response. Only one response
+ * should be received.
+ *
+ * The received message event's origin is checked against the list of
+ * allowed origins. If the origin is allowed, it is returned. If no origin
+ * is found after a short period, return `null`.
+ */
+'use strict';
+
+define([
+  'lib/promise',
+  'lib/constants',
+  'lib/channels/iframe'
+], function (p, Constants, IFrameChannel) {
+  var RESPONSE_TIMEOUT_MS = 100;
+
+  function OriginCheck(win) {
+    this._window = win;
+  }
+
+  OriginCheck.prototype = {
+    /**
+     * Get the origin of a targetWindow
+     *
+     * @method getOrigin
+     * @param {Window} targetWindow
+     * @param {Array of Strings} allowedOrigins - a list of allowed origins.
+     * @returns {Promise}
+     *          Resolves to the parent's origin, if the parent's origin is in
+     *          the list of allowed origins.
+     *          Resolves to `null` if no allowed origin found.
+     */
+    getOrigin: function (targetWindow, allowedOrigins) {
+      var win = this._window;
+      var deferred = p.defer();
+
+      var onMessage = function onMessage(event) {
+        if (allowedOrigins.indexOf(event.origin) === -1) {
+          // unexpected domain, ignore.
+          return;
+        }
+
+        var data = OriginCheck.parse(event.data);
+        if (data && data.command === 'ping') {
+          deferred.resolve(event.origin);
+        }
+      };
+
+      win.addEventListener('message', onMessage, true);
+
+      // ping the target window, sending a message to each of the allowed origins.
+      allowedOrigins.forEach(function (allowedOrigin) {
+        targetWindow.postMessage(OriginCheck.stringify('ping'), allowedOrigin);
+      });
+
+      return deferred.promise
+        // timeout after a short period. If no response is received,
+        // no parent is listening.
+        .timeout(RESPONSE_TIMEOUT_MS)
+        .fail(function (err) {
+          if (/Timed out/.test(String(err))) {
+            // a timeout is A-OK, no allowed origins are listening.
+            return null;
+          }
+        })
+        .fin(function () {
+          win.removeEventListener('message', onMessage, true);
+        });
+    }
+  };
+
+
+  OriginCheck.stringify = function (command) {
+    return IFrameChannel.stringify(command);
+  };
+
+  OriginCheck.parse = function (data) {
+    try {
+      return IFrameChannel.parse(data);
+    } catch (e) {
+      // malformed message, drop it on the ground.
+    }
+  };
+
+  return OriginCheck;
+});
+
+

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -38,17 +38,6 @@ define([
     },
 
     /**
-     * Select the start page. Returned promise can resolve to a string that
-     * will cause the start page to redirect. If returned promise resolves
-     * to a 'falsy' value, no redirection will occur.
-     * @returns {Promise}
-     */
-    selectStartPage: function () {
-      // the default is to use the page set in the URL
-      return p();
-    },
-
-    /**
      * Check if the environment supports the cancelling of the flow.
      */
     canCancel: function () {

--- a/app/scripts/models/auth_brokers/iframe.js
+++ b/app/scripts/models/auth_brokers/iframe.js
@@ -17,17 +17,6 @@ define([
 ], function (_, $, p, IframeChannel, AuthErrors, OAuthAuthenticationBroker,
         ChannelMixin) {
 
-  // A `ping` is sent out to the expected relier. The relier must respond.
-  // No response will be received if the parent is either:
-  // 1. not set up to respond correctly
-  // 2. not the expected origin
-  //
-  // either case is an error
-  function checkIframedByExpectedOrigin(context) {
-    //jshint validthis: true
-    return context.send('ping');
-  }
-
   var IframeAuthenticationBroker = OAuthAuthenticationBroker.extend({
     type: 'iframe',
     initialize: function (options) {
@@ -45,13 +34,6 @@ define([
       return this._channel;
     },
 
-    selectStartPage: function () {
-      var self = this;
-      return checkIframedByExpectedOrigin(self)
-        .then(function () {
-          return OAuthAuthenticationBroker.prototype.selectStartPage.call(self);
-        });
-    },
 
     sendOAuthResultToRelier: function (result) {
       return this.send('oauth_complete', result);

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -74,6 +74,7 @@ function (_, Backbone, NullStorage) {
 
     this.localStorage = new NullStorage();
     this.sessionStorage = new NullStorage();
+    this.top = this;
   }
 
   _.extend(WindowMock.prototype, Backbone.Events, {

--- a/app/tests/spec/head/startup-styles.js
+++ b/app/tests/spec/head/startup-styles.js
@@ -80,16 +80,6 @@ define([
         assert.isTrue(/iframe/.test(startupStyles.getClassName()));
       });
 
-      it('does not add `iframe` if window is framed by browser chrome', function () {
-        sinon.stub(environment, 'isFramed', function () {
-          return true;
-        });
-        windowMock.name = 'remote';
-
-        startupStyles.addIframeStyles();
-        assert.isFalse(/iframe/.test(startupStyles.getClassName()));
-      });
-
       it('does not add `iframe` if window is not iframed', function () {
         sinon.stub(environment, 'isFramed', function () {
           return false;

--- a/app/tests/spec/lib/environment.js
+++ b/app/tests/spec/lib/environment.js
@@ -84,12 +84,18 @@ define([
 
     describe('isFramed', function () {
       it('returns `true` if window is iframed', function () {
-        windowMock.top = {};
+        windowMock.top = new WindowMock();
 
         assert.isTrue(environment.isFramed());
       });
 
       it('returns `false` if window is not iframed', function () {
+        assert.isFalse(environment.isFramed());
+      });
+
+      it('returns `false` if the window\'s name is `remote`', function () {
+        windowMock.top = new WindowMock();
+        windowMock.name = 'remote';
         assert.isFalse(environment.isFramed());
       });
     });

--- a/app/tests/spec/lib/origin-check.js
+++ b/app/tests/spec/lib/origin-check.js
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'sinon',
+  'lib/origin-check',
+  '../../mocks/window'
+],
+function (chai, sinon, OriginCheck, WindowMock) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  describe('lib/origin-check', function () {
+    var originCheck;
+    var windowMock;
+    var parentMock;
+
+    function dispatchMessageEvent(target, message, origin) {
+      target.trigger('message', {
+        origin: origin,
+        data: message
+      });
+    }
+
+    beforeEach(function () {
+      windowMock = new WindowMock();
+      parentMock = new WindowMock();
+
+      windowMock.parent = parentMock;
+
+      originCheck = new OriginCheck(windowMock);
+    });
+
+    describe('getOrigin', function () {
+      it('queries all channels, returns `null` if no response', function () {
+        sinon.spy(parentMock, 'postMessage');
+
+        return originCheck.getOrigin(parentMock, ['http://origin1.org', 'http://origin2.org'])
+          .then(function (origin) {
+            assert.equal(parentMock.postMessage.callCount, 2);
+
+            assert.equal(parentMock.postMessage.args[0][0], OriginCheck.stringify('ping'));
+            assert.equal(parentMock.postMessage.args[0][1], 'http://origin1.org');
+            assert.equal(parentMock.postMessage.args[1][1], 'http://origin2.org');
+
+            assert.isNull(origin);
+          });
+      });
+
+      it('returns `null` response received from non-allowed origin', function () {
+        // synthesize a random origin sending a ping.
+        setTimeout(function () {
+          dispatchMessageEvent(
+            windowMock,
+            OriginCheck.stringify('ping'),
+            'http://not-allowed.org'
+          );
+        }, 10);
+
+        return originCheck.getOrigin(parentMock, ['http://origin1.org', 'http://origin2.org'])
+          .then(function (origin) {
+            assert.isNull(origin);
+          });
+      });
+
+      it('returns origin of allowed origin', function () {
+        sinon.stub(parentMock, 'postMessage', function (message, origin) {
+          if (origin === 'http://origin2.org') {
+            dispatchMessageEvent(
+              windowMock,
+              message,
+              origin
+            );
+          }
+        });
+
+        return originCheck.getOrigin(parentMock, ['http://origin1.org', 'http://origin2.org'])
+          .then(function (origin) {
+            assert.equal(origin, 'http://origin2.org');
+          });
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/models/auth_brokers/iframe.js
+++ b/app/tests/spec/models/auth_brokers/iframe.js
@@ -48,69 +48,6 @@ function (chai, sinon, $, IframeAuthenticationBroker, Relier, p, NullChannel,
       }
     });
 
-    describe('selectStartPage', function () {
-      it('does not continue if channel does not respond to `ping`', function () {
-
-        var deferred = p.defer();
-
-        sinon.stub(broker, 'send', function () {
-          // The timeout length is not really important as long as
-          // resolution occurs after other promises are established.
-          setTimeout(function () {
-            deferred.resolve();
-          }, 10);
-
-          // synthesize a response never being returned.
-          // change the next line to `return p()` or
-          // `return p.reject(<some err>)`
-          // to check the tests catch what they should
-          //return p.defer().promise;
-          return p.defer().promise;
-        });
-
-        broker.selectStartPage()
-          // the promise should not resolve if no response is received.
-          .then(function () {
-            deferred.reject(new Error('selectStartPage success is not supposed to complete'));
-          }, function () {
-            deferred.reject(new Error('selectStartPage failure is not supposed to complete'));
-          });
-
-        return deferred.promise
-          .then(function () {
-            assert.isTrue(broker.send.calledWith('ping'));
-          });
-      });
-
-      it('does not redirect if relier\'s origin matches the origin of the redirect_uri registered for the relier', function () {
-        sinon.stub(broker, 'send', function () {
-          return p({
-            origin: 'https://marketplace.firefox.com'
-          });
-        });
-
-        relierMock.set('redirectUri', 'https://marketplace.firefox.com/endpoint');
-
-        return broker.selectStartPage()
-          .then(function (page) {
-            assert.isUndefined(page);
-          });
-      });
-
-      it('re-throws errors', function () {
-        sinon.stub(broker, 'send', function () {
-          return p.reject(new Error('uh oh'));
-        });
-
-        relierMock.set('redirectUri', 'https://marketplace.firefox.com/endpoint');
-
-        return broker.selectStartPage()
-          .then(assert.fail, function (err) {
-            assert.equal(err.message, 'uh oh');
-          });
-      });
-    });
-
     describe('sendOAuthResultToRelier', function () {
       it('sends an `oauth_complete` message', function () {
         sinon.stub(broker, 'send', function () {

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -47,6 +47,7 @@ function (Translator, Session) {
     '../tests/spec/lib/able',
     '../tests/spec/lib/environment',
     '../tests/spec/lib/base64url',
+    '../tests/spec/lib/origin-check',
     '../tests/spec/head/startup-styles',
     '../tests/spec/views/base',
     '../tests/spec/views/tooltip',

--- a/server/config/local.json-dist
+++ b/server/config/local.json-dist
@@ -27,7 +27,7 @@
   "metrics": {
     "sample_rate": 0
   },
-  "iframe_allowed_origins": ["http://127.0.0.1:8080"],
+  "allowed_parent_origins": ["http://127.0.0.1:8080"],
   "csp": {
     "enabled": true,
     "reportUri": "/_/csp-violation"

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -142,7 +142,7 @@ var conf = module.exports = convict({
     default: 'ea3ca969f8c6bb0d',
     env: 'FXA_OAUTH_CLIENT_ID'
   },
-  iframe_allowed_origins: {
+  allowed_parent_origins: {
     doc: 'Origins that are allowed to embed the FxA within an IFRAME',
     format: Array,
     default: []

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -83,6 +83,7 @@ module.exports = function (config, i18n) {
     // an array is used instead of a regexp simply because the regexp
     // became too long. One route is created for each item.
     var FRONTEND_ROUTES = [
+      '/',
       '/signin',
       '/signup',
       '/signup_complete',
@@ -117,6 +118,7 @@ module.exports = function (config, i18n) {
     ];
 
     var ALLOWED_TO_FRAME = {
+      '/': true,
       '/oauth/': true,
       '/oauth/signin': true,
       '/oauth/signup': true,

--- a/server/lib/routes/get-config.js
+++ b/server/lib/routes/get-config.js
@@ -10,6 +10,8 @@ var clientId = config.get('oauth_client_id');
 var authServerUrl = config.get('fxaccount_url');
 var oauthServerUrl = config.get('oauth_url');
 var profileServerUrl = config.get('profile_url');
+var metricsSampleRate = config.get('metrics.sample_rate');
+var allowedParentOrigins = config.get('allowed_parent_origins');
 
 module.exports = function () {
   var route = {};
@@ -40,7 +42,8 @@ module.exports = function () {
       oAuthClientId: clientId,
       // req.lang is set by abide in a previous middleware.
       language: req.lang,
-      metricsSampleRate: config.get('metrics.sample_rate')
+      metricsSampleRate: metricsSampleRate,
+      allowedParentOrigins: allowedParentOrigins
     });
   };
 


### PR DESCRIPTION
Used for the new Firefox /firstrun flow, which allows users to sign up to Sync from web content.

Remove selectStartPage from the iframe broker. This functionality is now moved to app-start.js where it can be shared with either the OAuth or Sync flow.

fixes #1837 
issue #2242
ref #2101