### PR TITLE
chore(lint): Remove the eslint complexity checks

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -396,7 +396,6 @@ function (
     },
 
     initializeAuthenticationBroker: function () {
-      /*eslint complexity: [2, 8] */
       if (! this._authenticationBroker) {
         if (this._isFirstRun()) {
           this._authenticationBroker = new FirstRunAuthenticationBroker({

--- a/app/scripts/lib/cropper.js
+++ b/app/scripts/lib/cropper.js
@@ -30,8 +30,6 @@ function (_) {
    * }
    */
   function Cropper (options) {
-
-    /*eslint complexity: [2, 12] */
     this.displayLength = options.displayLength || DEFAULT_DISPLAY_LENGTH;
     this.exportLength = options.exportLength || DEFAULT_EXPORT_LENGTH;
 

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -71,7 +71,6 @@ define([
   }
 
   function Metrics (options) {
-    /*eslint complexity: [2, 27] */
     options = options || {};
 
     // by default, send the metrics to the content server.

--- a/app/scripts/lib/screen-info.js
+++ b/app/scripts/lib/screen-info.js
@@ -11,7 +11,6 @@ define([
   var NOT_REPORTED_VALUE = 'none';
 
   function ScreenInfo(win) {
-    /*eslint complexity: [2, 8] */
     var documentElement = win.document.documentElement || {};
     var screen = win.screen || {};
 

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -295,7 +295,6 @@ function (
     },
 
     onAnchorClick: function (event) {
-      /*eslint complexity: [2, 7] */
       // if someone killed this event, or the user is holding a modifier
       // key, ignore the event.
       if (event.isDefaultPrevented() ||

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -85,7 +85,6 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
 
   var BaseView = Backbone.View.extend({
     constructor: function (options) {
-      /*eslint complexity: [2, 10] */
       options = options || {};
 
       this.subviews = [];

--- a/server/lib/statsd-collector.js
+++ b/server/lib/statsd-collector.js
@@ -27,7 +27,6 @@ function _normalizeTag(item) {
 }
 
 function getGenericTags(body) {
-  /*eslint complexity: [2, 8] */
   // see more about tags here: http://docs.datadoghq.com/guides/metrics/
   var tags = [
     'campaign:' + body.campaign,

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -11,7 +11,6 @@ define([
   './tools/firefox_profile'
 ],
 function (intern, topic, firefoxProfile) {
-  /*eslint complexity: [2, 11] */
   var args = intern.args;
   var fxaAuthRoot = args.fxaAuthRoot || 'http://127.0.0.1:9000/v1';
   var fxaContentRoot = args.fxaContentRoot || 'http://127.0.0.1:3030/';


### PR DESCRIPTION
The **eslint-config-fxa** module was already updated, but this just finishes the cleanup.

Fixes #2789