### PR TITLE
feat(metrics): add Sentry metrics for front-end errors

### DIFF
--- a/app/scripts/lib/sentry.js
+++ b/app/scripts/lib/sentry.js
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'underscore',
+  'raven',
+  'lib/url'
+], function (_, Raven, Url) {
+  'use strict';
+
+  var ALLOWED_QUERY_PARAMETERS = [
+    'automatedBrowser',
+    'campaign',
+    'client_id',
+    'context',
+    'customizeSync',
+    'entrypoint',
+    'keys',
+    'migration',
+    'redirect_uri',
+    'scope',
+    'service',
+    'setting',
+    'style',
+    'verification_redirect'
+  ];
+
+  /**
+   * function that gets called before data gets sent to error metrics
+   *
+   * @param {Object} data
+   *  Error object data
+   * @returns {Object} data
+   *  Modified error object data
+   * @private
+   */
+  function beforeSend(data) {
+    if (data && data.request && data.request.url) {
+      data.request.url = cleanUpQueryParam(data.request.url);
+    }
+
+    return data;
+  }
+
+  /**
+   * Overwrites sensitive query parameters with a dummy value.
+   *
+   * @param {String} url
+   * @returns {String} url
+   * @private
+   */
+  function cleanUpQueryParam(url) {
+    var startOfParams = url.indexOf('?');
+    var newUrl = url;
+    var params;
+
+    if (startOfParams === -1) {
+      return newUrl;
+    }
+
+    params = Url.searchParams(url.substring(startOfParams + 1));
+    newUrl = url.substring(0, startOfParams);
+
+    if (_.isObject(params)) {
+      Object.keys(params).forEach(function (key) {
+        // if the param is a PII (not allowed) then reset the value.
+        if (! _.contains(ALLOWED_QUERY_PARAMETERS, key)) {
+          params[key] = 'VALUE';
+        }
+      });
+
+      newUrl += Url.objToSearchString(params);
+    }
+
+    return newUrl;
+  }
+
+  /**
+   * Creates a SentryMetrics object that starts up Raven.js
+   *
+   * Read more at https://github.com/getsentry/raven-js
+   *
+   * @param {String} host
+   * @constructor
+   */
+  function SentryMetrics (host) {
+    if (host) {
+      // use __API_KEY__ instead of the real API key because raven.js requires it
+      // we can configure the real API key on the server using our local endpoint instead.
+      // See issue https://github.com/getsentry/raven-js/issues/346 for more information
+
+      this._endpoint = '//__API_KEY__@' + host + '/metrics-errors';
+    } else {
+      console.error('No Sentry host provided');
+      return;
+    }
+
+    try {
+      Raven.config(this._endpoint, this._ravenOpts).install();
+      Raven.debug = false;
+    } catch (e) {
+      Raven.uninstall();
+      console.error(e);
+    }
+  }
+
+  SentryMetrics.prototype = {
+    /**
+     * Specialized raven.js endpoint string
+     *
+     * See https://raven-js.readthedocs.org/en/latest/config/index.html#configuration
+     */
+    _endpoint: null,
+    /**
+     * raven.js settings
+     *
+     * See https://raven-js.readthedocs.org/en/latest/config/index.html#optional-settings
+     */
+    _ravenOpts: {
+      dataCallback: beforeSend
+    },
+    /**
+     * Disable error metrics with raven.js
+     *
+     * window.onerror reverted back to normal, TraceKit disabled
+     */
+    remove: function () {
+      Raven.uninstall();
+    },
+    // Private functions, exposed for testing
+    __beforeSend: beforeSend,
+    __cleanUpQueryParam: cleanUpQueryParam
+  };
+
+  return SentryMetrics;
+});
+

