### PR TITLE
fix(oauth): Ensure we can derive relier keys during the signup flow.

### DIFF
--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -41,7 +41,35 @@ define([
         // ignore the parse error.
       }
 
-      this.set(values);
+      // Update new values, without overwriting items on the prototype.
+      _.each(values, function (value, key) {
+        if (! Session.prototype.hasOwnProperty(key)) {
+          this[key] = value;
+        }
+      }, this);
+
+      return values;
+    },
+
+
+    /**
+     * Reload in-memory values based on what's currently in storage.
+     * This method can be used to pull in any changes to localStorage
+     * made by other tabs.  Note that it will remove items from the session
+     * if they no longer appear in sessionStorage or localStorage.
+     * @method reload
+     */
+    reload: function () {
+      var values = this.load();
+      // Clear values that no longer exist in storage.
+      _.each(this, function (value, key) {
+        if (! Session.prototype.hasOwnProperty(key)) {
+          if (! values.hasOwnProperty(key)) {
+            this[key] = null;
+            delete this[key];
+          }
+        }
+      }, this);
     },
 
     /**

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -112,6 +112,7 @@ define([
           //jshint camelcase: false
           client_id: relier.get('clientId'),
           state: relier.get('state'),
+          keys: relier.get('keys'),
           scope: relier.get('scope'),
           action: relier.get('action')
         });

--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -117,6 +117,7 @@ define([
 
       self.set({
         state: resumeObj.state,
+        keys: resumeObj.keys,
         //jshint camelcase: false
         clientId: resumeObj.client_id,
         redirectUri: resumeObj.redirect_uri,

--- a/app/tests/spec/lib/session.js
+++ b/app/tests/spec/lib/session.js
@@ -89,6 +89,35 @@ function (chai, Session) {
         assert.equal(Session.key7, 'value7');
         assert.equal(Session.key8, 'value8');
       });
+
+    });
+
+    describe('reload', function () {
+      it('reloads new, modified, and cleared keys from storage', function () {
+        Session.set({
+          key9: 'value9',
+          key10: 'value10',
+          key11: 'value11'
+        });
+
+        sessionStorage.setItem('__fxa_session', JSON.stringify({
+          key10: 'newValue10',
+          key11: 'value11',
+          key12: 'value12'
+        }));
+
+        assert.equal(Session.key9, 'value9');
+        assert.equal(Session.key10, 'value10');
+        assert.equal(Session.key11, 'value11');
+        assert.isUndefined(Session.key12);
+
+        Session.reload();
+
+        assert.isUndefined(Session.key9);
+        assert.equal(Session.key10, 'newValue10');
+        assert.equal(Session.key11, 'value11');
+        assert.equal(Session.key12, 'value12');
+      });
     });
   });
 });

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -257,6 +257,19 @@ define([
           .execute(function (verificationLink, windowName) {
             var newWindow = window.open(verificationLink, windowName);
 
+            // Hook up the new window to listen for WebChannel messages.
+            // XXX TODO: this is pretty gross to do universally like this...
+            // XXX TODO: it will go away if we can make the original tab
+            //           reliably be the one to complete the oauth flow.
+            newWindow.addEventListener('WebChannelMessageToChrome', function (e) {
+              var command = e.detail.message.command;
+              var data = e.detail.message.data;
+              var element = newWindow.document.createElement('div');
+              element.setAttribute('id', 'message-' + command.replace(/:/g, '-'));
+              element.innerText = JSON.stringify(data);
+              newWindow.document.body.appendChild(element);
+            });
+
             // from http://dev.w3.org/html5/webstorage/
             // When a new top-level browsing context is created by a script in
             // an existing browsing context, then the session storage area of

--- a/tests/functional_oauth.js
+++ b/tests/functional_oauth.js
@@ -7,6 +7,7 @@ define([
   './functional/oauth_sign_up',
   './functional/oauth_reset_password',
   './functional/oauth_webchannel',
+  './functional/oauth_webchannel_keys',
   './functional/oauth_preverified_sign_up',
   './functional/oauth_iframe',
   './functional/oauth_force_email',


### PR DESCRIPTION
This is a rather brutal approach to ensuring that we can derive oauth relier keys during the signup flow.  It persists the `keys=true` state in the oauth session data, and persists `keyFetchToken` and `unwrapBKey` in the account data so that they can be used on the complete_sign_up page.

I'm putting it up here as a proof of concept.  We should find a way to do it without persisting the key-fetching material any more than necessary.

Fixes #2384.  But not in a way that I'm happy about.