### PR TITLE
fix(metrics): minimize flush timeout and flush event metrics on blur event

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -56,7 +56,7 @@ define([
     'utm_term'
   ];
 
-  var TEN_MINS_MS = 10 * 60 * 1000;
+  var DEFAULT_INACTIVITY_TIMEOUT_MS = 2 * 60 * 1000;
   var NOT_REPORTED_VALUE = 'none';
   var UNKNOWN_CAMPAIGN_ID = 'unknown';
 
@@ -114,7 +114,7 @@ define([
     this._utmSource = options.utmSource || NOT_REPORTED_VALUE;
     this._utmTerm = options.utmTerm || NOT_REPORTED_VALUE;
 
-    this._inactivityFlushMs = options.inactivityFlushMs || TEN_MINS_MS;
+    this._inactivityFlushMs = options.inactivityFlushMs || DEFAULT_INACTIVITY_TIMEOUT_MS;
 
     this._marketingImpressions = {};
 
@@ -128,6 +128,11 @@ define([
     init: function () {
       this._flush = _.bind(this.flush, this);
       $(this._window).on('unload', this._flush);
+      // iOS will not send events once the window is in the background,
+      // meaning the `unload` handler is ineffective. Send events on blur
+      // instead, so events are not lost when a user goes to verify their
+      // email.
+      $(this._window).on('blur', this._flush);
 
       // Set the initial inactivity timeout to clear navigation timing data.
       this._resetInactivityFlushTimeout();
@@ -135,6 +140,7 @@ define([
 
     destroy: function () {
       $(this._window).off('unload', this._flush);
+      $(this._window).off('blur', this._flush);
       this._clearInactivityFlushTimeout();
     },
 

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -336,13 +336,36 @@ function (chai, $, p, Metrics, AuthErrors, Environment, sinon, _, WindowMock, Te
         });
       });
 
-      describe('getFilteredData', function () {
+      describe('sends filtered data to the server on window unload', function () {
         beforeEach(function (done) {
           sandbox.stub(metrics, '_send', function () {
             done();
           });
           metrics.logEvent('qux');
           $(windowMock).trigger('unload');
+        });
+
+        it('calls send correctly', function () {
+          assert.isTrue(metrics._send.calledOnce);
+          assert.lengthOf(metrics._send.getCall(0).args, 2);
+          assert.equal(metrics._send.getCall(0).args[1], '/metrics');
+
+          var data = metrics._send.getCall(0).args[0];
+          assert.lengthOf(Object.keys(data), 22);
+          assert.lengthOf(data.events, 3);
+          assert.equal(data.events[0].type, 'foo');
+          assert.equal(data.events[1].type, 'bar');
+          assert.equal(data.events[2].type, 'qux');
+        });
+      });
+
+      describe('sends filtered data to the server on window blur', function () {
+        beforeEach(function (done) {
+          sandbox.stub(metrics, '_send', function () {
+            done();
+          });
+          metrics.logEvent('qux');
+          $(windowMock).trigger('blur');
         });
 
         it('calls send correctly', function () {


### PR DESCRIPTION
note by @shane-tomlinson, I rebased and updated the tests to use the same
convention as those just introduced by @philbooth for the window.unload
tests.

fixes #2577

re-opened from #2596