### PR TITLE
fix(client): Suppress spurious `login` messages to the browser.

### DIFF
--- a/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
@@ -32,7 +32,9 @@ define([
 
       user = new User();
       account = user.initAccount({
-        email: 'testuser@testuser.com'
+        email: 'testuser@testuser.com',
+        keyFetchToken: 'key-fetch-token',
+        unwrapBKey: 'unwrap-b-key'
       });
 
       broker = new FxDesktopV1AuthenticationBroker({

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -32,7 +32,9 @@ define([
 
       user = new User();
       account = user.initAccount({
-        email: 'testuser@testuser.com'
+        email: 'testuser@testuser.com',
+        keyFetchToken: 'key-fetch-token',
+        unwrapBKey: 'unwrap-b-key'
       });
 
       broker = new FxDesktopV2AuthenticationBroker({

--- a/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -32,7 +32,9 @@ function (chai, NullChannel, FxFennecV1AuthenticationBroker, Relier,
 
       user = new User();
       account = user.initAccount({
-        email: 'testuser@testuser.com'
+        email: 'testuser@testuser.com',
+        keyFetchToken: 'key-fetch-token',
+        unwrapBKey: 'unwrap-b-key'
       });
 
       broker = new FxFennecV1AuthenticationBroker({

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -50,7 +50,9 @@ define([
 
       user = new User();
       account = user.initAccount({
-        email: 'testuser@testuser.com'
+        email: 'testuser@testuser.com',
+        keyFetchToken: 'key-fetch-token',
+        unwrapBKey: 'unwrap-b-key'
       });
 
       createAuthBroker();
@@ -105,15 +107,19 @@ define([
     });
 
     describe('_notifyRelierOfLogin', function () {
-      it('sends a `login` message to the channel', function () {
+      it('does not send a `login` message to the channel if the account does not have a `keyFetchToken`', function () {
+        account.unset('keyFetchToken');
         return broker._notifyRelierOfLogin(account)
           .then(function () {
-            assert.isTrue(channelMock.send.calledWith('login'));
+            assert.isFalse(channelMock.send.called);
+          });
+      });
 
-            var data = channelMock.send.args[0][1];
-            assert.equal(data.email, 'testuser@testuser.com');
-            assert.isFalse(data.verified);
-            assert.isFalse(data.verifiedCanLinkAccount);
+      it('does not send a `login` message to the channel if the account does not have a `unwrapBKey`', function () {
+        account.unset('unwrapBKey');
+        return broker._notifyRelierOfLogin(account)
+          .then(function () {
+            assert.isFalse(channelMock.send.called);
           });
       });
 
@@ -124,6 +130,8 @@ define([
 
             var data = channelMock.send.args[0][1];
             assert.equal(data.email, 'testuser@testuser.com');
+            assert.equal(data.keyFetchToken, 'key-fetch-token');
+            assert.equal(data.unwrapBKey, 'unwrap-b-key');
             assert.isFalse(data.verified);
             assert.isFalse(data.verifiedCanLinkAccount);
           });


### PR DESCRIPTION
If the user signs up but does not verify their account,
then visit `/` or `/settings`, they are redirected to `/confirm`
which attempts to notify the browser of login.

Neither `unwrapBKey` and `keyFetchToken` are persisted to disk.

If `/confirm` is shown in a tab other than the original tab,
`notifyBrowserOfLogin` is called with an account without these
fields. The browser can't do anything without this information,
so don't actually send the message.

fixes #3078 

@vladikoff or @zaach - r?