### PR TITLE
fix(client): Log the correct screen name for the settings panels.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -92,23 +92,39 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
      */
     layoutClassName: null,
 
+    /**
+     * The default screen name
+     *
+     * @property screenName
+     */
+    screenName: '',
+
     constructor: function (options) {
       options = options || {};
 
-      this.subviews = [];
-      this.window = options.window || window;
-      this.navigator = options.navigator || this.window.navigator || navigator;
-      this.translator = options.translator || this.window.translator;
-      this.router = options.router || this.window.router;
-      this.ephemeralMessages = options.ephemeralMessages || ephemeralMessages;
-      this.metrics = options.metrics || nullMetrics;
-      this.sentryMetrics = options.sentryMetrics || Raven;
-      this.relier = options.relier;
       this.broker = options.broker;
-      this.user = options.user;
-      this.screenName = options.screenName || '';
-
+      this.ephemeralMessages = options.ephemeralMessages || ephemeralMessages;
       this.fxaClient = options.fxaClient;
+      this.metrics = options.metrics || nullMetrics;
+      this.relier = options.relier;
+      this.sentryMetrics = options.sentryMetrics || Raven;
+      this.subviews = [];
+      this.user = options.user;
+      this.window = options.window || window;
+
+      this.navigator = options.navigator || this.window.navigator || navigator;
+      this.router = options.router || this.window.router;
+      this.translator = options.translator || this.window.translator;
+
+      /**
+       * Prefer the `screenName` set on the object prototype. Subviews
+       * define their screenName on the prototype to avoid taking the
+       * name of the parent view. This is a terrible hack, but workable
+       * until a better solution arises. See #3029
+       */
+      if (! this.screenName && options.screenName) {
+        this.screenName = options.screenName;
+      }
 
       Backbone.View.call(this, options);
 
@@ -529,6 +545,11 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
       this.metrics.logError(err);
     },
 
+    /**
+     * Get the view's screen name.
+     *
+     * @returns {string}
+     */
     getScreenName: function () {
       return this.screenName;
     },

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -52,6 +52,7 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
     template: Template,
     className: 'settings',
     layoutClassName: 'settings',
