### PR TITLE
fix(client): Prevent the Firefox logo from being displayed on settings pages.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -84,6 +84,14 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
 
 
   var BaseView = Backbone.View.extend({
+    /**
+     * A class name that is added to the 'body' element pre-render
+     * and removed on destroy.
+     *
+     * @property layoutClassName
+     */
+    layoutClassName: null,
+
     constructor: function (options) {
       options = options || {};
 
@@ -122,6 +130,10 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
      */
     render: function () {
       var self = this;
+
+      if (this.layoutClassName) {
+        $('body').addClass(this.layoutClassName);
+      }
 
       return p()
         .then(function () {
@@ -347,7 +359,6 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
     },
 
     destroy: function (remove) {
-
       this.trigger('destroy');
 
       if (this.beforeDestroy) {
@@ -359,6 +370,10 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
       } else {
         this.stopListening();
         this.$el.off();
+      }
+
+      if (this.layoutClassName) {
+        $('body').removeClass(this.layoutClassName);
       }
 
       this.$(this.window).off('beforeunload', this._boundDisableErrors);

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -51,8 +51,7 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
   var View = BaseView.extend({
     template: Template,
     className: 'settings',
-
-    FADE_OUT_SETTINGS_MS: 250,
+    layoutClassName: 'settings',
 
     initialize: function (options) {
       options = options || {};
@@ -122,7 +121,6 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
 
     beforeRender: function () {
       var self = this;
-      $('body').addClass('settings');
       var account = self.getSignedInAccount();
 
       return account.fetchProfile()
@@ -148,12 +146,6 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
       }
 
       return self._showAvatar();
-    },
-
-    beforeDestroy: function () {
-      $('body.settings').fadeOut(this.FADE_OUT_SETTINGS_MS, function (){
-        $('body').removeClass('settings').show();
-      });
     },
 
     _setupAvatarChangeLinks: function () {

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -42,7 +42,8 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
     var screenName = 'screen';
 
     var View = BaseView.extend({
-      template: Template
+      template: Template,
+      layoutClassName: 'layout'
     });
 
 
@@ -89,9 +90,8 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
     });
 
     describe('render', function () {
-      it('renders the template without attaching it to the body', function () {
-        // render is called in beforeEach
-        assert.ok($('#focusMe').length);
+      it('adds the `layoutClassName` to the body', function () {
+        assert.isTrue($('body').hasClass('layout'));
       });
 
       it('updates the page title with the embedded h1 and h2 tags', function () {
@@ -313,6 +313,23 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
 
           view.afterVisible();
         }, done);
+      });
+    });
+
+    describe('destroy', function () {
+      it('destroys the view, any subviews, stops listening for messages, and triggers `destroy` and `destroyed` messages', function () {
+        sinon.spy(view, 'trigger');
+        sinon.spy(view, 'destroySubviews');
+        view.beforeDestroy = sinon.spy();
+
+        view.destroy();
+
+        assert.isTrue(view.beforeDestroy.called);
+        assert.isTrue(view.trigger.calledWith('destroy'));
+        assert.isTrue(view.trigger.calledWith('destroyed'));
+        assert.isTrue(view.destroySubviews.called);
+
+        assert.isFalse($('body').hasClass('layout'));
       });
     });
 

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -77,7 +77,6 @@ function (chai, $, sinon, Cocktail, View, BaseView, SubPanels,
         subPanels: subPanels,
         screenName: 'settings'
       });
-      view.FADE_OUT_SETTINGS_MS = 0;
     }
 
     beforeEach(function () {


### PR DESCRIPTION
Add an optional `layoutClassName` property to views.

If a view defines `layoutClassName`, the class name is added to the
`body` element as soon as rendering starts. The class name is
removed in destroy.

issue #3053 

@zaach - r?