### PR TITLE
fix(metrics): postpone OAuth navigation until metrics are flushed

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -167,9 +167,17 @@ function (
             // give a bit of time to flush the error logs,
             // otherwise Safari Mobile redirects too quickly.
             self._window.setTimeout(function () {
-              //Something terrible happened. Let's bail.
-              var redirectTo = self._getErrorPage(err);
-              self._window.location.href = redirectTo;
+              if (self._metrics) {
+                self._metrics.flush().then(redirect);
+              } else {
+                redirect();
+              }
+
+              function redirect () {
+                //Something terrible happened. Let's bail.
+                var redirectTo = self._getErrorPage(err);
+                self._window.location.href = redirectTo;
+              }
             }, ERROR_REDIRECT_TIMEOUT);
           });
       });
@@ -438,7 +446,8 @@ function (
             relier: this._relier,
             assertionLibrary: this._assertionLibrary,
             oAuthClient: this._oAuthClient,
-            session: Session
+            session: Session,
+            metrics: this._metrics
           });
         } else {
           this._authenticationBroker = new BaseAuthenticationBroker({

--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -111,10 +111,6 @@ function (
 ) {
   'use strict';
 
-  // delay before redirecting to the error page to
-  // ensure metrics are reported to the backend.
-  var ERROR_REDIRECT_TIMEOUT = 1000;
-
   function Start(options) {
     options = options || {};
 
@@ -130,6 +126,9 @@ function (
   }
 
   Start.prototype = {
+    // delay before redirecting to the error page to
+    // ensure metrics are reported to the backend.
+    ERROR_REDIRECT_TIMEOUT_MS: 1000,
     startApp: function () {
       var self = this;
 
@@ -158,27 +157,18 @@ function (
           self._metrics.logError(err);
         }
 
-        // this extra promise is to ensure the message is printed
-        // to the console in Firefox before redirecting. Without
-        // the delay, the console message is lost, even with
-        // persistent logs enabled. See #2183
-        return p()
+        // give a bit of time to flush the Sentry error logs,
+        // otherwise Safari Mobile redirects too quickly.
+        return p().delay(self.ERROR_REDIRECT_TIMEOUT_MS)
           .then(function () {
-            // give a bit of time to flush the error logs,
-            // otherwise Safari Mobile redirects too quickly.
-            self._window.setTimeout(function () {
-              if (self._metrics) {
-                self._metrics.flush().then(redirect);
-              } else {
-                redirect();
-              }
-
-              function redirect () {
-                //Something terrible happened. Let's bail.
-                var redirectTo = self._getErrorPage(err);
-                self._window.location.href = redirectTo;
-              }
-            }, ERROR_REDIRECT_TIMEOUT);
+            if (self._metrics) {
+              return self._metrics.flush();
+            }
+          })
+          .then(function () {
+            //Something terrible happened. Let's bail.
+            var redirectTo = self._getErrorPage(err);
+            self._window.location.href = redirectTo;
           });
       });
     },

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -119,13 +119,15 @@ define([
 
     this._able = options.able;
     this._env = options.environment || new Environment(this._window);
+
+    this._lastAbLength = 0;
   }
 
   _.extend(Metrics.prototype, Backbone.Events, {
     ALLOWED_FIELDS: ALLOWED_FIELDS,
 
     init: function () {
-      this._flush = _.bind(this.flush, this);
+      this._flush = _.bind(this.flush, this, true);
       $(this._window).on('unload', this._flush);
       // iOS will not send events once the window is in the background,
       // meaning the `unload` handler is ineffective. Send events on blur
@@ -146,18 +148,22 @@ define([
     /**
      * Send the collected data to the backend.
      */
-    flush: function () {
+    flush: function (isPageUnloading) {
       // Inactivity timer is restarted when the next event/timer comes in.
       // This avoids sending empty result sets if the tab is
       // just sitting there open with no activity.
       this._clearInactivityFlushTimeout();
 
+      var self = this;
       var filteredData = this.getFilteredData();
 
-      var url = this._collector + '/metrics';
-      var self = this;
+      if (! this._isFlushRequired(filteredData)) {
+        return p();
+      }
 
-      return this._send(filteredData, url)
+      this._lastAbLength = filteredData.ab.length;
+
+      return this._send(filteredData, isPageUnloading)
         .then(function (sent) {
           if (sent) {
             self._speedTrap.events.clear();
@@ -166,6 +172,12 @@ define([
 
           return sent;
         });
+    },
+
+    _isFlushRequired: function (data) {
+      return data.events.length !== 0 ||
+        Object.keys(data.timers).length !== 0 ||
+        data.ab.length !== this._lastAbLength;
     },
 
     _clearInactivityFlushTimeout: function () {
@@ -240,22 +252,29 @@ define([
       return filteredData;
     },
 
-    _send: function (data, url) {
+    _send: function (data, isPageUnloading) {
       var self = this;
+      var url = this._collector + '/metrics';
       var payload = JSON.stringify(data);
 
       if (this._env.hasSendBeacon()) {
+        // Always use sendBeacon if it is available because:
+        //   1. it works asynchronously, even on unload.
+        //   2. user agents SHOULD make "multiple attempts to transmit the
+        //      data in presence of transient network or server errors".
         return p().then(function () {
           return self._window.navigator.sendBeacon(url, payload);
         });
       }
 
+      // XHR is a fallback option because synchronous XHR has been deprecated,
+      // but we must call it synchronously in the unload case.
       return this._xhr.ajax({
-        async: false,
+        async: ! isPageUnloading,
         type: 'POST',
         url: url,
         contentType: 'application/json',
-        data: JSON.stringify(data)
+        data: payload
       })
       // Boolean return values imitate the behaviour of sendBeacon
       .then(function () {

--- a/app/scripts/models/auth_brokers/redirect.js
+++ b/app/scripts/models/auth_brokers/redirect.js
@@ -14,9 +14,17 @@ define([
 
   var RedirectAuthenticationBroker = OAuthAuthenticationBroker.extend({
     type: 'redirect',
+    initialize: function (options) {
+      options = options || {};
+
+      this._metrics = options.metrics;
+
+      return OAuthAuthenticationBroker.prototype.initialize.call(this, options);
+    },
+
     sendOAuthResultToRelier: function (result) {
       var win = this.window;
-      return p()
+      return this._metrics.flush()
         .then(function () {
           var extraParams = {};
           if (result.error) {

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -50,7 +50,10 @@ function (Cocktail, FormView, Template, Url, Constants, ServiceMixin,
     },
 
     submit: function () {
-      this.window.location.href = this.relier.get('redirectUri');
+      var self = this;
+      return this.metrics.flush().then(function () {
+        self.window.location.href = self.relier.get('redirectUri');
+      });
     },
 
     /**

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -104,8 +104,10 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
 
         return appStart.startApp()
           .then(function () {
+            sinon.spy(appStart._metrics, 'flush');
             setTimeout(function () {
               assert.equal(windowMock.location.href, Constants.INTERNAL_ERROR_PAGE);
+              assert.equal(appStart._metrics.flush.callCount, 1);
               done();
             }, 20);
           });

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -93,23 +93,21 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
           });
       });
 
-      it('redirects to the `INTERNAL_ERROR_PAGE` if an error occurs', function (done) {
+      it('redirects to the `INTERNAL_ERROR_PAGE` if an error occurs', function () {
         sinon.stub(appStart, 'allResourcesReady', function () {
+          sinon.stub(appStart._metrics, 'flush', function () {
+            return p();
+          });
+
           return p.reject(new Error('boom!'));
         });
 
-        sinon.stub(windowMock, 'setTimeout', function (callback) {
-          setTimeout(callback, 10);
-        });
+        appStart.ERROR_REDIRECT_TIMEOUT_MS = 10;
 
         return appStart.startApp()
           .then(function () {
-            sinon.spy(appStart._metrics, 'flush');
-            setTimeout(function () {
-              assert.equal(windowMock.location.href, Constants.INTERNAL_ERROR_PAGE);
-              assert.equal(appStart._metrics.flush.callCount, 1);
-              done();
-            }, 20);
+            assert.equal(windowMock.location.href, Constants.INTERNAL_ERROR_PAGE);
+            assert.equal(appStart._metrics.flush.callCount, 1);
           });
       });
 

--- a/app/tests/spec/models/auth_brokers/redirect.js
+++ b/app/tests/spec/models/auth_brokers/redirect.js
@@ -26,6 +26,7 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
     var windowMock;
     var user;
     var account;
+    var metrics;
 
     beforeEach(function () {
       windowMock = new WindowMock();
@@ -35,10 +36,13 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
         sessionToken: 'abc123'
       });
 
+      metrics = { flush: sinon.spy(p) };
+
       broker = new RedirectAuthenticationBroker({
         relier: relier,
         window: windowMock,
-        session: Session
+        session: Session,
+        metrics: metrics
       });
 
       sinon.stub(broker, 'finishOAuthFlow', function () {
@@ -53,6 +57,8 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
             redirect: REDIRECT_TO
           })
           .then(function () {
+            assert.isTrue(metrics.flush.calledOnce);
+            assert.lengthOf(metrics.flush.getCall(0).args, 0);
             assert.equal(windowMock.location.href, REDIRECT_TO);
           });
         });
@@ -65,6 +71,8 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
             error: 'error'
           })
           .then(function () {
+            assert.isTrue(metrics.flush.calledOnce);
+            assert.lengthOf(metrics.flush.getCall(0).args, 0);
             assert.include(windowMock.location.href, REDIRECT_TO);
             assert.include(windowMock.location.href, 'error=error');
           });
@@ -79,6 +87,8 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
             action: action
           })
           .then(function () {
+            assert.isTrue(metrics.flush.calledOnce);
+            assert.lengthOf(metrics.flush.getCall(0).args, 0);
             assert.include(windowMock.location.href, REDIRECT_TO);
             assert.include(windowMock.location.href, 'action=' + action);
           });
@@ -92,6 +102,8 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
             error: 'error'
           })
           .then(function () {
+            assert.isTrue(metrics.flush.calledOnce);
+            assert.lengthOf(metrics.flush.getCall(0).args, 0);
             assert.include(windowMock.location.href, REDIRECT_TO);
             assert.include(windowMock.location.href, 'test=param');
             assert.include(windowMock.location.href, 'error=error');


### PR DESCRIPTION
Fixes #2493.

This change performs an async metrics flush before redirecting during the OAuth flow. The `unload` (and, when it's merged, `blur`) flushes are unaffected, still being flushed synchronously unless `sendBeacon` is available.