### PR TITLE
refactor(client): Move back button related code from base.js to back-mixin.js

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -101,7 +101,6 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
       this.screenName = options.screenName || '';
 
       this.fxaClient = options.fxaClient;
-      this._canGoBack = options.canGoBack;
 
       Backbone.View.call(this, options);
 
@@ -290,7 +289,6 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
       var ctx = this._context;
 
       ctx.t = _.bind(this.translate, this);
-      ctx.canGoBack = this.canGoBack();
 
       return ctx;
     },
@@ -556,13 +554,6 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
 
     isErrorVisible: function () {
       return !! this._isErrorVisible;
-    },
-
-    /**
-     * Check if the back button should be shown.
-     */
-    canGoBack: function () {
-      return !! this._canGoBack;
     },
 
     /**

--- a/app/scripts/views/mixins/back-mixin.js
+++ b/app/scripts/views/mixins/back-mixin.js
@@ -9,29 +9,72 @@
  */
 
 define([
-], function () {
+  'views/base'
+], function (BaseView) {
   'use strict';
 
   var ENTER_BUTTON_CODE = 13;
 
   var BackMixin = {
+    _canGoBack: false,
+    initialize: function (options) {
+      options = options || {};
+
+      this._canGoBack = options.canGoBack;
+    },
+
     events: {
       'click #back': 'back',
       'keyup #back': 'backOnEnter'
     },
 
-    back: function (event) {
-      if (event && event.preventDefault) {
-        event.preventDefault();
+    /**
+     * Monkey patch BaseView.prototype.getContext to return a
+     * context with the `canGoBack` field. Note, this unfortunately
+     * means the mixed-in class cannot override `canGoBack`.
+     *
+     * @method getContext
+     * @returns {Object}
+     */
+    getContext: function () {
+      var context = BaseView.prototype.getContext.call(this);
+
+      if (! ('canGoBack' in context)) {
+        context.canGoBack = this.canGoBack();
       }
 
-      this.window.history.back();
+      return context;
     },
 
+    /**
+     * Go back to the last page.
+     *
+     * @method back
+     */
+    back: BaseView.preventDefaultThen(function () {
+      this.window.history.back();
+    }),
+
+    /**
+     * Go back to the last page, if the user pressed the enter key.
+     *
+     * @method backOnEnter
+     * @param {Object} event
+     */
     backOnEnter: function (event) {
       if (event.which === ENTER_BUTTON_CODE) {
         this.back();
       }
+    },
+
+    /**
+     * Check if the back button should be shown.
+     *
+     * @method canGoBack
+     * @returns {Boolean}
+     */
+    canGoBack: function () {
+      return !! this._canGoBack;
     }
   };
 

--- a/app/scripts/views/settings/communication_preferences.js
+++ b/app/scripts/views/settings/communication_preferences.js
@@ -10,14 +10,13 @@ define([
   'lib/metrics',
   'views/base',
   'views/form',
-  'views/mixins/back-mixin',
   'views/mixins/settings-mixin',
   'views/mixins/settings-panel-mixin',
   'views/mixins/checkbox-mixin',
   'stache!templates/settings/communication_preferences'
 ],
 function (Cocktail, Xss, Constants, MarketingEmailErrors, Metrics, BaseView, FormView,
-  BackMixin, SettingsMixin, SettingsPanelMixin, CheckboxMixin, Template) {
+  SettingsMixin, SettingsPanelMixin, CheckboxMixin, Template) {
   'use strict';
 
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;
@@ -107,7 +106,6 @@ function (Cocktail, Xss, Constants, MarketingEmailErrors, Metrics, BaseView, For
 
   Cocktail.mixin(
     View,
-    BackMixin,
     CheckboxMixin,
     SettingsMixin,
     SettingsPanelMixin

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -591,18 +591,6 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
       });
     });
 
-    describe('canGoBack', function () {
-      it('returns true if view created with `canGoBack: true` option', function () {
-        var view = new View({ canGoBack: true });
-        assert.isTrue(view.canGoBack());
-      });
-
-      it('returns false if view created with `canGoBack: false` option', function () {
-        var view = new View({ canGoBack: false });
-        assert.isFalse(view.canGoBack());
-      });
-    });
-
     describe('context call cache', function () {
       it('multiple calls to `getContext` only call `context` once', function () {
         view._context = null;

--- a/app/tests/spec/views/mixins/back-mixin.js
+++ b/app/tests/spec/views/mixins/back-mixin.js
@@ -68,5 +68,17 @@ define([
         assert.isFalse(windowMock.history.back.called);
       });
     });
+
+    describe('canGoBack', function () {
+      it('returns `true` if view created with `canGoBack: true` option', function () {
+        view = new View({ canGoBack: true });
+        assert.isTrue(view.canGoBack());
+      });
+
+      it('returns `false` if view created with `canGoBack: false` option', function () {
+        view = new View({ canGoBack: false });
+        assert.isFalse(view.canGoBack());
+      });
+    });
   });
 });


### PR DESCRIPTION
Old back button code was left over in base.js even though the back-mixin now
exists.

Removed the back-mixin from communication_preferences.js, it was no longer
used.

@vladikoff - r?