### PR TITLE
refactor(client): Constant renaming

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -612,7 +612,7 @@ function (
       // Firefox for iOS is using the desktop broker for now.
       // It provides a custom context value so that we can implement
       // a custom auth broker if necessary in the future.
-      return (this._searchParam('context') === Constants.FX_DESKTOP_CONTEXT ||
+      return (this._searchParam('context') === Constants.FX_DESKTOP_V1_CONTEXT ||
               this._searchParam('context') === Constants.FX_IOS_V1_CONTEXT);
     },
 

--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -605,7 +605,7 @@ function (
     },
 
     _isSync: function () {
-      return this._searchParam('service') === Constants.FX_DESKTOP_SYNC;
+      return this._searchParam('service') === Constants.SYNC_SERVICE;
     },
 
     _isFxDesktopV1: function () {

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -27,10 +27,11 @@ define([], function () {
 
     FX_DESKTOP_CONTEXT: 'fx_desktop_v1',
     FX_DESKTOP_V2_CONTEXT: 'fx_desktop_v2',
-    FX_DESKTOP_SYNC: 'sync',
     FX_IOS_V1_CONTEXT: 'fx_ios_v1',
-
     IFRAME_CONTEXT: 'iframe',
+
+    SYNC_SERVICE: 'sync',
+
 
     VERIFICATION_POLL_IN_MS: 4000,
 

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -25,7 +25,7 @@ define([], function () {
     // set of users to disconnect from Sync.
     SESSION_TOKEN_USED_FOR_SYNC: 'fx_desktop_v1',
 
-    FX_DESKTOP_CONTEXT: 'fx_desktop_v1',
+    FX_DESKTOP_V1_CONTEXT: 'fx_desktop_v1',
     FX_DESKTOP_V2_CONTEXT: 'fx_desktop_v2',
     FX_IOS_V1_CONTEXT: 'fx_ios_v1',
     IFRAME_CONTEXT: 'iframe',

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -97,7 +97,7 @@ define([
      * Check if the relier is Sync for Firefox Desktop
      */
     isSync: function () {
-      return this.get('service') === Constants.FX_DESKTOP_SYNC;
+      return this.get('service') === Constants.SYNC_SERVICE;
     },
 
     /**

--- a/app/scripts/views/marketing_snippet.js
+++ b/app/scripts/views/marketing_snippet.js
@@ -38,7 +38,7 @@ define([
 
     _shouldShowSignUpMarketing: function () {
       var isSignUp = this._type === 'sign_up';
-      var isSync = this._service === Constants.FX_DESKTOP_SYNC;
+      var isSync = this._service === Constants.SYNC_SERVICE;
       var isFirefoxMobile = this._isFirefoxMobile();
 
       // If the user is completing a signup for sync and ALWAYS

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -193,7 +193,7 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
 
         it('returns an FxDesktop broker if `service=sync&context=iframe`', function () {
           windowMock.location.search = Url.objToSearchString({
-            service: Constants.FX_DESKTOP_SYNC,
+            service: Constants.SYNC_SERVICE,
             context: Constants.IFRAME_CONTEXT
           });
 

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -185,7 +185,7 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
       describe('fx-desktop', function () {
         it('returns an FxDesktop broker if `context=fx_desktop_v1`', function () {
           windowMock.location.search = Url.objToSearchString({
-            context: Constants.FX_DESKTOP_CONTEXT
+            context: Constants.FX_DESKTOP_V1_CONTEXT
           });
 
           return testExpectedBrokerCreated(FxDesktopBroker);

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -98,9 +98,9 @@ function (chai, sinon, Backbone, Router, SignInView, SignUpView, ReadyView,
 
       it('preserves window search parameters across screen transition',
         function () {
-          windowMock.location.search = '?context=' + Constants.FX_DESKTOP_CONTEXT;
+          windowMock.location.search = '?context=' + Constants.FX_DESKTOP_V1_CONTEXT;
           router.navigate('/forgot');
-          assert.equal(navigateUrl, '/forgot?context=' + Constants.FX_DESKTOP_CONTEXT);
+          assert.equal(navigateUrl, '/forgot?context=' + Constants.FX_DESKTOP_V1_CONTEXT);
           assert.deepEqual(navigateOptions, { trigger: true });
         });
     });

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -83,7 +83,7 @@ define([
     'sign in to desktop context, go to settings, no way to sign out': function () {
       var self = this;
       return this.remote
-        .get(require.toUrl(SIGNIN_URL + '?context=' + Constants.FX_DESKTOP_CONTEXT))
+        .get(require.toUrl(SIGNIN_URL + '?context=' + Constants.FX_DESKTOP_V1_CONTEXT))
         .setFindTimeout(intern.config.pageLoadTimeout)
         .execute(listenForFxaCommands)
 

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -16,7 +16,7 @@ define([
 ], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
         FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers,
         Constants) {
-  var FX_DESKTOP_CONTEXT = Constants.FX_DESKTOP_CONTEXT;
+  var FX_DESKTOP_V1_CONTEXT = Constants.FX_DESKTOP_V1_CONTEXT;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
 
   var config = intern.config;
@@ -25,10 +25,10 @@ define([
   // The automatedBrowser query param tells signin/up to stub parts of the flow
   // that require a functioning desktop channel
   var PAGE_SIGNIN = config.fxaContentRoot + 'signin';
-  var PAGE_SIGNIN_DESKTOP = PAGE_SIGNIN + '?context=' + FX_DESKTOP_CONTEXT + '&service=sync';
+  var PAGE_SIGNIN_DESKTOP = PAGE_SIGNIN + '?context=' + FX_DESKTOP_V1_CONTEXT + '&service=sync';
   var PAGE_SIGNIN_NO_CACHED_CREDS = PAGE_SIGNIN + '?email=blank';
   var PAGE_SIGNUP = config.fxaContentRoot + 'signup';
-  var PAGE_SIGNUP_DESKTOP = config.fxaContentRoot + 'signup?context=' + FX_DESKTOP_CONTEXT + '&service=sync';
+  var PAGE_SIGNUP_DESKTOP = config.fxaContentRoot + 'signup?context=' + FX_DESKTOP_V1_CONTEXT + '&service=sync';
   var PAGE_SETTINGS = config.fxaContentRoot + 'settings';
 
 
@@ -254,7 +254,7 @@ define([
             }
           });
           return true;
-        }, [ email, FX_DESKTOP_CONTEXT, PAGE_SIGNIN ])
+        }, [ email, FX_DESKTOP_V1_CONTEXT, PAGE_SIGNIN ])
 
 
         .findByCssSelector('button[type="submit"]')


### PR DESCRIPTION
* `FX_DESKTOP_CONTEXT` => `FX_DESKTOP_V1_CONTEXT`
  * Rename for consistency now that there is a FX_DESKTOP_V2_CONTEXT
* `FX_DESKTOP_SYNC` => `SYNC_SERVICE`
  * This better reflects the constant's purpose since it's used on both desktop and mobile.


This is a pretty low risk PR, I'm comfortable with anybody reviewing this.
