### PR TITLE
refactor(client): Rename the FxDesktopRelier to the SyncRelier

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -47,7 +47,7 @@ define([
   'lib/height-observer',
   'models/reliers/relier',
   'models/reliers/oauth',
-  'models/reliers/fx-desktop',
+  'models/reliers/sync',
   'models/auth_brokers/base',
   'models/auth_brokers/fx-desktop',
   'models/auth_brokers/fx-desktop-v2',
@@ -95,7 +95,7 @@ function (
   HeightObserver,
   Relier,
   OAuthRelier,
-  FxDesktopRelier,
+  SyncRelier,
   BaseAuthenticationBroker,
   FxDesktopV1AuthenticationBroker,
   FxDesktopV2AuthenticationBroker,
@@ -288,7 +288,7 @@ function (
     _getAllowedParentOrigins: function () {
       if (! this._isInAnIframe()) {
         return [];
-      } else if (this._isFxDesktop()) {
+      } else if (this._isSync()) {
         // If in an iframe for sync, the origin is checked against
         // a pre-defined set of origins sent from the server.
         return this._config.allowedParentOrigins;
@@ -366,10 +366,10 @@ function (
       if (! this._relier) {
         var relier;
 
-        if (this._isFxDesktop()) {
-          // Use the FxDesktopRelier for sync verification so that
+        if (this._isSync()) {
+          // Use the SyncRelier for sync verification so that
           // the service name is translated correctly.
-          relier = new FxDesktopRelier({
+          relier = new SyncRelier({
             window: this._window,
             translator: this._translator
           });
@@ -643,16 +643,6 @@ function (
 
     _isFxiOSV1: function () {
       return this._searchParam('context') === Constants.FX_IOS_V1_CONTEXT;
-    },
-
-    _isFxDesktop: function () {
-      // In addition to the two obvious fx desktop choices, sync is always
-      // considered fx-desktop. If service=sync is on the URL, it's considered
-      // fx-desktop.
-      return this._isFxDesktopV1() ||
-             this._isFxDesktopV2() ||
-             this._isFxiOSV1() ||
-             this._isSync();
     },
 
     _isFirstRun: function () {

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -107,23 +107,6 @@ define([
     },
 
     /**
-     * Check if the relier is Sync for Firefox Desktop
-     */
-    isSync: function () {
-      return this.get('service') === Constants.SYNC_SERVICE;
-    },
-
-    /**
-     * We should always fetch keys for sync.  If the user verifies in a
-     * second tab on the same browser, the context will not be available,
-     * but we will need to ship the keyFetchToken and unwrapBKey over to
-     * the first tab.
-     */
-    wantsKeys: function () {
-      return this.isSync();
-    },
-
-    /**
      * Check if the relier allows cached credentials. A relier
      * can set email=blank to indicate they do not.
      */

--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * The FxDesktop for Sync relier. In addition to the fields available on
+ * The Sync for Sync relier. In addition to the fields available on
  * `Relier`, provides the following:
  *
  * - context
@@ -17,7 +17,7 @@ define([
 ], function (_, Relier, ServiceNameTranslator) {
   'use strict';
 
-  var FxDesktopRelier = Relier.extend({
+  var SyncRelier = Relier.extend({
     defaults: _.extend({}, Relier.prototype.defaults, {
       context: null,
       migration: null
@@ -54,7 +54,7 @@ define([
         });
     },
 
-    isFxDesktop: function () {
+    isSync: function () {
       return true;
     },
 
@@ -78,9 +78,9 @@ define([
      * Check if the relier wants to force the customize sync checkbox on
      */
     isCustomizeSyncChecked: function () {
-      return !! (this.isSync() && this.get('customizeSync'));
+      return !! this.get('customizeSync');
     }
   });
 
-  return FxDesktopRelier;
+  return SyncRelier;
 });

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -24,7 +24,7 @@ define([
   'models/auth_brokers/redirect',
   'models/auth_brokers/web-channel',
   'models/reliers/base',
-  'models/reliers/fx-desktop',
+  'models/reliers/sync',
   'models/reliers/oauth',
   'models/reliers/relier',
   'models/user',
@@ -38,7 +38,7 @@ define([
 function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
   Url, OAuthErrors, AuthErrors, Storage, BaseBroker, FxDesktopV1Broker,
   FxDesktopV2Broker, FxFennecV1Broker, FxiOSV1Broker, IframeBroker,
-  RedirectBroker, WebChannelBroker, BaseRelier, FxDesktopRelier,
+  RedirectBroker, WebChannelBroker, BaseRelier, SyncRelier,
   OAuthRelier, Relier, User, Metrics, StorageMetrics, WindowMock,
   RouterMock, HistoryMock, TestHelpers) {
   'use strict';
@@ -343,13 +343,13 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
         });
       });
 
-      it('creates an FxDesktopRelier if Firefox Desktop', function () {
-        sinon.stub(appStart, '_isFxDesktop', function () {
+      it('creates an SyncRelier if Sync', function () {
+        sinon.stub(appStart, '_isSync', function () {
           return true;
         });
 
         appStart.initializeRelier();
-        assert.instanceOf(appStart._relier, FxDesktopRelier);
+        assert.instanceOf(appStart._relier, SyncRelier);
       });
 
       it('creates an OAuthRelier if using the OAuth flow', function () {
@@ -603,7 +603,7 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
           return true;
         });
 
-        sinon.stub(appStart, '_isFxDesktop', function () {
+        sinon.stub(appStart, '_isSync', function () {
           return true;
         });
 

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -115,6 +115,14 @@ function (chai, $, sinon, FxaClient, p, testHelpers, FxaClientWrapper, AuthError
           });
         });
 
+        sinon.stub(relier, 'wantsKeys', function () {
+          return true;
+        });
+
+        sinon.stub(relier, 'isSync', function () {
+          return true;
+        });
+
         return client.signUp(email, password, relier, { customizeSync: true, resume: resumeToken })
           .then(function (sessionData) {
             assert.isTrue(realClient.signUp.calledWith(trim(email), password, {
@@ -207,6 +215,10 @@ function (chai, $, sinon, FxaClient, p, testHelpers, FxaClientWrapper, AuthError
           return p({});
         });
 
+        sinon.stub(relier, 'wantsKeys', function () {
+          return true;
+        });
+
         return client.signUp(email, password, relier, {
           preVerifyToken: preVerifyToken,
           resume: resumeToken
@@ -225,6 +237,9 @@ function (chai, $, sinon, FxaClient, p, testHelpers, FxaClientWrapper, AuthError
       it('signUp a user with an invalid preVerifyToken retries the signup without the token', function () {
         var preVerifyToken = 'somebiglongtoken';
         relier.set('preVerifyToken', preVerifyToken);
+        sinon.stub(relier, 'wantsKeys', function () {
+          return true;
+        });
 
         // we are going to take over from here.
         testHelpers.removeFxaClientSpy(realClient);
@@ -330,6 +345,14 @@ function (chai, $, sinon, FxaClient, p, testHelpers, FxaClientWrapper, AuthError
           });
         });
 
+        sinon.stub(relier, 'wantsKeys', function () {
+          return true;
+        });
+
+        sinon.stub(relier, 'isSync', function () {
+          return true;
+        });
+
         relier.set('service', 'sync');
         return client.signIn(email, password, relier, { customizeSync: true })
           .then(function (sessionData) {
@@ -396,8 +419,12 @@ function (chai, $, sinon, FxaClient, p, testHelpers, FxaClientWrapper, AuthError
           });
       });
 
-      it('informs browser of customizeSync option', function () {
+      it('Sync signIn informs browser of customizeSync option', function () {
         sinon.stub(relier, 'isSync', function () {
+          return true;
+        });
+
+        sinon.stub(relier, 'wantsKeys', function () {
           return true;
         });
 
@@ -418,6 +445,10 @@ function (chai, $, sinon, FxaClient, p, testHelpers, FxaClientWrapper, AuthError
       });
 
       it('passes along an optional `reason`', function () {
+        sinon.stub(relier, 'wantsKeys', function () {
+          return true;
+        });
+
         sinon.stub(realClient, 'signIn', function () {
           return p({});
         });

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -19,7 +19,6 @@ define([
     var windowMock;
 
     var SERVICE = 'service';
-    var SYNC_SERVICE = 'sync';
     var PREVERIFY_TOKEN = 'abigtoken';
     var EMAIL = 'email';
     var UID = 'uid';
@@ -133,26 +132,15 @@ define([
     });
 
     describe('isSync', function () {
-      it('returns true if `service=sync`', function () {
-        windowMock.location.search = TestHelpers.toSearchString({
-          service: SYNC_SERVICE
-        });
-
-        return relier.fetch()
-            .then(function () {
-              assert.isTrue(relier.isSync());
-            });
-      });
-
-      it('returns false otw', function () {
+      it('returns `false` by default', function () {
         windowMock.location.search = TestHelpers.toSearchString({
           service: SERVICE
         });
 
         return relier.fetch()
-            .then(function () {
-              assert.isFalse(relier.isSync());
-            });
+          .then(function () {
+            assert.isFalse(relier.isSync());
+          });
       });
     });
 

--- a/app/tests/spec/models/reliers/sync.js
+++ b/app/tests/spec/models/reliers/sync.js
@@ -4,7 +4,7 @@
 
 define([
   'chai',
-  'models/reliers/fx-desktop',
+  'models/reliers/sync',
   'lib/translator',
   '../../../mocks/window',
   '../../../lib/helpers'
@@ -13,13 +13,10 @@ define([
 
   var assert = chai.assert;
 
-  describe('models/reliers/fx-desktop', function () {
+  describe('models/reliers/sync', function () {
     var windowMock;
     var translator;
     var relier;
-
-    var SERVICE = 'service';
-    var SYNC_SERVICE = 'sync';
 
     beforeEach(function () {
       windowMock = new WindowMock();
@@ -72,16 +69,15 @@ define([
       });
     });
 
-    describe('isFxDesktop', function () {
+    describe('isSync', function () {
       it('returns `true`', function () {
-        assert.isTrue(relier.isFxDesktop());
+        assert.isTrue(relier.isSync());
       });
     });
 
     describe('isCustomizeSyncChecked', function () {
-      it('returns true if `service=sync` and `customizeSync=true`', function () {
+      it('returns true if `customizeSync=true`', function () {
         windowMock.location.search = TestHelpers.toSearchString({
-          service: SYNC_SERVICE,
           customizeSync: 'true'
         });
 
@@ -91,21 +87,8 @@ define([
           });
       });
 
-      it('returns false if `service!=sync`', function () {
+      it('returns false if `customizeSync=false`', function () {
         windowMock.location.search = TestHelpers.toSearchString({
-          service: SERVICE,
-          customizeSync: 'true'
-        });
-
-        return relier.fetch()
-          .then(function () {
-            assert.isFalse(relier.isCustomizeSyncChecked());
-          });
-      });
-
-      it('returns false if `customizeSync===false`', function () {
-        windowMock.location.search = TestHelpers.toSearchString({
-          service: SYNC_SERVICE,
           customizeSync: 'false'
         });
 

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -10,11 +10,11 @@ define([
   'lib/fxa-client',
   'lib/able',
   'lib/promise',
-  'models/reliers/fx-desktop',
+  'models/reliers/sync',
   'models/auth_brokers/oauth',
   '../../mocks/window'
 ],
-function (chai, sinon, View, Session, FxaClient, Able, p, FxDesktopRelier,
+function (chai, sinon, View, Session, FxaClient, Able, p, SyncRelier,
       OAuthBroker, WindowMock) {
   'use strict';
 
@@ -31,7 +31,7 @@ function (chai, sinon, View, Session, FxaClient, Able, p, FxDesktopRelier,
 
     function createView() {
       windowMock = new WindowMock();
-      relier = new FxDesktopRelier({
+      relier = new SyncRelier({
         window: windowMock
       });
       broker = new OAuthBroker({

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -664,10 +664,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
     });
 
     describe('_suggestedAccountAskPassword', function () {
-      it('asks for password right away if service is sync', function () {
-        relier.isSync = function () {
-          return true;
-        };
+      it('asks for password right away if the relier wants keys (Sync)', function () {
         var account = user.initAccount({
           sessionToken: 'abc123',
           email: 'a@a.com',
@@ -680,34 +677,9 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
           return account;
         });
 
-        relier.set('service', 'sync');
-
-        return view.render()
-          .then(function () {
-            assert.isTrue($('.email').hasClass('hidden'), 'should not show email input');
-            assert.ok($('.password').length, 'should show password input');
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.keys-required'));
-          });
-      });
-
-      it('asks for the password if the relier wants keys', function () {
         sinon.stub(relier, 'wantsKeys', function () {
           return true;
         });
-
-        var account = user.initAccount({
-          sessionToken: 'abc123',
-          email: 'a@a.com',
-          sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
-          verified: true,
-          accessToken: 'foo'
-        });
-
-        sinon.stub(view, 'getAccount', function () {
-          return account;
-        });
-
-        relier.set('service', 'Firefox Hello');
 
         return view.render()
           .then(function () {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -16,7 +16,7 @@ define([
   'lib/fxa-client',
   'lib/ephemeral-messages',
   'lib/able',
-  'models/reliers/fx-desktop',
+  'models/reliers/sync',
   'models/auth_brokers/base',
   'models/user',
   'models/form-prefill',
@@ -792,6 +792,14 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
         function setupCustomizeSyncTest(service, isCustomizeSyncChecked) {
           relier.set('service', service);
           relier.set('customizeSync', isCustomizeSyncChecked);
+
+          sinon.stub(relier, 'isSync', function () {
+            return service === 'sync';
+          });
+
+          sinon.stub(relier, 'isCustomizeSyncChecked', function () {
+            return isCustomizeSyncChecked;
+          });
 
           sinon.stub(user, 'signUpAccount', function (account) {
             account.set('verified', true);

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -136,7 +136,7 @@ function (Translator, Session) {
     '../tests/spec/models/reliers/base',
     '../tests/spec/models/reliers/relier',
     '../tests/spec/models/reliers/oauth',
-    '../tests/spec/models/reliers/fx-desktop',
+    '../tests/spec/models/reliers/sync',
     '../tests/spec/models/auth_brokers/base',
     '../tests/spec/models/auth_brokers/first-run',
     '../tests/spec/models/auth_brokers/fx-desktop',


### PR DESCRIPTION
The initial idea behind FxDesktopRelier was that there could be
multiple reliers that integrate with Fx and we wanted to provide
functionality to handle all of them. Our next two integrated
services came along and used OAuth, which was much cleaner.
No new services have required the FxDesktopRelier, and it's
generic functionality makes reasoning/testing more difficult
than need be.

With this PR, I rename the FxDesktopRelier to the SyncRelier.
The SyncRelier has Sync specific functionality. I was able to
simplify app-start and several tests as a result.

Not attached to an issue.

Re-issue of https://github.com/shane-tomlinson/fxa-content-server/pull/30 which @zaach has previously reviewed.

@zaach - mind doing a quick pass over this to make sure it's still good to go?