### PR TITLE
fix(tests): remove misguided time-based assertion

### DIFF
--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -461,7 +461,6 @@ function (chai, $, p, Metrics, AuthErrors, Environment, sinon, _, WindowMock, Te
           assert.lengthOf(data.timers.foo, 1);
           assert.isObject(data.timers.foo[0]);
           assert.isTrue(data.timers.foo[0].elapsed >= 4);
-          assert.isTrue(data.timers.foo[0].elapsed < 14);
         });
       });
     });


### PR DESCRIPTION
Fixes #2891.

I wrote this assertion naively thinking that 10 milliseconds should be plenty of leeway for it to pass in all environments but, of course, that kind of thinking is always wrong.

So I've removed it completely because the preceding `>= 4` assertion is sufficient for this test and also incapable of alerting false positives.