### PR TITLE
chore(version): display source repo last in {/ver.json,/__version__}

### DIFF
--- a/server/lib/version.js
+++ b/server/lib/version.js
@@ -116,11 +116,11 @@ function getVersionInfo() {
       logger.info('tos-pp (legal-docs) commit hash set to: ' + tosPpVersion);
 
       return {
-        source: sourceRepo,
         version: pkgVersion,
         commit: commitHash,
         l10n: l10nVersion,
-        tosPp: tosPpVersion
+        tosPp: tosPpVersion,
+        source: sourceRepo
       };
     });
   }

--- a/tests/server/ver.json.js
+++ b/tests/server/ver.json.js
@@ -25,7 +25,7 @@ define([
         assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
 
         var body = JSON.parse(res.body);
-        assert.deepEqual(Object.keys(body), ['source', 'version', 'commit', 'l10n', 'tosPp']);
+        assert.deepEqual(Object.keys(body), ['version', 'commit', 'l10n', 'tosPp', 'source' ]);
         assert.equal(body.version, pkg.version, 'package version');
         assert.ok(body.source && body.source !== 'unknown', 'source repository');
         assert.ok(body.l10n && body.l10n !== 'unknown', 'l10n version');


### PR DESCRIPTION
I know I just added this, but seeing this in practice, the source is (usually) the least interesting information in this output compared to versions/shas, so it should be last. 