### PR TITLE
[DO NOT MERGE YET] fix(l10n): add hi_IN to list of production-locales

### DIFF
--- a/server/config/production-locales.json
+++ b/server/config/production-locales.json
@@ -17,6 +17,7 @@
       "fr",
       "fy",
       "he",
+      "hi_IN",
       "hsb",
       "hu",
       "id",


### PR DESCRIPTION
In Verbatim, https://localize.mozilla.org/hi_IN/accounts/ shows as 100% translated, and there is content in https://localize.mozilla.org/hi_IN/accounts/LC_MESSAGES/translate.html#page=25. In a local build, with locales built, it also show translated content to a browser that requests 'accept-language: hi-IN'. And finally, a check of one phrase in google translate says it is Hindi and a bad but usable mechanical translation back to English.

However, Firefox allows the accept-language to be set to "Hindi" (hi), and FxA doesn't match that (returns default 'en'). I can't imagine that doing a copy of this content to 'hi' is not what we want, but probably want to get that in place if we do decide to merge this change.

@zaach, @mathjazz ?