### PR TITLE
fix(tests): use the regularly updated firefox binaries

### DIFF
--- a/tests/teamcity/defaults.sh
+++ b/tests/teamcity/defaults.sh
@@ -2,9 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+CHANNELS_DIR="$HOME/firefox-channels"
+
 FXA_CONTENT_ROOT="https://latest.dev.lcip.org/"
 FXA_AUTH_ROOT="https://latest.dev.lcip.org/auth/v1"
 FXA_OAUTH_APP_ROOT="https://123done-latest.dev.lcip.org/"
 FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done-latest.dev.lcip.org/"
-FXA_FIREFOX_BINARY="/usr/bin/firefox"
+FXA_FIREFOX_BINARY="$CHANNELS_DIR/latest/en-US/firefox/firefox-bin"
 


### PR DESCRIPTION
Hey, @vladikoff - I switched stable to use these startup scripts and realized that the default runs were using the system firefox (which is currently 38.0, not 38.0.5). So use the downloaded builds as intended.