### PR TITLE
fix(client): Fix the confirm_reset_password screen polling logic & tests.

### DIFF
--- a/app/scripts/views/mixins/timer-mixin.js
+++ b/app/scripts/views/mixins/timer-mixin.js
@@ -21,7 +21,7 @@ function (_) {
       if (! this._timeouts) {
         this._timeouts = [];
         // clear all timeouts when the view is destroyed.
-        this.on('destroy', clearAllTimeouts);
+        this.on('destroy', clearAllTimeouts.bind(this));
       }
 
       var win = this.window || window;


### PR DESCRIPTION
There were several problems:

1. Because promises are async, setTimeout could be called after the module was
   torn down, which caused completion logic to be run after it was expected.
1. The timer-mixin called clearAllTimeouts without a context when used as
   a `destroy` handler, which meant outstanding timeouts were not cleared on
   view destroy.
1. The unit tests had a lot of cross test pollution. New dependencies are set
   up for each test now.
1. The logic did not take into account that the `login` message could arrive
   from the other tab before, during, or after the XHR request that checks
   whether the user has verified. There were no tests for all of these cases
   either.

fixes #2483