### PR TITLE
refactor(client): Start email confirmation polling in afterVisible.

### DIFF
--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -85,7 +85,9 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
     afterRender: function () {
       var graphic = this.$el.find('.graphic');
       graphic.addClass('pulse');
+    },
 
+    afterVisible: function () {
       var self = this;
       return self.broker.persist()
         .then(function () {
@@ -96,7 +98,7 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
             return;
           }
 
-          self._waitForConfirmation()
+          return self._waitForConfirmation()
             .then(function () {
               self.logScreenEvent('verification.success');
               self.notify('verification.success');

--- a/app/scripts/views/confirm_account_unlock.js
+++ b/app/scripts/views/confirm_account_unlock.js
@@ -78,9 +78,6 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
     },
 
     afterVisible: function () {
-      var graphic = this.$el.find('.graphic');
-      graphic.addClass('pulse');
-
       var self = this;
       return self.broker.persist()
         .then(function () {

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -55,16 +55,14 @@ function (Cocktail, ConfirmView, BaseView, Template, p, Session, AuthErrors,
       }
     },
 
-    afterRender: function () {
-      var bounceGraphic = this.$el.find('.graphic');
-      bounceGraphic.addClass('pulse');
+    afterVisible: function () {
       var self = this;
 
       this.transformLinks();
 
       return self.broker.persist()
         .then(function () {
-          self._waitForConfirmation()
+          return self._waitForConfirmation()
             .then(function (sessionInfo) {
               self.logScreenEvent('verification.success');
               // The original window should finish the flow if the user

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -187,7 +187,7 @@ function (chai, sinon, p, AuthErrors, View, Metrics, EphemeralMessages,
       });
     });
 
-    describe('afterRender', function () {
+    describe('afterVisible', function () {
       beforeEach(function () {
         createDeps();
 
@@ -209,7 +209,7 @@ function (chai, sinon, p, AuthErrors, View, Metrics, EphemeralMessages,
           return p();
         });
 
-        return view.afterRender()
+        return view.afterVisible()
           .then(function () {
             assert.isTrue(broker.persist.called);
             assert.isTrue(
@@ -229,7 +229,7 @@ function (chai, sinon, p, AuthErrors, View, Metrics, EphemeralMessages,
         });
 
 
-        return view.afterRender()
+        return view.afterVisible()
           .then(function () {
             assert.isTrue(broker.persist.called);
             assert.isTrue(
@@ -239,24 +239,22 @@ function (chai, sinon, p, AuthErrors, View, Metrics, EphemeralMessages,
           });
       });
 
-      it('displays errors if `_waitForConfirmation` returns an error', function (done) {
+      it('displays errors if `_waitForConfirmation` returns an error', function () {
         sinon.stub(view, '_waitForConfirmation', function () {
           return p.reject(AuthErrors.toError('UNEXPECTED_ERROR'));
         });
 
-        sinon.stub(view, 'displayError', function (err) {
-          TestHelpers.wrapAssertion(function () {
+        sinon.spy(view, 'displayError');
+
+        return view.afterVisible()
+          .then(function () {
+            var err = view.displayError.args[0][0];
             assert.isTrue(AuthErrors.is(err, 'UNEXPECTED_ERROR'));
 
             assert.isTrue(broker.persist.called);
             assert.isFalse(TestHelpers.isEventLogged(
               metrics, 'confirm_reset_password.verification.success'));
-          }, done);
-        });
-
-        // the _waitForConfirmation promise is not returned by afterRender
-        // so `displayError` must be wrapped and the `done` callback used.
-        view.afterRender();
+          });
       });
     });
 


### PR DESCRIPTION
This makes testing much simplar because afterVisible can return the
`_waitForConfirmation` promises without blocking screen rendering.