### PR TITLE
fix(tests): skip functional/email_opt_in test if fxaProduction=true

### DIFF
--- a/tests/functional/email_opt_in.js
+++ b/tests/functional/email_opt_in.js
@@ -17,6 +17,7 @@ define([
   var PAGE_URL = intern.config.fxaContentRoot + 'signup';
   var CUTOFF_YEAR = new Date().getFullYear() - 13;
   var OLD_ENOUGH_YEAR = CUTOFF_YEAR - 1;
+  var fxaProduction = intern.config.fxaProduction;
 
   var email;
   var PASSWORD = '12345678';
@@ -47,8 +48,22 @@ define([
     };
   }
 
+  var suiteName = 'communication preferences';
+  if (fxaProduction) {
+    // The actual tests below depend on polling a real or mock implementation
+    // of Basket. This isn't something feasible when running this server
+    // against a remote server (api keys unavailable, or server only listening
+    // to its localhost interface). So, we skip these tests by registering an
+    // empty test suite.
+    registerSuite({
+      name: suiteName
+    });
+    return;
+  }
+
+  // okay, not remote so run these for real.
   registerSuite({
-    name: 'communication preferences',
+    name: suiteName,
 
     beforeEach: function () {
       email = TestHelpers.createEmail();


### PR DESCRIPTION
fixes #2530 

r? @vladikoff 

The comment in the PR explains, I think. 

The output when `fxaProduction=true`:
```
$ node ./node_modules/.bin/intern-runner config=tests/intern_functional_full fxaProduction=true
Creating Firefox profile...
Listening on 0.0.0.0:9090
Starting tunnel...
Initialised firefox 38.0.5 on MAC
Running: main
Running: communication preferences
No unit test coverage for firefox 38.0.5 on MAC
firefox 38.0.5 on MAC: 0/0 tests failed
d
TOTAL: tested 1 platforms, 0/0 tests failed
$
```

If this looks ok, I'll cherry-pick it onto a PR for train-38.

(I'll add a side-comment: fxaProduction has become overloaded in meaning (is it remote, or stage, or real production). I think we need a better way to specialize the tests with some sort of feature flags. But that won't likely happen soon).