### PR TITLE
fix(styles): align error and success correctly

### DIFF
--- a/app/styles/_state.scss
+++ b/app/styles/_state.scss
@@ -1,3 +1,10 @@
+header + section {
+  .success,
+  .error {
+    /*Display message at a safe distance from the header*/
+    top: -10px;
+  }
+}
 .error,
 .success,
 .info {


### PR DESCRIPTION
change `top` when success and error are below a header
Fixes #2770 
Might warrant change/removal of `nudge` class.
@shane-tomlinson 
@pdehaan 
