### PR TITLE
Clean up access token fetching

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -99,13 +99,6 @@ define([
           });
       }
 
-      // upgrade the credentials with an accessToken
-      promise = promise.then(function () {
-        if (self._needsAccessToken()) {
-          return self._fetchProfileOAuthToken();
-        }
-      });
-
       return promise;
     },
 
@@ -114,14 +107,18 @@ define([
       return self.createOAuthToken(PROFILE_SCOPE)
         .then(function (accessToken) {
           self.set('accessToken', accessToken.get('token'));
-        }, function () {
-          // Ignore errors; we'll just fetch again when needed
         });
     },
 
     profileClient: function () {
       var self = this;
-      return self.fetch()
+      var promise = self.fetch();
+
+      if (self._needsAccessToken()) {
+        promise = promise.then(self._fetchProfileOAuthToken.bind(self));
+      }
+
+      return promise
         .then(function () {
           return self._profileClient;
         });
@@ -360,11 +357,7 @@ define([
           .then(function (client) {
             profileClient = client;
             var accessToken = self.get('accessToken');
-            if (accessToken) {
-              return profileClient[method].apply(profileClient, [accessToken].concat(args));
-            } else {
-              throw ProfileClient.Errors.toError('UNAUTHORIZED');
-            }
+            return profileClient[method].apply(profileClient, [accessToken].concat(args));
           })
           .fail(function (err) {
             // If no oauth token existed, or it has gone stale,
@@ -373,11 +366,7 @@ define([
               return self._fetchProfileOAuthToken()
                 .then(function () {
                   var accessToken = self.get('accessToken');
-                  if (accessToken) {
-                    return profileClient[method].apply(profileClient, [accessToken].concat(args));
-                  } else {
-                    throw ProfileClient.Errors.toError('UNAUTHORIZED');
-                  }
+                  return profileClient[method].apply(profileClient, [accessToken].concat(args));
                 })
                 .fail(function (err) {
                   if (ProfileClient.Errors.is(err, 'UNAUTHORIZED')) {

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -114,6 +114,7 @@ define([
       var self = this;
       return self.fetch()
         .then(function () {
+          // If the account is not verified fail before attempting to fetch a token
           if (! self.get('verified')) {
             throw AuthErrors.toError('UNVERIFIED_ACCOUNT');
           } else if (self._needsAccessToken()) {

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -112,13 +112,14 @@ define([
 
     profileClient: function () {
       var self = this;
-      var promise = self.fetch();
-
-      if (self._needsAccessToken()) {
-        promise = promise.then(self._fetchProfileOAuthToken.bind(self));
-      }
-
-      return promise
+      return self.fetch()
+        .then(function () {
+          if (! self.get('verified')) {
+            throw AuthErrors.toError('UNVERIFIED_ACCOUNT');
+          } else if (self._needsAccessToken()) {
+            return self._fetchProfileOAuthToken();
+          }
+        })
         .then(function () {
           return self._profileClient;
         });

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -31,7 +31,7 @@ define([
         .then(function (profileImage) {
           // Cache the result to make sure we don't flash the default
           // image while fetching the latest profile image
-          self._updateCachedProfileImage(account.get('uid'), profileImage);
+          self._updateCachedProfileImage(account, profileImage);
           return profileImage;
         }, function (err) {
           if (! ProfileErrors.is(err, 'UNAUTHORIZED')) {
@@ -62,11 +62,10 @@ define([
 
     // Makes sure the account with uid has an uptodate image cache.
     // This should be called after fetching the current profile image.
-    _updateCachedProfileImage: function (uid, profileImage) {
-      var cachedAccount = this.user.getAccountByUid(uid);
-      if (! cachedAccount.isDefault()) {
-        cachedAccount.setProfileImage(profileImage);
-        this.user.setAccount(cachedAccount);
+    _updateCachedProfileImage: function (account, profileImage) {
+      if (! account.isDefault()) {
+        account.setProfileImage(profileImage);
+        this.user.setAccount(account);
       }
     },
 
@@ -83,8 +82,7 @@ define([
       }
     },
 
-    updateProfileImage: function (profileImage) {
-      var account = this.getSignedInAccount();
+    updateProfileImage: function (profileImage, account) {
       account.setProfileImage(profileImage);
       this.user.setAccount(account);
 
@@ -98,7 +96,7 @@ define([
       return account.deleteAvatar(self._displayedProfileImage.get('id'))
         .then(function () {
           // A blank image will clear the cache
-          self.updateProfileImage(new ProfileImage());
+          self.updateProfileImage(new ProfileImage(), account);
         });
     }
   };

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -36,7 +36,7 @@ define([
           return profileImage;
         }, function (err) {
           if (! ProfileErrors.is(err, 'UNAUTHORIZED') &&
-              ! AuthErrors.is(err, 'UNVERIFIED')) {
+              ! AuthErrors.is(err, 'UNVERIFIED_ACCOUNT')) {
             self.logError(err);
           }
           // Ignore errors; the image will be rendered as a

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -5,9 +5,10 @@
 // helper functions for views with a profile image. Meant to be mixed into views.
 
 define([
+  'lib/auth-errors',
   'lib/profile-errors',
   'models/profile-image'
-], function (ProfileErrors, ProfileImage) {
+], function (AuthErrors, ProfileErrors, ProfileImage) {
   'use strict';
 
   return {
@@ -31,10 +32,11 @@ define([
         .then(function (profileImage) {
           // Cache the result to make sure we don't flash the default
           // image while fetching the latest profile image
-          self._updateCachedProfileImage(account, profileImage);
+          self._updateCachedProfileImage(profileImage, account);
           return profileImage;
         }, function (err) {
-          if (! ProfileErrors.is(err, 'UNAUTHORIZED')) {
+          if (! ProfileErrors.is(err, 'UNAUTHORIZED') &&
+              ! AuthErrors.is(err, 'UNVERIFIED')) {
             self.logError(err);
           }
           // Ignore errors; the image will be rendered as a
@@ -60,9 +62,9 @@ define([
       return this._displayedProfileImage && ! this._displayedProfileImage.isDefault();
     },
 
-    // Makes sure the account with uid has an uptodate image cache.
+    // Makes sure the account has an up-to-date image cache.
     // This should be called after fetching the current profile image.
-    _updateCachedProfileImage: function (account, profileImage) {
+    _updateCachedProfileImage: function (profileImage, account) {
       if (! account.isDefault()) {
         account.setProfileImage(profileImage);
         this.user.setAccount(account);

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -161,7 +161,7 @@ function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
           self.stream.stop();
           delete self.stream;
 
-          self.updateProfileImage(new ProfileImage(result));
+          self.updateProfileImage(new ProfileImage(result), account);
           self.navigate('settings');
           return result;
         });

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -33,6 +33,13 @@ function ($, Cocktail, FormView, AvatarMixin, SettingsMixin, Template,
       this.FileReader = FileReader;
     },
 
+    getAccount: function () {
+      if (! this._account) {
+        this._account = this.getSignedInAccount();
+      }
+      return this._account;
+    },
+
     beforeRender: function () {
       if (this.relier.get('setting') === 'avatar') {
         this.relier.unset('setting');
@@ -41,7 +48,7 @@ function ($, Cocktail, FormView, AvatarMixin, SettingsMixin, Template,
 
     afterVisible: function () {
       FormView.prototype.afterVisible.call(this);
-      return this.displayAccountProfileImage(this.getSignedInAccount());
+      return this.displayAccountProfileImage(this.getAccount());
     },
 
     afterRender: function () {
@@ -53,7 +60,7 @@ function ($, Cocktail, FormView, AvatarMixin, SettingsMixin, Template,
 
     remove: function () {
       var self = this;
-      var account = self.getSignedInAccount();
+      var account = self.getAccount();
       return self.deleteDisplayedAccountProfileImage(account)
         .then(function () {
           self.navigate('settings');
@@ -86,7 +93,7 @@ function ($, Cocktail, FormView, AvatarMixin, SettingsMixin, Template,
       var self = this;
       var defer = p.defer();
       var file = e.target.files[0];
-      var account = self.getSignedInAccount();
+      var account = self.getAccount();
       self.logAccountImageChange(account);
 
       var imgOnError = function (e) {

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -107,7 +107,7 @@ function (p, Cocktail, FormView, SettingsMixin, AvatarMixin, Template,
           return account.uploadAvatar(data);
         })
         .then(function (result) {
-          self.updateProfileImage(new ProfileImage(result));
+          self.updateProfileImage(new ProfileImage(result), account);
           self.navigate('settings');
           return result;
         });

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -83,7 +83,7 @@ function ($, _, md5, Cocktail, FormView, SettingsMixin, AvatarMixin,
 
       return account.postAvatar(url, true)
         .then(function (result) {
-          self.updateProfileImage(new ProfileImage({ url: url, id: result.id }));
+          self.updateProfileImage(new ProfileImage({ url: url, id: result.id }), account);
 
           self.navigate('settings', {
             successUnsafe: t('Courtesy of <a href="https://www.gravatar.com">Gravatar</a>')

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -97,31 +97,25 @@ define([
 
     it('displayAccountProfileImage updates the cached account data', function () {
       var image = new ProfileImage({ url: 'url', id: 'foo', img: new Image() });
-      var cachedAccount = user.initAccount({ uid: 'uid' });
-      sinon.spy(cachedAccount, 'setProfileImage');
 
+      sinon.spy(account, 'setProfileImage');
       sinon.stub(account, 'fetchCurrentProfileImage', function () {
         return p(image);
-      });
-      sinon.stub(user, 'getAccountByUid', function () {
-        return cachedAccount;
       });
 
       return view.displayAccountProfileImage(account)
         .then(function () {
           assert.isTrue(account.fetchCurrentProfileImage.called);
-          assert.isTrue(user.getAccountByUid.calledWith(UID));
-          assert.isTrue(user.setAccount.calledWith(cachedAccount));
-          assert.isTrue(cachedAccount.setProfileImage.calledWith(image));
+          assert.isTrue(user.setAccount.calledWith(account));
+          assert.isTrue(account.setProfileImage.calledWith(image));
           assert.isTrue(view.hasDisplayedAccountProfileImage());
         });
     });
 
     describe('updateProfileImage', function () {
       it('stores the url', function () {
-        view.updateProfileImage(new ProfileImage({ url: 'url' }));
+        view.updateProfileImage(new ProfileImage({ url: 'url' }), account);
         assert.equal(account.get('profileImageUrl'), 'url');
-        assert.isTrue(view.getSignedInAccount.called);
         assert.isTrue(user.setAccount.calledWith(account));
         assert.isTrue(notifications.profileChanged.calledWith({ uid: UID }));
       });

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -90,11 +90,11 @@ define([
 
       it('does not log an error for an unverified account', function () {
         sinon.stub(account, 'fetchCurrentProfileImage', function () {
-          return p.reject(AuthErrors.toError('UNVERIFIED'));
+          return p.reject(AuthErrors.toError('UNVERIFIED_ACCOUNT'));
         });
         return view.displayAccountProfileImage(account)
           .then(function () {
-            var err = view._normalizeError(AuthErrors.toError('UNVERIFIED'));
+            var err = view._normalizeError(AuthErrors.toError('UNVERIFIED_ACCOUNT'));
             assert.isFalse(TestHelpers.isErrorLogged(metrics, err));
           });
       });

--- a/app/tests/spec/views/settings/avatar_camera.js
+++ b/app/tests/spec/views/settings/avatar_camera.js
@@ -212,6 +212,7 @@ function (chai, $, sinon, View, RouterMock, WindowMock, CanvasMock,
                   assert.equal(result.id, 'foo');
                   assert.isTrue(view.updateProfileImage.called);
                   assert.equal(view.updateProfileImage.args[0][0].get('url'), result.url);
+                  assert.equal(view.updateProfileImage.args[0][1], account);
                   assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.avatar.camera.submit.new'));
 
                   // check canvas drawImage args

--- a/app/tests/spec/views/settings/avatar_crop.js
+++ b/app/tests/spec/views/settings/avatar_crop.js
@@ -167,6 +167,7 @@ function (chai, $, ui, sinon, jQuerySimulate, View, RouterMock, ProfileMock, Use
             })
             .then(function (result) {
               assert.equal(view.updateProfileImage.args[0][0].get('url'), result.url);
+              assert.equal(view.updateProfileImage.args[0][1], account);
               assert.equal(result.url, 'test');
               assert.equal(result.id, 'foo');
               assert.equal(routerMock.page, 'settings');

--- a/app/tests/spec/views/settings/avatar_gravatar.js
+++ b/app/tests/spec/views/settings/avatar_gravatar.js
@@ -148,6 +148,7 @@ function (chai, $, sinon, View, RouterMock, ProfileMock, TestHelpers, User,
               assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.avatar.gravatar.submit.new'));
               assert.isFalse(TestHelpers.isEventLogged(metrics, 'settings.avatar.gravatar.submit.change'));
               assert.equal(view.updateProfileImage.args[0][0].get('id'), 'foo');
+              assert.equal(view.updateProfileImage.args[0][1], account);
               assert.equal(result.id, 'foo');
               assert.equal(routerMock.page, 'settings');
               assert.equal(view.ephemeralMessages.get('successUnsafe'), 'Courtesy of <a href="https://www.gravatar.com">Gravatar</a>');

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -484,6 +484,10 @@ define([
         .click()
         .end()
 
+        // ensure signin page is visible otherwise credentials might
+        // not be cleared by clicking .use-different
+        .then(FunctionalHelpers.visibleByQSA('#fxa-signin-header'))
+
         // This will clear the desktop credentials
         .findByCssSelector('.use-different')
         .click()


### PR DESCRIPTION
This PR has ~~three~~ four different commits that clean up how we fetch access tokens and pass the signed-in `account` instances around (it may help to review each separately). The net affect is a single `account` shared amongst views that only needs to fetch the `profile:write` access token once, rather than one or more times for each view.

Fixes #2921.

@vladikoff or @shane-tomlinson r?