### PR TITLE
fix(tests): add fxaDevBox config param

### DIFF
--- a/tests/intern.js
+++ b/tests/intern.js
@@ -19,7 +19,15 @@ function (intern, topic, firefoxProfile) {
   var fxaOauthApp = args.fxaOauthApp || 'http://127.0.0.1:8080/';
   var fxaUntrustedOauthApp = args.fxaUntrustedOauthApp || 'http://127.0.0.1:10139/';
   var fxaIframeOauthApp = args.fxaIframeOauthApp || 'http://127.0.0.1:8080/iframe';
+
+  // "fxaProduction" is a little overloaded in how it is used in the tests.
+  // Sometimes it means real "stage" or real production configuration, but
+  // sometimes it also means fxa-dev style boxes like "latest". Configuration
+  // parameter "fxaDevBox" can be used as a crude way to distinguish between
+  // two.
   var fxaProduction = !! args.fxaProduction;
+  var fxaDevBox = !! args.fxaDevBox;
+
   var fxaToken = args.fxaToken || 'http://';
   var asyncTimeout = parseInt(args.asyncTimeout || 5000, 10);
 
@@ -45,6 +53,7 @@ function (intern, topic, firefoxProfile) {
     fxaUntrustedOauthApp: fxaUntrustedOauthApp,
     fxaIframeOauthApp: fxaIframeOauthApp,
     fxaProduction: fxaProduction,
+    fxaDevBox: fxaDevBox,
     fxaToken: fxaToken,
 
     // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the

--- a/tests/server/l10n.js
+++ b/tests/server/l10n.js
@@ -44,7 +44,7 @@ define([
       //
       assert.ok(res.headers.vary, 'the vary header exists');
       var varyHeader = res.headers.vary.toLowerCase().split(/,\s*/);
-      if (intern.config.fxaProduction) {
+      if (intern.config.fxaProduction && ! intern.config.fxaDevBox) {
         if (process.versions['node'] < '0.11.11') {
           assert.ok(varyHeader.indexOf('accept-encoding') !== -1);
         } else {

--- a/tests/server/metrics.js
+++ b/tests/server/metrics.js
@@ -11,8 +11,10 @@ define([
 ], function (intern, registerSuite, assert, config, request) {
   var serverUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
 
-  // IMHO, metrics should be enabled in dev too.
-  var metricsSampleRate = intern.config.fxaProduction ? 0.1 : config.get('metrics.sample_rate');
+  var metricsSampleRate = config.get('metrics.sample_rate');
+  if (intern.config.fxaProduction && ! intern.config.fxaDevBox) {
+    metricsSampleRate = 0.1;
+  }
 
   var suite = {
     name: 'metrics'

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -136,12 +136,15 @@ define([
       assert.ok(headers.hasOwnProperty('x-frame-options'));
     }
 
-    if (intern.config.fxaProduction) {
-      assert.ok(headers.hasOwnProperty('content-security-policy-report-only'));
-    } else if (config.get('env') === 'development' &&
-               // the front end tests do not get CSP headers.
-               url.parse(route).pathname !== '/tests/index.html') {
-      assert.ok(headers.hasOwnProperty('content-security-policy'));
+    // fxa-dev boxes currently do not set CSP headers (but should - GH-2155)
+    if (! intern.config.fxaDevBox) {
+      if (intern.config.fxaProduction) {
+        assert.ok(headers.hasOwnProperty('content-security-policy-report-only'));
+      } else if (config.get('env') === 'development' &&
+                 // the front end tests do not get CSP headers.
+                 url.parse(route).pathname !== '/tests/index.html') {
+        assert.ok(headers.hasOwnProperty('content-security-policy'));
+      }
     }
 
     assert.equal(headers['x-content-type-options'], 'nosniff');


### PR DESCRIPTION
@vladikoff - r?

This introduces a `fxaDevBox` configuration parameter to indicate a box like `latest.dev.lcip.org` or `stage.dev.lcip.org` (or `vladikoff.dev.lcip.org`) and adjust tests to use that appropriately. It's a rather blunt solution (feature flags would be better) but it's the pragmatic way to allow the intern_server tests to run in regular CI against `latest`. 