### PR TITLE
feat(metrics): Report all metrics to our backend.

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -45,6 +45,7 @@ define([
     'timers',
     'broker',
     'ab',
+    'isSampledUser',
     'utm_campaign',
     'utm_content',
     'utm_medium',
@@ -67,7 +68,7 @@ define([
   }
 
   function Metrics (options) {
-    /*eslint complexity: [2, 24] */
+    /*eslint complexity: [2, 25] */
     options = options || {};
 
     // by default, send the metrics to the content server.
@@ -97,6 +98,10 @@ define([
     this._devicePixelRatio = options.devicePixelRatio || NOT_REPORTED_VALUE;
     this._screenHeight = options.screenHeight || NOT_REPORTED_VALUE;
     this._screenWidth = options.screenWidth || NOT_REPORTED_VALUE;
+
+    // All user metrics are sent to the backend. Data is only
+    // reported to Heka and Datadog if `isSampledUser===true`.
+    this._isSampledUser = options.isSampledUser || false;
 
     this._referrer = this._window.document.referrer || NOT_REPORTED_VALUE;
     this._utmCampaign = options.utmCampaign || NOT_REPORTED_VALUE;
@@ -189,6 +194,7 @@ define([
           width: this._screenWidth,
           height: this._screenHeight
         },
+        isSampledUser: this._isSampledUser,
         utm_campaign: this._utmCampaign, //eslint-disable-line camelcase
         utm_content: this._utmContent, //eslint-disable-line camelcase
         utm_medium: this._utmMedium, //eslint-disable-line camelcase
@@ -340,7 +346,7 @@ define([
     },
 
     isCollectionEnabled: function () {
-      return true;
+      return this._isSampledUser;
     }
   });
 

--- a/app/scripts/lib/storage-metrics.js
+++ b/app/scripts/lib/storage-metrics.js
@@ -34,6 +34,10 @@ define([
       storage.set('metrics_all', metrics);
 
       return p(data);
+    },
+
+    isMetricsCollectionEnabled: function () {
+      return false;
     }
   });
 

--- a/app/tests/spec/lib/storage-metrics.js
+++ b/app/tests/spec/lib/storage-metrics.js
@@ -91,7 +91,7 @@ function (chai, StorageMetrics, Metrics, Storage, WindowMock) {
     });
 
     it('reports that real collection is not enabled', function () {
-      assert.isTrue(storageMetrics.isCollectionEnabled());
+      assert.isFalse(storageMetrics.isCollectionEnabled());
     });
   });
 });

--- a/server/config/awsbox.json
+++ b/server/config/awsbox.json
@@ -7,8 +7,5 @@
   "static_max_age" : 0,
   "i18n": {
     "supportedLanguages": ["af", "an", "ar", "as", "ast", "be", "bg", "bn-BD", "bn-IN", "br", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "en-GB", "en-ZA", "eo", "es", "es-AR", "es-CL", "es-MX", "et", "eu", "fa", "ff", "fi", "fr", "fy", "fy-NL", "ga", "ga-IE", "gd", "gl", "gu", "gu-IN", "he", "hi-IN", "hr", "ht", "hu", "hy-AM", "id", "is", "it", "it-CH", "ja", "kk", "km", "kn", "ko", "ku", "lij", "lt", "lv", "mai", "mk", "ml", "mr", "ms", "nb-NO", "ne-NP", "nl", "nn-NO", "or", "pa", "pa-IN", "pl", "pt", "pt-BR", "pt-PT", "rm", "ro", "ru", "si", "sk", "sl", "son", "sq", "sr", "sr-LATN", "sv", "sv-SE", "ta", "te", "th", "tr", "uk", "ur", "vi", "xh", "zh-CN", "zh-TW", "zu"]
-  },
-  "metrics": {
-    "sample_rate": 0
   }
 }

--- a/server/config/local.json-dist
+++ b/server/config/local.json-dist
@@ -21,9 +21,6 @@
     "level": "debug"
   },
   "static_directory": "app",
