### PR TITLE
refactor(client): Extract change password account related logic from the view into models.

### DIFF
--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -249,6 +249,14 @@ define([
         .then(function () {
           return self.setSignedInAccount(account);
         });
+    },
+
+    changeAccountPassword: function (account, oldPassword, newPassword, relier) {
+      var self = this;
+      return account.changePassword(oldPassword, newPassword, relier)
+        .then(function () {
+          return self.setSignedInAccount(account);
+        });
     }
 
   });

--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -40,60 +40,34 @@ function (Cocktail, BaseView, FormView, AuthErrors, Template, PasswordMixin,
     submit: function () {
       var self = this;
       var account = self.getSignedInAccount();
-      var email = account.get('email');
       var oldPassword = self.$('#old_password').val();
       var newPassword = self.$('#new_password').val();
 
       self.hideError();
 
-      // Try to sign the user in before checking whether the
-      // passwords are the same. If the user typed the incorrect old
-      // password, they should know that first.
-      return self.fxaClient.checkPassword(email, oldPassword)
-          .then(function () {
-            if (oldPassword === newPassword) {
-              throw AuthErrors.toError('PASSWORDS_MUST_BE_DIFFERENT');
-            }
-
-            return self.fxaClient.changePassword(
-                     email, oldPassword, newPassword);
-          })
-          .then(function () {
-            // sign the user in, keeping the current sessionTokenContext. This
-            // prevents sync users from seeing the `sign out` button on the
-            // settings screen.
-
-            return self.fxaClient.signIn(
-              email,
-              newPassword,
-              self.relier,
-              {
-                reason: self.fxaClient.SIGNIN_REASON.PASSWORD_CHANGE,
-                sessionTokenContext: account.get('sessionTokenContext')
-              }
-            );
-          })
-          .then(function (updatedSessionData) {
-            account.set(updatedSessionData);
-            return self.user.setSignedInAccount(account);
-          })
-          .then(function () {
-            return self.broker.afterChangePassword(account);
-          })
-          .then(function () {
-            self.navigate('settings', {
-              success: t('Password changed successfully')
-            });
-          }, function (err) {
-            if (AuthErrors.is(err, 'ACCOUNT_LOCKED')) {
-              // the password is needed to poll whether the account has
-              // been unlocked.
-              account.set('password', oldPassword);
-              return self.notifyOfLockedAccount(account);
-            }
-
-            throw err;
+      return self.user.changeAccountPassword(
+          account,
+          oldPassword,
+          newPassword,
+          self.relier
+        )
+        .then(function () {
+          return self.broker.afterChangePassword(account);
+        })
+        .then(function () {
+          self.navigate('settings', {
+            success: t('Password changed successfully')
           });
+        }, function (err) {
+          if (AuthErrors.is(err, 'ACCOUNT_LOCKED')) {
+            // the password is needed to poll whether the account has
+            // been unlocked.
+            account.set('password', oldPassword);
+            return self.notifyOfLockedAccount(account);
+          }
+
+          throw err;
+        });
     }
   });
 

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -341,5 +341,30 @@ function (chai, sinon, p, Constants, Session, FxaClient, User) {
         });
     });
 
+    it('changeAccountPassword changes the account password', function () {
+      var relierMock = {};
+      var account = user.initAccount({ uid: 'uid', email: 'email' });
+
+      sinon.stub(account, 'changePassword', function () {
+        return p();
+      });
+      sinon.stub(user, 'setSignedInAccount', function () {
+        return p();
+      });
+
+      var oldPassword = 'password';
+      var newPassword = 'new_password';
+
+      return user.changeAccountPassword(account, oldPassword, newPassword, relierMock)
+        .then(function () {
+          assert.isTrue(account.changePassword.calledWith(
+            oldPassword,
+            newPassword,
+            relierMock
+          ));
+
+          assert.isTrue(user.setSignedInAccount.calledWith(account));
+        });
+    });
   });
 });

