### PR TITLE
feat(oauth): show permission screen for untrusted reliers

### DIFF
--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -18,11 +18,11 @@ function () {
   // Should be removed in favor of #992 and #993 when implemented
   t('Subscribe to Firefox news and tips');
 
-  // Strings for the permission screen. Remove when PR #2346 lands.
-  t('%(serviceName)s would like to know…');
+  // Was needed by #2346, but later deemed unnecessary. We'll keep it around since
+  // it's already being translated and may be used in the future.
   t('By proceeding, I agree to the <a id="service-tos" href="%(termsUri)s">Terms of Service</a> and' +
     '<a id="service-pp" href="%(privacyUri)s">Privacy Notice</a> of %(serviceName)s (%(serviceUri)s).');
-  t('Proceed');
+
 
   /**
    * Replace instances of %s and %(name)s with their corresponding values in

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -27,7 +27,8 @@ define([
     verified: undefined,
     profileImageUrl: undefined,
     profileImageId: undefined,
-    lastLogin: undefined
+    lastLogin: undefined,
+    grantedPermissions: undefined
   };
 
   var DEFAULTS = _.extend({
@@ -49,7 +50,9 @@ define([
 
       if (options.accountData) {
         ALLOWED_KEYS.forEach(function (key) {
-          self.set(key, options.accountData[key]);
+          if (typeof options.accountData[key] !== 'undefined') {
+            self.set(key, options.accountData[key]);
+          }
         });
       }
 
@@ -106,11 +109,11 @@ define([
       return this.get('sessionTokenContext') === Constants.FX_DESKTOP_CONTEXT;
     },
 
-    // returns true if all attributes within ALLOWED_KEYS are undefined
-    isEmpty: function () {
+    // returns true if all attributes within ALLOWED_KEYS are defaults
+    isDefault: function () {
       var self = this;
       return ! _.find(ALLOWED_KEYS, function (key) {
-        return typeof self.get(key) !== 'undefined';
+        return self.get(key) !== DEFAULTS[key];
       });
     },
 
@@ -174,6 +177,62 @@ define([
         .then(function () {
           return profileImage;
         });
+    },
+
+    signIn: function (relier) {
+      var self = this;
+      return p().then(function () {
+        var password = self.get('password');
+        var sessionToken = self.get('sessionToken');
+        var email = self.get('email');
+
+        if (password) {
+          return self._fxaClient.signIn(email, password, relier);
+        } else if (sessionToken) {
+          // We have a cached Sync session so just check that it hasn't expired.
+          // The result includes the latest verified state
+          return self._fxaClient.recoveryEmailStatus(sessionToken);
+        } else {
+          throw AuthErrors.toError('UNEXPECTED_ERROR');
+        }
+      })
+      .then(function (updatedSessionData) {
+        self.set(updatedSessionData);
+
+        if (! self.get('verified')) {
+          return self._fxaClient.signUpResend(relier, self.get('sessionToken'));
+        }
+      });
+    },
+
+    signUp: function (relier) {
+      var self = this;
+      return self._fxaClient.signUp(self.get('email'), self.get('password'), relier,
+        {
+          customizeSync: self.get('customizeSync')
+        })
+        .then(function (updatedSessionData) {
+          self.set(updatedSessionData);
+        });
+    },
+
+    saveGrantedPermissions: function (clientId, clientPermissions) {
+      var permissions = this.get('grantedPermissions') || {};
+      permissions[clientId] = clientPermissions;
+      this.set('grantedPermissions', permissions);
+    },
+
+    hasGrantedPermissions: function (clientId, scope) {
+      if (! scope) {
+        return true;
+      }
+      return this.ungrantedPermissions(clientId, scope).length === 0;
+    },
+
+    ungrantedPermissions: function (clientId, clientPermissions) {
+      var permissions = this.get('grantedPermissions') || {};
+      var clientGrantedPermissions = permissions[clientId] || [];
+      return _.difference(clientPermissions, clientGrantedPermissions);
     }
   });
 

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -212,13 +212,6 @@ define([
      */
     isAutomatedBrowser: function () {
       return !! this.get('automatedBrowser');
-    },
-
-    /**
-     * Indicates wether the permissions screen should be shown during sign in/up
-     */
-    shouldPromptForPermissions: function (/* account */) {
-      return false;
     }
   });
 

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -212,6 +212,13 @@ define([
      */
     isAutomatedBrowser: function () {
       return !! this.get('automatedBrowser');
+    },
+
+    /**
+     * Indicates wether the permissions screen should be shown during sign in/up
+     */
+    shouldPromptForPermissions: function (/* account */) {
+      return false;
     }
   });
 

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -138,16 +138,7 @@ define([
 
     transformLink: function (link) {
       return '/oauth' + link;
-    },
-
-    shouldPromptForPermissions: function (account) {
-      var relier = this.relier;
-      if (relier.isTrusted()) {
-        return false;
-      }
-      return ! account.hasGrantedPermissions(relier.get('clientId'), relier.get('permissions'));
     }
-
   });
 
   return OAuthAuthenticationBroker;

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -138,7 +138,16 @@ define([
 
     transformLink: function (link) {
       return '/oauth' + link;
+    },
+
+    shouldPromptForPermissions: function (account) {
+      var relier = this.relier;
+      if (relier.isTrusted()) {
+        return false;
+      }
+      return ! account.hasGrantedPermissions(relier.get('clientId'), relier.get('permissions'));
     }
+
   });
 
   return OAuthAuthenticationBroker;

--- a/app/scripts/models/reliers/base.js
+++ b/app/scripts/models/reliers/base.js
@@ -89,6 +89,13 @@ define([
      */
     allowCachedCredentials: function () {
       return true;
+    },
+
+    /**
+     * Indicates whether the relier is trusted
+     */
+    isTrusted: function () {
+      return true;
     }
   });
 

--- a/app/scripts/models/reliers/base.js
+++ b/app/scripts/models/reliers/base.js
@@ -96,6 +96,13 @@ define([
      */
     isTrusted: function () {
       return true;
+    },
+
+    /**
+     * Indicate whether the given accounts needs any additional permissions
+     */
+    accountNeedsPermissions: function (/* account */) {
+      return false;
     }
   });
 

