### PR TITLE
fix(avatars): disable the gravatar option on avatar change

### DIFF
--- a/app/scripts/templates/settings/avatar_change.mustache
+++ b/app/scripts/templates/settings/avatar_change.mustache
@@ -17,7 +17,9 @@
       <input type="file" id="imageLoader" name="imageLoader" accept="image/png, image/jpeg"/>
       <a href="#" id="file"><span class="icon-plus"></span>{{#t}}Upload{{/t}}</a>
       <a href="/settings/avatar/camera" id="camera"><span class="icon-camera-alt"></span>{{#t}}Camera{{/t}}</a>
+      {{#shouldShowGravatar}}
       <a href="/settings/avatar/gravatar" id="gravatar"><span class="gravatar-logo"></span>{{#t}}Gravatar{{/t}}</a>
+      {{/shouldShowGravatar}}
     </nav>
 
     <p id="settings-home">

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -34,6 +34,13 @@ function ($, Cocktail, FormView, AvatarMixin, SettingsMixin, Template,
       this.FileReader = FileReader;
     },
 
+    context: function () {
+      var email = this.getSignedInAccount().get('email');
+      return {
+        shouldShowGravatar: this._shouldShowGravatar(email)
+      };
+    },
+
     beforeRender: function () {
       if (this.relier.get('setting') === 'avatar') {
         this.relier.unset('setting');
@@ -125,6 +132,11 @@ function ($, Cocktail, FormView, AvatarMixin, SettingsMixin, Template,
       }
 
       return defer.promise;
+    },
+
+    // Hide Gravatar except for tests until #2515 is resolved
+    _shouldShowGravatar: function (email) {
+      return /^avatarAB-.+@restmail\.net$/.test(email);
     }
 
   });

--- a/app/tests/spec/views/settings/avatar_change.js
+++ b/app/tests/spec/views/settings/avatar_change.js
@@ -100,6 +100,18 @@ function (chai, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
         assert.isFalse(view.$(':file').is(':visible'));
       });
 
+      it('hides the gravatar option', function () {
+        assert.equal(view.$('#gravatar').length, 0);
+      });
+
+      it('shows the gravatar option for test emails', function () {
+        account.set('email', 'avatarAB-test@restmail.net');
+        return view.render()
+          .then(function () {
+            assert.equal(view.$('#gravatar').length, 1);
+          });
+      });
+
       it('can remove the avatar', function () {
         sinon.stub(view, 'deleteDisplayedAccountProfileImage', function () {
           return p();

--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -150,99 +150,122 @@ define([
         });
     },
 
-    'visit gravatar with gravatar set': function () {
+    // revert this and the gravatar tests once #2515 is resolved
+    'try to visit gravatar when it is disabled': function () {
       return this.get('remote')
         .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
 
-        // go to change avatar
-        .findById('gravatar')
-          .click()
-        .end()
-
-        .findByCssSelector('img[src*="https://secure.gravatar.com"]')
-        .end()
-
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
-        .findById('submit-btn')
-          .click()
-        .end()
-
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-
-        .findByCssSelector('.success')
-          .getVisibleText()
-          .then(function (val) {
-            assert.ok(val, 'has success text');
-          })
-        .end()
-
-        .then(testIsBrowserNotifiedOfAvatarChange(this))
-
-        //success is returning to the settings page
-        .findById('fxa-settings-header')
-        .end()
-
-        // check for an image with the gravatar url
-        .findByCssSelector('img[src*="https://secure.gravatar.com"]')
+        // gravatar link should be absent
+        .then(FunctionalHelpers.noSuchElement(this, '#gravatar'))
         .end();
+    },
+
+    'visit gravatar with gravatar set': function () {
+      var self = this;
+      return signUp(self, emailAvatarAb)
+        .then(function () {
+          return self.get('remote')
+            .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
+
+            // go to change avatar
+            .findById('gravatar')
+              .click()
+            .end()
+
+            .findByCssSelector('img[src*="https://secure.gravatar.com"]')
+            .end()
+
+            .execute(FunctionalHelpers.listenForWebChannelMessage)
+
+            .findById('submit-btn')
+              .click()
+            .end()
+
+            .then(FunctionalHelpers.visibleByQSA('.success'))
+
+            .findByCssSelector('.success')
+              .getVisibleText()
+              .then(function (val) {
+                assert.ok(val, 'has success text');
+              })
+            .end()
+
+            .then(testIsBrowserNotifiedOfAvatarChange(self))
+
+            //success is returning to the settings page
+            .findById('fxa-settings-header')
+            .end()
+
+            // check for an image with the gravatar url
+            .findByCssSelector('img[src*="https://secure.gravatar.com"]')
+            .end();
+        });
     },
 
     'visit gravatar with gravatar set then cancel': function () {
-      return this.get('remote')
-        .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
+      var self = this;
+      return signUp(self, emailAvatarAb)
+        .then(function () {
+          return self.get('remote')
+            .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
 
-        // go to change avatar
-        .findById('gravatar')
-          .click()
-        .end()
+            // go to change avatar
+            .findById('gravatar')
+              .click()
+            .end()
 
-        .findByCssSelector('img[src*="https://secure.gravatar.com"]')
-        .end()
+            .findByCssSelector('img[src*="https://secure.gravatar.com"]')
+            .end()
 
-        .findByCssSelector('a.cancel')
-          .click()
-        .end()
+            .findByCssSelector('a.cancel')
+              .click()
+            .end()
 
-        // redirected back to main avatar page after save
-        .findById('avatar-options')
-        .end()
+            // redirected back to main avatar page after save
+            .findById('avatar-options')
+            .end()
 
-        // give time for error to show up, there should be no error though
-        .sleep(500)
+            // give time for error to show up, there should be no error though
+            .sleep(500)
 
-        .findByCssSelector('.error')
-          .getVisibleText()
-          .then(function (val) {
-            assert.ok(! val, 'has no error text');
-          })
-        .end()
+            .findByCssSelector('.error')
+              .getVisibleText()
+              .then(function (val) {
+                assert.ok(! val, 'has no error text');
+              })
+            .end()
 
-        // success is seeing no profile image set
-        .waitForDeletedByCssSelector('.avatar-wrapper img')
-        .end();
+            // success is seeing no profile image set
+            .waitForDeletedByCssSelector('.avatar-wrapper img')
+            .end();
+        });
     },
+
     'visit gravatar with no gravatar set': function () {
-      return this.get('remote')
-        .get(require.toUrl(AVATAR_CHANGE_URL))
+      var self = this;
+      return signUp(self, emailAvatarAb)
+        .then(function () {
+          return self.get('remote')
+            .get(require.toUrl(AVATAR_CHANGE_URL))
 
-        // go to change avatar
-        .findById('gravatar')
-          .click()
-        .end()
+            // go to change avatar
+            .findById('gravatar')
+              .click()
+            .end()
 
-        // success is going to the change avatar page
-        .findById('avatar-options')
-        .end()
+            // success is going to the change avatar page
+            .findById('avatar-options')
+            .end()
 
-        // success is seeing the error text
-        .then(FunctionalHelpers.visibleByQSA('.error'))
-        .findByCssSelector('.error')
-          .getVisibleText()
-          .then(function (val) {
-            assert.ok(val, 'has error text');
-          })
-        .end();
+            // success is seeing the error text
+            .then(FunctionalHelpers.visibleByQSA('.error'))
+            .findByCssSelector('.error')
+              .getVisibleText()
+              .then(function (val) {
+                assert.ok(val, 'has error text');
+              })
+            .end();
+        });
     },
 
     'attempt to use webcam for avatar': function () {


### PR DESCRIPTION
This is a blocker for enabling avatars in Nightly.

This disables gravatar (except for tests).

We'll enable it again once #2515 is resolved.

@shane-tomlinson or @vladikoff r?