--- a/app/tests/spec/views/change_password.js
+++ b/app/tests/spec/views/change_password.js
@@ -36,7 +36,6 @@ function (chai, $, sinon, AuthErrors, FxaClient, Metrics, p,
     var account;
     var ephemeralMessages;
     var metrics;
-    var EMAIL = 'testuser@testuser.com';
 
     beforeEach(function () {
       routerMock = new RouterMock();
@@ -47,7 +46,9 @@ function (chai, $, sinon, AuthErrors, FxaClient, Metrics, p,
       fxaClient = new FxaClient({
         broker: broker
       });
-      user = new User();
+      user = new User({
+        fxaClient: fxaClient
+      });
       ephemeralMessages = new EphemeralMessages();
       metrics = new Metrics();
 
@@ -159,11 +160,11 @@ function (chai, $, sinon, AuthErrors, FxaClient, Metrics, p,
       });
 
       describe('submit', function () {
-        it('prints incorrect password error message if old password is incorrect (event if passwords are the same)', function () {
+        it('prints returned error messages', function () {
           $('#old_password').val('bad_password');
           $('#new_password').val('bad_password');
 
-          sinon.stub(view.fxaClient, 'checkPassword', function () {
+          sinon.stub(user, 'changeAccountPassword', function () {
             return p.reject(AuthErrors.toError('INCORRECT_PASSWORD'));
           });
 
@@ -173,115 +174,10 @@ function (chai, $, sinon, AuthErrors, FxaClient, Metrics, p,
             });
         });
 
-        it('prints passwords must be different message if both passwords are the same and the first password is correct', function () {
-          $('#old_password').val('password');
-          $('#new_password').val('password');
-
-          sinon.stub(view.fxaClient, 'checkPassword', function () {
-            return p();
-          });
-
-          return view.submit()
-            .then(assert.fail, function (err) {
-              assert.ok(AuthErrors.is(err, 'PASSWORDS_MUST_BE_DIFFERENT'));
-            });
-        });
-
-        it('changes from old to new password, redirects user to /settings', function () {
-          $('#old_password').val('password');
-          $('#new_password').val('new_password');
-
-          account.set('email', EMAIL);
-          var oldPassword = 'password';
-          var newPassword = 'new_password';
-
-          sinon.stub(view.fxaClient, 'checkPassword', function () {
-            return p();
-          });
-
-          sinon.stub(view.fxaClient, 'changePassword', function () {
-            return p();
-          });
-
-          sinon.stub(view.fxaClient, 'signIn', function () {
-            return p({});
-          });
-
-          sinon.stub(user, 'setSignedInAccount', function () {
-            return p({});
-          });
-
-          sinon.spy(broker, 'afterChangePassword');
-
-          return view.submit()
-            .then(function () {
-              assert.equal(routerMock.page, 'settings');
-              assert.isTrue(view.fxaClient.checkPassword.calledWith(
-                  EMAIL, oldPassword));
-              assert.isTrue(view.fxaClient.changePassword.calledWith(
-                  EMAIL, oldPassword, newPassword));
-              assert.isTrue(view.fxaClient.signIn.calledWith(
-                  EMAIL,
-                  newPassword,
-                  relier,
-                  {
-                    reason: view.fxaClient.SIGNIN_REASON.PASSWORD_CHANGE,
-                    sessionTokenContext: account.get('sessionTokenContext')
-                  }
-              ));
-              assert.isTrue(user.setSignedInAccount.calledWith(account));
-              assert.isTrue(broker.afterChangePassword.calledWith(account));
-            });
-        });
-
-        it('changes from old to new password, keeps sessionTokenContext', function () {
-          $('#old_password').val('password');
-          $('#new_password').val('new_password');
-
-          account.set('email', EMAIL);
-          account.set('sessionTokenContext', 'foo');
-
-          sinon.stub(view.fxaClient, 'checkPassword', function () {
-            return p();
-          });
-
-          sinon.stub(view.fxaClient, 'changePassword', function () {
-            return p();
-          });
-
-          sinon.stub(view.fxaClient, 'signIn', function () {
-            return p({});
-          });
-
-          sinon.stub(user, 'setSignedInAccount', function () {
-            return p({});
-          });
-
-          return view.submit()
-              .then(function () {
-                assert.isTrue(view.fxaClient.signIn.calledWith(
-                    EMAIL,
-                    'new_password',
-                    relier,
-                    {
-                      reason: view.fxaClient.SIGNIN_REASON.PASSWORD_CHANGE,
-                      sessionTokenContext: 'foo'
-                    }
-                ));
-                assert.isTrue(user.setSignedInAccount.calledWith(account));
-              });
-        });
-
         it('shows error message to locked out users', function () {
-          sinon.stub(view.fxaClient, 'checkPassword', function () {
-            return p();
-          });
-
-          sinon.stub(view.fxaClient, 'changePassword', function () {
+          sinon.stub(user, 'changeAccountPassword', function () {
             return p.reject(AuthErrors.toError('ACCOUNT_LOCKED'));
           });
-
-          account.set('email', EMAIL);
 
           $('#old_password').val('password');
           $('#new_password').val('new_password');
@@ -295,6 +191,27 @@ function (chai, $, sinon, AuthErrors, FxaClient, Metrics, p,
               assert.isTrue(TestHelpers.isErrorLogged(metrics, err));
 
               assert.isTrue(account.has('password'));
+            });
+        });
+
+        it('redirects user to /settings on success', function () {
+          var oldPassword = 'password';
+          var newPassword = 'new_password';
+          $('#old_password').val(oldPassword);
+          $('#new_password').val(newPassword);
+
+          sinon.stub(user, 'changeAccountPassword', function () {
+            return p({});
+          });
+
+          sinon.spy(broker, 'afterChangePassword');
+
+          return view.submit()
+            .then(function () {
+              assert.equal(routerMock.page, 'settings');
+              assert.isTrue(user.changeAccountPassword.calledWith(
+                  account, oldPassword, newPassword));
+              assert.isTrue(broker.afterChangePassword.calledWith(account));
             });
         });
       });


### PR DESCRIPTION
@zaach - r?

A small continuation of the work you started with signIn/signUp.

The change password account management logic was inside of the view, which smelled of mixed concerns. Moved logic to user & account models.

issue #2376