### PR TITLE
fix(client): Hide the border around the marketing snippet for the firstrun flow.

### DIFF
--- a/app/styles/modules/_marketing.scss
+++ b/app/styles/modules/_marketing.scss
@@ -75,3 +75,20 @@
     }
   }
 }
+
+.marketing-area {
+  .chromeless.iframe & {
+    @include respond-to('reasonableUI') {
+      // This is a hack. The width of the firstrun iframe is 400px.
+      // The max-width of the main-content area is 360px, leaving 20px
+      // on either side. A 20px bottom-padding exists on the body.
+      // This leaves a 20px white area around the marketing snippet.
+
+      // For the firstrun flow only, pull the marketing box
+      // out to the sides to get rid of the padding.
+      margin: 0px -20px;
+      position: relative;
+      bottom: -20px;
+    }
+  }
+}


### PR DESCRIPTION
### Before

![screen shot 2015-07-08 at 17 53 52](https://cloud.githubusercontent.com/assets/848085/8576668/9e43ef18-259b-11e5-9891-21eb9fcba41a.png)

### After

![screen shot 2015-07-21 at 09 23 28](https://cloud.githubusercontent.com/assets/848085/8796147/52dc42c0-2f8a-11e5-8e11-dd51e6dcafc1.png)


fixes #2709
ref #2101 