### PR TITLE
fix(tests): show the firefox --version in test logs

### DIFF
--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -43,6 +43,8 @@ node_modules/.bin/bower install --config.interactive=false
 
 set -o xtrace # echo the following commands
 
+$FXA_FIREFOX_BINARY --version
+
 ./node_modules/.bin/intern-runner \
     config="tests/intern_functional_full" \
     fxaAuthRoot="$FXA_AUTH_ROOT" \


### PR DESCRIPTION
I noticed that we stopped showing the Fx version in the log after the intern upgrade (which is great!).
This just puts it back.

r? - @vladikoff