### PR TITLE
chore(build): disable bower analytics collection

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-    "directory": "app/bower_components"
+  "directory": "app/bower_components",
+  "analytics": false
 }


### PR DESCRIPTION
http://bower.io/docs/config/#analytics

> Bower can collect anonymous usage statistics. This allows the community to improve Bower and publicly display insights into CLI usage and packages at bower.io/stats.

> Data is tracked using Google Analytics and instrumented via Insight. It is made available to all Bower team members. Tracking is opt-in upon initial usage. If you’d prefer to disable analytics altogether, set `"analytics": false` in your `.bowerrc` file.

r? @vladikoff 