### PR TITLE
chore(sass): update sass

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -63,3 +63,8 @@ $fox-logo-zindex: 999;
 //IFrame close button
 $close-button-color: #c5cdd4;
 $close-button-zindex: $fox-logo-zindex + 1;
+
+$image-url-path: "/images/" !default;
+@function image-url($url) {
+  @return url("#{$image-url-path}#{$url}");
+}

--- a/grunttasks/sass.js
+++ b/grunttasks/sass.js
@@ -4,9 +4,6 @@
 
 module.exports = function (grunt) {
   grunt.config('sass', {
-    options: {
-      imagePath: '/images'
-    },
     styles: {
       files: {
         '<%= yeoman.app %>/styles/main.css': '<%= yeoman.app %>/styles/main.scss',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -75,7 +75,7 @@
         },
         "qs": {
           "version": "4.0.0",
-          "from": "qs@4.0.0",
+          "from": "qs@>=4.0.0 <4.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
         },
         "raw-body": {
@@ -645,7 +645,7 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <2.1.0",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -1477,7 +1477,7 @@
                 },
                 "end-of-stream": {
                   "version": "1.1.0",
-                  "from": "end-of-stream@>=1.0.0 <2.0.0",
+                  "from": "end-of-stream@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                   "dependencies": {
                     "once": {
@@ -1671,9 +1671,9 @@
                           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                         },
                         "prepend-http": {
-                          "version": "1.0.1",
+                          "version": "1.0.2",
                           "from": "prepend-http@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
                         },
                         "read-all-stream": {
                           "version": "3.0.1",
@@ -1744,14 +1744,14 @@
                       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
                       "dependencies": {
                         "rc": {
-                          "version": "1.0.3",
+                          "version": "1.1.0",
                           "from": "rc@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.0.tgz",
                           "dependencies": {
                             "minimist": {
-                              "version": "0.0.10",
-                              "from": "minimist@>=0.0.7 <0.1.0",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                              "version": "1.1.2",
+                              "from": "minimist@>=1.1.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
                             },
                             "deep-extend": {
                               "version": "0.2.11",
@@ -2002,7 +2002,7 @@
       "dependencies": {
         "vary": {
           "version": "1.0.1",
-          "from": "vary@>=1.0.0 <2.0.0",
+          "from": "vary@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
         }
       }
@@ -2156,7 +2156,7 @@
         },
         "qs": {
           "version": "4.0.0",
-          "from": "qs@4.0.0",
+          "from": "qs@>=4.0.0 <4.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
         },
         "range-parser": {
@@ -2674,7 +2674,7 @@
                 },
                 "deep-equal": {
                   "version": "1.0.0",
-                  "from": "deep-equal@>=1.0.0 <2.0.0",
+                  "from": "deep-equal@*",
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
                 },
                 "defined": {
@@ -2777,9 +2777,16 @@
                   }
                 },
                 "has": {
-                  "version": "1.0.0",
+                  "version": "1.0.1",
                   "from": "has@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+                  "dependencies": {
+                    "function-bind": {
+                      "version": "1.0.2",
+                      "from": "function-bind@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.0.2.tgz"
+                    }
+                  }
                 },
                 "http-browserify": {
                   "version": "1.7.0",
@@ -2915,9 +2922,9 @@
                   }
                 },
                 "module-deps": {
-                  "version": "3.8.1",
+                  "version": "3.9.0",
                   "from": "module-deps@>=3.7.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.1.tgz",
+                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.0.tgz",
                   "dependencies": {
                     "JSONStream": {
                       "version": "1.0.4",
@@ -3481,9 +3488,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                         },
                         "moment": {
-                          "version": "2.10.3",
+                          "version": "2.10.5",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.5.tgz"
                         }
                       }
                     }
@@ -3505,9 +3512,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                         },
                         "moment": {
-                          "version": "2.10.3",
+                          "version": "2.10.5",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.5.tgz"
                         }
                       }
                     }
@@ -3605,9 +3612,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                         },
                         "moment": {
-                          "version": "2.10.3",
+                          "version": "2.10.5",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.5.tgz"
                         }
                       }
                     }
