### PR TITLE
feat(server): Support /v1/reset_password

### DIFF
--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -66,6 +66,11 @@ module.exports = function (config, i18n) {
       res.redirect(removeVersionPrefix(req.originalUrl));
     });
 
+    // handle reset password from notification emails
+    app.get(addVersionPrefix('/reset_password'), function (req, res) {
+      res.redirect(removeVersionPrefix(req.originalUrl));
+    });
+
     // front end mocha tests
     if (config.get('env') === 'development') {
       app.get('/tests/index.html', function (req, res) {

--- a/tests/functional/pages.js
+++ b/tests/functional/pages.js
@@ -13,8 +13,9 @@ define([
 
   var pages = [
     'v1/complete_reset_password',
-    'v1/verify_email',
     'v1/complete_unlock_account',
+    'v1/reset_password',
+    'v1/verify_email',
     '',
     'signin',
     'signup',

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -62,9 +62,10 @@ define([
     '/signin_permissions': { statusCode: 200 },
 
     // the following have a version prefix
-    '/v1/verify_email': { statusCode: 200 },
     '/v1/complete_reset_password': { statusCode: 200 },
-    '/v1/complete_unlock_account': { statusCode: 200 }
+    '/v1/complete_unlock_account': { statusCode: 200 },
+    '/v1/reset_password': { statusCode: 200 },
+    '/v1/verify_email': { statusCode: 200 }
   };
 
   if (config.get('are_dist_resources')) {


### PR DESCRIPTION
Used by the notification emails where users can reset their password if
another user took control of their account.

fixes #2560