### PR TITLE
fix(client): Fix incorrect OAuth errors in error table.

### DIFF
--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -43,13 +43,13 @@ function (_, Errors, Strings) {
       errno: 107,
       message: t('Expired code')
     },
-    INVALID_PARAMETER: {
+    INVALID_TOKEN: {
       errno: 108,
-      message: t('Invalid parameter in request body: %(param)s')
+      message: t('Invalid token')
     },
-    INVALID_REQUEST_SIGNATURE: {
+    INVALID_REQUEST_PARAMETER: {
       errno: 109,
-      message: t('Invalid request signature')
+      message: t('Invalid OAuth parameter: %(param)s')
     },
     INVALID_RESPONSE_TYPE: {
       errno: 110,
@@ -116,11 +116,15 @@ function (_, Errors, Strings) {
      */
     toInterpolationContext: function (err) {
       // For data returned by backend, see
-      // https://github.com/mozilla/fxa-auth-server/blob/master/error.js
+      // https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#errors
       try {
         if (this.is(err, 'MISSING_PARAMETER')) {
           return {
             param: err.param
+          };
+        } else if (this.is(err, 'INVALID_REQUEST_PARAMETER')) {
+          return {
+            param: err.validation.keys.join(',')
           };
         }
       } catch (e) {

--- a/app/tests/spec/lib/oauth-errors.js
+++ b/app/tests/spec/lib/oauth-errors.js
@@ -60,18 +60,33 @@ function (chai, OAuthErrors) {
     });
 
     describe('toInterpolationContext', function () {
-      it('context returns object', function () {
+      it('returns an empty object by default', function () {
         var result = OAuthErrors.toInterpolationContext(OAuthErrors.toError('UNKNOWN_CLIENT'));
         assert.equal(Object.keys(result).length, 0);
       });
 
-      it('context returns param', function () {
+      it('`MISSING_PARAMETER` returns object w/ `param`', function () {
         var err = OAuthErrors.toError('MISSING_PARAMETER');
         err.param = 'param';
         assert.equal(OAuthErrors.toInterpolationContext(err).param, 'param');
       });
 
-      it('context catches data exception', function () {
+      it('`INVALID_REQUEST_PARAMETER` returns object w/ `param`', function () {
+        var err = OAuthErrors.toError('INVALID_REQUEST_PARAMETER');
+        err.validation = {
+          keys: ['param']
+        };
+        assert.equal(OAuthErrors.toInterpolationContext(err).param, 'param');
+      });
+
+      it('malformed server responses are handled gracefully', function () {
+        var err = OAuthErrors.toError('INVALID_REQUEST_PARAMETER');
+        // validation should have a keys field that is an array.
+        err.validation = {};
+        assert.equal(Object.keys(OAuthErrors.toInterpolationContext(err)).length, 0);
+      });
+
+      it('undefined server responses are handled gracefully', function () {
         assert.equal(Object.keys(OAuthErrors.toInterpolationContext(undefined)).length, 0);
       });
     });


### PR DESCRIPTION
Errors 108 and 109 were incorrect in the OAuth error table
according to the spec at
https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#errors.

This fixes those errors and ensure invalid request parameters
are correctly interpolated.

fixes #2830