### PR TITLE
feat(style): The `chromeless` style hides the header.

### DIFF
--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -112,6 +112,10 @@ header {
       }
 
     }
+
+    .chromeless & {
+      display: none;
+    }
   }
 
   h2 {


### PR DESCRIPTION
@johngruen, @ryanfeeley - is this the appropriate place for this? Should I hide the entire `header` element, or just the `h1` for `chromeless`?

fixes #2565 
ref #2101
