### PR TITLE
chore(jshint): eliminate lint rule for extra comma in the app folder

### DIFF
--- a/app/.jshintrc
+++ b/app/.jshintrc
@@ -4,7 +4,6 @@
   "camelcase": true,
   "curly": true,
   "eqeqeq": true,
-  "es3": true,
   "esnext": true,
   "globalstrict": true,
   "immed": true,


### PR DESCRIPTION
Fixes #2296