### PR TITLE
fix(tests): set metrics.sample_rate based on FxaDevBox too

### DIFF
--- a/tests/server/metrics.js
+++ b/tests/server/metrics.js
@@ -12,8 +12,12 @@ define([
   var serverUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
 
   var metricsSampleRate = config.get('metrics.sample_rate');
+  // fxaProduction and fxaDevBox imply remote, so cannot use the
+  // local configuration for this expected value.
   if (intern.config.fxaProduction && ! intern.config.fxaDevBox) {
     metricsSampleRate = 0.1;
+  } else if (intern.config.fxaDevBox) {
+    metricsSampleRate = 1;
   }
 
   var suite = {


### PR DESCRIPTION
When run from `tests.dev.lcip.org`, there is no `server/config/local.json` file so `metrics.sample_rate` returns `0`. So, we need to override the expected value to run against `latest.dev.lcip.org`.