### PR TITLE
fix(client): `Invalid scopes` is an error message.

### DIFF
--- a/app/scripts/lib/errors.js
+++ b/app/scripts/lib/errors.js
@@ -48,7 +48,12 @@ define([
         return messageSource.message;
       }
 
-      // could not find an error with a message, return the original.
+      // the original is not a string, default to unexpected error
+      if (typeof err !== 'string') {
+        return this.toMessage('UNEXPECTED_ERROR');
+      }
+
+      // The original was already a string, just return it.
       return err;
     },
 

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -8,12 +8,15 @@
 
 define([
   'underscore',
-  'lib/errors'
+  'lib/errors',
+  'lib/strings'
 ],
-function (_, Errors) {
+function (_, Errors, Strings) {
   var t = function (msg) {
     return msg;
   };
+
+  var UNEXPECTED_ERROR = t('Unexpected error');
 
   var ERRORS = {
     UNKNOWN_CLIENT: {
@@ -28,6 +31,18 @@ function (_, Errors) {
       errno: 104,
       message: t('Invalid assertion')
     },
+    UNKNOWN_CODE: {
+      errno: 105,
+      message: t('Unknown code')
+    },
+    INCORRECT_CODE: {
+      errno: 106,
+      message: t('Incorrect code')
+    },
+    EXPIRED_CODE: {
+      errno: 107,
+      message: t('Expired code')
+    },
     INVALID_PARAMETER: {
       errno: 108,
       message: t('Invalid parameter in request body: %(param)s')
@@ -36,13 +51,35 @@ function (_, Errors) {
       errno: 109,
       message: t('Invalid request signature')
     },
+    INVALID_RESPONSE_TYPE: {
+      errno: 110,
+      message: UNEXPECTED_ERROR
+    },
+    UNAUTHORIZED: {
+      errno: 111,
+      message: t('Unauthorized')
+    },
+    FORBIDDEN: {
+      errno: 112,
+      message: t('Forbidden')
+    },
+    INVALID_CONTENT_TYPE: {
+      errno: 113,
+      message: UNEXPECTED_ERROR
+    },
+    INVALID_SCOPES: {
+      errno: 114,
+      message: Strings.interpolate(
+        // `scope` should not be translated, so interpolate it in.
+        t('Invalid OAuth parameter: %(param)s'), { param: 'scope' })
+    },
     SERVICE_UNAVAILABLE: {
       errno: 998,
       message: t('System unavailable, try again soon')
     },
     UNEXPECTED_ERROR: {
       errno: 999,
-      message: t('Unexpected error')
+      message: UNEXPECTED_ERROR
     },
     TRY_AGAIN: {
       errno: 1000,
@@ -50,15 +87,15 @@ function (_, Errors) {
     },
     INVALID_RESULT: {
       errno: 1001,
-      message: t('Unexpected error')
+      message: UNEXPECTED_ERROR
     },
     INVALID_RESULT_REDIRECT: {
       errno: 1002,
-      message: t('Unexpected error')
+      message: UNEXPECTED_ERROR
     },
     INVALID_RESULT_CODE: {
       errno: 1003,
-      message: t('Unexpected error')
+      message: UNEXPECTED_ERROR
     },
     USER_CANCELED_OAUTH_LOGIN: {
       errno: 1004,

--- a/app/tests/spec/lib/auth-errors.js
+++ b/app/tests/spec/lib/auth-errors.js
@@ -80,6 +80,10 @@ function (chai, AuthErrors) {
       it('converts SERVER_BUSY error correctly', function () {
         assert.equal(AuthErrors.toMessage(AuthErrors.toError('SERVER_BUSY')), 'Server busy, try again soon');
       });
+
+      it('converts an unknown object to `UNEXPECTED_ERROR`', function () {
+        assert.equal(AuthErrors.toMessage({}), 'Unexpected error');
+      });
     });
 
     describe('toInterpolationContext', function () {

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -311,6 +311,11 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
         assert.isTrue(TestHelpers.isErrorLogged(metrics, err));
       });
 
+      it('displays an `Unexpected Error` if error is unknown', function () {
+        view.displayError({ errno: -10001 });
+        assert.equal(view.$('.error').html(), AuthErrors.toMessage('UNEXPECTED_ERROR'));
+      });
+
       it('displays an `Unexpected Error` if no error passed in', function () {
         view.displayError();
         assert.equal(view.$('.error').html(), AuthErrors.toMessage('UNEXPECTED_ERROR'));


### PR DESCRIPTION
@rfk - r?

There were multiple problems. First, views/base.js would not display an error if it has no entry in one of the error tables. The OAuth error with `errno: 114` was not in the list of possible OAuth errors, so no message was ever displayed to the user.

* Unrecognized errors passed to errors->toMessage convert to `Unexpected error`.
* Ensure oauth errno 114 displays `Invalid scopes`.
* Add the missing error codes in oauth-errors.js and ensure they all have strings.

issue #2426