### PR TITLE
fix(tests): add a test runner for intern_server tests

### DIFF
--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -o nounset
+set -o errexit # exit on first command with non-zero status
+
+BASENAME=$(basename $0)
+DIRNAME=$(dirname $0)
+
+if [ "x$1" = "x" ]; then
+    echo "Usage: $0 test-name"
+    exit
+fi
+FXA_TEST_NAME=$1
+
+source $DIRNAME/defaults.sh
+source $DIRNAME/$FXA_TEST_NAME
+
+GIT_COMMIT=$(curl -s "$FXA_CONTENT_ROOT/ver.json" | jsawk  "return this.commit")
+
+echo "FXA_TEST_NAME      $FXA_TEST_NAME"
+echo "FXA_CONTENT_ROOT   $FXA_CONTENT_ROOT"
+echo "GIT_COMMIT         $GIT_COMMIT"
+
+WORKDIR=fxa-content-server-"$FXA_TEST_NAME"-server
+rm -rf "$WORKDIR"
+git clone https://github.com/mozilla/fxa-content-server.git -b master "$WORKDIR"
+cd "$WORKDIR"
+git checkout "$GIT_COMMIT"
+git show --summary
+
+npm config set cache ~/.fxacache
+export npm_config_cache=~/.fxacache
+export npm_config_tmp=~/fxatemp
+npm install theintern/intern#42aebd9beb942a11e2c6e6d7687c70a1c22b9bf7 bower \
+  zaach/node-XMLHttpRequest.git#onerror firefox-profile@0.3.3 request@2.40.0 \
+  sync-exec@0.5.0 convict@0.8.0 mozlog@1.0.1 node-statsd@0.1.1 ua-parser@0.3.5
+
+set -o xtrace # echo the following commands
+
+./node_modules/.bin/intern-client \
+  config=tests/intern_server \
+  fxaContentRoot="$FXA_CONTENT_ROOT" \
+  fxaProduction="true" \
+  asyncTimeout=10000


### PR DESCRIPTION
@vladikoff - this just adds a test runner for tests/intern_server that can be re-used to run both against stage and latest (when #2682 has been merged).  