@@ -3670,9 +3677,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                         },
                         "moment": {
-                          "version": "2.10.3",
+                          "version": "2.10.5",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.5.tgz"
                         }
                       }
                     }
@@ -4165,9 +4172,9 @@
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000240",
+              "version": "1.0.30000245",
               "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000240.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000245.tgz"
             }
           }
         },
@@ -4183,7 +4190,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -4451,7 +4458,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -4461,7 +4468,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -4473,7 +4480,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -4516,7 +4523,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -4526,7 +4533,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -4538,7 +4545,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -4574,7 +4581,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -4810,7 +4817,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -4820,7 +4827,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -4832,7 +4839,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -5042,7 +5049,7 @@
             },
             "uglify-js": {
               "version": "2.4.24",
-              "from": "uglify-js@>=2.4.0 <2.5.0",
+              "from": "uglify-js@>=2.4.19 <3.0.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
               "dependencies": {
                 "async": {
@@ -5235,7 +5242,7 @@
         },
         "maxmin": {
           "version": "1.1.0",
-          "from": "maxmin@>=1.0.0 <2.0.0",
+          "from": "maxmin@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
           "dependencies": {
             "figures": {
@@ -5672,9 +5679,9 @@
       "resolved": "https://registry.npmjs.org/grunt-rev/-/grunt-rev-0.1.0.tgz"
     },
     "grunt-sass": {
-      "version": "0.18.1",
-      "from": "grunt-sass@0.18.1",
-      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-0.18.1.tgz",
+      "version": "1.0.0",
+      "from": "grunt-sass@1.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-1.0.0.tgz",
       "dependencies": {
         "each-async": {
           "version": "1.1.1",
@@ -5694,65 +5701,58 @@
           }
         },
         "node-sass": {
-          "version": "2.1.1",
-          "from": "node-sass@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-2.1.1.tgz",
+          "version": "3.2.0",
+          "from": "node-sass@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.2.0.tgz",
           "dependencies": {
+            "async-foreach": {
+              "version": "0.1.3",
+              "from": "async-foreach@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
+            },
             "chalk": {
-              "version": "0.5.1",
-              "from": "chalk@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "version": "1.1.0",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                  "version": "2.1.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
-                  "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
-                  "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "version": "3.0.0",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
-                  "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-                }
-              }
-            },
-            "cross-spawn": {
-              "version": "0.2.9",
-              "from": "cross-spawn@>=0.2.6 <0.3.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.9.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "lru-cache@>=2.5.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
@@ -5814,9 +5814,74 @@
               "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
+            "glob": {
+              "version": "5.0.14",
+              "from": "glob@>=5.0.3 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
+            },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@>=3.0.0 <4.0.0",
+              "from": "meow@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
@@ -5874,116 +5939,9 @@
                 }
               }
             },
-            "mocha": {
-              "version": "2.2.5",
-              "from": "mocha@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.5.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.3.0",
-                  "from": "commander@2.3.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
-                },
-                "debug": {
-                  "version": "2.0.0",
-                  "from": "debug@2.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "diff": {
-                  "version": "1.4.0",
-                  "from": "diff@1.4.0",
-                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.2",
-                  "from": "escape-string-regexp@1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
-                },
-                "glob": {
-                  "version": "3.2.3",
-                  "from": "glob@3.2.3",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@>=0.2.11 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.6.5",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "2.0.3",
-                      "from": "graceful-fs@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "growl": {
-                  "version": "1.8.1",
-                  "from": "growl@1.8.1",
-                  "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
-                },
-                "jade": {
-                  "version": "0.26.3",
-                  "from": "jade@0.26.3",
-                  "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-                  "dependencies": {
-                    "commander": {
-                      "version": "0.6.1",
-                      "from": "commander@0.6.1",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.3.0",
-                      "from": "mkdirp@0.3.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.0",
-                  "from": "mkdirp@0.5.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "1.2.1",
-                  "from": "supports-color@>=1.2.0 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz"
-                }
-              }
-            },
             "nan": {
               "version": "1.8.4",
-              "from": "nan@>=1.6.2 <2.0.0",
+              "from": "nan@>=1.8.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
             },
             "npmconf": {
@@ -6054,6 +6012,11 @@
                     }
                   }
                 },
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                },
                 "uid-number": {
                   "version": "0.0.5",
                   "from": "uid-number@0.0.5",
@@ -6061,108 +6024,9 @@
                 }
               }
             },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            },
