### PR TITLE
fix(avatars): allow users to change their avatar if they have/had one

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -26,6 +26,7 @@ define([
     grantedPermissions: undefined,
     lastLogin: undefined,
     needsOptedInToMarketingEmail: undefined,
+    hadProfileImageSetBefore: undefined,
     profileImageId: undefined,
     profileImageUrl: undefined,
     sessionToken: undefined,
@@ -170,6 +171,11 @@ define([
     setProfileImage: function (profileImage) {
       this.set('profileImageUrl', profileImage.get('url'));
       this.set('profileImageId', profileImage.get('id'));
+      if (this.get('profileImageUrl')) {
+        // This is a heuristic to let us know if the user has, at some point,
+        // had a custom profile image.
+        this.set('hadProfileImageSetBefore', true);
+      }
     },
 
     fetchCurrentProfileImage: function () {

--- a/app/scripts/templates/settings.mustache
+++ b/app/scripts/templates/settings.mustache
@@ -7,19 +7,11 @@
     <div class="error"></div>
     <div class="success"></div>
 
-    {{#avatarLinkVisible}}
     <div class="avatar-wrapper avatar-view">
-      <a href="/settings/avatar/change" class="change-avatar"></a>
     </div>
     <p class="change-avatar-text links">
       <a href="/settings/avatar/change">{{#t}}Change{{/t}}</a>
     </p>
-    {{/avatarLinkVisible}}
-    {{^avatarLinkVisible}}
-    <div class="avatar-wrapper avatar-view">
-    </div>
-    {{/avatarLinkVisible}}
-
 
     <p class="signed-in-email-message">{{#t}}You are signed in as{{/t}}<br />{{email}}</p>
 

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -44,6 +44,7 @@ define([
 
           if (profileImage.isDefault()) {
             self.$(wrapperClass).addClass('with-default');
+            self.$(wrapperClass).append('<span></span>');
             self.logScreenEvent('profile_image_not_shown');
           } else {
             self.$(wrapperClass).removeClass('with-default');
@@ -51,6 +52,10 @@ define([
             self.logScreenEvent('profile_image_shown');
           }
         });
+    },
+
+    hasDisplayedAccountProfileImage: function () {
+      return this._displayedProfileImage && ! this._displayedProfileImage.isDefault();
     },
 
     // Makes sure the account with uid has an uptodate image cache.

--- a/app/styles/modules/_avatar.scss
+++ b/app/styles/modules/_avatar.scss
@@ -69,6 +69,7 @@
 .change-avatar-text {
   font-size: $small-font;
   margin-top: 0;
+  visibility: hidden;
 }
 
 #settings-home {

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -566,6 +566,7 @@ function (chai, sinon, p, Constants, Assertion, ProfileClient,
             assert.equal(profileImage.get('url'), PNG_URL);
             assert.equal(profileImage.get('id'), 'foo');
             assert.isTrue(profileImage.has('img'));
+            assert.isTrue(account.get('hadProfileImageSetBefore'));
             assert.isTrue(account.setProfileImage.calledWith(profileImage));
           });
       });

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -60,7 +60,7 @@ define([
     });
 
     it('displayAccountProfileImage updates the cached account data', function () {
-      var image = new ProfileImage({ url: 'url', id: 'foo' });
+      var image = new ProfileImage({ url: 'url', id: 'foo', img: new Image() });
       var cachedAccount = user.initAccount({ uid: 'uid' });
       sinon.spy(cachedAccount, 'setProfileImage');
 
@@ -77,6 +77,7 @@ define([
           assert.isTrue(user.getAccountByUid.calledWith(UID));
           assert.isTrue(user.setAccount.calledWith(cachedAccount));
           assert.isTrue(cachedAccount.setProfileImage.calledWith(image));
+          assert.isTrue(view.hasDisplayedAccountProfileImage());
         });
     });
 


### PR DESCRIPTION
Without this, nightly users won't be able to change their avatar from the /settings page– only from the direct link on the Sync preferences page, which is sub-optimal UX. This is a blocker for turning on avatars in Nightly.

@shane-tomlinson or @vladikoff r?