### PR TITLE
fix(metrics): Only check whether mailcheck is enabled once.

### DIFF
--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -199,15 +199,27 @@ function (Cocktail, _, p, BaseView, FormView, Template, AuthErrors, mailcheck,
         });
     },
 
-    suggestEmail: function () {
-      var abData = {
-        isMetricsEnabled: this.metrics.isCollectionEnabled(),
-        uniqueUserId: this.user.get('uniqueUserId'),
-        // the window parameter will override any ab testing features
-        forceMailcheck: Url.searchParam('mailcheck', this.window.location.search)
-      };
+    _isMailcheckEnabledValue: undefined,
+    _isMailcheckEnabled: function () {
+      // only check whether mailcheck is enabled once. Otherwise,
+      // an event is added to the able log every time the user
+      // blurs the email field, which could be multiple times.
+      if (typeof this._isMailcheckEnabledValue === 'undefined') {
+        var abData = {
+          isMetricsEnabledValue: this.metrics.isCollectionEnabled(),
+          uniqueUserId: this.user.get('uniqueUserId'),
+          // the window parameter will override any ab testing features
+          forceMailcheck: Url.searchParam('mailcheck', this.window.location.search)
+        };
 
-      if (this._able.choose('mailcheckEnabled', abData)) {
+        this._isMailcheckEnabledValue =
+              this._able.choose('mailcheckEnabled', abData);
+      }
+      return this._isMailcheckEnabledValue;
+    },
+
+    suggestEmail: function () {
+      if (this._isMailcheckEnabled()) {
         mailcheck(this.$el.find('.email'), this.metrics, this.translator);
       }
     },

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -728,6 +728,22 @@ function (chai, $, sinon, p, View, Coppa, Session, AuthErrors, Metrics,
         }, 50);
       });
 
+      it('only calls able.choose once on multiple `suggestEmail` calls', function () {
+        var sandbox = sinon.sandbox.create();
+
+        var ableChoose = sandbox.stub(view._able, 'choose', function () {
+          return true;
+        });
+
+        view.suggestEmail();
+        view.suggestEmail();
+        view.suggestEmail();
+
+        assert.equal(ableChoose.callCount, 1);
+
+        sandbox.restore();
+      });
+
       it('does not show when able chooses false', function (done) {
         var ableChoose = sinon.stub(view._able, 'choose', function () {
           return false;


### PR DESCRIPTION
This prevents the able log from filling up with `mailcheckEnabled` events.
Previously, the choice was made on every email field blur. If the user
blurred multiple times, multiple mailcheckEnabled events would show up
in the able log.

fixes #2858 

@philbooth - mind having a look at this one too?