### PR TITLE
fix(sync): do not send sessionTokenContext to Firefox Sync

### DIFF
--- a/app/scripts/models/auth_brokers/fx-desktop.js
+++ b/app/scripts/models/auth_brokers/fx-desktop.js
@@ -180,7 +180,6 @@ define([
         'email',
         'uid',
         'sessionToken',
-        'sessionTokenContext',
         'unwrapBKey',
         'keyFetchToken',
         'customizeSync',

--- a/app/tests/spec/models/auth_brokers/fx-desktop.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop.js
@@ -191,10 +191,10 @@ define([
             assert.equal(args[1].email, 'testuser@testuser.com');
             assert.equal(args[1].uid, 'uid');
             assert.equal(args[1].sessionToken, 'session_token');
-            assert.equal(args[1].sessionTokenContext, 'sync');
             assert.equal(args[1].unwrapBKey, 'unwrap_b_key');
             assert.equal(args[1].customizeSync, true);
             assert.equal(args[1].verified, true);
+            assert.isUndefined(args[1].sessionTokenContext);
 
             assert.isTrue(result.halt);
           });
@@ -286,11 +286,11 @@ define([
             assert.equal(args[1].email, 'testuser@testuser.com');
             assert.equal(args[1].uid, 'uid');
             assert.equal(args[1].sessionToken, 'session_token');
-            assert.equal(args[1].sessionTokenContext, 'sync');
             assert.equal(args[1].unwrapBKey, 'unwrap_b_key');
             assert.equal(args[1].customizeSync, true);
             assert.equal(args[1].verified, true);
             assert.isFalse('notSent' in args[1]);
+            assert.isUndefined(args[1].sessionTokenContext);
           });
       });
     });


### PR DESCRIPTION
Fixes #2766 

@mhammond @shane-tomlinson r?