### PR TITLE
feat(client): sign in/up messaging for migrating users

### DIFF
--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -23,10 +23,6 @@ function () {
   t('Edit profile');
   t('Name');
 
-  // Needed for PR #2823, issue #2786
-  t('Migrate your sync data by signing in to your Firefox&nbsp;Account.');
-  t('Migrate your sync data by creating a new Firefox&nbsp;Account.');
-
   /**
    * Replace instances of %s and %(name)s with their corresponding values in
    * the context

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -19,6 +19,9 @@
     {{^error}}
       <div class="error"></div>
       <div class="success"></div>
+        {{#isMigration}}
+          <div class="info nudge">{{#t}}Migrate your sync data by signing in to your Firefox&nbsp;Account.{{/t}}</div>
+        {{/isMigration}}
 
       {{#suggestedAccount}}
           <div class="avatar-wrapper avatar-view">

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -19,6 +19,9 @@
     {{^error}}
     <div class="error"></div>
     <div class="success"></div>
+    {{#isMigration}}
+      <div class="info nudge">{{#t}}Migrate your sync data by creating a new Firefox&nbsp;Account.{{/t}}</div>
+    {{/isMigration}}
 
     <form novalidate>
       <div class="input-row">

--- a/app/scripts/views/mixins/migration-mixin.js
+++ b/app/scripts/views/mixins/migration-mixin.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Helper functions for views with migration-specific behaviour.
+// Meant to be mixed into views.
+
+define([], function () {
+  'use strict';
+
+  return {
+    isMigration: function () {
+      return this.relier.has('migration');
+    }
+  };
+});

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -15,12 +15,13 @@ define([
   'views/mixins/service-mixin',
   'views/mixins/avatar-mixin',
   'views/mixins/account-locked-mixin',
+  'views/mixins/migration-mixin',
   'views/decorators/allow_only_one_submit',
   'views/decorators/progress_indicator'
 ],
 function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
       AuthErrors, PasswordMixin, ResumeTokenMixin, ServiceMixin, AvatarMixin,
-      AccountLockedMixin, allowOnlyOneSubmit, showProgressIndicator) {
+      AccountLockedMixin, MigrationMixin, allowOnlyOneSubmit, showProgressIndicator) {
   'use strict';
 
   var t = BaseView.t;
@@ -67,7 +68,8 @@ function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
         suggestedAccount: hasSuggestedAccount,
         chooserAskForPassword: this._suggestedAccountAskPassword(suggestedAccount),
         password: this._formPrefill.get('password'),
-        error: this.error
+        error: this.error,
+        isMigration: this.isMigration()
       };
     },
 
@@ -295,6 +297,7 @@ function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
     View,
     AccountLockedMixin,
     AvatarMixin,
+    MigrationMixin,
     PasswordMixin,
     ResumeTokenMixin,
     ServiceMixin

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -16,10 +16,12 @@ define([
   'views/mixins/service-mixin',
   'views/mixins/checkbox-mixin',
   'views/mixins/resume-token-mixin',
+  'views/mixins/migration-mixin',
   'views/coppa/coppa-date-picker'
 ],
 function (Cocktail, _, p, BaseView, FormView, Template, AuthErrors, mailcheck,
-      Url, PasswordMixin, ServiceMixin, CheckboxMixin, ResumeTokenMixin, CoppaDatePicker) {
+      Url, PasswordMixin, ServiceMixin, CheckboxMixin, ResumeTokenMixin,
+      MigrationMixin, CoppaDatePicker) {
   'use strict';
 
   var t = BaseView.t;
@@ -149,7 +151,8 @@ function (Cocktail, _, p, BaseView, FormView, Template, AuthErrors, mailcheck,
         shouldFocusEmail: autofocusEl === 'email',
         shouldFocusPassword: autofocusEl === 'password',
         error: this.error,
-        isEmailOptInVisible: this._isEmailOptInEnabled()
+        isEmailOptInVisible: this._isEmailOptInEnabled(),
+        isMigration: this.isMigration()
       };
     },
 
@@ -354,6 +357,7 @@ function (Cocktail, _, p, BaseView, FormView, Template, AuthErrors, mailcheck,
   Cocktail.mixin(
     View,
     CheckboxMixin,
+    MigrationMixin,
     PasswordMixin,
     ResumeTokenMixin,
     ServiceMixin

--- a/app/styles/_state.scss
+++ b/app/styles/_state.scss
@@ -1,5 +1,6 @@
 .error,
-.success {
+.success,
+.info {
   border-radius: $small-border-radius;
   color: $message-text-color;
   display: none;
@@ -16,9 +17,10 @@
   a {
     color: $message-text-color;
   }
-  /*Push the error message down to avoid being too close to the header*/
+
+  /*Pull the message up to bring it closer to the header*/
   &.nudge {
-    top: -5px;
+    top: -10px;
   }
 }
 
@@ -38,6 +40,11 @@
 .success {
   background: $success-background-color;
   display: none;
+}
+
+.info {
+  background: $info-background-color;
+  display: block;
 }
 
 // complete is like success, but without the associated styles.