-  "metrics": {
-    "sample_rate": 1
-  },
   "allowed_parent_origins": ["http://127.0.0.1:8080"],
   "csp": {
     "enabled": true,

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -250,14 +250,6 @@ var conf = module.exports = convict({
       }
     }
   },
-  metrics: {
-    sample_rate: {
-      doc: 'Front end metrics sample rate - must be between 0 and 1',
-      format: Number,
-      default: 0,
-      env: 'METRICS_SAMPLE_RATE'
-    }
-  },
   key_path: {
     doc: 'The location of the SSL key in pem format',
     default: path.resolve(__dirname, '..', '..', 'key.pem')

--- a/server/lib/routes/get-config.js
+++ b/server/lib/routes/get-config.js
@@ -10,7 +10,6 @@ var authServerUrl = config.get('fxaccount_url');
 var env = config.get('env');
 var oauthServerUrl = config.get('oauth_url');
 var profileServerUrl = config.get('profile_url');
-var metricsSampleRate = config.get('metrics.sample_rate');
 var allowedParentOrigins = config.get('allowed_parent_origins');
 var marketingEmailApiServerUrl = config.get('marketing_email.api_url');
 var marketingEmailPreferencesUrl = config.get('marketing_email.preferences_url');
@@ -47,7 +46,6 @@ module.exports = function () {
       oAuthUrl: oauthServerUrl,
       // req.lang is set by abide in a previous middleware.
       language: req.lang,
-      metricsSampleRate: metricsSampleRate,
       profileUrl: profileServerUrl
     });
   };

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -18,11 +18,14 @@ module.exports = function () {
       // don't wait around to send a response.
       res.json({ success: true });
 
-      var metrics = req.body;
+      var metrics = req.body || {};
       metrics.agent = req.get('user-agent');
-      metricsCollector.write(metrics);
-      // send the metrics body to the StatsD collector for processing
-      statsd.write(metrics);
+
+      if (metrics.isSampledUser) {
+        metricsCollector.write(metrics);
+        // send the metrics body to the StatsD collector for processing
+        statsd.write(metrics);
+      }
     }
   };
 };

--- a/tests/server/metrics.js
+++ b/tests/server/metrics.js
@@ -11,28 +11,8 @@ define([
 ], function (intern, registerSuite, assert, config, request) {
   var serverUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
 
-  var metricsSampleRate = config.get('metrics.sample_rate');
-  // fxaProduction and fxaDevBox imply remote, so cannot use the
-  // local configuration for this expected value.
-  if (intern.config.fxaProduction && ! intern.config.fxaDevBox) {
-    metricsSampleRate = 0.1;
-  } else if (intern.config.fxaDevBox) {
-    metricsSampleRate = 1;
-  }
-
   var suite = {
     name: 'metrics'
-  };
-
-  suite['#get /config returns a `metricsSampleRate`'] = function () {
-    var dfd = this.async(intern.config.asyncTimeout);
-
-    request(serverUrl + '/config',
-    dfd.callback(function (err, res) {
-      var results = JSON.parse(res.body);
-
-      assert.equal(results.metricsSampleRate, metricsSampleRate);
-    }, dfd.reject.bind(dfd)));
   };
 
   suite['#post /metrics - returns 200, all the time'] = function () {


### PR DESCRIPTION
## depends on https://github.com/mozilla/fxa-content-experiments/pull/23

Some teams send Google Analyics utm_* data to us so they can follow a
user through the funnel. utm_* data needs to be reported to Google
regardless of whether a user is part of our own sample set or not.
This approach ensures the relier does not have 100% of their user's
report to Google, but only 10% of ours do, causing data comparison
nightmares.

Use the uniqueUserId to determine whether a user is part of the sample set that
is reported to our metrics infrastructure from the backend.
The uniqueUserId allows a user to be opted in on both signup and verification
if they verify in different browsers.

issue #2579
fixes #2780

--------------------

See also:
* https://github.com/mozilla/fxa-dev/pull/166
* https://github.com/mozilla-services/puppet-config/pull/1444