### PR TITLE
fix(server): remove 'Fxa requires JavaScript' message in ie8/9

### DIFF
--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -46,9 +46,11 @@
         <![endif]-->
 
         <!-- this will be overwritten if JS is enabled -->
+        <!--[if !(IE) | (gte IE 10)]><!-->
         <noscript>
           {{#t}}Firefox Accounts requires JavaScript.{{/t}}
         </noscript>
+        <!--<![endif]-->
 
         <!-- no build declaration, main.js build
              is done by requirejs and not concat.


### PR DESCRIPTION
Fixes #2279
Add conditional comment to not display noscript in IE8 and 9
Yes, its ugly, but no, there's no shorter way.
@vladikoff 
@shane-tomlinson 
@johngruen 