### PR TITLE
fix(tests): wait for ".error" to be visible; fixes #2475

### DIFF
--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -236,6 +236,7 @@ define([
         .end()
 
         // success is seeing the error text
+        .then(FunctionalHelpers.visibleByQSA('.error'))
         .findByCssSelector('.error')
           .getVisibleText()
           .then(function (val) {


### PR DESCRIPTION
Per @vladikoff - https://github.com/mozilla/fxa-content-server/issues/2475#issuecomment-105704093 just wait for visible. r? @vladikoff or @shane-tomlinson 

This would be a good ride-along on a 0.38.1