### PR TITLE
fix(client): Mozilla Payments flow is not considered an iframe.

### DIFF
--- a/app/scripts/lib/environment.js
+++ b/app/scripts/lib/environment.js
@@ -67,9 +67,29 @@
 
     isFramed: function () {
       var win = this.window;
-      // about:accounts places FxA into an iframe, but is not considered
-      // to use the iframe flow. about:accounts sets window.name = 'remote'
-      return !! (win.top && win.top !== win && win.name !== 'remote');
+
+      // HACK:
+      // These are the iframe names when used in a native browser iframe.
+      // Do not consider windows with these names framed.
+      //
+      // 'remote' is for about:accounts
+      // 'payflow' is for Mozilla Payments reset PIN flow on Fx for Android.
+      //   See #2607
+
+      // use a hash instead of an array and array.indexOf
+      // b/c this module can only use ES3.
+      var nativeNames = {
+        remote: true,
+        payflow: true
+      };
+
+      var isNativelyEmbedded = nativeNames[win.name];
+
+      return !! (
+                 win.top &&
+                 win.top !== win &&
+                 ! isNativelyEmbedded
+                );
     },
 
     isFxiOS: function () {

--- a/app/tests/spec/lib/environment.js
+++ b/app/tests/spec/lib/environment.js
@@ -94,8 +94,18 @@ define([
       });
 
       it('returns `false` if the window\'s name is `remote`', function () {
+        // `name=remote` is used by `about:accounts` by Fx Desktop. Do not
+        // consider this framed.
         windowMock.top = new WindowMock();
         windowMock.name = 'remote';
+        assert.isFalse(environment.isFramed());
+      });
+
+      it('returns `false` if the window\'s name is `payflow`', function () {
+        // `name=payflow` is used by Marketplace on Fx for Android during
+        // the Reset PIN flow. Do not consider this framed.
+        windowMock.top = new WindowMock();
+        windowMock.name = 'payflow';
         assert.isFalse(environment.isFramed());
       });
     });


### PR DESCRIPTION
The Mozilla Payments flow on Fennec uses a trusted iframe with
the `mozbrowser` attribute to open FxA. Fennec should report
that window.top === window when the `mozbrowser` attribute is used,
but it does not.

fixes #2607 

@rfk, @andymckay 