### PR TITLE
fix(client): Allow the firstrun flow to halt after signin.

### DIFF
--- a/app/scripts/models/auth_brokers/first-run.js
+++ b/app/scripts/models/auth_brokers/first-run.js
@@ -33,6 +33,21 @@ define([
       return proto.initialize.call(this, options);
     },
 
+    fetch: function () {
+      var self = this;
+      return proto.fetch.call(self)
+        .then(function () {
+          // Some settings do not work in an iframe due to x-frame and
+          // same-origin policies. Allow the firstrun flow to decide whether
+          // they want to display the settings page after the `login` message
+          // is sent. If `haltAfterSignIn` is set to true, the firstrun page
+          // will take care of displaying an update to the user.
+          if (self.getSearchParam('haltAfterSignIn') === 'true') {
+            self.haltAfterSignIn = true;
+          }
+        });
+    },
+
     afterLoaded: function () {
       this._iframeChannel.send(this._iframeCommands.LOADED);
 

--- a/app/tests/spec/models/auth_brokers/first-run.js
+++ b/app/tests/spec/models/auth_brokers/first-run.js
@@ -47,13 +47,36 @@ function (chai, sinon, NullChannel, Account, FirstRunAuthenticationBroker, Relie
     });
 
     describe('afterSignIn', function () {
-      it('notifies the iframe channel, does not halt', function () {
+      it('notifies the iframe channel, does not halt by default', function () {
         sinon.spy(iframeChannel, 'send');
 
-        return broker.afterSignIn(account)
+        return broker.fetch()
+          .then(function () {
+            return broker.afterSignIn(account);
+          })
           .then(function (result) {
             assert.isTrue(iframeChannel.send.calledWith(broker._iframeCommands.LOGIN));
             assert.isFalse(result.halt);
+          });
+      });
+
+      it('halts if the `haltAfterSignIn` query parameter is set to `true`', function () {
+        sinon.spy(iframeChannel, 'send');
+
+        windowMock.location.search = '?haltAfterSignIn=true';
+        broker = new FirstRunAuthenticationBroker({
+          iframeChannel: iframeChannel,
+          relier: relier,
+          window: windowMock
+        });
+
+        return broker.fetch()
+          .then(function () {
+            return broker.afterSignIn(account);
+          })
+          .then(function (result) {
+            assert.isTrue(iframeChannel.send.calledWith(broker._iframeCommands.LOGIN));
+            assert.isTrue(result.halt);
           });
       });
     });

--- a/docs/query-params.md
+++ b/docs/query-params.md
@@ -113,6 +113,14 @@ If they user arrived at Firefox Accounts from within Firefox browser chrome, spe
 * /force_auth
 * /settings
 
+### `haltAfterSignIn`
+Halt after the user signs in, do not redirect to the settings page.
+
+#### When to specify (must specify context=iframe&service=sync)
+* /signin
+* /signup
+* /force_auth
+
 ### `migration`
 If the user is migrating their Sync account from "old sync" to "new sync", specify which sync they are migrating from.
 

--- a/tests/functional/firstrun_sign_in.js
+++ b/tests/functional/firstrun_sign_in.js
@@ -14,6 +14,7 @@ define([
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var PAGE_URL = config.fxaContentRoot + 'signin?context=iframe&service=sync';
+  var NO_REDIRECT_URL = PAGE_URL + '&haltAfterSignIn=true';
 
   var email;
   var PASSWORD = '12345678';
@@ -63,6 +64,26 @@ define([
 
         // user should be unable to sign out.
         .then(FunctionalHelpers.noSuchElement(self, '#signout'))
+        .end();
+    },
+
+    'sign in with an existing account with the `haltAfterSignIn=true` query parameter': function () {
+      var self = this;
+
+      return FunctionalHelpers.openPage(this, NO_REDIRECT_URL, '#fxa-signin-header')
+        .execute(listenForFxaCommands)
+
+        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
+
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+        })
+
+        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
+        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:login'))
+
+        .then(FunctionalHelpers.noSuchElement(self, '#fxa-settings-header'))
         .end();
     },
 


### PR DESCRIPTION
Some settings do not work in an iframe due to x-frame and
same-origin policies. Allow the firstrun flow to decide whether
they want to display the settings page after the `login` message
is sent. If the `haltAfterSignIn` query parameter is set to true,
the flow halts after signin and the firstrun page takes care of
displaying an update to the user.

fixes #2945

@vladikoff, @jpetto and @habber?