### PR TITLE
feat(openid): base OpenID login implementation

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -369,17 +369,20 @@ function (
           // the service name is translated correctly.
           relier = new FxDesktopRelier({
             window: this._window,
-            translator: this._translator
+            translator: this._translator,
+            authServerUrl: this._config.authServerUrl
           });
         } else if (this._isOAuth()) {
           relier = new OAuthRelier({
             window: this._window,
             oAuthClient: this._oAuthClient,
+            authServerUrl: this._config.authServerUrl,
             session: Session
           });
         } else {
           relier = new Relier({
-            window: this._window
+            window: this._window,
+            authServerUrl: this._config.authServerUrl
           });
         }
 

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -42,6 +42,7 @@ define([
       options = options || {};
 
       this.window = options.window || window;
+      this.authServerUrl = options.authServerUrl;
     },
 
     /**
@@ -80,6 +81,11 @@ define([
             self.importSearchParam('entryPoint', 'entrypoint');
           }
           self.importSearchParam('campaign');
+          self.importSearchParam('session');
+          self.importSearchParam('key');
+          self.importSearchParam('unwrap');
+          self.importSearchParam('email');
+          self.importSearchParam('err');
 
           self.importSearchParam('utm_campaign', 'utmCampaign');
           self.importSearchParam('utm_content', 'utmContent');

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -37,7 +37,9 @@ define([
   'views/cookies_disabled',
   'views/clear_storage',
   'views/unexpected_error',
-  'views/permissions'
+  'views/permissions',
+  'views/openid',
+  'views/start'
 ],
 function (
   _,
@@ -74,7 +76,9 @@ function (
   CookiesDisabledView,
   ClearStorageView,
   UnexpectedErrorView,
-  PermissionsView
+  PermissionsView,
+  OpenIdView,
+  StartView
 ) {
   'use strict';
 
@@ -122,7 +126,9 @@ function (
       'unexpected_error(/)': showView(UnexpectedErrorView),
       'confirm_account_unlock(/)': showView(ConfirmAccountUnlockView),
       'complete_unlock_account(/)': showView(CompleteAccountUnlockView),
-      'account_unlock_complete(/)': showView(ReadyView, { type: 'account_unlock' })
+      'account_unlock_complete(/)': showView(ReadyView, { type: 'account_unlock' }),
+      'openid(/)': showView(OpenIdView),
+      'start(/)': showView(StartView)
     },
 
     initialize: function (options) {

--- a/app/scripts/templates/openid.mustache
+++ b/app/scripts/templates/openid.mustache
@@ -1,0 +1,9 @@
+<div id="main-content" class="card">
+  <header>
+    <h1 id="fxa-openid-header"></h1>
+  </header>
+
+  <section>
+    <div class="error"></div>
+  </section>
+</div>

--- a/app/scripts/templates/start.mustache
+++ b/app/scripts/templates/start.mustache
@@ -1,0 +1,21 @@
+<div id="main-content" class="card">
+  <header id="partner-header">
+    <h1 id="fxa-partner-header">{{#t}}Sign in to Sync{{/t}}</h1>
+  </header>
+
+  <p>
+    {{#t}}Choose the account you would like to use to sync your tabs, bookmarks, passwords & more.{{/t}}
+  </p>
+
+  <form id="permissions" novalidate>
+    <div class="input-row">
+        <input id="openid" type="text" class="email" value="https://me.yahoo.com" />
+    </div>
+    <div class="button-row">
+      <button id="openid-button" type="submit">{{#t}}Use OpenID{{/t}}</button>
+    </div>
+    <div class="button-row">
+      <button id="fxa-button">{{#t}}Use Firefox Account{{/t}}</button>
+    </div>
+  </form>
+</div>

--- a/app/scripts/views/openid.js
+++ b/app/scripts/views/openid.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'cocktail',
+  'views/base',
+  'stache!templates/openid',
+  'lib/session'
+],
+function (Cocktail, BaseView, Template, Session) {
+  'use strict';
+
+  var View = BaseView.extend({
+    template: Template,
+    className: 'openid-sign-in',
+
+    initialize: function (options) {
+      BaseView.prototype.initialize.call(this, options);
+      options = options || {};
+
+      this._err = this.relier.get('err');
+      this._uid = this.relier.get('uid');
+      this._sessionToken = this.relier.get('session');
+      this._keyFetchToken = this.relier.get('key');
+      this._unwrapBKey = this.relier.get('unwrap');
+      this._email = this.relier.get('email')
+      Session.clear();
+      this.user.clearSignedInAccount();
+    },
+
+    beforeRender: function () {
+      var self = this;
+      if (self._err) {
+        throw new Error(self._err);
+      }
+      var account = self.user.initAccount({
+        uid: self._uid,
+        sessionToken: self._sessionToken,
+        keyFetchToken: self._keyFetchToken,
+        verified: true,
+        unwrapBKey: this._unwrapBKey,
+        email: this._email
+      });
+
+      return self.user.setSignedInAccount(account)
+        .then(function () {
+          self.logScreenEvent('success');
+          return self.broker.afterSignIn(account)
+            .then(function (result) {
+              self.navigate('settings');
+              return result;
+            });
+        });
+    },
+
+    context: function () {
+      return {};
+    }
+  });
+
+  Cocktail.mixin(
+    View
+  );
+
+  return View;
+});

--- a/app/scripts/views/start.js
+++ b/app/scripts/views/start.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'views/base',
+  'views/form',
+  'stache!templates/start'
+],
+function (BaseView, FormView, Template) {
+  'use strict';
+
+  var View = FormView.extend({
+    template: Template,
+    className: 'start',
+
+    events: {
+      'click #fxa-button': BaseView.preventDefaultThen('_goToSignUp')
+    },
+
+    _goToSignUp: function () {
+      this.navigate('signup');
+    },
+
+    submit: function () {
+      var form = this.getFormValues();
+
+      this.window.location = this.relier.authServerUrl +
+              '/v1/account/openid/authenticate?identifier=' +
+              encodeURIComponent(form.openid);
+      return { halt: true };
+    }
+
+  });
+
+  return View;
+});
+

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -110,7 +110,9 @@ module.exports = function (config, i18n) {
       '/account_unlock_complete',
       '/signup_permissions',
       '/signin_permissions',
-      '/unexpected_error'
+      '/unexpected_error',
+      '/openid',
+      '/start'
     ];
 
     var ALLOWED_TO_FRAME = {


### PR DESCRIPTION
Here's a minimal implementation of OpenID login. Its only meant to allow signup and login to sync with OpenID credentials for "testing" and "demo" purposes. Future work will refine the UX.

The `/start` page redirects through the OpenID auth flow and on to `/openid` which logs the user in and redirects to `/settings`. Error handling is still rudimentary with all errors ending up at `/unexpected_error`.

Requires https://github.com/mozilla/fxa-auth-server/pull/1007 and https://github.com/mozilla/fxa-auth-db-mysql/pull/78