### PR TITLE
fix(privacynotice): Remove the Learn More string in English-y locale's legal docs

### DIFF
--- a/grunttasks/replace.js
+++ b/grunttasks/replace.js
@@ -10,13 +10,18 @@ module.exports = function (grunt) {
         '<%= yeoman.tos_md_src %>/*.md'
       ],
       overwrite: true,
-      replacements: [{
-        from: /{:\s.*?\s}/g,
-        to: ''
-      }, {
-        from: /^#\s.*?\n$/m,
-        to: ''
-      }]
+      replacements: [
+        {
+          from: /{:\s.*?\s}/g,
+          to: ''
+        }, {
+          from: /^#\s.*?\n$/m,
+          to: ''
+        }, {
+          from: '.  Learn More.',
+          to: '.'
+        }
+      ]
     }
   });
 };


### PR DESCRIPTION
Only replaces "Learn more" text, so only works in **en-us**-esque locales.

Fixes #947 