### PR TITLE
chore(metrics): collect entrypoint metrics for non-fx-desktop reliers

### DIFF
--- a/app/scripts/models/reliers/fx-desktop.js
+++ b/app/scripts/models/reliers/fx-desktop.js
@@ -7,7 +7,7 @@
  * `Relier`, provides the following:
  *
  * - context
- * - entrypoint
+ * - migration
  */
 
 'use strict';
@@ -20,9 +20,7 @@ define([
 
   var FxDesktopRelier = Relier.extend({
     defaults: _.extend({}, Relier.prototype.defaults, {
-      campaign: null,
       context: null,
-      entrypoint: null,
       migration: null
     }),
 
@@ -39,8 +37,6 @@ define([
       return Relier.prototype.fetch.call(self)
         .then(function () {
           self.importSearchParam('context');
-          self.importSearchParam('entrypoint');
-          self.importSearchParam('campaign');
           self.importSearchParam('migration');
           try {
             self.importBooleanSearchParam('customizeSync');

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -21,7 +21,9 @@ define([
       service: null,
       preVerifyToken: null,
       email: null,
-      allowCachedCredentials: true
+      allowCachedCredentials: true,
+      entrypoint: null,
+      campaign: null
     },
 
     initialize: function (options) {
@@ -52,6 +54,8 @@ define([
           self.importSearchParam('preVerifyToken');
           self.importSearchParam('uid');
           self.importSearchParam('setting');
+          self.importSearchParam('entrypoint');
+          self.importSearchParam('campaign');
 
           // A relier can indicate they do not want to allow
           // cached credentials if they set email === 'blank'

--- a/app/tests/spec/models/reliers/fx-desktop.js
+++ b/app/tests/spec/models/reliers/fx-desktop.js
@@ -34,18 +34,14 @@ define([
     describe('fetch', function () {
       it('populates model from the search parameters', function () {
         windowMock.location.search = TestHelpers.toSearchString({
-          campaign: 'fennec',
           context: 'fx_desktop_v1',
-          entrypoint: 'menupanel',
           migration: 'sync1.5',
           service: 'sync'
         });
 
         return relier.fetch()
             .then(function () {
-              assert.equal(relier.get('campaign'), 'fennec');
               assert.equal(relier.get('context'), 'fx_desktop_v1');
-              assert.equal(relier.get('entrypoint'), 'menupanel');
               assert.equal(relier.get('migration'), 'sync1.5');
               assert.equal(relier.get('service'), 'sync');
             });

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -22,6 +22,8 @@ define([
     var PREVERIFY_TOKEN = 'abigtoken';
     var EMAIL = 'email';
     var UID = 'uid';
+    var ENTRYPOINT = 'preferences';
+    var CAMPAIGN = 'fennec';
 
     beforeEach(function () {
       windowMock = new WindowMock();
@@ -38,6 +40,8 @@ define([
           service: SERVICE,
           email: EMAIL,
           uid: UID,
+          entrypoint: ENTRYPOINT,
+          campaign: CAMPAIGN,
           ignored: 'ignored'
         });
 
@@ -47,6 +51,8 @@ define([
               assert.equal(relier.get('service'), SERVICE);
               assert.equal(relier.get('email'), EMAIL);
               assert.equal(relier.get('uid'), UID);
+              assert.equal(relier.get('entrypoint'), ENTRYPOINT);
+              assert.equal(relier.get('campaign'), CAMPAIGN);
               assert.isFalse(relier.has('ignored'));
             });
       });

--- a/docs/query-params.md
+++ b/docs/query-params.md
@@ -76,7 +76,6 @@ If the user arrived at Firefox Accounts via a Mozilla marketing campaign,
 specify the campaign identifier.
 
 #### When to specify
-Only available if `context=fx_desktop_v1`.
 
 * /signin
 * /signup
@@ -99,11 +98,10 @@ Only available if `context=fx_desktop_v1&service=sync`.
 If they user arrived at Firefox Accounts from within Firefox browser chrome, specify where in Firefox the user came from.
 
 #### When to specify
-Only available if `context=fx_desktop_v1`.
-
 * /signin
 * /signup
 * /force_auth
+* /settings
 
 ### `migration`
 If the user is migrating their Sync account from "old sync" to "new sync", specify which sync they are migrating from.


### PR DESCRIPTION
This goes along with https://bugzilla.mozilla.org/show_bug.cgi?id=1165510, which adds the `entrypoint` query param to links from the Sync preferences page to our settings page.

@shane-tomlinson or @vladikoff r?