### PR TITLE
chore(dev): add 'npm run start-production' command to make it easier …

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "start": "grunt server",
+    "start-production": "grunt build && CONFIG_FILES=server/config/local.json,server/config/production.json grunt serverproc:dist",
     "postinstall": "bower update --config.interactive=false -s",
     "test": "intern-runner config=tests/intern",
     "test-functional": "intern-runner config=tests/intern_functional",


### PR DESCRIPTION
…to run the server in prod mode


@shane-tomlinson @zaach r?

The goal of this is to make it really easy to test the 'built' app.
If you see a shorter way to do this let me know.