### PR TITLE
fix(client): Clear form prefill info after signin/signup/signout.

### DIFF
--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -59,6 +59,7 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
 
       this._able = options.able;
       this._subPanels = options.subPanels || this._initializeSubPanels(options);
+      this._formPrefill = options.formPrefill;
 
       this.router.on(this.router.NAVIGATE_FROM_SUBVIEW, this._onNavigateFromSubview.bind(this));
     },
@@ -189,6 +190,11 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
         .fin(function () {
           self.logScreenEvent('signout.success');
           self.user.clearSignedInAccount();
+          // The user has manually signed out, a pretty strong indicator
+          // the user does not want any of their information pre-filled
+          // on the signin page. Clear any remaining formPrefill info
+          // to ensure their data isn't sticking around in memory.
+          self._formPrefill.clear();
           Session.clear();
           self.navigate('signin', {
             success: t('Signed out successfully')

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -130,6 +130,11 @@ function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
           });
         })
         .then(function (account) {
+          // formPrefill information is no longer needed after the user
+          // has successfully signed in. Clear the info to ensure
+          // passwords aren't sticking around in memory.
+          self._formPrefill.clear();
+
           if (self.relier.accountNeedsPermissions(account)) {
             self.navigate('signin_permissions', {
               data: {

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -317,6 +317,11 @@ function (Cocktail, _, p, BaseView, FormView, Template, AuthErrors, mailcheck,
           });
         })
         .then(function (account) {
+          // formPrefill information is no longer needed after the user
+          // has successfully signed up. Clear the info to ensure
+          // passwords aren't sticking around in memory.
+          self._formPrefill.clear();
+
           if (preVerifyToken && account.get('verified')) {
             self.logScreenEvent('preverified.success');
           }

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -205,6 +205,23 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
         $('[type=password]').val('password');
       });
 
+      it('clears formPrefill information on successful sign in', function () {
+        sinon.stub(user, 'signInAccount', function (account) {
+          return p(account);
+        });
+
+        sinon.stub(view, 'navigate', function () { });
+
+        formPrefill.set('email', email);
+        formPrefill.set('password', 'password');
+
+        return view.submit()
+          .then(function () {
+            assert.isFalse(formPrefill.has('email'));
+            assert.isFalse(formPrefill.has('password'));
+          });
+      });
+
       it('redirects users to permissions page if relier needs permissions', function () {
         sinon.spy(user, 'initAccount');
         sinon.spy(broker, 'beforeSignIn');

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -543,6 +543,27 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
     });
 
     describe('submit', function () {
+      it('clears formPrefill information on successful sign in', function () {
+        sinon.stub(user, 'signUpAccount', function (account) {
+          return p(account);
+        });
+
+        sinon.stub(view, '_isUserOldEnough', function () {
+          return true;
+        });
+
+        sinon.stub(view, 'navigate', function () { });
+
+        formPrefill.set('email', email);
+        formPrefill.set('password', 'password');
+
+        return view.submit()
+          .then(function () {
+            assert.isFalse(formPrefill.has('email'));
+            assert.isFalse(formPrefill.has('password'));
+          });
+      });
+
       it('redirects users to permissions page if relier needs permissions', function () {
         var password = 'password';
         fillOutSignUp(email, password, true);

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -99,6 +99,33 @@ define([
         .then(function () {
           return testRepopulateFields.call(self, '/legal/privacy', 'fxa-pp-header');
         });
+    },
+
+    'form prefill information is cleared after sign in->sign out': function () {
+      var self = this;
+      return openFxa(self, email)
+
+        .then(function () {
+          return attemptSignIn(self);
+        })
+
+        .findById('fxa-settings-header')
+        .end()
+
+        .findByCssSelector('#signout')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        .findByCssSelector('input[type=password]')
+          .getProperty('value')
+          .then(function (resultText) {
+            // check the password address was cleared
+            assert.equal(resultText, '');
+          })
+        .end();
     }
   });
 

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -183,6 +183,40 @@ define([
 
     'visiting the tos links saves information for return': function () {
       return testRepopulateFields.call(this, '/legal/privacy', 'fxa-pp-header');
+    },
+
+    'form prefill information is cleared after sign in->sign out': function () {
+      var self = this;
+      return verifyUser(email, 0)
+        .then(function () {
+          return fillOutSignIn(self, email, PASSWORD)
+            // success is seeing the sign-in-complete screen.
+            .findById('fxa-settings-header')
+            .end()
+
+            .findByCssSelector('#signout')
+              .click()
+            .end()
+
+            .findByCssSelector('#fxa-signin-header')
+            .end()
+
+            .findByCssSelector('input[type=email]')
+              .getProperty('value')
+              .then(function (resultText) {
+                // check the email address was cleared
+                assert.equal(resultText, '');
+              })
+            .end()
+
+            .findByCssSelector('input[type=password]')
+              .getProperty('value')
+              .then(function (resultText) {
+                // check the password address was cleared
+                assert.equal(resultText, '');
+              })
+            .end();
+        });
     }
   });
 
@@ -229,7 +263,7 @@ define([
       .findByCssSelector('input[type=password]')
         .getProperty('value')
         .then(function (resultText) {
-          // check the email address was re-populated
+          // check the password was re-populated
           assert.equal(resultText, password);
         })
       .end();

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -392,6 +392,46 @@ define([
 
     'visiting the tos links saves information for return': function () {
       return testRepopulateFields.call(this, '/legal/privacy', 'fxa-pp-header');
+    },
+
+    'form prefill information is cleared after sign up->sign out': function () {
+      var self = this;
+      return fillOutSignUp(self, email, PASSWORD, OLD_ENOUGH_YEAR)
+        .then(function () {
+          return testAtConfirmScreen(self, email);
+        })
+
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkDifferentBrowser(client, email);
+        })
+
+        // The original tab should transition to the settings page w/ success
+        // message.
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+
+        .findByCssSelector('#signout')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        .findByCssSelector('input[type=email]')
+          .getProperty('value')
+          .then(function (resultText) {
+            // check the email address was cleared
+            assert.equal(resultText, '');
+          })
+        .end()
+
+        .findByCssSelector('input[type=password]')
+          .getProperty('value')
+          .then(function (resultText) {
+            // check the password address was cleared
+            assert.equal(resultText, '');
+          })
+        .end();
     }
   });
 


### PR DESCRIPTION
If a user signed in then signed out in the same FxA session, their
email and password were not cleared. This is certainly unexpected.

Clear the form prefill after a user successfully signs in, signs up,
or signs out, just to make sure.

fixes #3034