### PR TITLE
fix(cookies): redirect to /cookies_disabled if session/local storage is disabled, fixes #2480

### DIFF
--- a/app/scripts/lib/storage.js
+++ b/app/scripts/lib/storage.js
@@ -6,8 +6,9 @@
 // or sessionStorage.
 
 define([
-  'lib/null-storage'
-], function (NullStorage) {
+  'lib/null-storage',
+  'lib/url'
+], function (NullStorage, Url) {
   'use strict';
 
   var NAMESPACE = '__fxa_storage';
@@ -54,6 +55,11 @@ define([
       if (type === 'sessionStorage') {
         storage = win.sessionStorage;
       } else {
+        // HACK: Allows the functional tests to simulate disabled local storage.
+        if (Url.searchParam('disable_local_storage') === '1') {
+          throw null;
+        }
+
         storage = win.localStorage;
       }
 

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -137,10 +137,8 @@ function (
       this.formPrefill = options.formPrefill;
       this.notifications = options.notifications;
       this.able = options.able;
+      this.storage = Storage.factory('sessionStorage', this.window);
 
-      // back is enabled after the first view is rendered or
-      // if the user is re-starts the app.
-      this.canGoBack = this.window.sessionStorage.canGoBack || false;
       this.environment = options.environment || new Environment(this.window);
       this._firstViewHasLoaded = false;
 
@@ -194,7 +192,9 @@ function (
       // default options.
       var viewOptions = _.extend({
         broker: this.broker,
-        canGoBack: this.canGoBack,
+        // back is enabled after the first view is rendered or
+        // if the user is re-starts the app.
+        canGoBack: this.storage.get('canGoBack') || false,
         fxaClient: this.fxaClient,
         interTabChannel: this.interTabChannel,
         language: this.language,
@@ -214,8 +214,7 @@ function (
     },
 
     _checkForRefresh: function () {
-      var storage = Storage.factory('sessionStorage', this._window);
-      var refreshMetrics = storage.get('last_page_loaded');
+      var refreshMetrics = this.storage.get('last_page_loaded');
       var currentView = this.currentView;
       var screenName = currentView.getScreenName();
 
@@ -228,7 +227,7 @@ function (
         timestamp: Date.now()
       };
 
-      storage.set('last_page_loaded', refreshMetrics);
+      this.storage.set('last_page_loaded', refreshMetrics);
     },
 
     showView: function (viewToShow) {
@@ -274,7 +273,7 @@ function (
 
             // back is enabled after the first view is rendered or
             // if the user re-starts the app.
-            self.canGoBack = self.window.sessionStorage.canGoBack = true;
+            self.storage.set('canGoBack', true);
             self._firstViewHasLoaded = true;
           }
           self._checkForRefresh();

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -473,18 +473,18 @@ function (chai, sinon, Backbone, Router, SignInView, SignUpView, ReadyView,
         return router.createAndShowView(SignUpView, { canGoBack: false })
           .then(function () {
             assert.equal($('#fxa-signup-header').length, 1);
-            assert.isTrue(windowMock.sessionStorage.canGoBack);
+            assert.isTrue(router.storage.get('canGoBack'));
           });
       });
     });
 
     describe('canGoBack initial value', function () {
       it('is `false` if sessionStorage.canGoBack is not set', function () {
-        assert.isFalse(router.canGoBack);
+        assert.isUndefined(router.storage._backend.getItem('canGoBack'));
       });
 
       it('is `true` if sessionStorage.canGoBack is set', function () {
-        windowMock.sessionStorage.canGoBack = true;
+        windowMock.sessionStorage.setItem('canGoBack', true);
         router = new Router({
           window: windowMock,
           metrics: metrics,
@@ -493,7 +493,7 @@ function (chai, sinon, Backbone, Router, SignInView, SignUpView, ReadyView,
           user: user,
           formPrefill: formPrefill
         });
-        assert.isTrue(router.canGoBack);
+        assert.isTrue(router.storage._backend.getItem('canGoBack'));
       });
     });
   });


### PR DESCRIPTION
Fix to [the previous PR](https://github.com/mozilla/fxa-content-server/pull/2707), copying the `disable_local_storage` query parameter hack so that the functional tests can simulate disabled local storage.
