### PR TITLE
fix(styles): Fix the error/top spacing for the firstrun flow.

### DIFF
--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -48,12 +48,12 @@
   .chromeless & {
     border: none;
     box-shadow: none;
+    margin-top: 0;
   }
-
 }
 
 #stage {
-  
+
   display: block;
   opacity: 0;
 


### PR DESCRIPTION
* Remove the top-margin of the main-content element if using style=chromeless.

fixes #2669

With this fix, the entire error appears!

![screen shot 2015-07-02 at 21 16 44](https://cloud.githubusercontent.com/assets/848085/8486891/06469dcc-2100-11e5-82f2-9677da8b8c0e.png)

ref #2101 