### PR TITLE
WIP feat(oauth): signal action=signup or action=signin at end of oauth flow.

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -27,6 +27,8 @@ define([], function () {
     UID_LENGTH: 32,
 
     OAUTH_CODE_LENGTH: 64,
+    OAUTH_ACTION_SIGNIN: 'signin',
+    OAUTH_ACTION_SIGNUP: 'signup',
 
     RELIER_KEYS_LENGTH: 32,
     RELIER_KEYS_CONTEXT_INFO_PREFIX: 'identity.mozilla.com/picl/v1/oauth/',

--- a/app/scripts/lib/url.js
+++ b/app/scripts/lib/url.js
@@ -104,6 +104,17 @@ function (_) {
       var params = this.searchParams(str);
       delete params[name];
       return this.objToSearchString(params);
+    },
+
+    updateSearchString: function (uri, newParams) {
+      var params = {};
+      var startOfParams = uri.indexOf('?');
+      if (startOfParams >= 0) {
+        params = this.searchParams(uri.substring(startOfParams + 1));
+        uri = uri.substring(0, startOfParams);
+      }
+      _.extend(params, newParams);
+      return uri + this.objToSearchString(params);
     }
   };
 });

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -11,13 +11,16 @@
 
 define([
   'underscore',
+  'lib/constants',
   'lib/url',
   'lib/oauth-errors',
   'lib/auth-errors',
   'lib/promise',
   'lib/validate',
   'models/auth_brokers/base'
-], function (_, Url, OAuthErrors, AuthErrors, p, Validate, BaseAuthenticationBroker) {
+],
+function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
+      BaseAuthenticationBroker) {
 
   /**
    * Formats the OAuth "result.redirect" url into a {code, state} object
@@ -92,6 +95,18 @@ define([
       return p.reject(new Error('subclasses must override sendOAuthResultToRelier'));
     },
 
+    finishOAuthSignInFlow: function (account, additionalResultData) {
+      if (! additionalResultData) { additionalResultData = {}; }
+      additionalResultData.action = Constants.OAUTH_ACTION_SIGNIN;
+      return this.finishOAuthFlow(account, additionalResultData);
+    },
+
+    finishOAuthSignUpFlow: function (account, additionalResultData) {
+      if (! additionalResultData) { additionalResultData = {}; }
+      additionalResultData.action = Constants.OAUTH_ACTION_SIGNUP;
+      return this.finishOAuthFlow(account, additionalResultData);
+    },
+
     finishOAuthFlow: function (account, additionalResultData) {
       var self = this;
       return self.getOAuthResult(account)
@@ -120,7 +135,7 @@ define([
     },
 
     afterSignIn: function (account, additionalResultData) {
-      return this.finishOAuthFlow(account, additionalResultData)
+      return this.finishOAuthSignInFlow(account, additionalResultData)
         .then(function () {
           // the RP will take over from here, no need for a screen transition.
           return { halt: true };
@@ -129,12 +144,11 @@ define([
 
     afterSignUpConfirmationPoll: function (account) {
       // The original tab always finishes the OAuth flow if it is still open.
-      return this.finishOAuthFlow(account);
+      return this.finishOAuthSignUpFlow(account);
     },
 
     afterResetPasswordConfirmationPoll: function (account) {
-      // The original tab always finishes the OAuth flow if it is still open.
-      return this.finishOAuthFlow(account);
+      return this.finishOAuthSignInFlow(account);
     },
 
     transformLink: function (link) {

--- a/app/scripts/models/auth_brokers/web-channel.js
+++ b/app/scripts/models/auth_brokers/web-channel.js
@@ -11,11 +11,14 @@
 
 define([
   'underscore',
+  'lib/constants',
   'models/auth_brokers/oauth',
   'models/auth_brokers/mixins/channel',
   'lib/promise',
   'lib/channels/web'
-], function (_, OAuthAuthenticationBroker, ChannelMixin, p, WebChannel) {
+],
+function (_, Constants, OAuthAuthenticationBroker, ChannelMixin, p,
+      WebChannel) {
 
   var WebChannelAuthenticationBroker = OAuthAuthenticationBroker.extend({
     type: 'web-channel',
@@ -92,9 +95,13 @@ define([
         });
     },
 
-    afterSignIn: function (account) {
+    afterSignIn: function (account, additionalResultData) {
+      if (! additionalResultData) {
+        additionalResultData = {};
+      }
+      additionalResultData.closeWindow = true;
       return OAuthAuthenticationBroker.prototype.afterSignIn.call(
-                this, account, { closeWindow: true });
+                this, account, additionalResultData);
     },
 
     beforeSignUpConfirmationPoll: function (account) {
@@ -141,7 +148,7 @@ define([
 
     afterSignUpConfirmationPoll: function (account) {
       if (this.hasPendingOAuthFlow()) {
-        return this.finishOAuthFlow(account);
+        return this.finishOAuthSignUpFlow(account);
       }
       return p();
     },
@@ -161,14 +168,14 @@ define([
             account.set('keyFetchToken', self.session.oauth.keyFetchToken);
             account.set('unwrapBKey', self.session.oauth.unwrapBKey);
           }
-          return self.finishOAuthFlow(account);
+          return self.finishOAuthSignUpFlow(account);
         }
       });
     },
 
     afterResetPasswordConfirmationPoll: function (account) {
       if (this.hasPendingOAuthFlow()) {
-        return this.finishOAuthFlow(account);
+        return this.finishOAuthSignInFlow(account);
       }
       return p();
     },
@@ -182,7 +189,7 @@ define([
       var self = this;
       return p().delay(100).then(function () {
         if (self.hasPendingOAuthFlow()) {
-          return self.finishOAuthFlow(account);
+          return self.finishOAuthSignInFlow(account);
         }
       });
     },

--- a/app/tests/spec/lib/url.js
+++ b/app/tests/spec/lib/url.js
@@ -143,6 +143,31 @@ function (chai, _, Url) {
       });
     });
 
+    describe('updateSearchString', function () {
+      it('adds new params while leaving the old ones intact', function () {
+        var updated = Url.updateSearchString('?foo=one', {
+          bar: 'two',
+          baz: 'three'
+        });
+        assert.equal(updated, '?foo=one&bar=two&baz=three');
+      });
+
+      it('updates values for existing params', function () {
+        var updated = Url.updateSearchString('?foo=one', {
+          foo: 'two'
+        });
+        assert.equal(updated, '?foo=two');
+      });
+
+      it('adds a search string if none exists', function () {
+        var updated = Url.updateSearchString('http://example.com', {
+          foo: 'one',
+          bar: 'two'
+        });
+        assert.equal(updated, 'http://example.com?foo=one&bar=two');
+      });
+    });
+
     describe('isNavigable', function () {
       it('detects HTTP and HTTPS properly', function () {
         assert.isFalse(Url.isNavigable('urn:ietf:wg:oauth:2.0:fx:webchannel'), 'urn values are not navigable');

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -10,6 +10,7 @@ define([
   'sinon',
   'lib/session',
   'lib/promise',
+  'lib/constants',
   'lib/oauth-client',
   'lib/assertion',
   'lib/auth-errors',
@@ -18,7 +19,7 @@ define([
   'models/user',
   'models/auth_brokers/oauth'
 ],
-function (chai, sinon, Session, p, OAuthClient, Assertion, AuthErrors,
+function (chai, sinon, Session, p, Constants, OAuthClient, Assertion, AuthErrors,
       OAuthErrors, Relier, User, OAuthAuthenticationBroker) {
   var assert = chai.assert;
 
@@ -100,9 +101,12 @@ function (chai, sinon, Session, p, OAuthClient, Assertion, AuthErrors,
 
         return broker.afterSignIn(account)
           .then(function () {
-            assert.isTrue(broker.finishOAuthFlow.calledWith(account));
+            assert.isTrue(broker.finishOAuthFlow.calledWith(account, {
+              action: Constants.OAUTH_ACTION_SIGNIN
+            }));
             assert.isTrue(broker.sendOAuthResultToRelier.calledWith({
               redirect:  VALID_OAUTH_CODE_REDIRECT_URL,
+              action: Constants.OAUTH_ACTION_SIGNIN,
               state: 'state',
               code: VALID_OAUTH_CODE
             }));
@@ -138,9 +142,12 @@ function (chai, sinon, Session, p, OAuthClient, Assertion, AuthErrors,
 
         return broker.afterSignUpConfirmationPoll(account)
           .then(function () {
-            assert.isTrue(broker.finishOAuthFlow.calledWith(account));
+            assert.isTrue(broker.finishOAuthFlow.calledWith(account, {
+              action: Constants.OAUTH_ACTION_SIGNUP
+            }));
             assert.isTrue(broker.sendOAuthResultToRelier.calledWith({
               redirect:  VALID_OAUTH_CODE_REDIRECT_URL,
+              action: Constants.OAUTH_ACTION_SIGNUP,
               state: 'state',
               code: VALID_OAUTH_CODE
             }));
@@ -156,9 +163,12 @@ function (chai, sinon, Session, p, OAuthClient, Assertion, AuthErrors,
 
         return broker.afterResetPasswordConfirmationPoll(account)
           .then(function () {
-            assert.isTrue(broker.finishOAuthFlow.calledWith(account));
+            assert.isTrue(broker.finishOAuthFlow.calledWith(account, {
+              action: Constants.OAUTH_ACTION_SIGNIN
+            }));
             assert.isTrue(broker.sendOAuthResultToRelier.calledWith({
               redirect:  VALID_OAUTH_CODE_REDIRECT_URL,
+              action: Constants.OAUTH_ACTION_SIGNIN,
               state: 'state',
               code: VALID_OAUTH_CODE
             }));

--- a/app/tests/spec/models/auth_brokers/web-channel.js
+++ b/app/tests/spec/models/auth_brokers/web-channel.js
@@ -13,6 +13,7 @@ define([
   'models/user',
   'lib/fxa-client',
   'lib/promise',
+  'lib/constants',
   'lib/channels/null',
   'lib/session',
   'lib/auth-errors',
@@ -20,8 +21,7 @@ define([
   '../../../mocks/window'
 ],
 function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWrapper,
-      p, NullChannel, Session, AuthErrors, BaseView, WindowMock) {
-
+      p, Constants, NullChannel, Session, AuthErrors, BaseView, WindowMock) {
   var assert = chai.assert;
 
   describe('models/auth_brokers/web-channel', function () {
@@ -170,8 +170,10 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
 
         return broker.afterSignIn(account)
           .then(function () {
-            assert.isTrue(
-                broker.sendOAuthResultToRelier.calledWith({ closeWindow: true }));
+            assert.isTrue(broker.sendOAuthResultToRelier.calledWith({
+              action: Constants.OAUTH_ACTION_SIGNIN,
+              closeWindow: true
+            }));
             assert.isFalse(view.displayError.called);
           });
       });
@@ -221,7 +223,9 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
             return broker.afterCompleteSignUp(account);
           })
           .then(function () {
-            assert.isTrue(broker.sendOAuthResultToRelier.called);
+            assert.isTrue(broker.sendOAuthResultToRelier.calledWith({
+              action: Constants.OAUTH_ACTION_SIGNUP
+            }));
             assert.isFalse(view.displayError.called);
           });
       });
@@ -271,7 +275,9 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
             return broker.afterSignUpConfirmationPoll(account);
           })
           .then(function () {
-            assert.isTrue(broker.sendOAuthResultToRelier.called);
+            assert.isTrue(broker.sendOAuthResultToRelier.calledWith({
+              action: Constants.OAUTH_ACTION_SIGNUP
+            }));
             assert.isFalse(view.displayError.called);
           });
       });
@@ -298,7 +304,9 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
             return broker.afterCompleteResetPassword(account);
           })
           .then(function () {
-            assert.isTrue(broker.sendOAuthResultToRelier.called);
+            assert.isTrue(broker.sendOAuthResultToRelier.calledWith({
+              action: Constants.OAUTH_ACTION_SIGNIN
+            }));
             assert.isFalse(view.displayError.called);
           });
       });
@@ -325,7 +333,9 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
             return broker.afterResetPasswordConfirmationPoll(account);
           })
           .then(function () {
-            assert.isTrue(broker.sendOAuthResultToRelier.called);
+            assert.isTrue(broker.sendOAuthResultToRelier.calledWith({
+              action: Constants.OAUTH_ACTION_SIGNIN
+            }));
             assert.isFalse(view.displayError.called);
           });
       });


### PR DESCRIPTION
Here's my WIP experiment with signalling "action=signup" or "action=signin" at the end of the OAuth flow.  Most definitely now ready yet, but thought I'd put it out there early.

Fixes #2345