### PR TITLE
fix(client): Fix merge warning handling in the firstrun flow.

### DIFF
--- a/app/scripts/lib/channels/fx-desktop-v1.js
+++ b/app/scripts/lib/channels/fx-desktop-v1.js
@@ -64,7 +64,7 @@ define([
         // and
         // https://dxr.mozilla.org/mozilla-central/source/browser/base/content/aboutaccounts/aboutaccounts.js#193
         messageId: content.status,
-        data: content
+        data: content.data
       };
     }
   });

--- a/app/scripts/models/auth_brokers/fx-desktop.js
+++ b/app/scripts/models/auth_brokers/fx-desktop.js
@@ -77,7 +77,7 @@ define([
       // message='USER_CANCELED_LOGIN' and errno=1001 if that's the case.
       return self.request(self._commands.CAN_LINK_ACCOUNT, { email: email })
         .then(function (response) {
-          if (response && response.data && ! response.data.ok) {
+          if (response && ! response.ok) {
             throw AuthErrors.toError('USER_CANCELED_LOGIN');
           }
 

--- a/app/tests/spec/lib/channels/fx-desktop-v1.js
+++ b/app/tests/spec/lib/channels/fx-desktop-v1.js
@@ -50,15 +50,17 @@ function (chai, FxDesktopV1Channel, WindowMock) {
         var fixtureMessage = {
           content: {
             status: 'ok',
-            key: 'value'
+            key: 'value',
+            data: {
+              dataKey: 'data_value'
+            }
           }
         };
         var expectedResult = {
           command: 'ok',
           messageId: 'ok',
           data: {
-            status: 'ok',
-            key: 'value'
+            dataKey: 'data_value'
           }
         };
 

--- a/app/tests/spec/models/auth_brokers/fx-desktop.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop.js
@@ -59,7 +59,7 @@ define([
     describe('beforeSignIn', function () {
       it('is happy if the user clicks `yes`', function () {
         sinon.stub(channelMock, 'request', function () {
-          return p({ data: { ok: true }});
+          return p({ ok: true });
         });
 
         return broker.beforeSignIn('testuser@testuser.com')

--- a/tests/functional/firstrun_sign_in.js
+++ b/tests/functional/firstrun_sign_in.js
@@ -64,7 +64,25 @@ define([
         // user should be unable to sign out.
         .then(FunctionalHelpers.noSuchElement(self, '#signout'))
         .end();
+    },
 
+    'sign in, cancel merge warning': function () {
+      var self = this;
+      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signin-header')
+        .execute(listenForFxaCommands)
+
+        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: false } ))
+
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+        })
+
+        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
+
+        // user should not transition to the next screen
+        .then(FunctionalHelpers.noSuchElement(self, '#fxa-settings-header'))
+        .end();
     }
   });
 });

--- a/tests/functional/firstrun_sign_up.js
+++ b/tests/functional/firstrun_sign_up.js
@@ -97,6 +97,25 @@ define([
 
         .findByCssSelector('#fxa-sign-up-complete-header')
         .end();
+    },
+
+    'sign up, cancel merge warning': function () {
+      var self = this;
+      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
+        .execute(listenForFxaCommands)
+
+        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: false } ))
+
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR);
+        })
+
+        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
+
+        // user should not transition to the next screen
+        .then(FunctionalHelpers.noSuchElement(self, '#fxa-confirm-header'))
+        .end();
     }
   });
 });


### PR DESCRIPTION
Pressing `Cancel` in the merge warning in the firstrun flow had
no effect! Users would still be signed in, even if they indicated
they did not want to be.

This was caused by a data format discrepancy between Sync v1 and Sync v2.
Sync v1 sent messages with a payload that contained a `data` field whereas
Sync v2's payloads entire payload was what was contained in v1's data field.

This unifies the approach, sync v1 sends its data field as the data field
in the parsed message. Much simpler.

Reviews & Testers: please ensure signin and signup of the about:accounts
based sync flow and the new firstrun based sync both work, including
pressing `Cancel` in the merge dialog.

fixes #2844
ref #2101 
@vladikoff - could you r?