### PR TITLE
fix(client): Invalid client id's show a 400 page, not 500.

### DIFF
--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -171,9 +171,12 @@ define([
           self.set('trusted', serviceInfo.trusted);
           self.set('origin', Url.getOrigin(serviceInfo.redirect_uri));
         }, function (err) {
-          // the server returns an invalid request signature for an
+          // the server returns an invalid request parameter for an
           // invalid/unknown client_id
-          if (OAuthErrors.is(err, 'INVALID_REQUEST_SIGNATURE')) {
+          if (OAuthErrors.is(err, 'INVALID_REQUEST_PARAMETER') &&
+              err.validation &&
+              err.validation.keys &&
+              err.validation.keys[0] === 'client_id') {
             err = OAuthErrors.toError('UNKNOWN_CLIENT');
             // used for logging the error on the server.
             err.client_id = clientId; //eslint-disable-line camelcase

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -258,12 +258,16 @@ define([
 
         oAuthClient.getClientInfo.restore();
         sinon.stub(oAuthClient, 'getClientInfo', function () {
-          return p.reject(OAuthErrors.toError('INVALID_REQUEST_SIGNATURE'));
+          var err = OAuthErrors.toError('INVALID_REQUEST_PARAMETER');
+          err.validation = {
+            keys: ['client_id']
+          };
+          return p.reject(err);
         });
 
         return relier.fetch()
           .then(assert.fail, function (err) {
-            // INVALID_REQUEST_SIGNATURE should be converted to
+            // INVALID_REQUEST_PARAMETER should be converted to
             // UNKNOWN_CLIENT
             assert.isTrue(OAuthErrors.is(err, 'UNKNOWN_CLIENT'));
           });


### PR DESCRIPTION
When I updated the `INVALID_REQUEST_SIGNATURE` OAuth error to
`INVALID_REQUEST_PARAMETER`, I forgot to update it in the
OAuth relier.

fixes #2850