### PR TITLE
fix(client): Fix the submit button on communcation preferences page.

### DIFF
--- a/app/tests/spec/views/decorators/progress_indicator.js
+++ b/app/tests/spec/views/decorators/progress_indicator.js
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'chai',
+  'sinon',
+  'jquery',
+  'lib/promise',
+  'views/base',
+  'views/progress_indicator',
+  'views/decorators/progress_indicator'
+],
+function (chai, sinon, $, p, BaseView, ProgressIndicator, showProgressIndicator) {
+  var assert = chai.assert;
+
+  describe('views/decorators/progress_indicator', function () {
+    var view;
+    var progressIndicator;
+
+    var View = BaseView.extend({
+      template: function () {
+        return '<button type="submit">Button</button>';
+      },
+      longRunningAction: showProgressIndicator(function () {
+        return p().then(function () {
+          assert.isTrue(progressIndicator.start.called);
+        });
+      })
+    });
+
+    beforeEach(function () {
+      // set up a progress indicator to use for testing.
+      progressIndicator = new ProgressIndicator();
+      sinon.spy(progressIndicator, 'start');
+      sinon.spy(progressIndicator, 'done');
+
+      view = new View();
+
+      return view.render()
+        .then(function () {
+          // set up the initial progress indicator to use for testing.
+          view.$('button[type="submit"]').data('progressIndicator', progressIndicator);
+          $('#container').html(view.el);
+        });
+    });
+
+    afterEach(function () {
+      view.destroy();
+    });
+
+    describe('showProgressIndicator', function () {
+      it('starts and stops the progress indicator', function () {
+        return view.longRunningAction()
+          .then(function () {
+            assert.equal(progressIndicator.done.callCount, 1);
+          });
+      });
+
+      it('can be shown multiple times in a row on the same button', function () {
+        return view.longRunningAction()
+          .then(function () {
+            assert.equal(progressIndicator.done.callCount, 1);
+
+            return view.longRunningAction();
+          })
+          .then(function () {
+            assert.equal(progressIndicator.done.callCount, 2);
+          });
+      });
+
+      it('works even if the view re-renders after a button is shown', function () {
+        return view.longRunningAction()
+          .then(function () {
+            assert.equal(progressIndicator.done.callCount, 1);
+
+            // a new progress indicator should be created
+            // because of this action.
+            return view.render();
+          })
+          .then(function () {
+            return view.longRunningAction();
+          })
+          .then(function () {
+            var progressIndicatorAfterReRender = view.$('button[type="submit"]').data('progressIndicator');
+            assert.instanceOf(progressIndicatorAfterReRender, ProgressIndicator);
+            assert.notEqual(progressIndicator, progressIndicatorAfterReRender);
+
+            assert.equal(progressIndicator.done.callCount, 1);
+          });
+      });
+    });
+  });
+});
+

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -88,6 +88,7 @@ function (Translator, Session) {
     '../tests/spec/views/cannot_create_account',
     '../tests/spec/views/close_button',
     '../tests/spec/views/coppa/coppa-date-picker',
+    '../tests/spec/views/decorators/progress_indicator',
     '../tests/spec/views/mixins/floating-placeholder-mixin',
     '../tests/spec/views/mixins/timer-mixin',
     '../tests/spec/views/mixins/service-mixin',


### PR DESCRIPTION
The problem is a view was only allowed to have a single progress indicator,
attached to a single button. If a view was re-rendered with a new submit
button, the new submit button could not have a progress indicator.

Instead of saving a reference to the progress indicator on the view,
save it on the button the behavior is attached to. If the button goes
away, so does the progress indicator, and a new one will be created
when needed.

fixes #2502