### PR TITLE
chore(tests): Add missing test for base64url encoding.

### DIFF
--- a/app/tests/spec/lib/base64url.js
+++ b/app/tests/spec/lib/base64url.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'chai',
+  'sjcl',
+  'lib/base64url'
+], function (chai, sjcl, base64url) {
+  var assert = chai.assert;
+
+  describe('lib/base64url', function () {
+    it('encodes and decodes properly', function () {
+      // Test string chosen to encode to a value with "-" and "_" in it.
+      // Raw bytes are '\xFA\xAB?!'.
+      var raw = sjcl.codec.hex.toBits('faab3f21');
+      var encoded = '-qs_IQ==';
+      assert.equal(base64url.encode(raw), encoded);
+      assert.deepEqual(base64url.decode(encoded), raw);
+    });
+  });
+});
+

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -43,6 +43,7 @@ function (Translator, Session) {
     '../tests/spec/lib/relier-keys',
     '../tests/spec/lib/able',
     '../tests/spec/lib/environment',
+    '../tests/spec/lib/base64url',
     '../tests/spec/head/startup-styles',
     '../tests/spec/views/base',
     '../tests/spec/views/tooltip',


### PR DESCRIPTION
So I found this un-commited test file lying around in my checkout of fxa-content-server.  I suspect it was accidentally left behind from a previous PR.  Better late than never?