### PR TITLE
fix(signup): show red border only after tooltip rendered

### DIFF
--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -438,17 +438,17 @@ function (_, $, p, Validate, AuthErrors, BaseView, Tooltip,
         invalidEl.removeClass('invalid');
         self.trigger('validation_error_removed', el);
       }).render().then(function () {
+        try {
+          invalidEl.addClass('invalid').get(0).focus();
+        } catch (e) {
+          // IE can blow up if the element is not visible.
+        }
+
         // used for testing
         self.trigger('validation_error', el, message);
       });
 
       this.trackSubview(tooltip);
-
-      try {
-        invalidEl.addClass('invalid').get(0).focus();
-      } catch (e) {
-        // IE can blow up if the element is not visible.
-      }
 
       return message;
     },

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -352,9 +352,12 @@ function (chai, sinon, $, p, FormView, Template, Constants, Metrics, AuthErrors,
         view.showValidationError('#focusMe', err);
       });
 
-      it('adds invalid class to the invalid element', function () {
+      it('adds invalid class to the invalid element', function (done) {
         view.showValidationError('#focusMe', 'this is an error');
-        assert.isTrue(view.$('#focusMe').hasClass('invalid'));
+        setTimeout(function () {
+          assert.isTrue(view.$('#focusMe').hasClass('invalid'));
+          done();
+        }, 50);
       });
 
       it('invalid class is removed as soon as element is valid again', function (done) {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -302,7 +302,7 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
     });
 
     describe('afterVisible', function () {
-      it('shows a tooltip on the email element if ephemeralMessages.bouncedEmail is set', function () {
+      it('shows a tooltip on the email element if ephemeralMessages.bouncedEmail is set', function (done) {
         sinon.spy(view, 'showValidationError');
         ephemeralMessages.set('bouncedEmail', 'testuser@testuser.com');
 
@@ -312,6 +312,10 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
           })
           .then(function () {
             assert.isTrue(view.showValidationError.called);
+            setTimeout(function () {
+              assert.isTrue(view.$('input[type="email"]').hasClass('invalid'));
+              done();
+            }, 50);
           });
       });
 


### PR DESCRIPTION
Add addClass('invalid') to invalid field only after the tooltip rendered.

Closes #1865