### PR TITLE
fix(client): Ensure ask-password metrics are only logged once.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -142,6 +142,10 @@ function (Cocktail, _, Backbone, $, p, AuthErrors,
           return p().then(function () {
             self.destroySubviews();
 
+            // force a re-load of the context every time the
+            // view is rendered or else stale data may
+            // be returned.
+            self._context = null;
             self.$el.html(self.template(self.getContext()));
           })
           .then(_.bind(self.afterRender, self))
@@ -277,7 +281,12 @@ function (Cocktail, _, Backbone, $, p, AuthErrors,
     },
 
     getContext: function () {
-      var ctx = this.context() || {};
+      // use cached context, if available. This prevents the context()
+      // function from being called multiple times per render.
+      if (! this._context) {
+        this._context = this.context() || {};
+      }
+      var ctx = this._context;
 
       ctx.t = _.bind(this.translate, this);
       ctx.canGoBack = this.canGoBack();

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -561,6 +561,34 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
         assert.isFalse(view.canGoBack());
       });
     });
+
+    describe('context call cache', function () {
+      it('multiple calls to `getContext` only call `context` once', function () {
+        view._context = null;
+
+        sinon.spy(view, 'context');
+
+        view.getContext();
+        view.getContext();
+
+        assert.equal(view.context.callCount, 1);
+      });
+
+      it('the context cache is cleared each time `render` is called', function () {
+        sinon.spy(view, 'context');
+
+        return view.render()
+          .then(function () {
+            return view.render();
+          })
+          .then(function () {
+            return view.render();
+          })
+          .then(function () {
+            assert.equal(view.context.callCount, 3);
+          });
+      });
+    });
   });
 });
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -506,6 +506,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
           return account;
         });
 
+        metrics.events.clear();
         return view.render()
           .then(function () {
             sinon.stub(account, 'getAvatar', function () {
@@ -517,6 +518,10 @@ function (chai, $, sinon, p, View, Session, AuthErrors, Metrics, FxaClient,
             assert.notOk(view.$('.password').length, 'should not show password input');
             assert.ok(view.$('.avatar-view img').length, 'should show suggested avatar');
             assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.skipped'));
+            var askPasswordEvents = metrics.getFilteredData().events.filter(function (event) {
+              return event.type === 'signin.ask-password.skipped';
+            });
+            assert.equal(askPasswordEvents.length, 1, 'event should only be logged once');
           });
       });
 


### PR DESCRIPTION
`view.context()` was called once per render and once per translation,
causing the ask-password metrics to be logged over and over again.

This fix caches the results of context(), so the function is only called
once per screen render. If the screen must be re-rendered, the cache is
cleared and context() is called again.

fixes #2403
fixes #1523