### PR TITLE
 refactor(client): Rename `uuid` to `uniqueUserId`

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -136,7 +136,7 @@ function (
       var self = this;
 
       // set UUID early so other methods can use it for metrics and ab testing purposes.
-      this.initializeUuid();
+      this.initializeUniqueUserId();
 
       // fetch both config and translations in parallel to speed up load.
       return p.all([
@@ -239,7 +239,7 @@ function (
       if (this._config && this._config.env && this._able) {
         var abData = {
           env: this._config.env,
-          uuid: this._uuid
+          uniqueUserId: this._uniqueUserId
         };
         var abChoose = this._able.choose('sentryEnabled', abData);
 
@@ -487,7 +487,7 @@ function (
           marketingEmailClient: this._marketingEmailClient,
           assertion: this._assertionLibrary,
           storage: this._getStorageInstance(),
-          uuid: this._uuid
+          uniqueUserId: this._uniqueUserId
         });
       }
     },
@@ -508,16 +508,27 @@ function (
      * Sets a UUID value that is unrelated to any account information.
      * This value is useful to determine if the logged out user qualifies for ab testing or metrics.
      */
-    initializeUuid: function () {
+    initializeUniqueUserId: function () {
       var storage = Storage.factory('localStorage', this._window);
 
-      // we reuse the same uuid if it is available in local storage.
+      var uniqueUserId;
+
+      // Reuse a stored unique user id if available.
       if (storage.get('uuid')) {
-        this._uuid = storage.get('uuid');
+        // stomlinson on 2015-07-08:
+        // `uuid` is the old name, this is transition code
+        // and can hopefully be removed after a time.
+        uniqueUserId = storage.get('uuid');
+        storage.remove('uuid');
+      } else if (storage.get('uniqueUserId')) {
+        // uniqueUserId is the new name.
+        uniqueUserId = storage.get('uniqueUserId');
       } else {
-        this._uuid = uuid.v4();
-        storage.set('uuid', this._uuid);
+        uniqueUserId = uuid.v4();
       }
+
+      this._uniqueUserId = uniqueUserId;
+      storage.set('uniqueUserId', uniqueUserId);
     },
 
     upgradeStorageFormats: function () {

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -29,6 +29,11 @@ define([
       this._storage = options.storage || Storage.factory();
     },
 
+    defaults: {
+      // uniqueUserId is a stable identifier for this User on this computer.
+      uniqueUserId: null
+    },
+
     _accounts: function () {
       return this._storage.get('accounts') || {};
     },

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -201,7 +201,7 @@ function (Cocktail, _, p, BaseView, FormView, Template, AuthErrors, mailcheck,
     suggestEmail: function () {
       var abData = {
         isMetricsEnabled: this.metrics.isCollectionEnabled(),
-        uuid: this.user.get('uuid'),
+        uniqueUserId: this.user.get('uniqueUserId'),
         // the window parameter will override any ab testing features
         forceMailcheck: Url.searchParam('mailcheck', this.window.location.search)
       };

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -25,6 +25,7 @@ define([
   'models/reliers/relier',
   'models/user',
   'lib/metrics',
+  'lib/storage',
   'lib/storage-metrics',
   '../../mocks/window',
   '../../mocks/router',
@@ -34,8 +35,8 @@ define([
 function (chai, sinon, Raven, AppStart, Session, Constants, p, Url, OAuthErrors,
       AuthErrors, Storage, BaseBroker, FxDesktopBroker, IframeBroker, RedirectBroker,
       WebChannelBroker, BaseRelier, FxDesktopRelier, OAuthRelier, Relier,
-      User, Metrics, StorageMetrics, WindowMock, RouterMock, HistoryMock,
-      TestHelpers) {
+      User, Metrics, Storage, StorageMetrics, WindowMock, RouterMock,
+      HistoryMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -362,10 +363,10 @@ function (chai, sinon, Raven, AppStart, Session, Constants, p, Url, OAuthErrors,
         assert.isDefined(appStart._user);
       });
 
-      it('sets the user uuid', function () {
-        appStart.initializeUuid();
+      it('sets the user uniqueUserId', function () {
+        appStart.initializeUniqueUserId();
         appStart.initializeUser();
-        assert.isDefined(appStart._user.get('uuid'));
+        assert.isDefined(appStart._user.get('uniqueUserId'));
       });
     });
 
@@ -420,7 +421,7 @@ function (chai, sinon, Raven, AppStart, Session, Constants, p, Url, OAuthErrors,
       });
     });
 
-    describe('initializeUuid', function () {
+    describe('initializeUniqueUserId', function () {
       beforeEach(function () {
         appStart = new AppStart({
           window: windowMock,
@@ -432,17 +433,32 @@ function (chai, sinon, Raven, AppStart, Session, Constants, p, Url, OAuthErrors,
       });
 
       it('creates a user', function () {
-        appStart.initializeUuid();
-        assert.isDefined(appStart._uuid);
+        appStart.initializeUniqueUserId();
+        assert.isDefined(appStart._uniqueUserId);
       });
 
-      it('persistent via localStorage', function () {
-        appStart.initializeUuid();
-        assert.isDefined(appStart._uuid);
-        var uuid = appStart._uuid;
+      it('persists to & loads from localStorage', function () {
+        var storage = Storage.factory('localStorage', windowMock);
 
-        appStart.initializeUuid();
-        assert.equal(appStart._uuid, uuid);
+        // saves to localStorage
+        appStart.initializeUniqueUserId();
+        assert.equal(storage.get('uniqueUserId'), appStart._uniqueUserId);
+
+        // load from localStorage
+        storage.set('uniqueUserId', 'stored in uniqueUserId');
+        appStart.initializeUniqueUserId();
+        assert.equal(storage.get('uniqueUserId'), 'stored in uniqueUserId');
+        assert.equal(appStart._uniqueUserId, 'stored in uniqueUserId');
+      });
+
+      it('migrates data stored in `localStorage.uuid` to `localStorage.uniqueUserId`', function () {
+        var storage = Storage.factory('localStorage', windowMock);
+        storage.set('uuid', 'stored in uuid');
+
+        appStart.initializeUniqueUserId();
+
+        assert.equal(storage.get('uniqueUserId'), 'stored in uuid');
+        assert.isUndefined(storage.get('uuid'));
       });
     });
 


### PR DESCRIPTION
## Depends on https://github.com/mozilla/fxa-content-experiments/pull/17

I'm using this to address my nits with #2456, I merged that because the changes are all so far cosmetic.

@vladikoff - r?

~~I could add some localStorage migration code to migrate from `uuid` which is already stored to `uniqueUserId`. Worth it?~~ Migration code added.

fixes #2719 