### PR TITLE
fix(style): Fix the signin/signup width on mobile devices.

### DIFF
--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -6,7 +6,9 @@
   text-align: center;
 
   &.card {
-    width: 420px;
+    @include respond-to('big') {
+      width: 420px;
+    }
   }
 
   &.panel {


### PR DESCRIPTION
The minimum width of a `.card` element was 420px, which caused
layout chaos on mobile devices.

To the `.card` CSS declaration, add a `small` media query and set
the width to `auto`

fixes #3060