### PR TITLE
feat(client): Send a `signup_must_verify` message to the firstrun page on signup.

### DIFF
--- a/app/scripts/models/auth_brokers/first-run.js
+++ b/app/scripts/models/auth_brokers/first-run.js
@@ -18,6 +18,7 @@ define([
     _iframeCommands: {
        LOADED: 'loaded',
        LOGIN: 'login',
+       SIGNUP_MUST_VERIFY: 'signup_must_verify',
        VERIFICATION_COMPLETE: 'verification_complete'
      },
 
@@ -48,6 +49,12 @@ define([
       this._iframeChannel.send(this._iframeCommands.VERIFICATION_COMPLETE);
 
       return proto.afterResetPasswordConfirmationPoll.apply(this, arguments);
+    },
+
+    beforeSignUpConfirmationPoll: function () {
+      this._iframeChannel.send(this._iframeCommands.SIGNUP_MUST_VERIFY);
+
+      return proto.beforeSignUpConfirmationPoll.apply(this, arguments);
     },
 
     afterSignUpConfirmationPoll: function () {

--- a/app/tests/spec/models/auth_brokers/first-run.js
+++ b/app/tests/spec/models/auth_brokers/first-run.js
@@ -59,9 +59,12 @@ function (chai, sinon, NullChannel, Account, FirstRunAuthenticationBroker, Relie
     });
 
     describe('beforeSignUpConfirmationPoll', function () {
-      it('does not halt', function () {
+      it('notifies the iframe channel, does not halt', function () {
+        sinon.spy(iframeChannel, 'send');
+
         return broker.beforeSignUpConfirmationPoll(account)
           .then(function (result) {
+            assert.isTrue(iframeChannel.send.calledWith(broker._iframeCommands.SIGNUP_MUST_VERIFY));
             assert.isFalse(result.halt);
           });
       });


### PR DESCRIPTION
Triggered whenever a user successfully completes the signup form, or an
unverified user successfully completes the signin form.

fixes #2790
ref #2101 

@jpetto - this is for you!