### PR TITLE
fix(client): Firstrun flow should not halt the screens after login.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -53,6 +53,7 @@ define([
   'models/auth_brokers/base',
   'models/auth_brokers/fx-desktop',
   'models/auth_brokers/fx-desktop-v2',
+  'models/auth_brokers/first-run',
   'models/auth_brokers/web-channel',
   'models/auth_brokers/redirect',
   'models/auth_brokers/iframe',
@@ -99,6 +100,7 @@ function (
   BaseAuthenticationBroker,
   FxDesktopV1AuthenticationBroker,
   FxDesktopV2AuthenticationBroker,
+  FirstRunAuthenticationBroker,
   WebChannelAuthenticationBroker,
   RedirectAuthenticationBroker,
   IframeAuthenticationBroker,
@@ -384,9 +386,14 @@ function (
     },
 
     initializeAuthenticationBroker: function () {
-      /*eslint complexity: [2, 7] */
+      /*eslint complexity: [2, 8] */
       if (! this._authenticationBroker) {
-        if (this._isFxDesktopV2()) {
+        if (this._isFirstRun()) {
+          this._authenticationBroker = new FirstRunAuthenticationBroker({
+            relier: this._relier,
+            window: this._window
+          });
+        } else if (this._isFxDesktopV2()) {
           this._authenticationBroker = new FxDesktopV2AuthenticationBroker({
             window: this._window,
             relier: this._relier
@@ -622,6 +629,10 @@ function (
       // considered fx-desktop. If service=sync is on the URL, it's considered
       // fx-desktop.
       return this._isFxDesktopV1() || this._isFxDesktopV2() || this._isSync();
+    },
+
+    _isFirstRun: function () {
+      return this._isFxDesktopV2() && this._isIframeContext();
     },
 
     _isWebChannel: function () {

--- a/app/scripts/models/auth_brokers/first-run.js
+++ b/app/scripts/models/auth_brokers/first-run.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * The auth broker to coordinate authenticating for Sync when
+ * embedded in the Firefox firstrun flow.
+ */
+
+define([
+  'models/auth_brokers/fx-desktop-v2'
+], function (FxDesktopV2AuthenticationBroker) {
+  'use strict';
+
+  var FirstRunAuthenticationBroker = FxDesktopV2AuthenticationBroker.extend({
+    haltAfterResetPasswordConfirmationPoll: false,
+    haltAfterSignIn: false,
+    haltBeforeSignUpConfirmationPoll: false
+  });
+
+  return FirstRunAuthenticationBroker;
+});

--- a/app/tests/spec/models/auth_brokers/first-run.js
+++ b/app/tests/spec/models/auth_brokers/first-run.js
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'models/account',
+  'models/auth_brokers/first-run',
+  'models/reliers/relier',
+  '../../../mocks/window'
+],
+function (chai, Account, FirstRunAuthenticationBroker, Relier, WindowMock) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  describe('models/auth_brokers/first-run', function () {
+    var account;
+    var broker;
+    var relier;
+    var windowMock;
+
+    beforeEach(function () {
+      account = new Account({});
+      relier = new Relier();
+      windowMock = new WindowMock();
+      broker = new FirstRunAuthenticationBroker({
+        relier: relier,
+        window: windowMock
+      });
+    });
+
+    describe('afterSignIn', function () {
+      it('does not halt', function () {
+        return broker.afterSignIn(account)
+          .then(function (result) {
+            assert.isFalse(result.halt);
+          });
+      });
+    });
+
+    describe('beforeSignUpConfirmationPoll', function () {
+      it('does not halt', function () {
+        return broker.beforeSignUpConfirmationPoll(account)
+          .then(function (result) {
+            assert.isFalse(result.halt);
+          });
+      });
+    });
+
+    describe('afterResetPasswordConfirmationPoll', function () {
+      it('does not halt', function () {
+        return broker.afterResetPasswordConfirmationPoll(account)
+          .then(function (result) {
+            assert.isFalse(result.halt);
+          });
+      });
+    });
+  });
+});
+
+

--- a/app/tests/spec/models/auth_brokers/fx-desktop.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop.js
@@ -170,7 +170,7 @@ define([
     });
 
     describe('afterSignIn', function () {
-      it('notifies the channel of login', function () {
+      it('notifies the channel of login, halts by default', function () {
         sinon.spy(broker, 'send');
         account.set({
           uid: 'uid',
@@ -199,10 +199,23 @@ define([
             assert.isTrue(result.halt);
           });
       });
+
+      it('does not halt with `haltAfterSignIn: false`', function () {
+        broker = new FxDesktopAuthenticationBroker({
+          channel: channelMock,
+          haltAfterSignIn: false,
+          window: windowMock,
+        });
+
+        return broker.afterSignIn(account)
+          .then(function (result) {
+            assert.isFalse(result.halt);
+          });
+      });
     });
 
     describe('beforeSignUpConfirmationPoll', function () {
-      it('notifies the channel of login, halts the flow', function () {
+      it('notifies the channel of login, halts the flow by default', function () {
         sinon.spy(broker, 'send');
 
         return broker.beforeSignUpConfirmationPoll(account)
@@ -211,16 +224,42 @@ define([
             assert.isTrue(result.halt);
           });
       });
+
+      it('does not halt with `haltBeforeSignUpConfirmationPoll: false`', function () {
+        broker = new FxDesktopAuthenticationBroker({
+          channel: channelMock,
+          haltBeforeSignUpConfirmationPoll: false,
+          window: windowMock
+        });
+
+        return broker.beforeSignUpConfirmationPoll(account)
+          .then(function (result) {
+            assert.isFalse(result.halt);
+          });
+      });
     });
 
     describe('afterResetPasswordConfirmationPoll', function () {
-      it('notifies the channel of login', function () {
+      it('notifies the channel of login, halts by default', function () {
         sinon.spy(broker, 'send');
 
         return broker.afterResetPasswordConfirmationPoll(account)
           .then(function (result) {
             assert.isTrue(broker.send.calledWith('login'));
             assert.isTrue(result.halt);
+          });
+      });
+
+      it('does not halt with `haltAfterResetPasswordConfirmationPoll: false`', function () {
+        broker = new FxDesktopAuthenticationBroker({
+          channel: channelMock,
+          haltAfterResetPasswordConfirmationPoll: false,
+          window: windowMock
+        });
+
+        return broker.afterResetPasswordConfirmationPoll(account)
+          .then(function (result) {
+            assert.isFalse(result.halt);
           });
       });
     });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -119,6 +119,7 @@ function (Translator, Session) {
     '../tests/spec/models/reliers/oauth',
     '../tests/spec/models/reliers/fx-desktop',
     '../tests/spec/models/auth_brokers/base',
+    '../tests/spec/models/auth_brokers/first-run',
     '../tests/spec/models/auth_brokers/fx-desktop',
     '../tests/spec/models/auth_brokers/fx-desktop-v2',
     '../tests/spec/models/auth_brokers/web-channel',

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -10,6 +10,8 @@ define([
   './functional/complete_sign_up',
   './functional/sync_sign_up',
   './functional/sync_v2_sign_up',
+  './functional/firstrun_sign_up',
+  './functional/firstrun_sign_in',
   './functional/bounced_email',
   './functional/legal',
   './functional/tos',

--- a/tests/functional/firstrun_sign_in.js
+++ b/tests/functional/firstrun_sign_in.js
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/node_modules/dojo/node!xmlhttprequest',
+  'app/bower_components/fxa-js-client/fxa-client',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, nodeXMLHttpRequest, FxaClient,
+  TestHelpers, FunctionalHelpers) {
+  var config = intern.config;
+  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+  var PAGE_URL = config.fxaContentRoot + 'signin?context=iframe&service=sync';
+
+  var email;
+  var PASSWORD = '12345678';
+  var client;
+
+  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
+  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+
+  registerSuite({
+    name: 'Firstrun sign_in',
+
+    setup: function () {
+      email = TestHelpers.createEmail();
+      client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+
+      return client.signUp(email, PASSWORD, { preVerified: true });
+    },
+
+    beforeEach: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    teardown: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'sign in with an already existing account': function () {
+      var self = this;
+
+      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signin-header')
+        .execute(listenForFxaCommands)
+
+        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
+
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+        })
+
+        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
+        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:login'))
+
+        .findByCssSelector('#fxa-settings-header')
+        .end();
+    }
+  });
+});

--- a/tests/functional/firstrun_sign_up.js
+++ b/tests/functional/firstrun_sign_up.js
@@ -11,7 +11,7 @@ define([
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, require, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
-  var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_desktop_v2&service=sync';
+  var PAGE_URL = config.fxaContentRoot + 'signup?context=iframe&service=sync';
 
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
 
@@ -25,7 +25,7 @@ define([
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
 
   registerSuite({
-    name: 'Firefox Desktop Sync v2 sign_up',
+    name: 'Firstrun sign_up',
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
@@ -49,7 +49,7 @@ define([
         });
     },
 
-    'sign up, verify same browser': function () {
+    'sign up, verify same browser in a different tab': function () {
       var self = this;
 
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
@@ -65,6 +65,9 @@ define([
         .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
         .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:login'))
 
+        .findByCssSelector('#fxa-confirm-header')
+        .end()
+
         // verify the user
         .then(function () {
           return FunctionalHelpers.openVerificationLinkSameBrowser(
@@ -76,7 +79,7 @@ define([
         // In real life, the original browser window would show
         // a "welcome to sync!" screen that has a manage button
         // on it, and this screen should show the FxA success screen.
-        .findById('fxa-sign-up-complete-header')
+        .findByCssSelector('#fxa-sign-up-complete-header')
         .end()
 
         .findByCssSelector('.account-ready-service')
@@ -88,11 +91,11 @@ define([
         .end()
         .closeCurrentWindow()
 
-        // switch to the original window, it should not transition.
+        // switch back to the original window, it should not transition.
         .switchToWindow('')
         .end()
 
-        .findByCssSelector('#fxa-confirm-header')
+        .findByCssSelector('#fxa-sign-up-complete-header')
         .end();
     }
   });

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -559,6 +559,35 @@ define([
     return true;
   }
 
+  function respondToWebChannelMessage(context, expectedCommand, response) {
+    return function () {
+      return context.remote
+        .execute(function (expectedCommand, response) {
+          addEventListener('WebChannelMessageToChrome', function listener(e) {
+            removeEventListener('WebChannelMessageToChrome', listener);
+
+            var command = e.detail.message.command;
+            var messageId = e.detail.message.messageId;
+
+            if (command === expectedCommand) {
+              var event = new CustomEvent('WebChannelMessageToContent', {
+                detail: {
+                  id: 'account_updates',
+                  message: {
+                    messageId: messageId,
+                    command: command,
+                    data: response
+                  }
+                }
+              });
+
+              dispatchEvent(event);
+            }
+          });
+        }, [ expectedCommand, response ]);
+    };
+  }
+
   function testIsBrowserNotified(context, command, cb) {
     return function () {
       return context.remote
@@ -650,6 +679,7 @@ define([
     openFxaFromRp: openFxaFromRp,
     openFxaFromUntrustedRp: openFxaFromUntrustedRp,
     listenForWebChannelMessage: listenForWebChannelMessage,
+    respondToWebChannelMessage: respondToWebChannelMessage,
     testIsBrowserNotified: testIsBrowserNotified,
 
     fillOutSignIn: fillOutSignIn,

--- a/tests/intern_functional_circle.js
+++ b/tests/intern_functional_circle.js
@@ -14,6 +14,8 @@ define([
     'tests/functional/complete_sign_up',
     'tests/functional/sync_sign_up',
     'tests/functional/sync_v2_sign_up',
+    'tests/functional/firstrun_sign_up',
+    'tests/functional/firstrun_sign_in',
     'tests/functional/bounced_email',
     'tests/functional/confirm',
     'tests/functional/delete_account',


### PR DESCRIPTION
* Make fx-desktop authentication broker's halt behavior configurable
  with three new configuration options:
  * haltAfterResetPasswordConfirmationPoll
  * haltAfterSignIn
  * haltBeforeSignUpConfirmationPoll
* Add the FirstRunAuthenticationBroker which specifies its halt behavior.
  * Will also be used to communicate with the iframe.

Use these options when creating the first run's auth broker to prevent halting.

fixes #2674 
ref #2101