### PR TITLE
fix(client): Handle the `entryPoint` query parameter.

### DIFF
--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -74,6 +74,11 @@ define([
           self.importSearchParam('uid');
           self.importSearchParam('setting');
           self.importSearchParam('entrypoint');
+          if (! self.has('entrypoint')) {
+            // FxDesktop declares both `entryPoint` (capital P) and
+            // `entrypoint` (lowcase p). Normalize to `entrypoint`.
+            self.importSearchParam('entryPoint', 'entrypoint');
+          }
           self.importSearchParam('campaign');
 
           self.importSearchParam('utm_campaign', 'utmCampaign');

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -95,6 +95,31 @@ define([
       });
     });
 
+    describe('entryPoint', function () {
+      it('is correctly translated to `entrypoint` if `entrypoint` is not specified', function () {
+        windowMock.location.search = TestHelpers.toSearchString({
+          entryPoint: ENTRYPOINT
+        });
+
+        return relier.fetch()
+          .then(function () {
+            assert.equal(relier.get('entrypoint'), ENTRYPOINT);
+          });
+      });
+
+      it('is ignored if `entrypoint` is already specified', function () {
+        windowMock.location.search = TestHelpers.toSearchString({
+          entrypoint: ENTRYPOINT,
+          entryPoint: 'ignored entrypoint'
+        });
+
+        return relier.fetch()
+          .then(function () {
+            assert.equal(relier.get('entrypoint'), ENTRYPOINT);
+          });
+      });
+    });
+
     describe('isOAuth', function () {
       it('returns `false`', function () {
         assert.isFalse(relier.isOAuth());


### PR DESCRIPTION
@vladikoff - r?

Firefox Desktop specifies both `entrypoint` and `entryPoint`. Normalize
to `entrypoint`.

fixes #2885