### PR TITLE
WIP feat(server): minimize framing.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -280,12 +280,16 @@ function (
 
     initializeIframeChannel: function () {
       var self = this;
+      console.log('checking if in an iframe');
       if (! self._isInAnIframe()) {
         return p();
       }
 
+      console.log('initializing iframe channel');
+
       return self._checkParentOrigin()
         .then(function (parentOrigin) {
+          console.log('parentOrigin', parentOrigin);
           if (! parentOrigin) {
             // No allowed origins were found. Illegal iframe.
             throw AuthErrors.toError('ILLEGAL_IFRAME_PARENT');

--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -29,6 +29,7 @@ var consolidate = require('consolidate');
 var bodyParser = require('body-parser');
 var cookieParser = require('cookie-parser');
 var serveStatic = require('serve-static');
+var xFrameOptions = require('../lib/x-frame-options');
 
 var i18n = require('../lib/i18n')(config.get('i18n'));
 var routes = require('../lib/routes')(config, i18n);
@@ -64,7 +65,8 @@ function makeApp() {
   // render the correct template for the locale.
   app.use(localizedRender({ i18n: i18n }));
 
-  app.use(helmet.xframe('deny'));
+  /*app.use(helmet.xframe('deny'));*/
+  app.use(xFrameOptions(config));
   app.use(helmet.xssFilter());
   app.use(helmet.hsts({
     maxAge: config.get('hsts_max_age'),

--- a/server/lib/oauth-client-info.js
+++ b/server/lib/oauth-client-info.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// OAuth client info for the given client id
+
+// XXX - could probably just use the oauth client for this.
+
+const request = require('request');
+const Promise = require('bluebird');
+
+module.exports = function (oAuthUrl) {
+  var clientInfoCache = {};
+
+  // TODO should probably ensure oAuthUrl does not already end in a /
+  var CLIENT_INFO_URL_BASE = oAuthUrl + '/v1/client/';
+
+  return {
+    getClientInfo: function (clientId) {
+      if (clientInfoCache[clientId]) {
+        return Promise.resolve(clientInfoCache[clientId]);
+      }
+
+      var resolver = Promise.defer();
+
+      request.get({
+        url: CLIENT_INFO_URL_BASE + clientId
+      }, function (err, _, body) {
+        if (err) {
+          return resolver.reject(err);
+        }
+
+        if (body.code >= 400) {
+          return resolver.reject(new Error('Unauthorized'));
+        }
+
+        console.error('body!', body);
+        var clientInfo = JSON.parse(body);
+        clientInfoCache[clientId] = clientInfo;
+        resolver.resolve(clientInfo);
+      });
+
+      return resolver.promise;
+    }
+  };
+};

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -131,7 +131,7 @@ module.exports = function (config, i18n) {
     FRONTEND_ROUTES.forEach(function (route) {
       app.get(route, function (req, res, next) {
         if (ALLOWED_TO_FRAME[req.path]) {
-          res.removeHeader('x-frame-options');
+          /*res.removeHeader('x-frame-options');*/
         }
 
         // setting the url to / will use the correct
@@ -156,12 +156,12 @@ module.exports = function (config, i18n) {
       });
 
       app.get('/503.html', function (req, res) {
-        res.removeHeader('x-frame-options');
+        /*res.removeHeader('x-frame-options');*/
         return res.render('503');
       });
 
       app.get('/502.html', function (req, res) {
-        res.removeHeader('x-frame-options');
+        /*res.removeHeader('x-frame-options');*/
         return res.render('502');
       });
 
@@ -173,7 +173,7 @@ module.exports = function (config, i18n) {
 
     // we always want to handle these so we can do some logging.
     app.get('/400.html', function (req, res) {
-      res.removeHeader('x-frame-options');
+      /*res.removeHeader('x-frame-options');*/
       logger.error('400.html', {
         message: req.query.message,
         errno: req.query.errno,
@@ -188,7 +188,7 @@ module.exports = function (config, i18n) {
     });
 
     app.get('/500.html', function (req, res) {
-      res.removeHeader('x-frame-options');
+      /*res.removeHeader('x-frame-options');*/
       logger.error('500.html', {
         message: req.query.message,
         errno: req.query.errno,

--- a/server/lib/x-frame-options.js
+++ b/server/lib/x-frame-options.js
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const OAuthClientInfo = require('./oauth-client-info');
+const url = require('url');
+
+module.exports = function (config) {
+  var oAuthClientInfo = new OAuthClientInfo(config.get('oauth_url'));
+  var allowedParents = config.get('allowed_parent_origins');
+
+  return function (req, res, next) {
+    // only HTML files need the x-frame-header option.
+    if (! /text\/html/.test(req.get('accept'))) {
+      next();
+      return;
+    }
+
+    var HEADER_NAME = 'X-Frame-Options';
+    function allowFrom(origin) {
+      res.setHeader(HEADER_NAME, 'ALLOW-FROM ' + origin);
+    }
+
+    function deny() {
+      res.setHeader(HEADER_NAME, 'DENY');
+    }
+
+    if (req.query.client_id && req.query.context === 'iframe') {
+      oAuthClientInfo.getClientInfo(req.query.client_id)
+        .then(function (clientInfo) {
+          const parsedUrl = url.parse(clientInfo.redirect_uri);
+          const origin = parsedUrl.protocol + '//' + parsedUrl.host;
+          allowFrom(origin);
+          next();
+        });
+      return;
+    } else if (req.query.service === 'sync' && req.query.context === 'iframe') {
+      // this is based on the scheme proposed on RFC 7034
+      // - https://tools.ietf.org/html/rfc7034#section-2.3.2.3
+      // The RFC actually recommends the relier send a query parameter
+      // since some browsers do not send referrer.
+      var referrer = req.get('referrer').replace(/\/$/, '');
+      if (referrer && allowedParents.indexOf(referrer) > -1) {
+        allowFrom(referrer);
+        next();
+        return;
+      }
+    }
+
+    // Deny by default. If there is an OAuth client id, then
+    // go look up the client's info and create a valid origin.
+    //
+    // If embedded into a native Firefox chrome iframe, x-frame-options
+    // will be ignored anyway.
+    deny();
+    next();
+  };
+};


### PR DESCRIPTION
Let the browser handle frame restrictions!

Set x-frame-options: DENY to all reliers unless the `context=iframe`
query parameter is set. If context=iframe is set, set
x-frame-options: ALLOW-FROM <origin>.

<origin> is determined from the registered OAuth information if
a client_id is specified.
<origin> is determined from the referrer, if the referrer is amongst
the list of origins that are allowed to frame the sync flow, and service=sync.

issue #2606