### PR TITLE
feat(client): firstrun - notify the parent of important events.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -40,6 +40,7 @@ define([
   'lib/marketing-email-client',
   'lib/channels/inter-tab',
   'lib/channels/iframe',
+  'lib/channels/null',
   'lib/channels/web',
   'lib/storage',
   'lib/able',
@@ -87,6 +88,7 @@ function (
   MarketingEmailClient,
   InterTabChannel,
   IframeChannel,
+  NullChannel,
   WebChannel,
   Storage,
   Able,
@@ -303,6 +305,11 @@ function (
     initializeIframeChannel: function () {
       var self = this;
       if (! self._isInAnIframe()) {
+        // Create a NullChannel in case any dependencies require it, such
+        // as when the FirstRunAuthenticationBroker is used in functional
+        // tests. The firstrun tests don't actually use an iframe, so the
+        // real IframeChannel is not created.
+        self._iframeChannel = new NullChannel();
         return p();
       }
 
@@ -387,6 +394,7 @@ function (
       if (! this._authenticationBroker) {
         if (this._isFirstRun()) {
           this._authenticationBroker = new FirstRunAuthenticationBroker({
+            iframeChannel: this._iframeChannel,
             relier: this._relier,
             window: this._window
           });

--- a/app/scripts/models/auth_brokers/first-run.js
+++ b/app/scripts/models/auth_brokers/first-run.js
@@ -12,10 +12,49 @@ define([
 ], function (FxDesktopV2AuthenticationBroker) {
   'use strict';
 
+  var proto = FxDesktopV2AuthenticationBroker.prototype;
+
   var FirstRunAuthenticationBroker = FxDesktopV2AuthenticationBroker.extend({
+    _iframeCommands: {
+       LOADED: 'loaded',
+       LOGIN: 'login',
+       VERIFICATION_COMPLETE: 'verification_complete'
+     },
+
     haltAfterResetPasswordConfirmationPoll: false,
     haltAfterSignIn: false,
-    haltBeforeSignUpConfirmationPoll: false
+    haltBeforeSignUpConfirmationPoll: false,
+
+    initialize: function (options) {
+      options = options || {};
+
+      this._iframeChannel = options.iframeChannel;
+      return proto.initialize.call(this, options);
+    },
+
+    afterLoaded: function () {
+      this._iframeChannel.send(this._iframeCommands.LOADED);
+
+      return proto.afterLoaded.apply(this, arguments);
+    },
+
+    afterSignIn: function () {
+      this._iframeChannel.send(this._iframeCommands.LOGIN);
+
+      return proto.afterSignIn.apply(this, arguments);
+    },
+
+    afterResetPasswordConfirmationPoll: function () {
+      this._iframeChannel.send(this._iframeCommands.VERIFICATION_COMPLETE);
+
+      return proto.afterResetPasswordConfirmationPoll.apply(this, arguments);
+    },
+
+    afterSignUpConfirmationPoll: function () {
+      this._iframeChannel.send(this._iframeCommands.VERIFICATION_COMPLETE);
+
+      return proto.afterSignUpConfirmationPoll.apply(this, arguments);
+    }
   });
 
   return FirstRunAuthenticationBroker;

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -8,6 +8,7 @@ define([
   'raven',
   'lib/app-start',
   'lib/session',
+  'lib/channels/null',
   'lib/constants',
   'lib/promise',
   'lib/url',
@@ -31,10 +32,11 @@ define([
   '../../mocks/history',
   '../../lib/helpers'
 ],
-function (chai, sinon, Raven, AppStart, Session, Constants, p, Url, OAuthErrors,
-      AuthErrors, Storage, BaseBroker, FxDesktopBroker, IframeBroker, RedirectBroker,
-      WebChannelBroker, BaseRelier, FxDesktopRelier, OAuthRelier, Relier, User,
-      Metrics, StorageMetrics, WindowMock, RouterMock, HistoryMock, TestHelpers) {
+function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
+  Url, OAuthErrors, AuthErrors, Storage, BaseBroker, FxDesktopBroker, IframeBroker,
+  RedirectBroker, WebChannelBroker, BaseRelier, FxDesktopRelier, OAuthRelier,
+  Relier, User, Metrics, StorageMetrics, WindowMock, RouterMock, HistoryMock,
+  TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -490,12 +492,12 @@ function (chai, sinon, Raven, AppStart, Session, Constants, p, Url, OAuthErrors,
           });
       });
 
-      it('does not create an iframe channel if not in an iframe', function () {
+      it('creates a null iframe channel if not in an iframe', function () {
         sinon.spy(appStart, '_checkParentOrigin');
 
         return appStart.initializeIframeChannel()
           .then(function () {
-            assert.isUndefined(appStart._iframeChannel);
+            assert.instanceOf(appStart._iframeChannel, NullChannel);
             assert.isFalse(appStart._checkParentOrigin.called);
           });
       });


### PR DESCRIPTION
* `loaded` after the first screen is drawn.
* `login` after the user has signed in
* `verification_complete` after a signup/password reset verification is complete.

fixes #2704
ref #2101 