--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -185,6 +185,14 @@ define([
 
     isTrusted: function () {
       return this.get('trusted');
+    },
+
+    accountNeedsPermissions: function (account) {
+      if (this.isTrusted()) {
+        return false;
+      }
+
+      return ! account.hasGrantedPermissions(this.get('clientId'), this.get('permissions'));
     }
   });
 

--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -56,6 +56,10 @@ define([
           if (! self.has('service')) {
             self.set('service', self.get('clientId'));
           }
+          if (self.has('scope')) {
+            // Turn the scope string into an array of permissions
+            self.set('permissions', scopeStrToArray(self.get('scope')));
+          }
 
           return self._setupOAuthRPInfo();
         });
@@ -159,7 +163,13 @@ define([
           //jshint camelcase: false
           // server version always takes precedent over the search parameter
           self.set('redirectUri', serviceInfo.redirect_uri);
+          self.set('termsUri', serviceInfo.terms_uri);
+          self.set('privacyUri', serviceInfo.privacy_uri);
+          self.set('trusted', serviceInfo.trusted);
           self.set('origin', Url.getOrigin(serviceInfo.redirect_uri));
+
+          self.set('serviceUri', self.get('origin').replace(/https?:\/\//, ''));
+
         }, function (err) {
           // the server returns an invalid request signature for an
           // invalid/unknown client_id
@@ -171,8 +181,16 @@ define([
           }
           throw err;
         });
+    },
+
+    isTrusted: function () {
+      return this.get('trusted');
     }
   });
