### PR TITLE
fix(cookies): redirect to /cookies_disabled if session/local storage is disabled, fixes #2480

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -125,6 +125,7 @@ function (
     this._relier = options.relier;
     this._authenticationBroker = options.broker;
     this._user = options.user;
+    this._storage = options.storage || Storage;
 
     this._history = options.history || Backbone.history;
     this._configLoader = new ConfigLoader();
@@ -543,29 +544,26 @@ function (
     },
 
     allResourcesReady: function () {
-      var self = this;
-      return this._selectStartPage()
-          .then(function (startPage) {
-            // The IFrame cannot use pushState or else a page transition
-            // would cause the parent frame to redirect.
-            var usePushState = ! self._isInAnIframe();
+      // The IFrame cannot use pushState or else a page transition
+      // would cause the parent frame to redirect.
+      var usePushState = ! this._isInAnIframe();
 
-            if (! usePushState) {
-              // If pushState cannot be used, Backbone falls back to using
-              // the hashchange. Put the initial pathname onto the hash
-              // so the correct page loads.
-              self._window.location.hash = self._window.location.pathname;
-            }
+      if (! usePushState) {
+        // If pushState cannot be used, Backbone falls back to using
+        // the hashchange. Put the initial pathname onto the hash
+        // so the correct page loads.
+        this._window.location.hash = this._window.location.pathname;
+      }
 
-            // If a new start page is specified, do not attempt to render
-            // the route displayed in the URL because the user is
-            // immediately redirected
-            var isSilent = !! startPage;
-            self._history.start({ pushState: usePushState, silent: isSilent });
-            if (startPage) {
-              self._router.navigate(startPage);
-            }
-          });
+      // If a new start page is specified, do not attempt to render
+      // the route displayed in the URL because the user is
+      // immediately redirected
+      var startPage = this._selectStartPage();
+      var isSilent = !! startPage;
+      this._history.start({ pushState: usePushState, silent: isSilent });
+      if (startPage) {
+        this._router.navigate(startPage);
+      }
     },
 
     _getErrorPage: function (err) {
@@ -652,22 +650,12 @@ function (
     },
 
     _selectStartPage: function () {
-      var self = this;
-      return p().then(function () {
-        if (self._window.location.pathname === '/cookies_disabled') {
-          // If the user is already at the cookies_disabled page, don't even
-          // attempt the cookie check or else a blank screen is rendered if
-          // cookies are actually disabled.
-          return;
-        }
-
-        return self._configLoader.areCookiesEnabled(false, self._window)
-            .then(function (areCookiesEnabled) {
-              if (! areCookiesEnabled) {
-                return 'cookies_disabled';
-              }
-            });
-      });
+      if (
+        this._window.location.pathname !== '/cookies_disabled' &&
+        ! this._storage.isLocalStorageEnabled(this._window)
+      ) {
+        return 'cookies_disabled';
+      }
     },
 
     _createMetrics: function (sampleRate, options) {

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -137,10 +137,8 @@ function (
       this.formPrefill = options.formPrefill;
       this.notifications = options.notifications;
       this.able = options.able;
+      this.storage = Storage.factory('sessionStorage', this.window);
 
-      // back is enabled after the first view is rendered or
-      // if the user is re-starts the app.
-      this.canGoBack = this.window.sessionStorage.canGoBack || false;
       this.environment = options.environment || new Environment(this.window);
       this._firstViewHasLoaded = false;
 
@@ -194,7 +192,9 @@ function (
       // default options.
       var viewOptions = _.extend({
         broker: this.broker,
-        canGoBack: this.canGoBack,
+        // back is enabled after the first view is rendered or
+        // if the user is re-starts the app.
+        canGoBack: this.storage.get('canGoBack') || false,
         fxaClient: this.fxaClient,
         interTabChannel: this.interTabChannel,
         language: this.language,
@@ -214,8 +214,7 @@ function (
     },
 
     _checkForRefresh: function () {
-      var storage = Storage.factory('sessionStorage', this._window);
-      var refreshMetrics = storage.get('last_page_loaded');
+      var refreshMetrics = this.storage.get('last_page_loaded');
       var currentView = this.currentView;
       var screenName = currentView.getScreenName();
 
@@ -228,7 +227,7 @@ function (
         timestamp: Date.now()
       };
 
-      storage.set('last_page_loaded', refreshMetrics);
+      this.storage.set('last_page_loaded', refreshMetrics);
     },
 
     showView: function (viewToShow) {
@@ -274,7 +273,7 @@ function (
 
             // back is enabled after the first view is rendered or
             // if the user re-starts the app.
-            self.canGoBack = self.window.sessionStorage.canGoBack = true;
+            self.storage.set('canGoBack', true);
             self._firstViewHasLoaded = true;
           }
           self._checkForRefresh();

--- a/app/tests/mocks/storage.js
+++ b/app/tests/mocks/storage.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function () {
+  'use strict';
+
+  function StorageMock (options) {
+    options = options || {};
+
+    this.isSessionStorageEnabled = function () {
+      return options.isSessionStorageEnabled;
+    };
+
+    this.isLocalStorageEnabled = function () {
+      return options.isLocalStorageEnabled;
+    };
+  }
+
+  return StorageMock;
+});

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -473,18 +473,18 @@ function (chai, sinon, Backbone, Router, SignInView, SignUpView, ReadyView,
         return router.createAndShowView(SignUpView, { canGoBack: false })
           .then(function () {
             assert.equal($('#fxa-signup-header').length, 1);
-            assert.isTrue(windowMock.sessionStorage.canGoBack);
+            assert.isTrue(router.storage.get('canGoBack'));
           });
       });
     });
 
     describe('canGoBack initial value', function () {
       it('is `false` if sessionStorage.canGoBack is not set', function () {
-        assert.isFalse(router.canGoBack);
+        assert.isUndefined(router.storage._backend.getItem('canGoBack'));
       });
 
       it('is `true` if sessionStorage.canGoBack is set', function () {
-        windowMock.sessionStorage.canGoBack = true;
+        windowMock.sessionStorage.setItem('canGoBack', true);
         router = new Router({
           window: windowMock,
           metrics: metrics,
@@ -493,7 +493,7 @@ function (chai, sinon, Backbone, Router, SignInView, SignUpView, ReadyView,
           user: user,
           formPrefill: formPrefill
         });
-        assert.isTrue(router.canGoBack);
+        assert.isTrue(router.storage._backend.getItem('canGoBack'));
       });
     });
   });


### PR DESCRIPTION
After all that discussion, this was much easier than I realised. The key to it was the `Storage` object, which already encapsulates sane behaviour when session storage and local storage are disabled. It also has a synchronous `isLocalStorageEnabled` method that means `allResourcesReady` is no longer async.

Changing the tests was a little bit messier, hence there is a new `StorageMock` which I'm passing in to app-start. Hope that's okay.

You may want to view the diff using `?w=1`, some indentation changed as stuff was promise-unwrapped.