### PR TITLE
fix(tests): restore first tests to run are signin and signup

### DIFF
--- a/tests/functional.js
+++ b/tests/functional.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
-  './functional/refreshes_metrics',
   './functional/sign_in',
   './functional/sign_in_cached',
   './functional/sync_sign_in',
@@ -34,5 +33,6 @@ define([
   './functional/password_visibility',
   './functional/avatar',
   './functional/alternative_styles',
-  './functional/email_opt_in'
+  './functional/email_opt_in',
+  './functional/refreshes_metrics',
 ], function () {});


### PR DESCRIPTION
I think the way it has been forever, where the first tests are about signin and signup made a lot of sense to be first. So putting it back that way.