### PR TITLE
fix(client): Supress the malformed WebChannelMessageToContent log for errors

### DIFF
--- a/app/scripts/lib/channels/receivers/web-channel.js
+++ b/app/scripts/lib/channels/receivers/web-channel.js
@@ -31,7 +31,7 @@ define([
     receiveMessage: function (event) {
       var detail = event.detail;
 
-      if (! (detail && detail.id && detail.message)) {
+      if (! (detail && detail.id)) {
         // malformed message
         this._window.console.error('malformed WebChannelMessageToContent event', JSON.stringify(detail));
         return;
@@ -42,6 +42,11 @@ define([
         return;
       }
 
+      // Fx has an error where error responses are sent with neither
+      // an `error` nor a `message` field. See
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1173830
+      //
+      // Ignore events with no `message` field.
       var message = detail.message;
       if (message) {
         this.trigger('message', message);

--- a/app/tests/spec/lib/channels/receivers/web-channel.js
+++ b/app/tests/spec/lib/channels/receivers/web-channel.js
@@ -47,15 +47,19 @@ function (chai, sinon, WebChannelReceiver, WindowMock) {
         });
         assert.equal(windowMock.console.error.callCount, 2);
 
-        // missing message
+        windowMock.console.error.restore();
+      });
+
+      it('ignores messages without a `message`', function () {
+        sinon.spy(receiver, 'trigger');
+
         receiver.receiveMessage({
           detail: {
             id: 'channel_id'
           }
         });
-        assert.equal(windowMock.console.error.callCount, 3);
 
-        windowMock.console.error.restore();
+        assert.isFalse(receiver.trigger.called);
       });
 
       it('ignores messages from other channels', function () {


### PR DESCRIPTION
@vladikoff - r?

Fx has an error where error responses are sent with neither an `error` nor a `message` field. See
https://bugzilla.mozilla.org/show_bug.cgi?id=1173830

Ignore events with no `message` field.

fixes #2518