### PR TITLE
chore(deps): Update fxa-js-client to 0.1.29

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "chai": "1.8.1",
     "cocktail": "0.5.9",
     "fxa-content-server-l10n": "https://github.com/mozilla/fxa-content-server-l10n.git",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.28",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.29",
     "html5shiv": "3.7.2",
     "jquery": "1.11.1",
     "mocha": "1.18.2",


### PR DESCRIPTION
Contains the logic necessary to send `reason` and `service` when
calling /account/login.

@vladikoff - r?

fixes #2559