### PR TITLE
fix(metrics): Provide more detailed logging for errors fetching /config

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -20,7 +20,6 @@ define([
   'backbone',
   'lib/promise',
   'router',
-  'raven',
   'lib/translator',
   'lib/session',
   'lib/url',
@@ -68,7 +67,6 @@ function (
   Backbone,
   p,
   Router,
-  Raven,
   Translator,
   Session,
   Url,
@@ -153,7 +151,7 @@ function (
           self.enableSentryMetrics();
         }
 
-        Raven.captureException(err);
+        self._sentryMetrics.captureException(err);
 
         if (self._metrics) {
           self._metrics.logError(err);
@@ -551,6 +549,7 @@ function (
       if (! this._router) {
         this._router = new Router({
           metrics: this._metrics,
+          sentryMetrics: this._sentryMetrics,
           language: this._config.language,
           relier: this._relier,
           broker: this._authenticationBroker,

--- a/app/scripts/lib/config-loader.js
+++ b/app/scripts/lib/config-loader.js
@@ -5,16 +5,22 @@
 // fetch config from the backend and provide some helper functions.
 
 define([
+  'lib/errors',
+  'lib/promise',
   'lib/xhr',
-  'lib/promise'
-],
-function (
+  'underscore'
+], function (
+  Errors,
+  p,
   xhr,
-  p
+  _
 ) {
   'use strict';
 
-  function ConfigLoader() {
+  function ConfigLoader(options) {
+    options = options || {};
+
+    this._xhr = options.xhr || xhr;
   }
 
   ConfigLoader.prototype = {
@@ -22,12 +28,16 @@ function (
      * Pass in a configuration to use. Useful for unit testing.
      */
     useConfig: function (config) {
-      this._config = config;
+      this._configPromise = p(config);
     },
 
+    _configPromise: null,
     fetch: function (force) {
-      if (force !== true && this._config) {
-        return p(this._config);
+      var self = this;
+      if (force !== true && self._configPromise) {
+        // self will resolve to the eventual config value,
+        // but prevent multiple concurrent requests to /config
+        return self._configPromise;
       }
 
       // The content server sets no cookies of its own, and cannot check for
@@ -48,14 +58,32 @@ function (
         // did not receive the cookie.
       }
 
-      var self = this;
-      return xhr.getJSON('/config')
-          .then(function (config) {
-            self._config = config;
-            return config;
-          });
+      self._configPromise = self._xhr.getJSON('/config')
+        .fail(function (jqXHR) {
+          throw ConfigLoader.Errors.normalizeXHRError(jqXHR);
+        });
+
+      return self._configPromise;
     },
   };
+
+  var t = function (msg) {
+    return msg;
+  };
+
+  ConfigLoader.Errors = _.extend({}, Errors, {
+    ERRORS: {
+      SERVICE_UNAVAILABLE: {
+        errno: 998,
+        message: t('System unavailable, try again soon')
+      },
+      UNEXPECTED_ERROR: {
+        errno: 999,
+        message: t('Unexpected error')
+      }
+    },
+    NAMESPACE: 'config'
+  });
 
   return ConfigLoader;
 });

--- a/app/scripts/lib/errors.js
+++ b/app/scripts/lib/errors.js
@@ -137,13 +137,22 @@ define([
     },
 
     normalizeXHRError: function (xhr) {
+      var err;
+
       if (! xhr || xhr.status === 0) {
-        return this.toError('SERVICE_UNAVAILABLE');
+        err = this.toError('SERVICE_UNAVAILABLE');
+      } else {
+        var serverError = xhr.responseJSON || 'UNEXPECTED_ERROR';
+        err = this.toError(serverError);
       }
 
-      var serverError = xhr.responseJSON;
+      // copy over the HTTP status if not already part of the error.
+      if (! ('status' in err)) {
+        var status = (xhr && xhr.status) || 0;
+        err.status = status;
+      }
 
-      return this.toError(serverError || 'UNEXPECTED_ERROR');
+      return err;
     }
   };
 });

--- a/app/scripts/lib/sentry.js
+++ b/app/scripts/lib/sentry.js
@@ -125,6 +125,37 @@ define([
     _ravenOpts: {
       dataCallback: beforeSend
     },
+
+    /**
+     * Exception fields that are imported as tags
+     */
+    _exceptionTags: [
+      'code',
+      'errno',
+      'namespace',
+      'status'
+    ],
+
+    /**
+     * Capture an exception. Error fields listed in _exceptionTags
+     * will be added as tags to the raven data.
+     */
+    captureException: function (err) {
+      var tags = {};
+
+      this._exceptionTags.forEach(function (tagName) {
+        if (tagName in err) {
+          tags[tagName] = err[tagName];
+        }
+      });
+
+      var extraContext = {
+        tags: tags
+      };
+
+      Raven.captureException(err, extraContext);
+    },
+
     /**
      * Disable error metrics with raven.js
      *

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -131,6 +131,7 @@ function (
       this.window = options.window || window;
 
       this.metrics = options.metrics;
+      this.sentryMetrics = options.sentryMetrics;
       this.language = options.language;
       this.relier = options.relier;
       this.broker = options.broker;
@@ -202,6 +203,7 @@ function (
         interTabChannel: this.interTabChannel,
         language: this.language,
         metrics: this.metrics,
+        sentryMetrics: this.sentryMetrics,
         profileClient: this.profileClient,
         relier: this.relier,
         router: this,

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -94,6 +94,7 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
       this.router = options.router || this.window.router;
       this.ephemeralMessages = options.ephemeralMessages || ephemeralMessages;
       this.metrics = options.metrics || nullMetrics;
+      this.sentryMetrics = options.sentryMetrics || Raven;
       this.relier = options.relier;
       this.broker = options.broker;
       this.user = options.user;
@@ -489,7 +490,7 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
       if (typeof console !== 'undefined' && console) {
         console.error(err.message || err);
       }
-      Raven.captureException(err);
+      this.sentryMetrics.captureException(err);
       this.metrics.logError(err);
     },
 

--- a/app/tests/spec/lib/config-loader.js
+++ b/app/tests/spec/lib/config-loader.js
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'lib/config-loader',
+  'lib/promise',
+  'lib/xhr',
+  'sinon',
+],
+function (chai, ConfigLoader, p, Xhr, sinon) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  describe('lib/config-loader', function () {
+    describe('fetch', function () {
+      var configLoader;
+      var successfulConfigResponse = {
+        cookiesEnabled: true,
+        language: 'en-GB'
+      };
+
+      var sandbox;
+      var xhr;
+
+      beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+
+        xhr = Object.create(Xhr);
+        configLoader = new ConfigLoader({
+          xhr: xhr
+        });
+      });
+
+      afterEach(function () {
+        sandbox.restore();
+      });
+
+      it('fetches config from `/config`', function () {
+        sandbox.stub(xhr, 'getJSON', function () {
+          return p(successfulConfigResponse);
+        });
+
+        return configLoader.fetch()
+          .then(function (config) {
+            assert.strictEqual(config, successfulConfigResponse);
+            assert.isTrue(xhr.getJSON.calledOnce);
+          });
+      });
+
+      it('caches responses', function () {
+        sandbox.stub(xhr, 'getJSON', function () {
+          return p(successfulConfigResponse);
+        });
+
+        return configLoader.fetch()
+          .then(function () {
+            return configLoader.fetch();
+          })
+          .then(function (config) {
+            assert.strictEqual(config, successfulConfigResponse);
+            assert.isTrue(xhr.getJSON.calledOnce);
+          });
+      });
+
+      it('only makes one XHR request for multiple concurrent requests', function () {
+        sandbox.stub(xhr, 'getJSON', function () {
+          return p(successfulConfigResponse);
+        });
+
+        return p.all([
+          configLoader.fetch(),
+          configLoader.fetch()
+        ])
+        .spread(function (config1, config2) {
+          assert.strictEqual(config1, successfulConfigResponse);
+          assert.strictEqual(config2, successfulConfigResponse);
+          assert.isTrue(xhr.getJSON.calledOnce);
+        });
+      });
+
+      it('fails with `SERVICE_UNAVAILABLE` if the server cannot be reached', function () {
+        sandbox.stub(xhr, 'getJSON', function () {
+          return p.reject();
+        });
+
+        return configLoader.fetch()
+          .then(assert.fail, function (err) {
+            assert.isTrue(ConfigLoader.Errors.is(err, 'SERVICE_UNAVAILABLE'));
+            assert.equal(err.namespace, 'config');
+            assert.equal(err.status, 0);
+          });
+      });
+
+      it('fails with `SERVICE_UNAVAILABLE` if the HTTP status code is 0', function () {
+        sandbox.stub(xhr, 'getJSON', function () {
+          return p.reject({
+            status: 0
+          });
+        });
+
+        return configLoader.fetch()
+          .then(assert.fail, function (err) {
+            assert.isTrue(ConfigLoader.Errors.is(err, 'SERVICE_UNAVAILABLE'));
+            assert.equal(err.namespace, 'config');
+            assert.equal(err.status, 0);
+          });
+      });
+
+      it('fails with `UNEXPECTED_ERROR` if the HTTP status code is > 0', function () {
+        sandbox.stub(xhr, 'getJSON', function () {
+          return p.reject({
+            status: 400
+          });
+        });
+
+        return configLoader.fetch()
+          .then(assert.fail, function (err) {
+            assert.isTrue(ConfigLoader.Errors.is(err, 'UNEXPECTED_ERROR'));
+            assert.equal(err.namespace, 'config');
+            assert.equal(err.status, 400);
+          });
+      });
+    });
+  });
+});
+
+

--- a/app/tests/spec/lib/sentry.js
+++ b/app/tests/spec/lib/sentry.js
@@ -183,6 +183,35 @@ define([
         assert.equal(resultUrl, expectedUrl);
       });
     });
+
+    describe('captureException', function () {
+      it('reports the error to Raven, passing along tags', function () {
+        var sandbox = sinon.sandbox.create();
+        sandbox.spy(Raven, 'captureException');
+
+        var sentry = new SentryMetrics(host);
+
+        var err = new Error('uh oh');
+        err.code = 400;
+        err.errno = 998;
+        err.namespace = 'config';
+        err.status = 401;
+        err.ignored = true;
+
+        sentry.captureException(err);
+
+        assert.isTrue(Raven.captureException.calledWith(err, {
+          tags: {
+            code: 400,
+            errno: 998,
+            namespace: 'config',
+            status: 401
+          }
+        }));
+
+        sandbox.restore();
+      });
+    });
   });
 
 });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -54,6 +54,7 @@ function (Translator, Session) {
     '../tests/spec/lib/origin-check',
     '../tests/spec/lib/marketing-email-client',
     '../tests/spec/lib/height-observer',
+    '../tests/spec/lib/config-loader',
     '../tests/spec/head/startup-styles',
     '../tests/spec/views/base',
     '../tests/spec/views/tooltip',


### PR DESCRIPTION
Send along tags with Sentry metrics.

Many errors in the Sentry dashboard lack enough context to figure
out exactly where the originated, or why. To help with this,
send along tags with the error.

All errors are reported from sentry.js now instead of calling
Raven directly. To do so required passing a sentry reference
to the router and views.

@vladikoff - r?

Here is what a Sentry error looks like:

![screen shot 2015-08-17 at 15 20 28](https://cloud.githubusercontent.com/assets/848085/9306996/933411b2-44f3-11e5-9a51-4dc796c0e5a2.png)

With some new and improved tags:

![screen shot 2015-08-17 at 15 20 24](https://cloud.githubusercontent.com/assets/848085/9307005/9bd13a8e-44f3-11e5-944d-63407da3522b.png)
