### PR TITLE
fix(settings): unblock rendering of settings on communication prefs screen

### DIFF
--- a/app/scripts/templates/settings/communication_preferences.mustache
+++ b/app/scripts/templates/settings/communication_preferences.mustache
@@ -1,4 +1,4 @@
-<div id="communication-preferences" class="settings-unit">
+<div id="communication-preferences" class="settings-unit{{#isPanelOpen}} open{{/isPanelOpen}}">
   <div class="settings-unit-stub">
     <header class="settings-unit-summary">
       <h2 class="settings-unit-title">{{#t}}Communication preferences{{/t}}</h2>
@@ -12,7 +12,11 @@
     <div class="error visible nudge">
       {{error}}
     </div>
-    <button class="settings-button secondary cancel">{{#t}}Cancel{{/t}}</button>
+    <form novalidate>
+      <div class="button-row">
+        <button class="settings-button secondary cancel unpaired">{{#t}}Cancel{{/t}}</button>
+      </div>
+    </form>
   {{/error}}
   {{^error}}
     <div class="error"></div>

--- a/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/app/scripts/views/mixins/settings-panel-mixin.js
@@ -31,6 +31,10 @@ define([
       this.$('.settings-unit').addClass('open');
     },
 
+    isPanelOpen: function () {
+      return this.$('.settings-unit').hasClass('open');
+    },
+
     _closePanelReturnToSettings: function () {
       this.navigate('settings');
       this.closePanel();

--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -146,6 +146,10 @@ body.settings #main-content.panel, body.settings #main-content.card {
 
     &:last-child {
       float: right;
+
+      &.unpaired {
+        float: none;
+      }
     }
   }
 
@@ -206,6 +210,10 @@ body.settings #main-content.panel, body.settings #main-content.card {
     &.disabled {
       background: $button-background-disabled-color;
     }
+  }
+
+  &.unpaired {
+    width: 100%;
   }
 }
 

--- a/app/tests/spec/views/mixins/settings-panel-mixin.js
+++ b/app/tests/spec/views/mixins/settings-panel-mixin.js
@@ -71,8 +71,10 @@ define([
       it('open and close', function () {
         view.openPanel();
         assert.isTrue($('.settings-unit').hasClass('open'));
+        assert.isTrue(view.isPanelOpen());
         view.closePanel();
         assert.isFalse($('.settings-unit').hasClass('open'));
+        assert.isFalse(view.isPanelOpen());
       });
 
       it('displaySuccess', function () {

--- a/app/tests/spec/views/settings/communication_preferences.js
+++ b/app/tests/spec/views/settings/communication_preferences.js
@@ -37,6 +37,7 @@ function (chai, $, sinon, View, User, Account, MarketingEmailPrefs, Relier,
       return view.render()
         .then(function () {
           $('#container').html(view.el);
+          return view.afterVisible();
         });
     }
 


### PR DESCRIPTION
Fixes #3061. Using `afterVisible` from subviews does not block rendering of the settings page.

@shane-tomlinson r?