--- a/app/tests/spec/views/mixins/migration-mixin.js
+++ b/app/tests/spec/views/mixins/migration-mixin.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'sinon',
+  'views/mixins/migration-mixin',
+], function (chai, sinon, MigrationMixin) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  describe('views/mixins/migration-mixin', function () {
+    it('exports correct interface', function () {
+      assert.lengthOf(Object.keys(MigrationMixin), 1);
+      assert.isFunction(MigrationMixin.isMigration);
+    });
+
+    describe('call isMigration', function () {
+      var relier, result;
+
+      beforeEach(function () {
+        relier = {
+          has: sinon.spy(function () {
+            return 'foo';
+          })
+        };
+        result = MigrationMixin.isMigration.call({ relier: relier });
+      });
+
+      it('calls this.relier.has correctly', function () {
+        assert.equal(relier.has.callCount, 1);
+
+        var args = relier.has.getCall(0).args;
+        assert.lengthOf(args, 1);
+        assert.equal(args[0], 'migration');
+      });
+
+      it('returns this.relier.has result', function () {
+        assert.equal(result, 'foo');
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -146,6 +146,32 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
               assert.equal(view.$('[type=email]').val(), 'testuser@testuser.com');
             });
       });
+
+      it('displays a message if isMigration returns true', function () {
+        initView();
+        sinon.stub(view, 'isMigration', function (arg) {
+          return true;
+        });
+
+        return view.render()
+          .then(function () {
+            assert.equal(view.$('.info.nudge').html(), 'Migrate your sync data by signing in to your Firefox&nbsp;Account.');
+            view.isMigration.restore();
+          });
+      });
+
+      it('does not display a message if isMigration returns false', function () {
+        initView();
+        sinon.stub(view, 'isMigration', function (arg) {
+          return false;
+        });
+
+        return view.render()
+          .then(function () {
+            assert.lengthOf(view.$('.info.nudge'), 0);
+            view.isMigration.restore();
+          });
+      });
     });
 
     describe('isValid', function () {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -188,6 +188,30 @@ function (chai, $, sinon, p, View, Coppa, Session, AuthErrors, Metrics,
             });
         });
       });
+
+      it('displays a message if isMigration returns true', function () {
+        sinon.stub(view, 'isMigration', function (arg) {
+          return true;
+        });
+
+        return view.render()
+          .then(function () {
+            assert.equal(view.$('.info.nudge').html(), 'Migrate your sync data by creating a new Firefox&nbsp;Account.');
+            view.isMigration.restore();
+          });
+      });
+
+      it('does not display a message if isMigration returns false', function () {
+        sinon.stub(view, 'isMigration', function (arg) {
+          return false;
+        });
+
+        return view.render()
+          .then(function () {
+            assert.lengthOf(view.$('.info.nudge'), 0);
+            view.isMigration.restore();
+          });
+      });
     });
 
     describe('afterVisible', function () {

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -104,6 +104,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/account-locked-mixin',
     '../tests/spec/views/mixins/checkbox-mixin',
     '../tests/spec/views/mixins/loading-mixin',
+    '../tests/spec/views/mixins/migration-mixin',
     '../tests/spec/models/unique-user-id',
     '../tests/spec/models/user',
     '../tests/spec/models/account',

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -15,6 +15,7 @@ define([
         TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
+  var PAGE_URL_WITH_MIGRATION = PAGE_URL + '&migration=foo';
 
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
 
@@ -80,7 +81,6 @@ define([
         });
     },
 
-
     'unverified': function () {
       var self = this;
 
@@ -102,6 +102,16 @@ define([
         .then(function () {
           return testIsBrowserNotifiedOfLogin(self, email);
         });
+    },
+
+    'as a migrating user': function () {
+      return this.remote
+        .get(require.toUrl(PAGE_URL_WITH_MIGRATION))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+        .execute(listenForFxaCommands)
+        .findByCssSelector('.info.nudge')
+        .isDisplayed()
+        .end();
     }
   });
 });

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -16,6 +16,7 @@ define([
         FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_desktop_v1&service=sync';
+  var PAGE_URL_WITH_MIGRATION = PAGE_URL + '&migration=wibble';
 
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
 
@@ -308,6 +309,16 @@ define([
           .then(function (checkedAttribute) {
             assert.equal(checkedAttribute, 'checked');
           })
+        .end();
+    },
+
+    'as a migrating user': function () {
+      return this.remote
+        .get(require.toUrl(PAGE_URL_WITH_MIGRATION))
+        .setFindTimeout(intern.config.pageLoadTimeout)
+        .execute(listenForFxaCommands)
+        .findByCssSelector('.info.nudge')
+        .isDisplayed()
         .end();
     }
   });


### PR DESCRIPTION
**Hopefully** fixes #2786, adding messages to the sign-in and sign-up views for migrating users.

Based on [this documentation](https://github.com/mozilla/fxa-content-server/blob/master/docs/query-params.md#migration), I predicated the new messages on the presence of a `migration` query parameter. I was unsure how to initiate a genuine migration scenario on my local machine though, so I've only tested it manually, by adding the query parameter to the URL myself. Hence I don't actually know if this change works end-to-end. How can I test that out?

It's also the first time I've touched the CSS, so I was really unsure about introducing the `info` class to `app/styles/_state.scss`. Have I missed some pre-existing class that I should use instead?
