### PR TITLE
feat(client): notify other tabs of successful sign in/out

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -77,7 +77,12 @@ define([], function () {
     ACCESS_TYPE_ONLINE: 'online',
     ACCESS_TYPE_OFFLINE: 'offline',
 
-    DEFAULT_XHR_TIMEOUT_MS: 2500
+    DEFAULT_XHR_TIMEOUT_MS: 2500,
+
+    EVENTS: {
+      SIGNIN_SUCCESS: 'signin.success',
+      SIGNOUT_SUCCESS: 'signout.success'
+    }
   };
   /*eslint-enable sorting/sort-object-props*/
 });

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -263,6 +263,10 @@ define([
        */
       emailVerificationMarketingSnippet: true,
       /**
+       * Should the view try to synchronise sign-in state across tabs?
+       */
+      interTabSignIn: true,
+      /**
        * Is signup supported? the fx_ios_v1 broker can disable it.
        */
       signup: true,

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -61,6 +61,12 @@ function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
       afterSignIn: new HaltBehavior()
     }),
 
+    defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
+      // Disable inter-tab sign-in for OAuth due to the potential for unintended
+      // consequences from redirecting to a relier URL more than once.
+      interTabSignIn: false
+    }),
+
     initialize: function (options) {
       options = options || {};
 

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -4,22 +4,25 @@
 
 define([
   'cocktail',
-  'views/form',
-  'views/base',
-  'stache!templates/confirm',
-  'lib/promise',
   'lib/auth-errors',
   'lib/constants',
+  'lib/promise',
+  'stache!templates/confirm',
+  'views/base',
+  'views/form',
   'views/mixins/experiment-mixin',
+  'views/mixins/inter-tab-channel-mixin',
   'views/mixins/resend-mixin',
   'views/mixins/resume-token-mixin',
   'views/mixins/service-mixin'
 ],
-function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
-  ExperimentMixin, ResendMixin, ResumeTokenMixin, ServiceMixin) {
+function (Cocktail, AuthErrors, Constants, p, Template, BaseView, FormView,
+  ExperimentMixin, InterTabChannelMixin, ResendMixin, ResumeTokenMixin,
+  ServiceMixin) {
   'use strict';
 
   var t = BaseView.t;
+  var EVENTS = Constants.EVENTS;
 
   var View = FormView.extend({
     template: Template,
@@ -112,6 +115,9 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
             .then(function () {
               // the user is definitely authenticated here.
               if (self.relier.isDirectAccess()) {
+                setTimeout(function () {
+                  self.interTabSend(EVENTS.SIGNIN_SUCCESS, self.getAccount());
+                }, 0);
                 self.navigate('settings', {
                   success: t('Account verified successfully')
                 });
@@ -188,6 +194,7 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
   Cocktail.mixin(
     View,
     ExperimentMixin,
+    InterTabChannelMixin,
     ResendMixin,
     ResumeTokenMixin,
     ServiceMixin

--- a/app/scripts/views/mixins/inter-tab-signin-mixin.js
+++ b/app/scripts/views/mixins/inter-tab-signin-mixin.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'cocktail',
+  'lib/constants',
+  'lib/promise',
+  'views/mixins/inter-tab-channel-mixin'
+],
+function (cocktail, constants, p, interTabChannelMixin) {
+  'use strict';
+
+  var EVENTS = constants.EVENTS;
+
+  return cocktail.mixin({
+    afterVisible: function () {
+      this.navigateToSignedInView = navigateToSignedInView.bind(this);
+      this.interTabOn(EVENTS.SIGNIN_SUCCESS, this.navigateToSignedInView);
+    },
+
+    onSignInSuccess: function (account) {
+      this.interTabOff(EVENTS.SIGNIN_SUCCESS, this.navigateToSignedInView);
+      this.interTabSend(EVENTS.SIGNIN_SUCCESS, account);
+    }
+  }, interTabChannelMixin);
+
+  function navigateToSignedInView (event) {
+    if (this.broker.hasCapability('interTabSignIn')) {
+      var self = this;
+      return this.user.setSignedInAccount(event.data)
+        .then(function () {
+          self.navigate(self._redirectTo || 'settings');
+        });
+    }
+
+    return p();
+  }
+});

--- a/app/scripts/views/mixins/inter-tab-signout-mixin.js
+++ b/app/scripts/views/mixins/inter-tab-signout-mixin.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'cocktail',
+  'lib/constants',
+  'lib/session',
+  'views/base',
+  'views/mixins/inter-tab-channel-mixin'
+],
+function (cocktail, constants, session, BaseView, interTabChannelMixin) {
+  'use strict';
+
+  var EVENTS = constants.EVENTS;
+  var t = BaseView.t;
+
+  return cocktail.mixin({
+    afterVisible: function () {
+      this.clearSessionAndNavigateToSignin = clearSessionAndNavigateToSignin.bind(this);
+      this.interTabOn(EVENTS.SIGNOUT_SUCCESS, this.clearSessionAndNavigateToSignin);
+    },
+
+    onSignOutSuccess: function () {
+      this.interTabOff(EVENTS.SIGNOUT_SUCCESS, this.clearSessionAndNavigateToSignin);
+      this.interTabSend(EVENTS.SIGNOUT_SUCCESS);
+      this.clearSessionAndNavigateToSignin();
+    }
+  }, interTabChannelMixin);
+
+  function clearSessionAndNavigateToSignin () {
+    this.logScreenEvent(EVENTS.SIGNOUT_SUCCESS);
+    this.user.removeAllAccounts();
+    this._formPrefill.clear();
+    session.clear();
+    this.navigate('signin', {
+      success: t('Signed out successfully')
+    });
+  }
+});

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -7,9 +7,9 @@ define([
   'jquery',
   'modal',
   'cocktail',
-  'lib/session',
   'views/base',
   'views/mixins/avatar-mixin',
+  'views/mixins/inter-tab-signout-mixin',
   'views/settings/avatar',
   'views/settings/avatar_change',
   'views/settings/avatar_crop',
@@ -26,14 +26,12 @@ define([
   'views/decorators/allow_only_one_submit',
   'stache!templates/settings'
 ],
-function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
+function ($, modal, Cocktail, BaseView, AvatarMixin, InterTabSignoutMixin,
   AvatarView, AvatarChangeView, AvatarCropView, AvatarCameraView, GravatarView,
   GravatarPermissionsView, CommunicationPreferencesView, ChangePasswordView,
   DeleteAccountView, DisplayNameView, SubPanels, SettingsMixin, LoadingMixin,
   allowOnlyOneSubmit, Template) {
   'use strict';
-
-  var t = BaseView.t;
 
   var PANEL_VIEWS = [
     AvatarView,
@@ -202,17 +200,7 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
           self.logScreenEvent('signout.error');
         })
         .fin(function () {
-          self.logScreenEvent('signout.success');
-          self.user.clearSignedInAccount();
-          // The user has manually signed out, a pretty strong indicator
-          // the user does not want any of their information pre-filled
-          // on the signin page. Clear any remaining formPrefill info
-          // to ensure their data isn't sticking around in memory.
-          self._formPrefill.clear();
-          Session.clear();
-          self.navigate('signin', {
-            success: t('Signed out successfully')
-          });
+          self.onSignOutSuccess();
         });
     }),
 
@@ -240,6 +228,7 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
   Cocktail.mixin(
     View,
     AvatarMixin,
+    InterTabSignoutMixin,
     LoadingMixin,
     SettingsMixin
   );

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -4,26 +4,27 @@
 
 define([
   'cocktail',
+  'lib/auth-errors',
   'lib/promise',
+  'lib/session',
+  'stache!templates/sign_in',
   'views/base',
   'views/form',
-  'stache!templates/sign_in',
-  'lib/session',
-  'lib/auth-errors',
+  'views/decorators/allow_only_one_submit',
+  'views/decorators/progress_indicator',
+  'views/mixins/avatar-mixin',
+  'views/mixins/account-locked-mixin',
+  'views/mixins/inter-tab-signin-mixin',
+  'views/mixins/migration-mixin',
   'views/mixins/password-mixin',
   'views/mixins/resume-token-mixin',
   'views/mixins/service-mixin',
-  'views/mixins/signup-disabled-mixin',
-  'views/mixins/avatar-mixin',
-  'views/mixins/account-locked-mixin',
-  'views/mixins/migration-mixin',
-  'views/decorators/allow_only_one_submit',
-  'views/decorators/progress_indicator'
+  'views/mixins/signup-disabled-mixin'
 ],
-function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
-  AuthErrors, PasswordMixin, ResumeTokenMixin, ServiceMixin,
-  SignupDisabledMixin, AvatarMixin, AccountLockedMixin, MigrationMixin,
-  allowOnlyOneSubmit, showProgressIndicator) {
+function (Cocktail, AuthErrors, p, Session, SignInTemplate, BaseView, FormView,
+  allowOnlyOneSubmit, showProgressIndicator, AvatarMixin, AccountLockedMixin,
+  InterTabSigninMixin, MigrationMixin, PasswordMixin, ResumeTokenMixin,
+  ServiceMixin, SignupDisabledMixin) {
 
   'use strict';
 
@@ -302,6 +303,7 @@ function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
     View,
     AccountLockedMixin,
     AvatarMixin,
+    InterTabSigninMixin,
     MigrationMixin,
     PasswordMixin,
     ResumeTokenMixin,

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -3,28 +3,29 @@
 
 define([
   'cocktail',
-  'lib/promise',
-  'views/base',
-  'views/form',
-  'stache!templates/sign_up',
   'lib/auth-errors',
   'lib/mailcheck',
+  'lib/promise',
+  'stache!templates/sign_up',
+  'views/base',
+  'views/form',
+  'views/coppa/coppa-date-picker',
+  'views/coppa/coppa-age-input',
+  'views/mixins/checkbox-mixin',
   'views/mixins/experiment-mixin',
+  'views/mixins/inter-tab-signin-mixin',
+  'views/mixins/migration-mixin',
   'views/mixins/password-mixin',
   'views/mixins/password-strength-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/checkbox-mixin',
   'views/mixins/resume-token-mixin',
-  'views/mixins/migration-mixin',
+  'views/mixins/service-mixin',
   'views/mixins/signup-disabled-mixin',
-  'views/mixins/signup-success-mixin',
-  'views/coppa/coppa-date-picker',
-  'views/coppa/coppa-age-input'
+  'views/mixins/signup-success-mixin'
 ],
-function (Cocktail, p, BaseView, FormView, Template, AuthErrors, mailcheck,
-  ExperimentMixin, PasswordMixin, PasswordStrengthMixin, ServiceMixin,
-  CheckboxMixin, ResumeTokenMixin, MigrationMixin, SignupDisabledMixin,
-  SignupSuccessMixin, CoppaDatePicker, CoppaAgeInput) {
+function (Cocktail, AuthErrors, mailcheck, p, Template, BaseView, FormView,
+  CoppaDatePicker, CoppaAgeInput, CheckboxMixin, ExperimentMixin,
+  InterTabSigninMixin, MigrationMixin, PasswordMixin, PasswordStrengthMixin,
+  ResumeTokenMixin, ServiceMixin, SignupDisabledMixin, SignupSuccessMixin) {
   'use strict';
 
   var t = BaseView.t;
@@ -326,6 +327,7 @@ function (Cocktail, p, BaseView, FormView, Template, AuthErrors, mailcheck,
 
           if (preVerifyToken && account.get('verified')) {
             self.logScreenEvent('preverified.success');
+            self.onSignInSuccess();
           }
           self.logScreenEvent('success');
           return self.invokeBrokerMethod('afterSignUp', account);
@@ -367,6 +369,7 @@ function (Cocktail, p, BaseView, FormView, Template, AuthErrors, mailcheck,
     View,
     CheckboxMixin,
     ExperimentMixin,
+    InterTabSigninMixin,
     MigrationMixin,
     PasswordMixin,
     PasswordStrengthMixin,

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -14,6 +14,7 @@ define([
   'views/ready',
   'views/settings',
   'lib/able',
+  'lib/channels/inter-tab',
   'lib/constants',
   'lib/environment',
   'lib/metrics',
@@ -27,8 +28,8 @@ define([
   '../../lib/helpers'
 ],
 function (chai, sinon, Backbone, Router, BaseView, DisplayNameView, SignInView, SignUpView,
-      ReadyView, SettingsView, Able, Constants, Environment, Metrics, EphemeralMessages, p,
-      Relier, User, FormPrefill, NullBroker, WindowMock, TestHelpers) {
+      ReadyView, SettingsView, Able, InterTabChannel, Constants, Environment, Metrics,
+      EphemeralMessages, p, Relier, User, FormPrefill, NullBroker, WindowMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -45,6 +46,7 @@ function (chai, sinon, Backbone, Router, BaseView, DisplayNameView, SignInView, 
     var formPrefill;
     var able;
     var environment;
+    var interTabChannel;
 
     beforeEach(function () {
       navigateUrl = navigateOptions = null;
@@ -67,11 +69,13 @@ function (chai, sinon, Backbone, Router, BaseView, DisplayNameView, SignInView, 
       able = new Able();
 
       environment = new Environment(windowMock);
+      interTabChannel = new InterTabChannel();
       router = new Router({
         able: able,
         broker: broker,
         environment: environment,
         formPrefill: formPrefill,
+        interTabChannel: interTabChannel,
         metrics: metrics,
         relier: relier,
         user: user,
@@ -270,6 +274,7 @@ function (chai, sinon, Backbone, Router, BaseView, DisplayNameView, SignInView, 
           // ensure there is no cross talk with other tests.
           ephemeralMessages: new EphemeralMessages(),
           formPrefill: formPrefill,
+          interTabChannel: interTabChannel,
           metrics: metrics,
           relier: relier,
           router: router,
@@ -361,6 +366,7 @@ function (chai, sinon, Backbone, Router, BaseView, DisplayNameView, SignInView, 
         signInView = new SignInView({
           broker: broker,
           formPrefill: formPrefill,
+          interTabChannel: interTabChannel,
           metrics: metrics,
           relier: relier,
           router: router,
@@ -372,6 +378,7 @@ function (chai, sinon, Backbone, Router, BaseView, DisplayNameView, SignInView, 
           able: able,
           broker: broker,
           formPrefill: formPrefill,
+          interTabChannel: interTabChannel,
           metrics: metrics,
           relier: relier,
           router: router,

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -197,6 +197,18 @@ function (chai, Relier, BaseAuthenticationBroker,
         it('returns `true` for `signup` by default', function () {
           assert.isTrue(broker.hasCapability('signup'));
         });
+
+        it('returns `true` for `interTabSignIn` by default', function () {
+          assert.isTrue(broker.hasCapability('interTabSignIn'));
+        });
+
+        it('returns `true` for `emailVerificationMarketingSnippet` by default', function () {
+          assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+        });
+
+        it('returns `false` for `syncPreferencesNotification` by default', function () {
+          assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+        });
       });
 
       describe('getCapability', function () {

--- a/app/tests/spec/models/auth_brokers/first-run.js
+++ b/app/tests/spec/models/auth_brokers/first-run.js
@@ -35,6 +35,22 @@ function (chai, sinon, NullChannel, Account, FirstRunAuthenticationBroker, Relie
       });
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `interTabSignIn` capability by default', function () {
+      assert.isTrue(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('afterLoaded', function () {
       it('notifies the iframe channel', function () {
         sinon.spy(iframeChannel, 'send');

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
@@ -43,6 +43,22 @@ define([
       });
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `interTabSignIn` capability by default', function () {
+      assert.isTrue(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('createChannel', function () {
       it('creates a channel', function () {
         assert.ok(broker.createChannel());

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -43,6 +43,22 @@ define([
       });
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `interTabSignIn` capability by default', function () {
+      assert.isTrue(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('createChannel', function () {
       it('creates a channel', function () {
         assert.ok(broker.createChannel());

--- a/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -46,6 +46,22 @@ function (chai, NullChannel, FxFennecV1AuthenticationBroker, Relier,
       sinon.spy(broker, 'send');
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `interTabSignIn` capability by default', function () {
+      assert.isTrue(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('does not have the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isFalse(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('has the `syncPreferencesNotification` capability by default', function () {
+      assert.isTrue(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('afterForceAuth', function () {
       it('notifies the channel of `login`, redirects to `/force_auth_complete`', function () {
         return broker.afterForceAuth(account)

--- a/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -15,13 +15,12 @@ function (chai, NullChannel, FxiOSAuthenticationBroker, Relier, WindowMock) {
   var assert = chai.assert;
 
   describe('models/auth_brokers/fx-ios-v1', function () {
-    var broker;
     var channel;
     var relier;
     var windowMock;
 
     function createBroker () {
-      broker = new FxiOSAuthenticationBroker({
+      return new FxiOSAuthenticationBroker({
         channel: channel,
         relier: relier,
         window: windowMock
@@ -34,29 +33,86 @@ function (chai, NullChannel, FxiOSAuthenticationBroker, Relier, WindowMock) {
       windowMock = new WindowMock();
     });
 
-    describe('`signup` capability', function () {
-      it('returns `false` if `exclude_signup=1` is specified, a reason is provided', function () {
-        windowMock.location.search = '?exclude_signup=1';
-        createBroker();
+    describe('`exclude_signup` parameter is set', function () {
+      var broker;
 
-        return broker.fetch()
-          .then(function () {
-            assert.isFalse(broker.hasCapability('signup'));
-            assert.ok(broker.SIGNUP_DISABLED_REASON);
-          });
+      beforeEach(function () {
+        windowMock.location.search = '?exclude_signup=1';
+        broker = createBroker();
       });
 
-      it('returns `true` otherwise', function () {
+      afterEach(function () {
         windowMock.location.search = '';
-        createBroker();
+      });
 
-        return broker.fetch()
-          .then(function () {
-            assert.isTrue(broker.hasCapability('signup'));
-          });
+      it('has the `signup` capability by default', function () {
+        assert.isTrue(broker.hasCapability('signup'));
+      });
+
+      it('has the `interTabSignIn` capability by default', function () {
+        assert.isTrue(broker.hasCapability('interTabSignIn'));
+      });
+
+      it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+        assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+      });
+
+      it('does not have the `syncPreferencesNotification` capability by default', function () {
+        assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+      });
+
+      describe('`broker.fetch` is called', function () {
+        beforeEach(function () {
+          return broker.fetch();
+        });
+
+        it('does not have the `signup` capability', function () {
+          assert.isFalse(broker.hasCapability('signup'));
+        });
+
+        it('`broker.SIGNUP_DISABLED_REASON` is set', function () {
+          assert.instanceOf(broker.SIGNUP_DISABLED_REASON, Error);
+        });
       });
     });
 
+    describe('`exclude_signup` parameter is not set', function () {
+      var broker;
+
+      beforeEach(function () {
+        broker = createBroker();
+      });
+
+      it('has the `signup` capability by default', function () {
+        assert.isTrue(broker.hasCapability('signup'));
+      });
+
+      it('has the `interTabSignIn` capability by default', function () {
+        assert.isTrue(broker.hasCapability('interTabSignIn'));
+      });
+
+      it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+        assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+      });
+
+      it('does not have the `syncPreferencesNotification` capability by default', function () {
+        assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+      });
+
+      describe('`broker.fetch` is called', function () {
+        beforeEach(function () {
+          return broker.fetch();
+        });
+
+        it('has the `signup` capability', function () {
+          assert.isTrue(broker.hasCapability('signup'));
+        });
+
+        it('`broker.SIGNUP_DISABLED_REASON` is not set', function () {
+          assert.isUndefined(broker.SIGNUP_DISABLED_REASON);
+        });
+      });
+    });
   });
 });
 

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -58,6 +58,22 @@ define([
       createAuthBroker();
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `interTabSignIn` capability by default', function () {
+      assert.isTrue(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('afterLoaded', function () {
       it('sends a `loaded` message', function () {
         return broker.afterLoaded()

--- a/app/tests/spec/models/auth_brokers/iframe.js
+++ b/app/tests/spec/models/auth_brokers/iframe.js
@@ -46,6 +46,22 @@ function (chai, sinon, $, IframeAuthenticationBroker, Relier, p, NullChannel,
       }
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `interTabSignIn` capability by default', function () {
+      assert.isFalse(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('sendOAuthResultToRelier', function () {
       it('sends an `oauth_complete` message', function () {
         sinon.stub(broker, 'send', function () {

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -83,6 +83,22 @@ function (chai, sinon, Session, p, Constants, OAuthClient, Assertion, AuthErrors
       sinon.spy(broker, 'finishOAuthFlow');
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `interTabSignIn` capability by default', function () {
+      assert.isFalse(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('sendOAuthResultToRelier', function () {
       it('must be overridden', function () {
         return broker.sendOAuthResultToRelier()

--- a/app/tests/spec/models/auth_brokers/redirect.js
+++ b/app/tests/spec/models/auth_brokers/redirect.js
@@ -50,6 +50,22 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
       });
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `interTabSignIn` capability by default', function () {
+      assert.isFalse(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('sendOAuthResultToRelier', function () {
       describe('with no error', function () {
         it('prepares window to be closed', function () {

--- a/app/tests/spec/models/auth_brokers/web-channel.js
+++ b/app/tests/spec/models/auth_brokers/web-channel.js
@@ -91,6 +91,21 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
       };
     }
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `interTabSignIn` capability by default', function () {
+      assert.isFalse(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
 
     describe('fetch', function () {
       describe('for the signin/signup flow', function () {

--- a/app/tests/spec/views/mixins/inter-tab-signin-mixin.js
+++ b/app/tests/spec/views/mixins/inter-tab-signin-mixin.js
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'cocktail',
+  'sinon',
+  'lib/promise',
+  'views/base',
+  'views/mixins/inter-tab-signin-mixin'
+], function (chai, cocktail, sinon, p, BaseView, interTabSigninMixin) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  var View = BaseView.extend({});
+  cocktail.mixin(View, interTabSigninMixin);
+
+  describe('views/mixins/inter-tab-signin-mixin', function () {
+    var view;
+
+    beforeEach(function () {
+      view = new View();
+    });
+
+    afterEach(function () {
+      view.destroy();
+    });
+
+    it('exports correct interface', function () {
+      var methods = [
+        'afterVisible',
+        'initialize',
+        'interTabOn',
+        'interTabOff',
+        'interTabOffAll',
+        'interTabSend',
+        'interTabClear',
+        'onSignInSuccess'
+      ];
+      assert.lengthOf(Object.keys(interTabSigninMixin), methods.length);
+      methods.forEach(function (methodName) {
+        assert.isFunction(interTabSigninMixin[methodName]);
+        assert.isFunction(view[methodName]);
+      });
+      assert.isUndefined(view.navigateToSignedInView);
+    });
+
+    describe('afterVisible', function () {
+      beforeEach(function () {
+        view.interTabOn = sinon.spy();
+        view.afterVisible();
+      });
+
+      it('defines the navigateToSignedInView method', function () {
+        assert.isFunction(view.navigateToSignedInView);
+        assert.lengthOf(view.navigateToSignedInView, 1);
+      });
+
+      it('calls interTabOn correctly', function () {
+        assert.equal(view.interTabOn.callCount, 1);
+        assert.isTrue(view.interTabOn.alwaysCalledOn(view));
+        var args = view.interTabOn.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], 'signin.success');
+        assert.equal(args[1], view.navigateToSignedInView);
+      });
+
+      describe('navigateToSignedInView', function () {
+        beforeEach(function () {
+          view.broker = {
+            hasCapability: sinon.spy(function () {
+              return true;
+            })
+          };
+          view.user = {
+            setSignedInAccount: sinon.spy(function () {
+              return p();
+            })
+          };
+          view.navigate = sinon.spy();
+          return view.navigateToSignedInView({
+            data: 'foo'
+          });
+        });
+
+        it('calls broker.hasCapability correctly', function () {
+          assert.equal(view.broker.hasCapability.callCount, 1);
+          assert.isTrue(view.broker.hasCapability.alwaysCalledOn(view.broker));
+          var args = view.broker.hasCapability.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'interTabSignIn');
+        });
+
+        it('calls user.setSignedInAccount correctly', function () {
+          assert.equal(view.user.setSignedInAccount.callCount, 1);
+          assert.isTrue(view.user.setSignedInAccount.alwaysCalledOn(view.user));
+          var args = view.user.setSignedInAccount.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'foo');
+        });
+
+        it('calls navigate correctly', function () {
+          assert.equal(view.navigate.callCount, 1);
+          assert.isTrue(view.navigate.alwaysCalledOn(view));
+          assert.isTrue(view.navigate.calledAfter(view.user.setSignedInAccount));
+          var args = view.navigate.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'settings');
+        });
+      });
+
+      describe('navigateToSignedInView without interTabSignIn capability', function () {
+        beforeEach(function () {
+          view.broker = {
+            hasCapability: sinon.spy(function () {
+              return false;
+            })
+          };
+          view.user = {
+            setSignedInAccount: sinon.spy(function () {
+              return p();
+            })
+          };
+          view.navigate = sinon.spy();
+          view.navigateToSignedInView({
+            data: 'foo'
+          });
+        });
+
+        it('calls broker.hasCapability', function () {
+          assert.equal(view.broker.hasCapability.callCount, 1);
+        });
+
+        it('does not call user.setSignedInAccount', function () {
+          assert.equal(view.user.setSignedInAccount.callCount, 0);
+        });
+
+        it('does not call navigate', function () {
+          assert.equal(view.navigate.callCount, 0);
+        });
+      });
+
+      describe('navigateToSignedInView with OAuth redirect URL', function () {
+        beforeEach(function () {
+          view.broker = {
+            hasCapability: sinon.spy(function () {
+              return true;
+            })
+          };
+          view.user = {
+            setSignedInAccount: sinon.spy(function () {
+              return p();
+            })
+          };
+          view.navigate = sinon.spy();
+          view._redirectTo = 'foo';
+          return view.navigateToSignedInView({
+            data: 'bar'
+          });
+        });
+
+        it('calls broker.hasCapability', function () {
+          assert.equal(view.broker.hasCapability.callCount, 1);
+        });
+
+        it('calls user.setSignedInAccount correctly', function () {
+          assert.equal(view.user.setSignedInAccount.callCount, 1);
+          assert.equal(view.user.setSignedInAccount.args[0][0], 'bar');
+        });
+
+        it('calls navigate correctly', function () {
+          assert.equal(view.navigate.callCount, 1);
+          assert.equal(view.navigate.args[0][0], 'foo');
+        });
+      });
+
+      describe('onSignInSuccess', function () {
+        beforeEach(function () {
+          view.interTabOff = sinon.spy();
+          view.interTabSend = sinon.spy();
+          view.navigateToSignedInView = sinon.spy();
+          view.onSignInSuccess('foo');
+        });
+
+        it('calls interTabOff correctly', function () {
+          assert.equal(view.interTabOff.callCount, 1);
+          assert.isTrue(view.interTabOff.alwaysCalledOn(view));
+          var args = view.interTabOff.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'signin.success');
+          assert.equal(args[1], view.navigateToSignedInView);
+        });
+
+        it('calls interTabSend correctly', function () {
+          assert.equal(view.interTabSend.callCount, 1);
+          assert.isTrue(view.interTabSend.alwaysCalledOn(view));
+          assert.isTrue(view.interTabSend.calledAfter(view.interTabOff));
+          var args = view.interTabSend.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'signin.success');
+          assert.equal(args[1], 'foo');
+        });
+
+        it('does not call navigateToSignedInView', function () {
+          assert.equal(view.navigateToSignedInView.callCount, 0);
+        });
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/mixins/inter-tab-signout-mixin.js
+++ b/app/tests/spec/views/mixins/inter-tab-signout-mixin.js
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'cocktail',
+  'sinon',
+  'views/base',
+  'views/mixins/inter-tab-signout-mixin'
+], function (chai, cocktail, sinon, BaseView, interTabSignoutMixin) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  var View = BaseView.extend({});
+  cocktail.mixin(View, interTabSignoutMixin);
+
+  describe('views/mixins/inter-tab-signout-mixin', function () {
+    var view;
+
+    beforeEach(function () {
+      view = new View();
+    });
+
+    afterEach(function () {
+      view.destroy();
+    });
+
+    it('exports correct interface', function () {
+      var methods = [
+        'afterVisible',
+        'initialize',
+        'interTabOn',
+        'interTabOff',
+        'interTabOffAll',
+        'interTabSend',
+        'interTabClear',
+        'onSignOutSuccess'
+      ];
+      assert.lengthOf(Object.keys(interTabSignoutMixin), methods.length);
+      methods.forEach(function (methodName) {
+        assert.isFunction(interTabSignoutMixin[methodName]);
+        assert.isFunction(view[methodName]);
+      });
+      assert.isUndefined(view.clearSessionAndNavigateToSignin);
+    });
+
+    describe('afterVisible', function () {
+      beforeEach(function () {
+        view.interTabOn = sinon.spy();
+        view.afterVisible();
+      });
+
+      it('defines the clearSessionAndNavigateToSignin method', function () {
+        assert.isFunction(view.clearSessionAndNavigateToSignin);
+        assert.lengthOf(view.clearSessionAndNavigateToSignin, 0);
+      });
+
+      it('calls interTabOn correctly', function () {
+        assert.equal(view.interTabOn.callCount, 1);
+        assert.isTrue(view.interTabOn.alwaysCalledOn(view));
+        var args = view.interTabOn.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], 'signout.success');
+        assert.equal(args[1], view.clearSessionAndNavigateToSignin);
+      });
+
+      describe('clearSessionAndNavigateToSignin', function () {
+        beforeEach(function () {
+          view.logScreenEvent = sinon.spy();
+          view.user = {
+            removeAllAccounts: sinon.spy()
+          };
+          view._formPrefill = {
+            clear: sinon.spy()
+          };
+          view.navigate = sinon.spy();
+          view.clearSessionAndNavigateToSignin();
+        });
+
+        it('calls logScreenEvent correctly', function () {
+          assert.equal(view.logScreenEvent.callCount, 1);
+          assert.isTrue(view.logScreenEvent.alwaysCalledOn(view));
+          var args = view.logScreenEvent.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'signout.success');
+        });
+
+        it('calls user.removeAllAccounts correctly', function () {
+          assert.equal(view.user.removeAllAccounts.callCount, 1);
+          assert.isTrue(view.user.removeAllAccounts.alwaysCalledOn(view.user));
+          assert.lengthOf(view.user.removeAllAccounts.args[0], 0);
+        });
+
+        it('calls _formPrefill.clear correctly', function () {
+          assert.equal(view._formPrefill.clear.callCount, 1);
+          assert.isTrue(view._formPrefill.clear.alwaysCalledOn(view._formPrefill));
+          assert.lengthOf(view._formPrefill.clear.args[0], 0);
+        });
+
+        it('calls navigate correctly', function () {
+          assert.equal(view.navigate.callCount, 1);
+          assert.isTrue(view.navigate.alwaysCalledOn(view));
+          assert.isTrue(view.navigate.calledAfter(view.user.removeAllAccounts));
+          assert.isTrue(view.navigate.calledAfter(view._formPrefill.clear));
+          var args = view.navigate.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'signin');
+          assert.isObject(args[1]);
+          assert.lengthOf(Object.keys(args[1]), 1);
+          assert.equal(args[1].success, 'Signed out successfully');
+        });
+      });
+
+      describe('onSignOutSuccess', function () {
+        beforeEach(function () {
+          view.interTabOff = sinon.spy();
+          view.interTabSend = sinon.spy();
+          view.clearSessionAndNavigateToSignin = sinon.spy();
+          view.onSignOutSuccess();
+        });
+
+        it('calls interTabOff correctly', function () {
+          assert.equal(view.interTabOff.callCount, 1);
+          assert.isTrue(view.interTabOff.alwaysCalledOn(view));
+          var args = view.interTabOff.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'signout.success');
+          assert.equal(args[1], view.clearSessionAndNavigateToSignin);
+        });
+
+        it('calls interTabSend correctly', function () {
+          assert.equal(view.interTabSend.callCount, 1);
+          assert.isTrue(view.interTabSend.alwaysCalledOn(view));
+          assert.isTrue(view.interTabSend.calledAfter(view.interTabOff));
+          var args = view.interTabSend.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'signout.success');
+        });
+
+        it('calls clearSessionAndNavigateToSignin correctly', function () {
+          assert.equal(view.clearSessionAndNavigateToSignin.callCount, 1);
+          assert.isTrue(view.clearSessionAndNavigateToSignin.alwaysCalledOn(view));
+          assert.lengthOf(view.clearSessionAndNavigateToSignin.args[0], 0);
+        });
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -14,6 +14,7 @@ define([
   'lib/oauth-client',
   'lib/assertion',
   'lib/able',
+  'lib/channels/inter-tab',
   'models/reliers/oauth',
   'models/auth_brokers/oauth',
   'models/user',
@@ -24,8 +25,8 @@ define([
   '../../lib/helpers'
 ],
 function (chai, $, sinon, View, p, Session, FxaClient, Metrics, OAuthClient,
-      Assertion, Able, OAuthRelier, OAuthBroker, User, FormPrefill, Notifications, WindowMock,
-      RouterMock, TestHelpers) {
+      Assertion, Able, InterTabChannel, OAuthRelier, OAuthBroker, User,
+      FormPrefill, Notifications, WindowMock, RouterMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -69,6 +70,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, OAuthClient,
     var formPrefill;
     var able;
     var notifications;
+    var interTabChannel;
 
     beforeEach(function () {
       Session.clear();
@@ -112,6 +114,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, OAuthClient,
       formPrefill = new FormPrefill();
       able = new Able();
       notifications = new Notifications();
+      interTabChannel = new InterTabChannel();
 
       view = new View({
         able: able,
@@ -119,6 +122,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, OAuthClient,
         broker: broker,
         formPrefill: formPrefill,
         fxaClient: fxaClient,
+        interTabChannel: interTabChannel,
         metrics: metrics,
         notifications: notifications,
         oAuthClient: oAuthClient,

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -22,6 +22,7 @@ define([
   'lib/auth-errors',
   'lib/able',
   'lib/metrics',
+  'lib/channels/inter-tab',
   'models/form-prefill',
   'models/notifications',
   'models/reliers/relier',
@@ -32,7 +33,8 @@ define([
 function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
   CommunicationPreferencesView, SettingsPanelMixin, RouterMock, TestHelpers,
   FxaClient, p, ProfileClient, ProfileErrors, AuthErrors, Able, Metrics,
-  FormPrefill, Notifications, Relier, ProfileImage, User, TestTemplate) {
+  InterTabChannel, FormPrefill, Notifications, Relier, ProfileImage, User,
+  TestTemplate) {
   'use strict';
 
   var assert = chai.assert;
@@ -59,6 +61,7 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
     var panelViews;
     var initialSubView;
     var subPanels;
+    var interTabChannel;
 
     var ACCESS_TOKEN = 'access token';
     var UID = 'uid';
@@ -68,6 +71,7 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
         able: able,
         formPrefill: formPrefill,
         fxaClient: fxaClient,
+        interTabChannel: interTabChannel,
         metrics: metrics,
         notifications: notifications,
         panelViews: panelViews,
@@ -94,6 +98,7 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
       notifications = new Notifications();
 
       formPrefill = new FormPrefill();
+      interTabChannel = new InterTabChannel();
 
       account = user.initAccount({
         email: 'a@a.com',
@@ -226,41 +231,54 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
         $.modal.close.restore();
       });
 
-      it('afterVisible', function () {
-        sinon.stub(subPanels, 'setElement', function () {});
-        return view.render()
-          .then(function () {
-            $('#container').append(view.el);
-            return view.afterVisible();
-          })
-          .then(function () {
-            assert.isTrue(subPanels.setElement.called);
-            assert.isTrue(subPanels.render.called);
-          });
-      });
+      describe('afterVisible', function () {
+        beforeEach(function () {
+          sinon.stub(subPanels, 'setElement', function () {});
+          sinon.spy(view, 'interTabOn');
+          return view.render()
+            .then(function () {
+              $('#container').append(view.el);
+              return view.afterVisible();
+            });
+        });
 
-      it('on profile change', function () {
-        return view.render()
-          .then(function () {
-            $('#container').append(view.el);
-            return view.afterVisible();
-          })
-          .then(function () {
+        afterEach(function () {
+          subPanels.setElement.restore();
+          view.interTabOn.restore();
+        });
+
+        it('calls subPanel methods correctly', function () {
+          assert.isTrue(subPanels.setElement.called);
+          assert.isTrue(subPanels.render.called);
+        });
+
+        it('shows avatar change link', function () {
+          assert.ok(view.$('.avatar-wrapper a').length);
+        });
+
+        it('calls this.interTabOn correctly', function () {
+          assert.isTrue(view.interTabOn.calledOnce);
+          var args = view.interTabOn.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'signout.success');
+          assert.equal(args[1], view.clearSessionAndNavigateToSignin);
+        });
+
+        describe('on profile change', function () {
+          beforeEach(function () {
             sinon.spy(view, 'displayAccountProfileImage');
             view.onProfileUpdate();
-            assert.isTrue(view.displayAccountProfileImage.calledWith(account));
           });
-      });
 
-      it('shows avatar change link', function () {
-        return view.render()
-          .then(function () {
-            $('#container').append(view.el);
-            return view.afterVisible();
-          })
-          .then(function () {
-            assert.ok(view.$('.avatar-wrapper a').length);
+          afterEach(function () {
+            view.displayAccountProfileImage.restore();
           });
+
+          it('calls displayAccountProfileImage correctly', function () {
+            assert.isTrue(view.displayAccountProfileImage.calledOnce);
+            assert.isTrue(view.displayAccountProfileImage.calledWithExactly(account));
+          });
+        });
       });
 
       describe('with a profile image set', function () {
@@ -351,18 +369,24 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
       });
 
       describe('signOut', function () {
+        beforeEach(function () {
+          sinon.spy(user, 'removeAllAccounts');
+          view.afterVisible();
+        });
+
         it('on success, signs the user out, clears formPrefill info, redirects to the signin page', function () {
           sinon.stub(fxaClient, 'signOut', function () {
             return p();
           });
-          sinon.spy(user, 'clearSignedInAccount');
+          var signoutHandler = sinon.spy();
+          interTabChannel.on('signout.success', signoutHandler);
 
           formPrefill.set('email', 'testuser@testuser.com');
           formPrefill.set('password', 'password');
 
           return view.signOut()
             .then(function () {
-              assert.isTrue(user.clearSignedInAccount.called);
+              assert.isTrue(user.removeAllAccounts.calledOnce);
               assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.signout.submit'));
               assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.signout.success'));
               assert.isFalse(TestHelpers.isEventLogged(metrics, 'settings.signout.error'));
@@ -371,6 +395,8 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
               assert.isFalse(formPrefill.has('password'));
 
               assert.equal(routerMock.page, 'signin');
+
+              assert.isTrue(signoutHandler.calledOnce);
             });
         });
 
@@ -378,11 +404,10 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
           sinon.stub(fxaClient, 'signOut', function () {
             return p.reject(AuthErrors.toError('UNEXPECTED_ERROR'));
           });
-          sinon.spy(user, 'clearSignedInAccount');
 
           return view.signOut()
             .then(function () {
-              assert.isTrue(user.clearSignedInAccount.called);
+              assert.isTrue(user.removeAllAccounts.calledOnce);
               assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.signout.submit'));
               // track the error, but success is still finally called
               assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.signout.error'));

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -16,6 +16,7 @@ define([
   'lib/fxa-client',
   'lib/ephemeral-messages',
   'lib/able',
+  'lib/channels/inter-tab',
   'models/reliers/sync',
   'models/auth_brokers/base',
   'models/user',
@@ -26,7 +27,7 @@ define([
   '../../lib/helpers'
 ],
 function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, ExperimentInterface, Metrics,
-      FxaClient, EphemeralMessages, Able, Relier, Broker, User, FormPrefill,
+      FxaClient, EphemeralMessages, Able, InterTabChannel, Relier, Broker, User, FormPrefill,
       Notifications, RouterMock, WindowMock, TestHelpers) {
   'use strict';
 
@@ -46,6 +47,7 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
     var coppa;
     var able;
     var notifications;
+    var interTabChannel;
 
     function fillOutSignUp(email, password, isCoppaValid) {
       view.$('[type=email]').val(email);
@@ -68,6 +70,7 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
         ephemeralMessages: ephemeralMessages,
         formPrefill: formPrefill,
         fxaClient: fxaClient,
+        interTabChannel: interTabChannel,
         metrics: metrics,
         notifications: notifications,
         relier: relier,
@@ -101,6 +104,7 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
       coppa = new CoppaDatePicker();
       able = new Able();
       notifications = new Notifications();
+      interTabChannel = new InterTabChannel();
 
       createView();
 
@@ -618,10 +622,14 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
           return true;
         });
 
+        sinon.stub(view, 'onSignInSuccess', function () {});
+
         return view.submit()
             .then(function () {
               assert.isTrue(user.signUpAccount.called);
               assert.isTrue(broker.afterSignIn.called);
+              assert.equal(view.onSignInSuccess.callCount, 1);
+              assert.lengthOf(view.onSignInSuccess.args[0], 0);
             });
       });
 

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -123,6 +123,8 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/account-locked-mixin',
     '../tests/spec/views/mixins/checkbox-mixin',
     '../tests/spec/views/mixins/inter-tab-channel-mixin',
+    '../tests/spec/views/mixins/inter-tab-signin-mixin',
+    '../tests/spec/views/mixins/inter-tab-signout-mixin',
     '../tests/spec/views/mixins/loading-mixin',
     '../tests/spec/views/mixins/migration-mixin',
     '../tests/spec/views/mixins/modal-settings-panel-mixin',

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -22,6 +22,7 @@ define([
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
   var SIGNUP_URL = config.fxaContentRoot + 'signup';
   var RESET_PASSWORD_URL = config.fxaContentRoot + 'reset_password';
+  var SETTINGS_URL = config.fxaContentRoot + 'settings';
 
   var EXTERNAL_SITE_URL = 'http://example.com';
   var EXTERNAL_SITE_LINK_TEXT = 'More information';
@@ -247,39 +248,40 @@ define([
 
     return getVerificationLink(user, index)
       .then(function (verificationLink) {
-        return context.remote
-          .execute(function (verificationLink, windowName) {
-            var newWindow = window.open(verificationLink, windowName);
-
-            // Hook up the new window to listen for WebChannel messages.
-            // XXX TODO: this is pretty gross to do universally like this...
-            // XXX TODO: it will go away if we can make the original tab
-            //           reliably be the one to complete the oauth flow.
-            newWindow.addEventListener('WebChannelMessageToChrome', function (e) {
-              var command = e.detail.message.command;
-              var data = e.detail.message.data;
-              var element = newWindow.document.createElement('div');
-              element.setAttribute('id', 'message-' + command.replace(/:/g, '-'));
-              element.innerText = JSON.stringify(data);
-              newWindow.document.body.appendChild(element);
-            });
-
-            // from http://dev.w3.org/html5/webstorage/
-            // When a new top-level browsing context is created by a script in
-            // an existing browsing context, then the session storage area of
-            // the origin of that Document must be copied into the new
-            // browsing context when it is created. From that point on,
-            // however, the two session storage areas must be considered
-            // separate, not affecting each other in any way.
-            //
-            // We want to pretend this is a new tab that the user opened using
-            // CTRL-T, which does NOT copy sessionStorage over. Wipe
-            // sessionStorage in this new context;
-            newWindow.sessionStorage.clear();
-
-            return true;
-          }, [ verificationLink, windowName ]);
+        return context.remote.execute(openWindow, [ verificationLink, windowName ]);
       });
+  }
+
+  function openWindow (url, name) {
+    var newWindow = window.open(url, name);
+
+    // Hook up the new window to listen for WebChannel messages.
+    // XXX TODO: this is pretty gross to do universally like this...
+    // XXX TODO: it will go away if we can make the original tab
+    //           reliably be the one to complete the oauth flow.
+    newWindow.addEventListener('WebChannelMessageToChrome', function (e) {
+      var command = e.detail.message.command;
+      var data = e.detail.message.data;
+      var element = newWindow.document.createElement('div');
+      element.setAttribute('id', 'message-' + command.replace(/:/g, '-'));
+      element.innerText = JSON.stringify(data);
+      newWindow.document.body.appendChild(element);
+    });
+
+    // from http://dev.w3.org/html5/webstorage/
+    // When a new top-level browsing context is created by a script in
+    // an existing browsing context, then the session storage area of
+    // the origin of that Document must be copied into the new
+    // browsing context when it is created. From that point on,
+    // however, the two session storage areas must be considered
+    // separate, not affecting each other in any way.
+    //
+    // We want to pretend this is a new tab that the user opened using
+    // CTRL-T, which does NOT copy sessionStorage over. Wipe
+    // sessionStorage in this new context;
+    newWindow.sessionStorage.clear();
+
+    return true;
   }
 
   function openVerificationLinkDifferentBrowser(client, email) {
@@ -312,6 +314,18 @@ define([
       .then(function (result) {
         return client.accountReset(email, password, result.accountResetToken);
       });
+  }
+
+  function openSettingsSameBrowser(context, windowName) {
+    return context.remote.execute(openWindow, [ SETTINGS_URL, windowName ]);
+  }
+
+  function openSigninSameBrowser(context, windowName) {
+    return context.remote.execute(openWindow, [ SIGNIN_URL, windowName ]);
+  }
+
+  function openSignupSameBrowser(context, windowName) {
+    return context.remote.execute(openWindow, [ SIGNUP_URL, windowName ]);
   }
 
   function openUnlockLinkDifferentBrowser(client, email) {
@@ -716,6 +730,9 @@ define([
     openFxaFromUntrustedRp: openFxaFromUntrustedRp,
     openPage: openPage,
     openPasswordResetLinkDifferentBrowser: openPasswordResetLinkDifferentBrowser,
+    openSettingsSameBrowser: openSettingsSameBrowser,
+    openSigninSameBrowser: openSigninSameBrowser,
+    openSignupSameBrowser: openSignupSameBrowser,
     openUnlockLinkDifferentBrowser: openUnlockLinkDifferentBrowser,
     openVerificationLinkDifferentBrowser: openVerificationLinkDifferentBrowser,
     openVerificationLinkSameBrowser: openVerificationLinkSameBrowser,

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -189,8 +189,28 @@ define([
         })
         .findById('avatar-options')
         .end();
-    }
+    },
 
+    'sign in, open settings in a second tab, sign out': function () {
+      var windowName = 'sign-out inter-tab functional test';
+      var self = this;
+      return FunctionalHelpers.fillOutSignIn(this, email, FIRST_PASSWORD)
+        .then(function () {
+          return FunctionalHelpers.openSettingsSameBrowser(self, windowName);
+        })
+        .switchToWindow(windowName)
+        .findById('fxa-settings-header')
+        .end()
+        .findById('signout')
+          .click()
+        .end()
+        .findById('fxa-signin-header')
+        .end()
+        .closeCurrentWindow()
+        .switchToWindow('')
+        .findById('fxa-signin-header')
+        .end();
+    }
   });
 
   registerSuite({

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -217,6 +217,62 @@ define([
               })
             .end();
         });
+    },
+
+    'sign in with a second sign-in tab open': function () {
+      var windowName = 'sign-in inter-tab functional test';
+      var self = this;
+      return verifyUser(email, 0)
+        .then(function () {
+          return FunctionalHelpers.openSigninSameBrowser(self, windowName);
+        })
+        .then(function () {
+          return self.remote
+            .switchToWindow(windowName)
+            .findById('fxa-signin-header')
+            .end();
+        })
+        .then(function () {
+          return fillOutSignIn(self, email, PASSWORD);
+        })
+        .then(function () {
+          return self.remote
+            .findById('fxa-settings-header')
+            .end()
+            .closeCurrentWindow()
+            .switchToWindow('')
+            .findById('fxa-settings-header')
+            .end();
+        });
+    },
+
+    'sign in with a second sign-up tab open': function () {
+      var windowName = 'sign-in inter-tab functional test';
+      var self = this;
+      return verifyUser(email, 0)
+        .then(function () {
+          return FunctionalHelpers.openSignupSameBrowser(self, windowName);
+        })
+        .then(function () {
+          return self.remote
+            .switchToWindow(windowName)
+            .findById('fxa-signup-header')
+            .end()
+            .switchToWindow('');
+        })
+        .then(function () {
+          return fillOutSignIn(self, email, PASSWORD);
+        })
+        .then(function () {
+          return self.remote
+            .switchToWindow(windowName)
+            .findById('fxa-settings-header')
+            .end()
+            .closeCurrentWindow()
+            .switchToWindow('')
+            .findById('fxa-settings-header')
+            .end();
+        });
     }
   });
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -432,6 +432,64 @@ define([
             assert.equal(resultText, '');
           })
         .end();
+    },
+
+    'sign up and verify with a second sign-in tab open': function () {
+      var windowName = 'sign-up inter-tab functional test';
+      var self = this;
+      return fillOutSignUp(this, email, PASSWORD, OLD_ENOUGH_YEAR)
+        .then(function () {
+          return testAtConfirmScreen(self, email);
+        })
+        .then(function () {
+          return FunctionalHelpers.openSigninSameBrowser(self, windowName);
+        })
+        .switchToWindow(windowName)
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+        })
+        .switchToWindow('newwindow')
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+        .closeCurrentWindow()
+        .switchToWindow(windowName)
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+        .closeCurrentWindow()
+        .switchToWindow('')
+        .findByCssSelector('#fxa-settings-header')
+        .end();
+    },
+
+    'sign up and verify with a second sign-up tab open': function () {
+      var windowName = 'sign-up inter-tab functional test';
+      var self = this;
+      return fillOutSignUp(this, email, PASSWORD, OLD_ENOUGH_YEAR)
+        .then(function () {
+          return testAtConfirmScreen(self, email);
+        })
+        .then(function () {
+          return FunctionalHelpers.openSignupSameBrowser(self, windowName);
+        })
+        .switchToWindow(windowName)
+        .findByCssSelector('#fxa-signup-header')
+        .end()
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+        })
+        .switchToWindow('newwindow')
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+        .closeCurrentWindow()
+        .switchToWindow(windowName)
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+        .closeCurrentWindow()
+        .switchToWindow('')
+        .findByCssSelector('#fxa-settings-header')
+        .end();
     }
   });
 


### PR DESCRIPTION
Fixes #3024, redirecting to sign-in/settings across multiple tabs.

Deliberately does not address OAuth sign-in because of potential unintended consequences from redirecting to a relier URL more than once. Maybe that is something that can be opted in to per-relier in the future. There's also no attempt to cover successful sign-up here either.

Because `InterTabChannelMixin` is now a dependency of the sign-in and settings views, there was a little bit of collateral damage (`force_auth::initialize`, the router tests) where the new dependency also needed to be met.

The change makes use of the broker capabilities, which weren't comprehensively covered by the unit tests before. So I added a bunch of assertions for their default capabilities as part of this change, since some of the new tests assumed that the capabilities would be correct.

There is no new functional test for OAuth sign-in, because I couldn't work out how to reliably test that a thing *doesn't* happen with Selenium. If I simply `findById('fxa-signin-header')`, it succeeds immediately instead of waiting for navigation. I could `sleep()`, but I've been bitten by those before; if you have better suggestions, I'll be happy to implement them. The OAuth behaviour is covered in the unit tests though, by stubbing `hasCapability` to return `false` and asserting that the sign-in activity does not occur.