### PR TITLE
fix(server): let server task fail if port is in use

### DIFF
--- a/scripts/run_locally.js
+++ b/scripts/run_locally.js
@@ -19,7 +19,7 @@ module.exports = function (done) {
   fxaccntbridge.on('exit', function (code, signal) {
     console.log('fxa-content-server killed, exiting');
     if (done) {
-      done(code);
+      done(code === 0);
     } else {
       process.exit(code); //eslint-disable-line no-process-exit
     }


### PR DESCRIPTION
@zaach r?

To reproduce the issue:
start all servers via fxa-local-dev, then `npm start` content server. It will throw port in use error but grunt task will succeed with no errors. 

This sometimes causes infinite loops with fxa-local-dev  :sob: 