### PR TITLE
fix(tests): Speed up the iframe origin tests.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -302,7 +302,9 @@ function (
 
     _checkParentOrigin: function (originCheck) {
       var self = this;
-      originCheck = originCheck || new OriginCheck(self._window);
+      originCheck = originCheck || new OriginCheck({
+        window: self._window
+      });
       var allowedOrigins = self._getAllowedParentOrigins();
 
       return originCheck.getOrigin(self._window.parent, allowedOrigins);

--- a/app/scripts/lib/origin-check.js
+++ b/app/scripts/lib/origin-check.js
@@ -34,11 +34,22 @@ define([
   // See https://github.com/mozilla/fxa-content-server/issues/2946 for details
   var RESPONSE_TIMEOUT_MS = 5000;
 
-  function OriginCheck(win) {
-    this._window = win;
+  function OriginCheck(options) {
+    options = options || {};
+
+    this._window = options.window || window;
+    if ('responseTimeoutMS' in options) {
+      this._responseTimeoutMS = options.responseTimeoutMS;
+    }
   }
 
   OriginCheck.prototype = {
+    /**
+     * Amount of time in milliseconds to wait for a response
+     * from the parent before giving up.
+     */
+    _responseTimeoutMS: RESPONSE_TIMEOUT_MS,
+
     /**
      * Get the origin of a targetWindow
      *
@@ -75,7 +86,7 @@ define([
       return deferred.promise
         // timeout after a short period. If no response is received,
         // no parent is listening.
-        .timeout(RESPONSE_TIMEOUT_MS)
+        .timeout(this._responseTimeoutMS)
         .fail(function (err) {
           if (/Timed out/.test(String(err))) {
             // a timeout is A-OK, no allowed origins are listening.

--- a/app/tests/spec/lib/origin-check.js
+++ b/app/tests/spec/lib/origin-check.js
@@ -31,7 +31,10 @@ function (chai, sinon, OriginCheck, WindowMock) {
 
       windowMock.parent = parentMock;
 
-      originCheck = new OriginCheck(windowMock);
+      originCheck = new OriginCheck({
+        responseTimeoutMS: 100,
+        window: windowMock
+      });
     });
 
     describe('getOrigin', function () {


### PR DESCRIPTION
The responseTimeoutMS was hard coded to 5 seconds, which made the tests
that hit the timeout incredibly slow. For testing, make the responseTimeoutMS
configurable, set it to 100ms for unit tests.

Nearly 10 seconds saved per test run!

fixes #2986

@vladikoff - r?