### PR TITLE
fix(metrics): use sendBeacon where available

### DIFF
--- a/app/scripts/lib/environment.js
+++ b/app/scripts/lib/environment.js
@@ -93,6 +93,10 @@
     isFxiOS: function () {
       // User agent sniffing. Gross.
       return /FxiOS/.test(this.window.navigator.userAgent);
+    },
+
+    hasSendBeacon: function () {
+      return typeof this.window.navigator.sendBeacon === 'function';
     }
   };
 

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -69,7 +69,8 @@ function (Backbone, sinon, _, NullStorage) {
           }
           self.trigger('stream');
         }, 0);
-      }
+      },
+      sendBeacon: function () {}
     };
 
     this.URL = {

--- a/app/tests/spec/lib/environment.js
+++ b/app/tests/spec/lib/environment.js
@@ -123,6 +123,18 @@ define([
         assert.isFalse(environment.isFxiOS());
       });
     });
+
+    describe('hasSendBeacon', function () {
+      it('returns `true` if sendBeacon function exists', function () {
+        windowMock.navigator.sendBeacon = function () {};
+        assert.isTrue(environment.hasSendBeacon());
+      });
+
+      it('returns `false` if sendBeacon is undefined', function () {
+        windowMock.navigator.sendBeacon = undefined;
+        assert.isFalse(environment.hasSendBeacon());
+      });
+    });
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "husky": "0.9.1",
     "intern": "git://github.com/theintern/intern#42aebd9beb942a11e2c6e6d7687c70a1c22b9bf7",
     "proxyquire": "1.6.0",
+    "sinon": "1.15.4",
     "sync-exec": "0.6.1",
     "xmlhttprequest": "git://github.com/zaach/node-XMLHttpRequest.git#onerror"
   },

