### PR TITLE
[PROPOASL] SSO: Support to prevent asking password again to already authenticated users on supported reliers

### DIFF
--- a/app/scripts/models/reliers/base.js
+++ b/app/scripts/models/reliers/base.js
@@ -47,6 +47,16 @@ define([
     },
 
     /**
+     * Check if we whitelisted/authorized service to
+     * ask for password only once.
+     *
+     * So far, only OAuth relier whould possibly make it return true.
+     */
+    isSsoAuthorizedRelier: function () {
+      return false;
+    },
+
+    /**
      * Check if the relier is Sync for Firefox Desktop
      */
     isSync: function () {

--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -37,7 +37,11 @@ define([
       // whether to fetch and derive relier-specific keys
       keys: false,
       // verification redirect to the rp, useful during email verification signup flow
-      verificationRedirect: Constants.VERIFICATION_REDIRECT_NO
+      verificationRedirect: Constants.VERIFICATION_REDIRECT_NO,
+      // Feature flag to allow prevent to ask password twice to authenticated user
+      // ... default value should be false and if, only if, relier config has canSso: true
+      // would enable it.
+      canSso: true
     }),
 
     initialize: function (options) {
@@ -91,6 +95,15 @@ define([
         return true;
       }
       return Relier.prototype.wantsKeys.call(this);
+    },
+
+    /**
+     * Check if oauth relier entry has a trusted boolean.
+     * Only OAuth2 relier with trusted: (bool) true should
+     * make thi method call return true.
+     */
+    isSsoAuthorizedRelier: function () {
+      return this.get('canSso');
     },
 
     deriveRelierKeys: function (keys, uid) {

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -109,7 +109,11 @@ define([
       var self = this;
 
       var account = _.find(self._accounts(), function (account) {
-        return self.isSyncAccount(account);
+        // We want true in two cases
+        // - self.isSyncAccount(account)
+        // - Ask relier.isSsoAuthorizedRelier()
+        console.debug('getChooserAccount (account)', account );
+        return true;//self.isSyncAccount(account);
       }) || self._getSignedInAccount();
 
       return self.initAccount(account);


### PR DESCRIPTION
How about separate, trusted+supported,  web application could just "log you in" without asking your password more than once. a.k.a. SSO

The following patch would make FxA able to give an OAuth2 one time `code` string so a configured relier would be able to get an OAuth `Bearer` token.

Idea is that each relier could then use the token, ask a "source of truth" (i.e. `fxa-profile-server`), the relier could then make sure a user exists locally and start a session. This has to be done in two separate components. [An initializer JavaScript module](#An initializer JavaScript module), and [Set in place two HTTP handlers on web app relier](#Set in place two HTTP handlers on web app relier)

To see the idea in action, [see this video](http://www.youtube.com/watch?v=rutwd1Z_1TE) where you'll see two separate wikis, on different domains, ensures the session state is in sync with FxA.
 
[![Synchronize session state accross separate web applications](http://img.youtube.com/vi/rutwd1Z_1TE/0.jpg)](http://www.youtube.com/watch?v=rutwd1Z_1TE)

## More notes about the feature

* [this comment](https://github.com/mozilla/fxa-content-server/issues/1386#issuecomment-51381907)

## Dependencies

### OAuth server patch

ref: mozilla/fxa-oauth-server#279

### An initializer JavaScript module

Refer [to this this **gist**](https://gist.github.com/WebPlatformDocs/fe3149c60d6ed95c7e16)

### Set in place two HTTP handlers on web app relier

* Each web application has to be registered to the OAuth server as both: `{trusted: true, canSso: true}`
* Backend has to support reading from a  "source of truth" (i.e. `fxa-profile-server`)
  * If FxA has no session, ensure relier web app kills any session (done through [JavaScript initializer module](An initializer JavaScript module))
  * If FxA has session, it MUST match session it has locally
* Ensure possible user data changes are reflected on relier web application locally

#### PHP Backend strawaman

The following is planned to be factored out as a PHP module so that other systems would take care of the specifics the  [JavaScript initializer module](An initializer JavaScript module) would trigger via xhr HTTP calls from its iframe.

* [FirefoxAccountsManager class](https://github.com/webplatform/mediawiki-fxa-sso/compare/master...webplatform-sso#diff-df6204a5520d4e71eaa9ebfa75e6034eR1)
* [a very rough (clumsy) attempt to handle session based on data from profile server](https://github.com/webplatform/mediawiki-fxa-sso/blob/2eff4350d6f09445fa5a9b0ded43d170c43409b7/includes/WebPlatformAuthHooks.php#L241), the block at `if ( is_string( $state_key ) && is_string( $code ) ) { /* here */ }`