### PR TITLE
fix(views): only log ephemeral messages on the screen navigated from

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -229,6 +229,10 @@ function (_, Errors) {
     AGE_REQUIRED: {
       errno: 1031,
       message: t('Age is required')
+    },
+    NO_GRAVATAR_FOUND: {
+      errno: 1032,
+      message: t('No Gravatar found')
     }
   };
 

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -11,13 +11,14 @@ define([
   'views/mixins/settings-mixin',
   'views/mixins/avatar-mixin',
   'stache!templates/settings/avatar_gravatar',
+  'lib/auth-errors',
   'lib/constants',
   'lib/image-loader',
   'views/decorators/progress_indicator',
   'models/profile-image'
 ],
-function ($, _, md5, Cocktail, FormView, SettingsMixin, AvatarMixin,
-    Template, Constants, ImageLoader, showProgressIndicator, ProfileImage) {
+function ($, _, md5, Cocktail, FormView, SettingsMixin, AvatarMixin, Template,
+    AuthErrors, Constants, ImageLoader, showProgressIndicator, ProfileImage) {
   'use strict';
 
   function t (s) { return s; }
@@ -54,7 +55,7 @@ function ($, _, md5, Cocktail, FormView, SettingsMixin, AvatarMixin,
 
     _notFound: function () {
       this.navigate('settings/avatar/change', {
-        error: t('No Gravatar found')
+        error: AuthErrors.toError('NO_GRAVATAR_FOUND')
       });
     },
 

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -138,6 +138,23 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
             });
       });
 
+      it('logError is called for ephemeral error', function () {
+        var error = AuthErrors.toError('UNEXPECTED_ERROR');
+        sinon.spy(view, 'logError');
+        ephemeralMessages.set('error', error);
+        view.showEphemeralMessages();
+        assert.isTrue(view.logError.called);
+        assert.isTrue(error.logged);
+      });
+
+      it('displayError does not log an already logged error', function () {
+        var error = AuthErrors.toError('UNEXPECTED_ERROR');
+        error.logged = true;
+        sinon.stub(metrics, 'logError', function () { });
+        view.displayError(error);
+        assert.isFalse(metrics.logError.called);
+      });
+
       it('shows one time error messages', function () {
         ephemeralMessages.set('error', 'error message');
         return view.render()

--- a/app/tests/spec/views/settings/avatar_gravatar.js
+++ b/app/tests/spec/views/settings/avatar_gravatar.js
@@ -13,12 +13,13 @@ define([
   'models/user',
   'models/reliers/relier',
   'models/auth_brokers/base',
+  'lib/auth-errors',
   'lib/promise',
   'lib/metrics',
   'lib/profile-client'
 ],
 function (chai, $, sinon, View, RouterMock, ProfileMock, TestHelpers, User,
-    Relier, AuthBroker, p, Metrics, ProfileClient) {
+    Relier, AuthBroker, AuthErrors, p, Metrics, ProfileClient) {
   'use strict';
 
   var assert = chai.assert;
@@ -98,7 +99,7 @@ function (chai, $, sinon, View, RouterMock, ProfileMock, TestHelpers, User,
             return view._showGravatar()
               .then(function () {
                 assert.equal(routerMock.page, 'settings/avatar/change');
-                assert.equal(view.ephemeralMessages.get('error'), 'No Gravatar found');
+                assert.isTrue(AuthErrors.is(view.ephemeralMessages.get('error'), 'NO_GRAVATAR_FOUND'));
               });
           });
       });

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -172,14 +172,16 @@ The event stream is a log of events and the time they occurred while the user is
 
 #### settings/avatar/gravatar
 
-* settings.avatar.gravatar.submit - user submit the gravatar avatar view 
+* settings.avatar.gravatar.submit - user submit the gravatar avatar view
 * settings.avatar.gravatar.submit.change - user submit the gravatar and had an avatar set before
 * settings.avatar.gravatar.submit.new - user submit the gravatar and had no avatar set
+* error.settings.avatar.gravatar.auth.1032 - No gravatar found
 
 #### settings/avatar/gravatar_permissions
 
 * settings.avatar.gravatar-permissions.accepted - user accepted permission prompt
 * settings.avatar.gravatar-permissions.alreadly-accepted - user accepted permission prompt
+* settings.avatar.gravatar-permissions.submit - user accepted permission prompt
 
 #### settings/communication_preferences
 


### PR DESCRIPTION
Fixes #2519. We were logging ephemeral errors on the page that calls `navigate` as well as on the page that displays the error, when it should only be logged on the former.