--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -82,6 +82,9 @@ function makeApp() {
   app.use(routeLogging());
   app.use(cookieParser());
   app.use(bodyParser.json());
+  app.use(bodyParser.text({
+    type: 'text/plain'
+  }));
 
   var ableOptions = {
     dir: config.get('experiments.dir'),

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -6,6 +6,7 @@
 var MetricsCollector = require('../metrics-collector-stderr');
 var StatsDCollector = require('../statsd-collector');
 var GACollector = require('../ga-collector');
+var logger = require('mozlog')('server.post-metrics');
 
 module.exports = function () {
   var metricsCollector = new MetricsCollector();
@@ -19,8 +20,20 @@ module.exports = function () {
     process: function (req, res) {
       // don't wait around to send a response.
       res.json({ success: true });
+
       process.nextTick(function () {
         var metrics = req.body || {};
+
+        var contentType = req.get('content-type') || '';
+        if (contentType.indexOf('text/plain') === 0) {
+          try {
+            metrics = JSON.parse(req.body);
+          } catch (error) {
+            logger.error(error);
+            return;
+          }
+        }
+
         metrics.agent = req.get('user-agent');
 
         if (metrics.isSampledUser) {
@@ -28,10 +41,8 @@ module.exports = function () {
           // send the metrics body to the StatsD collector for processing
           statsd.write(metrics);
         }
-
         ga.write(metrics);
       });
-
     }
   };
 };

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -19,6 +19,7 @@ define([
     'tests/server/metrics-collector-stderr',
     'tests/server/metrics-errors',
     'tests/server/metrics-ga',
+    'tests/server/metrics-unit',
     'tests/server/configuration',
     'tests/server/statsd-collector'
   ];

--- a/tests/server/metrics-unit.js
+++ b/tests/server/metrics-unit.js
@@ -1,0 +1,231 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!./helpers/init-logging',
+  'intern/dojo/node!path',
+  'intern/dojo/node!proxyquire',
+  'intern/dojo/node!sinon'
+], function (intern, registerSuite, assert, initLogging, path, proxyquire, sinon) {
+  var suite = {};
+
+  suite['sanity check'] = function () {
+    var test = setUp();
+
+    assert.equal(test.metrics.method, 'post');
+    assert.equal(test.metrics.path, '/metrics');
+    assert.equal(typeof test.metrics.process, 'function');
+    assert.equal(test.mocks.statsdCollector.init.callCount, 1);
+    assert.lengthOf(test.mocks.statsdCollector.init.getCall(0).args, 0);
+
+    tearDown();
+  };
+
+  suite['process responds with success immediately, calls process.nextTick'] = function () {
+    var test = setUp();
+
+    test.metrics.process(test.mocks.request, test.mocks.response);
+
+    assert.equal(test.mocks.response.json.callCount, 1);
+    assert.lengthOf(test.mocks.response.json.getCall(0).args, 1);
+    var data = test.mocks.response.json.getCall(0).args[0];
+    assert.lengthOf(Object.keys(data), 1);
+    assert.isTrue(data.success);
+
+    assert.equal(process.nextTick.callCount, 1);
+
+    tearDown();
+  };
+
+  suite['Content-Type is unset, user is not sampled'] = function () {
+    var test = setUp();
+
+    test.mocks.request.body = {};
+    test.metrics.process(test.mocks.request, test.mocks.response);
+    test.callbacks.nextTick();
+
+    assert.equal(test.mocks.logger.error.callCount, 0);
+
+    assert.equal(test.mocks.request.get.callCount, 2);
+    assert.lengthOf(test.mocks.request.get.getCall(0).args, 1);
+    assert.equal(test.mocks.request.get.getCall(0).args[0], 'content-type');
+    assert.lengthOf(test.mocks.request.get.getCall(1).args, 1);
+    assert.equal(test.mocks.request.get.getCall(1).args[0], 'user-agent');
+
+    assert.equal(test.mocks.metricsCollector.write.callCount, 0);
+    assert.equal(test.mocks.statsdCollector.write.callCount, 0);
+    assert.equal(test.mocks.gaCollector.write.callCount, 1);
+    assert.lengthOf(test.mocks.gaCollector.write.getCall(0).args, 1);
+
+    tearDown();
+  };
+
+  suite['Content-Type is unset, user is sampled'] = function () {
+    var test = setUp(function () {
+      return 'foo';
+    });
+    test.mocks.request.body = { bar: 'baz', isSampledUser: true };
+    test.metrics.process(test.mocks.request, test.mocks.response);
+    test.callbacks.nextTick();
+
+    assert.equal(test.mocks.logger.error.callCount, 0);
+
+    assert.equal(test.mocks.metricsCollector.write.callCount, 1);
+    assert.lengthOf(test.mocks.metricsCollector.write.getCall(0).args, 1);
+    var data = test.mocks.metricsCollector.write.getCall(0).args[0];
+    assert.lengthOf(Object.keys(data), 3);
+    assert.equal(data.agent, 'foo');
+    assert.equal(data.bar, 'baz');
+    assert.equal(data.isSampledUser, true);
+
+    assert.equal(test.mocks.statsdCollector.write.callCount, 1);
+    assert.lengthOf(test.mocks.statsdCollector.write.getCall(0).args, 1);
+    assert.equal(test.mocks.statsdCollector.write.getCall(0).args[0], data);
+
+    assert.equal(test.mocks.gaCollector.write.callCount, 1);
+    assert.lengthOf(test.mocks.gaCollector.write.getCall(0).args, 1);
+    assert.equal(test.mocks.gaCollector.write.getCall(0).args[0], data);
+
+    tearDown();
+  };
+
+  suite['Content-Type is text/plain, data is invalid JSON'] = function () {
+    var test = setUp(function (headerName) {
+      if (headerName.toLowerCase() === 'content-type') {
+        return 'text/plain';
+      }
+
+      return 'foo';
+    });
+    test.mocks.request.body = 'bar';
+    test.metrics.process(test.mocks.request, test.mocks.response);
+    test.callbacks.nextTick();
+
+    assert.equal(test.mocks.logger.error.callCount, 1);
+    assert.lengthOf(test.mocks.logger.error.getCall(0).args, 1);
+    assert.instanceOf(test.mocks.logger.error.getCall(0).args[0], Error);
+
+    assert.equal(test.mocks.metricsCollector.write.callCount, 0);
+    assert.equal(test.mocks.statsdCollector.write.callCount, 0);
+    assert.equal(test.mocks.gaCollector.write.callCount, 0);
+
+    tearDown();
+  };
+
+  suite['Content-Type is text/plain, data is valid JSON, user is sampled'] = function () {
+    var test = setUp(function (headerName) {
+      if (headerName.toLowerCase() === 'content-type') {
+        return 'text/plain';
+      }
+
+      return 'wibble';
+    });
+    test.mocks.request.body = '{"foo":"bar","isSampledUser":true}';
+    test.metrics.process(test.mocks.request, test.mocks.response);
+    test.callbacks.nextTick();
+
+    assert.equal(test.mocks.logger.error.callCount, 0);
+
+    assert.equal(test.mocks.metricsCollector.write.callCount, 1);
+    var data = test.mocks.metricsCollector.write.getCall(0).args[0];
+    assert.lengthOf(Object.keys(data), 3);
+    assert.equal(data.agent, 'wibble');
+    assert.equal(data.foo, 'bar');
+    assert.equal(data.isSampledUser, true);
+
+    assert.equal(test.mocks.statsdCollector.write.callCount, 1);
+    assert.equal(test.mocks.statsdCollector.write.getCall(0).args[0], data);
+
+    assert.equal(test.mocks.gaCollector.write.callCount, 1);
+    assert.equal(test.mocks.gaCollector.write.getCall(0).args[0], data);
+
+    tearDown();
+  };
+
+  suite['Content-Type is text/plain;charset=UTF-8, data is valid JSON, user is sampled'] = function () {
+    var test = setUp(function (headerName) {
+      if (headerName.toLowerCase() === 'content-type') {
+        return 'text/plain;charset=UTF-8';
+      }
+
+      return 'foo';
+    });
+    test.mocks.request.body = '{"isSampledUser":true}';
+    test.metrics.process(test.mocks.request, test.mocks.response);
+    test.callbacks.nextTick();
+
+    assert.equal(test.mocks.logger.error.callCount, 0);
+
+    assert.equal(test.mocks.metricsCollector.write.callCount, 1);
+    var data = test.mocks.metricsCollector.write.getCall(0).args[0];
+    assert.lengthOf(Object.keys(data), 2);
+    assert.equal(data.agent, 'foo');
+    assert.equal(data.isSampledUser, true);
+
+    assert.equal(test.mocks.statsdCollector.write.callCount, 1);
+    assert.equal(test.mocks.statsdCollector.write.getCall(0).args[0], data);
+
+    assert.equal(test.mocks.gaCollector.write.callCount, 1);
+    assert.equal(test.mocks.gaCollector.write.getCall(0).args[0], data);
+
+    tearDown();
+  };
+
+  registerSuite(suite);
+
+  function setUp (requestGet) {
+    var mocks = {
+      request: {
+        get: requestGet ? sinon.spy(requestGet) : sinon.stub()
+      },
+      response: {
+        json: sinon.stub()
+      },
+      logger: {
+        error: sinon.stub()
+      },
+      metricsCollector: {
+        write: sinon.stub()
+      },
+      statsdCollector: {
+        init: sinon.stub(),
+        write: sinon.stub()
+      },
+      gaCollector: {
+        write: sinon.stub()
+      }
+    };
+    var callbacks = {};
+
+    sinon.stub(process, 'nextTick', function (callback) {
+      callbacks.nextTick = callback;
+    });
+
+    return {
+      mocks: mocks,
+      callbacks: callbacks,
+      metrics: proxyquire(path.join(process.cwd(), 'server', 'lib', 'routes', 'post-metrics'), {
+        mozlog: function () {
+          return mocks.logger;
+        },
+        '../metrics-collector-stderr': function () {
+          return mocks.metricsCollector;
+        },
+        '../statsd-collector': function () {
+          return mocks.statsdCollector;
+        },
+        '../ga-collector': function () {
+          return mocks.gaCollector;
+        }
+      })()
+    };
+  }
+
+  function tearDown () {
+    process.nextTick.restore();
+  }
+});

--- a/tests/server/metrics.js
+++ b/tests/server/metrics.js
@@ -15,12 +15,26 @@ define([
     name: 'metrics'
   };
 
-  suite['#post /metrics - returns 200, all the time'] = function () {
+  suite['#post /metrics - returns 200'] = function () {
     var dfd = this.async(intern.config.asyncTimeout);
 
     request.post(serverUrl + '/metrics', {
       data: {
         events: [ { type: 'event1', offset: 1 } ]
+      }
+    },
+    dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+    }, dfd.reject.bind(dfd)));
+  };
+
+  suite['#post /metrics - returns 200 if Content-Type is text/plain'] = function () {
+    var dfd = this.async(intern.config.asyncTimeout);
+
+    request.post(serverUrl + '/metrics', {
+      data: '',
+      headers: {
+        'Content-Type': 'text/plain;charset=UTF-8'
       }
     },
     dfd.callback(function (err, res) {


### PR DESCRIPTION
This changeset partially addresses the problem from #2493, that synchronous XHR has been deprecated by the WHATWG. The approach taken is to use `sendBeacon` if it is implemented, otherwise it falls back to the current behaviour of synchronous XHR.

Because `sendBeacon` returns a boolean, the XHR condition has been modified to do likewise for the benefit of calling code. Doing this also meant reworking the tests because previously they relied on comparing the result of `metrics.flush()` to the data that was passed in, rather than actually interrogating test spies for any assertions. I think they're better tests for it.

There is one behavioural difference, in so much as events and timers are no longer cleared if the beacon request fails. It was [pointed out](https://github.com/mozilla/fxa-content-server/issues/2493#issuecomment-120425102) that such an occurrence would be extremely improbable anyway but, as I was rewriting the tests, it felt wrong to knowingly write bad assertions.

There is another, related change that could be made in addition to these, [suggested in the issue](https://github.com/mozilla/fxa-content-server/issues/2493#issuecomment-109809007):

> I'd be curious how frequently we navigate ourselves away from the page (e.g. when completing an oauth redirect) versus how frequently we get unload by user action. In the former case we could do an async XHR and ensure it completes before proceeding.

That fix didn't seem predicated on the existence of this one, so I thought it correct to get them reviewed separately. But I'm also happy to roll them up and submit them together, if people would prefer it that way.