### PR TITLE
fix(tests): allow override of expected value from remote server

### DIFF
--- a/tests/server/metrics-errors.js
+++ b/tests/server/metrics-errors.js
@@ -12,6 +12,9 @@ define([
   var serverUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
 
   var env = config.get('env');
+  if (intern.config.fxaProduction) {
+    env = 'production';
+  }
 
   var suite = {
     name: 'metrics-errors'


### PR DESCRIPTION
When running this test against a remote server like latest.dev.lcip.org or accounts.stage.mozaws.net, the expected value can't be determined from the local configuration on the intern-client side. So, if `fxaProduction`, then expect `production` to be returned.

r? @vladikoff 