### PR TITLE
feat(client): Add the internal capabilities API (no handshake)

### DIFF
--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -8,15 +8,16 @@
  */
 
 define([
-  'underscore',
   'backbone',
   'lib/promise',
-  'models/mixins/search-param'
-], function (_, Backbone, p, SearchParamMixin) {
+  'models/mixins/search-param',
+  'underscore',
+], function (Backbone, p, SearchParamMixin, _) {
   'use strict';
 
   var BaseAuthenticationBroker = Backbone.Model.extend({
     type: 'base',
+
     initialize: function (options) {
       options = options || {};
 
@@ -24,6 +25,7 @@ define([
       this.window = options.window || window;
 
       this._behaviors = _.extend({}, this.defaultBehaviors);
+      this._capabilities = new Backbone.Model(this.defaultCapabilities);
     },
 
     /**
@@ -272,13 +274,53 @@ define([
     },
 
     /**
-     * Is FxA account signup disabled?
+     * The default list of capabilities. Set to a capability's value to
+     * a truthy value to indicate whether it's supported.
      *
+     * @property defaultCapabilities
+     */
+    defaultCapabilities: {
+      signup: true
+    },
+
+    /**
+     * Check if a capability is supported.
+     *
+     * @param {string} capabilityName
      * @return {boolean}
      */
-    isSignupDisabled: function () {
-      return false;
+    hasCapability: function (capabilityName) {
+      return this._capabilities.has(capabilityName);
     },
+
+    /**
+     * Set whether a capability is supported
+     *
+     * @param {string} capabilityName
+     * @param {variant} capabilityValue
+     */
+    setCapability: function (capabilityName, capabilityValue) {
+      this._capabilities.set(capabilityName, capabilityValue);
+    },
+
+    /**
+     * Remove support for a capability
+     *
+     * @param {string} capabilityName
+     */
+    unsetCapability: function (capabilityName) {
+      this._capabilities.unset(capabilityName);
+    },
+
+    /**
+     * Get the capability value
+     *
+     * @param {string} capabilityName
+     * @return {variant}
+     */
+    getCapability: function (capabilityName) {
+      return this._capabilities.get(capabilityName);
+    }
   });
 
   _.extend(BaseAuthenticationBroker.prototype, SearchParamMixin);

--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -13,23 +13,21 @@ define([
 ], function (AuthErrors, FxDesktopV1AuthenticationBroker) {
   'use strict';
 
+  var proto = FxDesktopV1AuthenticationBroker.prototype;
+
   var FxiOSAuthenticationBroker = FxDesktopV1AuthenticationBroker.extend({
     fetch: function () {
       var self = this;
-      return FxDesktopV1AuthenticationBroker.prototype.fetch.call(self)
+
+      return proto.fetch.call(self)
         .then(function () {
           if (self.getSearchParam('exclude_signup') === '1') {
-            self._isSignupDisabled = true;
+            self.unsetCapability('signup');
+            self.SIGNUP_DISABLED_REASON =
+                AuthErrors.toError('IOS_SIGNUP_DISABLED');
           }
         });
-    },
-
-    _isSignupDisabled: false,
-    isSignupDisabled: function () {
-      return this._isSignupDisabled;
-    },
-
-    SIGNUP_DISABLED_REASON: AuthErrors.toError('IOS_SIGNUP_DISABLED')
+    }
   });
 
   return FxiOSAuthenticationBroker;

--- a/app/scripts/views/mixins/signup-disabled-mixin.js
+++ b/app/scripts/views/mixins/signup-disabled-mixin.js
@@ -9,7 +9,7 @@ define([], function () {
 
   return {
     isSignupDisabled: function () {
-      return this.broker.isSignupDisabled();
+      return ! this.broker.hasCapability('signup');
     },
 
     getSignupDisabledReason: function () {

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -155,9 +155,43 @@ function (chai, Relier, BaseAuthenticationBroker,
       });
     });
 
-    describe('isSignupDisabled', function () {
-      it('returns `false` by default', function () {
-        assert.isFalse(broker.isSignupDisabled());
+    describe('capabilities', function () {
+      describe('hasCapability', function () {
+        it('returns `false` by default', function () {
+          assert.isFalse(broker.hasCapability('some-capability'));
+        });
+
+        it('returns `true` if `setCapability` was called with truthy value', function () {
+          broker.setCapability('some-capability', { key: 'value' });
+          assert.isTrue(broker.hasCapability('some-capability'));
+
+          broker.setCapability('other-capability', true);
+          assert.isTrue(broker.hasCapability('other-capability'));
+
+          broker.unsetCapability('other-capability');
+          assert.isFalse(broker.hasCapability('other-capability'));
+        });
+
+        it('returns `true` for `signup` by default', function () {
+          assert.isTrue(broker.hasCapability('signup'));
+        });
+      });
+
+      describe('getCapability', function () {
+        it('returns `undefined` by default', function () {
+          assert.isUndefined(broker.getCapability('missing-capability'));
+        });
+
+        it('returns the capability value if available', function () {
+          var capabilityMetadata = { key: 'value' };
+          broker.setCapability('some-capability', capabilityMetadata);
+          assert.deepEqual(
+            broker.getCapability('some-capability'), capabilityMetadata);
+
+
+          broker.unsetCapability('some-capability');
+          assert.isUndefined(broker.getCapability('some-capability'));
+        });
       });
     });
 

--- a/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -34,25 +34,25 @@ function (chai, NullChannel, FxiOSAuthenticationBroker, Relier, WindowMock) {
       windowMock = new WindowMock();
     });
 
-    describe('isSignupDisabled', function () {
-      it('returns `true` if `exclude_signup=1` is specified, a reason is provided', function () {
+    describe('`signup` capability', function () {
+      it('returns `false` if `exclude_signup=1` is specified, a reason is provided', function () {
         windowMock.location.search = '?exclude_signup=1';
         createBroker();
 
         return broker.fetch()
           .then(function () {
-            assert.isTrue(broker.isSignupDisabled());
+            assert.isFalse(broker.hasCapability('signup'));
             assert.ok(broker.SIGNUP_DISABLED_REASON);
           });
       });
 
-      it('returns `false` otherwise', function () {
+      it('returns `true` otherwise', function () {
         windowMock.location.search = '';
         createBroker();
 
         return broker.fetch()
           .then(function () {
-            assert.isFalse(broker.isSignupDisabled());
+            assert.isTrue(broker.hasCapability('signup'));
           });
       });
     });

--- a/app/tests/spec/views/mixins/signup-enabled-mixin.js
+++ b/app/tests/spec/views/mixins/signup-enabled-mixin.js
@@ -30,8 +30,8 @@ define([
 
       beforeEach(function () {
         broker = {
-          isSignupDisabled: sinon.spy(function () {
-            return true;
+          hasCapability: sinon.spy(function () {
+            return false;
           })
         };
 
@@ -39,7 +39,7 @@ define([
       });
 
       it('calls this.broker.isSignupDisabled correctly', function () {
-        assert.equal(broker.isSignupDisabled.callCount, 1);
+        assert.equal(broker.hasCapability.callCount, 1);
 
         assert.isTrue(result);
       });

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -392,9 +392,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
       });
 
       it('show a link to to signup page if user enters unknown account and signup is enabled', function () {
-        sinon.stub(broker, 'isSignupDisabled', function () {
-          return false;
-        });
+        broker.setCapability('signup', true);
 
         sinon.stub(view.fxaClient, 'signIn', function () {
           return p.reject(AuthErrors.toError('UNKNOWN_ACCOUNT'));
@@ -407,9 +405,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
       });
 
       it('do not show a link to signup page if user enters unknown account and signup is disabled', function () {
-        sinon.stub(broker, 'isSignupDisabled', function () {
-          return true;
-        });
+        broker.setCapability('signup', false);
 
         sinon.stub(view.fxaClient, 'signIn', function () {
           return p.reject(AuthErrors.toError('UNKNOWN_ACCOUNT'));


### PR DESCRIPTION
Capabilities are a way to query whether the given environment supports
a feature. The goal is to query Firefox to see which FxA features it supports.
With this PR, the `signup` capability is hard coded, without querying Firefox.

issue #2771

@vladikoff - mind reviewing this to give feedback and see if this is in line with how you were imagining the capabilities API?