-            "sass-graph": {
-              "version": "1.3.0",
-              "from": "sass-graph@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-1.3.0.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.8.1",
-                  "from": "commander@>=2.6.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "glob": {
-                  "version": "4.5.3",
-                  "from": "glob@>=4.3.4 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "2.0.10",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.0",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.0",
-                              "from": "balanced-match@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "2.4.2",
-                  "from": "lodash@>=2.4.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
-                }
-              }
-            },
-            "semver": {
-              "version": "4.3.6",
-              "from": "semver@>=4.2.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-            },
-            "shelljs": {
-              "version": "0.3.0",
-              "from": "shelljs@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-            },
             "pangyp": {
               "version": "2.2.1",
-              "from": "pangyp@>=2.1.0 <3.0.0",
+              "from": "pangyp@>=2.2.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.1.tgz",
               "dependencies": {
                 "fstream": {
@@ -6520,6 +6384,11 @@
                   "from": "rimraf@>=2.2.8 <2.3.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "semver@>=4.3.6 <4.4.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                },
                 "tar": {
                   "version": "1.0.3",
                   "from": "tar@>=1.0.3 <1.1.0",
@@ -6541,6 +6410,110 @@
                   "version": "1.0.9",
                   "from": "which@>=1.0.8 <1.1.0",
                   "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+                }
+              }
+            },
+            "sass-graph": {
+              "version": "2.0.0",
+              "from": "sass-graph@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.0",
+                  "from": "lodash@>=3.8.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
+                },
+                "yargs": {
+                  "version": "3.15.0",
+                  "from": "yargs@>=3.8.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.1",
+                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.3",
+                              "from": "align-text@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "2.0.0",
+                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.3",
+                              "from": "align-text@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "2.0.0",
+                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.2",
+                      "from": "window-size@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
+                    }
+                  }
                 }
               }
             }
@@ -6575,7 +6548,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -6834,7 +6807,7 @@
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@1.0.1",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
@@ -7061,7 +7034,7 @@
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.6 <0.3.0",
+                      "from": "async@>=0.2.9 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "source-map": {
@@ -7155,7 +7128,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "wordwrap@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
@@ -8004,7 +7977,7 @@
             },
             "commander": {
               "version": "2.8.1",
-              "from": "commander@>=2.8.1 <3.0.0",
+              "from": "commander@>=2.8.0 <2.9.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
               "dependencies": {
                 "graceful-readlink": {
@@ -8015,9 +7988,9 @@
               }
             },
             "is-my-json-valid": {
-              "version": "2.12.0",
+              "version": "2.12.1",
               "from": "is-my-json-valid@>=2.12.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -8138,7 +8111,7 @@
             },
             "statuses": {
               "version": "1.2.1",
-              "from": "statuses@>=1.2.1 <1.3.0",
+              "from": "statuses@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
             }
           }
@@ -8162,7 +8135,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -8315,12 +8288,12 @@
       "dependencies": {
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.0.0 <2.0.0",
+          "from": "underscore@>=1.3.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         },
         "node-uuid": {
           "version": "1.4.3",
-          "from": "node-uuid@>=1.0.0 <2.0.0",
+          "from": "node-uuid@>=1.4.1 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
         },
         "async": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "grunt-po2json": "git://github.com/shane-tomlinson/grunt-po2json.git#aa276503e",
     "grunt-requirejs": "0.4.2",
     "grunt-rev": "0.1.0",
-    "grunt-sass": "0.18.1",
+    "grunt-sass": "1.0.0",
     "grunt-text-replace": "0.4.0",
     "grunt-usemin": "3.0.0",
     "grunt-z-schema": "0.1.0",


### PR DESCRIPTION
sass got rid of `image-url`; this adds it back for our needs, namely prefixing all image urls with `/images/`.

@vladikoff r?