### PR TITLE
fix(oauth): sanitize scope of untrusted reliers

### DIFF
--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -65,13 +65,16 @@ define([
           if (! self.has('service')) {
             self.set('service', self.get('clientId'));
           }
-          if (self.has('scope')) {
-            // Turn the scope string into an array of permissions
-            self.set('permissions',
-              stripNonWhiteListedPermissions(scopeStrToArray(self.get('scope'))));
-          }
-
-          return self._setupOAuthRPInfo();
+          return self._setupOAuthRPInfo()
+            .then(function () {
+              var permissions;
+              // Sanitize permissions for untrusted reliers
+              if (! self.isTrusted() && self.has('scope')) {
+                permissions = stripNonWhiteListedPermissions(scopeStrToArray(self.get('scope')));
+                self.set('scope', permissions.join(' '));
+                self.set('permissions', permissions);
+              }
+            });
         });
     },
 

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -204,16 +204,39 @@ define([
           });
       });
 
-      it('only populates whitelisted permissions from scope', function () {
+      it('sanitizes the scope of untrusted reliers', function () {
         windowMock.location.search = TestHelpers.toSearchString({
           //jshint camelcase: false
           client_id: CLIENT_ID,
           scope: SCOPE_WITH_EXTRAS
         });
 
+        sinon.stub(relier, 'isTrusted', function () {
+          return false;
+        });
+
         return relier.fetch()
           .then(function () {
+            assert.equal(relier.get('scope'), SCOPE);
             assert.deepEqual(relier.get('permissions'), PERMISSIONS);
+          });
+      });
+
+      it('does not sanitize the scope of trusted reliers', function () {
+        windowMock.location.search = TestHelpers.toSearchString({
+          //jshint camelcase: false
+          client_id: CLIENT_ID,
+          scope: SCOPE_WITH_EXTRAS
+        });
+
+        sinon.stub(relier, 'isTrusted', function () {
+          return true;
+        });
+
+        return relier.fetch()
+          .then(function () {
+            assert.equal(relier.get('scope'), SCOPE_WITH_EXTRAS);
+            assert.isFalse(relier.has('permissions'), 'permissions not set for trusted reliers');
           });
       });
 


### PR DESCRIPTION
This was missed in #2478.

@vladikoff r?

/cc @jrgm