--- a/app/scripts/require_config.js
+++ b/app/scripts/require_config.js
@@ -24,7 +24,8 @@ require.config({
     mailcheck: '../bower_components/mailcheck/src/mailcheck',
     crosstab: 'vendor/crosstab',
     uuid: '../bower_components/node-uuid/uuid',
-    'jquery-simulate': '../bower_components/jquery-simulate/jquery.simulate'
+    'jquery-simulate': '../bower_components/jquery-simulate/jquery.simulate',
+    raven: '../bower_components/raven-js/dist/raven'
   },
   config: {
     moment: {

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -6,6 +6,7 @@ define([
   'cocktail',
   'underscore',
   'backbone',
+  'raven',
   'jquery',
   'lib/promise',
   'lib/auth-errors',
@@ -14,7 +15,7 @@ define([
   'lib/null-metrics',
   'views/mixins/timer-mixin'
 ],
-function (Cocktail, _, Backbone, $, p, AuthErrors,
+function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
       Strings, EphemeralMessages, NullMetrics, TimerMixin) {
   'use strict';
 
@@ -487,7 +488,7 @@ function (Cocktail, _, Backbone, $, p, AuthErrors,
       if (typeof console !== 'undefined' && console) {
         console.error(err.message);
       }
-
+      Raven.captureException(err);
       this.metrics.logError(err);
     },
 

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -32,7 +32,8 @@ function (Backbone, sinon, _, NullStorage) {
       href: window.location.href,
       search: window.location.search,
       pathname: '/',
-      origin: window.location.origin
+      origin: window.location.origin,
+      host: window.location.host
     };
 
     this.document = {

--- a/app/tests/spec/lib/sentry.js
+++ b/app/tests/spec/lib/sentry.js
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'sinon',
+  'lib/sentry',
+  'raven',
+  '../../mocks/window'
+], function (chai, sinon, SentryMetrics, Raven, WindowMock) {
+  'use strict';
+
+  var assert = chai.assert;
+  var windowMock;
+  var host;
+
+  describe('lib/sentry', function () {
+
+    beforeEach(function () {
+      windowMock = new WindowMock();
+      host = windowMock.location.host;
+    });
+
+    afterEach(function () {
+      Raven.uninstall();
+    });
+
+    describe('init', function () {
+      it('properly inits', function () {
+        try {
+          void new SentryMetrics();
+        } catch (e) {
+          assert.isNull(e);
+        }
+      });
+
+      it('properly inits with host', function () {
+        var sentry;
+        try {
+          sentry = new SentryMetrics(host);
+        } catch (e) {
+          assert.isNull(e);
+        }
+
+        assert.equal(sentry._endpoint, '//__API_KEY__@' + host + '/metrics-errors');
+      });
+
+      it('catches init errors', function () {
+        sinon.stub(Raven, 'config', function () {
+          throw new Error('Config error');
+        });
+
+        try {
+          void new SentryMetrics(host);
+        } catch (e) {
+          assert.isNull(e);
+        }
+
+        assert.isTrue(Raven.config.called);
+
+        Raven.config.restore();
+      });
+
+    });
+
+    describe('remove', function () {
+      it('properly removes itself', function () {
+        var sentry = new SentryMetrics(host);
+        try {
+          sentry.remove();
+        } catch (e) {
+          assert.isNull(e);
+        }
+      });
+    });
+
+    describe('captureException', function () {
+      it('does not throw errors', function () {
+        // captureException will not throw before init;
+        try {
+          Raven.captureException(new Error('tests'));
+        } catch (e) {
+          assert.isNull(e);
+        }
+
+        void new SentryMetrics(host);
+
+        // does not throw after init
+        try {
+          Raven.captureException(new Error('tests'));
+        } catch (e) {
+          assert.isNull(e);
+        }
+
+      });
+    });
+
+    describe('beforeSend', function () {
+      it('works without request url', function () {
+        var data = {
+          key: 'value'
+        };
+        var sentry = new SentryMetrics(host);
+        var resultData = sentry.__beforeSend(data);
+
+        assert.equal(data, resultData);
+      });
+
+      it('properly erases sensitive information from url', function () {
+        var url = 'https://accounts.firefox.com/complete_reset_password';
+        var badQuery = '?token=foo&code=bar&email=some%40restmail.net&service=sync';
+        var goodQuery = '?token=VALUE&code=VALUE&email=VALUE&service=sync';
+        var badData = {
+          request: {
+            url: url + badQuery
+          }
+        };
+
+        var goodData = {
+          request: {
+            url: url + goodQuery
+          }
+        };
+
+        var sentry = new SentryMetrics(host);
+        var resultData = sentry.__beforeSend(badData);
+
+        assert.equal(resultData.key, goodData.key);
+        assert.equal(resultData.url, goodData.url);
+      });
+    });
+
+    describe('cleanUpQueryParam', function () {
+      it('properly erases sensitive information', function () {
+        var fixtureUrl1 = 'https://accounts.firefox.com/complete_reset_password?token=foo&code=bar&email=some%40restmail.net';
+        var expectedUrl1 = 'https://accounts.firefox.com/complete_reset_password?token=VALUE&code=VALUE&email=VALUE';
+        var sentry = new SentryMetrics(host);
+        var resultUrl1 = sentry.__cleanUpQueryParam(fixtureUrl1);
+
+        assert.equal(resultUrl1, expectedUrl1);
+      });
+
+      it('properly erases sensitive information, keeps allowed fields', function () {
+        var fixtureUrl2 = 'https://accounts.firefox.com/signup?client_id=foo&preVerifyToken=bar&service=sync';
+        var expectedUrl2 = 'https://accounts.firefox.com/signup?client_id=foo&preVerifyToken=VALUE&service=sync';
+        var sentry = new SentryMetrics(host);
+        var resultUrl2 = sentry.__cleanUpQueryParam(fixtureUrl2);
+
+        assert.equal(resultUrl2, expectedUrl2);
+      });
+
+      it('properly returns the url when there is no query', function () {
+        var expectedUrl = 'https://accounts.firefox.com/signup';
+        var sentry = new SentryMetrics(host);
+        var resultUrl = sentry.__cleanUpQueryParam(expectedUrl);
+
+        assert.equal(resultUrl, expectedUrl);
+      });
+    });
+  });
+
+});
+

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -45,6 +45,7 @@ function (Translator, Session) {
     '../tests/spec/lib/xhr',
     '../tests/spec/lib/storage',
     '../tests/spec/lib/null-storage',
+    '../tests/spec/lib/sentry',
     '../tests/spec/lib/relier-keys',
     '../tests/spec/lib/able',
     '../tests/spec/lib/environment',

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "node-uuid": "1.4.3",
     "normalize-css": "2.1.3",
     "p": "https://github.com/rkatic/p.git#ce57958635f71376a4563ca1ae5820f6fbe1f956",
+    "raven-js": "https://github.com/vladikoff/raven-js.git#customEndpoint",
     "requirejs": "2.1.11",
     "requirejs-mustache": "https://github.com/jfparadis/requirejs-mustache.git#5fb8c0a3e8560526e8f9617a689e2924a8532d0a",
     "requirejs-text": "2.0.10",

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -77,6 +77,18 @@ var conf = module.exports = convict({
     },
     sample_rate: 1
   },
+  sentry: {
+    endpoint: {
+      doc: 'Remote Sentry endpoint',
+      format: String,
+      default: undefined
+    },
+    api_key: {
+      doc: 'Sentry API key',
+      format: String,
+      default: undefined
+    }
+  },
   logging: {
     app: {
       default: 'fxa-content-server'

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -25,7 +25,8 @@ module.exports = function (config, i18n) {
     require('./routes/get-ver.json'),
     require('./routes/get-config')(i18n),
     require('./routes/get-client.json')(i18n),
-    require('./routes/post-metrics')()
+    require('./routes/post-metrics')(),
+    require('./routes/get-metrics-errors')()
   ];
 
   if (config.get('api_proxy.enabled')) {

--- a/server/lib/routes/get-config.js
+++ b/server/lib/routes/get-config.js
@@ -7,6 +7,7 @@ var config = require('../configuration');
 var clientId = config.get('oauth_client_id');
 
 var authServerUrl = config.get('fxaccount_url');
+var env = config.get('env');
 var oauthServerUrl = config.get('oauth_url');
 var profileServerUrl = config.get('profile_url');
 var metricsSampleRate = config.get('metrics.sample_rate');
@@ -38,6 +39,7 @@ module.exports = function () {
       // the `__cookie_check` cookie will not arrive.
       allowedParentOrigins: allowedParentOrigins,
       authServerUrl: authServerUrl,
+      env: env,
       cookiesEnabled: !!req.cookies['__cookie_check'],
       marketingEmailServerUrl: marketingEmailApiServerUrl,
       marketingEmailPreferencesUrl: marketingEmailPreferencesUrl,

--- a/server/lib/routes/get-metrics-errors.js
+++ b/server/lib/routes/get-metrics-errors.js
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var logger = require('mozlog')('server.metrics-errors');
+var request = require('request');
+var querystring = require('querystring');
+
+var config = require('../configuration');
+var sentryConfig = config.get('sentry');
+
+var API_KEY = sentryConfig.api_key;
+
+/**
+ * Reports errors to Sentry
+ * @param {String} query
+ *          Query from the error request.
+ */
+function reportError(query) {
+  if (! query) {
+    return;
+  }
+
+  if (sentryConfig && sentryConfig.endpoint && API_KEY) {
+    // set API_KEY using the server
+    query['sentry_key'] = API_KEY;
+    var newQuery = querystring.stringify(query);
+
+    process.nextTick(function () {
+      var sentryRequest = sentryConfig.endpoint + '?' + newQuery;
+
+      request(sentryRequest, function (err, resp, body) {
+        if (err || resp.statusCode !== 200) {
+          logger.error(err, body);
+        }
+      });
+    });
+  }
+}
+
+/**
+ * This module serves as an endpoint for front-end errors.
+ * The errors are sent to Sentry service for triage.
+ *
+ * The content server sends a GET request via forked version of raven-js, i.e GET /metrics-errors?sentry_version=4&...
+ * The query parameters are forwarded to the appropriate Sentry metrics dashboard.
+ *
+ * @returns {{method: string, path: string, process: Function}}
+ */
+module.exports = function () {
+
+  return {
+    method: 'get',
+    path: '/metrics-errors',
+    process: function (req, res) {
+      // respond right away
+      res.json({ success: true });
+
+      reportError(req.query);
+    }
+  };
+};

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -16,6 +16,7 @@ define([
     'tests/server/l10n',
     'tests/server/metrics',
     'tests/server/metrics-collector-stderr',
+    'tests/server/metrics-errors',
     'tests/server/configuration',
     'tests/server/proxy',
     'tests/server/statsd-collector'

--- a/tests/server/metrics-errors.js
+++ b/tests/server/metrics-errors.js
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../server/lib/configuration',
+  'intern/dojo/node!request'
+], function (intern, registerSuite, assert, config, request) {
+  var serverUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
+
+  var env = config.get('env');
+
+  var suite = {
+    name: 'metrics-errors'
+  };
+
+  suite['#get /config returns env that is used for error metrics'] = function () {
+    var dfd = this.async(intern.config.asyncTimeout);
+
+    request(serverUrl + '/config',
+    dfd.callback(function (err, res) {
+      var results = JSON.parse(res.body);
+
+      assert.equal(results.env, env);
+    }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#get /metrics-errors - returns 200 without query'] = function () {
+    var dfd = this.async(intern.config.asyncTimeout);
+
+    request.get(serverUrl + '/metrics-errors', dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+    }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#get /metrics-errors - returns 200 with an error query'] = function () {
+    var dfd = this.async(intern.config.asyncTimeout);
+
+    request.get(serverUrl + '/metrics-errors?sentry_version=4', dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+    }, dfd.reject.bind(dfd)));
+  };
+
+  registerSuite(suite);
+});

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -58,6 +58,7 @@ define([
     '/account_unlock_complete': { statusCode: 200 },
     '/signup_permissions': { statusCode: 200 },
     '/signin_permissions': { statusCode: 200 },
+    '/metrics-errors': { statusCode: 200 },
 
     // the following have a version prefix
     '/v1/complete_reset_password': { statusCode: 200 },


### PR DESCRIPTION
TODO:
- [x] Front-end tests
- [x] Server tests
- [x] Fix protocol, http vs https in the endpoint
- [x] Operations stuff for stage / prod (got access + filed https://github.com/mozilla/fxa-content-server/issues/2552)
- [x] Add Sample Rate
- [x] Remove PII

## depends on https://github.com/mozilla/fxa-content-experiments/pull/9