### PR TITLE
[DO-NOT-MERGE]: refactor(client): Convert to CommonJS require statements.

### DIFF
--- a/app/scripts/lib/able.js
+++ b/app/scripts/lib/able.js
@@ -11,8 +11,9 @@
  * will always return `undefined` and `report` will return an empty array.
  */
 
-define([], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   function AbleWrapper() {
     // nothing to do here.

--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -15,101 +15,54 @@
  * 6) Start the app if cookies are enabled.
  */
 
-define([
-  'underscore',
-  'backbone',
-  'lib/promise',
-  'router',
-  'raven',
-  'lib/translator',
-  'lib/session',
-  'lib/url',
-  'lib/config-loader',
-  'lib/screen-info',
-  'lib/metrics',
-  'lib/sentry',
-  'lib/storage-metrics',
-  'lib/fxa-client',
-  'lib/assertion',
-  'lib/constants',
-  'lib/oauth-client',
-  'lib/oauth-errors',
-  'lib/auth-errors',
-  'lib/profile-client',
-  'lib/marketing-email-client',
-  'lib/channels/inter-tab',
-  'lib/channels/iframe',
-  'lib/channels/null',
-  'lib/channels/web',
-  'lib/storage',
-  'lib/able',
-  'lib/environment',
-  'lib/origin-check',
-  'lib/height-observer',
-  'models/reliers/relier',
-  'models/reliers/oauth',
-  'models/reliers/fx-desktop',
-  'models/auth_brokers/base',
-  'models/auth_brokers/fx-desktop',
-  'models/auth_brokers/fx-desktop-v2',
-  'models/auth_brokers/first-run',
-  'models/auth_brokers/web-channel',
-  'models/auth_brokers/redirect',
-  'models/auth_brokers/iframe',
-  'models/unique-user-id',
-  'models/user',
-  'models/form-prefill',
-  'models/notifications',
-  'views/close_button'
-],
-function (
-  _,
-  Backbone,
-  p,
-  Router,
-  Raven,
-  Translator,
-  Session,
-  Url,
-  ConfigLoader,
-  ScreenInfo,
-  Metrics,
-  SentryMetrics,
-  StorageMetrics,
-  FxaClient,
-  Assertion,
-  Constants,
-  OAuthClient,
-  OAuthErrors,
-  AuthErrors,
-  ProfileClient,
-  MarketingEmailClient,
-  InterTabChannel,
-  IframeChannel,
-  NullChannel,
-  WebChannel,
-  Storage,
-  Able,
-  Environment,
-  OriginCheck,
-  HeightObserver,
-  Relier,
-  OAuthRelier,
-  FxDesktopRelier,
-  BaseAuthenticationBroker,
-  FxDesktopV1AuthenticationBroker,
-  FxDesktopV2AuthenticationBroker,
-  FirstRunAuthenticationBroker,
-  WebChannelAuthenticationBroker,
-  RedirectAuthenticationBroker,
-  IframeAuthenticationBroker,
-  UniqueUserId,
-  User,
-  FormPrefill,
-  Notifications,
-  CloseButtonView
-) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Able = require('lib/able');
+  var Assertion = require('lib/assertion');
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
+  var BaseAuthenticationBroker = require('models/auth_brokers/base');
+  var CloseButtonView = require('views/close_button');
+  var ConfigLoader = require('lib/config-loader');
+  var Constants = require('lib/constants');
+  var Environment = require('lib/environment');
+  var FirstRunAuthenticationBroker = require('models/auth_brokers/first-run');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var FxDesktopRelier = require('models/reliers/fx-desktop');
+  var FxDesktopV1AuthenticationBroker = require('models/auth_brokers/fx-desktop');
+  var FxDesktopV2AuthenticationBroker = require('models/auth_brokers/fx-desktop-v2');
+  var HeightObserver = require('lib/height-observer');
+  var IframeAuthenticationBroker = require('models/auth_brokers/iframe');
+  var IframeChannel = require('lib/channels/iframe');
+  var InterTabChannel = require('lib/channels/inter-tab');
+  var MarketingEmailClient = require('lib/marketing-email-client');
+  var Metrics = require('lib/metrics');
+  var Notifications = require('models/notifications');
+  var NullChannel = require('lib/channels/null');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthErrors = require('lib/oauth-errors');
+  var OAuthRelier = require('models/reliers/oauth');
+  var OriginCheck = require('lib/origin-check');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var Raven = require('raven');
+  var RedirectAuthenticationBroker = require('models/auth_brokers/redirect');
+  var Relier = require('models/reliers/relier');
+  var Router = require('router');
+  var ScreenInfo = require('lib/screen-info');
+  var SentryMetrics = require('lib/sentry');
+  var Session = require('lib/session');
+  var Storage = require('lib/storage');
+  var StorageMetrics = require('lib/storage-metrics');
+  var Translator = require('lib/translator');
+  var UniqueUserId = require('models/unique-user-id');
+  var Url = require('lib/url');
+  var User = require('models/user');
+  var WebChannel = require('lib/channels/web');
+  var WebChannelAuthenticationBroker = require('models/auth_brokers/web-channel');
 
   // delay before redirecting to the error page to
   // ensure metrics are reported to the backend.

--- a/app/scripts/lib/assertion.js
+++ b/app/scripts/lib/assertion.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/promise',
-  'vendor/jwcrypto'
-],
-function (P, jwcrypto) {
+define(function(require, exports, module) {
   'use strict';
+
+  var jwcrypto = require('vendor/jwcrypto');
+  var P = require('lib/promise');
 
   var CERT_DURATION_MS = 1000 * 60 * 60 * 6; // 6hrs
   var ASSERTION_DURATION_MS = 1000 * 3600 * 24 * 365 * 25; // 25 years

--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -4,12 +4,11 @@
 
 // provides functions to work with errors returned by the auth server.
 
-define([
-  'underscore',
-  'lib/errors'
-],
-function (_, Errors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Errors = require('lib/errors');
 
   var t = function (msg) {
     return msg;

--- a/app/scripts/lib/base64url.js
+++ b/app/scripts/lib/base64url.js
@@ -9,10 +9,10 @@
  * variant, which is needed for JWTs.
  */
 
-define([
-  'sjcl'
-], function (sjcl) {
+define(function(require, exports, module) {
   'use strict';
+
+  var sjcl = require('sjcl');
 
   return {
 

--- a/app/scripts/lib/channels/base.js
+++ b/app/scripts/lib/channels/base.js
@@ -4,12 +4,11 @@
 
 // A channel interface.
 
-define([
-  'underscore',
-  'backbone'
-],
-function (_, Backbone) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   function BaseChannel() {
     // nothing to do.

--- a/app/scripts/lib/channels/duplex.js
+++ b/app/scripts/lib/channels/duplex.js
@@ -10,12 +10,12 @@
  * receive messages via a postMessage (Fx Desktop Sync v1).
  */
 
-define([
-  'underscore',
-  'lib/promise',
-  'lib/channels/base'
-], function (_, p, BaseChannel) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var BaseChannel = require('lib/channels/base');
+  var p = require('lib/promise');
 
   var DEFAULT_SEND_TIMEOUT_LENGTH_MS = 90 * 1000;
 

--- a/app/scripts/lib/channels/fx-desktop-v1.js
+++ b/app/scripts/lib/channels/fx-desktop-v1.js
@@ -6,13 +6,13 @@
 // a CustomEvent sender and a postMessage receiver. This is
 // the v1 way of communicating with the browser for Sync.
 
-define([
-  'underscore',
-  'lib/channels/duplex',
-  'lib/channels/senders/fx-desktop-v1',
-  'lib/channels/receivers/postmessage'
-], function (_, DuplexChannel, FxDesktopV1Sender, PostMessageReceiver) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var DuplexChannel = require('lib/channels/duplex');
+  var FxDesktopV1Sender = require('lib/channels/senders/fx-desktop-v1');
+  var PostMessageReceiver = require('lib/channels/receivers/postmessage');
 
   function FxDesktopV1Channel() {
   }

--- a/app/scripts/lib/channels/iframe.js
+++ b/app/scripts/lib/channels/iframe.js
@@ -9,13 +9,13 @@
  * on the URL.
  */
 
-define([
-  'underscore',
-  'lib/channels/duplex',
-  'lib/channels/receivers/postmessage',
-  'lib/channels/senders/postmessage'
-], function (_, DuplexChannel, PostMessageReceiver, PostMessageSender) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var DuplexChannel = require('lib/channels/duplex');
+  var PostMessageReceiver = require('lib/channels/receivers/postmessage');
+  var PostMessageSender = require('lib/channels/senders/postmessage');
 
   function IFrameChannel() {
     // constructor, nothing to do.

--- a/app/scripts/lib/channels/inter-tab.js
+++ b/app/scripts/lib/channels/inter-tab.js
@@ -7,10 +7,10 @@
  * tabs of the same browser. It uses localStorage to communicate.
  */
 
-define([
-  'crosstab'
-], function (crosstab) {
+define(function(require, exports, module) {
   'use strict';
+
+  var crosstab = require('crosstab');
 
   function InterTabChannel(options) {
     options = options || {};

--- a/app/scripts/lib/channels/null.js
+++ b/app/scripts/lib/channels/null.js
@@ -4,12 +4,11 @@
 
 // A shell of a channel. Doesn't do anything yet, but is a useful standin.
 
-define([
-  'underscore',
-  'lib/channels/base'
-],
-function (_, BaseChannel) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var BaseChannel = require('lib/channels/base');
 
   function NullChannel() {
     // nothing to do.

--- a/app/scripts/lib/channels/receivers/null.js
+++ b/app/scripts/lib/channels/receivers/null.js
@@ -6,11 +6,11 @@
  * A null receiver. Doesn't actually receive any messages
  */
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   function NullReceiver() {
     // nothing to do

--- a/app/scripts/lib/channels/receivers/postmessage.js
+++ b/app/scripts/lib/channels/receivers/postmessage.js
@@ -6,12 +6,12 @@
  * Receive a message over postMessage.
  */
 
-define([
-  'backbone',
-  'underscore',
-  'lib/auth-errors'
-], function (Backbone, _, AuthErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
 
 
   function PostMessageReceiver() {

--- a/app/scripts/lib/channels/receivers/web-channel.js
+++ b/app/scripts/lib/channels/receivers/web-channel.js
@@ -8,11 +8,11 @@
  */
 
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   function WebChannelReceiver() {
     // nothing to do

--- a/app/scripts/lib/channels/senders/fx-desktop-v1.js
+++ b/app/scripts/lib/channels/senders/fx-desktop-v1.js
@@ -6,10 +6,10 @@
  * Send a message to the browser using a FirefoxAccountsCommand.
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   function FxDesktopV1Sender() {
     // nothing to do here.

--- a/app/scripts/lib/channels/senders/null.js
+++ b/app/scripts/lib/channels/senders/null.js
@@ -6,10 +6,10 @@
  * A null sender. Sends messages nowhere.
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   function NullSender() {
     // nothing to do here.

--- a/app/scripts/lib/channels/senders/postmessage.js
+++ b/app/scripts/lib/channels/senders/postmessage.js
@@ -20,10 +20,10 @@
  * `data` is an object with any extra data.
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   function PostMessageSender() {
     // nothing to do here.

--- a/app/scripts/lib/channels/senders/web-channel.js
+++ b/app/scripts/lib/channels/senders/web-channel.js
@@ -7,10 +7,10 @@
  * https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   function WebChannelSender() {
     // nothing to do here.

--- a/app/scripts/lib/channels/web.js
+++ b/app/scripts/lib/channels/web.js
@@ -6,13 +6,13 @@
 // https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
 // https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/FxAccountsOAuthClient.jsm
 
-define([
-  'underscore',
-  'lib/channels/duplex',
-  'lib/channels/senders/web-channel',
-  'lib/channels/receivers/web-channel'
-], function (_, DuplexChannel, WebChannelSender, WebChannelReceiver) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var DuplexChannel = require('lib/channels/duplex');
+  var WebChannelReceiver = require('lib/channels/receivers/web-channel');
+  var WebChannelSender = require('lib/channels/senders/web-channel');
 
   function WebChannel(id) {
     if (! id) {

--- a/app/scripts/lib/config-loader.js
+++ b/app/scripts/lib/config-loader.js
@@ -4,15 +4,11 @@
 
 // fetch config from the backend and provide some helper functions.
 
-define([
-  'lib/xhr',
-  'lib/promise'
-],
-function (
-  xhr,
-  p
-) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
+  var xhr = require('lib/xhr');
 
   function ConfigLoader() {
   }

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   return {
     // All browsers have a max length of URI that they can handle.

--- a/app/scripts/lib/cropper.js
+++ b/app/scripts/lib/cropper.js
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore'
-],
-function (_) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
 
   var DEFAULT_DISPLAY_LENGTH = 240;
   var DEFAULT_EXPORT_LENGTH = 480;

--- a/app/scripts/lib/ephemeral-messages.js
+++ b/app/scripts/lib/ephemeral-messages.js
@@ -5,10 +5,10 @@
 // an ephemeral messages model. Ephemeral messages are allowed
 // a single `get` and no more.
 
-define([
-  'backbone'
-], function (Backbone) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
 
   var Model = Backbone.Model.extend({
     get: function (attribute) {

--- a/app/scripts/lib/errors.js
+++ b/app/scripts/lib/errors.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore',
-  'lib/strings'
-], function (_, Strings) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Strings = require('lib/strings');
 
   return {
     /**

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -6,15 +6,14 @@
 // and to allow us to develop to features that are not yet present in the real
 // client.
 
-define([
-  'fxaClient',
-  'jquery',
-  'lib/promise',
-  'lib/session',
-  'lib/auth-errors'
-],
-function (FxaClient, $, p, Session, AuthErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var FxaClient = require('fxaClient');
+  var p = require('lib/promise');
+  var Session = require('lib/session');
 
   function trim(str) {
     return $.trim(str);

--- a/app/scripts/lib/height-observer.js
+++ b/app/scripts/lib/height-observer.js
@@ -7,11 +7,11 @@
  * if the element's height changes.
  */
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   function HeightObserver (options) {
     options = options || {};

--- a/app/scripts/lib/hkdf.js
+++ b/app/scripts/lib/hkdf.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'sjcl',
-  'lib/promise'
-],
-function (sjcl, p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
+  var sjcl = require('sjcl');
 
   /**
    * hkdf - The HMAC-based Key Derivation Function

--- a/app/scripts/lib/image-loader.js
+++ b/app/scripts/lib/image-loader.js
@@ -4,9 +4,11 @@
 
 // A utility for pre-loading images
 
-define(['underscore', 'lib/promise'],
-function (_, p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var p = require('lib/promise');
 
   /**
    * Returns true if given "uri" has HTTP or HTTPS scheme

--- a/app/scripts/lib/mailcheck.js
+++ b/app/scripts/lib/mailcheck.js
@@ -4,13 +4,11 @@
 
 // A ux utility to suggest correct spelling of email domains
 
-/* exceptsPaths: mailcheck */
-define([
-  'views/tooltip',
-  'mailcheck'
-],
-function (Tooltip) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Tooltip = require('views/tooltip');
+  var mailcheck = require('mailcheck'); //eslint-disable-line no-unused-vars
 
   var DOMAINS = [];
   var SECOND_LEVEL_DOMAINS = [ // domains that get suggested, i.e gnail => gmail

--- a/app/scripts/lib/marketing-email-client.js
+++ b/app/scripts/lib/marketing-email-client.js
@@ -6,12 +6,12 @@
  * A client to talk to the basket marketing email server
  */
 
-define([
-  'lib/constants',
-  'lib/xhr',
-  'lib/marketing-email-errors'
-], function (Constants, xhr, MarketingEmailErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Constants = require('lib/constants');
+  var MarketingEmailErrors = require('lib/marketing-email-errors');
+  var xhr = require('lib/xhr');
 
   function MarketingEmailClient(options) {
     options = options || {};

--- a/app/scripts/lib/marketing-email-errors.js
+++ b/app/scripts/lib/marketing-email-errors.js
@@ -4,12 +4,11 @@
 
 // provides functions to work with errors returned by the auth server.
 
-define([
-  'underscore',
-  'lib/errors'
-],
-function (_, Errors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Errors = require('lib/errors');
 
   var t = function (msg) {
     return msg;

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -14,17 +14,17 @@
  * but can also be sent by calling metrics.flush();
  */
 
-define([
-  'underscore',
-  'backbone',
-  'jquery',
-  'speedTrap',
-  'lib/xhr',
-  'lib/strings',
-  'lib/environment',
-  'lib/promise'
-], function (_, Backbone, $, speedTrap, xhr, Strings, Environment, p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var Environment = require('lib/environment');
+  var p = require('lib/promise');
+  var speedTrap = require('speedTrap');
+  var Strings = require('lib/strings');
+  var xhr = require('lib/xhr');
 
   // Speed trap is a singleton, convert it
   // to an instantiable function.

--- a/app/scripts/lib/null-metrics.js
+++ b/app/scripts/lib/null-metrics.js
@@ -7,12 +7,12 @@
  * or for unit tests.
  */
 
-define([
-  'underscore',
-  'lib/promise',
-  'lib/metrics'
-], function (_, p, Metrics) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
 
   function NullMetrics () {
     // do nothing

--- a/app/scripts/lib/null-storage.js
+++ b/app/scripts/lib/null-storage.js
@@ -5,9 +5,9 @@
 // This is a memory store that's api compatible with localStorage/sessionStorage.
 // It's used for testing lib/storage.
 
-define([
-], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   function NullStorage () {
     this._storage = {};

--- a/app/scripts/lib/oauth-client.js
+++ b/app/scripts/lib/oauth-client.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/xhr',
-  'lib/oauth-errors'
-],
-function (xhr, OAuthErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var OAuthErrors = require('lib/oauth-errors');
+  var xhr = require('lib/xhr');
 
   var GET_CLIENT = '/v1/client/';
   var GET_CODE = '/v1/authorization';

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -4,13 +4,12 @@
 
 // provides functions to work with errors returned by the auth server.
 
-define([
-  'underscore',
-  'lib/errors',
-  'lib/strings'
-],
-function (_, Errors, Strings) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Errors = require('lib/errors');
+  var Strings = require('lib/strings');
 
   var t = function (msg) {
     return msg;

--- a/app/scripts/lib/origin-check.js
+++ b/app/scripts/lib/origin-check.js
@@ -23,11 +23,11 @@
  * is found after a short period, return `null`.
  */
 
-define([
-  'lib/promise',
-  'lib/channels/iframe'
-], function (p, IFrameChannel) {
+define(function(require, exports, module) {
   'use strict';
+
+  var IFrameChannel = require('lib/channels/iframe');
+  var p = require('lib/promise');
 
   var RESPONSE_TIMEOUT_MS = 100;
 

--- a/app/scripts/lib/profile-client.js
+++ b/app/scripts/lib/profile-client.js
@@ -4,12 +4,11 @@
 
 // This module handles communication with the fxa-profile-server.
 
-define([
-  'lib/xhr',
-  'lib/profile-errors'
-],
-function (xhr, ProfileErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var ProfileErrors = require('lib/profile-errors');
+  var xhr = require('lib/xhr');
 
   function ProfileClient(options) {
     options = options || {};

--- a/app/scripts/lib/profile-errors.js
+++ b/app/scripts/lib/profile-errors.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore',
-  'lib/errors'
-], function (_, Errors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Errors = require('lib/errors');
 
   var t = function (msg) {
     return msg;

--- a/app/scripts/lib/promise.js
+++ b/app/scripts/lib/promise.js
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // monkey patch p to be able to convert jQuery XHR promises to our promises.
-define([
-  'p-promise'
-], function (p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('p-promise');
 
   // for more background, read
   // https://github.com/kriskowal/q/wiki/Coming-from-jQuery

--- a/app/scripts/lib/relier-keys.js
+++ b/app/scripts/lib/relier-keys.js
@@ -6,14 +6,14 @@
  * Derive relier-specific encryption keys from account master keys.
  */
 
-define([
-  'sjcl',
-  'p-promise',
-  'lib/hkdf',
-  'lib/base64url',
-  'lib/constants'
-], function (sjcl, p, hkdf, base64url, Constants) {
+define(function(require, exports, module) {
   'use strict';
+
+  var base64url = require('lib/base64url');
+  var Constants = require('lib/constants');
+  var hkdf = require('lib/hkdf');
+  var p = require('p-promise');
+  var sjcl = require('sjcl');
 
   var KEY_CLASS_TAG_A = 'kAr';
   var KEY_CLASS_TAG_B = 'kBr';

--- a/app/scripts/lib/screen-info.js
+++ b/app/scripts/lib/screen-info.js
@@ -4,9 +4,9 @@
 
 // module to calculate screen dimentions given a window.
 
-define([
-], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   var NOT_REPORTED_VALUE = 'none';
 

--- a/app/scripts/lib/sentry.js
+++ b/app/scripts/lib/sentry.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore',
-  'raven',
-  'lib/url'
-], function (_, Raven, Url) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Raven = require('raven');
+  var Url = require('lib/url');
 
   var ALLOWED_QUERY_PARAMETERS = [
     'automatedBrowser',

--- a/app/scripts/lib/service-name.js
+++ b/app/scripts/lib/service-name.js
@@ -4,9 +4,9 @@
 
 // Look up friendly service names by their 'slug'
 
-define([],
-function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   function t(str) {
     return str;

--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -5,10 +5,10 @@
 // Session saves session information about the user. Data is automatically
 // saved to sessionStorage and automatically loaded from sessionStorage on startup.
 
-define([
-  'underscore'
-], function (_) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
 
   var NAMESPACE = '__fxa_session';
 

--- a/app/scripts/lib/storage-metrics.js
+++ b/app/scripts/lib/storage-metrics.js
@@ -7,13 +7,13 @@
  * tests
  */
 
-define([
-  'underscore',
-  'lib/promise',
-  'lib/metrics',
-  'lib/storage'
-], function (_, p, Metrics, Storage) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Storage = require('lib/storage');
 
   var storage = Storage.factory('localStorage');
 

--- a/app/scripts/lib/storage.js
+++ b/app/scripts/lib/storage.js
@@ -5,11 +5,11 @@
 // This module abstracts interaction with storage backends such as localStorage
 // or sessionStorage.
 
-define([
-  'lib/null-storage',
-  'lib/url'
-], function (NullStorage, Url) {
+define(function(require, exports, module) {
   'use strict';
+
+  var NullStorage = require('lib/null-storage');
+  var Url = require('lib/url');
 
   var NAMESPACE = '__fxa_storage';
 

--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-],
-function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   var t = function (msg) {
     return msg;

--- a/app/scripts/lib/translator.js
+++ b/app/scripts/lib/translator.js
@@ -7,14 +7,13 @@
 // is chosen on the backend based on the user's `Accept-Language`
 // headers.
 
-define([
-  'underscore',
-  'jquery',
-  'lib/promise',
-  'lib/strings'
-],
-function (_, $, p, Strings) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var p = require('lib/promise');
+  var Strings = require('lib/strings');
 
   var Translator = function () {
     this.translations = {};

--- a/app/scripts/lib/url.js
+++ b/app/scripts/lib/url.js
@@ -4,9 +4,10 @@
 
 // utilities to deal with urls
 
-define(['underscore'],
-function (_) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
 
   function searchParams (str, whitelist) {
     var search = (typeof str === 'string' ? str : window.location.search).replace(/^\?/, '');

--- a/app/scripts/lib/validate.js
+++ b/app/scripts/lib/validate.js
@@ -4,10 +4,10 @@
 
 // Do some validation.
 
-define([
-  'lib/constants'
-], function (Constants) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Constants = require('lib/constants');
 
   // taken from the fxa-auth-server
   var HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;

--- a/app/scripts/lib/xhr.js
+++ b/app/scripts/lib/xhr.js
@@ -12,12 +12,12 @@
  *    a default data type. See issue #1786.
  */
 
-define([
-  'underscore',
-  'jquery',
-  'lib/promise'
-], function (_, $, p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var p = require('lib/promise');
 
   var DEFAULT_DATA_TYPE = 'json';
 

--- a/app/scripts/lib/xss.js
+++ b/app/scripts/lib/xss.js
@@ -4,12 +4,11 @@
 
 // Basic XSS protection
 
-define([
-  'underscore',
-  'lib/constants'
-],
-function (_, Constants) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Constants = require('lib/constants');
 
   return {
     // only allow http or https URLs, encoding the URL.

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -5,19 +5,18 @@
 // This model abstracts interaction between the user's account
 // and the profile server and also handles (de)serialization.
 
-define([
-  'backbone',
-  'underscore',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/profile-client',
-  'lib/constants',
-  'models/profile-image',
-  'models/oauth-token',
-  'models/marketing-email-prefs'
-], function (Backbone, _, p, AuthErrors, ProfileClient, Constants,
-  ProfileImage, OAuthToken, MarketingEmailPrefs) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
+  var Constants = require('lib/constants');
+  var MarketingEmailPrefs = require('models/marketing-email-prefs');
+  var OAuthToken = require('models/oauth-token');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var ProfileImage = require('models/profile-image');
 
   // Account attributes that can be persisted
   var PERSISTENT = {

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -7,13 +7,13 @@
  * the outside world.
  */
 
-define([
-  'underscore',
-  'backbone',
-  'lib/promise',
-  'models/mixins/search-param'
-], function (_, Backbone, p, SearchParamMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var p = require('lib/promise');
+  var SearchParamMixin = require('models/mixins/search-param');
 
   var BaseAuthenticationBroker = Backbone.Model.extend({
     type: 'base',

--- a/app/scripts/models/auth_brokers/first-run.js
+++ b/app/scripts/models/auth_brokers/first-run.js
@@ -7,10 +7,10 @@
  * embedded in the Firefox firstrun flow.
  */
 
-define([
-  'models/auth_brokers/fx-desktop-v2'
-], function (FxDesktopV2AuthenticationBroker) {
+define(function(require, exports, module) {
   'use strict';
+
+  var FxDesktopV2AuthenticationBroker = require('models/auth_brokers/fx-desktop-v2');
 
   var proto = FxDesktopV2AuthenticationBroker.prototype;
 

--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -10,13 +10,12 @@
  * If Sync is iframed by web content, v2 of the protocol is assumed.
  */
 
-define([
-  './fx-desktop',
-  'lib/channels/web',
-  'lib/constants'
-
-], function (FxDesktopAuthenticationBroker, WebChannel, Constants) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Constants = require('lib/constants');
+  var FxDesktopAuthenticationBroker = require('./fx-desktop');
+  var WebChannel = require('lib/channels/web');
 
   var FxDesktopV2AuthenticationBroker = FxDesktopAuthenticationBroker.extend({
     type: 'fx-desktop-v2',

--- a/app/scripts/models/auth_brokers/fx-desktop.js
+++ b/app/scripts/models/auth_brokers/fx-desktop.js
@@ -14,17 +14,16 @@
  *   `haltBeforeSignUpConfirmationPoll`
  */
 
-define([
-  'cocktail',
-  'underscore',
-  'models/auth_brokers/base',
-  'models/auth_brokers/mixins/channel',
-  'lib/auth-errors',
-  'lib/channels/fx-desktop-v1',
-  'lib/url'
-], function (Cocktail, _, BaseAuthenticationBroker, ChannelMixin, AuthErrors,
-  FxDesktopChannel, Url) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseAuthenticationBroker = require('models/auth_brokers/base');
+  var ChannelMixin = require('models/auth_brokers/mixins/channel');
+  var Cocktail = require('cocktail');
+  var FxDesktopChannel = require('lib/channels/fx-desktop-v1');
+  var Url = require('lib/url');
 
   var FxDesktopAuthenticationBroker = BaseAuthenticationBroker.extend({
     type: 'fx-desktop-v1',

--- a/app/scripts/models/auth_brokers/iframe.js
+++ b/app/scripts/models/auth_brokers/iframe.js
@@ -4,12 +4,12 @@
 
 // Finishes the OAuth flow by redirecting the window.
 
-define([
-  'underscore',
-  'models/auth_brokers/oauth',
-  'models/auth_brokers/mixins/channel'
-], function (_, OAuthAuthenticationBroker, ChannelMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var ChannelMixin = require('models/auth_brokers/mixins/channel');
+  var OAuthAuthenticationBroker = require('models/auth_brokers/oauth');
 
   var IframeAuthenticationBroker = OAuthAuthenticationBroker.extend({
     type: 'iframe',

--- a/app/scripts/models/auth_brokers/mixins/channel.js
+++ b/app/scripts/models/auth_brokers/mixins/channel.js
@@ -12,10 +12,10 @@
  * instance
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   // normalize the channel action. New channels return promises, old
   // channels use NodeJS style callbacks. Convert the old channel style

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -7,19 +7,17 @@
  * to override `sendOAuthResultToRelier`
  */
 
-define([
-  'underscore',
-  'lib/constants',
-  'lib/url',
-  'lib/oauth-errors',
-  'lib/auth-errors',
-  'lib/promise',
-  'lib/validate',
-  'models/auth_brokers/base'
-],
-function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
-      BaseAuthenticationBroker) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseAuthenticationBroker = require('models/auth_brokers/base');
+  var Constants = require('lib/constants');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var Url = require('lib/url');
+  var Validate = require('lib/validate');
 
   /**
    * Formats the OAuth "result.redirect" url into a {code, state} object

--- a/app/scripts/models/auth_brokers/redirect.js
+++ b/app/scripts/models/auth_brokers/redirect.js
@@ -4,13 +4,13 @@
 
 // Finishes the OAuth flow by redirecting the window.
 
-define([
-  'lib/promise',
-  'lib/constants',
-  'lib/url',
-  'models/auth_brokers/oauth'
-], function (p, Constants, Url, OAuthAuthenticationBroker) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Constants = require('lib/constants');
+  var OAuthAuthenticationBroker = require('models/auth_brokers/oauth');
+  var p = require('lib/promise');
+  var Url = require('lib/url');
 
   var RedirectAuthenticationBroker = OAuthAuthenticationBroker.extend({
     type: 'redirect',

--- a/app/scripts/models/auth_brokers/web-channel.js
+++ b/app/scripts/models/auth_brokers/web-channel.js
@@ -7,16 +7,14 @@
  * with the browser
  */
 
-define([
-  'underscore',
-  'models/auth_brokers/oauth',
-  'models/auth_brokers/mixins/channel',
-  'lib/promise',
-  'lib/channels/web'
-],
-function (_, OAuthAuthenticationBroker, ChannelMixin, p,
-      WebChannel) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var ChannelMixin = require('models/auth_brokers/mixins/channel');
+  var OAuthAuthenticationBroker = require('models/auth_brokers/oauth');
+  var p = require('lib/promise');
+  var WebChannel = require('lib/channels/web');
 
   var WebChannelAuthenticationBroker = OAuthAuthenticationBroker.extend({
     type: 'web-channel',

--- a/app/scripts/models/cropper-image.js
+++ b/app/scripts/models/cropper-image.js
@@ -4,12 +4,12 @@
 
 // This model abstracts images used by the cropper view
 
-define([
-  'backbone',
-  'lib/constants',
-  'lib/auth-errors'
-], function (Backbone, Constants, AuthErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
+  var Constants = require('lib/constants');
 
   // a 1x1 jpeg
   var jpegSrc = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsM' +

--- a/app/scripts/models/email-resend.js
+++ b/app/scripts/models/email-resend.js
@@ -4,11 +4,11 @@
 
 // This model limits the number of emails a component can send
 
-define([
-  'backbone',
-  'lib/constants'
-], function (Backbone, Constants) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var Constants = require('lib/constants');
 
   function shouldResend (tries, maxTries) {
     return tries === 1 || tries === maxTries;

--- a/app/scripts/models/form-prefill.js
+++ b/app/scripts/models/form-prefill.js
@@ -9,10 +9,10 @@
 //
 // These values are not persisted across browser sessions.
 
-define([
-  'backbone'
-], function (Backbone) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
 
   var FormPrefill = Backbone.Model.extend({
     defaults: {

--- a/app/scripts/models/marketing-email-prefs.js
+++ b/app/scripts/models/marketing-email-prefs.js
@@ -8,12 +8,12 @@
  * loaded on demand, independently of account information.
  */
 
-define([
-  'underscore',
-  'backbone',
-  'lib/promise'
-], function (_, Backbone, p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var p = require('lib/promise');
 
   var SCOPES = 'basket:write profile:email';
 

--- a/app/scripts/models/mixins/resume-token.js
+++ b/app/scripts/models/mixins/resume-token.js
@@ -9,10 +9,10 @@
  * fields that are saved to and populated from the ResumeToken.
  */
 
-define([
-  'models/resume-token'
-], function (ResumeToken) {
+define(function(require, exports, module) {
   'use strict';
+
+  var ResumeToken = require('models/resume-token');
 
   return {
     /**

--- a/app/scripts/models/mixins/search-param.js
+++ b/app/scripts/models/mixins/search-param.js
@@ -6,10 +6,10 @@
  * A mixin that allows models to get/import search parameters
  */
 
-define([
-  'lib/url'
-], function (Url) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Url = require('lib/url');
 
   return {
     /**

--- a/app/scripts/models/notifications.js
+++ b/app/scripts/models/notifications.js
@@ -6,11 +6,11 @@
  * The notifier broadcasts messages across multiple channels (iframe, tabs, browsers, etc).
  */
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   var EVENTS = {
     PROFILE_CHANGE: 'profile:change'

--- a/app/scripts/models/oauth-token.js
+++ b/app/scripts/models/oauth-token.js
@@ -8,10 +8,10 @@
  * with an Account model.
  */
 
-define([
-  'backbone'
-], function (Backbone) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
 
   var Model = Backbone.Model.extend({
     defaults: {

--- a/app/scripts/models/profile-image.js
+++ b/app/scripts/models/profile-image.js
@@ -4,13 +4,13 @@
 
 // This model abstracts profile images
 
-define([
-  'backbone',
-  'lib/promise',
-  'lib/image-loader',
-  'lib/profile-errors'
-], function (Backbone, p, ImageLoader, ProfileErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var ImageLoader = require('lib/image-loader');
+  var p = require('lib/promise');
+  var ProfileErrors = require('lib/profile-errors');
 
   var ProfileImage = Backbone.Model.extend({
     defaults: {

--- a/app/scripts/models/reliers/base.js
+++ b/app/scripts/models/reliers/base.js
@@ -7,11 +7,11 @@
  * depending on how you want to use it.
  */
 
-define([
-  'backbone',
-  'lib/promise'
-], function (Backbone, p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var p = require('lib/promise');
 
   var Relier = Backbone.Model.extend({
     defaults: {},

--- a/app/scripts/models/reliers/fx-desktop.js
+++ b/app/scripts/models/reliers/fx-desktop.js
@@ -10,12 +10,12 @@
  * - migration
  */
 
-define([
-  'underscore',
-  'models/reliers/relier',
-  'lib/service-name'
-], function (_, Relier, ServiceNameTranslator) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Relier = require('models/reliers/relier');
+  var ServiceNameTranslator = require('lib/service-name');
 
   var FxDesktopRelier = Relier.extend({
     defaults: _.extend({}, Relier.prototype.defaults, {

--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -6,15 +6,15 @@
  * An OAuth Relier - holds OAuth information.
  */
 
-define([
-  'underscore',
-  'models/reliers/relier',
-  'lib/oauth-errors',
-  'lib/relier-keys',
-  'lib/url',
-  'lib/constants'
-], function (_, Relier, OAuthErrors, RelierKeys, Url, Constants) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Constants = require('lib/constants');
+  var OAuthErrors = require('lib/oauth-errors');
+  var Relier = require('models/reliers/relier');
+  var RelierKeys = require('lib/relier-keys');
+  var Url = require('lib/url');
 
   var RELIER_FIELDS_IN_RESUME_TOKEN = ['state', 'verificationRedirect'];
   // We only grant permissions that our UI currently prompts for. Others

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -10,16 +10,15 @@
  * query parameter.
  */
 
-define([
-  'cocktail',
-  'models/reliers/base',
-  'models/mixins/resume-token',
-  'models/mixins/search-param',
-  'lib/promise',
-  'lib/constants'
-], function (Cocktail, BaseRelier, ResumeTokenMixin, SearchParamMixin, p,
-  Constants) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseRelier = require('models/reliers/base');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var p = require('lib/promise');
+  var ResumeTokenMixin = require('models/mixins/resume-token');
+  var SearchParamMixin = require('models/mixins/search-param');
 
   var RELIER_FIELDS_IN_RESUME_TOKEN = ['campaign', 'entrypoint'];
 

--- a/app/scripts/models/resume-token.js
+++ b/app/scripts/models/resume-token.js
@@ -7,11 +7,11 @@
  * search parameters post-verification in the OAuth flow
  */
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   var ResumeToken = Backbone.Model.extend({
     defaults: {

--- a/app/scripts/models/unique-user-id.js
+++ b/app/scripts/models/unique-user-id.js
@@ -17,16 +17,15 @@
  * If not in localStorage either, create a new uniqueUserId.
  */
 
-define([
-  'backbone',
-  'cocktail',
-  'lib/storage',
-  'models/mixins/resume-token',
-  'models/mixins/search-param',
-  'uuid'
-], function (Backbone, Cocktail, Storage, ResumeTokenMixin, SearchParamMixin,
-  uuid) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var Cocktail = require('cocktail');
+  var ResumeTokenMixin = require('models/mixins/resume-token');
+  var SearchParamMixin = require('models/mixins/search-param');
+  var Storage = require('lib/storage');
+  var uuid = require('uuid');
 
   var Model = Backbone.Model.extend({
     initialize: function (options) {

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -8,16 +8,16 @@
 //
 // i.e. User hasMany Accounts.
 
-define([
-  'backbone',
-  'cocktail',
-  'underscore',
-  'lib/promise',
-  'lib/storage',
-  'models/account',
-  'models/mixins/resume-token'
-], function (Backbone, Cocktail, _, p, Storage, Account, ResumeTokenMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Account = require('models/account');
+  var Backbone = require('backbone');
+  var Cocktail = require('cocktail');
+  var p = require('lib/promise');
+  var ResumeTokenMixin = require('models/mixins/resume-token');
+  var Storage = require('lib/storage');
 
   var User = Backbone.Model.extend({
     initialize: function (options) {

--- a/app/scripts/models/verification/account-unlock.js
+++ b/app/scripts/models/verification/account-unlock.js
@@ -7,11 +7,11 @@
  * A model to hold account unlock verification data
  */
 
-define([
-  './base',
-  'lib/validate'
-], function (VerificationInfo, Validate) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Validate = require('lib/validate');
+  var VerificationInfo = require('./base');
 
   return VerificationInfo.extend({
     defaults: {

--- a/app/scripts/models/verification/base.js
+++ b/app/scripts/models/verification/base.js
@@ -12,11 +12,11 @@
  * whose values are validation functions.
  */
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   var VerificationInfo = Backbone.Model.extend({
     initialize: function (options) {

--- a/app/scripts/models/verification/reset-password.js
+++ b/app/scripts/models/verification/reset-password.js
@@ -6,11 +6,11 @@
  * A model to hold reset password verification data
  */
 
-define([
-  './base',
-  'lib/validate'
-], function (VerificationInfo, Validate) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Validate = require('lib/validate');
+  var VerificationInfo = require('./base');
 
   return VerificationInfo.extend({
     defaults: {

--- a/app/scripts/models/verification/sign-up.js
+++ b/app/scripts/models/verification/sign-up.js
@@ -6,11 +6,11 @@
  * A model to hold sign up verification data
  */
 
-define([
-  './base',
-  'lib/validate'
-], function (VerificationInfo, Validate) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Validate = require('lib/validate');
+  var VerificationInfo = require('./base');
 
   return VerificationInfo.extend({
     defaults: {

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -2,81 +2,44 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore',
-  'jquery',
-  'backbone',
-  'lib/environment',
-  'lib/promise',
-  'lib/storage',
-  'views/sign_in',
-  'views/force_auth',
-  'views/sign_up',
-  'views/confirm',
-  'views/legal',
-  'views/tos',
-  'views/pp',
-  'views/cannot_create_account',
-  'views/complete_sign_up',
-  'views/reset_password',
-  'views/confirm_reset_password',
-  'views/complete_reset_password',
-  'views/confirm_account_unlock',
-  'views/complete_account_unlock',
-  'views/ready',
-  'views/settings',
-  'views/settings/avatar',
-  'views/settings/avatar_change',
-  'views/settings/avatar_crop',
-  'views/settings/avatar_gravatar',
-  'views/settings/avatar_camera',
-  'views/settings/communication_preferences',
-  'views/settings/gravatar_permissions',
-  'views/change_password',
-  'views/delete_account',
-  'views/cookies_disabled',
-  'views/clear_storage',
-  'views/unexpected_error',
-  'views/permissions'
-],
-function (
-  _,
-  $,
-  Backbone,
-  Environment,
-  p,
-  Storage,
-  SignInView,
-  ForceAuthView,
-  SignUpView,
-  ConfirmView,
-  LegalView,
-  TosView,
-  PpView,
-  CannotCreateAccountView,
-  CompleteSignUpView,
-  ResetPasswordView,
-  ConfirmResetPasswordView,
-  CompleteResetPasswordView,
-  ConfirmAccountUnlockView,
-  CompleteAccountUnlockView,
-  ReadyView,
-  SettingsView,
-  AvatarView,
-  AvatarChangeView,
-  AvatarCropView,
-  AvatarGravatarView,
-  AvatarCameraView,
-  CommunicationPreferencesView,
-  GravatarPermissions,
-  ChangePasswordView,
-  DeleteAccountView,
-  CookiesDisabledView,
-  ClearStorageView,
-  UnexpectedErrorView,
-  PermissionsView
-) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var AvatarCameraView = require('views/settings/avatar_camera');
+  var AvatarChangeView = require('views/settings/avatar_change');
+  var AvatarCropView = require('views/settings/avatar_crop');
+  var AvatarGravatarView = require('views/settings/avatar_gravatar');
+  var AvatarView = require('views/settings/avatar');
+  var Backbone = require('backbone');
+  var CannotCreateAccountView = require('views/cannot_create_account');
+  var ChangePasswordView = require('views/change_password');
+  var ClearStorageView = require('views/clear_storage');
+  var CommunicationPreferencesView = require('views/settings/communication_preferences');
+  var CompleteAccountUnlockView = require('views/complete_account_unlock');
+  var CompleteResetPasswordView = require('views/complete_reset_password');
+  var CompleteSignUpView = require('views/complete_sign_up');
+  var ConfirmAccountUnlockView = require('views/confirm_account_unlock');
+  var ConfirmResetPasswordView = require('views/confirm_reset_password');
+  var ConfirmView = require('views/confirm');
+  var CookiesDisabledView = require('views/cookies_disabled');
+  var DeleteAccountView = require('views/delete_account');
+  var Environment = require('lib/environment');
+  var ForceAuthView = require('views/force_auth');
+  var GravatarPermissions = require('views/settings/gravatar_permissions');
+  var LegalView = require('views/legal');
+  var p = require('lib/promise');
+  var PermissionsView = require('views/permissions');
+  var PpView = require('views/pp');
+  var ReadyView = require('views/ready');
+  var ResetPasswordView = require('views/reset_password');
+  var SettingsView = require('views/settings');
+  var SignInView = require('views/sign_in');
+  var SignUpView = require('views/sign_up');
+  var Storage = require('lib/storage');
+  var TosView = require('views/tos');
+  var UnexpectedErrorView = require('views/unexpected_error');
 
   function showView(View, options) {
     return function () {

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'underscore',
-  'backbone',
-  'raven',
-  'jquery',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/strings',
-  'lib/ephemeral-messages',
-  'lib/null-metrics',
-  'views/mixins/timer-mixin'
-],
-function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
-      Strings, EphemeralMessages, NullMetrics, TimerMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
+  var Cocktail = require('cocktail');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var NullMetrics = require('lib/null-metrics');
+  var p = require('lib/promise');
+  var Raven = require('raven');
+  var Strings = require('lib/strings');
+  var TimerMixin = require('views/mixins/timer-mixin');
 
   var DEFAULT_TITLE = window.document.title;
   var EPHEMERAL_MESSAGE_ANIMATION_MS = 150;

--- a/app/scripts/views/cannot_create_account.js
+++ b/app/scripts/views/cannot_create_account.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/base',
-  'stache!templates/cannot_create_account'
-],
-function (BaseView, CannotCreateAccountTemplate) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var CannotCreateAccountTemplate = require('stache!templates/cannot_create_account');
 
   var CannotCreateAccountView = BaseView.extend({
     template: CannotCreateAccountTemplate,

--- a/app/scripts/views/change_password.js
+++ b/app/scripts/views/change_password.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'views/form',
-  'lib/auth-errors',
-  'stache!templates/change_password',
-  'views/mixins/password-mixin',
-  'views/mixins/floating-placeholder-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/back-mixin',
-  'views/mixins/account-locked-mixin'
-],
-function (Cocktail, BaseView, FormView, AuthErrors, Template, PasswordMixin,
-  FloatingPlaceholderMixin, ServiceMixin, BackMixin, AccountLockedMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AccountLockedMixin = require('views/mixins/account-locked-mixin');
+  var AuthErrors = require('lib/auth-errors');
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  var FormView = require('views/form');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/change_password');
 
   var t = BaseView.t;
 

--- a/app/scripts/views/clear_storage.js
+++ b/app/scripts/views/clear_storage.js
@@ -7,12 +7,11 @@
  * to clear browser storage state between tests.
  */
 
-define([
-  'views/base',
-  'stache!templates/clear_storage'
-],
-function (BaseView, Template) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Template = require('stache!templates/clear_storage');
 
   var View = BaseView.extend({
     template: Template,

--- a/app/scripts/views/close_button.js
+++ b/app/scripts/views/close_button.js
@@ -8,14 +8,13 @@
  * to the parent that indicates "close me!"
  */
 
-define([
-  'views/base',
-  'lib/promise',
-  'lib/oauth-errors',
-  'stache!templates/partial/close-button'
-],
-function (BaseView, p, OAuthErrors, CloseTemplate) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var CloseTemplate = require('stache!templates/partial/close-button');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
 
   var View = BaseView.extend({
     template: CloseTemplate,

--- a/app/scripts/views/complete_account_unlock.js
+++ b/app/scripts/views/complete_account_unlock.js
@@ -2,16 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/form',
-  'stache!templates/complete_account_unlock',
-  'lib/auth-errors',
-  'lib/url',
-  'models/verification/account-unlock'
-],
-function (FormView, CompleteAccountUnlockTemplate, AuthErrors,
-    Url, VerificationInfo) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var CompleteAccountUnlockTemplate = require('stache!templates/complete_account_unlock');
+  var FormView = require('views/form');
+  var Url = require('lib/url');
+  var VerificationInfo = require('models/verification/account-unlock');
 
   var CompleteAccountUnlockView = FormView.extend({
     template: CompleteAccountUnlockTemplate,

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -2,24 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'views/form',
-  'stache!templates/complete_reset_password',
-  'views/mixins/floating-placeholder-mixin',
-  'views/mixins/password-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin',
-  'models/verification/reset-password',
-  'lib/auth-errors',
-  'lib/url'
-],
-function (Cocktail, BaseView, FormView, Template, FloatingPlaceholderMixin,
-  PasswordMixin, ResumeTokenMixin, ServiceMixin, VerificationInfo,
-  AuthErrors, Url) {
-
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  var FormView = require('views/form');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/complete_reset_password');
+  var Url = require('lib/url');
+  var VerificationInfo = require('models/verification/reset-password');
 
   var t = BaseView.t;
   var View = FormView.extend({

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -2,23 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'views/base',
-  'stache!templates/complete_sign_up',
-  'lib/auth-errors',
-  'views/mixins/resend-mixin',
-  'views/mixins/loading-mixin',
-  'views/mixins/resume-token-mixin',
-  'models/verification/sign-up',
-  'lib/url',
-  'lib/constants'
-],
-function (Cocktail, FormView, BaseView, CompleteSignUpTemplate,
-  AuthErrors, ResendMixin, LoadingMixin, ResumeTokenMixin, VerificationInfo,
-  Url, Constants) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var CompleteSignUpTemplate = require('stache!templates/complete_sign_up');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var LoadingMixin = require('views/mixins/loading-mixin');
+  var ResendMixin = require('views/mixins/resend-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var Url = require('lib/url');
+  var VerificationInfo = require('models/verification/sign-up');
 
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;
   var t = BaseView.t;

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'views/base',
-  'stache!templates/confirm',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/constants',
-  'views/mixins/resend-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin'
-],
-function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
-    ResendMixin, ResumeTokenMixin, ServiceMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var ResendMixin = require('views/mixins/resend-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/confirm');
 
   var t = BaseView.t;
 

--- a/app/scripts/views/confirm_account_unlock.js
+++ b/app/scripts/views/confirm_account_unlock.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'views/base',
-  'stache!templates/confirm_account_unlock',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/constants',
-  'views/mixins/back-mixin',
-  'views/mixins/resend-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin'
-],
-function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
-    BackMixin, ResendMixin, ResumeTokenMixin, ServiceMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var ResendMixin = require('views/mixins/resend-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/confirm_account_unlock');
 
   var t = BaseView.t;
 

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'underscore',
-  'views/confirm',
-  'views/base',
-  'stache!templates/confirm_reset_password',
-  'lib/promise',
-  'lib/session',
-  'lib/auth-errors',
-  'views/mixins/resend-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin'
-],
-function (Cocktail, _, ConfirmView, BaseView, Template, p, Session, AuthErrors,
-      ResendMixin, ResumeTokenMixin, ServiceMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var ConfirmView = require('views/confirm');
+  var p = require('lib/promise');
+  var ResendMixin = require('views/mixins/resend-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Session = require('lib/session');
+  var Template = require('stache!templates/confirm_reset_password');
 
   var t = BaseView.t;
 

--- a/app/scripts/views/cookies_disabled.js
+++ b/app/scripts/views/cookies_disabled.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'lib/config-loader',
-  'lib/auth-errors',
-  'lib/storage',
-  'stache!templates/cookies_disabled',
-  'views/mixins/back-mixin'
-],
-function (Cocktail, BaseView, ConfigLoader, AuthErrors, Storage, Template, BackMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var ConfigLoader = require('lib/config-loader');
+  var Storage = require('lib/storage');
+  var Template = require('stache!templates/cookies_disabled');
 
   var View = BaseView.extend({
     constructor: function (options) {

--- a/app/scripts/views/coppa/coppa-date-picker.js
+++ b/app/scripts/views/coppa/coppa-date-picker.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/form',
-  'stache!templates/partial/coppa-date-picker',
-  'lib/strings',
-  'lib/auth-errors',
-  'lib/promise'
-], function (FormView, Template, Strings, AuthErrors, p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var Strings = require('lib/strings');
+  var Template = require('stache!templates/partial/coppa-date-picker');
 
   var now = new Date();
   var CUTOFF_AGE = {

--- a/app/scripts/views/decorators/allow_only_one_submit.js
+++ b/app/scripts/views/decorators/allow_only_one_submit.js
@@ -8,11 +8,10 @@
  * Requires the invokeHandler function.
  */
 
-define([
-  'lib/promise'
-],
-function (p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   function allowOnlyOneSubmit(handler) {
     return function () {

--- a/app/scripts/views/decorators/notify_delayed_request.js
+++ b/app/scripts/views/decorators/notify_delayed_request.js
@@ -7,12 +7,11 @@
  * longer than expected
  */
 
-define([
-  'lib/promise',
-  'lib/auth-errors'
-],
-function (p, AuthErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var p = require('lib/promise');
 
   function notifyDelayedRequest(handler) {
     return function () {

--- a/app/scripts/views/decorators/progress_indicator.js
+++ b/app/scripts/views/decorators/progress_indicator.js
@@ -12,12 +12,11 @@
  * Requires the invokeHandler function.
  */
 
-define([
-  'lib/promise',
-  'views/progress_indicator'
-],
-function (p, ProgressIndicator) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
+  var ProgressIndicator = require('views/progress_indicator');
 
   function showProgressIndicator(handler, _el) {
     var el = _el || 'button[type=submit]';

--- a/app/scripts/views/delete_account.js
+++ b/app/scripts/views/delete_account.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'views/form',
-  'stache!templates/delete_account',
-  'lib/session',
-  'lib/auth-errors',
-  'views/mixins/password-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/back-mixin',
-  'views/mixins/account-locked-mixin'
-],
-function (Cocktail, BaseView, FormView, Template, Session, AuthErrors,
-      PasswordMixin, ServiceMixin, BackMixin, AccountLockedMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AccountLockedMixin = require('views/mixins/account-locked-mixin');
+  var AuthErrors = require('lib/auth-errors');
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Session = require('lib/session');
+  var Template = require('stache!templates/delete_account');
 
   var t = BaseView.t;
 

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/promise',
-  'views/base',
-  'views/form',
-  'views/sign_in',
-  'views/mixins/password-mixin',
-  'views/mixins/resume-token-mixin',
-  'stache!templates/force_auth',
-  'lib/session',
-  'lib/auth-errors'
-],
-function (Cocktail, p, BaseView, FormView, SignInView, PasswordMixin,
-    ResumeTokenMixin, Template, Session, AuthErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var Session = require('lib/session');
+  var SignInView = require('views/sign_in');
+  var Template = require('stache!templates/force_auth');
 
   function getFatalErrorMessage(self, fatalError) {
     if (fatalError) {

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -17,21 +17,19 @@
  * See documentation for an explanation of each.
  */
 
-define([
-  'underscore',
-  'jquery',
-  'lib/promise',
-  'lib/validate',
-  'lib/auth-errors',
-  'views/base',
-  'views/tooltip',
-  'views/decorators/progress_indicator',
-  'views/decorators/notify_delayed_request',
-  'views/decorators/allow_only_one_submit'
-],
-function (_, $, p, Validate, AuthErrors, BaseView, Tooltip,
-    showButtonProgressIndicator, notifyDelayedRequest, allowOnlyOneSubmit) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var notifyDelayedRequest = require('views/decorators/notify_delayed_request');
+  var p = require('lib/promise');
+  var showButtonProgressIndicator = require('views/decorators/progress_indicator');
+  var Tooltip = require('views/tooltip');
+  var Validate = require('lib/validate');
 
   /**
    * Decorator that checks whether the form has changed, and if so, call

--- a/app/scripts/views/legal.js
+++ b/app/scripts/views/legal.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/base',
-  'stache!templates/legal'
-],
-function (BaseView, Template) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Template = require('stache!templates/legal');
 
   var View = BaseView.extend({
     template: Template,

--- a/app/scripts/views/legal_copy.js
+++ b/app/scripts/views/legal_copy.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/xhr',
-  'views/base',
-  'views/mixins/back-mixin'
-],
-function (Cocktail, xhr, BaseView, BackMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var xhr = require('lib/xhr');
 
   // A view to fetch and render legal copy. Sub-classes must provide
   // a `copyUrl` where the copy template can be fetched, as well a

--- a/app/scripts/views/marketing_snippet.js
+++ b/app/scripts/views/marketing_snippet.js
@@ -9,14 +9,14 @@
  * signup for sync in Firefox Desktop.
  */
 
-define([
-  'cocktail',
-  'views/base',
-  'lib/constants',
-  'views/mixins/marketing-mixin',
-  'stache!templates/marketing_snippet'
-], function (Cocktail, BaseView, Constants, MarketingMixin, Template) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var MarketingMixin = require('views/mixins/marketing-mixin');
+  var Template = require('stache!templates/marketing_snippet');
 
   var View = BaseView.extend({
     template: Template,

--- a/app/scripts/views/marketing_snippet_ios.js
+++ b/app/scripts/views/marketing_snippet_ios.js
@@ -9,12 +9,12 @@
  * signup for sync in Firefox Desktop.
  */
 
-define([
-  'underscore',
-  'views/marketing_snippet',
-  'stache!templates/marketing_snippet_ios'
-], function (_, MarketingSnippetView, Template) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var MarketingSnippetView = require('views/marketing_snippet');
+  var Template = require('stache!templates/marketing_snippet_ios');
 
   var playStoreImageLanguages = [
     'ca',

--- a/app/scripts/views/mixins/account-locked-mixin.js
+++ b/app/scripts/views/mixins/account-locked-mixin.js
@@ -8,13 +8,13 @@
  * @class AccountLockedMixin
  */
 
-define([
-  'underscore',
-  'lib/auth-errors',
-  'views/base',
-  'views/mixins/resume-token-mixin'
-], function (_, AuthErrors, BaseView, ResumeTokenMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
 
   var t = BaseView.t;
 

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -4,11 +4,11 @@
 
 // helper functions for views with a profile image. Meant to be mixed into views.
 
-define([
-  'lib/profile-errors',
-  'models/profile-image'
-], function (ProfileErrors, ProfileImage) {
+define(function(require, exports, module) {
   'use strict';
+
+  var ProfileErrors = require('lib/profile-errors');
+  var ProfileImage = require('models/profile-image');
 
   return {
     initialize: function (options) {

--- a/app/scripts/views/mixins/back-mixin.js
+++ b/app/scripts/views/mixins/back-mixin.js
@@ -8,9 +8,9 @@
  * @class BackMixin
  */
 
-define([
-], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   var ENTER_BUTTON_CODE = 13;
 

--- a/app/scripts/views/mixins/checkbox-mixin.js
+++ b/app/scripts/views/mixins/checkbox-mixin.js
@@ -6,11 +6,11 @@
  * Log when checkbox values are changed, if the checkbox has an id.
  */
 
-define([
-  'jquery',
-  'lib/strings'
-], function ($, Strings) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Strings = require('lib/strings');
 
   return {
     events: {

--- a/app/scripts/views/mixins/floating-placeholder-mixin.js
+++ b/app/scripts/views/mixins/floating-placeholder-mixin.js
@@ -5,10 +5,10 @@
 // FormView plugin to convert a placeholder into a
 // floating label if the input changes.
 
-define([
-  'jquery'
-], function ($) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
 
   return {
     //when a user begins typing in an input, grab the placeholder,

--- a/app/scripts/views/mixins/loading-mixin.js
+++ b/app/scripts/views/mixins/loading-mixin.js
@@ -7,11 +7,11 @@
  * the View's normal template is rendered.
  */
 
-define([
-  'jquery',
-  'stache!templates/loading'
-], function ($, loadingTemplate) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var loadingTemplate = require('stache!templates/loading');
 
   return {
     initialize: function () {

--- a/app/scripts/views/mixins/marketing-mixin.js
+++ b/app/scripts/views/mixins/marketing-mixin.js
@@ -7,10 +7,10 @@
  * and clicks.
  */
 
-define([
-  'jquery'
-], function ($) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
 
   var MarketingMixin = {
     events: {

--- a/app/scripts/views/mixins/password-mixin.js
+++ b/app/scripts/views/mixins/password-mixin.js
@@ -4,9 +4,9 @@
 
 // helper functions for views with passwords. Meant to be mixed into views.
 
-define([
-], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   return {
     events: {

--- a/app/scripts/views/mixins/resend-mixin.js
+++ b/app/scripts/views/mixins/resend-mixin.js
@@ -5,10 +5,10 @@
 // helper functions for views with passwords. Meant to be mixed into views.
 // Note, this mixin overrides beforeSubmit and is incompatible with Cocktail.
 
-define([
-  'models/email-resend'
-], function (EmailResend) {
+define(function(require, exports, module) {
   'use strict';
+
+  var EmailResend = require('models/email-resend');
 
   var SHOW_RESEND_IN_MS = 5 * 60 * 1000; // 5 minutes.
 

--- a/app/scripts/views/mixins/resume-token-mixin.js
+++ b/app/scripts/views/mixins/resume-token-mixin.js
@@ -4,11 +4,11 @@
 
 // View mixin to get a ResumeToken model in a consistent fashion.
 
-define([
-  'models/resume-token',
-  'underscore'
-], function (ResumeToken, _) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var ResumeToken = require('models/resume-token');
 
   return {
     /**

--- a/app/scripts/views/mixins/service-mixin.js
+++ b/app/scripts/views/mixins/service-mixin.js
@@ -5,10 +5,10 @@
 // The service-mixin is used in views that know about services, which is mostly
 // OAuth services but also Sync.
 
-define([
-  'views/base'
-], function (BaseView) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
 
   return {
     transformLinks: function () {

--- a/app/scripts/views/mixins/settings-mixin.js
+++ b/app/scripts/views/mixins/settings-mixin.js
@@ -4,10 +4,10 @@
 
 // helper functions for views with a profile image. Meant to be mixed into views.
 
-define([
-  'lib/session'
-], function (Session) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Session = require('lib/session');
 
   return {
     // user must be authenticated and verified to see Settings pages

--- a/app/scripts/views/mixins/timer-mixin.js
+++ b/app/scripts/views/mixins/timer-mixin.js
@@ -10,11 +10,10 @@
  * the view.
  */
 
-define([
-  'underscore'
-],
-function (_) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
 
   var Mixin = {
     setTimeout: function (callback, timeoutMS) {

--- a/app/scripts/views/permissions.js
+++ b/app/scripts/views/permissions.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'stache!templates/permissions',
-  'lib/promise',
-  'views/mixins/back-mixin',
-  'views/mixins/service-mixin'
-],
-function (Cocktail, FormView, Template, p, BackMixin, ServiceMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BackMixin = require('views/mixins/back-mixin');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/permissions');
 
   var View = FormView.extend({
     template: Template,

--- a/app/scripts/views/pp.js
+++ b/app/scripts/views/pp.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/legal_copy',
-  'stache!templates/pp',
-  'lib/auth-errors'
-],
-function (LegalCopyView, Template, AuthErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var LegalCopyView = require('views/legal_copy');
+  var Template = require('stache!templates/pp');
 
   var View = LegalCopyView.extend({
     template: Template,

--- a/app/scripts/views/progress_indicator.js
+++ b/app/scripts/views/progress_indicator.js
@@ -16,13 +16,13 @@
 // is never shown. If `done` then `start` are called within HIDE_DELAY_MS, then
 // the progress indicator is not hidden.
 
-define([
-  'underscore',
-  'jquery',
-  'backbone',
-  'views/mixins/timer-mixin'
-], function (_, $, Backbone, TimerMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var TimerMixin = require('views/mixins/timer-mixin');
 
   // The show and hide delays are to minimize flash.
   var SHOW_DELAY_MS = 100;

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -7,19 +7,17 @@
  * "All ready! You can go visit {{ service }}"
  */
 
-define([
-  'cocktail',
-  'views/form',
-  'stache!templates/ready',
-  'lib/url',
-  'lib/constants',
-  'views/mixins/service-mixin',
-  'views/marketing_snippet',
-  'views/marketing_snippet_ios'
-],
-function (Cocktail, FormView, Template, Url, Constants, ServiceMixin,
-      MarketingSnippet, MarketingSnippetiOS) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var MarketingSnippet = require('views/marketing_snippet');
+  var MarketingSnippetiOS = require('views/marketing_snippet_ios');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/ready');
+  var Url = require('lib/url');
 
   var View = FormView.extend({
     template: Template,

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'views/form',
-  'stache!templates/reset_password',
-  'lib/session',
-  'lib/auth-errors',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/back-mixin'
-],
-function (Cocktail, BaseView, FormView, Template, Session,
-  AuthErrors, ResumeTokenMixin, ServiceMixin, BackMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Session = require('lib/session');
+  var Template = require('stache!templates/reset_password');
 
   var t = BaseView.t;
 

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -2,18 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/session',
-  'views/form',
-  'views/base',
-  'views/mixins/avatar-mixin',
-  'views/mixins/settings-mixin',
-  'stache!templates/settings'
-],
-function (Cocktail, Session, FormView, BaseView, AvatarMixin,
-  SettingsMixin, Template) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var Session = require('lib/session');
+  var SettingsMixin = require('views/mixins/settings-mixin');
+  var Template = require('stache!templates/settings');
 
   var t = BaseView.t;
 

--- a/app/scripts/views/settings/avatar.js
+++ b/app/scripts/views/settings/avatar.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'stache!templates/settings/avatar',
-  'views/mixins/avatar-mixin',
-  'views/mixins/settings-mixin'
-],
-function (Cocktail, FormView, Template, AvatarMixin, SettingsMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var SettingsMixin = require('views/mixins/settings-mixin');
+  var Template = require('stache!templates/settings/avatar');
 
   var View = FormView.extend({
     template: Template,

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -2,26 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* exceptsPaths: canvasToBlob */
-define([
-  'underscore',
-  'cocktail',
-  'canvasToBlob',
-  'views/form',
-  'views/progress_indicator',
-  'views/mixins/settings-mixin',
-  'views/mixins/avatar-mixin',
-  'stache!templates/settings/avatar_camera',
-  'lib/constants',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/environment',
-  'models/profile-image'
-],
-function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
-    SettingsMixin, AvatarMixin, Template, Constants, p, AuthErrors,
-    Environment, ProfileImage) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var canvasToBlob = require('canvasToBlob'); //eslint-disable-line no-unused-vars
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var Environment = require('lib/environment');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var ProfileImage = require('models/profile-image');
+  var ProgressIndicator = require('views/progress_indicator');
+  var SettingsMixin = require('views/mixins/settings-mixin');
+  var Template = require('stache!templates/settings/avatar_camera');
 
   // a blank 1x1 png
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'cocktail',
-  'views/form',
-  'views/mixins/avatar-mixin',
-  'views/mixins/settings-mixin',
-  'stache!templates/settings/avatar_change',
-  'lib/auth-errors',
-  'lib/image-loader',
-  'lib/promise',
-  'models/cropper-image'
-],
-function ($, Cocktail, FormView, AvatarMixin, SettingsMixin, Template,
-    AuthErrors, ImageLoader, p, CropperImage) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var Cocktail = require('cocktail');
+  var CropperImage = require('models/cropper-image');
+  var FormView = require('views/form');
+  var ImageLoader = require('lib/image-loader');
+  var p = require('lib/promise');
+  var SettingsMixin = require('views/mixins/settings-mixin');
+  var Template = require('stache!templates/settings/avatar_change');
 
   var View = FormView.extend({
     template: Template,

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'p-promise',
-  'cocktail',
-  'views/form',
-  'views/mixins/settings-mixin',
-  'views/mixins/avatar-mixin',
-  'stache!templates/settings/avatar_crop',
-  'lib/constants',
-  'lib/cropper',
-  'lib/auth-errors',
-  'models/cropper-image',
-  'models/profile-image'
-],
-function (p, Cocktail, FormView, SettingsMixin, AvatarMixin, Template,
-    Constants, Cropper, AuthErrors, CropperImage, ProfileImage) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var Cropper = require('lib/cropper');
+  var CropperImage = require('models/cropper-image');
+  var FormView = require('views/form');
+  var p = require('p-promise');
+  var ProfileImage = require('models/profile-image');
+  var SettingsMixin = require('views/mixins/settings-mixin');
+  var Template = require('stache!templates/settings/avatar_crop');
 
   var HORIZONTAL_GUTTER = 90;
   var VERTICAL_GUTTER = 0;

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -2,23 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'underscore',
-  'md5',
-  'cocktail',
-  'views/form',
-  'views/mixins/settings-mixin',
-  'views/mixins/avatar-mixin',
-  'stache!templates/settings/avatar_gravatar',
-  'lib/constants',
-  'lib/image-loader',
-  'views/decorators/progress_indicator',
-  'models/profile-image'
-],
-function ($, _, md5, Cocktail, FormView, SettingsMixin, AvatarMixin,
-    Template, Constants, ImageLoader, showProgressIndicator, ProfileImage) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var ImageLoader = require('lib/image-loader');
+  var md5 = require('md5');
+  var ProfileImage = require('models/profile-image');
+  var SettingsMixin = require('views/mixins/settings-mixin');
+  var showProgressIndicator = require('views/decorators/progress_indicator');
+  var Template = require('stache!templates/settings/avatar_gravatar');
 
   function t (s) { return s; }
 

--- a/app/scripts/views/settings/communication_preferences.js
+++ b/app/scripts/views/settings/communication_preferences.js
@@ -2,23 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/xss',
-  'lib/constants',
-  'lib/marketing-email-errors',
-  'lib/metrics',
-  'views/base',
-  'views/form',
-  'views/mixins/back-mixin',
-  'views/mixins/settings-mixin',
-  'views/mixins/checkbox-mixin',
-  'views/mixins/loading-mixin',
-  'stache!templates/settings/communication_preferences'
-],
-function (Cocktail, Xss, Constants, MarketingEmailErrors, Metrics, BaseView, FormView,
-  BackMixin, SettingsMixin, CheckboxMixin, LoadingMixin, Template) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var CheckboxMixin = require('views/mixins/checkbox-mixin');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var LoadingMixin = require('views/mixins/loading-mixin');
+  var MarketingEmailErrors = require('lib/marketing-email-errors');
+  var Metrics = require('lib/metrics');
+  var SettingsMixin = require('views/mixins/settings-mixin');
+  var Template = require('stache!templates/settings/communication_preferences');
+  var Xss = require('lib/xss');
 
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;
   var t = BaseView.t;

--- a/app/scripts/views/settings/gravatar_permissions.js
+++ b/app/scripts/views/settings/gravatar_permissions.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'stache!templates/settings/gravatar_permissions',
-  'lib/promise',
-  'views/mixins/back-mixin',
-  'views/mixins/service-mixin'
-],
-function (Cocktail, FormView, Template, p, BackMixin, ServiceMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BackMixin = require('views/mixins/back-mixin');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/settings/gravatar_permissions');
 
   var View = FormView.extend({
     template: Template,

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -2,26 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/promise',
-  'views/base',
-  'views/form',
-  'stache!templates/sign_in',
-  'lib/session',
-  'lib/auth-errors',
-  'views/mixins/password-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/avatar-mixin',
-  'views/mixins/account-locked-mixin',
-  'views/decorators/allow_only_one_submit',
-  'views/decorators/progress_indicator'
-],
-function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
-      AuthErrors, PasswordMixin, ResumeTokenMixin, ServiceMixin, AvatarMixin,
-      AccountLockedMixin, allowOnlyOneSubmit, showProgressIndicator) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AccountLockedMixin = require('views/mixins/account-locked-mixin');
+  var allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
+  var AuthErrors = require('lib/auth-errors');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Session = require('lib/session');
+  var showProgressIndicator = require('views/decorators/progress_indicator');
+  var SignInTemplate = require('stache!templates/sign_in');
 
   var t = BaseView.t;
 

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -2,25 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'underscore',
-  'lib/promise',
-  'views/base',
-  'views/form',
-  'stache!templates/sign_up',
-  'lib/auth-errors',
-  'lib/mailcheck',
-  'lib/url',
-  'views/mixins/password-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/checkbox-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/coppa/coppa-date-picker'
-],
-function (Cocktail, _, p, BaseView, FormView, Template, AuthErrors, mailcheck,
-      Url, PasswordMixin, ServiceMixin, CheckboxMixin, ResumeTokenMixin, CoppaDatePicker) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var CheckboxMixin = require('views/mixins/checkbox-mixin');
+  var Cocktail = require('cocktail');
+  var CoppaDatePicker = require('views/coppa/coppa-date-picker');
+  var FormView = require('views/form');
+  var mailcheck = require('lib/mailcheck');
+  var p = require('lib/promise');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/sign_up');
+  var Url = require('lib/url');
 
   var t = BaseView.t;
 

--- a/app/scripts/views/tooltip.js
+++ b/app/scripts/views/tooltip.js
@@ -4,12 +4,12 @@
 
 // It's a tooltip!
 
-define([
-  'underscore',
-  'jquery',
-  'views/base'
-], function (_, $, BaseView) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var BaseView = require('views/base');
 
   var displayedTooltip;
   var PADDING_BELOW_TOOLTIP_PX = 2;

--- a/app/scripts/views/tos.js
+++ b/app/scripts/views/tos.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/legal_copy',
-  'stache!templates/tos',
-  'lib/auth-errors'
-],
-function (LegalCopyView, Template, AuthErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var LegalCopyView = require('views/legal_copy');
+  var Template = require('stache!templates/tos');
 
   var View = LegalCopyView.extend({
     template: Template,

--- a/app/scripts/views/unexpected_error.js
+++ b/app/scripts/views/unexpected_error.js
@@ -7,12 +7,11 @@
  * to clear browser storage state between tests.
  */
 
-define([
-  'views/base',
-  'stache!templates/unexpected_error'
-],
-function (BaseView, Template) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Template = require('stache!templates/unexpected_error');
 
   var View = BaseView.extend({
     template: Template,

--- a/app/tests/lib/helpers.js
+++ b/app/tests/lib/helpers.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'sinon',
-  'lib/promise',
-  '../mocks/profile.js'
-], function (sinon, p, ProfileMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
+  var ProfileMock = require('../mocks/profile.js');
+  var sinon = require('sinon');
 
   function requiresFocus(callback, done) {
     // Give the document focus

--- a/app/tests/mocks/canvas.js
+++ b/app/tests/mocks/canvas.js
@@ -4,9 +4,9 @@
 
 // stub out the router object for testing.
 
-define([
-], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   function CanvasMock() {
     // nothing to do here.

--- a/app/tests/mocks/crosstab.js
+++ b/app/tests/mocks/crosstab.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'crosstab'
-], function (crosstab) {
+define(function(require, exports, module) {
   'use strict';
+
+  var crosstab = require('crosstab');
 
   function deepStub(target, source) {
     for (var key in source) {

--- a/app/tests/mocks/dom-event.js
+++ b/app/tests/mocks/dom-event.js
@@ -4,9 +4,9 @@
 
 // mock out a DOM event
 
-define([
-], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   function DOMEventMock() {
     // nothing to do

--- a/app/tests/mocks/file-reader.js
+++ b/app/tests/mocks/file-reader.js
@@ -4,9 +4,9 @@
 
 // mock out a FileReader
 
-define([
-], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAACZJREFUeNrtwQEBAAAAgiD' +
                '/r25IQAEAAAAAAAAAAAAAAAAAAADvBkCAAAEehacTAAAAAElFTkSuQmCC';

--- a/app/tests/mocks/fxa-client.js
+++ b/app/tests/mocks/fxa-client.js
@@ -4,11 +4,11 @@
 
 // stub out the fxa-client object for testing.
 
-define([
-  'lib/promise',
-  'lib/fxa-client'
-], function (p, FxaClientWrapper) {
+define(function(require, exports, module) {
   'use strict';
+
+  var FxaClientWrapper = require('lib/fxa-client');
+  var p = require('lib/promise');
 
   function FxaClientWrapperMock() {
   }

--- a/app/tests/mocks/history.js
+++ b/app/tests/mocks/history.js
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // A mock for Backbone.history
-define([
-], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   function History() {}
 

--- a/app/tests/mocks/oauth_servers.js
+++ b/app/tests/mocks/oauth_servers.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'sinon'
-], function (sinon) {
+define(function(require, exports, module) {
   'use strict';
+
+  var sinon = require('sinon');
 
   /**
    * Create a fake set of OAuth servers through instantiation.

--- a/app/tests/mocks/profile.js
+++ b/app/tests/mocks/profile.js
@@ -4,9 +4,9 @@
 
 // stub out the router object for testing.
 
-define([
-], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   function Profile() {
   }

--- a/app/tests/mocks/router.js
+++ b/app/tests/mocks/router.js
@@ -4,11 +4,11 @@
 
 // stub out the router object for testing.
 
-define([
-  'underscore',
-  'backbone'
-], function (_, Backbone) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   function RouterMock() {
     // nothing to do here.

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -4,14 +4,13 @@
 
 // stub out the window object for testing.
 
-define([
-  'backbone',
-  'sinon',
-  'underscore',
-  'lib/null-storage'
-],
-function (Backbone, sinon, _, NullStorage) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var NullStorage = require('lib/null-storage');
+  var sinon = require('sinon');
 
   function MutationObserver (notifier) {
     return {

--- a/app/tests/setup.js
+++ b/app/tests/setup.js
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([], function () {
+define(function(require, exports, module) {
   'use strict';
+
 
   mocha.setup('bdd');
   mocha.timeout(20000);

--- a/app/tests/spec/head/startup-styles.js
+++ b/app/tests/spec/head/startup-styles.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'head/startup-styles',
-  'lib/environment',
-  '../../mocks/window'
-], function (chai, sinon, StartupStyles, Environment, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Environment = require('lib/environment');
+  var sinon = require('sinon');
+  var StartupStyles = require('head/startup-styles');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/able.js
+++ b/app/tests/spec/lib/able.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/able'
-],
-function (chai, sinon, Able) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var chai = require('chai');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -2,42 +2,37 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'raven',
-  'lib/app-start',
-  'lib/session',
-  'lib/channels/null',
-  'lib/constants',
-  'lib/promise',
-  'lib/url',
-  'lib/oauth-errors',
-  'lib/auth-errors',
-  'lib/storage',
-  'models/auth_brokers/base',
-  'models/auth_brokers/fx-desktop',
-  'models/auth_brokers/iframe',
-  'models/auth_brokers/redirect',
-  'models/auth_brokers/web-channel',
-  'models/reliers/base',
-  'models/reliers/fx-desktop',
-  'models/reliers/oauth',
-  'models/reliers/relier',
-  'models/user',
-  'lib/metrics',
-  'lib/storage-metrics',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../mocks/history',
-  '../../lib/helpers'
-],
-function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
-  Url, OAuthErrors, AuthErrors, Storage, BaseBroker, FxDesktopBroker, IframeBroker,
-  RedirectBroker, WebChannelBroker, BaseRelier, FxDesktopRelier, OAuthRelier,
-  Relier, User, Metrics, StorageMetrics, WindowMock, RouterMock, HistoryMock,
-  TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AppStart = require('lib/app-start');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseBroker = require('models/auth_brokers/base');
+  var BaseRelier = require('models/reliers/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxDesktopBroker = require('models/auth_brokers/fx-desktop');
+  var FxDesktopRelier = require('models/reliers/fx-desktop');
+  var HistoryMock = require('../../mocks/history');
+  var IframeBroker = require('models/auth_brokers/iframe');
+  var Metrics = require('lib/metrics');
+  var NullChannel = require('lib/channels/null');
+  var OAuthErrors = require('lib/oauth-errors');
+  var OAuthRelier = require('models/reliers/oauth');
+  var p = require('lib/promise');
+  var Raven = require('raven');
+  var RedirectBroker = require('models/auth_brokers/redirect');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var StorageMetrics = require('lib/storage-metrics');
+  var TestHelpers = require('../../lib/helpers');
+  var Url = require('lib/url');
+  var User = require('models/user');
+  var WebChannelBroker = require('models/auth_brokers/web-channel');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
   var FIRSTRUN_ORIGIN = 'https://firstrun.firefox.com';

--- a/app/tests/spec/lib/assertion.js
+++ b/app/tests/spec/lib/assertion.js
@@ -2,25 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* exceptsPaths: vendor/jwcrypto/lib/algs/rs */
-define([
-  'chai',
-  'jquery',
-  '../../lib/helpers',
-  'lib/promise',
-  'lib/config-loader',
-  'lib/assertion',
-  'lib/fxa-client',
-  'models/reliers/relier',
-  'vendor/jwcrypto',
-  'vendor/jwcrypto/lib/algs/rs'
-],
-// FxaClientWrapper is the object that is used in
-// fxa-content-server views. It wraps FxaClient to
-// take care of some app-specific housekeeping.
-function (chai, $, TestHelpers, p, ConfigLoader, Assertion, FxaClientWrapper,
-      Relier, jwcrypto) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Assertion = require('lib/assertion');
+  var chai = require('chai');
+  var ConfigLoader = require('lib/config-loader');
+  var FxaClientWrapper = require('lib/fxa-client');
+  var jwcrypto = require('vendor/jwcrypto');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var TestHelpers = require('../../lib/helpers');
+  var rs = require('vendor/jwcrypto/lib/algs/rs'); //eslint-disable-line no-unused-vars
 
   var assert = chai.assert;
   var AUDIENCE = 'http://123done.org';

--- a/app/tests/spec/lib/auth-errors.js
+++ b/app/tests/spec/lib/auth-errors.js
@@ -4,12 +4,11 @@
 
 // test the interpolated library
 
-define([
-  'chai',
-  'lib/auth-errors'
-],
-function (chai, AuthErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/base64url.js
+++ b/app/tests/spec/lib/base64url.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sjcl',
-  'lib/base64url'
-], function (chai, sjcl, base64url) {
+define(function(require, exports, module) {
   'use strict';
+
+  var base64url = require('lib/base64url');
+  var chai = require('chai');
+  var sjcl = require('sjcl');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/channels/duplex.js
+++ b/app/tests/spec/lib/channels/duplex.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/duplex',
-  'lib/channels/senders/null',
-  'lib/channels/receivers/null',
-  '../../../mocks/window'
-],
-function (chai, sinon, DuplexChannel, NullSender, NullReceiver, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var DuplexChannel = require('lib/channels/duplex');
+  var NullReceiver = require('lib/channels/receivers/null');
+  var NullSender = require('lib/channels/senders/null');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var channel;
   var windowMock;

--- a/app/tests/spec/lib/channels/fx-desktop-v1.js
+++ b/app/tests/spec/lib/channels/fx-desktop-v1.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/channels/fx-desktop-v1',
-  '../../../mocks/window'
-],
-function (chai, FxDesktopV1Channel, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FxDesktopV1Channel = require('lib/channels/fx-desktop-v1');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/channels/iframe.js
+++ b/app/tests/spec/lib/channels/iframe.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/auth-errors',
-  'lib/channels/iframe',
-  '../../../mocks/window'
-],
-function (chai, sinon, AuthErrors, IFrameChannel, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var IFrameChannel = require('lib/channels/iframe');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var channel;
   var windowMock;

--- a/app/tests/spec/lib/channels/inter-tab.js
+++ b/app/tests/spec/lib/channels/inter-tab.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  '../../../mocks/crosstab',
-  'lib/channels/inter-tab'
-], function (chai, sinon, CrossTabMock, InterTabChannel) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var CrossTabMock = require('../../../mocks/crosstab');
+  var InterTabChannel = require('lib/channels/inter-tab');
+  var sinon = require('sinon');
 
   describe('lib/channels/inter-tab', function () {
     var assert = chai.assert;

--- a/app/tests/spec/lib/channels/null.js
+++ b/app/tests/spec/lib/channels/null.js
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/channels/null'
-],
-function (NullChannel) {
+define(function(require, exports, module) {
   'use strict';
+
+  var NullChannel = require('lib/channels/null');
 
   var channel;
 

--- a/app/tests/spec/lib/channels/receivers/postmessage.js
+++ b/app/tests/spec/lib/channels/receivers/postmessage.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/auth-errors',
-  'lib/channels/receivers/postmessage',
-  '../../../../mocks/window'
-],
-function (chai, sinon, AuthErrors, PostMessageReceiver, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var PostMessageReceiver = require('lib/channels/receivers/postmessage');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../../mocks/window');
 
   var windowMock;
   var receiver;

--- a/app/tests/spec/lib/channels/receivers/web-channel.js
+++ b/app/tests/spec/lib/channels/receivers/web-channel.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/receivers/web-channel',
-  '../../../../mocks/window'
-],
-function (chai, sinon, WebChannelReceiver, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var sinon = require('sinon');
+  var WebChannelReceiver = require('lib/channels/receivers/web-channel');
+  var WindowMock = require('../../../../mocks/window');
 
   var windowMock;
   var receiver;

--- a/app/tests/spec/lib/channels/senders/fx-desktop-v1.js
+++ b/app/tests/spec/lib/channels/senders/fx-desktop-v1.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/senders/fx-desktop-v1',
-  '../../../../mocks/window'
-],
-function (chai, sinon, FxDesktopV1Sender, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FxDesktopV1Sender = require('lib/channels/senders/fx-desktop-v1');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../../mocks/window');
 
   var windowMock;
   var sender;

--- a/app/tests/spec/lib/channels/senders/web-channel.js
+++ b/app/tests/spec/lib/channels/senders/web-channel.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/senders/web-channel',
-  '../../../../mocks/window'
-],
-function (chai, sinon, WebChannelSender, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var sinon = require('sinon');
+  var WebChannelSender = require('lib/channels/senders/web-channel');
+  var WindowMock = require('../../../../mocks/window');
 
   var windowMock;
   var sender;

--- a/app/tests/spec/lib/channels/web.js
+++ b/app/tests/spec/lib/channels/web.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/web',
-  '/tests/mocks/window.js'
-],
-function (chai, sinon, WebChannel, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var sinon = require('sinon');
+  var WebChannel = require('lib/channels/web');
+  var WindowMock = require('/tests/mocks/window.js');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/cropper.js
+++ b/app/tests/spec/lib/cropper.js
@@ -2,24 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* exceptsPaths: jquery-simulate */
-define([
-  'chai',
-  'sinon',
-  'jquery-simulate',
-  '../../mocks/router',
-  '../../mocks/canvas',
-  'lib/promise',
-  'lib/cropper',
-  'lib/ephemeral-messages',
-  'views/settings/avatar_crop',
-  'models/cropper-image',
-  'models/user',
-  'models/reliers/relier'
-],
-function (chai, sinon, jQuerySimulate, RouterMock, CanvasMock, p, Cropper, EphemeralMessages, View,
-    CropperImage, User, Relier) {
+define(function(require, exports, module) {
   'use strict';
+
+  var CanvasMock = require('../../mocks/canvas');
+  var chai = require('chai');
+  var Cropper = require('lib/cropper');
+  var CropperImage = require('models/cropper-image');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var jQuerySimulate = require('jquery-simulate'); //eslint-disable-line no-unused-vars
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var View = require('views/settings/avatar_crop');
 
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';

--- a/app/tests/spec/lib/environment.js
+++ b/app/tests/spec/lib/environment.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/environment',
-  '../../mocks/window'
-], function (chai, sinon, Environment, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Environment = require('lib/environment');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -2,25 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'fxaClient',
-  'lib/promise',
-  '../../lib/helpers',
-  'lib/fxa-client',
-  'lib/auth-errors',
-  'lib/constants',
-  'models/resume-token',
-  'models/reliers/oauth'
-],
-// FxaClientWrapper is the object that is used in
-// fxa-content-server views. It wraps FxaClient to
-// take care of some app-specific housekeeping.
-function (chai, $, sinon, FxaClient, p, testHelpers, FxaClientWrapper, AuthErrors,
-      Constants, ResumeToken, OAuthRelier) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClient = require('fxaClient');
+  var FxaClientWrapper = require('lib/fxa-client');
+  var OAuthRelier = require('models/reliers/oauth');
+  var p = require('lib/promise');
+  var ResumeToken = require('models/resume-token');
+  var sinon = require('sinon');
+  var testHelpers = require('../../lib/helpers');
 
   var STATE = 'state';
   var SERVICE = 'sync';

--- a/app/tests/spec/lib/height-observer.js
+++ b/app/tests/spec/lib/height-observer.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  '../../mocks/window',
-  'lib/height-observer'
-],
-function (chai, sinon, WindowMock, HeightObserver) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var HeightObserver = require('lib/height-observer');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/image-loader.js
+++ b/app/tests/spec/lib/image-loader.js
@@ -4,12 +4,11 @@
 
 // test the metrics library
 
-define([
-  'chai',
-  'lib/image-loader'
-],
-function (chai, ImageLoader) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ImageLoader = require('lib/image-loader');
 
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';

--- a/app/tests/spec/lib/mailcheck.js
+++ b/app/tests/spec/lib/mailcheck.js
@@ -4,14 +4,13 @@
 
 // test the metrics library
 
-define([
-  'sinon',
-  'chai',
-  'jquery',
-  'lib/mailcheck'
-],
-function (sinon, chai, $, mailcheck) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var mailcheck = require('lib/mailcheck');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
   var MAILCHECK_ID = 'mailcheck-test';

--- a/app/tests/spec/lib/marketing-email-client.js
+++ b/app/tests/spec/lib/marketing-email-client.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/marketing-email-client',
-  'lib/marketing-email-errors',
-  'lib/promise',
-  'lib/xhr'
-],
-function (chai, sinon, MarketingEmailClient, MarketingEmailErrors, p, xhr) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var MarketingEmailClient = require('lib/marketing-email-client');
+  var MarketingEmailErrors = require('lib/marketing-email-errors');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var xhr = require('lib/xhr');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -4,20 +4,19 @@
 
 // test the metrics library
 
-define([
-  'chai',
-  'jquery',
-  'lib/promise',
-  'lib/metrics',
-  'lib/auth-errors',
-  'lib/environment',
-  'sinon',
-  'underscore',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, $, p, Metrics, AuthErrors, Environment, sinon, _, WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Environment = require('lib/environment');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/null-metrics.js
+++ b/app/tests/spec/lib/null-metrics.js
@@ -4,13 +4,12 @@
 
 // test the metrics library
 
-define([
-  'chai',
-  'lib/null-metrics',
-  'lib/metrics'
-],
-function (chai, NullMetrics, Metrics) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var NullMetrics = require('lib/null-metrics');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/null-storage.js
+++ b/app/tests/spec/lib/null-storage.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/null-storage'
-],
-function (chai, NullStorage) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var NullStorage = require('lib/null-storage');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/oauth-client.js
+++ b/app/tests/spec/lib/oauth-client.js
@@ -2,19 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/oauth-client',
-  'lib/oauth-errors',
-  'lib/xhr',
-  'lib/promise'
-],
-// FxaClientWrapper is the object that is used in
-// fxa-content-server views. It wraps FxaClient to
-// take care of some app-specific housekeeping.
-function (chai, sinon, OAuthClient, OAuthErrors, Xhr, p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var Xhr = require('lib/xhr');
 
   var OAUTH_URL = 'http://127.0.0.1:9010';
   var RP_URL = 'http://127.0.0.1:8080/api/oauth';

--- a/app/tests/spec/lib/oauth-errors.js
+++ b/app/tests/spec/lib/oauth-errors.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/oauth-errors'
-],
-function (chai, OAuthErrors) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var OAuthErrors = require('lib/oauth-errors');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/origin-check.js
+++ b/app/tests/spec/lib/origin-check.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/origin-check',
-  '../../mocks/window'
-],
-function (chai, sinon, OriginCheck, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var OriginCheck = require('lib/origin-check');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/profile-client.js
+++ b/app/tests/spec/lib/profile-client.js
@@ -2,17 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/session',
-  'lib/profile-client'
-],
-// FxaClientWrapper is the object that is used in
-// fxa-content-server views. It wraps FxaClient to
-// take care of some app-specific housekeeping.
-function (chai, sinon, Session, ProfileClient) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ProfileClient = require('lib/profile-client');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
 
   var PROFILE_URL = 'http://127.0.0.1:1111';
   var assert = chai.assert;

--- a/app/tests/spec/lib/relier-keys.js
+++ b/app/tests/spec/lib/relier-keys.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/relier-keys'
-], function (chai, RelierKeys) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var RelierKeys = require('lib/relier-keys');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -2,31 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'backbone',
-  'router',
-  'views/sign_in',
-  'views/sign_up',
-  'views/ready',
-  'lib/able',
-  'lib/constants',
-  'lib/environment',
-  'lib/metrics',
-  'lib/ephemeral-messages',
-  'lib/promise',
-  'models/reliers/relier',
-  'models/user',
-  'models/form-prefill',
-  'models/auth_brokers/base',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, Backbone, Router, SignInView, SignUpView, ReadyView,
-      Able, Constants, Environment, Metrics, EphemeralMessages, p, Relier,
-      User, FormPrefill, NullBroker, WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var Backbone = require('backbone');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var Environment = require('lib/environment');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FormPrefill = require('models/form-prefill');
+  var Metrics = require('lib/metrics');
+  var NullBroker = require('models/auth_brokers/base');
+  var p = require('lib/promise');
+  var ReadyView = require('views/ready');
+  var Relier = require('models/reliers/relier');
+  var Router = require('router');
+  var SignInView = require('views/sign_in');
+  var SignUpView = require('views/sign_up');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/screen-info.js
+++ b/app/tests/spec/lib/screen-info.js
@@ -4,13 +4,12 @@
 
 // test the screen-info module
 
-define([
-  'chai',
-  'lib/screen-info',
-  '../../mocks/window'
-],
-function (chai, ScreenInfo, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ScreenInfo = require('lib/screen-info');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/sentry.js
+++ b/app/tests/spec/lib/sentry.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/sentry',
-  'raven',
-  '../../mocks/window'
-], function (chai, sinon, SentryMetrics, Raven, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Raven = require('raven');
+  var SentryMetrics = require('lib/sentry');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
   var windowMock;

--- a/app/tests/spec/lib/service-name.js
+++ b/app/tests/spec/lib/service-name.js
@@ -4,13 +4,12 @@
 
 // test the service-name library
 
-define([
-  'chai',
-  'lib/translator',
-  'lib/service-name'
-],
-function (chai, Translator, ServiceName) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ServiceName = require('lib/service-name');
+  var Translator = require('lib/translator');
 
   var assert = chai.assert;
   var serviceName;

--- a/app/tests/spec/lib/session.js
+++ b/app/tests/spec/lib/session.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/session'
-],
-function (chai, Session) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Session = require('lib/session');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/storage-metrics.js
+++ b/app/tests/spec/lib/storage-metrics.js
@@ -4,15 +4,14 @@
 
 // test the metrics library
 
-define([
-  'chai',
-  'lib/storage-metrics',
-  'lib/metrics',
-  'lib/storage',
-  '../../mocks/window'
-],
-function (chai, StorageMetrics, Metrics, Storage, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var Storage = require('lib/storage');
+  var StorageMetrics = require('lib/storage-metrics');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/storage.js
+++ b/app/tests/spec/lib/storage.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/storage',
-  'lib/null-storage',
-  '../../mocks/window'
-],
-function (chai, sinon, Storage, NullStorage, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var NullStorage = require('lib/null-storage');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/strings.js
+++ b/app/tests/spec/lib/strings.js
@@ -4,12 +4,11 @@
 
 // test the interpolated library
 
-define([
-  'chai',
-  'lib/strings'
-],
-function (chai, Strings) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Strings = require('lib/strings');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/translator.js
+++ b/app/tests/spec/lib/translator.js
@@ -4,12 +4,11 @@
 
 // test the translation library
 
-define([
-  'chai',
-  'lib/translator'
-],
-function (chai, Translator) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Translator = require('lib/translator');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/url.js
+++ b/app/tests/spec/lib/url.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/url'
-],
-function (chai, Url) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Url = require('lib/url');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/validate.js
+++ b/app/tests/spec/lib/validate.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/validate',
-  'lib/constants',
-  '../../lib/helpers'
-],
-function (chai, Validate, Constants, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var TestHelpers = require('../../lib/helpers');
+  var Validate = require('lib/validate');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/xhr.js
+++ b/app/tests/spec/lib/xhr.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  'underscore',
-  'lib/xhr',
-  'lib/promise'
-],
-function (chai, sinon, $, _, Xhr, p) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var chai = require('chai');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var Xhr = require('lib/xhr');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/xss.js
+++ b/app/tests/spec/lib/xss.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'underscore',
-  'lib/xss',
-  'lib/constants'
-],
-function (chai, _, XSS, Constants) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var XSS = require('lib/xss');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -2,26 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/constants',
-  'lib/assertion',
-  'lib/profile-client',
-  'lib/oauth-client',
-  'lib/fxa-client',
-  'lib/auth-errors',
-  'lib/profile-errors',
-  'lib/marketing-email-client',
-  'models/account',
-  'models/oauth-token',
-  'models/reliers/relier'
-],
-function (chai, sinon, p, Constants, Assertion, ProfileClient,
-    OAuthClient, FxaClientWrapper, AuthErrors, ProfileErrors,
-    MarketingEmailClient, Account, OAuthToken, Relier) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Account = require('models/account');
+  var Assertion = require('lib/assertion');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClientWrapper = require('lib/fxa-client');
+  var MarketingEmailClient = require('lib/marketing-email-client');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthToken = require('models/oauth-token');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var ProfileErrors = require('lib/profile-errors');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'views/base',
-  '../../../mocks/window'
-],
-function (chai, Relier, BaseAuthenticationBroker, BaseView, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseAuthenticationBroker = require('models/auth_brokers/base');
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Relier = require('models/reliers/relier');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/first-run.js
+++ b/app/tests/spec/models/auth_brokers/first-run.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/null',
-  'models/account',
-  'models/auth_brokers/first-run',
-  'models/reliers/relier',
-  '../../../mocks/window'
-],
-function (chai, sinon, NullChannel, Account, FirstRunAuthenticationBroker, Relier, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Account = require('models/account');
+  var chai = require('chai');
+  var FirstRunAuthenticationBroker = require('models/auth_brokers/first-run');
+  var NullChannel = require('lib/channels/null');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/null',
-  'lib/promise',
-  'models/auth_brokers/fx-desktop-v2',
-  '../../../mocks/window'
-], function (chai, sinon, NullChannel, p, FxDesktopV2AuthenticationBroker,
-  WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FxDesktopV2AuthenticationBroker = require('models/auth_brokers/fx-desktop-v2');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/fx-desktop.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop.js
@@ -2,18 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'models/auth_brokers/fx-desktop',
-  'models/user',
-  'lib/auth-errors',
-  'lib/channels/null',
-  'lib/promise',
-  '../../../mocks/window'
-], function (chai, sinon, FxDesktopAuthenticationBroker, User,
-        AuthErrors, NullChannel, p, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var FxDesktopAuthenticationBroker = require('models/auth_brokers/fx-desktop');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/iframe.js
+++ b/app/tests/spec/models/auth_brokers/iframe.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  'models/auth_brokers/iframe',
-  'models/reliers/relier',
-  'lib/promise',
-  'lib/channels/null',
-  'lib/session',
-  '../../../mocks/window'
-],
-function (chai, sinon, $, IframeAuthenticationBroker, Relier, p, NullChannel,
-      Session, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var IframeAuthenticationBroker = require('models/auth_brokers/iframe');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -2,23 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/session',
-  'lib/promise',
-  'lib/constants',
-  'lib/oauth-client',
-  'lib/assertion',
-  'lib/auth-errors',
-  'lib/oauth-errors',
-  'models/reliers/relier',
-  'models/user',
-  'models/auth_brokers/oauth'
-],
-function (chai, sinon, Session, p, Constants, OAuthClient, Assertion, AuthErrors,
-      OAuthErrors, Relier, User, OAuthAuthenticationBroker) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Assertion = require('lib/assertion');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var OAuthAuthenticationBroker = require('models/auth_brokers/oauth');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var User = require('models/user');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/redirect.js
+++ b/app/tests/spec/models/auth_brokers/redirect.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/constants',
-  'lib/session',
-  'models/auth_brokers/redirect',
-  'models/reliers/base',
-  'models/user',
-  '../../../mocks/window'
-],
-function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
-    Relier, User, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var p = require('lib/promise');
+  var RedirectAuthenticationBroker = require('models/auth_brokers/redirect');
+  var Relier = require('models/reliers/base');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
   var REDIRECT_TO = 'https://redirect.here';

--- a/app/tests/spec/models/auth_brokers/web-channel.js
+++ b/app/tests/spec/models/auth_brokers/web-channel.js
@@ -2,23 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'models/auth_brokers/web-channel',
-  'models/reliers/relier',
-  'models/user',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/constants',
-  'lib/channels/null',
-  'lib/session',
-  'views/base',
-  '../../../mocks/window'
-],
-function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWrapper,
-      p, Constants, NullChannel, Session, BaseView, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClientWrapper = require('lib/fxa-client');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WebChannelAuthenticationBroker = require('models/auth_brokers/web-channel');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/email-resend.js
+++ b/app/tests/spec/models/email-resend.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'models/email-resend',
-  'lib/constants'
-],
-function (chai, sinon, EmailResend, Constants) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var EmailResend = require('models/email-resend');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/form-prefill.js
+++ b/app/tests/spec/models/form-prefill.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/form-prefill'
-], function (chai, FormPrefill) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/marketing-email-prefs.js
+++ b/app/tests/spec/models/marketing-email-prefs.js
@@ -2,19 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/constants',
-  'lib/marketing-email-client',
-  'models/marketing-email-prefs',
-  'models/account',
-  'models/oauth-token'
-],
-function (chai, sinon, p, Constants, MarketingEmailClient,
-  MarketingEmailPrefs, Account, OAuthToken) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Account = require('models/account');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var MarketingEmailClient = require('lib/marketing-email-client');
+  var MarketingEmailPrefs = require('models/marketing-email-prefs');
+  var OAuthToken = require('models/oauth-token');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/mixins/resume-token.js
+++ b/app/tests/spec/models/mixins/resume-token.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'backbone',
-  'chai',
-  'cocktail',
-  'models/mixins/resume-token',
-  'models/resume-token'
-], function (Backbone, chai, Cocktail, ResumeTokenMixin, ResumeToken) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var ResumeToken = require('models/resume-token');
+  var ResumeTokenMixin = require('models/mixins/resume-token');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/mixins/search-param.js
+++ b/app/tests/spec/models/mixins/search-param.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'backbone',
-  'cocktail',
-  'models/mixins/search-param',
-  '../../../mocks/window',
-  '../../../lib/helpers'
-], function (chai, Backbone, Cocktail, SearchParamMixin, WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var SearchParamMixin = require('models/mixins/search-param');
+  var TestHelpers = require('../../../lib/helpers');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/notifications.js
+++ b/app/tests/spec/models/notifications.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'models/notifications',
-  'lib/channels/null'
-],
-function (chai, sinon, Notifications, NullChannel) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Notifications = require('models/notifications');
+  var NullChannel = require('lib/channels/null');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/oauth-token.js
+++ b/app/tests/spec/models/oauth-token.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'models/oauth-token'
-],
-function (chai, sinon, p, OAuthToken) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var OAuthToken = require('models/oauth-token');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/profile-image.js
+++ b/app/tests/spec/models/profile-image.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/profile-errors',
-  'models/profile-image'
-],
-function (chai, ProfileErrors, ProfileImage) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ProfileErrors = require('lib/profile-errors');
+  var ProfileImage = require('models/profile-image');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/reliers/base.js
+++ b/app/tests/spec/models/reliers/base.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/reliers/base'
-], function (chai, BaseRelier) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseRelier = require('models/reliers/base');
+  var chai = require('chai');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/reliers/fx-desktop.js
+++ b/app/tests/spec/models/reliers/fx-desktop.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/reliers/fx-desktop',
-  'lib/translator',
-  '../../../mocks/window',
-  '../../../lib/helpers'
-], function (chai, Relier, Translator, WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Relier = require('models/reliers/fx-desktop');
+  var TestHelpers = require('../../../lib/helpers');
+  var Translator = require('lib/translator');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -2,22 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'models/reliers/oauth',
-  'models/user',
-  'lib/session',
-  'lib/oauth-client',
-  'lib/oauth-errors',
-  'lib/promise',
-  'lib/relier-keys',
-  'lib/url',
-  '../../../mocks/window',
-  '../../../lib/helpers'
-], function (chai, sinon, OAuthRelier, User, Session, OAuthClient, OAuthErrors,
-      p, RelierKeys, Url, WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthErrors = require('lib/oauth-errors');
+  var OAuthRelier = require('models/reliers/oauth');
+  var p = require('lib/promise');
+  var RelierKeys = require('lib/relier-keys');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var Url = require('lib/url');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   /*eslint-disable camelcase */
   var assert = chai.assert;

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/constants',
-  'models/reliers/relier',
-  'models/resume-token',
-  '../../../mocks/window',
-  '../../../lib/helpers'
-], function (chai, Constants, Relier, ResumeToken, WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var Relier = require('models/reliers/relier');
+  var ResumeToken = require('models/resume-token');
+  var TestHelpers = require('../../../lib/helpers');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/resume-token.js
+++ b/app/tests/spec/models/resume-token.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/resume-token'
-],
-function (chai, ResumeToken) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ResumeToken = require('models/resume-token');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/unique-user-id.js
+++ b/app/tests/spec/models/unique-user-id.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/storage',
-  'lib/url',
-  'models/resume-token',
-  'models/unique-user-id',
-  '../../mocks/window'
-],
-function (chai, Storage, Url, ResumeToken, UniqueUserId, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ResumeToken = require('models/resume-token');
+  var Storage = require('lib/storage');
+  var UniqueUserId = require('models/unique-user-id');
+  var Url = require('lib/url');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/constants',
-  'lib/session',
-  'lib/fxa-client',
-  'models/user'
-],
-function (chai, sinon, p, Constants, Session, FxaClient, User) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClient = require('lib/fxa-client');
+  var p = require('lib/promise');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var User = require('models/user');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/verification/base.js
+++ b/app/tests/spec/models/verification/base.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/verification/base'
-], function (chai, BaseModel) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseModel = require('models/verification/base');
+  var chai = require('chai');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/verification/reset-password.js
+++ b/app/tests/spec/models/verification/reset-password.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/constants',
-  'models/verification/reset-password',
-  '../../../lib/helpers'
-], function (chai, Constants, Model, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var Model = require('models/verification/reset-password');
+  var TestHelpers = require('../../../lib/helpers');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/verification/sign-up.js
+++ b/app/tests/spec/models/verification/sign-up.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/constants',
-  'models/verification/sign-up',
-  '../../../lib/helpers'
-], function (chai, Constants, Model, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var Model = require('models/verification/sign-up');
+  var TestHelpers = require('../../../lib/helpers');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -2,28 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/base',
-  'lib/promise',
-  'lib/translator',
-  'lib/ephemeral-messages',
-  'lib/metrics',
-  'lib/auth-errors',
-  'lib/fxa-client',
-  'models/user',
-  'stache!templates/test_template',
-  '../../mocks/dom-event',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
-          AuthErrors, FxaClient, User, Template, DOMEventMock, RouterMock,
-          WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var DOMEventMock = require('../../mocks/dom-event');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var Template = require('stache!templates/test_template');
+  var TestHelpers = require('../../lib/helpers');
+  var Translator = require('lib/translator');
+  var User = require('models/user');
+  var WindowMock = require('../../mocks/window');
 
   var requiresFocus = TestHelpers.requiresFocus;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/cannot_create_account.js
+++ b/app/tests/spec/views/cannot_create_account.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/cannot_create_account',
-  'models/reliers/relier'
-],
-function (chai, sinon, View, Relier) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var View = require('views/cannot_create_account');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/change_password.js
+++ b/app/tests/spec/views/change_password.js
@@ -2,25 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/auth-errors',
-  'lib/fxa-client',
-  'lib/metrics',
-  'lib/promise',
-  'lib/ephemeral-messages',
-  'views/change_password',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, AuthErrors, FxaClient, Metrics, p,
-    EphemeralMessages, View, Relier, Broker, User, RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/change_password');
 
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/clear_storage.js
+++ b/app/tests/spec/views/clear_storage.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'views/clear_storage'
-],
-function (chai, View) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var View = require('views/clear_storage');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/close_button.js
+++ b/app/tests/spec/views/close_button.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  '../../mocks/window',
-  '../../lib/helpers',
-  'lib/promise',
-  'lib/metrics',
-  'lib/oauth-errors',
-  'views/close_button',
-  'models/auth_brokers/oauth'
-],
-function (chai, sinon, $, WindowMock, TestHelpers, p, Metrics,
-      OAuthErrors, View, OAuthBroker) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var OAuthBroker = require('models/auth_brokers/oauth');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var View = require('views/close_button');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/complete_account_unlock.js
+++ b/app/tests/spec/views/complete_account_unlock.js
@@ -2,26 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'views/complete_account_unlock',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/constants',
-  'lib/fxa-client',
-  'lib/url',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, View, AuthErrors, Metrics, Constants, FxaClient,
-      Url, Relier, Broker, User, RouterMock, WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var Url = require('lib/url');
+  var User = require('models/user');
+  var View = require('views/complete_account_unlock');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -2,25 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/channels/inter-tab',
-  'views/complete_reset_password',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, AuthErrors, Metrics, FxaClient, InterTabChannel,
-      View, Relier, Broker, User, RouterMock, WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var FxaClient = require('lib/fxa-client');
+  var InterTabChannel = require('lib/channels/inter-tab');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/complete_reset_password');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -2,27 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'views/complete_sign_up',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/constants',
-  'lib/fxa-client',
-  'lib/marketing-email-errors',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, View, AuthErrors, Metrics, Constants,
-      FxaClient, MarketingEmailErrors, Relier, Broker, User, RouterMock,
-      WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClient = require('lib/fxa-client');
+  var MarketingEmailErrors = require('lib/marketing-email-errors');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/complete_sign_up');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -2,27 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/session',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/ephemeral-messages',
-  'views/confirm',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient,
-      EphemeralMessages, View, Relier, BaseBroker, User,
-      WindowMock, RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseBroker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/confirm');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/confirm_account_unlock.js
+++ b/app/tests/spec/views/confirm_account_unlock.js
@@ -2,27 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/session',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/ephemeral-messages',
-  'views/confirm_account_unlock',
-  'models/reliers/relier',
-  'models/user',
-  'models/auth_brokers/oauth',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient,
-      EphemeralMessages, View, Relier, User, OAuthBroker, RouterMock,
-      WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var OAuthBroker = require('models/auth_brokers/oauth');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/confirm_account_unlock');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -2,28 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/auth-errors',
-  'views/confirm_reset_password',
-  'lib/metrics',
-  'lib/ephemeral-messages',
-  'lib/channels/inter-tab',
-  'lib/storage',
-  '../../mocks/fxa-client',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, AuthErrors, View, Metrics, EphemeralMessages,
-      InterTabChannel, Storage, FxaClient, Relier, Broker, User,
-      RouterMock, WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('../../mocks/fxa-client');
+  var InterTabChannel = require('lib/channels/inter-tab');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/confirm_reset_password');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/cookies_disabled.js
+++ b/app/tests/spec/views/cookies_disabled.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'chai',
-  'sinon',
-  'views/cookies_disabled',
-  '../../mocks/window',
-  'lib/storage'
-],
-function ($, chai, sinon, View, WindowMock, Storage) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var View = require('views/cookies_disabled');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/coppa/coppa-date-picker.js
+++ b/app/tests/spec/views/coppa/coppa-date-picker.js
@@ -2,19 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'moment',
-  'sinon',
-  'views/coppa/coppa-date-picker',
-  'models/form-prefill',
-  'lib/auth-errors',
-  'lib/metrics',
-  '../../../lib/helpers'
-],
-function (chai, $, moment, sinon, View, FormPrefill, AuthErrors, Metrics, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
+  var Metrics = require('lib/metrics');
+  var moment = require('moment');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var View = require('views/coppa/coppa-date-picker');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/decorators/progress_indicator.js
+++ b/app/tests/spec/views/decorators/progress_indicator.js
@@ -3,17 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  'lib/promise',
-  'views/base',
-  'views/progress_indicator',
-  'views/decorators/progress_indicator'
-],
-function (chai, sinon, $, p, BaseView, ProgressIndicator, showProgressIndicator) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var p = require('lib/promise');
+  var ProgressIndicator = require('views/progress_indicator');
+  var showProgressIndicator = require('views/decorators/progress_indicator');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/delete_account.js
+++ b/app/tests/spec/views/delete_account.js
@@ -2,24 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/delete_account',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, View, FxaClient, p, AuthErrors, Metrics,
-    Relier, Broker, User, RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/delete_account');
 
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -2,25 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/force_auth',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/auth-errors',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  'models/form-prefill',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, View, FxaClient, p, AuthErrors, Relier, Broker,
-      User, FormPrefill, WindowMock, RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/force_auth');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  'lib/promise',
-  'views/form',
-  'stache!templates/test_template',
-  'lib/constants',
-  'lib/metrics',
-  'lib/auth-errors',
-  '../../lib/helpers'
-],
-function (chai, sinon, $, p, FormView, Template, Constants, Metrics, AuthErrors,
-      TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var Template = require('stache!templates/test_template');
+  var TestHelpers = require('../../lib/helpers');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/marketing_snippet.js
+++ b/app/tests/spec/views/marketing_snippet.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'views/marketing_snippet',
-  'lib/metrics',
-  '../../mocks/window'
-],
-function (chai, View, Metrics, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var View = require('views/marketing_snippet');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/marketing_snippet_ios.js
+++ b/app/tests/spec/views/marketing_snippet_ios.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/marketing_snippet_ios',
-  'lib/able',
-  'lib/metrics',
-  '../../mocks/window'
-],
-function (chai, sinon, View, Able, Metrics, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var sinon = require('sinon');
+  var View = require('views/marketing_snippet_ios');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/account-locked-mixin.js
+++ b/app/tests/spec/views/mixins/account-locked-mixin.js
@@ -2,24 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'cocktail',
-  'sinon',
-  'models/reliers/base',
-  'models/user',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics',
-  'views/mixins/account-locked-mixin',
-  'views/base',
-  'stache!templates/test_template',
-  '../../../mocks/router',
-  '../../../lib/helpers'
-], function (Chai, Cocktail, sinon, Relier, User, FxaClient, p, AuthErrors,
-    Metrics, AccountLockedMixin, BaseView, Template, RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var AccountLockedMixin = require('views/mixins/account-locked-mixin');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/base');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var Template = require('stache!templates/test_template');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -2,26 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'underscore',
-  'views/mixins/avatar-mixin',
-  'views/base',
-  'models/notifications',
-  'models/reliers/relier',
-  'models/user',
-  'models/account',
-  'models/profile-image',
-  'lib/metrics',
-  'lib/profile-errors',
-  'lib/promise',
-  'lib/channels/null',
-  '../../../lib/helpers'
-], function (Chai, sinon, _, AvatarMixin, BaseView, Notifications, Relier,
-    User, Account, ProfileImage, Metrics, ProfileErrors, p, NullChannel,
-    TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Account = require('models/account');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var Notifications = require('models/notifications');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var ProfileErrors = require('lib/profile-errors');
+  var ProfileImage = require('models/profile-image');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/back-mixin.js
+++ b/app/tests/spec/views/mixins/back-mixin.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'chai',
-  'sinon',
-  '../../../mocks/window',
-  'views/mixins/back-mixin',
-  'views/base',
-  'stache!templates/test_template'
-], function (Cocktail, Chai, sinon, WindowMock,
-        BackMixin, BaseView, TestTemplate) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var sinon = require('sinon');
+  var TestTemplate = require('stache!templates/test_template');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = Chai.assert;
   var ENTER_BUTTON_CODE = 13;

--- a/app/tests/spec/views/mixins/checkbox-mixin.js
+++ b/app/tests/spec/views/mixins/checkbox-mixin.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'chai',
-  'sinon',
-  'views/mixins/checkbox-mixin',
-  'views/base',
-  'stache!templates/test_template'
-], function (Cocktail, Chai, sinon, CheckboxMixin, BaseView, Template) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var CheckboxMixin = require('views/mixins/checkbox-mixin');
+  var Cocktail = require('cocktail');
+  var sinon = require('sinon');
+  var Template = require('stache!templates/test_template');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/floating-placeholder-mixin.js
+++ b/app/tests/spec/views/mixins/floating-placeholder-mixin.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'underscore',
-  'chai',
-  'views/form',
-  'stache!templates/test_template',
-  'views/mixins/floating-placeholder-mixin'
-], function ($, _, chai, FormView, Template, FloatingPlaceholderMixin) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var chai = require('chai');
+  var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  var FormView = require('views/form');
+  var Template = require('stache!templates/test_template');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/loading-mixin.js
+++ b/app/tests/spec/views/mixins/loading-mixin.js
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'cocktail',
-  'chai',
-  'views/mixins/loading-mixin',
-  'views/base',
-  'stache!templates/test_template',
-  '../../../mocks/window'
-], function ($, Cocktail, Chai, LoadingMixin, BaseView, Template, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var LoadingMixin = require('views/mixins/loading-mixin');
+  var Template = require('stache!templates/test_template');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/password-mixin.js
+++ b/app/tests/spec/views/mixins/password-mixin.js
@@ -2,20 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'chai',
-  'sinon',
-  'underscore',
-  'lib/metrics',
-  'views/mixins/password-mixin',
-  'views/base',
-  'models/reliers/relier',
-  'stache!templates/test_template',
-  '../../../lib/helpers'
-], function ($, chai, sinon, _, Metrics, PasswordMixin, BaseView, Relier,
-  TestTemplate, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var TestTemplate = require('stache!templates/test_template');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/resume-token-mixin.js
+++ b/app/tests/spec/views/mixins/resume-token-mixin.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'cocktail',
-  'models/reliers/relier',
-  'models/resume-token',
-  'stache!templates/test_template',
-  'views/base',
-  'views/mixins/resume-token-mixin',
-], function (chai, Cocktail, Relier, ResumeToken, TestTemplate,
-  BaseView, ResumeTokenMixin ) {
+define(function(require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Relier = require('models/reliers/relier');
+  var ResumeToken = require('models/resume-token');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var TestTemplate = require('stache!templates/test_template');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/service-mixin.js
+++ b/app/tests/spec/views/mixins/service-mixin.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'underscore',
-  '../../../mocks/window',
-  'views/mixins/service-mixin',
-  'views/base',
-  'lib/session',
-  'stache!templates/test_template',
-  'models/reliers/oauth',
-  'models/auth_brokers/base'
-], function (Chai, sinon, _, WindowMock,
-        ServiceMixin, BaseView, Session,
-        TestTemplate, OAuthRelier, NullBroker) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var NullBroker = require('models/auth_brokers/base');
+  var OAuthRelier = require('models/reliers/oauth');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestTemplate = require('stache!templates/test_template');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/timer-mixin.js
+++ b/app/tests/spec/views/mixins/timer-mixin.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'underscore',
-  '../../../lib/helpers',
-  'views/mixins/timer-mixin',
-  'views/base'
-], function (Chai, _, TestHelpers, TimerMixin, BaseView) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var TestHelpers = require('../../../lib/helpers');
+  var TimerMixin = require('views/mixins/timer-mixin');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/oauth_sign_in.js
+++ b/app/tests/spec/views/oauth_sign_in.js
@@ -2,26 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/sign_in',
-  'lib/session',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/metrics',
-  'models/reliers/oauth',
-  'models/auth_brokers/oauth',
-  'models/user',
-  'models/form-prefill',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, View, Session, FxaClient, p, Metrics, OAuthRelier,
-      OAuthBroker, User, FormPrefill, WindowMock, RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var OAuthBroker = require('models/auth_brokers/oauth');
+  var OAuthRelier = require('models/reliers/oauth');
+  var p = require('lib/promise');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/sign_in');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -2,30 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/sign_up',
-  'lib/promise',
-  'lib/session',
-  'lib/fxa-client',
-  'lib/metrics',
-  'lib/oauth-client',
-  'lib/assertion',
-  'lib/able',
-  'models/reliers/oauth',
-  'models/auth_brokers/oauth',
-  'models/user',
-  'models/form-prefill',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, View, p, Session, FxaClient, Metrics, OAuthClient,
-      Assertion, Able, OAuthRelier, OAuthBroker, User, FormPrefill, WindowMock,
-      RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Able = require('lib/able');
+  var Assertion = require('lib/assertion');
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var OAuthBroker = require('models/auth_brokers/oauth');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthRelier = require('models/reliers/oauth');
+  var p = require('lib/promise');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/sign_up');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/permissions.js
+++ b/app/tests/spec/views/permissions.js
@@ -2,25 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/promise',
-  'views/permissions',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/ephemeral-messages',
-  'models/reliers/relier',
-  'models/user',
-  'models/auth_brokers/base',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, p, View, Metrics, FxaClient, EphemeralMessages,
-      Relier, User, Broker, WindowMock, RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/permissions');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/pp.js
+++ b/app/tests/spec/views/pp.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/pp',
-  'lib/promise',
-  '../../mocks/window'
-],
-function (chai, sinon, View, p, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var View = require('views/pp');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/progress_indicator.js
+++ b/app/tests/spec/views/progress_indicator.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  'views/progress_indicator'
-],
-function (chai, sinon, $, ProgressIndicator) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var ProgressIndicator = require('views/progress_indicator');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
   var progressIndicator;

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/ready',
-  'lib/session',
-  'lib/fxa-client',
-  'lib/able',
-  'models/reliers/fx-desktop',
-  'models/auth_brokers/oauth',
-  '../../mocks/window'
-],
-function (chai, sinon, View, Session, FxaClient, Able, FxDesktopRelier,
-      OAuthBroker, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var chai = require('chai');
+  var FxaClient = require('lib/fxa-client');
+  var FxDesktopRelier = require('models/reliers/fx-desktop');
+  var OAuthBroker = require('models/auth_brokers/oauth');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var View = require('views/ready');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -2,24 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore',
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'views/reset_password',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/form-prefill',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (_, chai, sinon, p, AuthErrors, Metrics, FxaClient, View, Relier,
-      Broker, FormPrefill, RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var View = require('views/reset_password');
 
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -2,26 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings',
-  '../../mocks/router',
-  '../../lib/helpers',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/profile-errors',
-  'lib/auth-errors',
-  'lib/able',
-  'lib/metrics',
-  'models/reliers/relier',
-  'models/profile-image',
-  'models/user'
-],
-function (chai, $, sinon, View, RouterMock, TestHelpers,
-      FxaClient, p, ProfileErrors, AuthErrors, Able, Metrics, Relier, ProfileImage, User) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Able = require('lib/able');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var ProfileErrors = require('lib/profile-errors');
+  var ProfileImage = require('models/profile-image');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/settings/avatar.js
+++ b/app/tests/spec/views/settings/avatar.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/avatar',
-  '../../../mocks/router',
-  '../../../mocks/fxa-client',
-  'lib/promise',
-  'lib/auth-errors',
-  'models/reliers/relier',
-  'models/user'
-],
-function (chai, $, sinon, View, RouterMock, FxaClientMock,
-    p, AuthErrors, Relier, User) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var FxaClientMock = require('../../../mocks/fxa-client');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var View = require('views/settings/avatar');
 
   var assert = chai.assert;
   var IMG_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';

--- a/app/tests/spec/views/settings/avatar_camera.js
+++ b/app/tests/spec/views/settings/avatar_camera.js
@@ -2,25 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/avatar_camera',
-  '../../../mocks/router',
-  '../../../mocks/window',
-  '../../../mocks/canvas',
-  '../../../mocks/profile',
-  '../../../lib/helpers',
-  'models/user',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'lib/promise',
-  'lib/metrics'
-],
-function (chai, $, sinon, View, RouterMock, WindowMock, CanvasMock,
-    ProfileMock, TestHelpers, User, Relier, AuthBroker, p, Metrics) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthBroker = require('models/auth_brokers/base');
+  var CanvasMock = require('../../../mocks/canvas');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var ProfileMock = require('../../../mocks/profile');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/avatar_camera');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
   var SCREEN_NAME = 'settings.avatar.camera';

--- a/app/tests/spec/views/settings/avatar_change.js
+++ b/app/tests/spec/views/settings/avatar_change.js
@@ -2,26 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/avatar_change',
-  '../../../mocks/router',
-  '../../../mocks/file-reader',
-  '../../../mocks/profile',
-  '../../../mocks/window',
-  '../../../lib/helpers',
-  'models/user',
-  'models/reliers/relier',
-  'lib/profile-client',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics'
-],
-function (chai, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
-            WindowMock, TestHelpers, User, Relier, ProfileClient, p, AuthErrors, Metrics) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var FileReaderMock = require('../../../mocks/file-reader');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var ProfileMock = require('../../../mocks/profile');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/avatar_change');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAACZJREFUeNrtwQEBAAAAgiD' +

--- a/app/tests/spec/views/settings/avatar_crop.js
+++ b/app/tests/spec/views/settings/avatar_crop.js
@@ -2,29 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* exceptsPaths: draggable, jquery-simulate */
-define([
-  'chai',
-  'jquery',
-  'draggable',
-  'sinon',
-  'jquery-simulate',
-  'views/settings/avatar_crop',
-  '../../../mocks/router',
-  '../../../mocks/profile',
-  'models/user',
-  'models/cropper-image',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'lib/promise',
-  'lib/ephemeral-messages',
-  'lib/auth-errors',
-  'lib/metrics',
-  '../../../lib/helpers'
-],
-function (chai, $, ui, sinon, jQuerySimulate, View, RouterMock, ProfileMock, User, CropperImage,
-    Relier, AuthBroker, p, EphemeralMessages, AuthErrors, Metrics, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthBroker = require('models/auth_brokers/base');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var CropperImage = require('models/cropper-image');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var jQuerySimulate = require('jquery-simulate'); //eslint-disable-line no-unused-vars
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var ProfileMock = require('../../../mocks/profile');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var ui = require('draggable'); //eslint-disable-line no-unused-vars
+  var User = require('models/user');
+  var View = require('views/settings/avatar_crop');
 
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAACZJREFUeNrtwQEBAAAAgiD' +

--- a/app/tests/spec/views/settings/avatar_gravatar.js
+++ b/app/tests/spec/views/settings/avatar_gravatar.js
@@ -2,24 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/avatar_gravatar',
-  '../../../mocks/router',
-  '../../../mocks/profile',
-  '../../../lib/helpers',
-  'models/user',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'lib/promise',
-  'lib/metrics',
-  'lib/profile-client'
-],
-function (chai, $, sinon, View, RouterMock, ProfileMock, TestHelpers, User,
-    Relier, AuthBroker, p, Metrics, ProfileClient) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthBroker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var ProfileMock = require('../../../mocks/profile');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/avatar_gravatar');
 
   var assert = chai.assert;
   var GRAVATAR_URL = 'https://secure.gravatar.com/avatar/';

--- a/app/tests/spec/views/settings/communication_preferences.js
+++ b/app/tests/spec/views/settings/communication_preferences.js
@@ -2,24 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/communication_preferences',
-  'models/user',
-  'models/account',
-  'models/marketing-email-prefs',
-  'models/reliers/relier',
-  'lib/promise',
-  'lib/constants',
-  'lib/marketing-email-errors',
-  'lib/metrics',
-  '../../../lib/helpers'
-],
-function (chai, $, sinon, View, User, Account, MarketingEmailPrefs, Relier,
-  p, Constants, MarketingEmailErrors, Metrics, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Account = require('models/account');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var MarketingEmailErrors = require('lib/marketing-email-errors');
+  var MarketingEmailPrefs = require('models/marketing-email-prefs');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/communication_preferences');
 
   var assert = chai.assert;
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;

--- a/app/tests/spec/views/settings/gravatar_permissions.js
+++ b/app/tests/spec/views/settings/gravatar_permissions.js
@@ -2,18 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/gravatar_permissions',
-  'lib/metrics',
-  'models/user',
-  '../../../mocks/router',
-  '../../../lib/helpers'
-],
-function (chai, $, sinon, View, Metrics, User, RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/gravatar_permissions');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -2,30 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/promise',
-  'views/sign_in',
-  'lib/session',
-  'lib/auth-errors',
-  'lib/oauth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/constants',
-  'models/reliers/relier',
-  'models/user',
-  'models/form-prefill',
-  'models/auth_brokers/base',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
-      FxaClient, Constants, Relier, User, FormPrefill, Broker, WindowMock,
-      RouterMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/sign_in');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -3,32 +3,29 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 /*global translator */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/promise',
-  'views/sign_up',
-  'views/coppa/coppa-date-picker',
-  'lib/session',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/ephemeral-messages',
-  'lib/mailcheck',
-  'lib/able',
-  'models/reliers/fx-desktop',
-  'models/auth_brokers/base',
-  'models/user',
-  'models/form-prefill',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, p, View, Coppa, Session, AuthErrors, Metrics,
-      FxaClient, EphemeralMessages, mailcheck, Able, Relier, Broker, User, FormPrefill,
-      RouterMock, WindowMock, TestHelpers) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Able = require('lib/able');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var Coppa = require('views/coppa/coppa-date-picker');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var mailcheck = require('lib/mailcheck');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/fx-desktop');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/sign_up');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/tooltip.js
+++ b/app/tests/spec/views/tooltip.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'views/tooltip'
-],
-function (chai, $, Tooltip) {
+define(function(require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var Tooltip = require('views/tooltip');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/tos.js
+++ b/app/tests/spec/views/tos.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/tos',
-  'lib/promise',
-  '../../mocks/window'
-],
-function (chai, sinon, View, p, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var View = require('views/tos');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/unexpected_error.js
+++ b/app/tests/spec/views/unexpected_error.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/ephemeral-messages',
-  'views/unexpected_error',
-  '../../mocks/window'
-],
-function (chai, EphemeralMessages, View, WindowMock) {
+define(function(require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var View = require('views/unexpected_error');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/grunttasks/amdcheck.js
+++ b/grunttasks/amdcheck.js
@@ -12,8 +12,6 @@ module.exports = function (grunt) {
       files: [{
         expand: true,
         src: [
-          'app/{scripts,tests}/**/*.js',
-          'app/!scripts/vendor/**',
           'tests/functional/**/*.js'
         ]
       }]


### PR DESCRIPTION
This is not a full refactoring away from AMD to CommonJS, but a step there. All I have done is handle the dependencies, I have not updated to use module.exports or anything like that. I have multiple end goals: 

1. Code clarity. I find it difficult to keep track of how dependency paths map to module names in modules with many dependencies, like [router.js](https://github.com/mozilla/fxa-content-server/blob/master/app/scripts/router.js) or [app-start.js](https://github.com/mozilla/fxa-content-server/blob/master/app/scripts/lib/app-start.js). I find the CommonJS style much simpler to read.
1. Be able to use WebPack or another module loader/bundler to chunk up the dependencies into smaller batches. WebPack works with AMD modules. browserify is designed to work with CommonJS modules.
1. Simplify object creation and remove hand coded creation of the object graph, work started by @eoger in [#2792].
1. Spend a Friday night playing with ASTs and doing transforms because I haven't had a reason to in a long time.

I do not advocate merging this just yet, I am trying to use this as another point of discussion into how we can both simplify the object graph and chunk up dependencies into smaller JS bundles.