### PR TITLE
fix(tests): add a run script for beta on latest

### DIFF
--- a/tests/teamcity/latest-beta
+++ b/tests/teamcity/latest-beta
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+CHANNELS_DIR="$HOME/firefox-channels"
+
+source $(dirname $0)/latest
+FXA_FIREFOX_BINARY="${CHANNELS_DIR}/latest-beta/en-US/firefox/firefox-bin"


### PR DESCRIPTION
Say, @vladikoff. I'm assuming you changed the config in teamcity to use run.sh, but there is no latest-beta, so here it is.