+
+  function scopeStrToArray(scopes) {
+    return typeof scopes === 'string' ? _.uniq(scopes.split(/\s+/g)) : scopes;
+  }
 
   return OAuthRelier;
 });

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -34,7 +34,8 @@ define([
   'views/delete_account',
   'views/cookies_disabled',
   'views/clear_storage',
-  'views/unexpected_error'
+  'views/unexpected_error',
+  'views/permissions'
 ],
 function (
   _,
@@ -66,7 +67,8 @@ function (
   DeleteAccountView,
   CookiesDisabledView,
   ClearStorageView,
-  UnexpectedErrorView
+  UnexpectedErrorView,
+  PermissionsView
 ) {
 
   function showView(View, options) {
@@ -79,12 +81,14 @@ function (
     routes: {
       '(/)': 'redirectToSignupOrSettings',
       'signin(/)': showView(SignInView),
+      'signin_permissions(/)': showView(PermissionsView, { type: 'sign_in' }),
       'oauth(/)': 'redirectToBestOAuthChoice',
       'oauth/signin(/)': showView(SignInView),
       'oauth/signup(/)': showView(SignUpView),
       'oauth/force_auth(/)': showView(ForceAuthView),
       'signup(/)': showView(SignUpView),
       'signup_complete(/)': showView(ReadyView, { type: 'sign_up' }),
+      'signup_permissions(/)': showView(PermissionsView, { type: 'sign_up' }),
       'cannot_create_account(/)': showView(CannotCreateAccountView),
       'verify_email(/)': showView(CompleteSignUpView),
       'confirm(/)': showView(ConfirmView),
@@ -164,7 +168,7 @@ function (
       var account = this.user.getChooserAccount();
       var route = '/oauth/signin';
 
-      if (account.isEmpty()) {
+      if (account.isDefault()) {
         route = '/oauth/signup';
       }
 

--- a/app/scripts/templates/permissions.mustache
+++ b/app/scripts/templates/permissions.mustache
@@ -1,0 +1,26 @@
+<div id="main-content" class="card">
+  <header>
+    <h1 id="fxa-permissions-header">{{#t}}%(serviceName)s would like to know…{{/t}}</h1>
+  </header>
+
+  <section>
+    <div class="error"></div>
+    <div class="success"></div>
+
+    <p id="permissions">
+      <span class="permission">{{#t}}Email{{/t}}</span>
+      <span class="value">{{ email }}</span>
+    </p>
+
+    <form novalidate>
+      <div class="button-row">
+        <button id="proceed" type="submit">{{#t}}Proceed{{/t}}</button>
+      </div>
+    </form>
+
+    <ul class="links permission-links">
+      <li><a href="#" id="back">{{#t}}Cancel{{/t}}</a></li>
+    </ul>
+
+  </section>
+</div>

--- a/app/scripts/views/confirm_account_unlock.js
+++ b/app/scripts/views/confirm_account_unlock.js
@@ -69,7 +69,7 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
       // browsing directly to the page should not be allowed.
       var self = this;
       return p().then(function () {
-        if (self.getAccount().isEmpty()) {
+        if (self.getAccount().isDefault()) {
           self.navigate('signup');
           return false;
         }

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -74,12 +74,12 @@ function (Cocktail, p, BaseView, FormView, SignInView, PasswordMixin,
       return this._signIn(account);
     },
 
-    onSignInError: function (err) {
+    onSignInError: function (account, err) {
       if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
         // dead end, do not allow the user to sign up.
         this.displayError(err);
       } else {
-        return SignInView.prototype.onSignInError.call(this, err);
+        return SignInView.prototype.onSignInError.call(this, account, err);
       }
     },
 

--- a/app/scripts/views/mixins/settings-mixin.js
+++ b/app/scripts/views/mixins/settings-mixin.js
@@ -24,7 +24,7 @@ define([
       // it exists in our list of cached accounts. If it doesn't,
       // clear the current account.
       // The `mustVerify` flag will ensure that the account is valid.
-      if (! self.user.getAccountByUid(uid).isEmpty()) {
+      if (! self.user.getAccountByUid(uid).isDefault()) {
         // The account with uid exists; set it to our current account.
         self.user.setSignedInAccountByUid(uid);
       } else if (uid) {

--- a/app/scripts/views/permissions.js
+++ b/app/scripts/views/permissions.js
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'cocktail',
+  'underscore',
+  'views/form',
+  'views/base',
+  'stache!templates/permissions',
+  'lib/promise',
+  'views/mixins/back-mixin',
+  'views/mixins/service-mixin'
+],
+function (Cocktail, _, FormView, BaseView, Template, p,
+    BackMixin, ServiceMixin) {
+
+  var View = FormView.extend({
+    template: Template,
+    className: 'permissions',
+
+    initialize: function (options) {
+      // Account data is passed in from sign up and sign in flows.
+      var data = this.ephemeralData();
+      this._account = data && this.user.initAccount(data.account);
+
+      this.type = options.type;
+    },
+
+    getAccount: function () {
+      return this._account;
+    },
+
+    context: function () {
+      var account = this.getAccount();
+      return {
+        email: account.get('email'),
+        serviceName: this.relier.get('serviceName'),
+        termsUri: this.relier.get('termsUri'),
+        privacyUri: this.relier.get('privacyUri'),
+        serviceUri: this.relier.get('serviceUri')
+      };
+    },
+
+    beforeRender: function () {
+      // user cannot proceed if they have not initiated a sign up/in.
+      if (! this.getAccount().get('sessionToken')) {
+        this.navigate(this._previousScreen());
+        return false;
+      }
+    },
+
+    submit: function () {
+      var self = this;
+      var account = self.getAccount();
+
+      self.logScreenEvent('proceed');
+
+      return p().then(function () {
+        account.saveGrantedPermissions(self.relier.get('clientId'), self.relier.get('permissions'));
+        self.user.setAccount(account);
+
+        if (self.is('sign_up')) {
+          return self.onSignUpSuccess(account);
+        } else if (account.get('verified')) {
+          return self.onSignInSuccess(account);
+        }
+        return self.onSignInUnverified(account);
+      });
+    },
+
+    onSignUpSuccess: function (account) {
+      var self = this;
+      if (account.get('verified')) {
+        // user was pre-verified, notify the broker.
+        return self.broker.afterSignIn(account)
+          .then(function (result) {
+            if (! (result && result.halt)) {
+              self.navigate('signup_complete');
+            }
+          });
+      } else {
+        self.navigate('confirm', {
+          data: {
+            account: account
+          }
+        });
+      }
+    },
+
+    onSignInSuccess: function (account) {
+      var self = this;
+      self.logScreenEvent('success');
+      return self.broker.afterSignIn(account)
+        .then(function (result) {
+          if (! (result && result.halt)) {
+            self.navigate('settings');
+          }
+
+          return result;
+        });
+    },
+
+    onSignInUnverified: function (account) {
+      this.navigate('confirm', {
+        data: {
+          account: account
+        }
+      });
+    },
+
+    _previousScreen: function () {
+      var page = this.is('sign_up') ? '/signup' : '/signin';
+      return this.broker.transformLink(page);
+    },
+
+    is: function (type) {
+      return this.type === type;
+    }
+  });
+
+  Cocktail.mixin(
+    View,
+    ServiceMixin,
+    BackMixin
+  );
+
+  return View;
+});

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -118,7 +118,7 @@ function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
           return self.user.signInAccount(account, self.relier);
         })
         .then(function (account) {
-          if (self.broker.shouldPromptForPermissions(account)) {
+          if (self.relier.accountNeedsPermissions(account)) {
             self.navigate('signin_permissions', {
               data: {
                 account: account

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -256,7 +256,7 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
           }
           self.logScreenEvent('success');
 
-          if (self.broker.shouldPromptForPermissions(account)) {
+          if (self.relier.accountNeedsPermissions(account)) {
             self.navigate('signup_permissions', {
               data: {
                 account: account

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -205,7 +205,7 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
     },
 
     _isEmailFirefoxDomain: function () {
-      var email = this.$('.email').val();
+      var email = this.getElementValue('.email');
 
       // some users input a "@firefox.com" email.
       // this is not a valid email at this time, therefore we block the attempt.
@@ -230,54 +230,45 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
 
     _initAccount: function () {
       var self = this;
-      var email = self.$('.email').val();
-      var password = self.$('.password').val();
-      var customizeSync = self.$('.customize-sync').is(':checked');
+
       var preVerifyToken = self.relier.get('preVerifyToken');
+      var account = self.user.initAccount({
+        email: self.getElementValue('.email'),
+        password: self.getElementValue('.password'),
+        customizeSync: self.$('.customize-sync').is(':checked')
+      });
 
       if (preVerifyToken) {
         self.logScreenEvent('preverified');
       }
 
       if (self.relier.isSync()) {
-        self.logScreenEvent('customizeSync.' + String(customizeSync));
+        self.logScreenEvent('customizeSync.' + String(account.get('customizeSync')));
       }
 
-      return self.broker.beforeSignIn(email)
+      return self.broker.beforeSignIn(account.get('email'))
         .then(function () {
-          return self.fxaClient.signUp(
-                        email, password, self.relier, {
-                          customizeSync: customizeSync
-                        });
-        }).then(function (accountData) {
-          var account = self.user.initAccount(accountData);
-
+          return self.user.signUpAccount(account, self.relier);
+        })
+        .then(function (account) {
           if (preVerifyToken && account.get('verified')) {
             self.logScreenEvent('preverified.success');
           }
           self.logScreenEvent('success');
 
-          return self.user.setSignedInAccount(account)
-            .then(function () {
-              return account;
+          if (self.broker.shouldPromptForPermissions(account)) {
+            self.navigate('signup_permissions', {
+              data: {
+                account: account
+              }
             });
-        })
-        .then(_.bind(self.onSignUpSuccess, self))
-        .then(null, function (err) {
-          // Account already exists. No attempt is made at signing the
-          // user in directly, instead, point the user to the signin page
-          // where the entered email/password will be prefilled.
-          if (AuthErrors.is(err, 'ACCOUNT_ALREADY_EXISTS')) {
-            return self._suggestSignIn(err);
-          } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
-            self.logEvent('login.canceled');
-            // if user canceled login, just stop
+
             return;
           }
 
-          // re-throw error, it will be handled at a lower level.
-          throw err;
-        });
+          return self.onSignUpSuccess(account);
+        })
+        .fail(_.bind(self.signUpError, self));
     },
 
     onSignUpSuccess: function (account) {
@@ -297,6 +288,23 @@ function (Cocktail, _, p, BaseView, FormView, Template, Session, AuthErrors,
           }
         });
       }
+    },
+
+    signUpError: function (err) {
+      var self = this;
+      // Account already exists. No attempt is made at signing the
+      // user in directly, instead, point the user to the signin page
+      // where the entered email/password will be prefilled.
+      if (AuthErrors.is(err, 'ACCOUNT_ALREADY_EXISTS')) {
+        return self._suggestSignIn(err);
+      } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
+        self.logEvent('login.canceled');
+        // if user canceled login, just stop
+        return;
+      }
+
+      // re-throw error, it will be handled at a lower level.
+      throw err;
     },
 
     _suggestSignIn: function (err) {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -31,6 +31,7 @@ $text-color: #424f59;
 $faint-text-color: #8a9ba8;
 $cropper-background-color: #000;
 $horizontal-rule-color: #e4e4e4;
+$permissions-border-color: #c3cfd8;
 
 //Font-Size Variables
 $large-font: 24px;

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -132,6 +132,7 @@ ul.links {
   border: 1px solid $permissions-border-color;
   text-align: left;
   padding: 10px;
+  word-wrap: break-word;
 
   .permission {
     font-size: $base-font;

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -126,3 +126,25 @@ ul.links {
   top: 0;
   z-index: 1;
 }
+
+#permissions {
+  border-radius: $big-border-radius;
+  border: 1px solid $permissions-border-color;
+  text-align: left;
+  padding: 10px;
+
+  .permission {
+    font-size: $base-font;
+  }
+  .value {
+    display: block;
+  }
+}
+
+
+ul.permission-links {
+  li {
+    margin:  0;
+    padding: 0;
+  }
+}

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -127,6 +127,12 @@ function (chai, sinon, Relier, BaseAuthenticationBroker, BaseView, WindowMock) {
           });
       });
     });
+
+    describe('shouldPromptForPermissions', function () {
+      it('returns `false`', function () {
+        assert.isFalse(broker.shouldPromptForPermissions());
+      });
+    });
   });
 });
 

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -127,12 +127,6 @@ function (chai, sinon, Relier, BaseAuthenticationBroker, BaseView, WindowMock) {
           });
       });
     });
-
-    describe('shouldPromptForPermissions', function () {
-      it('returns `false`', function () {
-        assert.isFalse(broker.shouldPromptForPermissions());
-      });
-    });
   });
 });
 

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -260,6 +260,45 @@ function (chai, sinon, Session, p, OAuthClient, Assertion, AuthErrors,
         assert.equal(transformed, '/oauth/signin');
       });
     });
+
+    describe('shouldPromptForPermissions', function () {
+      it('should not prompt when relier is trusted', function () {
+        sinon.stub(relier, 'isTrusted', function () {
+          return true;
+        });
+        assert.isFalse(broker.shouldPromptForPermissions(user.initAccount()));
+        assert.isTrue(relier.isTrusted.called);
+      });
+
+      it('should not prompt when relier is untrusted and has permissions', function () {
+        var account = user.initAccount();
+        sinon.stub(relier, 'isTrusted', function () {
+          return false;
+        });
+        sinon.stub(account, 'hasGrantedPermissions', function () {
+          return true;
+        });
+        relier.set('permissions', ['profile:email']);
+        assert.isFalse(broker.shouldPromptForPermissions(account));
+        assert.isTrue(relier.isTrusted.called);
+        assert.isTrue(account.hasGrantedPermissions.calledWith(relier.get('clientId'), ['profile:email']));
+      });
+
+      it('should prompt when relier is untrusted and needs permissions', function () {
+        var account = user.initAccount();
+        sinon.stub(relier, 'isTrusted', function () {
+          return false;
+        });
+        sinon.stub(account, 'hasGrantedPermissions', function () {
+          return false;
+        });
+        relier.set('permissions', ['profile:email']);
+        assert.isTrue(broker.shouldPromptForPermissions(account));
+        assert.isTrue(relier.isTrusted.called);
+        assert.isTrue(account.hasGrantedPermissions.calledWith(relier.get('clientId'), ['profile:email']));
+      });
+    });
+
   });
 });
 

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -261,44 +261,6 @@ function (chai, sinon, Session, p, OAuthClient, Assertion, AuthErrors,
       });
     });
 
