### PR TITLE
fix(l10n): Do not show fuzzy strings to users.

### DIFF
--- a/grunttasks/po2json.js
+++ b/grunttasks/po2json.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
     },
     options: {
       format: 'raw',
-      fuzzy: true,
+      fuzzy: false,
       output_filename: function (file) { //eslint-disable-line camelcase
         /**
          * the files are stored in the locale subdirectory with a directory


### PR DESCRIPTION
Sometimes the context is completely off.

Ref https://github.com/mozilla/fxa-content-server-l10n/issues/73

fixes #3113