### PR TITLE
fix(tests): only update Fx binaries if they are stale

### DIFF
--- a/tests/teamcity/update-builds.sh
+++ b/tests/teamcity/update-builds.sh
@@ -6,6 +6,25 @@
 
 set -o errexit # exit on first command with non-zero status
 
+function update_needed() {
+  echo -n "Checking whether Firefox binaries should be updated... "
+
+  if [ ! -f "$LASTUPDATE_FILE" ]; then
+    touch "$LASTUPDATE_FILE" # ensure it exists
+  fi
+
+  # allow environment override of $update_interval
+  local update_interval=${UPDATE_INTERVAL:-86400}
+
+  # isn't date math in bash so much fun?
+  local now=$(date +%s)
+  local was=$(date -r "$LASTUPDATE_FILE" +%s)
+  local age=$(( $now - $was ))
+  local fresh=$(( $age < $update_interval ))
+
+  return $fresh
+}
+
 CHANNELS_DIR=$1
 if [ -z "$1" ]; then
   CHANNELS_DIR="$HOME/firefox-channels"
@@ -16,8 +35,16 @@ if [ -z "$2" ]; then
   FXDOWNLOAD_DIR="$HOME/fxdownload"
 fi
 
+LASTUPDATE_FILE="$CHANNELS_DIR/.lastupdate"
 mkdir -p $CHANNELS_DIR
 
+if ! update_needed; then
+  echo No update of Firefox builds is needed at this time.
+  exit 0
+fi
+echo Firefox builds update needed. Beginning update.
+
+echo Updating jrgm/fxdownload repo, if needed ...
 if [ ! -d $FXDOWNLOAD_DIR ]; then
   git clone git://github.com/jrgm/fxdownload $FXDOWNLOAD_DIR
 else
@@ -33,3 +60,6 @@ done
 for d in latest-beta latest latest-esr; do
   $CHANNELS_DIR/$d/en-US/firefox/firefox-bin --version
 done
+
+touch "$LASTUPDATE_FILE"
+echo Firefox binaries update complete!


### PR DESCRIPTION
@vladikoff - I want to change this to only update if they haven't been updated in the last day. That's not different that currently since the job only runs once a day. But this is a first step to getting rid of that task, and just having `run.sh` do the check as each job runs; no cost if it's been run recently. 

Note: this is for train-42, so no rush to merge this.