-    describe('shouldPromptForPermissions', function () {
-      it('should not prompt when relier is trusted', function () {
-        sinon.stub(relier, 'isTrusted', function () {
-          return true;
-        });
-        assert.isFalse(broker.shouldPromptForPermissions(user.initAccount()));
-        assert.isTrue(relier.isTrusted.called);
-      });
-
-      it('should not prompt when relier is untrusted and has permissions', function () {
-        var account = user.initAccount();
-        sinon.stub(relier, 'isTrusted', function () {
-          return false;
-        });
-        sinon.stub(account, 'hasGrantedPermissions', function () {
-          return true;
-        });
-        relier.set('permissions', ['profile:email']);
-        assert.isFalse(broker.shouldPromptForPermissions(account));
-        assert.isTrue(relier.isTrusted.called);
-        assert.isTrue(account.hasGrantedPermissions.calledWith(relier.get('clientId'), ['profile:email']));
-      });
-
-      it('should prompt when relier is untrusted and needs permissions', function () {
-        var account = user.initAccount();
-        sinon.stub(relier, 'isTrusted', function () {
-          return false;
-        });
-        sinon.stub(account, 'hasGrantedPermissions', function () {
-          return false;
-        });
-        relier.set('permissions', ['profile:email']);
-        assert.isTrue(broker.shouldPromptForPermissions(account));
-        assert.isTrue(relier.isTrusted.called);
-        assert.isTrue(account.hasGrantedPermissions.calledWith(relier.get('clientId'), ['profile:email']));
-      });
-    });
-
   });
 });
 

--- a/app/tests/spec/models/reliers/base.js
+++ b/app/tests/spec/models/reliers/base.js
@@ -85,6 +85,12 @@ define([
         assert.isTrue(relier.allowCachedCredentials());
       });
     });
+
+    describe('isTrusted', function () {
+      it('returns `true`', function () {
+        assert.isTrue(relier.isTrusted());
+      });
+    });
   });
 });
 

--- a/app/tests/spec/models/reliers/base.js
+++ b/app/tests/spec/models/reliers/base.js
@@ -91,6 +91,12 @@ define([
         assert.isTrue(relier.isTrusted());
       });
     });
+
+    describe('accountNeedsPermissions', function () {
+      it('returns `false`', function () {
+        assert.isFalse(relier.accountNeedsPermissions());
+      });
+    });
   });
 });
 

