### PR TITLE
Revert "feat(client): Add Easter Egg to Content Server"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,8 +28,7 @@
     "jquery-ui-touch-punch": "https://github.com/zaach/jquery-ui-touch-punch.git#89e5a9159494de37df1e09cccf9036dda5429830",
     "blueimp-canvas-to-blob": "2.1.0",
     "mailcheck": "https://github.com/mailcheck/mailcheck.git#9fcf9c40da06f6769e5d702dd0fd1f33f36e55a6",
-    "node-uuid": "1.4.3",
-    "easteregg": "https://github.com/TDA/JavaScript.git#bf3a8870"
+    "node-uuid": "1.4.3"
   },
   "devDependencies": {
     "moment": "2.8.3"

--- a/grunttasks/concat.js
+++ b/grunttasks/concat.js
@@ -7,10 +7,6 @@ module.exports = function (grunt) {
     requirejs: {
       dest: '<%= yeoman.tmp %>/scripts/main.js',
       src: ['app/bower_components/requirejs/require.js', '<%= yeoman.tmp %>/scripts/main.js']
-    },
-    easteregg: {
-      dest: '<%= yeoman.tmp %>/scripts/main.js',
-      src: ['<%= yeoman.tmp %>/scripts/main.js', 'app/bower_components/easteregg/easteregg/easteregg.js']
     }
   });
 };


### PR DESCRIPTION
Reverting until we can get a couple of issues cleared up:

* Remove the DEATH FROM ABOVE text.
* Decide if we want to use the Cloud Services logo or the Mozilla logo.
* Add some docs about the build process.
* Move the easter egg repo to a name that is more clear.
* Add some unit tests to the easter egg repo.
* Ensure we don't blow up IE8 which does not have window.console unless the dev tools are open.

This reverts commit 0a5ea8ed461575fa4d194a0d1bab857278524bee.