### PR TITLE
fix(config): copy 'local.json-dist' to 'local.json' if it don't exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.46.0",
   "description": "Firefox Accounts Content Server",
   "scripts": {
-    "start": "grunt server",
+    "start": "node scripts/check-local-config && grunt server",
     "start-production": "grunt build && CONFIG_FILES=server/config/local.json,server/config/production.json grunt serverproc:dist",
     "postinstall": "bower update --config.interactive=false -s",
     "test": "intern-runner config=tests/intern",

--- a/scripts/check-local-config.js
+++ b/scripts/check-local-config.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var fs = require('fs');
+var path = require('path');
+
+var RELATIVE_FILE = path.join('server', 'config', 'local.json');
+var CONFIG_FILE = path.resolve(__dirname, '..', RELATIVE_FILE);
+
+if (! fs.existsSync(CONFIG_FILE) && ! process.env.CONFIG_FILES) {
+  console.log('%s doesn\'t exist. Creating...', RELATIVE_FILE);
+  fs.createReadStream(CONFIG_FILE + '-dist').pipe(fs.createWriteStream(CONFIG_FILE));
+}


### PR DESCRIPTION
Create 'scripts/check-config.js' to check if 'local.json' don't exists.
This script will run on 'npm start' before 'grant server'.

Closes #2619