### PR TITLE
fix(avatars): Redirect to settings/avatar/change on error

### DIFF
--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -54,7 +54,7 @@ function ($, _, md5, Cocktail, FormView, SettingsMixin, AvatarMixin,
     },
 
     _notFound: function () {
-      this.navigate('settings', {
+      this.navigate('settings/avatar/change', {
         error: t('No Gravatar found')
       });
     },

--- a/app/tests/spec/views/settings/avatar_change.js
+++ b/app/tests/spec/views/settings/avatar_change.js
@@ -143,31 +143,25 @@ function (chai, _, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
               var ev = FileReaderMock._mockTextEvent();
               view.fileSet(ev);
 
-              assert.equal(routerMock.page, 'settings');
-              assert.equal(view.ephemeralMessages.get('error'), AuthErrors.toMessage('UNUSABLE_IMAGE'));
+              assert.equal(view.$('.error').text(), AuthErrors.toMessage('UNUSABLE_IMAGE'));
+              assert.isTrue(view.isErrorVisible());
             });
         });
 
-        it('errors on a bad image', function (done) {
+        it('errors on a bad image', function () {
           view.FileReader = FileReaderMock;
 
-          view.afterVisible()
+          return view.afterVisible()
             .then(function () {
               var ev = FileReaderMock._mockBadPngEvent();
-
-              view.router.on('navigate', function () {
-                try {
-                  assert.equal(routerMock.page, 'settings');
-                  assert.equal(view.ephemeralMessages.get('error'), AuthErrors.toMessage('UNUSABLE_IMAGE'));
-                  done();
-                } catch (e) {
-                  return done(e);
-                }
-              });
-
-              view.fileSet(ev);
-            })
-            .fail(done);
+              return view.fileSet(ev)
+                .then(function () {
+                  assert.fail('unexpected success');
+                }, function () {
+                  assert.equal(view.$('.error').text(), AuthErrors.toMessage('UNUSABLE_IMAGE'));
+                  assert.isTrue(view.isErrorVisible());
+                });
+            });
         });
 
         it('loads a supported file', function (done) {

--- a/app/tests/spec/views/settings/avatar_gravatar.js
+++ b/app/tests/spec/views/settings/avatar_gravatar.js
@@ -92,8 +92,8 @@ function (chai, _, $, sinon, View, RouterMock, ProfileMock, User,
         return view.render()
           .then(function () {
             return view._showGravatar()
-              .then(null, function () {
-                assert.equal(routerMock.page, 'settings');
+              .then(function () {
+                assert.equal(routerMock.page, 'settings/avatar/change');
                 assert.equal(view.ephemeralMessages.get('error'), 'No Gravatar found');
               });
           });

--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -232,8 +232,8 @@ define([
           .click()
         .end()
 
-        //success is returning to the settings page
-        .findById('fxa-settings-header')
+        // success is going to the change avatar page
+        .findById('avatar-options')
         .end()
 
         // success is seeing the error text


### PR DESCRIPTION
Fixes #2428,

I also took the liberty to redirect errors to settings/avatar/change when an uploaded avatar is invalid or corrupted.