### PR TITLE
refactor(client): Simplify the floating placeholder mixin logic.

### DIFF
--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -66,7 +66,6 @@ function (Cocktail, BaseView, FormView, Template, FloatingPlaceholderMixin,
       // The originating tab will start listening for `login` events once
       // it knows the complete reset password tab is open in the same browser.
       this.interTabSend('complete_reset_password_tab_open');
-      this.initializePlaceholderFields();
     },
 
     context: function () {

--- a/app/scripts/views/coppa/coppa-age-input.js
+++ b/app/scripts/views/coppa/coppa-age-input.js
@@ -5,11 +5,10 @@
 define([
   'cocktail',
   'lib/auth-errors',
-  'lib/promise',
   'stache!templates/partial/coppa-age-input',
   'views/form',
   'views/mixins/floating-placeholder-mixin'
-], function (Cocktail, AuthErrors, p, Template, FormView, FloatingPlaceholderMixin) {
+], function (Cocktail, AuthErrors, Template, FormView, FloatingPlaceholderMixin) {
   'use strict';
 
   var CUTOFF_AGE = 13;
@@ -45,15 +44,8 @@ define([
       age.val(age.val().substr(0, 3));
     },
 
-    render: function () {
-      var self = this;
-
-      return p()
-        .then(function () {
-          self.$el.html(self.template(self.getContext()));
-          self.initializePlaceholderFields();
-          self._selectPrefillAge('age');
-        });
+    afterRender: function () {
+      this._selectPrefillAge('age');
     },
 
     /**
@@ -93,7 +85,9 @@ define([
     _selectPrefillAge: function (context) {
       var prefillYear = this._formPrefill.get(context);
       if (prefillYear) {
-        this.$('#age').val(prefillYear);
+        var ageEl = this.$('#age');
+        ageEl.val(prefillYear);
+        this.showFloatingPlaceholder(ageEl);
       }
     },
 

--- a/app/scripts/views/mixins/floating-placeholder-mixin.js
+++ b/app/scripts/views/mixins/floating-placeholder-mixin.js
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// FormView plugin to convert a placeholder into a
-// floating label if the input changes.
+/**
+ * FormView plugin to convert a placeholder into a
+ * floating label if the input changes. Behavior is automatically
+ * hooked up in `afterRender`
+ */
 
 define([
   'jquery'
@@ -11,34 +14,47 @@ define([
   'use strict';
 
   return {
-    //when a user begins typing in an input, grab the placeholder,
-    // put it in a label and then unbind the event
-    // this is done to prevent user confustion about multiple password inputs
-    togglePlaceholderPattern: function (el) {
-      var self = this;
-      var input = el || this.$('input');
+    events: {
+      'input input[placeholder]': 'floatingPlaceholderMixinOnInput'
+    },
 
-      input.one('input', function () {
-        // if values haven't changed, reattach the event listener for
-        // just this element
-        if (! self.detectFormValueChanges()) {
-          self.togglePlaceholderPattern($(this));
-          return true;
-        }
-        var placeholder = $(this).attr('placeholder');
-        if (placeholder !== '') {
-          $(this).removeAttr('placeholder');
-          $(this).prev('.label-helper').text(placeholder).animate( {'top': '-17px'}, 400);
-        }
-      });
+    afterRender: function () {
+      this.updateFormValueChanges();
     },
 
     /**
-     * Initialize fields with placeholder text that can toggle position.
+     * Force the display of the floating placeholder field
+     * for an element
+     *
+     * @param {object} inputEl - input element whose placeholder
+     *        should be shown.
      */
-    initializePlaceholderFields: function () {
-      this.updateFormValueChanges();
-      this.togglePlaceholderPattern();
+    showFloatingPlaceholder: function (inputEl) {
+      var $inputEl = $(inputEl);
+      var placeholder = $inputEl.attr('placeholder');
+
+      // If the placeholder for the element was already converted, no
+      // further conversion will occur.
+      if (placeholder !== '') {
+        $inputEl.removeAttr('placeholder');
+        $inputEl.prev('.label-helper').text(placeholder).animate( {'top': '-17px'}, 400);
+      }
+    },
+
+    /**
+     * The ridiculous name is to avoid collisions with
+     * functions on consumers.
+     */
+    floatingPlaceholderMixinOnInput: function (event) {
+      var $inputEl = $(event.currentTarget);
+
+      // If no form values have changed, no need to show the
+      // placeholder text.
+      if (! this.detectFormValueChanges()) {
+        return;
+      }
+
+      this.showFloatingPlaceholder($inputEl);
     }
   };
 });

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -32,10 +32,6 @@ function (Cocktail, BaseView, FormView, AuthErrors, Template, PasswordMixin,
       };
     },
 
-    afterRender: function () {
-      this.initializePlaceholderFields();
-    },
-
     submit: function () {
       var self = this;
       var account = self.getSignedInAccount();

--- a/app/scripts/views/settings/delete_account.js
+++ b/app/scripts/views/settings/delete_account.js
@@ -36,10 +36,6 @@ function (Cocktail, BaseView, FormView, Template, Session, AuthErrors,
       };
     },
 
-    afterRender: function () {
-      this.initializePlaceholderFields();
-    },
-
     submit: function () {
       var self = this;
       var account = self.getSignedInAccount();

--- a/app/scripts/views/settings/display_name.js
+++ b/app/scripts/views/settings/display_name.js
@@ -41,10 +41,6 @@ function (Cocktail, BaseView, FormView, Template,
         });
     },
 
-    afterRender: function () {
-      this.initializePlaceholderFields();
-    },
-
     submit: function () {
       var self = this;
       var account = self.getSignedInAccount();

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -111,7 +111,7 @@ function (Cocktail, p, BaseView, FormView, Template, AuthErrors, mailcheck,
       self.logScreenEvent('email-optin.visible.' +
           String(self._isEmailOptInEnabled()));
 
-      self._createCoppaView()
+      return self._createCoppaView()
         .then(function () {
           self.transformLinks();
 

--- a/app/tests/spec/views/mixins/floating-placeholder-mixin.js
+++ b/app/tests/spec/views/mixins/floating-placeholder-mixin.js
@@ -3,27 +3,27 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
-  'jquery',
-  'underscore',
   'chai',
-  'views/form',
+  'cocktail',
+  'jquery',
   'stache!templates/test_template',
+  'views/form',
   'views/mixins/floating-placeholder-mixin'
-], function ($, _, chai, FormView, Template, FloatingPlaceholderMixin) {
+], function (chai, Cocktail, $, Template, FormView, FloatingPlaceholderMixin) {
   'use strict';
 
   var assert = chai.assert;
 
   var TestView = FormView.extend({
-    template: Template,
-    afterRender: function () {
-      this.initializePlaceholderFields();
-    }
+    template: Template
   });
 
-  _.extend(TestView.prototype, FloatingPlaceholderMixin);
+  Cocktail.mixin(
+    TestView,
+    FloatingPlaceholderMixin
+  );
 
-  describe('lib/floating-placeholder-mixin', function () {
+  describe('views/mixins/floating-placeholder-mixin', function () {
     var view;
 
     beforeEach(function () {
@@ -31,27 +31,36 @@ define([
       return view.render();
     });
 
-    it('no action if enter is pressed with no other input', function () {
-      console.log('val: %s', view.$('#float_me').length);
-      var event = new $.Event('input');
-      event.which = 13;
+    describe('keyboard input', function () {
+      it('no action if enter is pressed with no other input', function () {
+        var event = new $.Event('input');
+        event.which = 13;
 
-      view.$('#float_me').trigger(event);
+        view.$('#float_me').trigger(event);
 
-      assert.equal(view.$('#float_me').attr('placeholder'), 'placeholder text');
-      assert.equal(view.$('.label-helper').text(), '');
+        assert.equal(view.$('#float_me').attr('placeholder'), 'placeholder text');
+        assert.equal(view.$('.label-helper').text(), '');
+      });
+
+      it('floats the placeholder if the input changes', function () {
+        view.$('#float_me').val('a');
+
+        var event = new $.Event('input');
+        event.which = 13;
+
+        view.$('#float_me').trigger(event);
+
+        assert.equal(typeof view.$('#float_me').attr('placeholder'), 'undefined');
+        assert.equal(view.$('.label-helper').text(), 'placeholder text');
+      });
     });
 
-    it('floats the placeholder if the input changes', function () {
-      view.$('#float_me').val('a');
-
-      var event = new $.Event('input');
-      event.which = 13;
-
-      view.$('#float_me').trigger(event);
-
-      assert.equal(typeof view.$('#float_me').attr('placeholder'), 'undefined');
-      assert.equal(view.$('.label-helper').text(), 'placeholder text');
+    describe('showFloatingPlaceholder', function () {
+      it('forces the display of a floating placeholder', function () {
+        view.showFloatingPlaceholder('#float_me');
+        assert.equal(view.$('#float_me').attr('placeholder'), 'placeholder text');
+        assert.equal(view.$('.label-helper').text(), '');
+      });
     });
   });
 });


### PR DESCRIPTION
The floating-placeholder-mixin was written before Cocktail was used. This meant
its behavior had to be hooked up manually. Using Cocktail, a mixin's behavior
and DOM event handlers can be hooked up automagically.

* Use an `events` hash in the mixin to listen for changes.
* Automatically attach the behavior in afterRender.

@vladikoff - since you were just digging around in there, mind an r?