### PR TITLE
feat(ios) Provide a custom context string for use by FxiOS

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -613,7 +613,7 @@ function (
       // It provides a custom context value so that we can implement
       // a custom auth broker if necessary in the future.
       return (this._searchParam('context') === Constants.FX_DESKTOP_CONTEXT ||
-              this._searchParam('context') === Constants.FX_IOS_CONTEXT);
+              this._searchParam('context') === Constants.FX_IOS_V1_CONTEXT);
     },
 
     _isFxDesktopV2: function () {

--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -609,7 +609,11 @@ function (
     },
 
     _isFxDesktopV1: function () {
-      return this._searchParam('context') === Constants.FX_DESKTOP_CONTEXT;
+      // Firefox for iOS is using the desktop broker for now.
+      // It provides a custom context value so that we can implement
+      // a custom auth broker if necessary in the future.
+      return (this._searchParam('context') === Constants.FX_DESKTOP_CONTEXT ||
+              this._searchParam('context') === Constants.FX_IOS_CONTEXT);
     },
 
     _isFxDesktopV2: function () {

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -28,6 +28,7 @@ define([], function () {
     FX_DESKTOP_CONTEXT: 'fx_desktop_v1',
     FX_DESKTOP_V2_CONTEXT: 'fx_desktop_v2',
     FX_DESKTOP_SYNC: 'sync',
+    FX_IOS_CONTEXT: 'fx_ios_v1',
 
     IFRAME_CONTEXT: 'iframe',
 

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -28,7 +28,7 @@ define([], function () {
     FX_DESKTOP_CONTEXT: 'fx_desktop_v1',
     FX_DESKTOP_V2_CONTEXT: 'fx_desktop_v2',
     FX_DESKTOP_SYNC: 'sync',
-    FX_IOS_CONTEXT: 'fx_ios_v1',
+    FX_IOS_V1_CONTEXT: 'fx_ios_v1',
 
     IFRAME_CONTEXT: 'iframe',
 

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -201,6 +201,17 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
         });
       });
 
+      describe('fx-ios', function () {
+        it('returns an FxDesktop broker if `context=fx_ios_v1`', function () {
+          windowMock.location.search = Url.objToSearchString({
+            context: Constants.FX_IOS_CONTEXT
+          });
+
+          return testExpectedBrokerCreated(FxDesktopBroker);
+        });
+      });
+
+
       describe('web channel', function () {
         it('returns a WebChannel broker if `webChannelId` is present', function () {
           windowMock.location.search = Url.objToSearchString({

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -201,10 +201,10 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
         });
       });
 
-      describe('fx-ios', function () {
+      describe('fx-ios v1', function () {
         it('returns an FxDesktop broker if `context=fx_ios_v1`', function () {
           windowMock.location.search = Url.objToSearchString({
-            context: Constants.FX_IOS_CONTEXT
+            context: Constants.FX_IOS_V1_CONTEXT
           });
 
           return testExpectedBrokerCreated(FxDesktopBroker);

--- a/docs/query-params.md
+++ b/docs/query-params.md
@@ -100,7 +100,7 @@ Set the default value of the "Customize which values to sync" checkbox.
 * `false` (default)
 
 #### When to specify
-Only available if `context` equals `fx_desktop_v1`, `fx_desktop_v2`, or `iframe` and `service` equals `sync`.
+Only available if `context` equals `fx_desktop_v1`, `fx_desktop_v2`, `fx_ios_v1`, or `iframe` and `service` equals `sync`.
 
 * /signup
 
@@ -118,7 +118,7 @@ If they user arrived at Firefox Accounts from within Firefox browser chrome, spe
 If the user is migrating their Sync account from "old sync" to "new sync", specify which sync they are migrating from.
 
 #### When to specify
-Only available if `context` equals `fx_desktop_v1`, `fx_desktop_v2`, or `iframe`.
+Only available if `context` equals `fx_desktop_v1`, `fx_desktop_v2`, `fx_ios_v1`, or `iframe`.
 
 * /signin
 * /signup
@@ -130,7 +130,7 @@ Specify which non-OAuth service a user is signing in to.
 * `sync`
 
 #### When to specify
-Only available if `context` equals `fx_desktop_v1`, `fx_desktop_v2`, or `iframe`.
+Only available if `context` equals `fx_desktop_v1`, `fx_desktop_v2`, `fx_ios_v1`, or `iframe`.
 
 * /signin
 * /signup
@@ -153,8 +153,12 @@ If Firefox Accounts is opened to `/settings` and a profile field should be made 
 Specify an alternate context in which Firefox Accounts is being run, if not as a standard web page.
 
 #### Options
-* `fx_desktop_v1` - Firefox Accounts is being used to sign in to Sync using CustomEvents.
-* `fx_desktop_v2` - Firefox Accounts is being used to sign in to Sync using WebChannels.
+* `fx_desktop_v1` - Firefox Accounts is being used to sign in to Sync on
+   Firefox Desktop using CustomEvents.
+* `fx_desktop_v2` - Firefox Accounts is being used to sign in to Sync on
+   Firefox Desktop using WebChannels.
+* `fx_ios_v1` - Firefox Accounts is being used to sign in to Sync on Firefox
+   for iOS using CustomEvents.
 * `iframe` - Firefox Accounts is displayed in an iframe.
 
 ### `email`

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -12,6 +12,7 @@ define([
   './functional/sync_v2_sign_up',
   './functional/firstrun_sign_up',
   './functional/firstrun_sign_in',
+  './functional/fx_ios_v1_sign_in',
   './functional/bounced_email',
   './functional/legal',
   './functional/tos',

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/node_modules/dojo/node!xmlhttprequest',
+  'app/bower_components/fxa-js-client/fxa-client',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers',
+  'tests/functional/lib/fx-desktop'
+], function (intern, registerSuite, nodeXMLHttpRequest, FxaClient,
+  TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
+  var config = intern.config;
+  var PAGE_URL = config.fxaContentRoot + 'signin?context=fx_ios_v1&service=sync';
+
+  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+
+  var client;
+  var email;
+  var PASSWORD = '12345678';
+
+  var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+
+  function createUser(isPreVerified) {
+    email = TestHelpers.createEmail();
+    return client.signUp(email, PASSWORD,
+      {
+        preVerified: isPreVerified || false
+      }
+    );
+  }
+
+  registerSuite({
+    name: 'FxiOS v1 sign_in',
+
+    setup: function () {
+      client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+    },
+
+    beforeEach: function () {
+      // clear localStorage to avoid pollution from other tests.
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    teardown: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'sign in verified': function () {
+      var self = this;
+      return createUser(true)
+        .then(function () {
+          return FunctionalHelpers.openPage(self, PAGE_URL, '#fxa-signin-header')
+            .execute(listenForFxaCommands)
+
+            .then(function () {
+              return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+            })
+
+            .then(function () {
+              return testIsBrowserNotifiedOfLogin(self, email, { checkVerified: true });
+            });
+        });
+    },
+
+    'unverified': function () {
+      var self = this;
+
+      return createUser(false)
+        .then(function () {
+          return FunctionalHelpers.openPage(self, PAGE_URL, '#fxa-signin-header')
+            .execute(listenForFxaCommands)
+
+            .then(function () {
+              return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+            })
+
+            .findByCssSelector('#fxa-confirm-header')
+            .end()
+
+            .then(function () {
+              return testIsBrowserNotifiedOfLogin(self, email);
+            });
+        });
+    }
+  });
+});


### PR DESCRIPTION
This is a very small step towards imlementing a custom auth broker for Firefox-on-iOS.  It just adds support for `context=fx_ios_v1` and maps it directly to the existing `fx_desktop_v1` behaviour.  The idea is to support the new context value ASAP so that the client can bake that into its URLs, and give us a bit of space to nuance the behaviour on our side.

@shane-tomlinson r?

fixes #2861