### PR TITLE
fix(server):inconsistent use of 'use strict'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ install:
 
 # now run the tests!
 script:
+  - npm ls --depth 0
   - grunt validate-shrinkwrap --force # check for vulnerable modules via nodesecurity.io
   - grunt lint
   - travis_retry npm run test-travis

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,9 +12,9 @@
 // 'test/spec/{,*/}*.js'
 // use this if you want to recursively match all subfolders:
 // 'test/spec/**/*.js'
-module.exports = function (grunt) {
-  'use strict';
+'use strict';
 
+module.exports = function (grunt) {
   // load all grunt tasks based on environment
   if (process.env.NODE_ENV && process.env.NODE_ENV === 'production') {
     require('load-grunt-tasks')(grunt, {scope: 'dependencies'});

--- a/app/scripts/head/boot.js
+++ b/app/scripts/head/boot.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 (function () {
-  'use strict';
-
   // Add a global namespace that modules in the HEAD can attach
   // to. The namespace will be removed when complete.
   window.FxaHead = {

--- a/app/scripts/head/start.js
+++ b/app/scripts/head/start.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 (function () {
-  'use strict';
-
   var startupStyles = new FxaHead.StartupStyles({
     window: window
   });

--- a/app/scripts/lib/hkdf.js
+++ b/app/scripts/lib/hkdf.js
@@ -1,13 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
+
 define([
   'sjcl',
   'lib/promise'
 ],
 function (sjcl, p) {
-  'use strict';
-
   /**
    * hkdf - The HMAC-based Key Derivation Function
    * based on https://github.com/mozilla/node-hkdf

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 /*
  * A metrics module!
@@ -22,8 +23,6 @@ define([
   'lib/xhr',
   'lib/strings'
 ], function (_, Backbone, $, speedTrap, xhr, Strings) {
-  'use strict';
-
   // Speed trap is a singleton, convert it
   // to an instantiable function.
   var SpeedTrap = function () {};

--- a/app/scripts/lib/null-metrics.js
+++ b/app/scripts/lib/null-metrics.js
@@ -6,14 +6,13 @@
  * A null metrics module. For use as a standin if metrics are disabled
  * or for unit tests.
  */
+'use strict';
 
 define([
   'underscore',
   'lib/promise',
   'lib/metrics'
 ], function (_, p, Metrics) {
-  'use strict';
-
   function NullMetrics () {
     // do nothing
   }

--- a/app/scripts/lib/promise.js
+++ b/app/scripts/lib/promise.js
@@ -1,13 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // monkey patch p to be able to convert jQuery XHR promises to our promises.
 define([
   'p-promise'
 ], function (p) {
-  'use strict';
-
   // for more background, read
   // https://github.com/kriskowal/q/wiki/Coming-from-jQuery
 

--- a/app/scripts/lib/storage-metrics.js
+++ b/app/scripts/lib/storage-metrics.js
@@ -6,6 +6,7 @@
  * A Storage metrics module. For use as a standin when running functional
  * tests
  */
+'use strict';
 
 define([
   'underscore',
@@ -13,8 +14,6 @@ define([
   'lib/metrics',
   'lib/storage'
 ], function (_, p, Metrics, Storage) {
-  'use strict';
-
   var storage = Storage.factory('localStorage');
 
   function StorageMetrics() {

--- a/app/scripts/lib/validate.js
+++ b/app/scripts/lib/validate.js
@@ -1,14 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // Do some validation.
 
 define([
   'lib/constants'
 ], function (Constants) {
-  'use strict';
-
   // taken from the fxa-auth-server
   var HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;
 

--- a/app/scripts/views/progress_indicator.js
+++ b/app/scripts/views/progress_indicator.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // Handles screen updates to indicate progress.
 //
@@ -22,8 +23,6 @@ define([
   'backbone',
   'views/mixins/timer-mixin'
 ], function (_, $, Backbone, TimerMixin) {
-  'use strict';
-
   // The show and hide delays are to minimize flash.
   var SHOW_DELAY_MS = 100;
   var HIDE_DELAY_MS = 100;

--- a/app/tests/main.js
+++ b/app/tests/main.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 require([
   '../scripts/require_config',
   './test_start'
 ],
-function () {
-  'use strict';
-  // don't need to do anything.
+function () {  // don't need to do anything.
 });

--- a/app/tests/mocks/canvas.js
+++ b/app/tests/mocks/canvas.js
@@ -1,13 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // stub out the router object for testing.
 
 define([
 ], function () {
-  'use strict';
-
   function CanvasMock() {
     // nothing to do here.
   }

--- a/app/tests/mocks/dom-event.js
+++ b/app/tests/mocks/dom-event.js
@@ -1,13 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // mock out a DOM event
 
 define([
 ], function () {
-  'use strict';
-
   function DOMEventMock() {
     // nothing to do
   }

--- a/app/tests/mocks/file-reader.js
+++ b/app/tests/mocks/file-reader.js
@@ -1,13 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // mock out a FileReader
 
 define([
 ], function () {
-  'use strict';
-
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
 
   function FileReaderMock() {

--- a/app/tests/mocks/fxa-client.js
+++ b/app/tests/mocks/fxa-client.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // stub out the fxa-client object for testing.
 
@@ -8,8 +9,6 @@ define([
   'lib/promise',
   'lib/fxa-client'
 ], function (p, FxaClientWrapper) {
-  'use strict';
-
   function FxaClientWrapperMock() {
   }
 

--- a/app/tests/mocks/history.js
+++ b/app/tests/mocks/history.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // A mock for Backbone.history
 define([
 ], function () {
-  'use strict';
-
   function History() {}
 
   History.prototype = {

--- a/app/tests/mocks/oauth_servers.js
+++ b/app/tests/mocks/oauth_servers.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'sinon'
 ], function (sinon) {
-  'use strict';
-
   /**
    * Create a fake set of OAuth servers through instantiation.
    * Note, these servers completely take over the XHR object, so as long as

--- a/app/tests/mocks/profile.js
+++ b/app/tests/mocks/profile.js
@@ -1,13 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // stub out the router object for testing.
 
 define([
 ], function () {
-  'use strict';
-
   function Profile() {
   }
 

--- a/app/tests/mocks/router.js
+++ b/app/tests/mocks/router.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // stub out the router object for testing.
 
@@ -8,8 +9,6 @@ define([
   'underscore',
   'backbone'
 ], function (_, Backbone) {
-  'use strict';
-
   function RouterMock() {
     // nothing to do here.
   }

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // stub out the window object for testing.
 
@@ -10,8 +11,6 @@ define([
   'lib/null-storage'
 ],
 function (_, Backbone, NullStorage) {
-  'use strict';
-
   function WindowMock() {
     var self = this;
 

--- a/app/tests/setup.js
+++ b/app/tests/setup.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([], function () {
-  'use strict';
-
   /*global mocha */
   mocha.setup('bdd');
   mocha.timeout(20000);

--- a/app/tests/spec/lib/auth-errors.js
+++ b/app/tests/spec/lib/auth-errors.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // test the interpolated library
 
@@ -9,8 +10,6 @@ define([
   'lib/auth-errors'
 ],
 function (chai, AuthErrors) {
-  'use strict';
-
   /*global describe, it*/
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'chai',
@@ -20,8 +21,6 @@ define([
 // take care of some app-specific housekeeping.
 function (chai, $, sinon, FxaClient, p, testHelpers, FxaClientWrapper, AuthErrors,
       Constants, ResumeToken, OAuthRelier) {
-  'use strict';
-
   var STATE = 'state';
   var SERVICE = 'sync';
   var REDIRECT_TO = 'https://sync.firefox.com';

--- a/app/tests/spec/lib/image-loader.js
+++ b/app/tests/spec/lib/image-loader.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // test the metrics library
 
@@ -9,8 +10,6 @@ define([
   'lib/image-loader'
 ],
 function (chai, ImageLoader) {
-  'use strict';
-
   /*global describe, it*/
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';

--- a/app/tests/spec/lib/mailcheck.js
+++ b/app/tests/spec/lib/mailcheck.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // test the metrics library
 
@@ -11,8 +12,6 @@ define([
   'lib/mailcheck'
 ],
 function (sinon, chai, $, mailcheck) {
-  'use strict';
-
   /*global describe, it*/
   var assert = chai.assert;
   var MAILCHECK_ID = 'mailcheck-test';

--- a/app/tests/spec/lib/marketing-email-client.js
+++ b/app/tests/spec/lib/marketing-email-client.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'chai',
@@ -11,8 +12,6 @@ define([
   'lib/xhr'
 ],
 function (chai, sinon, MarketingEmailClient, MarketingEmailErrors, p, xhr) {
-  'use strict';
-
   var assert = chai.assert;
 
   describe('lib/marketing-email-client', function () {

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // test the metrics library
 
@@ -14,8 +15,6 @@ define([
   '../../lib/helpers'
 ],
 function (chai, $, p, Metrics, AuthErrors, WindowMock, TestHelpers) {
-  'use strict';
-
   /*global describe, it*/
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/null-metrics.js
+++ b/app/tests/spec/lib/null-metrics.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // test the metrics library
 
@@ -10,8 +11,6 @@ define([
   'lib/metrics'
 ],
 function (chai, NullMetrics, Metrics) {
-  'use strict';
-
   /*global describe, it*/
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/oauth-errors.js
+++ b/app/tests/spec/lib/oauth-errors.js
@@ -1,14 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'chai',
   'lib/oauth-errors'
 ],
 function (chai, OAuthErrors) {
-  'use strict';
-
   /*global describe, it*/
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/origin-check.js
+++ b/app/tests/spec/lib/origin-check.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'chai',
@@ -9,8 +10,6 @@ define([
   '../../mocks/window'
 ],
 function (chai, sinon, OriginCheck, WindowMock) {
-  'use strict';
-
   var assert = chai.assert;
 
   describe('lib/origin-check', function () {

--- a/app/tests/spec/lib/screen-info.js
+++ b/app/tests/spec/lib/screen-info.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // test the screen-info module
 
@@ -10,8 +11,6 @@ define([
   '../../mocks/window'
 ],
 function (chai, ScreenInfo, WindowMock) {
-  'use strict';
-
   /*global describe, it*/
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/storage-metrics.js
+++ b/app/tests/spec/lib/storage-metrics.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // test the metrics library
 
@@ -12,8 +13,6 @@ define([
   '../../mocks/window'
 ],
 function (chai, StorageMetrics, Metrics, Storage, WindowMock) {
-  'use strict';
-
   /*global describe, it*/
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/validate.js
+++ b/app/tests/spec/lib/validate.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'chai',
@@ -9,8 +10,6 @@ define([
   '../../lib/helpers'
 ],
 function (chai, Validate, Constants, TestHelpers) {
-  'use strict';
-
   var assert = chai.assert;
 
   var createRandomHexString = TestHelpers.createRandomHexString;

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'chai',
@@ -22,8 +23,6 @@ define([
 function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient,
       EphemeralMessages, View, Relier, BaseBroker, User,
       WindowMock, RouterMock, TestHelpers) {
-  'use strict';
-
   var assert = chai.assert;
 
   describe('views/confirm', function () {

--- a/app/tests/spec/views/confirm_account_unlock.js
+++ b/app/tests/spec/views/confirm_account_unlock.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'chai',
@@ -22,8 +23,6 @@ define([
 function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient,
       EphemeralMessages, View, Relier, User, OAuthBroker, RouterMock,
       WindowMock, TestHelpers) {
-  'use strict';
-
   var assert = chai.assert;
 
   describe('views/confirm_account_unlock', function () {

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'chai',
@@ -23,8 +24,6 @@ define([
 function (chai, sinon, p, AuthErrors, View, Metrics, EphemeralMessages,
       InterTabChannel, Storage, FxaClient, Relier, Broker, User,
       RouterMock, WindowMock, TestHelpers) {
-  'use strict';
-
   var assert = chai.assert;
 
   describe('views/confirm_reset_password', function () {

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -1,14 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
+
 require([
   'lib/translator',
   'lib/session',
   '../tests/setup'
 ],
 function (Translator, Session) {
-  'use strict';
-
   var tests = [
     '../tests/spec/lib/channels/null',
     '../tests/spec/lib/channels/fx-desktop',

--- a/grunttasks/amdcheck.js
+++ b/grunttasks/amdcheck.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('amdcheck', {
     app: {
       options: {

--- a/grunttasks/autoprefixer.js
+++ b/grunttasks/autoprefixer.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('autoprefixer', {
     options: {
       browsers: ['> 1%', 'last 5 versions', 'ff >= 16', 'Explorer >= 8']

--- a/grunttasks/build.js
+++ b/grunttasks/build.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('build', [
     // Clean files and folders from any previous build
     'clean',

--- a/grunttasks/bump.js
+++ b/grunttasks/bump.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // takes care of bumping the version number in package.json
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('bump', {
     options: {
       files: [ 'package.json' ],

--- a/grunttasks/changelog.js
+++ b/grunttasks/changelog.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('changelog', {
     dest: 'CHANGELOG.md'
   });

--- a/grunttasks/clean.js
+++ b/grunttasks/clean.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('clean', {
     tos_pp: {
       files: [{

--- a/grunttasks/concat.js
+++ b/grunttasks/concat.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('concat', {
     requirejs: {
       dest: '<%= yeoman.tmp %>/scripts/main.js',

--- a/grunttasks/concurrent.js
+++ b/grunttasks/concurrent.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('concurrent', {
     server: [
       'copy:styles',

--- a/grunttasks/connect-fonts.js
+++ b/grunttasks/connect-fonts.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // task to take care of generating connect-fonts CSS and copying font files.
 
@@ -8,8 +9,6 @@
 // fonts care copied from npm packages into app/fonts
 
 module.exports = function (grunt) {
-  'use strict';
-
   var path = require('path');
   var i18n = require('i18n-abide');
 

--- a/grunttasks/copy.js
+++ b/grunttasks/copy.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('copy', {
     strings: {
       files: [{

--- a/grunttasks/copyright.js
+++ b/grunttasks/copyright.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('copyright', {
     app: {
       options: {

--- a/grunttasks/coverage.js
+++ b/grunttasks/coverage.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // Code coverage analysis test!
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('coverage', [
     'blanket_mocha'
   ]);

--- a/grunttasks/css.js
+++ b/grunttasks/css.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // meta grunt task to convert and auto-prefix Sass.
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('css', [
     'sass',
     'autoprefixer',

--- a/grunttasks/csslint.js
+++ b/grunttasks/csslint.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('csslint', {
     strict: {
       options: {

--- a/grunttasks/cssmin.js
+++ b/grunttasks/cssmin.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('cssmin', {
     // This task is pre-configured if you do not wish to use Usemin
     // blocks for your CSS. By default, the Usemin block from your

--- a/grunttasks/default.js
+++ b/grunttasks/default.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // meta grunt task to run other linters.
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('default', [
     'build'
   ]);

--- a/grunttasks/htmlmin.js
+++ b/grunttasks/htmlmin.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('htmlmin', {
     dist: {
       options: {

--- a/grunttasks/imagemin.js
+++ b/grunttasks/imagemin.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('imagemin', {
     dist: {
       options: {

--- a/grunttasks/jscs.js
+++ b/grunttasks/jscs.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('jscs', {
     server: {
       src: '{,tests/**/,grunttasks/**/,server/**/,scripts/**/}*.js',
@@ -19,7 +18,8 @@ module.exports = function (grunt) {
         '!<%= yeoman.app %>/scripts/vendor/**'
       ],
       options: {
-        config: '.jscsrc'
+        config: '.jscsrc',
+        requirePaddingNewLinesAfterUseStrict: true
       }
     }
   });

--- a/grunttasks/jshint.js
+++ b/grunttasks/jshint.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('jshint', {
     options: {
       jshintrc: '.jshintrc',

--- a/grunttasks/jsonlint.js
+++ b/grunttasks/jsonlint.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('jsonlint', {
     config: {
       src: [

--- a/grunttasks/l10n-create-json.js
+++ b/grunttasks/l10n-create-json.js
@@ -1,20 +1,19 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // grunt task convert translated .po files to .json
 
-const mkdirp         = require('mkdirp');
-const fs             = require('fs');
-const path           = require('path');
+var mkdirp         = require('mkdirp');
+var fs             = require('fs');
+var path           = require('path');
 
 // where to place the json files.
-const jsonOutputPath = path.join(__dirname, '..', 'app', 'i18n');
+var jsonOutputPath = path.join(__dirname, '..', 'app', 'i18n');
 
 
 module.exports = function (grunt) {
-  'use strict';
-
   // po2json is configured in po2json.js
   grunt.registerTask('l10n-create-json', 'Create localized string bundles for the client.', function () {
     if (! fs.existsSync(jsonOutputPath)) {

--- a/grunttasks/l10n-extract.js
+++ b/grunttasks/l10n-extract.js
@@ -1,20 +1,19 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // grunt task to extract strings.
 
-const fs = require('fs');
-const path = require('path');
-const mkdirp = require('mkdirp');
-const extract = require('jsxgettext-recursive');
+var fs = require('fs');
+var path = require('path');
+var mkdirp = require('mkdirp');
+var extract = require('jsxgettext-recursive');
 
 // where to place the pot files.
-const messagesOutputPath = path.join(__dirname, '..', 'locale', 'templates', 'LC_MESSAGES');
+var messagesOutputPath = path.join(__dirname, '..', 'locale', 'templates', 'LC_MESSAGES');
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('l10n-extract', 'Extract strings from templates for localization.', function () {
     var done = this.async();
 

--- a/grunttasks/l10n-generate-pages.js
+++ b/grunttasks/l10n-generate-pages.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // grunt task to create a copy of each static page for each locale.
 // Three steps are performed to create the pages:
@@ -13,8 +14,6 @@
 // (requirejs, minification, revving).
 
 module.exports = function (grunt) {
-  'use strict';
-
   var path = require('path');
   var Handlebars = require('handlebars');
   var Promise = require('bluebird');

--- a/grunttasks/l10n-generate-tos-pp.js
+++ b/grunttasks/l10n-generate-tos-pp.js
@@ -1,11 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // grunt task to extract strings.
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('l10n-generate-tos-pp',
     'Generate translated TOS/PP agreement partial templates',
     function () {

--- a/grunttasks/l10n-merge.js
+++ b/grunttasks/l10n-merge.js
@@ -1,14 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // grunt task to extract strings.
 
-const path = require('path');
+var path = require('path');
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('l10n-merge', 'Merge extracted strings with .PO files.', function () {
     var done = this.async();
     grunt.util.spawn({

--- a/grunttasks/l10n-supported-locales.js
+++ b/grunttasks/l10n-supported-locales.js
@@ -1,18 +1,17 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
-const path = require('path');
-const i18n = require('i18n-abide');
+var path = require('path');
+var i18n = require('i18n-abide');
 
 // percentage of strings that must be translated for a supported locale
-const supportedThreshold = 90;
+var supportedThreshold = 90;
 // percentage of strings that must be translated for verbose feedback
-const verboseThreshold = 60;
+var verboseThreshold = 60;
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('l10n-supported-locales', ['selectconfig:dist', 'l10n-create-json', 'l10n-locale-counts']);
 
   var getCount = function (clientKeys, serverKeys, src) {

--- a/grunttasks/lint.js
+++ b/grunttasks/lint.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // meta grunt task to run other linters.
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('lint', 'lint all the things', [
     'concurrent:lint'
   ]);

--- a/grunttasks/localeschema.js
+++ b/grunttasks/localeschema.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('localeschema', {
     app: {
       files: [

--- a/grunttasks/marked.js
+++ b/grunttasks/marked.js
@@ -1,13 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
-const path = require('path');
-const i18n = require('i18n-abide');
+var path = require('path');
+var i18n = require('i18n-abide');
 
 module.exports = function (grunt) {
-  'use strict';
-
   // convert localized TOS/PP agreements from markdown to html partials.
 
   function rename(destPath, destFile) {

--- a/grunttasks/po2json.js
+++ b/grunttasks/po2json.js
@@ -1,16 +1,15 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // grunt task to create .json files out of .po files.
 // .po files are expected to already be downloaded.
 
-const path = require('path');
-const i18n = require('i18n-abide');
+var path = require('path');
+var i18n = require('i18n-abide');
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('po2json', {
     options: {
       format: 'raw',

--- a/grunttasks/polint.js
+++ b/grunttasks/polint.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // meta grunt task to run other .po lint scripts.
 
@@ -27,8 +28,6 @@
 
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('polint', [
     'jsonlint:i18n',
     'po2json:template',

--- a/grunttasks/replace.js
+++ b/grunttasks/replace.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('replace', {
     tos_pp: {
       src: [

--- a/grunttasks/requirejs.js
+++ b/grunttasks/requirejs.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('requirejs', {
     dist: {
       // Options: https://github.com/jrburke/r.js/blob/master/build/example.build.js

--- a/grunttasks/rev.js
+++ b/grunttasks/rev.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('rev', {
     dist: {
       files: {

--- a/grunttasks/sass.js
+++ b/grunttasks/sass.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('sass', {
     options: {
       imagePath: '/images'

--- a/grunttasks/selectconfig.js
+++ b/grunttasks/selectconfig.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   var path = require('path');
 
   var CONFIG_ROOT = path.join(__dirname, '..', 'server', 'config');

--- a/grunttasks/server.js
+++ b/grunttasks/server.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('server', 'Start the server after performing necessary build.', function (target) {
     if (target === 'dist') {
       return grunt.task.run(['build', 'serverproc:dist']);

--- a/grunttasks/serverproc.js
+++ b/grunttasks/serverproc.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   var runServer = require('../scripts/run_locally');
 
   grunt.registerTask('serverproc', 'Start the server. ** Use `grunt server:<target>` instead **.', function () {

--- a/grunttasks/sourcemap-source.js
+++ b/grunttasks/sourcemap-source.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   /**
    *  This small task adjusts the 'sources' property of the main.js.map sourcemap.
    *  It changes the sources from '.tmp/scripts/main.js' to 'main.js', which makes

--- a/grunttasks/todo.js
+++ b/grunttasks/todo.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('todo', {
     options: {
       marks: [{

--- a/grunttasks/uglify.js
+++ b/grunttasks/uglify.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // grunt task to uglify all the js.
 
 module.exports = function (grunt) {
-  'use strict';
-
   /**
    * Uglify all of the scripts in the dist directory
    */

--- a/grunttasks/usemin.js
+++ b/grunttasks/usemin.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('useminPrepare', {
     client_rendered: {
       dest: '<%= yeoman.dist %>',

--- a/grunttasks/validate-shrinkwrap.js
+++ b/grunttasks/validate-shrinkwrap.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('validate-shrinkwrap', {
     // no options.
   });

--- a/grunttasks/version.js
+++ b/grunttasks/version.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // A task to stamp a new version.
 //
@@ -10,8 +11,6 @@
 // * git commit with updated package.json and CHANGELOG.md created.
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.registerTask('version', [
     'bump-only:minor',
     'changelog',

--- a/grunttasks/watch.js
+++ b/grunttasks/watch.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('watch', {
     grunt: { files: ['Gruntfile.js'] },
     sass: {

--- a/grunttasks/yeoman.js
+++ b/grunttasks/yeoman.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   var TEMP_DIR = '.tmp';
   var TEMPLATE_ROOT = 'server/templates';
   var TOS_PP_REPO_ROOT = 'app/bower_components/tos-pp';

--- a/grunttasks/zschema.js
+++ b/grunttasks/zschema.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 module.exports = function (grunt) {
-  'use strict';
-
   grunt.config('zschema', {
     options: {
       noExtraKeywords: true

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   './functional/refreshes_metrics',
@@ -35,6 +36,4 @@ define([
   './functional/avatar',
   './functional/alternative_styles',
   './functional/email_opt_in'
-], function () {
-  'use strict';
-});
+], function () {});

--- a/tests/functional/404.js
+++ b/tests/functional/404.js
@@ -1,14 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
   'intern!object',
   'require'
 ], function (intern, registerSuite, require) {
-  'use strict';
-
   var url = intern.config.fxaContentRoot + 'four-oh-four';
 
   registerSuite({

--- a/tests/functional/500.js
+++ b/tests/functional/500.js
@@ -1,14 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
   'intern!object',
   'require'
 ], function (intern, registerSuite, require) {
-  'use strict';
-
   var url = intern.config.fxaContentRoot + 'boom';
 
   registerSuite({

--- a/tests/functional/alternative_styles.js
+++ b/tests/functional/alternative_styles.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'tests/functional/lib/test',
   'require'
 ], function (intern, registerSuite, FunctionalHelpers, Test, require) {
-  'use strict';
-
   var INVALID_CHROMELESS_URL = intern.config.fxaContentRoot + 'signup?style=chromeless';
   var CHROMELESS_IFRAME_SYNC_URL = intern.config.fxaContentRoot + 'signup?service=sync&context=iframe&style=chromeless';
 

--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -12,8 +13,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var SIGNIN_URL = config.fxaContentRoot + 'signin';

--- a/tests/functional/back_button_after_start.js
+++ b/tests/functional/back_button_after_start.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -8,8 +9,6 @@ define([
   'intern/chai!assert',
   'require'
 ], function (intern, registerSuite, assert, require) {
-  'use strict';
-
   var FROM_URL = 'http://example.com/';
   var FXA_ROOT_URL = intern.config.fxaContentRoot;
 

--- a/tests/functional/bounced_email.js
+++ b/tests/functional/bounced_email.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -10,8 +11,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var CUTOFF_YEAR = new Date().getFullYear() - 13;

--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -14,8 +15,6 @@ define([
   'tests/functional/lib/test'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
       FxaClient, TestHelpers, FunctionalHelpers, Test) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var SIGNIN_URL = config.fxaContentRoot + 'signin';

--- a/tests/functional/complete_sign_up.js
+++ b/tests/functional/complete_sign_up.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -14,8 +15,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Constants, restmail, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;

--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -10,8 +11,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var CONFIRM_URL = config.fxaContentRoot + 'confirm';
   var SIGNUP_URL = config.fxaContentRoot + 'signup';

--- a/tests/functional/cookies_disabled.js
+++ b/tests/functional/cookies_disabled.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'require',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, FunctionalHelpers) {
-  'use strict';
-
   // there is no way to disable cookies using wd. Add `disable_cookies`
   // to the URL to synthesize cookies being disabled.
   var config = intern.config;

--- a/tests/functional/delete_account.js
+++ b/tests/functional/delete_account.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -13,8 +14,6 @@ define([
   'tests/functional/lib/test'
 ], function (intern, registerSuite, require, nodeXMLHttpRequest,
       FxaClient, TestHelpers, FunctionalHelpers, Test)  {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var PAGE_URL = config.fxaContentRoot + 'delete_account';

--- a/tests/functional/email_opt_in.js
+++ b/tests/functional/email_opt_in.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -12,8 +13,6 @@ define([
   'tests/functional/lib/helpers',
   'tests/functional/lib/test'
 ], function (intern, registerSuite, assert, require, TestHelpers, waitForBasket, FunctionalHelpers, Test) {
-  'use strict';
-
   var PAGE_URL = intern.config.fxaContentRoot + 'signup';
   var CUTOFF_YEAR = new Date().getFullYear() - 13;
   var OLD_ENOUGH_YEAR = CUTOFF_YEAR - 1;

--- a/tests/functional/firefox/functional_firefox.js
+++ b/tests/functional/firefox/functional_firefox.js
@@ -1,8 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
-], function () {
-  'use strict';
-});
+], function () {});

--- a/tests/functional/firefox/same_account.js
+++ b/tests/functional/firefox/same_account.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'tests/lib/restmail',
   'tests/lib/helpers'
 ], function (intern, registerSuite, require, restmail, TestHelpers) {
-  'use strict';
-
   var config = intern.config;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
   var PASSWORD = 'password';

--- a/tests/functional/fonts.js
+++ b/tests/functional/fonts.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -8,8 +9,6 @@ define([
   'intern/chai!assert',
   'require'
 ], function (intern, registerSuite, assert, require) {
-  'use strict';
-
   var url = intern.config.fxaContentRoot + 'signin';
   var nonFiraUrl = intern.config.fxaContentRoot + 'zh-CN/legal/privacy';
 

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -12,8 +13,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var FORCE_AUTH_URL = config.fxaContentRoot + 'force_auth';

--- a/tests/functional/legal.js
+++ b/tests/functional/legal.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'require',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, FunctionalHelpers) {
-  'use strict';
-
   var url = intern.config.fxaContentRoot + 'legal';
 
   registerSuite({

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -13,8 +14,6 @@ define([
   'intern/chai!assert'
 ], function (intern, require, restmail, TestHelpers, pollUntil,
         Url, Querystring, assert) {
-  'use strict';
-
   var config = intern.config;
   var CONTENT_SERVER = config.fxaContentRoot;
   var OAUTH_APP = config.fxaOauthApp;

--- a/tests/functional/lib/test.js
+++ b/tests/functional/lib/test.js
@@ -5,13 +5,12 @@
 /**
  * Additional tests.
  */
+'use strict';
 
 define([
   'intern',
   'intern/chai!assert'
 ], function (intern, assert) {
-  'use strict';
-
   function noElementByCssSelector(context, selector) {
     return function () {
       return context.get('remote')

--- a/tests/functional/mocha.js
+++ b/tests/functional/mocha.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -12,8 +13,6 @@ define([
   'require',
   'intern/node_modules/dojo/has!host-node?intern/node_modules/dojo/node!child_process'
 ], function (intern, registerSuite, assert, config, Deferred, all, require, child_process) {
-  'use strict';
-
   var ERROR_COLOR = '\x1b[1;31m';       // red
   var DESCRIPTION_COLOR = '\x1b[1;36m'; // cyan
   var DEFAULT_COLOR = '\x1b[0;0m';      // off

--- a/tests/functional/oauth_force_email.js
+++ b/tests/functional/oauth_force_email.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -11,8 +12,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var OAUTH_APP = config.fxaOauthApp;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;

--- a/tests/functional/oauth_iframe.js
+++ b/tests/functional/oauth_iframe.js
@@ -6,6 +6,7 @@
 /**
  * Test the iframe oauth flow
  */
+'use strict';
 
 define([
   'intern',
@@ -18,8 +19,6 @@ define([
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
         FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var IFRAME_OAUTH_APP = config.fxaIframeOauthApp;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -12,8 +13,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var OAUTH_APP = config.fxaUntrustedOauthApp;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;

--- a/tests/functional/oauth_preverified_sign_up.js
+++ b/tests/functional/oauth_preverified_sign_up.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -10,8 +11,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var OAUTH_APP = config.fxaOauthApp;
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;

--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -13,8 +14,6 @@ define([
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
       FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
 
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -12,8 +13,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var OAUTH_APP = config.fxaOauthApp;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -13,8 +14,6 @@ define([
   'tests/functional/lib/test',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers, Test, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var SIGNUP_ROOT = config.fxaContentRoot + 'oauth/signup';
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;

--- a/tests/functional/oauth_sign_up_verification_redirect.js
+++ b/tests/functional/oauth_sign_up_verification_redirect.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern!object',
@@ -9,8 +10,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (registerSuite, assert, require, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var TOO_YOUNG_YEAR = new Date().getFullYear() - 13;
   var OLD_ENOUGH_YEAR = TOO_YOUNG_YEAR - 1;
 

--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -14,8 +15,6 @@ define([
   'tests/functional/lib/fx-desktop'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
         FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
-  'use strict';
-
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;

--- a/tests/functional/oauth_webchannel.js
+++ b/tests/functional/oauth_webchannel.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -13,8 +14,6 @@ define([
   'tests/functional/lib/helpers',
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
         FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
 

--- a/tests/functional/oauth_webchannel_keys.js
+++ b/tests/functional/oauth_webchannel_keys.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -14,8 +15,6 @@ define([
   'tests/functional/lib/fx-desktop'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
         FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var SYNC_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';

--- a/tests/functional/pages.js
+++ b/tests/functional/pages.js
@@ -1,14 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
   'intern!object',
   'require'
 ], function (intern, registerSuite, require) {
-  'use strict';
-
   var url = intern.config.fxaContentRoot;
 
   var pages = [

--- a/tests/functional/password_visibility.js
+++ b/tests/functional/password_visibility.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'require',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
   var SYNC_SIGNIN_URL = config.fxaContentRoot + 'signin?service=sync&context=fx_desktop_v1';

--- a/tests/functional/pp.js
+++ b/tests/functional/pp.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'tests/functional/lib/test',
   'require'
 ], function (intern, registerSuite, FunctionalHelpers, Test, require) {
-  'use strict';
-
   var PAGE_URL = intern.config.fxaContentRoot + 'legal/privacy';
   var SIGNUP_URL = intern.config.fxaContentRoot + 'signup';
 

--- a/tests/functional/refreshes_metrics.js
+++ b/tests/functional/refreshes_metrics.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -8,8 +9,6 @@ define([
   'require',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, require, TestHelpers) {
-  'use strict';
-
   var AUTOMATED = '?automatedBrowser=true';
   var url = intern.config.fxaContentRoot + 'signup' + AUTOMATED;
   var signin = intern.config.fxaContentRoot + 'signin' + AUTOMATED;

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -15,8 +16,6 @@ define([
   'tests/functional/lib/test'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
       FxaClient, restmail, TestHelpers, FunctionalHelpers, Test) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;

--- a/tests/functional/robots_txt.js
+++ b/tests/functional/robots_txt.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -8,8 +9,6 @@ define([
   'intern/chai!assert',
   'require'
 ], function (intern, registerSuite, assert, require) {
-  'use strict';
-
   var url = intern.config.fxaContentRoot + 'robots.txt';
 
   registerSuite({

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -15,8 +16,6 @@ define([
   'tests/functional/lib/fx-desktop'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
       FxaClient, Constants, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
-  'use strict';
-
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
 

--- a/tests/functional/settings_common.js
+++ b/tests/functional/settings_common.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -12,8 +13,6 @@ define([
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, require, nodeXMLHttpRequest, FxaClient,
       TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var SETTINGS_URL = config.fxaContentRoot + 'settings';

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -12,8 +13,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var PAGE_URL = config.fxaContentRoot + 'signin';

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -16,8 +17,6 @@ define([
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
         FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers,
         Constants) {
-  'use strict';
-
   var FX_DESKTOP_CONTEXT = Constants.FX_DESKTOP_CONTEXT;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -12,8 +13,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var PAGE_URL = config.fxaContentRoot + 'signup';

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -14,8 +15,6 @@ define([
   'tests/functional/lib/fx-desktop'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
         FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
-  'use strict';
-
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'reset_password?context=fx_desktop_v1&service=sync';
 

--- a/tests/functional/sync_settings.js
+++ b/tests/functional/sync_settings.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -13,8 +14,6 @@ define([
   'tests/functional/lib/fx-desktop'
 ], function (intern, registerSuite, require, nodeXMLHttpRequest, FxaClient,
       TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
-  'use strict';
-
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
   var testIsBrowserNotifiedOfMessage = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -13,8 +14,6 @@ define([
   'tests/functional/lib/fx-desktop'
 ], function (intern, registerSuite, require, nodeXMLHttpRequest, FxaClient,
         TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
-  'use strict';
-
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
 

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -14,8 +15,6 @@ define([
   'tests/functional/lib/fx-desktop'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
         FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
-  'use strict';
-
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_desktop_v1&service=sync';
 

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -13,8 +14,6 @@ define([
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
         FxaClient, TestHelpers, FunctionalHelpers) {
-  'use strict';
-
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=iframe&service=sync';
 

--- a/tests/functional/tos.js
+++ b/tests/functional/tos.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'tests/functional/lib/test',
   'require'
 ], function (intern, registerSuite, FunctionalHelpers, Test, require) {
-  'use strict';
-
   var PAGE_URL = intern.config.fxaContentRoot + 'legal/terms';
   var SIGNUP_URL = intern.config.fxaContentRoot + 'signup';
 

--- a/tests/functional_oauth.js
+++ b/tests/functional_oauth.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   './functional/oauth_sign_in',
@@ -13,6 +14,4 @@ define([
   './functional/oauth_iframe',
   './functional/oauth_force_email',
   './functional/oauth_permissions'
-], function () {
-  'use strict';
-});
+], function () {});

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 // Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
 // These default settings work OK for most people. The options that *must* be changed below are the
@@ -12,8 +13,6 @@ define([
 ],
 function (args, topic, firefoxProfile) {
   /*jshint maxcomplexity:11 */
-  'use strict';
-
   var fxaAuthRoot = args.fxaAuthRoot || 'http://127.0.0.1:9000/v1';
   var fxaContentRoot = args.fxaContentRoot || 'http://127.0.0.1:3030/';
   var fxaEmailRoot = args.fxaEmailRoot || 'http://127.0.0.1:9001';

--- a/tests/intern_functional.js
+++ b/tests/intern_functional.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   './intern'
 ], function (intern) {
-  'use strict';
-
   intern.functionalSuites = [ 'tests/functional' ];
 
   return intern;

--- a/tests/intern_functional_firefox.js
+++ b/tests/intern_functional_firefox.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   './intern'
 ], function (intern) {
-  'use strict';
-
   intern.functionalSuites = [
     // NOTE: these are disabled for now, see https://github.com/mozilla/fxa-content-server/issues/1769
     // 'tests/functional/firefox/functional_firefox'

--- a/tests/intern_functional_full.js
+++ b/tests/intern_functional_full.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   './intern'
 ], function (intern) {
-  'use strict';
-
   intern.functionalSuites = [
     'tests/functional',
     'tests/functional_oauth'

--- a/tests/intern_functional_oauth.js
+++ b/tests/intern_functional_oauth.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   './intern'
 ], function (intern) {
-  'use strict';
-
   intern.functionalSuites = [ 'tests/functional_oauth' ];
 
   return intern;

--- a/tests/intern_sauce.js
+++ b/tests/intern_sauce.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   './intern'
 ], function (intern) {
-  'use strict';
-
   // override the main config file and adjust it to suit Sauce Labs
   intern.tunnel = 'SauceLabsTunnel';
   intern.tunnelOptions = {

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   './intern'
 ], function (intern) {
-  'use strict';
-
   intern.capabilities = {};
   intern.webdriver = {};
   intern.environments = [];

--- a/tests/intern_travis.js
+++ b/tests/intern_travis.js
@@ -1,12 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   './intern'
 ], function (intern) {
-  'use strict';
-
   intern.functionalSuites = [
     'tests/functional/mocha',
     // a few basic functional tests

--- a/tests/lib/basket.js
+++ b/tests/lib/basket.js
@@ -1,14 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'tests/lib/request',
   'intern/node_modules/dojo/Deferred',
   'intern/dojo/node!../../server/lib/configuration'
 ], function (request, Deferred, config) {
-  'use strict';
-
   var API_KEY = config.get('basket.api_key');
   var API_URL = config.get('basket.api_url');
 

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([], function () {
-  'use strict';
-
   function createRandomHexString(length) {
     var str = '';
     var lettersToChooseFrom = 'abcdefABCDEF01234567890';

--- a/tests/lib/request.js
+++ b/tests/lib/request.js
@@ -1,13 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern/node_modules/dojo/node!xmlhttprequest',
   'intern/node_modules/dojo/Deferred'
 ], function (nodeXMLHttpRequest, Deferred) {
-  'use strict';
-
   function request(uri, method, jsonPayload, headers) {
     var dfd = new Deferred();
     var xhr = new nodeXMLHttpRequest.XMLHttpRequest();

--- a/tests/lib/restmail.js
+++ b/tests/lib/restmail.js
@@ -1,13 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'tests/lib/request',
   'intern/node_modules/dojo/Deferred'
 ], function (request, Deferred) {
-  'use strict';
-
   function waitForEmail(uri, number) {
     if (!number) {
       number = 1;

--- a/tests/server/configuration.js
+++ b/tests/server/configuration.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -8,8 +9,6 @@ define([
   'intern/chai!assert',
   'intern/dojo/node!child_process'
 ], function (intern, registerSuite, assert, cp) {
-  'use strict';
-
   var suite = {
     name: 'configuration'
   };

--- a/tests/server/cookies_disabled.js
+++ b/tests/server/cookies_disabled.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'intern/dojo/node!../../server/lib/configuration',
   'intern/dojo/node!request'
 ], function (intern, registerSuite, assert, config, request) {
-  'use strict';
-
   var serverUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
 
   var suite = {

--- a/tests/server/l10n.js
+++ b/tests/server/l10n.js
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
+'use strict';
 
 // Ensure l10n is working as expected based on the
 // user's `Accept-Language` headers
@@ -13,8 +13,6 @@ define([
   'intern/dojo/node!../../server/lib/configuration',
   'intern/dojo/node!request'
 ], function (intern, registerSuite, assert, config, request) {
-  'use strict';
-
   var serverUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
 
   var suite = {

--- a/tests/server/metrics-collector-stderr.js
+++ b/tests/server/metrics-collector-stderr.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -8,8 +9,6 @@ define([
   'intern/chai!assert',
   'intern/dojo/node!../../server/lib/metrics-collector-stderr'
 ], function (intern, registerSuite, assert, StdErrCollector) {
-  'use strict';
-
   var und;
 
   var suite = {

--- a/tests/server/metrics.js
+++ b/tests/server/metrics.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'intern/dojo/node!../../server/lib/configuration',
   'intern/dojo/node!request'
 ], function (intern, registerSuite, assert, config, request) {
-  'use strict';
-
   var serverUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
 
   // IMHO, metrics should be enabled in dev too.

--- a/tests/server/proxy.js
+++ b/tests/server/proxy.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'intern/dojo/node!../../server/lib/configuration',
   'intern/dojo/node!request'
 ], function (intern, registerSuite, assert, config, request) {
-  'use strict';
-
   var httpsUrl = config.get('public_url');
 
   var suite = {

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -10,8 +11,6 @@ define([
   'intern/dojo/node!request',
   'intern/dojo/node!url'
 ], function (intern, registerSuite, assert, config, request, url) {
-  'use strict';
-
   var httpUrl, httpsUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
 
   if (intern.config.fxaProduction) {

--- a/tests/server/statsd-collector.js
+++ b/tests/server/statsd-collector.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -12,8 +13,6 @@ define([
   'intern/dojo/node!dgram',
   'intern/dojo/node!../../server/lib/statsd-collector'
 ], function (intern, registerSuite, assert, Deferred, initLogging, fs, dgram, StatsDCollector) {
-  'use strict';
-
   var STATSD_PORT = 8125;
   var STATSD_HOST = '127.0.0.1';
 

--- a/tests/server/ver.json.js
+++ b/tests/server/ver.json.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern',
@@ -9,8 +10,6 @@ define([
   'intern/dojo/node!../../server/lib/configuration',
   'intern/dojo/node!request'
 ], function (intern, registerSuite, assert, config, request) {
-  'use strict';
-
   var serverUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
 
   var suite = {

--- a/tests/tdd.js
+++ b/tests/tdd.js
@@ -1,9 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   './tdd/assertion_service'
-], function () {
-  'use strict';
-});
+], function () {});

--- a/tests/tools/firefox_profile.js
+++ b/tests/tools/firefox_profile.js
@@ -1,14 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict';
 
 define([
   'intern/node_modules/dojo/has!host-node?intern/node_modules/dojo/node!path',
   'intern/node_modules/dojo/has!host-node?intern/node_modules/dojo/node!sync-exec'
 ],
 function (path, exec) {
-  'use strict';
-
   var createProfile = function (config) {
     var profileProcess = null;
     var encodedProfile = '';


### PR DESCRIPTION
Fixes #1318
This fixes the files that use 'use strict' inside function scope and puts all the 'use strict' directives in the global scope.
This excludes files in the following directories:
.tmp
node_modules
app/bower_components
app/scripts/vendor
dist

@zaach 