### PR TITLE
feat(client): campaign and entrypoint are sent to metrics on verification.

### DIFF
--- a/app/scripts/models/mixins/resume-token.js
+++ b/app/scripts/models/mixins/resume-token.js
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A model mixin to work with ResumeTokens.
+ *
+ * A model should set the array `resumeTokenFields` to add/change
+ * fields that are saved to and populated from the ResumeToken.
+ */
+
+define([
+  'models/resume-token'
+], function (ResumeToken) {
+  'use strict';
+
+  return {
+    /**
+     * Get an object of values that should be stored in a ResumeToken
+     *
+     * @method pickResumeTokenInfo
+     * @returns {Object}
+     */
+    pickResumeTokenInfo: function () {
+      if (this.resumeTokenFields) {
+        return this.pick(this.resumeTokenFields);
+      }
+    },
+
+    /**
+     * Sets model properties from a stringified ResumeToken. A stringified
+     * ResumeToken is generally one passed in the `resume` query parameter.
+     *
+     * @method populateFromStringifiedResumeToken
+     * @param {String} stringifiedResumeToken
+     */
+    populateFromStringifiedResumeToken: function (stringifiedResumeToken) {
+      if (this.resumeTokenFields) {
+        var resumeToken =
+          ResumeToken.createFromStringifiedResumeToken(stringifiedResumeToken);
+
+        this.populateFromResumeToken(resumeToken);
+      }
+    },
+
+    /**
+     * Sets model properties from a ResumeToken.
+     *
+     * @method populateFromResumeToken
+     * @param {ResumeToken} resumeToken
+     */
+    populateFromResumeToken: function (resumeToken) {
+      if (this.resumeTokenFields) {
+        this.set(resumeToken.pick(this.resumeTokenFields));
+      }
+    }
+  };
+});
+

