### PR TITLE
fix(avatars): cache the profile image after fetching

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -172,6 +172,7 @@ define([
       return self.getAvatar()
         .then(function (result) {
           profileImage = new ProfileImage({ url: result.avatar, id: result.id });
+          self.setProfileImage(profileImage);
           return profileImage.fetch();
         })
         .then(function () {

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -29,6 +29,9 @@ define([
 
       return account.fetchCurrentProfileImage()
         .then(function (profileImage) {
+          // Cache the result to make sure we don't flash the default
+          // image while fetching the latest profile image
+          self._updateCachedProfileImage(account.get('uid'), profileImage);
           return profileImage;
         }, function (err) {
           self.logError(err);
@@ -48,6 +51,16 @@ define([
             self.logScreenEvent('profile_image_shown');
           }
         });
+    },
+
+    // Makes sure the account with uid has an uptodate image cache.
+    // This should be called after fetching the current profile image.
+    _updateCachedProfileImage: function (uid, profileImage) {
+      var cachedAccount = this.user.getAccountByUid(uid);
+      if (! cachedAccount.isDefault()) {
+        cachedAccount.setProfileImage(profileImage);
+        this.user.setAccount(cachedAccount);
+      }
     },
 
     _shouldShowDefaultProfileImage: function (account) {

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -555,11 +555,14 @@ function (chai, sinon, p, Constants, Assertion, ProfileClient,
           return p({ avatar: PNG_URL, id: 'foo' });
         });
 
+        sinon.spy(account, 'setProfileImage');
+
         return account.fetchCurrentProfileImage()
           .then(function (profileImage) {
             assert.equal(profileImage.get('url'), PNG_URL);
             assert.equal(profileImage.get('id'), 'foo');
             assert.isTrue(profileImage.has('img'));
+            assert.isTrue(account.setProfileImage.calledWith(profileImage));
           });
       });
 

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -55,9 +55,30 @@ define([
       sinon.stub(view, 'getSignedInAccount', function () {
         return account;
       });
-      sinon.stub(user, 'setAccount', function () { });
+      sinon.spy(user, 'setAccount');
 
       sinon.stub(notifications, 'profileChanged', function () { });
+    });
+
+    it('displayAccountProfileImage updates the cached account data', function () {
+      var image = new ProfileImage({ url: 'url', id: 'foo' });
+      var cachedAccount = user.initAccount({ uid: 'uid' });
+      sinon.spy(cachedAccount, 'setProfileImage');
+
+      sinon.stub(account, 'fetchCurrentProfileImage', function () {
+        return p(image);
+      });
+      sinon.stub(user, 'getAccountByUid', function () {
+        return cachedAccount;
+      });
+
+      return view.displayAccountProfileImage(account)
+        .then(function () {
+          assert.isTrue(account.fetchCurrentProfileImage.called);
+          assert.isTrue(user.getAccountByUid.calledWith(UID));
+          assert.isTrue(user.setAccount.calledWith(cachedAccount));
+          assert.isTrue(cachedAccount.setProfileImage.calledWith(image));
+        });
     });
 
     describe('updateProfileImage', function () {


### PR DESCRIPTION
The default profile image will flash in cases where the account has a profile
image but it hasn't been cached locally. To ensure this doesn't happen ever time
the image is displayed, we update the cache when the image is fetched.

Fixes #2429.

@vladikoff r? This should make your metrics PR more accurate– we didn't always have the profile image cached even when it was displayed.