### PR TITLE
fix(links): Only obscure links when viewing legal pages on small resolution

### DIFF
--- a/app/styles/modules/_legal.scss
+++ b/app/styles/modules/_legal.scss
@@ -75,33 +75,35 @@
     padding-left: 20px;
   }
 
-  .show-visible-url & {
-    // Links cannot be opened from the TOS/PP text when signing
-    // in to Sync on Fx for iOS. When signing in elsewhere, links
-    // replace the app. Yuck. Show the links href next to the link text.
-    // The href is fetched from the data-visible-url attribute instead of
-    // the href attribute because some links are the same as their
-    // text. In those cases, there is no point showing both.
-    //
-    // hrefs are only visible from the app, when the TOS/PP agreements
-    // are opened directly, the links display/act normally.
-    a[href^=http] {
-      // using text-decoration: underline underlines the ::after
-      // section as well, with no way to remove it.
-      // So, add a border to the entire element, then hide
-      // the border in the ::after using a border that is the same
-      // color as the background.
-      border-bottom: 1px dotted $text-color;
-      color: $text-color;
-      cursor: default;
-      pointer-events: none;
-      text-decoration: none;
-    }
+  @include respond-to('small') {
+    .show-visible-url & {
+      // Links cannot be opened from the TOS/PP text when signing
+      // in to Sync on Fx for iOS. When signing in elsewhere, links
+      // replace the app. Yuck. Show the links href next to the link text.
+      // The href is fetched from the data-visible-url attribute instead of
+      // the href attribute because some links are the same as their
+      // text. In those cases, there is no point showing both.
+      //
+      // hrefs are only visible from the app, when the TOS/PP agreements
+      // are opened directly, the links display/act normally.
+      a[href^=http] {
+        // using text-decoration: underline underlines the ::after
+        // section as well, with no way to remove it.
+        // So, add a border to the entire element, then hide
+        // the border in the ::after using a border that is the same
+        // color as the background.
+        border-bottom: 1px dotted $text-color;
+        color: $text-color;
+        cursor: default;
+        pointer-events: none;
+        text-decoration: none;
+      }
 
-    a[data-visible-url^=http]:after,
-    a[data-visible-url^=http]::after {
-      border-bottom: 1px solid $content-background-color;
-      content: " [" attr(href) "] ";
+      a[data-visible-url^=http]:after,
+      a[data-visible-url^=http]::after {
+        border-bottom: 1px solid $content-background-color;
+        content: " [" attr(href) "] ";
+      }
     }
-  }
+}
 }


### PR DESCRIPTION
This should only obscure the links on the legal pages when viewing on the following breakpoints:

`small: '(max-width: 520px), (orientation:landscape) and (min-width:481px) and (max-height: 480px)'`

r? @johngruen 

Fixes #2504