### PR TITLE
feat(metrics): Log metrics about whether we ask for a password at signin

### DIFF
--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -140,6 +140,12 @@ The event stream is a log of events and the time they occurred while the user is
 * error.signin.auth.121 - account locked
 * signin.unlock-email.send - user attempted to send unlock email
 * signin.unlock-email.send.success - unlock email successfully sent
+* signin.ask-password.skipped - skipped asking for password thanks to existing session token
+* signin.ask-password.shown.account-unknown - asked for password due to missing account data
+* signin.ask-password.shown.keys-required - asked for password because the relier wanted keys
+* signin.ask-password.shown.email-mismatch - asked for password due to using a different email
+* signin.ask-password.shown.session-from-web - asked for password because session was created via web content
+* signin.ask-password.shown.session-expired - asked for password due to expired session token
 
 #### signup
 * tooltip.mailcheck-suggested - an email address correction was suggested


### PR DESCRIPTION
Log metrics about whether we ask for a password at signin, and if we do, the reason why:

* signin.ask-password.skipped - skipped asking for password thanks to existing session token
* signin.ask-password.shown.no-account - asked for password due to missing account data
* signin.ask-password.shown.wants-keys - asked for password due to relier wanting keys
* signin.ask-password.shown.non-sync-account - asked for password due to non-sync session token
* signin.ask-password.shown.expired-session - asked for password due to expired session token
* signin.ask-password.shown.email-mismatch - asked for password due to using a different email

I could easily be convinced that six separate events is too much granularity, but it seemed better to start with too much than too little.

Fixes #2393