--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -9,12 +9,11 @@
 define([
   'underscore',
   'models/reliers/relier',
-  'models/resume-token',
   'lib/oauth-errors',
   'lib/relier-keys',
   'lib/url',
   'lib/constants'
-], function (_, Relier, ResumeToken, OAuthErrors, RelierKeys, Url, Constants) {
+], function (_, Relier, OAuthErrors, RelierKeys, Url, Constants) {
   'use strict';
 
   var RELIER_FIELDS_IN_RESUME_TOKEN = ['state', 'verificationRedirect'];
@@ -40,6 +39,11 @@ define([
       verificationRedirect: Constants.VERIFICATION_REDIRECT_NO
     }),
 
+    resumeTokenFields: _.union(
+      RELIER_FIELDS_IN_RESUME_TOKEN,
+      Relier.prototype.resumeTokenFields
+    ),
+
     initialize: function (options) {
       options = options || {};
 
@@ -53,10 +57,6 @@ define([
       var self = this;
       return Relier.prototype.fetch.call(this)
         .then(function () {
-          // parse the resume token before importing server provided data,
-          // the server values might take precedent over the parsed values
-          self._parseResumeToken();
-
           if (self._isVerificationFlow()) {
             self._setupVerificationFlow();
           } else {
@@ -95,21 +95,6 @@ define([
 
     deriveRelierKeys: function (keys, uid) {
       return RelierKeys.deriveRelierKeys(keys, uid, this.get('clientId'));
-    },
-
-    pickResumeTokenInfo: function () {
-      return this.pick(RELIER_FIELDS_IN_RESUME_TOKEN);
-    },
-
-    /**
-     * Sets relier properties from the resume token value
-     * @private
-     */
-    _parseResumeToken: function () {
-      var resumeParam = this.getSearchParam('resume');
-      var resumeToken = new ResumeToken(ResumeToken.parse(resumeParam));
-
-      this.set(resumeToken.pick(RELIER_FIELDS_IN_RESUME_TOKEN));
     },
 
     _isVerificationFlow: function () {

--- a/app/scripts/models/resume-token.js
+++ b/app/scripts/models/resume-token.js
@@ -13,22 +13,11 @@ define([
 ], function (Backbone, _) {
   'use strict';
 
-  function parse(resumeToken) {
-    try {
-      return JSON.parse(atob(resumeToken));
-    } catch(e) {
-      // do nothing, its an invalid token.
-    }
-  }
-
-  function stringify(resumeObj) {
-    var encoded = btoa(JSON.stringify(resumeObj));
-    return encoded;
-  }
-
   var ResumeToken = Backbone.Model.extend({
     defaults: {
-      // fields from a relier
+      // fields from a Relier
+      campaign: undefined,
+      entrypoint: undefined,
       state: undefined,
       verificationRedirect: undefined
     },
@@ -48,10 +37,30 @@ define([
     }
   });
 
+  function parse(resumeToken) {
+    try {
+      return JSON.parse(atob(resumeToken));
+    } catch(e) {
+      // do nothing, its an invalid token.
+    }
+  }
+
+  function stringify(resumeObj) {
+    var encoded = btoa(JSON.stringify(resumeObj));
+    return encoded;
+  }
+
+  function createFromStringifiedResumeToken(stringifiedResumeToken) {
+    var parsedResumeToken = parse(stringifiedResumeToken);
+    return new ResumeToken(parsedResumeToken);
+  }
+
+
   // static methods on the ResumeToken object itself, not its prototype.
   _.extend(ResumeToken, {
     parse: parse,
-    stringify: stringify
+    stringify: stringify,
+    createFromStringifiedResumeToken: createFromStringifiedResumeToken
   });
 
   return ResumeToken;

--- a/app/tests/spec/models/mixins/resume-token.js
+++ b/app/tests/spec/models/mixins/resume-token.js
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'backbone',
+  'chai',
+  'cocktail',
+  'models/mixins/resume-token',
+  'models/resume-token'
+], function (Backbone, chai, Cocktail, ResumeTokenMixin, ResumeToken) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  describe('models/mixins/resume-token', function () {
+    var model;
+    var CAMPAIGN = 'campaign id';
+    var RESUME_DATA = {
+      campaign: CAMPAIGN,
+      notResumeable: 'this should not be picked'
+    };
+
+    var Model = Backbone.Model.extend({
+      initialize: function (options) {
+        this.window = options.window;
+      },
+
+      resumeTokenFields: ['campaign']
+    });
+
+    Cocktail.mixin(
+      Model,
+      ResumeTokenMixin
+    );
+
+    beforeEach(function () {
+      model = new Model({});
+    });
+
+    describe('pickResumeTokenInfo', function () {
+      it('returns an object with info to be passed along with email verification links', function () {
+        model.set(RESUME_DATA);
+
+        assert.deepEqual(model.pickResumeTokenInfo(), {
+          campaign: CAMPAIGN
+        });
+      });
+    });
+
+    describe('populateFromResumeToken', function () {
+      it('populates the model with data from the ResumeToken', function () {
+        var resumeToken = new ResumeToken(RESUME_DATA);
+        model.populateFromResumeToken(resumeToken);
+
+        assert.equal(model.get('campaign'), CAMPAIGN);
+        assert.isFalse(model.has('notResumeable'), 'only allow specific resume token values');
+      });
+    });
+
+    describe('populateFromStringifiedResumeToken', function () {
+      it('parses the resume param into an object', function () {
+        var stringifiedResumeToken = ResumeToken.stringify(RESUME_DATA);
+
+        model.populateFromStringifiedResumeToken(stringifiedResumeToken);
+
+        assert.equal(model.get('campaign'), CAMPAIGN);
+        assert.isFalse(model.has('notResumeable'), 'only allow specific resume token values');
+      });
+    });
+  });
+});

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -12,12 +12,11 @@ define([
   'lib/oauth-errors',
   'lib/promise',
   'lib/relier-keys',
-  'models/resume-token',
   'lib/url',
   '../../../mocks/window',
   '../../../lib/helpers'
 ], function (chai, sinon, OAuthRelier, User, Session, OAuthClient, OAuthErrors,
-      p, RelierKeys, ResumeToken, Url, WindowMock, TestHelpers) {
+      p, RelierKeys, Url, WindowMock, TestHelpers) {
   'use strict';
 
   /*eslint-disable camelcase */
@@ -329,41 +328,27 @@ define([
 
     describe('pickResumeTokenInfo', function () {
       it('returns an object with info to be passed along with email verification links', function () {
+        var CAMPAIGN = 'campaign id';
+        var ENTRYPOINT = 'entry point';
         var STATE = 'some long opaque state token';
         var VERIFICATION_REDIRECT = 'https://redirect.here.org';
 
-        relier.set('state', STATE);
-        relier.set('verificationRedirect', VERIFICATION_REDIRECT);
-        relier.set('notPassed', 'this should not be picked');
+        relier.set({
+          campaign: CAMPAIGN,
+          entrypoint: ENTRYPOINT,
+          notPassed: 'this should not be picked',
+          state: STATE,
+          verificationRedirect: VERIFICATION_REDIRECT,
+        });
 
         assert.deepEqual(relier.pickResumeTokenInfo(), {
+          // ensure campaign and entrypoint from
+          // the Relier are still passed.
+          campaign: CAMPAIGN,
+          entrypoint: ENTRYPOINT,
           state: STATE,
           verificationRedirect: VERIFICATION_REDIRECT
         });
-      });
-    });
-
-    describe('_parseResumeToken', function () {
-      it('parses the resume param into an object', function () {
-        var resumeData = {
-          state: 'state',
-          verificationRedirect: 'always',
-          random: 'yes'
-        };
-        var resumeToken = ResumeToken.stringify(resumeData);
-
-        windowMock.location.search = TestHelpers.toSearchString({
-          client_id: CLIENT_ID,
-          scope: SCOPE,
-          resume: resumeToken
-        });
-
-        return relier.fetch()
-          .then(function () {
-            assert.equal(relier.get('state'), 'state');
-            assert.equal(relier.get('verificationRedirect'), 'always');
-            assert.isUndefined(relier.get('random'), 'only allow specific resume token values');
-          });
       });
     });
 

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -113,6 +113,7 @@ function (Translator, Session) {
     '../tests/spec/models/notifications',
     '../tests/spec/models/oauth-token',
     '../tests/spec/models/resume-token',
+    '../tests/spec/models/mixins/resume-token',
     '../tests/spec/models/mixins/search-param',
     '../tests/spec/models/reliers/base',
     '../tests/spec/models/reliers/relier',


### PR DESCRIPTION
feat(client): `campaign` and `entrypoint` are sent to metrics on verification.

* Pass the `campaign` and `entrypoint` to the verification page via the ResumeToken.
* The base relier always passes `campaign` and `entrypoint`
* Add a ResumeToken model mixin to provide models some functionality for picking data for ResumeTokens and for re-populating from a stringified ResumeToken.

issue #2491, #2101

@rfk and @vladikoff - r?