### PR TITLE
chore(build): Include license header at the top of minified main.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,6 +29,7 @@ module.exports = function (grunt) {
   mozlog.config(config.get('logging'));
 
   grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json')
   });
 
   grunt.loadTasks('grunttasks');

--- a/grunttasks/uglify.js
+++ b/grunttasks/uglify.js
@@ -9,6 +9,15 @@ module.exports = function (grunt) {
    * Uglify all of the scripts in the dist directory
    */
   grunt.config('uglify', {
+    options: {
+      banner: '/*! <%= pkg.name %>@<%= pkg.version %> -- <%= grunt.template.today() %>\n *\n' +
+        ' * This Source Code Form is subject to the terms of the Mozilla Public\n' +
+        ' * License, v. 2.0. If a copy of the MPL was not distributed with this\n' +
+        ' * file, You can obtain one at http://mozilla.org/MPL/2.0/.\n *\n' +
+        ' * For more information, see https://github.com/mozilla/fxa-content-server/\n' +
+        ' */\n',
+      sourceMap: true
+    },
     dist: {
       files: [
         {
@@ -17,10 +26,7 @@ module.exports = function (grunt) {
           src: ['**/*.js'],
           dest: '<%= yeoman.dist %>/scripts'
         }
-      ],
-      options: {
-        sourceMap: true
-      }
+      ]
     }
   });
 };


### PR DESCRIPTION
Current output:
```js
/*! fxa-content-server@0.40.0 -- Tue Jun 30 2015 14:29:01
 *
 * This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 *
 * For more information, see https://github.com/mozilla/fxa-content-server/
 */
```

Fixes #2626 