### PR TITLE
fix(tests): increase timeout for password reset tests

### DIFF
--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -21,6 +21,7 @@ define([
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
 
   var PASSWORD = 'password';
+  var TIMEOUT = 90 * 1000;
   var user;
   var email;
   var client;
@@ -31,7 +32,7 @@ define([
 
     setup: function () {
       // timeout after 90 seconds
-      this.timeout = 90000;
+      this.timeout = TIMEOUT;
 
       client = new FxaClient(AUTH_SERVER_ROOT, {
         xhr: nodeXMLHttpRequest.XMLHttpRequest
@@ -58,6 +59,7 @@ define([
 
     'reset password, verify same browser': function () {
       var self = this;
+      self.timeout = TIMEOUT;
 
       return FunctionalHelpers.openFxaFromRp(self, 'signin')
         .getCurrentUrl()

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -26,6 +26,7 @@ define([
   var COMPLETE_PAGE_URL_ROOT = config.fxaContentRoot + 'complete_reset_password';
 
   var PASSWORD = 'password';
+  var TIMEOUT = 90 * 1000;
   var email;
   var code;
   var token;
@@ -332,6 +333,7 @@ define([
 
     'reset password, verify same browser': function () {
       var self = this;
+      self.timeout = TIMEOUT;
 
       return FunctionalHelpers.fillOutResetPassword(self, email)
 


### PR DESCRIPTION
password reset tests are really slow against remote and need a bit more time. 
![](http://v14d.com/i/5554f796e737c.png)