### PR TITLE
fix(client): Only one sessionStatus check call should be made from /settings

### DIFF
--- a/app/scripts/views/mixins/settings-mixin.js
+++ b/app/scripts/views/mixins/settings-mixin.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// helper functions for views with a profile image. Meant to be mixed into views.
+// View mixin the checks whether the uid specified by the relier is
+// is cached and valid.
 
 define([
   'lib/session'
@@ -19,9 +20,11 @@ define([
 
       // A uid param is set by RPs linking directly to the settings
       // page for a particular account.
+      //
       // We set the current account to the one with `uid` if
-      // it exists in our list of cached accounts. If it doesn't,
-      // clear the current account.
+      // it exists in our list of cached accounts. If the account is
+      // not in the list of cached accounts, clear the current account.
+      //
       // The `mustVerify` flag will ensure that the account is valid.
       if (! self.user.getAccountByUid(uid).isDefault()) {
         // The account with uid exists; set it to our current account.

--- a/app/scripts/views/settings/avatar.js
+++ b/app/scripts/views/settings/avatar.js
@@ -7,11 +7,9 @@ define([
   'views/form',
   'stache!templates/settings/avatar',
   'views/mixins/avatar-mixin',
-  'views/mixins/settings-mixin',
   'views/mixins/settings-panel-mixin'
 ],
-function (Cocktail, FormView, Template, AvatarMixin, SettingsMixin,
-    SettingsPanelMixin) {
+function (Cocktail, FormView, Template, AvatarMixin, SettingsPanelMixin) {
   'use strict';
 
   var View = FormView.extend({
@@ -31,7 +29,7 @@ function (Cocktail, FormView, Template, AvatarMixin, SettingsMixin,
 
   });
 
-  Cocktail.mixin(View, AvatarMixin, SettingsMixin, SettingsPanelMixin);
+  Cocktail.mixin(View, AvatarMixin, SettingsPanelMixin);
 
   return View;
 });

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -11,7 +11,6 @@ define([
   'views/progress_indicator',
   'views/mixins/avatar-mixin',
   'views/mixins/modal-settings-panel-mixin',
-  'views/mixins/settings-mixin',
   'stache!templates/settings/avatar_camera',
   'lib/constants',
   'lib/promise',
@@ -20,7 +19,7 @@ define([
   'models/profile-image'
 ],
 function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
-    AvatarMixin, ModalSettingsPanelMixin, SettingsMixin, Template, Constants, p,
+    AvatarMixin, ModalSettingsPanelMixin, Template, Constants, p,
     AuthErrors, Environment, ProfileImage) {
   'use strict';
 
@@ -236,8 +235,7 @@ function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
   Cocktail.mixin(
     View,
     AvatarMixin,
-    ModalSettingsPanelMixin,
-    SettingsMixin
+    ModalSettingsPanelMixin
   );
 
   return View;

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -7,7 +7,6 @@ define([
   'cocktail',
   'views/form',
   'views/mixins/avatar-mixin',
-  'views/mixins/settings-mixin',
   'views/mixins/modal-settings-panel-mixin',
   'stache!templates/settings/avatar_change',
   'lib/auth-errors',
@@ -15,7 +14,7 @@ define([
   'lib/promise',
   'models/cropper-image'
 ],
-function ($, Cocktail, FormView, AvatarMixin, SettingsMixin, ModalSettingsPanelMixin,
+function ($, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
   Template, AuthErrors, ImageLoader, p, CropperImage) {
   'use strict';
 
@@ -148,8 +147,7 @@ function ($, Cocktail, FormView, AvatarMixin, SettingsMixin, ModalSettingsPanelM
   Cocktail.mixin(
     View,
     AvatarMixin,
-    ModalSettingsPanelMixin,
-    SettingsMixin
+    ModalSettingsPanelMixin
   );
 
   return View;

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -8,7 +8,6 @@ define([
   'views/form',
   'views/mixins/avatar-mixin',
   'views/mixins/modal-settings-panel-mixin',
-  'views/mixins/settings-mixin',
   'stache!templates/settings/avatar_crop',
   'lib/constants',
   'lib/cropper',
@@ -16,7 +15,7 @@ define([
   'models/cropper-image',
   'models/profile-image'
 ],
-function (p, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin, SettingsMixin,
+function (p, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
     Template, Constants, Cropper, AuthErrors, CropperImage, ProfileImage) {
   'use strict';
 
@@ -140,8 +139,7 @@ function (p, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin, SettingsM
   Cocktail.mixin(
     View,
     AvatarMixin,
-    ModalSettingsPanelMixin,
-    SettingsMixin
+    ModalSettingsPanelMixin
   );
 
   return View;

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -10,7 +10,6 @@ define([
   'views/form',
   'views/mixins/avatar-mixin',
   'views/mixins/modal-settings-panel-mixin',
-  'views/mixins/settings-mixin',
   'stache!templates/settings/avatar_gravatar',
   'lib/auth-errors',
   'lib/constants',
@@ -18,7 +17,7 @@ define([
   'views/decorators/progress_indicator',
   'models/profile-image'
 ],
-function ($, _, md5, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin, SettingsMixin,
+function ($, _, md5, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
     Template, AuthErrors, Constants, ImageLoader, showProgressIndicator, ProfileImage) {
   'use strict';
 
@@ -98,8 +97,7 @@ function ($, _, md5, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin, S
   Cocktail.mixin(
     View,
     AvatarMixin,
-    ModalSettingsPanelMixin,
-    SettingsMixin
+    ModalSettingsPanelMixin
   );
 
   return View;

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -10,23 +10,19 @@ define([
   'stache!templates/settings/change_password',
   'views/mixins/password-mixin',
   'views/mixins/floating-placeholder-mixin',
-  'views/mixins/settings-mixin',
   'views/mixins/settings-panel-mixin',
   'views/mixins/service-mixin',
   'views/mixins/back-mixin',
   'views/mixins/account-locked-mixin'
 ],
 function (Cocktail, BaseView, FormView, AuthErrors, Template, PasswordMixin,
-  FloatingPlaceholderMixin, SettingsMixin, SettingsPanelMixin, ServiceMixin,
+  FloatingPlaceholderMixin, SettingsPanelMixin, ServiceMixin,
   BackMixin, AccountLockedMixin) {
   'use strict';
 
   var t = BaseView.t;
 
   var View = FormView.extend({
-    // user must be authenticated to change password
-    mustAuth: true,
-
     template: Template,
     className: 'change-password',
 
@@ -79,7 +75,6 @@ function (Cocktail, BaseView, FormView, AuthErrors, Template, PasswordMixin,
     View,
     PasswordMixin,
     FloatingPlaceholderMixin,
-    SettingsMixin,
     SettingsPanelMixin,
     ServiceMixin,
     BackMixin,

--- a/app/scripts/views/settings/communication_preferences.js
+++ b/app/scripts/views/settings/communication_preferences.js
@@ -10,13 +10,12 @@ define([
   'lib/metrics',
   'views/base',
   'views/form',
-  'views/mixins/settings-mixin',
   'views/mixins/settings-panel-mixin',
   'views/mixins/checkbox-mixin',
   'stache!templates/settings/communication_preferences'
 ],
 function (Cocktail, Xss, Constants, MarketingEmailErrors, Metrics, BaseView, FormView,
-  SettingsMixin, SettingsPanelMixin, CheckboxMixin, Template) {
+  SettingsPanelMixin, CheckboxMixin, Template) {
   'use strict';
 
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;
@@ -107,7 +106,6 @@ function (Cocktail, Xss, Constants, MarketingEmailErrors, Metrics, BaseView, For
   Cocktail.mixin(
     View,
     CheckboxMixin,
-    SettingsMixin,
     SettingsPanelMixin
   );
 

--- a/app/scripts/views/settings/delete_account.js
+++ b/app/scripts/views/settings/delete_account.js
@@ -10,13 +10,12 @@ define([
   'lib/session',
   'lib/auth-errors',
   'views/mixins/password-mixin',
-  'views/mixins/settings-mixin',
   'views/mixins/service-mixin',
   'views/mixins/settings-panel-mixin',
   'views/mixins/account-locked-mixin'
 ],
 function (Cocktail, BaseView, FormView, Template, Session, AuthErrors,
-      PasswordMixin, SettingsMixin, SettingsPanelMixin, ServiceMixin,
+      PasswordMixin, SettingsPanelMixin, ServiceMixin,
       AccountLockedMixin) {
   'use strict';
 
@@ -75,7 +74,6 @@ function (Cocktail, BaseView, FormView, Template, Session, AuthErrors,
   Cocktail.mixin(
     View,
     PasswordMixin,
-    SettingsMixin,
     SettingsPanelMixin,
     ServiceMixin,
     AccountLockedMixin

--- a/app/scripts/views/settings/display_name.js
+++ b/app/scripts/views/settings/display_name.js
@@ -7,12 +7,11 @@ define([
   'views/base',
   'views/form',
   'stache!templates/settings/display_name',
-  'views/mixins/settings-mixin',
   'views/mixins/settings-panel-mixin',
   'views/mixins/avatar-mixin'
 ],
 function (Cocktail, BaseView, FormView, Template,
-  SettingsMixin, SettingsPanelMixin, AvatarMixin) {
+  SettingsPanelMixin, AvatarMixin) {
   'use strict';
 
   var t = BaseView.t;
@@ -59,7 +58,6 @@ function (Cocktail, BaseView, FormView, Template,
   Cocktail.mixin(
     View,
     AvatarMixin,
-    SettingsMixin,
     SettingsPanelMixin
   );
 

--- a/app/scripts/views/settings/gravatar_permissions.js
+++ b/app/scripts/views/settings/gravatar_permissions.js
@@ -8,11 +8,10 @@ define([
   'stache!templates/settings/gravatar_permissions',
   'lib/promise',
   'views/mixins/modal-settings-panel-mixin',
-  'views/mixins/settings-mixin',
   'views/mixins/service-mixin'
 ],
 function (Cocktail, FormView, Template, p,
-  ModalSettingsPanelMixin, SettingsMixin, ServiceMixin) {
+  ModalSettingsPanelMixin, ServiceMixin) {
   'use strict';
 
   var View = FormView.extend({
@@ -57,7 +56,6 @@ function (Cocktail, FormView, Template, p,
   Cocktail.mixin(
     View,
     ModalSettingsPanelMixin,
-    SettingsMixin,
     ServiceMixin
   );
 

--- a/app/tests/spec/views/mixins/settings-mixin.js
+++ b/app/tests/spec/views/mixins/settings-mixin.js
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'cocktail',
+  'models/reliers/relier',
+  'models/user',
+  'sinon',
+  'stache!templates/test_template',
+  'views/base',
+  'views/mixins/settings-mixin'
+], function (chai, Cocktail, Relier, User, sinon, TestTemplate,
+  BaseView, SettingsMixin) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  var SettingsView = BaseView.extend({
+    template: TestTemplate
+  });
+
+  Cocktail.mixin(SettingsView, SettingsMixin);
+
+  describe('views/mixins/settings-mixin', function () {
+    var relier;
+    var sandbox;
+    var user;
+    var view;
+
+    function createView() {
+      view = new SettingsView({
+        relier: relier,
+        user: user
+      });
+    }
+
+    beforeEach(function () {
+      relier = new Relier();
+      user = new User();
+
+      sandbox = new sinon.sandbox.create();
+      sandbox.spy(user, 'setSignedInAccountByUid');
+      sandbox.spy(user, 'clearSignedInAccount');
+    });
+
+    afterEach(function () {
+      view.remove();
+      view.destroy();
+
+      sandbox.restore();
+    });
+
+    describe('mustVerify', function () {
+      it('all consumers of the SettingsMixin `mustVerify`', function () {
+        createView();
+
+        assert.isTrue(view.mustVerify);
+      });
+    });
+
+    describe('with no relier specified uid', function () {
+      it('does nothing', function () {
+        relier.unset('uid');
+        createView();
+
+        assert.isFalse(user.setSignedInAccountByUid.called);
+        assert.isFalse(user.clearSignedInAccount.called);
+      });
+    });
+
+    describe('with uncached relier specified uid', function () {
+      it('clears the signed in account', function () {
+        relier.set('uid', 'uid');
+
+        createView();
+
+        assert.isFalse(user.setSignedInAccountByUid.called);
+        assert.isTrue(user.clearSignedInAccount.called);
+      });
+    });
+
+    describe('with cached relier specified uid', function () {
+      it('sets the signed in account', function () {
+        relier.set('uid', 'uid');
+
+        return user.setAccount({ uid: 'uid' })
+          .then(function () {
+            createView();
+
+            assert.isTrue(user.setSignedInAccountByUid.calledWith('uid'));
+            assert.isFalse(user.clearSignedInAccount.called);
+          });
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/settings/avatar.js
+++ b/app/tests/spec/views/settings/avatar.js
@@ -50,17 +50,7 @@ function (chai, $, sinon, View, RouterMock, FxaClientMock,
       fxaClientMock = null;
     });
 
-    describe('with no session', function () {
-      it('redirects to signin', function () {
-        return view.render()
-          .then(function () {
-            assert.equal(routerMock.page, 'signin');
-          });
-      });
-    });
-
     describe('with session', function () {
-
       beforeEach(function () {
         view.isUserAuthorized = function () {
           return p(true);

--- a/app/tests/spec/views/settings/avatar_camera.js
+++ b/app/tests/spec/views/settings/avatar_camera.js
@@ -81,15 +81,6 @@ function (chai, $, sinon, View, RouterMock, WindowMock, CanvasMock,
       profileClientMock = null;
     });
 
-    describe('with no session', function () {
-      it('redirects to signin', function () {
-        return view.render()
-            .then(function () {
-              assert.equal(routerMock.page, 'signin');
-            });
-      });
-    });
-
     describe('with session', function () {
       beforeEach(function () {
         view.isUserAuthorized = function () {

--- a/app/tests/spec/views/settings/avatar_change.js
+++ b/app/tests/spec/views/settings/avatar_change.js
@@ -64,15 +64,6 @@ function (chai, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
       profileClientMock = null;
     });
 
-    describe('with no session', function () {
-      it('redirects to signin', function () {
-        return view.render()
-            .then(function () {
-              assert.equal(routerMock.page, 'signin');
-            });
-      });
-    });
-
     describe('with session', function () {
       var accessToken = 'token';
       beforeEach(function () {

--- a/app/tests/spec/views/settings/avatar_crop.js
+++ b/app/tests/spec/views/settings/avatar_crop.js
@@ -70,15 +70,6 @@ function (chai, $, ui, sinon, jQuerySimulate, View, RouterMock, ProfileMock, Use
       metrics = null;
     });
 
-    describe('with no session', function () {
-      it('redirects to signin', function () {
-        return view.render()
-            .then(function () {
-              assert.equal(routerMock.page, 'signin');
-            });
-      });
-    });
-
     describe('with session', function () {
       beforeEach(function () {
         view.isUserAuthorized = function () {

--- a/app/tests/spec/views/settings/avatar_gravatar.js
+++ b/app/tests/spec/views/settings/avatar_gravatar.js
@@ -70,15 +70,6 @@ function (chai, $, sinon, View, RouterMock, ProfileMock, TestHelpers, User,
       profileClientMock = null;
     });
 
-    describe('with no session', function () {
-      it('redirects to signin', function () {
-        return view.render()
-            .then(function () {
-              assert.equal(routerMock.page, 'signin');
-            });
-      });
-    });
-
     describe('with session', function () {
       beforeEach(function () {
         sinon.stub(view, 'getSignedInAccount', function () {

--- a/app/tests/spec/views/settings/change_password.js
+++ b/app/tests/spec/views/settings/change_password.js
@@ -70,15 +70,6 @@ function (chai, $, sinon, AuthErrors, FxaClient, Metrics, p,
       routerMock = null;
     });
 
-    describe('with no session', function () {
-      it('redirects to signin', function () {
-        return view.render()
-          .then(function () {
-            assert.equal(routerMock.page, 'signin');
-          });
-      });
-    });
-
     describe('with session', function () {
       beforeEach(function () {
         sinon.stub(view.fxaClient, 'isSignedIn', function () {

--- a/app/tests/spec/views/settings/delete_account.js
+++ b/app/tests/spec/views/settings/delete_account.js
@@ -74,15 +74,6 @@ function (chai, $, sinon, View, FxaClient, p, AuthErrors, Metrics, NullChannel,
       routerMock = null;
     });
 
-    describe('with no session', function () {
-      it('redirects to signin', function () {
-        return view.render()
-            .then(function () {
-              assert.equal(routerMock.page, 'signin');
-            });
-      });
-    });
-
     describe('with session', function () {
       beforeEach(function () {
         email = TestHelpers.createEmail();

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -110,6 +110,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/timer-mixin',
     '../tests/spec/views/mixins/resume-token-mixin',
     '../tests/spec/views/mixins/service-mixin',
+    '../tests/spec/views/mixins/settings-mixin',
     '../tests/spec/views/mixins/password-mixin',
     '../tests/spec/views/mixins/password-strength-mixin',
     '../tests/spec/views/mixins/avatar-mixin',


### PR DESCRIPTION
Remove the SettingsMixin from all the Settings pages except for the root
Settings view. This ensures only `/settings` calls isUserAuthorized.

Add tests for the settings-mixin

fixes #3007

@zaach - r?