### PR TITLE
fix(client): Ensure the password manager has an email to work with.

### DIFF
--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -27,7 +27,7 @@
 
         {{#chooserAskForPassword}}
           <form novalidate>
-            <input type="hidden" class="email" value="{{ email }}" />
+            <input type="email" class="email hidden" value="{{ email }}" />
 
             <div class="input-row password-row">
               <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required {{#isPasswordAutoCompleteDisabled}}autocomplete="off"{{/isPasswordAutoCompleteDisabled}} autofocus />

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -595,7 +595,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
 
         return view.render()
           .then(function () {
-            assert.equal($('.email').attr('type'), 'hidden', 'should not show email input');
+            assert.isTrue($('.email').hasClass('hidden'), 'should not show email input');
             assert.ok($('.password').length, 'should show password input');
             assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.keys-required'));
           });
@@ -622,7 +622,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
 
         return view.render()
           .then(function () {
-            assert.equal($('.email').attr('type'), 'hidden', 'should not show email input');
+            assert.isTrue($('.email').hasClass('hidden'), 'should not show email input');
             assert.ok($('.password').length, 'should show password input');
             assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.keys-required'));
           });
@@ -667,7 +667,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
 
         return view.render()
           .then(function () {
-            assert.equal($('.email').attr('type'), 'hidden', 'should not show email input');
+            assert.isTrue($('.email').hasClass('hidden'), 'should not show email input');
             assert.ok($('.password').length, 'should show password input');
             assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.session-from-web'));
           });
@@ -694,7 +694,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
 
         return view.render()
           .then(function () {
-            assert.equal($('.email').attr('type'), 'hidden', 'should not show email input');
+            assert.isTrue($('.email').hasClass('hidden'), 'should not show email input');
             assert.ok($('.password').length, 'should show password input');
             assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.email-mismatch'));
           });
@@ -718,7 +718,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
         view.chooserAskForPassword = true;
         return view.render()
           .then(function () {
-            assert.equal($('.email').attr('type'), 'hidden', 'should not show email input');
+            assert.isTrue($('.email').hasClass('hidden'), 'should not show email input');
             assert.ok($('.password').length, 'should show password input');
             assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.session-expired'));
           });


### PR DESCRIPTION
The password manager was unable to pick up the email when using cached
credentials with the `input type=hidden` element. Change the type to
`email` and hide the element using CSS.

fixes #2754