### PR TITLE
chore(license): Update MPL license string to be SPDX compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/mozilla/fxa-content-server",
   "bugs": "https://github.com/mozilla/fxa-content-server/issues",
   "author": "Mozilla (https://mozilla.org/)",
-  "license": "MPL 2.0",
+  "license": "MPL-2.0",
   "dependencies": {
     "bluebird": "2.2.2",
     "body-parser": "1.12.2",


### PR DESCRIPTION
There are a few npm changes in newer versions of npm where npm prefers valid SPDX license identifiers (see https://spdx.org/licenses/).

https://docs.npmjs.com/files/package.json#license and http://npm1k.org/

```sh
$ node index 'MPL 2.0'
MPL 2.0 ==> null

$ node index 'MPL-2.0'
MPL-2.0 ==> true
```

```sh
$ npm-next --version
2.10.1

$ npm-next init
...
license: (WTFPL) MPL 2.0
Sorry, license should be a valid SPDX license expression and license is similar to the valid expression "MPL-2.0".
license: (WTFPL)
```