+    screenName: 'settings',
 
     initialize: function (options) {
       options = options || {};

--- a/app/scripts/views/settings/avatar.js
+++ b/app/scripts/views/settings/avatar.js
@@ -15,6 +15,7 @@ function (Cocktail, FormView, Template, AvatarMixin, SettingsPanelMixin) {
   var View = FormView.extend({
     template: Template,
     className: 'avatar',
+    screenName: 'settings.avatar',
 
     onProfileUpdate: function () {
       this.render();

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -34,6 +34,7 @@ function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
   var View = FormView.extend({
     template: Template,
     className: 'avatar-camera',
+    screenName: 'settings.avatar.camera',
 
     context: function () {
       return {

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -21,6 +21,7 @@ function ($, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
   var View = FormView.extend({
     template: Template,
     className: 'avatar-change',
+    screenName: 'settings.avatar.change',
 
     events: {
       'change #imageLoader': 'fileSet',

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -25,6 +25,7 @@ function (p, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
   var View = FormView.extend({
     template: Template,
     className: 'avatar-crop',
+    screenName: 'settings.avatar.crop',
 
     initialize: function (options) {
       options = options || {};

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -30,6 +30,7 @@ function ($, _, md5, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
   var View = FormView.extend({
     template: Template,
     className: 'avatar-gravatar',
+    screenName: 'settings.avatar.gravatar',
 
     context: function () {
       return {

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -25,6 +25,7 @@ function (Cocktail, BaseView, FormView, AuthErrors, Template, PasswordMixin,
   var View = FormView.extend({
     template: Template,
     className: 'change-password',
+    screenName: 'settings.change-password',
 
     context: function () {
       return {

--- a/app/scripts/views/settings/communication_preferences.js
+++ b/app/scripts/views/settings/communication_preferences.js
@@ -23,6 +23,7 @@ function (Cocktail, Xss, Constants, MarketingEmailErrors, Metrics, BaseView, For
   var View = FormView.extend({
     template: Template,
     className: 'communication-preferences',
+    screenName: 'settings.communication-preferences',
 
     enableSubmitIfValid: function () {
       // overwrite this to prevent the default FormView method from hiding errors

--- a/app/scripts/views/settings/delete_account.js
+++ b/app/scripts/views/settings/delete_account.js
@@ -25,6 +25,7 @@ function (Cocktail, BaseView, FormView, Template, Session, AuthErrors,
   var View = FormView.extend({
     template: Template,
     className: 'delete-account',
+    screenName: 'settings.delete-account',
 
     initialize: function (options) {
       this.notifications = options.notifications;

--- a/app/scripts/views/settings/display_name.js
+++ b/app/scripts/views/settings/display_name.js
@@ -20,6 +20,7 @@ function (Cocktail, BaseView, FormView, Template,
   var View = FormView.extend({
     template: Template,
     className: 'display-name',
+    screenName: 'settings.display-name',
 
     onProfileUpdate: function () {
       this.render();

--- a/app/scripts/views/settings/gravatar_permissions.js
+++ b/app/scripts/views/settings/gravatar_permissions.js
@@ -17,6 +17,7 @@ function (Cocktail, FormView, Template, p,
   var View = FormView.extend({
     template: Template,
     className: 'gravatar-permissions',
+    screenName: 'settings.gravatar-permissions',
 
     context: function () {
       var account = this.getSignedInAccount();

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -691,5 +691,43 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
           });
       });
     });
+
+    describe('getScreenName', function () {
+      describe('with a `screenName` on the view prototype', function () {
+        var view;
+
+        before(function () {
+          var ScreenNameView = View.extend({
+            screenName: 'set on the prototype'
+          });
+
+          view = new ScreenNameView({
+            screenName: 'set on creation'
+          });
+        });
+
+        it('returns the `screenName` from the prototype', function () {
+          assert.equal(view.getScreenName(), 'set on the prototype');
+        });
+      });
+
+      describe('without a `screenName` on the view prototype', function () {
+        var view;
+
+        before(function () {
+          var ScreenNameView = View.extend({
+            screenName: undefined
+          });
+
+          view = new ScreenNameView({
+            screenName: 'set on creation'
+          });
+        });
+
+        it('returns `screenName` passed in on creation', function () {
+          assert.equal(view.getScreenName(), 'set on creation');
+        });
+      });
+    });
   });
 });

--- a/app/tests/spec/views/settings/avatar_camera.js
+++ b/app/tests/spec/views/settings/avatar_camera.js
@@ -24,7 +24,6 @@ function (chai, $, sinon, View, RouterMock, WindowMock, CanvasMock,
   'use strict';
 
   var assert = chai.assert;
-  var SCREEN_NAME = 'settings.avatar.camera';
 
   function mockVideo (w, h) {
     return {
@@ -60,7 +59,6 @@ function (chai, $, sinon, View, RouterMock, WindowMock, CanvasMock,
         metrics: metrics,
         relier: relier,
         router: routerMock,
-        screenName: SCREEN_NAME,
         user: user,
         window: windowMock
       });
@@ -204,7 +202,6 @@ function (chai, $, sinon, View, RouterMock, WindowMock, CanvasMock,
           metrics: metrics,
           relier: relier,
           router: routerMock,
-          screenName: SCREEN_NAME,
           user: user,
           window: windowMock
         });

--- a/app/tests/spec/views/settings/avatar_change.js
+++ b/app/tests/spec/views/settings/avatar_change.js
@@ -26,9 +26,8 @@ function (chai, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAACZJREFUeNrtwQEBAAAAgiD' +
                '/r25IQAEAAAAAAAAAAAAAAAAAAADvBkCAAAEehacTAAAAAElFTkSuQmCC';
-  var SCREEN_NAME = 'settings.avatar.change';
 
-  describe('views/settings/avatar/change', function () {
+  describe('views/settings/avatar_change', function () {
     var view;
     var routerMock;
     var profileClientMock;
@@ -50,7 +49,6 @@ function (chai, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
         metrics: metrics,
         relier: relier,
         router: routerMock,
-        screenName: SCREEN_NAME,
         user: user,
         window: windowMock
       });
@@ -71,7 +69,6 @@ function (chai, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
           metrics: metrics,
           relier: relier,
           router: routerMock,
-          screenName: SCREEN_NAME,
           user: user,
           window: windowMock
         });

--- a/app/tests/spec/views/settings/avatar_crop.js
+++ b/app/tests/spec/views/settings/avatar_crop.js
@@ -113,7 +113,6 @@ function (chai, $, ui, sinon, jQuerySimulate, View, RouterMock, ProfileMock, Use
             metrics: metrics,
             relier: relier,
             router: routerMock,
-            screenName: 'settings.avatar.crop',
             user: user
           });
           view.isUserAuthorized = function () {

--- a/app/tests/spec/views/settings/avatar_gravatar.js
+++ b/app/tests/spec/views/settings/avatar_gravatar.js
@@ -51,7 +51,6 @@ function (chai, $, sinon, View, RouterMock, ProfileMock, TestHelpers, User,
         metrics: metrics,
         relier: relier,
         router: routerMock,
-        screenName: 'settings.avatar.gravatar',
         user: user
       });
 

--- a/app/tests/spec/views/settings/change_password.js
+++ b/app/tests/spec/views/settings/change_password.js
@@ -58,7 +58,6 @@ function (chai, $, sinon, AuthErrors, FxaClient, Metrics, p,
         metrics: metrics,
         relier: relier,
         router: routerMock,
-        screenName: 'change-password',
         user: user
       });
     });

--- a/app/tests/spec/views/settings/communication_preferences.js
+++ b/app/tests/spec/views/settings/communication_preferences.js
@@ -73,7 +73,6 @@ function (chai, $, sinon, View, User, Account, MarketingEmailPrefs, Relier,
       view = new View({
         metrics: metrics,
         relier: relier,
-        screenName: 'settings.communication-preferences',
         user: user
       });
 

--- a/app/tests/spec/views/settings/delete_account.js
+++ b/app/tests/spec/views/settings/delete_account.js
@@ -62,7 +62,6 @@ function (chai, $, sinon, View, FxaClient, p, AuthErrors, Metrics, NullChannel,
         notifications: notifications,
         relier: relier,
         router: routerMock,
-        screenName: 'delete-account',
         user: user
       });
     });
@@ -162,7 +161,7 @@ function (chai, $, sinon, View, FxaClient, p, AuthErrors, Metrics, NullChannel,
                   .calledWith(email, password));
                 assert.isTrue(user.removeAccount.calledWith(account));
                 assert.isTrue(broker.afterDeleteAccount.calledWith(account));
-                assert.isTrue(TestHelpers.isEventLogged(metrics, 'delete-account.deleted'));
+                assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.delete-account.deleted'));
                 assert.isTrue(notifications.accountDeleted.calledWith({ uid: UID }));
               });
         });

--- a/app/tests/spec/views/settings/display_name.js
+++ b/app/tests/spec/views/settings/display_name.js
@@ -60,7 +60,6 @@ function (chai, $, sinon, p, View, Metrics, Notifications, Relier, User, RouterM
         notifications: notifications,
         relier: relier,
         router: routerMock,
-        screenName: 'display-name',
         user: user
       });
 
@@ -147,7 +146,7 @@ function (chai, $, sinon, p, View, Metrics, Notifications, Relier, User, RouterM
             assert.isTrue(view.updateDisplayName.calledWith(expectedName));
             assert.isTrue(view.displaySuccess.called);
             assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                  'display-name.success'));
+                                  'settings.display-name.success'));
             assert.equal(routerMock.page, 'settings');
           });
       });

--- a/app/tests/spec/views/settings/gravatar_permissions.js
+++ b/app/tests/spec/views/settings/gravatar_permissions.js
@@ -57,7 +57,6 @@ function (chai, $, sinon, p, View, Metrics, Relier, User, RouterMock, TestHelper
         metrics: metrics,
         relier: relier,
         router: routerMock,
-        screenName: 'gravatar-permissions',
         user: user
       });
       sinon.stub(view, 'navigate', function () { });
@@ -86,7 +85,7 @@ function (chai, $, sinon, p, View, Metrics, Relier, User, RouterMock, TestHelper
           .then(function () {
             assert.isTrue(account.hasGrantedPermissions.calledWith(View.GRAVATAR_MOCK_CLIENT_ID, View.PERMISSIONS));
             assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                  'gravatar-permissions.already-accepted'));
+                                  'settings.gravatar-permissions.already-accepted'));
             assert.isTrue(view.navigate.calledWith('settings/avatar/gravatar'));
           });
       });
@@ -126,13 +125,11 @@ function (chai, $, sinon, p, View, Metrics, Relier, User, RouterMock, TestHelper
                 assert.isTrue(account.saveGrantedPermissions.calledWith(View.GRAVATAR_MOCK_CLIENT_ID, View.PERMISSIONS));
                 assert.isTrue(user.setAccount.calledWith(account));
                 assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                  'gravatar-permissions.accept'));
+                                  'settings.gravatar-permissions.accept'));
                 assert.isTrue(view.navigate.calledWith('settings/avatar/gravatar'));
               });
           });
       });
-
     });
-
   });
 });


### PR DESCRIPTION
There were two problems:
* Subviews always took the screen name of their parent because subviews
  are created with the same options as the parent view, which includes
  the parent view's screen name.
* If the user opened the site directly to a subview, the settings panel
  would take the screen name of the child view, because the settings panel
  took its screen name from the URL, which was the subview's URL.

Add a `screenName` property with the correct name to all settings pages.
If `screenName` is set on the prototype, ignore the screen name passed
in on construction.

fixes #3029

@philbooth or @vladikoff - r?