### PR TITLE
fix(oauth): strip permissions that are not on the whitelist

### DIFF
--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -18,6 +18,9 @@ define([
   'lib/constants'
 ], function (_, Relier, ResumeToken, OAuthErrors, RelierKeys, Url, Constants) {
   var RELIER_FIELDS_IN_RESUME_TOKEN = ['state', 'verificationRedirect'];
+  // We only grant permissions that our UI currently prompts for. Others
+  // will be stripped.
+  var PERMISSION_WHITE_LIST = ['profile:uid', 'profile:email'];
 
   var OAuthRelier = Relier.extend({
     defaults: _.extend({}, Relier.prototype.defaults, {
@@ -64,7 +67,8 @@ define([
           }
           if (self.has('scope')) {
             // Turn the scope string into an array of permissions
-            self.set('permissions', scopeStrToArray(self.get('scope')));
+            self.set('permissions',
+              stripNonWhiteListedPermissions(scopeStrToArray(self.get('scope'))));
           }
 
           return self._setupOAuthRPInfo();
@@ -220,6 +224,12 @@ define([
 
   function scopeStrToArray(scopes) {
     return typeof scopes === 'string' ? _.uniq(scopes.split(/\s+/g)) : scopes;
+  }
+
+  function stripNonWhiteListedPermissions(permissions) {
+    return permissions.filter(function (permission) {
+      return PERMISSION_WHITE_LIST.indexOf(permission) !== -1;
+    });
   }
 
   return OAuthRelier;

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -35,6 +35,7 @@ define([
     var REDIRECT_URI = 'http://redirect.here';
     var SERVER_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
     var SCOPE = 'profile:email profile:uid';
+    var SCOPE_WITH_EXTRAS = 'profile:email profile:uid profile:non_whitelisted';
     var PERMISSIONS = ['profile:email', 'profile:uid'];
     var ACTION = 'signup';
     var PREVERIFY_TOKEN = 'abigtoken';
@@ -195,6 +196,19 @@ define([
           //jshint camelcase: false
           client_id: CLIENT_ID,
           scope: SCOPE
+        });
+
+        return relier.fetch()
+          .then(function () {
+            assert.deepEqual(relier.get('permissions'), PERMISSIONS);
+          });
+      });
+
+      it('only populates whitelisted permissions from scope', function () {
+        windowMock.location.search = TestHelpers.toSearchString({
+          //jshint camelcase: false
+          client_id: CLIENT_ID,
+          scope: SCOPE_WITH_EXTRAS
         });
 
         return relier.fetch()


### PR DESCRIPTION
This pares down the scopes we receive from the relier so that we only grant the ones we currently prompt for.

@vladikoff r?