### PR TITLE
chore(version): add /__version__ route; add source git repo to result

### DIFF
--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -23,6 +23,7 @@ module.exports = function (config, i18n) {
     require('./routes/get-terms-privacy')(i18n),
     require('./routes/get-index')(),
     require('./routes/get-ver.json'),
+    require('./routes/get-version.json'),
     require('./routes/get-config')(i18n),
     require('./routes/get-client.json')(i18n),
     require('./routes/post-metrics')(),

--- a/server/lib/routes/get-version.json.js
+++ b/server/lib/routes/get-version.json.js
@@ -6,11 +6,11 @@
  * Return version info based on package.json, the git sha, and source repo
  *
  * @see lib/version.js
- * @see lib/routes/get-version.json.js
+ * @see lib/routes/get-ver.json.js
  */
 
 var version = require('../version');
 
-exports.path = '/ver.json';
+exports.path = '/__version__';
 exports.method = 'get';
 exports.process = version.process;

--- a/server/lib/version.js
+++ b/server/lib/version.js
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Return version info based on package.json, the git sha, and source repo
+ *
+ * Try to statically determine commitHash, sourceRepo, l10nVersion, and
+ * tosPpVersion at startup.
+ *
+ * If l10nVersion and tosPpVersion cannot be loaded statically from the
+ * content in ../../app/bower_components, then just show UNKNOWN.
+ *
+ * If commitHash cannot be found from ./config/version.json (i.e., this is not
+ * production or stage), then an attempt will be made to determine commitHash
+ * and sourceRepo dynamically from `git`. If it cannot be found with `git`,
+ * just show UNKNOWN for commitHash and sourceRepo.
+ *
+ */
+
+var cp = require('child_process');
+var logger = require('mozlog')('server.version');
+
+var pkgVersion = require('../../package.json').version;
+
+const UNKNOWN = 'unknown';
+
+var commitHash;
+var sourceRepo;
+var l10nVersion = UNKNOWN;
+var tosPpVersion = UNKNOWN;
+
+// commitHash and sourceRepo
+(function () {
+  try {
+    var versionJsonPath = '../../config/version.json';
+    var versionInfo = require(versionJsonPath);
+    var ver = versionInfo.version;
+    commitHash = ver.hash;
+    sourceRepo = ver.source;
+    if (commitHash) {
+      logger.info('source set to: %s', sourceRepo);
+      logger.info('commit hash set to: %s', commitHash);
+    }
+  } catch(e) {
+    /* ignore */
+  }
+})();
+
+// l10nVersion
+(function () {
+  try {
+    var bowerPath = '../../app/bower_components/fxa-content-server-l10n/.bower.json';
+    var bowerInfo = require(bowerPath);
+    l10nVersion = bowerInfo && bowerInfo._release;
+  } catch(e) {
+    /* ignore */
+  }
+})();
+
+// tosPpVersion
+(function () {
+  try {
+    var bowerPath = '../../app/bower_components/tos-pp/.bower.json';
+    var bowerInfo = require(bowerPath);
+    tosPpVersion = bowerInfo && bowerInfo._release;
+  } catch(e) {
+    /* ignore */
+  }
+})();
+
+
+(function getCommitHashFromGit() {
+  // Only if we haven't figured out the value of commitHash,
+  // try to read commitHash and sourceRepo with `git`.
+  if (commitHash) {
+    return;
+  }
+
+  // ignore errors and default to UNKNOWN if not found
+  cp.exec('git rev-parse HEAD', function (err, stdout1) {
+    cp.exec('git config --get remote.origin.url', function (err, stdout2) {
+      commitHash = (stdout1 && stdout1.trim()) || UNKNOWN;
+      sourceRepo = (stdout2 && stdout2.trim()) || UNKNOWN;
+      logger.info('source set to: %s', sourceRepo);
+      logger.info('commit hash set to: %s', commitHash);
+    });
+  });
+})();
+
+logger.info('version set to: %s', pkgVersion);
+logger.info('fxa-content-server-l10n commit hash set to: %s', l10nVersion);
+logger.info('tos-pp (legal-docs) commit hash set to: %s', tosPpVersion);
+
+exports.process = function (req, res) {
+  var versionInfo = {
+    source: sourceRepo,
+    version: pkgVersion,
+    commit: commitHash,
+    l10n: l10nVersion,
+    tosPp: tosPpVersion
+  };
+
+  // charset must be set on json responses.
+  res.charset = 'utf-8';
+  res.json(versionInfo);
+};


### PR DESCRIPTION
@shane-tomlinson r?

This retains `/ver.json` and adds a route `/__version__` that reuses the same code. It also adds the source repo to the returned json struct (assuming it is remote.origin; no real way to know the true upstream, of course).

A bit of a big thwack to the previous code, that now tries to determine everything one time at startup (no promises, pun intended). (Also removes the attempts to lookup awsbox stuff, which is now unused.)

There's a tiny race in dev environments where it tries to load the git info by shelling out. Thought about moving the `sync-exec` to prod dependencies to make the git calls synchronous, but didn't. Thoughts?
