### PR TITLE
update express-able to 0.4.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1669,923 +1669,17 @@
       }
     },
     "express-able": {
-      "version": "0.2.0",
-      "from": "express-able@0.2.0",
+      "version": "0.4.2",
+      "from": "express-able@0.4.2",
       "dependencies": {
         "able": {
-          "version": "0.2.0",
-          "from": "able@0.2.0",
+          "version": "0.4.1",
+          "from": "able@0.4.1",
           "dependencies": {
             "abatar": {
-              "version": "0.2.6",
-              "from": "abatar@0.2.6",
+              "version": "0.3.1",
+              "from": "abatar@0.3.1",
               "dependencies": {
-                "browserify": {
-                  "version": "8.0.3",
-                  "from": "browserify@8.0.3",
-                  "dependencies": {
-                    "JSONStream": {
-                      "version": "0.8.4",
-                      "from": "JSONStream@~0.8.4",
-                      "dependencies": {
-                        "jsonparse": {
-                          "version": "0.0.5",
-                          "from": "jsonparse@0.0.5"
-                        },
-                        "through": {
-                          "version": "2.3.7",
-                          "from": "through@>=2.2.7 <3"
-                        }
-                      }
-                    },
-                    "assert": {
-                      "version": "1.1.2",
-                      "from": "assert@~1.1.0"
-                    },
-                    "browser-pack": {
-                      "version": "3.2.0",
-                      "from": "browser-pack@^3.2.0",
-                      "dependencies": {
-                        "combine-source-map": {
-                          "version": "0.3.0",
-                          "from": "combine-source-map@~0.3.0",
-                          "dependencies": {
-                            "inline-source-map": {
-                              "version": "0.3.1",
-                              "from": "inline-source-map@~0.3.0",
-                              "dependencies": {
-                                "source-map": {
-                                  "version": "0.3.0",
-                                  "from": "source-map@~0.3.0",
-                                  "dependencies": {
-                                    "amdefine": {
-                                      "version": "0.1.0",
-                                      "from": "amdefine@>=0.0.4"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "convert-source-map": {
-                              "version": "0.3.5",
-                              "from": "convert-source-map@~0.3.0"
-                            },
-                            "source-map": {
-                              "version": "0.1.43",
-                              "from": "source-map@~0.1.31",
-                              "dependencies": {
-                                "amdefine": {
-                                  "version": "0.1.0",
-                                  "from": "amdefine@>=0.0.4"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "0.5.1",
-                          "from": "through2@~0.5.1"
-                        }
-                      }
-                    },
-                    "browser-resolve": {
-                      "version": "1.8.2",
-                      "from": "browser-resolve@^1.3.0",
-                      "dependencies": {
-                        "resolve": {
-                          "version": "1.1.6",
-                          "from": "resolve@1.1.6"
-                        }
-                      }
-                    },
-                    "browserify-zlib": {
-                      "version": "0.1.4",
-                      "from": "browserify-zlib@~0.1.2",
-                      "dependencies": {
-                        "pako": {
-                          "version": "0.2.6",
-                          "from": "pako@~0.2.0"
-                        }
-                      }
-                    },
-                    "buffer": {
-                      "version": "3.1.2",
-                      "from": "buffer@^3.0.0",
-                      "dependencies": {
-                        "base64-js": {
-                          "version": "0.0.8",
-                          "from": "base64-js@0.0.8"
-                        },
-                        "ieee754": {
-                          "version": "1.1.4",
-                          "from": "ieee754@^1.1.4"
-                        },
-                        "is-array": {
-                          "version": "1.0.1",
-                          "from": "is-array@^1.0.1"
-                        }
-                      }
-                    },
-                    "builtins": {
-                      "version": "0.0.7",
-                      "from": "builtins@~0.0.3"
-                    },
-                    "commondir": {
-                      "version": "0.0.1",
-                      "from": "commondir@0.0.1"
-                    },
-                    "concat-stream": {
-                      "version": "1.4.8",
-                      "from": "concat-stream@~1.4.1",
-                      "dependencies": {
-                        "typedarray": {
-                          "version": "0.0.6",
-                          "from": "typedarray@~0.0.5"
-                        },
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "from": "readable-stream@~1.1.9",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "console-browserify": {
-                      "version": "1.1.0",
-                      "from": "console-browserify@^1.1.0",
-                      "dependencies": {
-                        "date-now": {
-                          "version": "0.1.4",
-                          "from": "date-now@^0.1.4"
-                        }
-                      }
-                    },
-                    "constants-browserify": {
-                      "version": "0.0.1",
-                      "from": "constants-browserify@~0.0.1"
-                    },
-                    "crypto-browserify": {
-                      "version": "3.9.14",
-                      "from": "crypto-browserify@^3.0.0",
-                      "dependencies": {
-                        "browserify-aes": {
-                          "version": "1.0.0",
-                          "from": "browserify-aes@^1.0.0"
-                        },
-                        "browserify-sign": {
-                          "version": "3.0.1",
-                          "from": "browserify-sign@^3.0.1",
-                          "dependencies": {
-                            "bn.js": {
-                              "version": "1.3.0",
-                              "from": "bn.js@^1.0.0"
-                            },
-                            "browserify-rsa": {
-                              "version": "2.0.0",
-                              "from": "browserify-rsa@^2.0.0"
-                            },
-                            "elliptic": {
-                              "version": "1.0.1",
-                              "from": "elliptic@^1.0.0",
-                              "dependencies": {
-                                "brorand": {
-                                  "version": "1.0.5",
-                                  "from": "brorand@^1.0.1"
-                                },
-                                "hash.js": {
-                                  "version": "1.0.2",
-                                  "from": "hash.js@^1.0.0"
-                                }
-                              }
-                            },
-                            "parse-asn1": {
-                              "version": "3.0.0",
-                              "from": "parse-asn1@^3.0.0",
-                              "dependencies": {
-                                "asn1.js": {
-                                  "version": "1.0.4",
-                                  "from": "asn1.js@^1.0.0",
-                                  "dependencies": {
-                                    "minimalistic-assert": {
-                                      "version": "1.0.0",
-                                      "from": "minimalistic-assert@^1.0.0"
-                                    }
-                                  }
-                                },
-                                "pbkdf2-compat": {
-                                  "version": "3.0.2",
-                                  "from": "pbkdf2-compat@^3.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "create-ecdh": {
-                          "version": "2.0.0",
-                          "from": "create-ecdh@^2.0.0",
-                          "dependencies": {
-                            "bn.js": {
-                              "version": "1.3.0",
-                              "from": "bn.js@^1.0.0"
-                            },
-                            "elliptic": {
-                              "version": "1.0.1",
-                              "from": "elliptic@^1.0.0",
-                              "dependencies": {
-                                "brorand": {
-                                  "version": "1.0.5",
-                                  "from": "brorand@^1.0.1"
-                                },
-                                "hash.js": {
-                                  "version": "1.0.2",
-                                  "from": "hash.js@^1.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "create-hash": {
-                          "version": "1.1.1",
-                          "from": "create-hash@^1.1.0",
-                          "dependencies": {
-                            "ripemd160": {
-                              "version": "1.0.0",
-                              "from": "ripemd160@^1.0.0"
-                            },
-                            "sha.js": {
-                              "version": "2.4.0",
-                              "from": "sha.js@^2.3.6"
-                            }
-                          }
-                        },
-                        "create-hmac": {
-                          "version": "1.1.3",
-                          "from": "create-hmac@^1.1.0"
-                        },
-                        "diffie-hellman": {
-                          "version": "3.0.1",
-                          "from": "diffie-hellman@^3.0.1",
-                          "dependencies": {
-                            "bn.js": {
-                              "version": "1.3.0",
-                              "from": "bn.js@^1.0.0"
-                            },
-                            "miller-rabin": {
-                              "version": "1.1.5",
-                              "from": "miller-rabin@^1.1.2",
-                              "dependencies": {
-                                "brorand": {
-                                  "version": "1.0.5",
-                                  "from": "brorand@^1.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pbkdf2": {
-                          "version": "3.0.4",
-                          "from": "pbkdf2@^3.0.3"
-                        },
-                        "public-encrypt": {
-                          "version": "2.0.0",
-                          "from": "public-encrypt@^2.0.0",
-                          "dependencies": {
-                            "bn.js": {
-                              "version": "1.3.0",
-                              "from": "bn.js@^1.0.0"
-                            },
-                            "browserify-rsa": {
-                              "version": "2.0.0",
-                              "from": "browserify-rsa@^2.0.0"
-                            },
-                            "parse-asn1": {
-                              "version": "3.0.0",
-                              "from": "parse-asn1@^3.0.0",
-                              "dependencies": {
-                                "asn1.js": {
-                                  "version": "1.0.4",
-                                  "from": "asn1.js@^1.0.0",
-                                  "dependencies": {
-                                    "minimalistic-assert": {
-                                      "version": "1.0.0",
-                                      "from": "minimalistic-assert@^1.0.0"
-                                    }
-                                  }
-                                },
-                                "pbkdf2-compat": {
-                                  "version": "3.0.2",
-                                  "from": "pbkdf2-compat@^3.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "randombytes": {
-                          "version": "2.0.1",
-                          "from": "randombytes@^2.0.0"
-                        }
-                      }
-                    },
-                    "deep-equal": {
-                      "version": "0.2.2",
-                      "from": "deep-equal@~0.2.1"
-                    },
-                    "defined": {
-                      "version": "0.0.0",
-                      "from": "defined@~0.0.0"
-                    },
-                    "deps-sort": {
-                      "version": "1.3.5",
-                      "from": "deps-sort@^1.3.5",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.2.0",
-                          "from": "minimist@~0.2.0"
-                        },
-                        "through2": {
-                          "version": "0.5.1",
-                          "from": "through2@~0.5.1"
-                        }
-                      }
-                    },
-                    "domain-browser": {
-                      "version": "1.1.4",
-                      "from": "domain-browser@~1.1.0"
-                    },
-                    "duplexer2": {
-                      "version": "0.0.2",
-                      "from": "duplexer2@~0.0.2",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "from": "readable-stream@~1.1.9",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "events": {
-                      "version": "1.0.2",
-                      "from": "events@~1.0.0"
-                    },
-                    "glob": {
-                      "version": "4.5.3",
-                      "from": "glob@^4.0.5",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "from": "inflight@^1.0.4",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@1"
-                            }
-                          }
-                        },
-                        "minimatch": {
-                          "version": "2.0.4",
-                          "from": "minimatch@^2.0.1",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.0",
-                              "from": "brace-expansion@^1.0.0",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.2.0",
-                                  "from": "balanced-match@^0.2.0"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.1",
-                          "from": "once@^1.3.0",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "http-browserify": {
-                      "version": "1.7.0",
-                      "from": "http-browserify@^1.4.0",
-                      "dependencies": {
-                        "Base64": {
-                          "version": "0.2.1",
-                          "from": "Base64@~0.2.0"
-                        }
-                      }
-                    },
-                    "https-browserify": {
-                      "version": "0.0.0",
-                      "from": "https-browserify@~0.0.0"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1"
-                    },
-                    "insert-module-globals": {
-                      "version": "6.2.1",
-                      "from": "insert-module-globals@^6.2.0",
-                      "dependencies": {
-                        "JSONStream": {
-                          "version": "0.7.4",
-                          "from": "JSONStream@~0.7.1",
-                          "dependencies": {
-                            "jsonparse": {
-                              "version": "0.0.5",
-                              "from": "jsonparse@0.0.5"
-                            }
-                          }
-                        },
-                        "combine-source-map": {
-                          "version": "0.3.0",
-                          "from": "combine-source-map@~0.3.0",
-                          "dependencies": {
-                            "inline-source-map": {
-                              "version": "0.3.1",
-                              "from": "inline-source-map@~0.3.0",
-                              "dependencies": {
-                                "source-map": {
-                                  "version": "0.3.0",
-                                  "from": "source-map@~0.3.0",
-                                  "dependencies": {
-                                    "amdefine": {
-                                      "version": "0.1.0",
-                                      "from": "amdefine@>=0.0.4"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "convert-source-map": {
-                              "version": "0.3.5",
-                              "from": "convert-source-map@~0.3.0"
-                            },
-                            "source-map": {
-                              "version": "0.1.43",
-                              "from": "source-map@~0.1.31",
-                              "dependencies": {
-                                "amdefine": {
-                                  "version": "0.1.0",
-                                  "from": "amdefine@>=0.0.4"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lexical-scope": {
-                          "version": "1.1.0",
-                          "from": "lexical-scope@~1.1.0",
-                          "dependencies": {
-                            "astw": {
-                              "version": "1.1.0",
-                              "from": "astw@~1.1.0",
-                              "dependencies": {
-                                "esprima-fb": {
-                                  "version": "3001.1.0-dev-harmony-fb",
-                                  "from": "esprima-fb@3001.1.0-dev-harmony-fb"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "process": {
-                          "version": "0.6.0",
-                          "from": "process@~0.6.0"
-                        },
-                        "through": {
-                          "version": "2.3.7",
-                          "from": "through@~2.3.4"
-                        }
-                      }
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1"
-                    },
-                    "labeled-stream-splicer": {
-                      "version": "1.0.2",
-                      "from": "labeled-stream-splicer@^1.0.0",
-                      "dependencies": {
-                        "stream-splicer": {
-                          "version": "1.3.1",
-                          "from": "stream-splicer@^1.1.0",
-                          "dependencies": {
-                            "readable-stream": {
-                              "version": "1.1.13",
-                              "from": "readable-stream@^1.1.13-1",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.1",
-                                  "from": "core-util-is@~1.0.0"
-                                }
-                              }
-                            },
-                            "readable-wrap": {
-                              "version": "1.0.0",
-                              "from": "readable-wrap@^1.0.0"
-                            },
-                            "indexof": {
-                              "version": "0.0.1",
-                              "from": "indexof@0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "module-deps": {
-                      "version": "3.7.6",
-                      "from": "module-deps@^3.6.3",
-                      "dependencies": {
-                        "JSONStream": {
-                          "version": "0.7.4",
-                          "from": "JSONStream@~0.7.1",
-                          "dependencies": {
-                            "jsonparse": {
-                              "version": "0.0.5",
-                              "from": "jsonparse@0.0.5"
-                            },
-                            "through": {
-                              "version": "2.3.7",
-                              "from": "through@>=2.2.7 <3"
-                            }
-                          }
-                        },
-                        "detective": {
-                          "version": "4.0.0",
-                          "from": "detective@^4.0.0",
-                          "dependencies": {
-                            "acorn": {
-                              "version": "0.9.0",
-                              "from": "acorn@~0.9.0"
-                            },
-                            "escodegen": {
-                              "version": "1.6.1",
-                              "from": "escodegen@^1.4.1",
-                              "dependencies": {
-                                "estraverse": {
-                                  "version": "1.9.3",
-                                  "from": "estraverse@^1.9.1"
-                                },
-                                "esutils": {
-                                  "version": "1.1.6",
-                                  "from": "esutils@^1.1.6"
-                                },
-                                "esprima": {
-                                  "version": "1.2.5",
-                                  "from": "esprima@^1.2.2"
-                                },
-                                "optionator": {
-                                  "version": "0.5.0",
-                                  "from": "optionator@^0.5.0",
-                                  "dependencies": {
-                                    "prelude-ls": {
-                                      "version": "1.1.1",
-                                      "from": "prelude-ls@~1.1.1"
-                                    },
-                                    "deep-is": {
-                                      "version": "0.1.3",
-                                      "from": "deep-is@~0.1.2"
-                                    },
-                                    "wordwrap": {
-                                      "version": "0.0.2",
-                                      "from": "wordwrap@~0.0.2"
-                                    },
-                                    "type-check": {
-                                      "version": "0.3.1",
-                                      "from": "type-check@~0.3.1"
-                                    },
-                                    "levn": {
-                                      "version": "0.2.5",
-                                      "from": "levn@~0.2.5"
-                                    },
-                                    "fast-levenshtein": {
-                                      "version": "1.0.6",
-                                      "from": "fast-levenshtein@~1.0.0"
-                                    }
-                                  }
-                                },
-                                "source-map": {
-                                  "version": "0.1.43",
-                                  "from": "source-map@~0.1.40",
-                                  "dependencies": {
-                                    "amdefine": {
-                                      "version": "0.1.0",
-                                      "from": "amdefine@>=0.0.4"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "minimist": {
-                          "version": "0.2.0",
-                          "from": "minimist@~0.2.0"
-                        },
-                        "parents": {
-                          "version": "1.0.1",
-                          "from": "parents@^1.0.0",
-                          "dependencies": {
-                            "path-platform": {
-                              "version": "0.11.15",
-                              "from": "path-platform@~0.11.15"
-                            }
-                          }
-                        },
-                        "resolve": {
-                          "version": "1.1.6",
-                          "from": "resolve@^1.1.3"
-                        },
-                        "stream-combiner2": {
-                          "version": "1.0.2",
-                          "from": "stream-combiner2@~1.0.0",
-                          "dependencies": {
-                            "through2": {
-                              "version": "0.5.1",
-                              "from": "through2@~0.5.1",
-                              "dependencies": {
-                                "xtend": {
-                                  "version": "3.0.0",
-                                  "from": "xtend@~3.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "subarg": {
-                          "version": "0.0.1",
-                          "from": "subarg@0.0.1",
-                          "dependencies": {
-                            "minimist": {
-                              "version": "0.0.10",
-                              "from": "minimist@~0.0.7"
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "0.4.2",
-                          "from": "through2@~0.4.1",
-                          "dependencies": {
-                            "xtend": {
-                              "version": "2.1.2",
-                              "from": "xtend@~2.1.1",
-                              "dependencies": {
-                                "object-keys": {
-                                  "version": "0.4.0",
-                                  "from": "object-keys@~0.4.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "xtend": {
-                          "version": "4.0.0",
-                          "from": "xtend@^4.0.0"
-                        }
-                      }
-                    },
-                    "os-browserify": {
-                      "version": "0.1.2",
-                      "from": "os-browserify@~0.1.1"
-                    },
-                    "parents": {
-                      "version": "0.0.3",
-                      "from": "parents@~0.0.1",
-                      "dependencies": {
-                        "path-platform": {
-                          "version": "0.0.1",
-                          "from": "path-platform@^0.0.1"
-                        }
-                      }
-                    },
-                    "path-browserify": {
-                      "version": "0.0.0",
-                      "from": "path-browserify@~0.0.0"
-                    },
-                    "process": {
-                      "version": "0.8.0",
-                      "from": "process@^0.8.0"
-                    },
-                    "punycode": {
-                      "version": "1.2.4",
-                      "from": "punycode@~1.2.3"
-                    },
-                    "querystring-es3": {
-                      "version": "0.2.1",
-                      "from": "querystring-es3@~0.2.0"
-                    },
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "readable-stream@^1.0.33-1",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0"
-                        }
-                      }
-                    },
-                    "resolve": {
-                      "version": "0.7.4",
-                      "from": "resolve@~0.7.1"
-                    },
-                    "shallow-copy": {
-                      "version": "0.0.1",
-                      "from": "shallow-copy@0.0.1"
-                    },
-                    "shasum": {
-                      "version": "1.0.1",
-                      "from": "shasum@^1.0.0",
-                      "dependencies": {
-                        "json-stable-stringify": {
-                          "version": "0.0.1",
-                          "from": "json-stable-stringify@~0.0.0",
-                          "dependencies": {
-                            "jsonify": {
-                              "version": "0.0.0",
-                              "from": "jsonify@~0.0.0"
-                            }
-                          }
-                        },
-                        "sha.js": {
-                          "version": "2.3.6",
-                          "from": "sha.js@~2.3.0"
-                        }
-                      }
-                    },
-                    "shell-quote": {
-                      "version": "0.0.1",
-                      "from": "shell-quote@~0.0.1"
-                    },
-                    "stream-browserify": {
-                      "version": "1.0.0",
-                      "from": "stream-browserify@^1.0.0"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.0"
-                    },
-                    "subarg": {
-                      "version": "1.0.0",
-                      "from": "subarg@^1.0.0",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.1.1",
-                          "from": "minimist@^1.1.0"
-                        }
-                      }
-                    },
-                    "syntax-error": {
-                      "version": "1.1.2",
-                      "from": "syntax-error@^1.1.1",
-                      "dependencies": {
-                        "acorn": {
-                          "version": "0.9.0",
-                          "from": "acorn@~0.9.0"
-                        }
-                      }
-                    },
-                    "through2": {
-                      "version": "1.1.1",
-                      "from": "through2@^1.0.0",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0"
-                            }
-                          }
-                        },
-                        "xtend": {
-                          "version": "4.0.0",
-                          "from": "xtend@>=4.0.0 <4.1.0-0"
-                        }
-                      }
-                    },
-                    "timers-browserify": {
-                      "version": "1.4.0",
-                      "from": "timers-browserify@^1.0.1",
-                      "dependencies": {
-                        "process": {
-                          "version": "0.10.1",
-                          "from": "process@~0.10.0"
-                        }
-                      }
-                    },
-                    "tty-browserify": {
-                      "version": "0.0.0",
-                      "from": "tty-browserify@~0.0.0"
-                    },
-                    "umd": {
-                      "version": "2.1.0",
-                      "from": "umd@~2.1.0",
-                      "dependencies": {
-                        "rfile": {
-                          "version": "1.0.0",
-                          "from": "rfile@~1.0.0",
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "from": "callsite@~1.0.0"
-                            },
-                            "resolve": {
-                              "version": "0.3.1",
-                              "from": "resolve@~0.3.0"
-                            }
-                          }
-                        },
-                        "ruglify": {
-                          "version": "1.0.0",
-                          "from": "ruglify@~1.0.0",
-                          "dependencies": {
-                            "uglify-js": {
-                              "version": "2.2.5",
-                              "from": "uglify-js@~2.2",
-                              "dependencies": {
-                                "source-map": {
-                                  "version": "0.1.43",
-                                  "from": "source-map@~0.1.7",
-                                  "dependencies": {
-                                    "amdefine": {
-                                      "version": "0.1.0",
-                                      "from": "amdefine@>=0.0.4"
-                                    }
-                                  }
-                                },
-                                "optimist": {
-                                  "version": "0.3.7",
-                                  "from": "optimist@~0.3.5",
-                                  "dependencies": {
-                                    "wordwrap": {
-                                      "version": "0.0.2",
-                                      "from": "wordwrap@~0.0.2"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "through": {
-                          "version": "2.3.7",
-                          "from": "through@~2.3.4"
-                        }
-                      }
-                    },
-                    "url": {
-                      "version": "0.10.3",
-                      "from": "url@~0.10.1",
-                      "dependencies": {
-                        "punycode": {
-                          "version": "1.3.2",
-                          "from": "punycode@1.3.2"
-                        },
-                        "querystring": {
-                          "version": "0.2.0",
-                          "from": "querystring@0.2.0"
-                        }
-                      }
-                    },
-                    "util": {
-                      "version": "0.10.3",
-                      "from": "util@~0.10.1"
-                    },
-                    "vm-browserify": {
-                      "version": "0.0.4",
-                      "from": "vm-browserify@~0.0.1",
-                      "dependencies": {
-                        "indexof": {
-                          "version": "0.0.1",
-                          "from": "indexof@0.0.1"
-                        }
-                      }
-                    },
-                    "xtend": {
-                      "version": "3.0.0",
-                      "from": "xtend@^3.0.0"
-                    }
-                  }
-                },
                 "js-sha1": {
                   "version": "0.2.0",
                   "from": "js-sha1@0.2.0"
@@ -2601,14 +1695,14 @@
               "from": "boom@2.6.1",
               "dependencies": {
                 "hoek": {
-                  "version": "2.12.0",
+                  "version": "2.13.0",
                   "from": "hoek@2.x.x"
                 }
               }
             },
             "browserify": {
-              "version": "9.0.3",
-              "from": "browserify@9.0.3",
+              "version": "9.0.8",
+              "from": "browserify@9.0.8",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.10.0",
@@ -2629,23 +1723,9 @@
                   "from": "assert@~1.3.0"
                 },
                 "browser-pack": {
-                  "version": "4.0.1",
+                  "version": "4.0.2",
                   "from": "browser-pack@^4.0.0",
                   "dependencies": {
-                    "JSONStream": {
-                      "version": "0.8.4",
-                      "from": "JSONStream@~0.8.4",
-                      "dependencies": {
-                        "jsonparse": {
-                          "version": "0.0.5",
-                          "from": "jsonparse@0.0.5"
-                        },
-                        "through": {
-                          "version": "2.3.7",
-                          "from": "through@>=2.2.7 <3"
-                        }
-                      }
-                    },
                     "combine-source-map": {
                       "version": "0.3.0",
                       "from": "combine-source-map@~0.3.0",
@@ -2682,6 +1762,10 @@
                         }
                       }
                     },
+                    "defined": {
+                      "version": "1.0.0",
+                      "from": "defined@^1.0.0"
+                    },
                     "through2": {
                       "version": "0.5.1",
                       "from": "through2@~0.5.1",
@@ -2699,7 +1783,7 @@
                       }
                     },
                     "umd": {
-                      "version": "3.0.0",
+                      "version": "3.0.1",
                       "from": "umd@^3.0.0"
                     }
                   }
@@ -2719,7 +1803,7 @@
                   }
                 },
                 "buffer": {
-                  "version": "3.1.2",
+                  "version": "3.2.2",
                   "from": "buffer@^3.0.0",
                   "dependencies": {
                     "base64-js": {
@@ -2727,7 +1811,7 @@
                       "from": "base64-js@0.0.8"
                     },
                     "ieee754": {
-                      "version": "1.1.4",
+                      "version": "1.1.5",
                       "from": "ieee754@^1.1.4"
                     },
                     "is-array": {
@@ -2853,7 +1937,7 @@
                       "from": "create-hash@^1.1.0",
                       "dependencies": {
                         "ripemd160": {
-                          "version": "1.0.0",
+                          "version": "1.0.1",
                           "from": "ripemd160@^1.0.0"
                         },
                         "sha.js": {
@@ -2939,27 +2023,9 @@
                   "from": "defined@~0.0.0"
                 },
                 "deps-sort": {
-                  "version": "1.3.5",
+                  "version": "1.3.6",
                   "from": "deps-sort@^1.3.5",
                   "dependencies": {
-                    "JSONStream": {
-                      "version": "0.8.4",
-                      "from": "JSONStream@~0.8.4",
-                      "dependencies": {
-                        "jsonparse": {
-                          "version": "0.0.5",
-                          "from": "jsonparse@0.0.5"
-                        },
-                        "through": {
-                          "version": "2.3.7",
-                          "from": "through@>=2.2.7 <3"
-                        }
-                      }
-                    },
-                    "minimist": {
-                      "version": "0.2.0",
-                      "from": "minimist@~0.2.0"
-                    },
                     "through2": {
                       "version": "0.5.1",
                       "from": "through2@~0.5.1",
@@ -3005,7 +2071,7 @@
                       }
                     },
                     "minimatch": {
-                      "version": "2.0.4",
+                      "version": "2.0.7",
                       "from": "minimatch@^2.0.1",
                       "dependencies": {
                         "brace-expansion": {
@@ -3025,7 +2091,7 @@
                       }
                     },
                     "once": {
-                      "version": "1.3.1",
+                      "version": "1.3.2",
                       "from": "once@^1.3.0",
                       "dependencies": {
                         "wrappy": {
@@ -3054,24 +2120,10 @@
                   "version": "0.0.0",
                   "from": "https-browserify@~0.0.0"
                 },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1"
-                },
                 "insert-module-globals": {
-                  "version": "6.2.1",
+                  "version": "6.4.0",
                   "from": "insert-module-globals@^6.2.0",
                   "dependencies": {
-                    "JSONStream": {
-                      "version": "0.7.4",
-                      "from": "JSONStream@~0.7.1",
-                      "dependencies": {
-                        "jsonparse": {
-                          "version": "0.0.5",
-                          "from": "jsonparse@0.0.5"
-                        }
-                      }
-                    },
                     "combine-source-map": {
                       "version": "0.3.0",
                       "from": "combine-source-map@~0.3.0",
@@ -3109,28 +2161,32 @@
                       }
                     },
                     "lexical-scope": {
-                      "version": "1.1.0",
+                      "version": "1.1.1",
                       "from": "lexical-scope@~1.1.0",
                       "dependencies": {
                         "astw": {
-                          "version": "1.1.0",
-                          "from": "astw@~1.1.0",
+                          "version": "2.0.0",
+                          "from": "astw@^2.0.0",
                           "dependencies": {
-                            "esprima-fb": {
-                              "version": "3001.1.0-dev-harmony-fb",
-                              "from": "esprima-fb@3001.1.0-dev-harmony-fb"
+                            "acorn": {
+                              "version": "1.0.3",
+                              "from": "acorn@^1.0.3"
                             }
                           }
                         }
                       }
                     },
                     "process": {
-                      "version": "0.6.0",
-                      "from": "process@~0.6.0"
+                      "version": "0.11.0",
+                      "from": "process@~0.11.0"
                     },
                     "through": {
                       "version": "2.3.7",
                       "from": "through@~2.3.4"
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@^4.0.0"
                     }
                   }
                 },
@@ -3159,30 +2215,24 @@
                   }
                 },
                 "module-deps": {
-                  "version": "3.7.6",
+                  "version": "3.7.8",
                   "from": "module-deps@^3.7.0",
                   "dependencies": {
-                    "JSONStream": {
-                      "version": "0.7.4",
-                      "from": "JSONStream@~0.7.1",
-                      "dependencies": {
-                        "jsonparse": {
-                          "version": "0.0.5",
-                          "from": "jsonparse@0.0.5"
-                        },
-                        "through": {
-                          "version": "2.3.7",
-                          "from": "through@>=2.2.7 <3"
-                        }
-                      }
+                    "defined": {
+                      "version": "1.0.0",
+                      "from": "defined@^1.0.0"
                     },
                     "detective": {
-                      "version": "4.0.0",
+                      "version": "4.0.1",
                       "from": "detective@^4.0.0",
                       "dependencies": {
                         "acorn": {
-                          "version": "0.9.0",
-                          "from": "acorn@~0.9.0"
+                          "version": "1.0.3",
+                          "from": "acorn@^1.0.3"
+                        },
+                        "defined": {
+                          "version": "0.0.0",
+                          "from": "defined@0.0.0"
                         },
                         "escodegen": {
                           "version": "1.6.1",
@@ -3244,10 +2294,6 @@
                         }
                       }
                     },
-                    "minimist": {
-                      "version": "0.2.0",
-                      "from": "minimist@~0.2.0"
-                    },
                     "stream-combiner2": {
                       "version": "1.0.2",
                       "from": "stream-combiner2@~1.0.0",
@@ -3271,16 +2317,6 @@
                               "from": "xtend@~3.0.0"
                             }
                           }
-                        }
-                      }
-                    },
-                    "subarg": {
-                      "version": "0.0.1",
-                      "from": "subarg@0.0.1",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.10",
-                          "from": "minimist@~0.0.7"
                         }
                       }
                     },
@@ -3346,9 +2382,19 @@
                   "version": "0.2.1",
                   "from": "querystring-es3@~0.2.0"
                 },
+                "read-only-stream": {
+                  "version": "1.1.1",
+                  "from": "read-only-stream@^1.1.1",
+                  "dependencies": {
+                    "readable-wrap": {
+                      "version": "1.0.0",
+                      "from": "readable-wrap@^1.0.0"
+                    }
+                  }
+                },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@1.1",
+                  "from": "readable-stream@^1.1.13",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
@@ -3407,12 +2453,12 @@
                   }
                 },
                 "syntax-error": {
-                  "version": "1.1.2",
+                  "version": "1.1.3",
                   "from": "syntax-error@^1.1.1",
                   "dependencies": {
                     "acorn": {
-                      "version": "0.9.0",
-                      "from": "acorn@~0.9.0"
+                      "version": "1.0.3",
+                      "from": "acorn@^1.0.3"
                     }
                   }
                 },
@@ -3545,8 +2591,8 @@
               }
             },
             "github-url-to-object": {
-              "version": "1.4.2",
-              "from": "github-url-to-object@1.4.2",
+              "version": "1.5.2",
+              "from": "github-url-to-object@1.5.2",
               "dependencies": {
                 "is-url": {
                   "version": "1.2.0",
@@ -3555,8 +2601,8 @@
               }
             },
             "glob": {
-              "version": "5.0.2",
-              "from": "glob@5.0.2",
+              "version": "5.0.5",
+              "from": "glob@5.0.5",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
@@ -3568,12 +2614,8 @@
                     }
                   }
                 },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2"
-                },
                 "minimatch": {
-                  "version": "2.0.4",
+                  "version": "2.0.7",
                   "from": "minimatch@^2.0.1",
                   "dependencies": {
                     "brace-expansion": {
@@ -3593,7 +2635,7 @@
                   }
                 },
                 "once": {
-                  "version": "1.3.1",
+                  "version": "1.3.2",
                   "from": "once@^1.3.0",
                   "dependencies": {
                     "wrappy": {
@@ -3601,12 +2643,16 @@
                       "from": "wrappy@1"
                     }
                   }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@^1.0.0"
                 }
               }
             },
             "hapi": {
-              "version": "8.3.1",
-              "from": "hapi@8.3.1",
+              "version": "8.4.0",
+              "from": "hapi@8.4.0",
               "dependencies": {
                 "accept": {
                   "version": "1.0.0",
@@ -3621,24 +2667,8 @@
                   "from": "call@2.0.1"
                 },
                 "catbox": {
-                  "version": "4.2.1",
-                  "from": "catbox@4.2.1",
-                  "dependencies": {
-                    "joi": {
-                      "version": "5.1.0",
-                      "from": "joi@5.x.x",
-                      "dependencies": {
-                        "isemail": {
-                          "version": "1.1.1",
-                          "from": "isemail@1.x.x"
-                        },
-                        "moment": {
-                          "version": "2.10.2",
-                          "from": "moment@2.x.x"
-                        }
-                      }
-                    }
-                  }
+                  "version": "4.2.2",
+                  "from": "catbox@4.2.2"
                 },
                 "catbox-memory": {
                   "version": "1.1.1",
@@ -3646,7 +2676,7 @@
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@2.x.x"
+                  "from": "cryptiles@2.0.4"
                 },
                 "h2o2": {
                   "version": "4.0.0",
@@ -3711,12 +2741,12 @@
                   "from": "items@1.1.0"
                 },
                 "joi": {
-                  "version": "6.0.5",
-                  "from": "joi@6.0.5",
+                  "version": "6.0.8",
+                  "from": "joi@6.0.8",
                   "dependencies": {
                     "isemail": {
                       "version": "1.1.1",
-                      "from": "isemail@1.1.1"
+                      "from": "isemail@1.x.x"
                     },
                     "moment": {
                       "version": "2.9.0",
@@ -3743,8 +2773,8 @@
                   "from": "peekaboo@1.0.0"
                 },
                 "qs": {
-                  "version": "2.3.3",
-                  "from": "qs@2.3.3"
+                  "version": "2.4.0",
+                  "from": "qs@2.4.0"
                 },
                 "shot": {
                   "version": "1.4.2",
@@ -3846,9 +2876,13 @@
                 }
               }
             },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2.0.1"
+            },
             "mozlog": {
-              "version": "1.0.3",
-              "from": "mozlog@1.0.3",
+              "version": "2.0.0",
+              "from": "mozlog@2.0.0",
               "dependencies": {
                 "intel": {
                   "version": "1.0.0",
@@ -3872,7 +2906,7 @@
                           "dependencies": {
                             "ansi-regex": {
                               "version": "0.2.1",
-                              "from": "ansi-regex@^0.2.1"
+                              "from": "ansi-regex@^0.2.0"
                             }
                           }
                         },
@@ -3921,8 +2955,8 @@
               }
             },
             "uglify-js": {
-              "version": "2.4.17",
-              "from": "uglify-js@2.4.17",
+              "version": "2.4.20",
+              "from": "uglify-js@2.4.20",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
@@ -3939,12 +2973,80 @@
                   }
                 },
                 "yargs": {
-                  "version": "1.3.3",
-                  "from": "yargs@~1.3.3"
+                  "version": "3.5.4",
+                  "from": "yargs@~3.5.4",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.0.2",
+                      "from": "camelcase@^1.0.2"
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "decamelize@^1.0.0"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2"
+                    }
+                  }
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
                   "from": "uglify-to-browserify@~1.0.0"
+                }
+              }
+            },
+            "xhr": {
+              "version": "2.0.1",
+              "from": "xhr@2.0.1",
+              "dependencies": {
+                "global": {
+                  "version": "4.3.0",
+                  "from": "global@~4.3.0",
+                  "dependencies": {
+                    "min-document": {
+                      "version": "2.14.0",
+                      "from": "min-document@^2.6.1",
+                      "dependencies": {
+                        "dom-walk": {
+                          "version": "0.1.1",
+                          "from": "dom-walk@^0.1.0"
+                        }
+                      }
+                    },
+                    "process": {
+                      "version": "0.5.2",
+                      "from": "process@~0.5.1"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.1.1",
+                  "from": "once@~1.1.1"
+                },
+                "parse-headers": {
+                  "version": "2.0.0",
+                  "from": "parse-headers@^2.0.0",
+                  "dependencies": {
+                    "for-each": {
+                      "version": "0.3.2",
+                      "from": "for-each@^0.3.2",
+                      "dependencies": {
+                        "is-function": {
+                          "version": "1.0.1",
+                          "from": "is-function@~1.0.0"
+                        }
+                      }
+                    },
+                    "trim": {
+                      "version": "0.0.1",
+                      "from": "trim@0.0.1"
+                    }
+                  }
                 }
               }
             }
@@ -4365,17 +3467,14 @@
             "node-font-face-generator": {
               "version": "0.1.5",
               "from": "https://registry.npmjs.org/node-font-face-generator/-/node-font-face-generator-0.1.5.tgz",
-              "resolved": "https://registry.npmjs.org/node-font-face-generator/-/node-font-face-generator-0.1.5.tgz",
               "dependencies": {
                 "ejs": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/ejs/-/ejs-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ejs/-/ejs-1.0.0.tgz"
+                  "from": "https://registry.npmjs.org/ejs/-/ejs-1.0.0.tgz"
                 },
                 "useragent": {
                   "version": "2.0.9",
                   "from": "https://registry.npmjs.org/useragent/-/useragent-2.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.9.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.2.4",
@@ -4387,8 +3486,7 @@
             },
             "mime": {
               "version": "1.2.11",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "oppressor": {
               "version": "0.0.1",
@@ -4410,8 +3508,7 @@
             },
             "tmp": {
               "version": "0.0.23",
-              "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz",
-              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
+              "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
             }
           }
         }
@@ -6312,8 +5409,7 @@
         },
         "gobbledygook": {
           "version": "0.0.4",
-          "from": "https://github.com/lloyd/gobbledygook/tarball/354042684056e57ca77f036989e907707a36cff2",
-          "resolved": "https://github.com/lloyd/gobbledygook/tarball/354042684056e57ca77f036989e907707a36cff2"
+          "from": "https://github.com/lloyd/gobbledygook/tarball/354042684056e57ca77f036989e907707a36cff2"
         },
         "jsxgettext": {
           "version": "0.3.9",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "convict": "0.6.0",
     "cookie-parser": "1.3.4",
     "express": "4.12.3",
-    "express-able": "0.2.0",
+    "express-able": "0.4.2",
     "grunt": "0.4.5",
     "grunt-autoprefixer": "1.0.0",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
This updates express-able to 0.4.2 which supports basic reporting of experiment data from the browser and some bug fixes. Another PR will add the `reportHandler` to enable reporting.