### PR TITLE
fix(client): Do not allow firstrun Sync based flows to sign out.

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -12,6 +12,19 @@ define([], function () {
     // See http://blogs.msdn.com/b/ieinternals/archive/2014/08/13/url-length-limits-in-internet-explorer.aspx
     URL_MAX_LENGTH: 2048,
 
+    // Used to indicate that a sessionToken was shared with Sync. The value
+    // `fx_desktop_v1` is historical to avoid problems in case of a rollback.
+    //
+    // The quick background, an accounts sessionTokenContext is used to
+    // indicate whether that account's sessionToken is shared with Firefox to
+    // sign into Sync. This is all it is ever used for. The original value
+    // could only be `fx_desktop_v1`, but with the firstrun flow, it can now
+    // be `iframe`. This broke a lot of expectations. Trying to change the
+    // name of the field in localStorage to reflect its true intent is
+    // problematic because we can't cleanly handle rollback w/o causing some
+    // set of users to disconnect from Sync.
+    SESSION_TOKEN_USED_FOR_SYNC: 'fx_desktop_v1',
+
     FX_DESKTOP_CONTEXT: 'fx_desktop_v1',
     FX_DESKTOP_V2_CONTEXT: 'fx_desktop_v2',
     FX_DESKTOP_SYNC: 'sync',

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -9,11 +9,12 @@
 define([
   'fxaClient',
   'jquery',
+  'lib/constants',
   'lib/promise',
   'lib/session',
   'lib/auth-errors'
 ],
-function (FxaClient, $, p, Session, AuthErrors) {
+function (FxaClient, $, Constants, p, Session, AuthErrors) {
   'use strict';
 
   function trim(str) {
@@ -113,8 +114,10 @@ function (FxaClient, $, p, Session, AuthErrors) {
     },
 
     _getUpdatedSessionData: function (email, relier, accountData, options) {
-      var sessionTokenContext = options.sessionTokenContext ||
-                                  relier.get('context');
+      var sessionTokenContext = options.sessionTokenContext;
+      if (! sessionTokenContext && relier.isSync()) {
+        sessionTokenContext = Constants.SESSION_TOKEN_USED_FOR_SYNC;
+      }
 
       var updatedSessionData = {
         email: email,

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -29,6 +29,16 @@ define([
     profileImageId: undefined,
     profileImageUrl: undefined,
     sessionToken: undefined,
+    // Hint for future code spelunkers. sessionTokenContext is a misnomer,
+    // what the field is really used for is to indicate whether the
+    // sessionToken is shared with Sync. It will be set to `fx_desktop_v1` if
+    // the sessionToken is shared. Users cannot sign out of Sync shared
+    // sessions from within the content server, instead they must go into the
+    // Sync panel and disconnect there. The reason this field has not been
+    // renamed is because we cannot gracefully handle rollback without the
+    // side effect of users being able to sign out of their Sync based
+    // session. Data migration within the client goes one way. It's easy to
+    // move forward, very hard to move back.
     sessionTokenContext: undefined,
     uid: undefined,
     verified: undefined
@@ -118,7 +128,7 @@ define([
     },
 
     isFromSync: function () {
-      return this.get('sessionTokenContext') === Constants.FX_DESKTOP_CONTEXT;
+      return this.get('sessionTokenContext') === Constants.SESSION_TOKEN_USED_FOR_SYNC;
     },
 
     // returns true if all attributes within ALLOWED_KEYS are defaults

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -479,7 +479,7 @@ function (chai, sinon, p, Constants, Assertion, ProfileClient,
     });
 
     it('isFromSync returns true in the right context', function () {
-      account.set('sessionTokenContext', Constants.FX_DESKTOP_CONTEXT);
+      account.set('sessionTokenContext', Constants.SESSION_TOKEN_USED_FOR_SYNC);
       assert.isTrue(account.isFromSync());
     });
 

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -44,7 +44,7 @@ function (chai, sinon, p, Constants, Session, FxaClient, User) {
     it('isSyncAccount', function () {
       var account = user.initAccount({
         email: 'email',
-        sessionTokenContext: Constants.FX_DESKTOP_CONTEXT
+        sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC
       });
 
       assert.isTrue(user.isSyncAccount(account));
@@ -90,7 +90,7 @@ function (chai, sinon, p, Constants, Session, FxaClient, User) {
 
     it('getChooserAccount', function () {
       return user.setSignedInAccount({ uid: 'uid2', email: 'email',
-        sessionTokenContext: Constants.FX_DESKTOP_CONTEXT
+        sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC
       })
         .then(function () {
           return user.setSignedInAccount({ uid: 'uid', email: 'email' });
@@ -170,7 +170,7 @@ function (chai, sinon, p, Constants, Session, FxaClient, User) {
       var accountData = {
         email: 'a@a.com',
         sessionToken: 'session token',
-        sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+        sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
         uid: 'uid'
       };
       Session.set('cachedCredentials', accountData);
@@ -195,7 +195,7 @@ function (chai, sinon, p, Constants, Session, FxaClient, User) {
       var accountData = {
         email: 'a@a.com',
         sessionToken: 'session token',
-        sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+        sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
         uid: 'uid'
       };
       Session.set('cachedCredentials', accountData);
@@ -212,7 +212,7 @@ function (chai, sinon, p, Constants, Session, FxaClient, User) {
       var accountData = {
         email: 'a@a.com',
         sessionToken: 'session token',
-        sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+        sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
         uid: 'uid'
       };
       Session.set('cachedCredentials', accountData);
@@ -260,7 +260,7 @@ function (chai, sinon, p, Constants, Session, FxaClient, User) {
       var accountData = {
         email: 'a@a.com',
         sessionToken: 'session token',
-        sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+        sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
         uid: 'uid'
       };
       Session.set('cachedCredentials', accountData);

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -520,7 +520,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
         var account = user.initAccount({
           sessionToken: 'abc123',
           email: 'a@a.com',
-          sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+          sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
           verified: true,
           accessToken: 'foo'
         });
@@ -555,7 +555,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
         var account = user.initAccount({
           sessionToken: 'abc123',
           email: 'a@a.com',
-          sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+          sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
           verified: true,
           accessToken: 'foo'
         });
@@ -583,7 +583,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
           return user.initAccount({
             sessionToken: 'abc123',
             email: 'a@a.com',
-            sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+            sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
             verified: true,
             accessToken: 'foo'
           });
@@ -606,7 +606,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
         var account = user.initAccount({
           sessionToken: 'abc123',
           email: 'a@a.com',
-          sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+          sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
           verified: true,
           accessToken: 'foo'
         });
@@ -633,7 +633,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
         var account = user.initAccount({
           sessionToken: 'abc123',
           email: 'a@a.com',
-          sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+          sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
           verified: true,
           accessToken: 'foo'
         });
@@ -656,7 +656,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
         var account = user.initAccount({
           sessionToken: 'abc123',
           email: 'a@a.com',
-          sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+          sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
           verified: true,
           accessToken: 'foo'
         });
@@ -702,7 +702,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
           sessionToken: 'abc123',
           email: 'a@a.com',
           verified: true,
-          sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+          sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
           accessToken: 'foo'
         });
 
@@ -728,7 +728,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
         var account = user.initAccount({
           sessionToken: 'abc123',
           email: 'a@a.com',
-          sessionTokenContext: Constants.FX_DESKTOP_CONTEXT,
+          sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
           verified: true,
           accessToken: 'foo'
         });

--- a/tests/functional/firstrun_sign_in.js
+++ b/tests/functional/firstrun_sign_in.js
@@ -59,7 +59,12 @@ define([
         .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:login'))
 
         .findByCssSelector('#fxa-settings-header')
+        .end()
+
+        // user should be unable to sign out.
+        .then(FunctionalHelpers.noSuchElement(self, '#signout'))
         .end();
+
     }
   });
 });

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -25,10 +25,10 @@ define([
   // The automatedBrowser query param tells signin/up to stub parts of the flow
   // that require a functioning desktop channel
   var PAGE_SIGNIN = config.fxaContentRoot + 'signin';
-  var PAGE_SIGNIN_DESKTOP = PAGE_SIGNIN + '?context=' + FX_DESKTOP_CONTEXT;
+  var PAGE_SIGNIN_DESKTOP = PAGE_SIGNIN + '?context=' + FX_DESKTOP_CONTEXT + '&service=sync';
   var PAGE_SIGNIN_NO_CACHED_CREDS = PAGE_SIGNIN + '?email=blank';
   var PAGE_SIGNUP = config.fxaContentRoot + 'signup';
-  var PAGE_SIGNUP_DESKTOP = config.fxaContentRoot + 'signup?context=' + FX_DESKTOP_CONTEXT;
+  var PAGE_SIGNUP_DESKTOP = config.fxaContentRoot + 'signup?context=' + FX_DESKTOP_CONTEXT + '&service=sync';
   var PAGE_SETTINGS = config.fxaContentRoot + 'settings';
 
 


### PR DESCRIPTION
@zaach - can you review this? I'm trying to get this into Train-43 so that users who sign up via the first run flow are unable to sign out, causing their Sync session to be destroyed.

My firefox profile's user.js is [in this gist](https://gist.github.com/shane-tomlinson/7b50f687c80b3987bc7e).

Ah yes, you can fake signing in to sync via the firstrun flow by going to:
http://127.0.0.1:3030/signup?service=sync&context=iframe

or, you can clone https://github.com/shane-tomlinson/firstrun-example/
and add http://127.0.0.1:8111 to the list of allowed_parent_origins in your
local.json


fixes #2658
ref #2101 