### PR TITLE
feat(client): Pass Google Analytics query params to metrics.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -272,7 +272,12 @@ function (
         devicePixelRatio: screenInfo.devicePixelRatio,
         screenHeight: screenInfo.screenHeight,
         screenWidth: screenInfo.screenWidth,
-        able: this._able
+        able: this._able,
+        utmCampaign: relier.get('utmCampaign'),
+        utmContent: relier.get('utmContent'),
+        utmMedium: relier.get('utmMedium'),
+        utmSource: relier.get('utmSource'),
+        utmTerm: relier.get('utmTerm')
       });
       this._metrics.init();
     },

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -44,7 +44,12 @@ define([
     'service',
     'timers',
     'broker',
-    'ab'
+    'ab',
+    'utm_campaign',
+    'utm_content',
+    'utm_medium',
+    'utm_source',
+    'utm_term'
   ];
 
   var TEN_MINS_MS = 10 * 60 * 1000;
@@ -62,7 +67,7 @@ define([
   }
 
   function Metrics (options) {
-    /*eslint complexity: [2, 18] */
+    /*eslint complexity: [2, 24] */
     options = options || {};
 
     // by default, send the metrics to the content server.
@@ -92,6 +97,13 @@ define([
     this._devicePixelRatio = options.devicePixelRatio || NOT_REPORTED_VALUE;
     this._screenHeight = options.screenHeight || NOT_REPORTED_VALUE;
     this._screenWidth = options.screenWidth || NOT_REPORTED_VALUE;
+
+    this._referrer = this._window.document.referrer || NOT_REPORTED_VALUE;
+    this._utmCampaign = options.utmCampaign || NOT_REPORTED_VALUE;
+    this._utmContent = options.utmContent || NOT_REPORTED_VALUE;
+    this._utmMedium = options.utmMedium || NOT_REPORTED_VALUE;
+    this._utmSource = options.utmSource || NOT_REPORTED_VALUE;
+    this._utmTerm = options.utmTerm || NOT_REPORTED_VALUE;
 
     this._inactivityFlushMs = options.inactivityFlushMs || TEN_MINS_MS;
 
@@ -169,13 +181,19 @@ define([
         migration: this._migration,
         marketing: flattenMarketingImpressions(this._marketingImpressions),
         campaign: this._campaign,
+        referrer: this._referrer,
         screen: {
           devicePixelRatio: this._devicePixelRatio,
           clientWidth: this._clientWidth,
           clientHeight: this._clientHeight,
           width: this._screenWidth,
           height: this._screenHeight
-        }
+        },
+        utm_campaign: this._utmCampaign, //eslint-disable-line camelcase
+        utm_content: this._utmContent, //eslint-disable-line camelcase
+        utm_medium: this._utmMedium, //eslint-disable-line camelcase
+        utm_source: this._utmSource, //eslint-disable-line camelcase
+        utm_term: this._utmTerm, //eslint-disable-line camelcase
       });
 
       return allData;

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -30,7 +30,12 @@ define([
       email: null,
       allowCachedCredentials: true,
       entrypoint: null,
-      campaign: null
+      campaign: null,
+      utmCampaign: null,
+      utmContent: null,
+      utmMedium: null,
+      utmSource: null,
+      utmTerm: null
     },
 
     initialize: function (options) {
@@ -70,6 +75,12 @@ define([
           self.importSearchParam('setting');
           self.importSearchParam('entrypoint');
           self.importSearchParam('campaign');
+
+          self.importSearchParam('utm_campaign', 'utmCampaign');
+          self.importSearchParam('utm_content', 'utmContent');
+          self.importSearchParam('utm_medium', 'utmMedium');
+          self.importSearchParam('utm_source', 'utmSource');
+          self.importSearchParam('utm_term', 'utmTerm');
 
           // A relier can indicate they do not want to allow
           // cached credentials if they set email === 'blank'

--- a/app/scripts/models/resume-token.js
+++ b/app/scripts/models/resume-token.js
@@ -19,6 +19,11 @@ define([
       campaign: undefined,
       entrypoint: undefined,
       state: undefined,
+      utmCampaign: null,
+      utmContent: null,
+      utmMedium: null,
+      utmSource: null,
+      utmTerm: null,
       verificationRedirect: undefined,
       // fields from a User
       uniqueUserId: undefined

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -38,6 +38,7 @@ function (Backbone, sinon, _, NullStorage) {
 
     this.document = {
       body: window.document.body,
+      referrer: window.document.referrer,
       title: window.document.title,
       documentElement: {
         className: '',

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -24,6 +24,7 @@ function (chai, $, p, Metrics, AuthErrors, WindowMock, TestHelpers) {
 
     beforeEach(function () {
       windowMock = new WindowMock();
+      windowMock.document.referrer = 'https://marketplace.firefox.com';
 
       metrics = new Metrics({
         window: windowMock,
@@ -38,7 +39,12 @@ function (chai, $, p, Metrics, AuthErrors, WindowMock, TestHelpers) {
         clientWidth: 1033,
         clientHeight: 966,
         screenWidth: 1600,
-        screenHeight: 1200
+        screenHeight: 1200,
+        utmCampaign: 'utm_campaign',
+        utmContent: 'utm_content',
+        utmMedium: 'utm_medium',
+        utmSource: 'utm_source',
+        utmTerm: 'utm_term'
       });
       metrics.init();
     });
@@ -74,11 +80,18 @@ function (chai, $, p, Metrics, AuthErrors, WindowMock, TestHelpers) {
         assert.equal(filteredData.migration, 'sync1.5');
         assert.equal(filteredData.campaign, 'fennec');
 
+        assert.equal(filteredData.referrer, 'https://marketplace.firefox.com');
         assert.equal(filteredData.screen.width, 1600);
         assert.equal(filteredData.screen.height, 1200);
         assert.equal(filteredData.screen.devicePixelRatio, 2);
         assert.equal(filteredData.screen.clientWidth, 1033);
         assert.equal(filteredData.screen.clientHeight, 966);
+
+        assert.equal(filteredData.utm_campaign, 'utm_campaign');
+        assert.equal(filteredData.utm_content, 'utm_content');
+        assert.equal(filteredData.utm_medium, 'utm_medium');
+        assert.equal(filteredData.utm_source, 'utm_source');
+        assert.equal(filteredData.utm_term, 'utm_term');
       });
     });
 

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -25,6 +25,12 @@ define([
     var UID = 'uid';
     var ENTRYPOINT = 'preferences';
     var CAMPAIGN = 'fennec';
+    var SETTING = 'avatar';
+    var UTM_CAMPAIGN = 'utm_campaign';
+    var UTM_CONTENT = 'utm_content';
+    var UTM_MEDIUM = 'utm_medium';
+    var UTM_SOURCE = 'utm_source';
+    var UTM_TERM = 'utm_term';
 
     beforeEach(function () {
       windowMock = new WindowMock();
@@ -48,23 +54,42 @@ define([
 
       it('populates expected fields from the search parameters, unexpected search parameters are ignored', function () {
         windowMock.location.search = TestHelpers.toSearchString({
+          allowCachedCredentials: false,
           preVerifyToken: PREVERIFY_TOKEN,
           service: SERVICE,
           email: EMAIL,
           uid: UID,
           entrypoint: ENTRYPOINT,
           campaign: CAMPAIGN,
-          ignored: 'ignored'
+          ignored: 'ignored',
+          setting: SETTING,
+          utm_campaign: UTM_CAMPAIGN, //eslint-disable-line camelcase
+          utm_content: UTM_CONTENT, //eslint-disable-line camelcase
+          utm_medium: UTM_MEDIUM, //eslint-disable-line camelcase
+          utm_source: UTM_SOURCE, //eslint-disable-line camelcase
+          utm_term: UTM_TERM //eslint-disable-line camelcase
         });
 
         return relier.fetch()
             .then(function () {
+              // not imported from the search parameters, but is set manually.
+              assert.isTrue(relier.get('allowCachedCredentials'));
+
               assert.equal(relier.get('preVerifyToken'), PREVERIFY_TOKEN);
               assert.equal(relier.get('service'), SERVICE);
               assert.equal(relier.get('email'), EMAIL);
+
+              assert.equal(relier.get('setting'), SETTING);
               assert.equal(relier.get('uid'), UID);
               assert.equal(relier.get('entrypoint'), ENTRYPOINT);
               assert.equal(relier.get('campaign'), CAMPAIGN);
+
+              assert.equal(relier.get('utmCampaign'), UTM_CAMPAIGN);
+              assert.equal(relier.get('utmContent'), UTM_CONTENT);
+              assert.equal(relier.get('utmMedium'), UTM_MEDIUM);
+              assert.equal(relier.get('utmSource'), UTM_SOURCE);
+              assert.equal(relier.get('utmTerm'), UTM_TERM);
+
               assert.isFalse(relier.has('ignored'));
             });
       });

--- a/docs/query-params.md
+++ b/docs/query-params.md
@@ -180,6 +180,62 @@ A preVerifyToken is accepted from certain trusted reliers.
 #### When to specify
 * /signup or /oauth/signup
 
+
+### `utm_campaign`
+The Google Analytics `utm_campaign` field. Will be passed back to the relier
+when authentication completes.
+
+#### When to specify
+
+* /signin
+* /signup
+* /force_auth
+* /
+
+### `utm_content`
+The Google Analytics `utm_content` field. Will be passed back to the relier
+when authentication completes.
+
+#### When to specify
+
+* /signin
+* /signup
+* /force_auth
+* /
+
+### `utm_medium`
+The Google Analytics `utm_medium` field. Will be passed back to the relier
+when authentication completes.
+
+#### When to specify
+
+* /signin
+* /signup
+* /force_auth
+* /
+
+### `utm_source`
+The Google Analytics `utm_source` field. Will be passed back to the relier
+when authentication completes.
+
+#### When to specify
+
+* /signin
+* /signup
+* /force_auth
+* /
+
+### `utm_term`
+The Google Analytics `utm_term` field. Will be passed back to the relier
+when authentication completes.
+
+#### When to specify
+
+* /signin
+* /signup
+* /force_auth
+* /
+
 ### `webChannelId`
 Sign into a Firefox service that listens on a [WebChannel](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm).
 


### PR DESCRIPTION
* Reliers can specify Google Analytics query parameters to be logged/sent to our metrics infrastructure.
* Consume the following Google Analytics query parameters:
  * utm_campaign
  * utm_content
  * utm_medium
  * utm_source
  * utm_term

fixes #2579
ref #2101 