### PR TITLE
feat(client): Notify IFRAME reliers when the content height changes.

### DIFF
--- a/app/scripts/lib/height-observer.js
+++ b/app/scripts/lib/height-observer.js
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Observe the height of an element, trigger the `change` notification
+ * if the element's height changes.
+ */
+
+define([
+  'backbone',
+  'underscore'
+], function (Backbone, _) {
+  'use strict';
+
+  function HeightObserver (options) {
+    options = options || {};
+
+    this._targetEl = options.target;
+    this._window = options.window;
+
+    if ('delayMS' in options) {
+      this._delayMS = options.delayMS;
+    }
+  }
+
+  _.extend(HeightObserver.prototype, Backbone.Events, {
+    _delayMS: 50,
+
+    start: function () {
+      var self = this;
+
+      if (self._observer) {
+        throw new Error('Already started');
+      }
+
+      // For more info, see
+      // https://developer.mozilla.org/docs/Web/API/MutationObserver
+      var MutationObserver = self._window.MutationObserver;
+      if (MutationObserver) {
+        var onMutation = _.debounce(self._onMutation.bind(self), self._delayMS);
+        self._observer = new MutationObserver(onMutation);
+
+        self._observer.observe(self._targetEl, {
+          attributes: true,
+          attributeFilter: ['class', 'style'],
+          characterData: true,
+          childList: true,
+          subtree: true
+        });
+
+        // trigger the initial notification
+        self._onMutation();
+      }
+    },
+
+    _lastHeight: -Infinity,
+    _onMutation: function () {
+      var self = this;
+      var currentHeight = self._targetEl.clientHeight;
+      // An element's clientHeight can be misreported on some versions of
+      // Fennec - see https://bugzilla.mozilla.org/show_bug.cgi?id=1071620
+      // don't make any update unless the clientHeight is actually a number.
+      if (typeof currentHeight === 'number' &&
+          currentHeight !== self._lastHeight) {
+        self.trigger('change', currentHeight);
+        self._lastHeight = currentHeight;
+      }
+    },
+
+    stop: function () {
+      var observer = this._observer;
+      if (observer) {
+        observer.disconnect();
+        delete this._observer;
+      }
+    }
+  });
+
+  return HeightObserver;
+});
+

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -5,12 +5,24 @@
 // stub out the window object for testing.
 
 define([
-  'underscore',
   'backbone',
+  'sinon',
+  'underscore',
   'lib/null-storage'
 ],
-function (_, Backbone, NullStorage) {
+function (Backbone, sinon, _, NullStorage) {
   'use strict';
+
+  function MutationObserver (notifier) {
+    return {
+      observe: sinon.spy(),
+      disconnect: sinon.spy(),
+      // test function to call notifier.
+      mockNotify: function (mutations) {
+        notifier(mutations);
+      }
+    };
+  }
 
   function WindowMock() {
     var self = this;
@@ -24,9 +36,11 @@ function (_, Backbone, NullStorage) {
     };
 
     this.document = {
+      body: window.document.body,
       title: window.document.title,
       documentElement: {
-        className: ''
+        className: '',
+        clientHeight: window.document.documentElement.clientHeight
       }
     };
 
@@ -75,6 +89,9 @@ function (_, Backbone, NullStorage) {
     this.localStorage = new NullStorage();
     this.sessionStorage = new NullStorage();
     this.top = this;
+
+
+    this.MutationObserver = MutationObserver;
   }
 
   _.extend(WindowMock.prototype, Backbone.Events, {

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -579,6 +579,34 @@ function (chai, sinon, AppStart, Session, Constants, p, Url, OAuthErrors,
       });
     });
 
+    describe('initializeHeightObserver', function () {
+      beforeEach(function () {
+        appStart = new AppStart({
+          window: windowMock,
+          router: routerMock,
+          history: historyMock,
+          user: userMock,
+          broker: brokerMock
+        });
+      });
+
+      it('sets up the HeightObserver, triggers a `resize` notification on the iframe channel when the height changes', function (done) {
+        sinon.stub(appStart, '_isInAnIframe', function () {
+          return true;
+        });
+
+        appStart._iframeChannel = {
+          send: function (message, data) {
+            TestHelpers.wrapAssertion(function () {
+              assert.equal(message, 'resize');
+              assert.typeOf(data.height, 'number');
+            }, done);
+          }
+        };
+
+        appStart.initializeHeightObserver();
+      });
+    });
 
     describe('allResourcesReady', function () {
       beforeEach(function () {

--- a/app/tests/spec/lib/height-observer.js
+++ b/app/tests/spec/lib/height-observer.js
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'sinon',
+  '../../mocks/window',
+  'lib/height-observer'
+],
+function (chai, sinon, WindowMock, HeightObserver) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  describe('lib/height-observer', function () {
+    var heightObserver;
+    var windowMock;
+    var containerEl = document.body.querySelector('#container');
+    var targetEl;
+    var delayMS = 10;
+
+    beforeEach(function () {
+      containerEl.innerHTML = '<div id="target">content to ensure set height</div>';
+      targetEl = document.body.querySelector('#target');
+
+      windowMock = new WindowMock();
+      heightObserver = new HeightObserver({
+        delayMS: delayMS,
+        target: targetEl,
+        window: windowMock
+      });
+    });
+
+    afterEach(function () {
+      heightObserver.stop();
+    });
+
+    describe('start', function () {
+      it('hooks up the MutationObserver', function () {
+        heightObserver.start();
+
+        assert.isTrue(
+          heightObserver._observer.observe.calledWith(targetEl));
+      });
+
+      it('can only be started once', function () {
+        heightObserver.start();
+        assert.throws(function () {
+          heightObserver.start();
+        });
+      });
+    });
+
+    describe('notifications', function () {
+
+      it('triggers the `change` event if the height has changed', function (done) {
+        var isNotificationExpected = false;
+        var onChange = sinon.spy(function () {
+          assert.isTrue(isNotificationExpected);
+          done();
+        });
+
+        heightObserver.start();
+
+        // set the initial height
+        heightObserver._onMutation();
+
+        heightObserver.on('change', onChange);
+
+        // no height changes because the content has not changed.
+        heightObserver._onMutation();
+        heightObserver._onMutation();
+        heightObserver._onMutation();
+
+        // height change, should trigger the notification
+        targetEl.innerHTML = targetEl.innerHTML + '<br /> line2';
+        isNotificationExpected = true;
+        heightObserver._onMutation();
+      });
+
+      it('`change` event only triggered once for closely spaced events', function (done) {
+        var onChange = sinon.spy();
+
+        heightObserver.on('change', onChange);
+
+        // triggers the first event.
+        heightObserver.start();
+
+        // without a debounce, these all trigger notifications
+        targetEl.innerHTML = targetEl.innerHTML + '<br /> line2';
+
+        // use _observer.mockNotify instead of _onMutation because
+        // _onMutation is not debounced.
+        heightObserver._observer.mockNotify();
+
+        targetEl.innerHTML = targetEl.innerHTML + '<br /> line3';
+        heightObserver._observer.mockNotify();
+
+        targetEl.innerHTML = targetEl.innerHTML + '<br /> line4';
+        heightObserver._observer.mockNotify();
+
+        targetEl.innerHTML = targetEl.innerHTML + '<br /> line5';
+        heightObserver._observer.mockNotify();
+
+        // after a slight delay, this should trigger a new event.
+        setTimeout(function () {
+          targetEl.innerHTML = targetEl.innerHTML + '<br /> line5';
+          heightObserver._observer.mockNotify();
+        }, delayMS);
+
+        setTimeout(function () {
+          done(assert.equal(onChange.callCount, 2));
+        }, 2 * delayMS);
+      });
+
+      it('does not report a `change` if the element\'s clientHeight is not a number', function () {
+        var onChange = sinon.spy();
+
+        // An element's clientHeight can be misreported on some versions of
+        // Fennec - see https://bugzilla.mozilla.org/show_bug.cgi?id=1071620
+        // don't make any update unless the clientHeight is actually a number.
+        var elementMockWithNoClientHeight = {};
+
+        heightObserver = new HeightObserver({
+          delayMS: delayMS,
+          target: elementMockWithNoClientHeight,
+          window: windowMock
+        });
+        heightObserver.on('change', onChange);
+
+        targetEl.parentNode.removeChild(targetEl);
+        heightObserver.start();
+
+        assert.isFalse(onChange.called);
+      });
+    });
+
+    describe('stop', function () {
+      it('disconnect the MutationObserver', function () {
+        heightObserver.start();
+
+        // save a local reference because it's deleted off of the object.
+        var mutationObserver = heightObserver._observer;
+        heightObserver.stop();
+
+        assert.isTrue(
+          mutationObserver.disconnect.called);
+      });
+    });
+  });
+});

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -51,6 +51,7 @@ function (Translator, Session) {
     '../tests/spec/lib/base64url',
     '../tests/spec/lib/origin-check',
     '../tests/spec/lib/marketing-email-client',
+    '../tests/spec/lib/height-observer',
     '../tests/spec/head/startup-styles',
     '../tests/spec/views/base',
     '../tests/spec/views/tooltip',

--- a/docs/relier-communication-protocols/iframe.md
+++ b/docs/relier-communication-protocols/iframe.md
@@ -20,6 +20,10 @@ Sent if the user completes authentication. The `data` field will be an object wi
 #### oauth_cancel
 Sent when a user indicates they want to close the iframe. The parent should close the iframe.
 
+#### resize
+Sent when the content height changes. The `data` field will be an object that contains `height`.
+* `height` {Number} - the content height
+
 ### Message format
 Since all messages are sent over postMessage, commands and data must be represented by strings. A JSON.stringify serialized object containing a command and data object is used.
 


### PR DESCRIPTION
Use MutationObservers in browsers that support them to inform any iframe parents of a content height change.

Initial use is for the first run flow where they want to adjust the iframe height based on the height of the content.

fixes #2566.
ref #2101