### PR TITLE
feat(l10n): add en-GB as a supported locale.

### DIFF
--- a/server/config/production-locales.json
+++ b/server/config/production-locales.json
@@ -8,6 +8,7 @@
       "de",
       "dsb",
       "en",
+      "en-GB",
       "es",
       "es-AR",
       "es-CL",


### PR DESCRIPTION
The en-GB locale is 100% translated and seems to work correctly in the dev environment.

Fixes #2942.