--- a/app/tests/spec/views/confirm_account_unlock.js
+++ b/app/tests/spec/views/confirm_account_unlock.js
@@ -98,7 +98,7 @@ function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient,
 
     describe('beforeRender', function () {
       it('redirects users who browse directly to the page to /signup', function () {
-        sinon.stub(account, 'isEmpty', function () {
+        sinon.stub(account, 'isDefault', function () {
           return true;
         });
 

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -92,7 +92,7 @@ function (chai, $, sinon, View, Session, FxaClient, p, AuthErrors, Relier,
 
       describe('submit', function () {
         it('is able to submit the form on click', function (done) {
-          sinon.stub(view.fxaClient, 'signIn', function () {
+          sinon.stub(user, 'signInAccount', function () {
             done();
           });
           view.$('#submit-btn').click();
@@ -100,20 +100,16 @@ function (chai, $, sinon, View, Session, FxaClient, p, AuthErrors, Relier,
 
         it('submits the sign in', function () {
           var password = 'password';
-          sinon.stub(view.fxaClient, 'signIn', function () {
-            return p({
-              verified: true
-            });
-          });
-          sinon.stub(view.fxaClient, 'recoveryEmailStatus', function () {
-            return p.reject(assert.fail);
+          sinon.stub(user, 'signInAccount', function (account) {
+            account.set('verified', true);
+            return p(account);
           });
           view.$('input[type=password]').val(password);
 
           return view.submit()
             .then(function () {
-              assert.isTrue(view.fxaClient.signIn.calledWith(
-                  email, password, relier));
+              assert.equal(user.signInAccount.args[0][0].get('email'), email);
+              assert.equal(user.signInAccount.args[0][0].get('password'), password);
             });
         });
       });
@@ -245,7 +241,7 @@ function (chai, $, sinon, View, Session, FxaClient, p, AuthErrors, Relier,
 
       describe('submit', function () {
         it('prints an error message and does not allow the user to sign up', function () {
-          sinon.stub(view.fxaClient, 'signIn', function () {
+          sinon.stub(user, 'signInAccount', function () {
             return p.reject(AuthErrors.toError('UNKNOWN_ACCOUNT'));
           });
 

--- a/app/tests/spec/views/oauth_sign_in.js
+++ b/app/tests/spec/views/oauth_sign_in.js
@@ -122,7 +122,7 @@ function (chai, $, sinon, View, Session, FxaClient, p, Metrics, OAuthRelier,
           account.set('verified', true);
           return p(account);
         });
-        sinon.stub(broker, 'shouldPromptForPermissions', function () {
+        sinon.stub(relier, 'accountNeedsPermissions', function () {
           return false;
         });
         sinon.stub(broker, 'afterSignIn', function () {

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -154,7 +154,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, AuthErrors,
           return p(account);
         });
 
-        sinon.stub(broker, 'shouldPromptForPermissions', function () {
+        sinon.stub(relier, 'accountNeedsPermissions', function () {
           return false;
         });
 
@@ -184,7 +184,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, AuthErrors,
         sinon.stub(user, 'signUpAccount', function (account) {
           return p(account);
         });
-        sinon.stub(broker, 'shouldPromptForPermissions', function () {
+        sinon.stub(relier, 'accountNeedsPermissions', function () {
           return true;
         });
         sinon.stub(view, 'navigate', function () { });
@@ -196,7 +196,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, AuthErrors,
             assert.equal(account.get('email'), email);
             assert.isTrue(broker.beforeSignIn.calledWith(email));
             assert.isTrue(user.signUpAccount.calledWith(account));
-            assert.isTrue(broker.shouldPromptForPermissions.calledWith(account));
+            assert.isTrue(relier.accountNeedsPermissions.calledWith(account));
             assert.isTrue(view.navigate.calledWith('signup_permissions', {
               data: {
                 account: account
@@ -215,7 +215,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, AuthErrors,
         sinon.stub(broker, 'afterSignIn', function () {
           return p();
         });
-        sinon.stub(broker, 'shouldPromptForPermissions', function () {
+        sinon.stub(relier, 'accountNeedsPermissions', function () {
           return false;
         });
 
@@ -240,7 +240,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, AuthErrors,
           account.set('verified', false);
           return p(account);
         });
-        sinon.stub(broker, 'shouldPromptForPermissions', function () {
+        sinon.stub(relier, 'accountNeedsPermissions', function () {
           return false;
         });
 

--- a/app/tests/spec/views/permissions.js
+++ b/app/tests/spec/views/permissions.js
@@ -1,0 +1,212 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+
+define([
+  'chai',
+  'jquery',
+  'sinon',
+  'lib/promise',
+  'views/permissions',
+  'lib/auth-errors',
+  'lib/metrics',
+  'lib/fxa-client',
+  'lib/ephemeral-messages',
+  'lib/constants',
+  'models/reliers/relier',
+  'models/user',
+  'models/auth_brokers/base',
+  '../../mocks/window',
+  '../../mocks/router',
+  '../../lib/helpers'
+],
+function (chai, $, sinon, p, View, AuthErrors, Metrics, FxaClient,
+      EphemeralMessages, Constants, Relier, User, Broker, WindowMock, RouterMock,
+      TestHelpers) {
+  var assert = chai.assert;
+
+  describe('views/permissions', function () {
+    var view;
+    var email;
+    var routerMock;
+    var metrics;
+    var windowMock;
+    var fxaClient;
+    var relier;
+    var broker;
+    var user;
+    var ephemeralMessages;
+    var account;
+    var SERVICE_NAME = 'Relier';
+    var CLIENT_ID = 'relier';
+    var SERVICE_URI = 'relier.com';
+    var EMAIL = 'a@a.com';
+    var PERMISSIONS = ['profile:email', 'profile:uid'];
+
+    beforeEach(function () {
+      email = TestHelpers.createEmail();
+
+      routerMock = new RouterMock();
+      windowMock = new WindowMock();
+      metrics = new Metrics();
+      relier = new Relier();
+      relier.set({
+        clientId: CLIENT_ID,
+        serviceName: SERVICE_NAME,
+        serviceUri: SERVICE_URI,
+        permissions: PERMISSIONS
+      });
+      broker = new Broker();
+      fxaClient = new FxaClient();
+      user = new User({
+        fxaClient: fxaClient
+      });
+      ephemeralMessages = new EphemeralMessages();
+      account = user.initAccount({
+        email: EMAIL,
+        uid: 'uid',
+        sessionToken: 'fake session token'
+      });
+      ephemeralMessages.set('data', {
+        account: account
+      });
+    });
+
+    afterEach(function () {
+      metrics.destroy();
+
+      view.remove();
+      view.destroy();
+
+      view = metrics = null;
+    });
+
+    function initView (type) {
+      view = new View({
+        router: routerMock,
+        metrics: metrics,
+        window: windowMock,
+        fxaClient: fxaClient,
+        user: user,
+        relier: relier,
+        broker: broker,
+        screenName: 'permissions',
+        ephemeralMessages: ephemeralMessages,
+        type: type
+      });
+
+      return view.render()
+        .then(function () {
+          $('#container').html(view.el);
+        });
+    }
+
+    describe('renders', function () {
+      it('coming from sign in, redirects to /signin when session token missing', function () {
+        account.clear('sessionToken');
+        return initView('sign_in')
+          .then(function () {
+            assert.equal(routerMock.page, '/signin');
+          });
+      });
+      it('coming from sign up, redirects to /signup when session token missing', function () {
+        account.clear('sessionToken');
+        return initView('sign_up')
+          .then(function () {
+            assert.equal(routerMock.page, '/signup');
+          });
+      });
+      it('renders relier info', function () {
+        return initView('sign_up')
+          .then(function () {
+            assert(!! view.$('#fxa-permissions-header').text().match(SERVICE_NAME),
+              'service name shows in header');
+
+            assert(!! view.$('#permissions').text().match(EMAIL),
+              'shows email in permissions list');
+          });
+      });
+    });
+
+    describe('submit', function () {
+      beforeEach(function () {
+        sinon.spy(account, 'saveGrantedPermissions');
+        sinon.spy(user, 'setAccount');
+      });
+      it('coming from sign in, redirects unverified users to the confirm page on success', function () {
+        return initView('sign_in')
+          .then(function () {
+            sinon.spy(view, 'navigate');
+
+            return view.submit()
+              .then(function () {
+                assert.isTrue(account.saveGrantedPermissions.calledWith(CLIENT_ID, PERMISSIONS));
+                assert.isTrue(user.setAccount.calledWith(account));
+                assert.isTrue(view.navigate.calledWith('confirm', {
+                  data: { account: account }
+                }));
+              });
+          });
+      });
+
+      it('coming from sign up, redirects unverified users to the confirm page on success', function () {
+        return initView('sign_up')
+          .then(function () {
+            sinon.spy(view, 'navigate');
+
+            return view.submit()
+              .then(function () {
+                assert.isTrue(account.saveGrantedPermissions.calledWith(CLIENT_ID, PERMISSIONS));
+                assert.isTrue(user.setAccount.calledWith(account));
+                assert.isTrue(view.navigate.calledWith('confirm', {
+                  data: { account: account }
+                }));
+              });
+          });
+      });
+
+      it('notifies the broker when a verified user signs in', function () {
+        sinon.stub(broker, 'afterSignIn', function () {
+          return p();
+        });
+
+        return initView('sign_in')
+          .then(function () {
+            account.set('verified', true);
+            return view.submit()
+              .then(function () {
+                assert.isTrue(account.saveGrantedPermissions.calledWith(CLIENT_ID, PERMISSIONS));
+                assert.isTrue(user.setAccount.calledWith(account));
+                assert.isTrue(TestHelpers.isEventLogged(metrics,
+                                  'permissions.success'));
+                assert.isTrue(broker.afterSignIn.calledWith(account));
+                assert.equal(routerMock.page, 'settings');
+              });
+          });
+      });
+
+      it('notifies the broker when a pre-verified user signs up', function () {
+        sinon.stub(broker, 'afterSignIn', function () {
+          return p();
+        });
+
+        return initView('sign_up')
+          .then(function () {
+            account.set('verified', true);
+            return view.submit()
+              .then(function () {
+                assert.isTrue(account.saveGrantedPermissions.calledWith(CLIENT_ID, PERMISSIONS));
+                assert.isTrue(user.setAccount.calledWith(account));
+                assert.isTrue(broker.afterSignIn.calledWith(account));
+                assert.equal(routerMock.page, 'signup_complete');
+              });
+          });
+      });
+
+    });
+
+  });
+});

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -174,7 +174,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
           account.set('sessionToken', sessionToken);
           return p(account);
         });
-        sinon.stub(broker, 'shouldPromptForPermissions', function () {
+        sinon.stub(relier, 'accountNeedsPermissions', function () {
           return true;
         });
         sinon.stub(view, 'navigate', function () { });
@@ -191,7 +191,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
             assert.equal(account.get('sessionToken'), sessionToken);
             assert.isTrue(broker.beforeSignIn.calledWith(email));
             assert.isTrue(user.signInAccount.calledWith(account, relier));
-            assert.isTrue(broker.shouldPromptForPermissions.calledWith(account));
+            assert.isTrue(relier.accountNeedsPermissions.calledWith(account));
             assert.isTrue(view.navigate.calledWith('signin_permissions', {
               data: {
                 account: account
@@ -208,7 +208,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
           account.set('verified', false);
           return p(account);
         });
-        sinon.stub(broker, 'shouldPromptForPermissions', function () {
+        sinon.stub(relier, 'accountNeedsPermissions', function () {
           return false;
         });
 
@@ -232,7 +232,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
           account.set('verified', true);
           return p(account);
         });
-        sinon.stub(broker, 'shouldPromptForPermissions', function () {
+        sinon.stub(relier, 'accountNeedsPermissions', function () {
           return false;
         });
         sinon.stub(broker, 'afterSignIn', function () {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -400,7 +400,7 @@ function (chai, _, $, moment, sinon, p, View, Coppa, Session, AuthErrors, Metric
         sinon.stub(user, 'signUpAccount', function (account) {
           return p(account);
         });
-        sinon.stub(broker, 'shouldPromptForPermissions', function () {
+        sinon.stub(relier, 'accountNeedsPermissions', function () {
           return true;
         });
         sinon.stub(view, 'navigate', function () { });
@@ -412,7 +412,7 @@ function (chai, _, $, moment, sinon, p, View, Coppa, Session, AuthErrors, Metric
             assert.equal(account.get('email'), email);
             assert.isTrue(broker.beforeSignIn.calledWith(email));
             assert.isTrue(user.signUpAccount.calledWith(account));
-            assert.isTrue(broker.shouldPromptForPermissions.calledWith(account));
+            assert.isTrue(relier.accountNeedsPermissions.calledWith(account));
             assert.isTrue(view.navigate.calledWith('signup_permissions', {
               data: {
                 account: account

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -66,6 +66,7 @@ function (Translator, Session) {
     '../tests/spec/views/change_password',
     '../tests/spec/views/delete_account',
     '../tests/spec/views/confirm',
+    '../tests/spec/views/permissions',
     '../tests/spec/views/tos',
     '../tests/spec/views/pp',
     '../tests/spec/views/reset_password',

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "sjcl": "1.0.2",
     "speed-trap": "0.0.5",
     "tos-pp": "https://github.com/mozilla/legal-docs.git",
-    "underscore": "1.5.2",
+    "underscore": "1.8.3",
     "jquery-ui": "1.11.0",
     "JavaScript-MD5": "1.1.0",
     "jquery-ui-touch-punch": "https://github.com/zaach/jquery-ui-touch-punch.git#89e5a9159494de37df1e09cccf9036dda5429830",

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -146,10 +146,14 @@ The event stream is a log of events and the time they occurred while the user is
 * signin.ask-password.shown.email-mismatch - asked for password due to using a different email
 * signin.ask-password.shown.session-from-web - asked for password because session was created via web content
 * signin.ask-password.shown.session-expired - asked for password due to expired session token
-
+#### signin_permissions
+* proceed - user proceeds and grants the requested permissions
 #### signup
 * tooltip.mailcheck-suggested - an email address correction was suggested
 * tooltip.mailcheck-used - an email address correction was chosen by the user
 * tooltip.mailcheck-dismissed - an email address correction tooltip was dismissed without the selection being made.
+#### signup_permissions
+* proceed - user proceeds and grants the requested permissions
+
 #### tos
 #### unexpected_error

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -147,13 +147,14 @@ The event stream is a log of events and the time they occurred while the user is
 * signin.ask-password.shown.session-from-web - asked for password because session was created via web content
 * signin.ask-password.shown.session-expired - asked for password due to expired session token
 #### signin_permissions
-* proceed - user proceeds and grants the requested permissions
+* signin-permissions.proceed - user proceeds and grants the requested permissions
+* signin-permissions.success - sign in successfully occurred
 #### signup
 * tooltip.mailcheck-suggested - an email address correction was suggested
 * tooltip.mailcheck-used - an email address correction was chosen by the user
 * tooltip.mailcheck-dismissed - an email address correction tooltip was dismissed without the selection being made.
 #### signup_permissions
-* proceed - user proceeds and grants the requested permissions
+* signup-permissions.proceed - user proceeds and grants the requested permissions
 
 #### tos
 #### unexpected_error

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-sauce": "intern-runner config=tests/intern_sauce",
     "test-travis": "intern-runner config=tests/intern_travis",
     "test-server": "intern-client config=tests/intern_server",
-    "test-latest": "intern-runner config=tests/intern_functional_full fxaAuthRoot=https://latest.dev.lcip.org/auth/v1 fxaContentRoot=https://latest.dev.lcip.org/ fxaEmailRoot=http://restmail.net fxaOauthApp=https://123done-latest.dev.lcip.org/ fxaIframeOauthApp=https://123done-latest.dev.lcip.org/iframe fxaProduction=true fxaToken=https://token.dev.lcip.org/1.0/sync/1.5",
+    "test-latest": "intern-runner config=tests/intern_functional_full fxaAuthRoot=https://latest.dev.lcip.org/auth/v1 fxaContentRoot=https://latest.dev.lcip.org/ fxaEmailRoot=http://restmail.net fxaOauthApp=https://123done-latest.dev.lcip.org/ fxaIframeOauthApp=https://123done-latest.dev.lcip.org/iframe fxaUntrustedOauthApp=https://321done-latest.dev.lcip.org/ fxaProduction=true fxaToken=https://token.dev.lcip.org/1.0/sync/1.5",
     "contributors": "git shortlog -s | cut -c8- | sort -f > AUTHORS"
   },
   "repository": {

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -111,7 +111,9 @@ module.exports = function (config, i18n) {
       '/clear',
       '/confirm_account_unlock',
       '/complete_unlock_account',
-      '/account_unlock_complete'
+      '/account_unlock_complete',
+      '/signup_permissions',
+      '/signin_permissions'
     ];
 
     var ALLOWED_TO_FRAME = {

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -1,0 +1,223 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'require',
+  'intern/node_modules/dojo/node!xmlhttprequest',
+  'app/bower_components/fxa-js-client/fxa-client',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
+  'use strict';
+
+  var config = intern.config;
+  var OAUTH_APP = config.fxaUntrustedOauthApp;
+  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+  var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
+  var OLD_ENOUGH_YEAR = TOO_YOUNG_YEAR - 1;
+
+  var PASSWORD = 'password';
+  var user;
+  var email;
+
+  var client;
+
+  registerSuite({
+    name: 'oauth permissions',
+
+    beforeEach: function () {
+      email = TestHelpers.createEmail();
+      user = TestHelpers.emailToUser(email);
+      client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+
+      return FunctionalHelpers.clearBrowserState(this, {
+        contentServer: true,
+        '321done': true
+      });
+    },
+
+    'sign in verified': function () {
+      var self = this;
+
+      return FunctionalHelpers.openFxaFromUntrustedRp(self, 'signin')
+        .then(function () {
+          return client.signUp(email, PASSWORD, { preVerified: true });
+        })
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+        })
+
+        .findByCssSelector('#fxa-permissions-header')
+        .end()
+
+        .findByCssSelector('#proceed')
+          .click()
+        .end()
+
+        .findByCssSelector('#loggedin')
+        .getCurrentUrl()
+        .then(function (url) {
+          // redirected back to the App
+          assert.ok(url.indexOf(OAUTH_APP) > -1);
+        })
+        .end();
+    },
+
+    'sign in unverified, acts like signup': function () {
+      var self = this;
+
+      return FunctionalHelpers.openFxaFromUntrustedRp(self, 'signin')
+        .then(function () {
+          return client.signUp(email, PASSWORD, { preVerified: false });
+        })
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+        })
+
+        .findByCssSelector('#fxa-permissions-header')
+        .end()
+
+        .findByCssSelector('#proceed')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-confirm-header')
+
+        .then(function () {
+          // get the second email, the first was sent on client.signUp w/
+          // preVerified: false above. The second email has the `service` and
+          // `resume` parameters.
+          return FunctionalHelpers.getVerificationLink(user, 1);
+        })
+        .then(function (verifyUrl) {
+          return self.get('remote')
+            // user verifies in the same tab, so they are logged in to the RP.
+            .get(require.toUrl(verifyUrl))
+
+            .findByCssSelector('#loggedin')
+            .end();
+        });
+    },
+
+
+    'signup, verify same browser': function () {
+      var self = this;
+      return FunctionalHelpers.openFxaFromUntrustedRp(self, 'signup')
+        .findByCssSelector('#fxa-signup-header .service')
+        .end()
+
+        .getCurrentUrl()
+        .then(function (url) {
+          assert.ok(url.indexOf('client_id=') > -1);
+          assert.ok(url.indexOf('redirect_uri=') > -1);
+          assert.ok(url.indexOf('state=') > -1);
+        })
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR);
+        })
+
+        .findByCssSelector('#fxa-permissions-header')
+        .end()
+        .findByCssSelector('#proceed')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-confirm-header')
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkSameBrowser(
+                      self, email, 0);
+        })
+
+        .switchToWindow('newwindow')
+        // wait for the verified window in the new tab
+        .findById('fxa-sign-up-complete-header')
+        .end()
+
+        .sleep(5000)
+        .findByCssSelector('.account-ready-service')
+        .getVisibleText()
+        .then(function (text) {
+          // user sees the name of the RP,
+          // but cannot redirect
+          assert.ok(/321done Untrusted/i.test(text));
+        })
+        .end()
+
+        // switch to the original window
+        .closeCurrentWindow()
+        .switchToWindow('')
+
+        .findByCssSelector('#loggedin')
+        .end();
+    },
+
+    'preverified sign up': function () {
+      var self = this;
+
+      var SIGNUP_URL = OAUTH_APP + 'api/preverified-signup?' +
+                        'email=' + encodeURIComponent(email);
+
+      return self.get('remote')
+        .get(require.toUrl(SIGNUP_URL))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+
+        .findByCssSelector('#fxa-signup-header')
+        .end()
+
+        .findByCssSelector('form input.password')
+          .click()
+          .type(PASSWORD)
+        .end()
+
+        .findByCssSelector('#fxa-age-year')
+        .end()
+
+        .findById('fxa-' + (TOO_YOUNG_YEAR - 1))
+          .click()
+        .end()
+
+        .findByCssSelector('button[type="submit"]')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-permissions-header')
+        .end()
+        .findByCssSelector('#proceed')
+          .click()
+        .end()
+
+        // user is redirected to 123done, wait for the footer first,
+        // and then for the loggedin user to be visible. If we go
+        // straight for the loggedin user, visibleByQSA blows up
+        // because 123done isn't loaded yet and it complains about
+        // the unload event of the content server.
+        .findByCssSelector('#footer-main')
+        .end()
+
+        // user is pre-verified and sent directly to the RP.
+        .then(FunctionalHelpers.visibleByQSA('#loggedin'))
+        .end()
+
+        .findByCssSelector('#loggedin')
+        .getVisibleText()
+        .then(function (text) {
+          // user is signed in as pre-verified email
+          assert.equal(text, email);
+        })
+        .end();
+    }
+  });
+
+});

--- a/tests/functional/pages.js
+++ b/tests/functional/pages.js
@@ -57,7 +57,9 @@ define([
     'boom',
     'confirm_account_unlock',
     'complete_unlock_account',
-    'account_unlock_complete'
+    'account_unlock_complete',
+    'signup_permissions',
+    'signin_permissions'
   ];
 
   var suite = {

--- a/tests/functional_oauth.js
+++ b/tests/functional_oauth.js
@@ -9,7 +9,8 @@ define([
   './functional/oauth_webchannel',
   './functional/oauth_preverified_sign_up',
   './functional/oauth_iframe',
-  './functional/oauth_force_email'
+  './functional/oauth_force_email',
+  './functional/oauth_permissions'
 ], function () {
   'use strict';
 });

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -11,13 +11,14 @@ define([
   './tools/firefox_profile'
 ],
 function (args, topic, firefoxProfile) {
-  /*jshint maxcomplexity:10 */
+  /*jshint maxcomplexity:11 */
   'use strict';
 
   var fxaAuthRoot = args.fxaAuthRoot || 'http://127.0.0.1:9000/v1';
   var fxaContentRoot = args.fxaContentRoot || 'http://127.0.0.1:3030/';
   var fxaEmailRoot = args.fxaEmailRoot || 'http://127.0.0.1:9001';
   var fxaOauthApp = args.fxaOauthApp || 'http://127.0.0.1:8080/';
+  var fxaUntrustedOauthApp = args.fxaUntrustedOauthApp || 'http://127.0.0.1:10139/';
   var fxaIframeOauthApp = args.fxaIframeOauthApp || 'http://127.0.0.1:8080/iframe';
   var fxaProduction = !!args.fxaProduction;
   var fxaToken = args.fxaToken || 'http://';
@@ -42,6 +43,7 @@ function (args, topic, firefoxProfile) {
     fxaContentRoot: fxaContentRoot,
     fxaEmailRoot: fxaEmailRoot,
     fxaOauthApp: fxaOauthApp,
+    fxaUntrustedOauthApp: fxaUntrustedOauthApp,
     fxaIframeOauthApp: fxaIframeOauthApp,
     fxaProduction: fxaProduction,
     fxaToken: fxaToken,

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -58,6 +58,8 @@ define([
     '/confirm_account_unlock': { statusCode: 200 },
     '/complete_unlock_account': { statusCode: 200 },
     '/account_unlock_complete': { statusCode: 200 },
+    '/signup_permissions': { statusCode: 200 },
+    '/signin_permissions': { statusCode: 200 },
 
     // the following have a version prefix
     '/v1/verify_email': { statusCode: 200 },


### PR DESCRIPTION
I refactored sign up/in to use the `account` and `user` models, but still need to get the permission screen working.

cc @shane-tomlinson 