### PR TITLE
feat(oauth): allow access_type query parameter

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -54,7 +54,10 @@ define([], function () {
     VERIFICATION_REDIRECT_ALWAYS: 'always',
     VERIFICATION_REDIRECT_NO: 'no',
 
-    MARKETING_EMAIL_NEWSLETTER_ID: 'firefox-accounts-journey'
+    MARKETING_EMAIL_NEWSLETTER_ID: 'firefox-accounts-journey',
+
+    ACCESS_TYPE_ONLINE: 'online',
+    ACCESS_TYPE_OFFLINE: 'offline'
   };
 });
 

--- a/app/scripts/lib/oauth-client.js
+++ b/app/scripts/lib/oauth-client.js
@@ -29,7 +29,8 @@ function (xhr, OAuthErrors) {
         });
     },
 
-    // params = { assertion, client_id, redirect_uri, scope, state }
+    // params = { assertion, client_id, redirect_uri, scope, state,
+    // access_type }
     getCode: function getCode(params) {
       return this._request('post', GET_CODE, params);
     },

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -77,6 +77,10 @@ function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
             scope: relier.get('scope'),
             state: relier.get('state')
           };
+          if (relier.get('accessType') === Constants.ACCESS_TYPE_OFFLINE) {
+            //jshint camelcase: false
+            oauthParams.access_type = Constants.ACCESS_TYPE_OFFLINE;
+          }
           return self._oAuthClient.getCode(oauthParams);
         })
         .then(_formatOAuthResult);
@@ -129,7 +133,9 @@ function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
           state: relier.get('state'),
           keys: relier.get('keys'),
           scope: relier.get('scope'),
-          action: relier.get('action')
+          action: relier.get('action'),
+          //jshint camelcase: false
+          access_type: relier.get('access_type')
         });
       });
     },

--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -30,6 +30,7 @@ define([
       // redirectUri is used by the oauth flow
       redirectUri: null,
       scope: null,
+      accessType: null,
       // redirectTo is for future use by the oauth flow. redirectTo
       // would have redirectUri as its base.
       redirectTo: null,
@@ -151,7 +152,9 @@ define([
         //jshint camelcase: false
         clientId: resumeObj.client_id,
         redirectUri: resumeObj.redirect_uri,
-        scope: resumeObj.scope
+        scope: resumeObj.scope,
+        //jshint camelcase: false
+        accessType: resumeObj.access_type
       });
 
       if (! self.has('clientId')) {
@@ -170,6 +173,7 @@ define([
       self._importRequiredSearchParam('scope', 'scope');
       self.importSearchParam('state');
       self.importSearchParam('redirect_uri', 'redirectUri');
+      self.importSearchParam('access_type', 'accessType');
       self.importSearchParam('redirectTo');
       self.importSearchParam('verification_redirect', 'verificationRedirect');
       self.importBooleanSearchParam('keys');

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -39,13 +39,15 @@ define([
     var PERMISSIONS = ['profile:email', 'profile:uid'];
     var ACTION = 'signup';
     var PREVERIFY_TOKEN = 'abigtoken';
+    var ACCESS_TYPE = 'offline';
 
     var RESUME_INFO = {
       state: STATE,
       //jshint camelcase: false
       client_id: CLIENT_ID,
       scope: SCOPE,
-      action: ACTION
+      action: ACTION,
+      access_type: ACCESS_TYPE
     };
 
     beforeEach(function () {
@@ -78,7 +80,8 @@ define([
           client_id: CLIENT_ID,
           redirect_uri: REDIRECT_URI,
           scope: SCOPE,
-          action: ACTION
+          action: ACTION,
+          access_type: ACCESS_TYPE
         });
 
         return relier.fetch()
@@ -90,6 +93,7 @@ define([
             // client_id and redirect_uri are converted to camelCase
             // for consistency with other variables in the app.
             assert.equal(relier.get('clientId'), CLIENT_ID);
+            assert.equal(relier.get('accessType'), ACCESS_TYPE);
 
             // The redirect_uri passed in is ignored, we only care about
             // the redirect_uri returned by the oauth server
@@ -131,6 +135,7 @@ define([
             assert.equal(relier.get('state'), STATE);
             assert.equal(relier.get('clientId'), CLIENT_ID);
             assert.equal(relier.get('scope'), SCOPE);
+            assert.equal(relier.get('accessType'), ACCESS_TYPE);
           });
       });
 


### PR DESCRIPTION
The goal is to allow someone to `GET /v1/authorization?access_type=offline`, and have the content-server `POST` that value when fetching a code.

I *think* this is all that's needed to collect that value, persist it, and post it, but I'm new here. Also, I wasn't quite sure if/how to write tests for this.