### PR TITLE
refactor(client): move router.showView logic to the AppView.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -118,15 +118,15 @@ function (
   function Start(options) {
     options = options || {};
 
-    this._window = options.window || window;
-    this._router = options.router;
-    this._relier = options.relier;
     this._authenticationBroker = options.broker;
-    this._user = options.user;
-    this._storage = options.storage || Storage;
-
-    this._history = options.history || Backbone.history;
     this._configLoader = new ConfigLoader();
+    this._history = options.history || Backbone.history;
+    this._notifications = options.notifications;
+    this._relier = options.relier;
+    this._router = options.router;
+    this._storage = options.storage || Storage;
+    this._user = options.user;
+    this._window = options.window || window;
   }
 
   Start.prototype = {
@@ -527,15 +527,17 @@ function (
     },
 
     initializeNotifications: function () {
-      var notificationWebChannel =
-            new WebChannel(Constants.ACCOUNT_UPDATES_WEBCHANNEL_ID);
-      notificationWebChannel.initialize();
+      if (! this._notifications) {
+        var notificationWebChannel =
+              new WebChannel(Constants.ACCOUNT_UPDATES_WEBCHANNEL_ID);
+        notificationWebChannel.initialize();
 
-      this._notifications = new Notifications({
-        iframeChannel: this._iframeChannel,
-        tabChannel: this._interTabChannel,
-        webChannel: notificationWebChannel
-      });
+        this._notifications = new Notifications({
+          iframeChannel: this._iframeChannel,
+          tabChannel: this._interTabChannel,
+          webChannel: notificationWebChannel
+        });
+      }
     },
 
     _uniqueUserId: null,
@@ -581,7 +583,9 @@ function (
     initializeAppView: function () {
       if (! this._appView) {
         this._appView = new AppView({
+          el: 'body',
           environment: new Environment(this._window),
+          notifications: this._notifications,
           router: this._router,
           window: this._window
         });

--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -4,11 +4,8 @@
 
 define([
   'backbone',
-  'jquery',
-  './promise',
   './storage',
   'underscore',
-  '../views/base',
   '../views/cannot_create_account',
   '../views/choose_what_to_sync',
   '../views/clear_storage',
@@ -44,11 +41,8 @@ define([
 ],
 function (
   Backbone,
-  $,
-  p,
   Storage,
   _,
-  BaseView,
   CannotCreateAccountView,
   ChooseWhatToSyncView,
   ClearStorageView,
@@ -84,82 +78,62 @@ function (
 ) {
   'use strict';
 
-  function showView(View, options) {
+  function createViewHandler(View, options) {
     return function () {
-      // If the current view is an instance of View, that means we're
-      // navigating from a subview of the current view
-      if (this.currentView instanceof View) {
-        this.trigger(this.NAVIGATE_FROM_SUBVIEW, options);
-        this.setDocumentTitle(this.currentView.titleFromView());
-      } else {
-        this.createAndShowView(View, options);
-      }
+      return this.showView(View, options);
     };
   }
 
-  // Show a sub-view, creating and initializing the SuperView if needed.
-  function showSubView(SuperView, options) {
+  function createSubViewHandler(SubView, ParentView, options) {
     return function () {
-      var self = this;
-      // If currentView is of the SuperView type, simply show the subView
-      if (self.currentView instanceof SuperView) {
-        self.showSubView(options);
-      } else {
-        // Create the SuperView; its initialization method should handle the subView option.
-        self.createAndShowView(SuperView, options)
-          .then(function () {
-            self.showSubView(options);
-          });
-      }
+      return this.showSubView(SubView, ParentView, options);
     };
   }
 
   var Router = Backbone.Router.extend({
-    NAVIGATE_FROM_SUBVIEW: 'navigate-from-subview',
-
     routes: {
       '(/)': 'redirectToSignupOrSettings',
-      'account_unlock_complete(/)': showView(ReadyView, { type: 'account_unlock' }),
-      'cannot_create_account(/)': showView(CannotCreateAccountView),
-      'choose_what_to_sync(/)': showView(ChooseWhatToSyncView),
-      'clear(/)': showView(ClearStorageView),
-      'complete_reset_password(/)': showView(CompleteResetPasswordView),
-      'complete_unlock_account(/)': showView(CompleteAccountUnlockView),
-      'confirm(/)': showView(ConfirmView),
-      'confirm_account_unlock(/)': showView(ConfirmAccountUnlockView),
-      'confirm_reset_password(/)': showView(ConfirmResetPasswordView),
-      'cookies_disabled(/)': showView(CookiesDisabledView),
-      'force_auth(/)': showView(ForceAuthView),
-      'force_auth_complete(/)': showView(ReadyView, { type: 'force_auth' }),
-      'legal(/)': showView(LegalView),
-      'legal/privacy(/)': showView(PpView),
-      'legal/terms(/)': showView(TosView),
+      'account_unlock_complete(/)': createViewHandler(ReadyView, { type: 'account_unlock' }),
+      'cannot_create_account(/)': createViewHandler(CannotCreateAccountView),
+      'choose_what_to_sync(/)': createViewHandler(ChooseWhatToSyncView),
+      'clear(/)': createViewHandler(ClearStorageView),
+      'complete_reset_password(/)': createViewHandler(CompleteResetPasswordView),
+      'complete_unlock_account(/)': createViewHandler(CompleteAccountUnlockView),
+      'confirm(/)': createViewHandler(ConfirmView),
+      'confirm_account_unlock(/)': createViewHandler(ConfirmAccountUnlockView),
+      'confirm_reset_password(/)': createViewHandler(ConfirmResetPasswordView),
+      'cookies_disabled(/)': createViewHandler(CookiesDisabledView),
+      'force_auth(/)': createViewHandler(ForceAuthView),
+      'force_auth_complete(/)': createViewHandler(ReadyView, { type: 'force_auth' }),
+      'legal(/)': createViewHandler(LegalView),
+      'legal/privacy(/)': createViewHandler(PpView),
+      'legal/terms(/)': createViewHandler(TosView),
       'oauth(/)': 'redirectToBestOAuthChoice',
-      'oauth/force_auth(/)': showView(ForceAuthView),
-      'oauth/signin(/)': showView(SignInView),
-      'oauth/signup(/)': showView(SignUpView),
-      'openid/login(/)': showView(OpenIdLoginView),
-      'openid/start(/)': showView(OpenIdStartView),
-      'reset_password(/)': showView(ResetPasswordView),
-      'reset_password_complete(/)': showView(ReadyView, { type: 'reset_password' }),
-      'settings(/)': showView(SettingsView),
-      'settings/avatar/camera(/)': showSubView(SettingsView, { subView: AvatarCameraView }),
-      'settings/avatar/change(/)': showSubView(SettingsView, { subView: AvatarChangeView }),
-      'settings/avatar/crop(/)': showSubView(SettingsView, { subView: AvatarCropView }),
-      'settings/avatar/gravatar(/)': showSubView(SettingsView, { subView: AvatarGravatarView }),
-      'settings/avatar/gravatar_permissions(/)': showSubView(SettingsView, { subView: GravatarPermissionsView }),
-      'settings/change_password(/)': showSubView(SettingsView, { subView: ChangePasswordView }),
-      'settings/communication_preferences(/)': showSubView(SettingsView, { subView: CommunicationPreferencesView }),
-      'settings/delete_account(/)': showSubView(SettingsView, { subView: DeleteAccountView }),
-      'settings/display_name(/)': showSubView(SettingsView, { subView: DisplayNameView }),
-      'signin(/)': showView(SignInView),
-      'signin_complete(/)': showView(ReadyView, { type: 'sign_in' }),
-      'signin_permissions(/)': showView(PermissionsView, { type: 'sign_in' }),
-      'signup(/)': showView(SignUpView),
-      'signup_complete(/)': showView(ReadyView, { type: 'sign_up' }),
-      'signup_permissions(/)': showView(PermissionsView, { type: 'sign_up' }),
-      'unexpected_error(/)': showView(UnexpectedErrorView),
-      'verify_email(/)': showView(CompleteSignUpView)
+      'oauth/force_auth(/)': createViewHandler(ForceAuthView),
+      'oauth/signin(/)': createViewHandler(SignInView),
+      'oauth/signup(/)': createViewHandler(SignUpView),
+      'openid/login(/)': createViewHandler(OpenIdLoginView),
+      'openid/start(/)': createViewHandler(OpenIdStartView),
+      'reset_password(/)': createViewHandler(ResetPasswordView),
+      'reset_password_complete(/)': createViewHandler(ReadyView, { type: 'reset_password' }),
+      'settings(/)': createViewHandler(SettingsView),
+      'settings/avatar/camera(/)': createSubViewHandler(AvatarCameraView, SettingsView),
+      'settings/avatar/change(/)': createSubViewHandler(AvatarChangeView, SettingsView),
+      'settings/avatar/crop(/)': createSubViewHandler(AvatarCropView, SettingsView),
+      'settings/avatar/gravatar(/)': createSubViewHandler(AvatarGravatarView, SettingsView),
+      'settings/avatar/gravatar_permissions(/)': createSubViewHandler(GravatarPermissionsView, SettingsView),
+      'settings/change_password(/)': createSubViewHandler(ChangePasswordView, SettingsView),
+      'settings/communication_preferences(/)': createSubViewHandler(CommunicationPreferencesView, SettingsView),
+      'settings/delete_account(/)': createSubViewHandler(DeleteAccountView, SettingsView),
+      'settings/display_name(/)': createSubViewHandler(DisplayNameView, SettingsView),
+      'signin(/)': createViewHandler(SignInView),
+      'signin_complete(/)': createViewHandler(ReadyView, { type: 'sign_in' }),
+      'signin_permissions(/)': createViewHandler(PermissionsView, { type: 'sign_in' }),
+      'signup(/)': createViewHandler(SignUpView),
+      'signup_complete(/)': createViewHandler(ReadyView, { type: 'sign_up' }),
+      'signup_permissions(/)': createViewHandler(PermissionsView, { type: 'sign_up' }),
+      'unexpected_error(/)': createViewHandler(UnexpectedErrorView),
+      'verify_email(/)': createViewHandler(CompleteSignUpView)
     },
 
     initialize: function (options) {
@@ -177,6 +151,9 @@ function (
       this.sentryMetrics = options.sentryMetrics;
       this.user = options.user;
       this.window = options.window || window;
+
+      this.notifications.once('view-shown', this._afterFirstViewHasRendered.bind(this));
+      this.notifications.on('view-shown', this._checkForRefresh.bind(this));
 
       this.storage = Storage.factory('sessionStorage', this.window);
     },
@@ -215,26 +192,16 @@ function (
       return this.navigate(route, { replace: true, trigger: true });
     },
 
-    createAndShowView: function (View, options) {
-      var self = this;
-      var view;
-      return p().then(function () {
-        view = self.createView(View, options);
-        return self.showView(view);
-      })
-      .fail(function (err) {
-        view = view || self.currentView || new BaseView({
-          router: self
-        });
-        // The router's navigate method doesn't set ephemeral messages,
-        // so use the view's higher level navigate method.
-        return view.navigate('unexpected_error', {
-          error: err
-        });
-      });
-    },
-
-    createView: function (View, options) {
+    /**
+     * Get the options to pass to a View constructor.
+     *
+     * TODO - this only exists because this module used to create the views.
+     * There should be a View factory that takes ownership of this logic.
+     *
+     * @param {object} options - additional options
+     * @returns {object}
+     */
+    getViewOptions: function (options) {
       // passed in options block can override
       // default options.
       var viewOptions = _.extend({
@@ -258,17 +225,11 @@ function (
         window: this.window
       }, options || {});
 
-      return new View(viewOptions);
+      return viewOptions;
     },
 
-    createSubView: function (SubView, options) {
-      options.superView = this.currentView;
-      return this.createView(SubView, options);
-    },
-
-    _checkForRefresh: function () {
+    _checkForRefresh: function (currentView) {
       var refreshMetrics = this.storage.get('last_page_loaded');
-      var currentView = this.currentView;
       var screenName = currentView.getScreenName();
 
       if (refreshMetrics && refreshMetrics.view === screenName && this.metrics) {
@@ -283,95 +244,27 @@ function (
       this.storage.set('last_page_loaded', refreshMetrics);
     },
 
-    showView: function (viewToShow) {
-      if (this.currentView) {
-        this.currentView.destroy();
-      }
-
-      this.currentView = viewToShow;
-
-      // render will return false if the view could not be
-      // rendered for any reason, including if the view was
-      // automatically redirected.
-      var self = this;
-
-      viewToShow.logScreen();
-      return viewToShow.render()
-        .then(function (isShown) {
-          if (! isShown) {
-            return;
-          }
-
-          self.setDocumentTitle(viewToShow.titleFromView());
-
-          // Render the new view while stage is invisible then fade it in using css animations
-          // catch problems with an explicit opacity rule after class is added.
-          $('#stage').html(viewToShow.el).addClass('fade-in-forward').css('opacity', 1);
-          viewToShow.afterVisible();
-
-          // The user may be scrolled part way down the page
-          // on screen transition. Force them to the top of the page.
-          self.window.scrollTo(0, 0);
-
-          $('#fox-logo').addClass('fade-in-forward').css('opacity', 1);
-
-          // if the first view errors, the fail branch of the promise will be
-          // followed. The view will navigate to `unexpected_error`, which will
-          // eventually find its way here. `_hasFirstViewRendered` will still be
-          // false, so broker.afterLoaded will be called. See
-          // https://github.com/mozilla/fxa-content-server/pull/2147#issuecomment-76155999
-          if (! self._hasFirstViewRendered) {
-            self._afterFirstViewHasRendered();
-          }
-          self._checkForRefresh();
-        });
-    },
-
-    _hasFirstViewRendered: false,
     _afterFirstViewHasRendered: function () {
-      var self = this;
-      self._hasFirstViewRendered = true;
-
       // afterLoaded lets the relier know when the first screen has been
       // loaded. It does not expect a response, so no error handler
       // is attached and the promise is not returned.
-      self.broker.afterLoaded();
+      this.broker.afterLoaded();
 
       // `loaded` is used to determine how long until the
       // first screen is rendered and the user can interact
       // with FxA. Similar to window.onload, but FxA specific.
-      self.metrics.logEvent('loaded');
+      this.metrics.logEvent('loaded');
 
       // back is enabled after the first view is rendered or
       // if the user re-starts the app.
-      self.storage.set('canGoBack', true);
+      this.storage.set('canGoBack', true);
     },
 
-    renderSubView: function (viewToShow) {
-      return viewToShow.render()
-        .then(function (shown) {
-          if (! shown) {
-            viewToShow.destroy(true);
-            return;
-          }
-
-          viewToShow.afterVisible();
-
-          return viewToShow;
-        });
-    },
-
-    showSubView: function (options) {
-      var self = this;
-      return self.currentView.showSubView(options.subView, options)
-        .then(function (viewToShow) {
-          // Use the super view's title as the base title
-          var title = viewToShow.titleFromView(self.currentView.titleFromView());
-          self.setDocumentTitle(title);
-          viewToShow.logScreen();
-        });
-    },
-
+    /**
+     * TODO - this is used by views/base to redirect unauthenticated users,
+     * pass the currentPage in getViewOptions so that views do not need
+     * to reach back into the router to get this information.
+     */
     getCurrentPage: function () {
       return Backbone.history.fragment;
     },
@@ -390,9 +283,50 @@ function (
                 .replace(/_/g, '-');
     },
 
-    setDocumentTitle: function (title) {
-      this.window.document.title = title;
-    }
+    /**
+     * Notify the system a new View should be shown.
+     *
+     * @param {function} View - view constructor
+     * @param {object} [options]
+     */
+    showView: function (View, options) {
+      this.notifications.trigger(
+          'show-view', View, this.getViewOptions(options));
+    },
+
+    /**
+     * Notify the system a new SubView should be shown.
+     *
+     * @param {function} SubView - view constructor
+     * @param {function} ParentView - view constructor,
+     *     the parent of the SubView
+     * @param {object} [options]
+     */
+    showSubView: function (SubView, ParentView, options) {
+      this.notifications.trigger(
+          'show-sub-view', SubView, ParentView, this.getViewOptions(options));
+    },
+
+    /**
+     * Create a route handler that is used to display a View
+     *
+     * @param {function} View - constructor of view to show
+     * @param {object} [options] - options to pass to View constructor
+     * @returns {function} - a function that can be given to the router.
+     */
+    createViewHandler: createViewHandler,
+
+    /**
+     * Create a route handler that is used to display a SubView inside of
+     * a ParentView. Views will be created as needed.
+     *
+     * @param {function} SubView - constructor of SubView to show
+     * @param {function} ParentView - constructor of ParentView to show
+     * @param {object} [options] - options to pass to SubView &
+     *     ParentView constructors
+     * @returns {function} - a function that can be given to the router.
+     */
+    createSubViewHandler: createSubViewHandler
   });
 
   return Router;

--- a/app/scripts/views/app.js
+++ b/app/scripts/views/app.js
@@ -7,17 +7,21 @@
  */
 
 define([
+  'jquery',
+  'lib/promise',
   'views/base'
-], function (BaseView) {
+], function ($, p, BaseView) {
   'use strict';
 
   var AppView = BaseView.extend({
-    el: 'body',
-
     initialize: function (options) {
       options = options || {};
 
       this._environment = options.environment;
+      this._notifications = options.notifications;
+
+      this._notifications.on('show-view', this.showView.bind(this));
+      this._notifications.on('show-sub-view', this.showSubView.bind(this));
     },
 
     events: {
@@ -44,9 +48,121 @@ define([
         return;
       }
 
-      // Instruct Backbone to trigger routing events
       this.navigate(url);
+    },
+
+    _currentView: null,
+
+    /**
+     * Show a View. If the view is already displayed the view is not
+     * re-rendered. If the view is not displayed, the current view is
+     * replaced.
+     *
+     * @param {function} View - the View's constructor
+     * @param {object} options - options to pass to the constructor
+     */
+    showView: function (View, options) {
+      var self = this;
+
+      return p().then(function () {
+        var currentView = self._currentView;
+        if (currentView) {
+          if (currentView instanceof View) {
+            // if the View to display is the same as the current view, then
+            // the user is navigating from a subview back to the parent view.
+            // No need to re-render, but notify interested parties of the event.
+            self._notifications.trigger('navigate-from-subview', options);
+            self.setTitle(currentView.titleFromView());
+
+            return currentView;
+          }
+
+          currentView.destroy();
+        }
+
+        var viewToShow = new View(options);
+        self._currentView = viewToShow;
+
+        viewToShow.logScreen();
+        return viewToShow.render()
+          .then(function (isShown) {
+            // render will return false if the view could not be
+            // rendered for any reason, including if the view was
+            // automatically redirected.
+            if (! isShown) {
+              viewToShow.destroy();
+              self._currentView = null;
+
+              return p(null);
+            }
+
+            self.setTitle(viewToShow.titleFromView());
+
+            // Render the new view while stage is invisible then fade it in
+            // using css animations to catch problems with an explicit
+            // opacity rule after class is added.
+            $('#stage').html(viewToShow.el).addClass('fade-in-forward').css('opacity', 1);
+            viewToShow.afterVisible();
+
+            // The user may be scrolled part way down the page
+            // on screen transition. Force them to the top of the page.
+            self.window.scrollTo(0, 0);
+
+            $('#fox-logo').addClass('fade-in-forward').css('opacity', 1);
+
+            self._notifications.trigger('view-shown', viewToShow);
+
+            return viewToShow;
+          });
+      }).fail(function (err) {
+        // uh oh, bad jiji. There was an error somewhere, send the user to
+        // unexpected_error where the error will be logged.
+        return self.navigate('unexpected_error', {
+          error: err
+        });
+      });
+    },
+
+    /**
+     * Show a SubView
+     *
+     * @param {function} SubView - constructor of subview to show.
+     * @param {function} SuperView - constructor of the subview's parent.
+     * @param {object} options used to create the SuperView as well as
+     *        display the sub view.
+     */
+    showSubView: function (SubView, SuperView, options) {
+      var self = this;
+      // If currentView is of the SuperView type, simply show the subView
+      return p().then(function () {
+        if (! (self._currentView instanceof SuperView)) {
+          // Create the SuperView; its initialization method should
+          // handle the subView option.
+          return self.showView(SuperView, options);
+        }
+      })
+      .then(function () {
+        return self._currentView.showSubView(SubView, options);
+      })
+      .then(function (subView) {
+        // Use the super view's title as the base title
+        var title = subView.titleFromView(self._currentView.titleFromView());
+        self.setTitle(title);
+        subView.logScreen();
+
+        return subView;
+      });
+    },
+
+    /**
+     * Set the window's title
+     *
+     * @param {string} title
+     */
+    setTitle: function (title) {
+      this.window.document.title = title;
     }
+
   });
 
   return AppView;

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -60,7 +60,9 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
       this._able = options.able;
       this._subPanels = options.subPanels || this._initializeSubPanels(options);
       this._formPrefill = options.formPrefill;
-      this.router.on(this.router.NAVIGATE_FROM_SUBVIEW, this._onNavigateFromSubview.bind(this));
+      this._notifications = options.notifications;
+
+      this._notifications.on('navigate-from-subview', this._onNavigateFromSubview.bind(this));
     },
 
     _initializeSubPanels: function (options) {
@@ -83,6 +85,7 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
       return new SubPanels({
         initialSubView: options.subView,
         panelViews: panelViews,
+        parent: this,
         router: this.router
       });
     },

--- a/app/tests/mocks/router.js
+++ b/app/tests/mocks/router.js
@@ -15,8 +15,6 @@ define([
   }
 
   _.extend(RouterMock.prototype, Backbone.Events, {
-    NAVIGATE_FROM_SUBVIEW: 'navigate-from-subview',
-
     navigate: function (page, opts) {
       this.page = page;
       this.opts = opts;
@@ -27,18 +25,8 @@ define([
     getCurrentPage: function () {
     },
 
-    createView: function (View) {
-      return new View();
-    },
-
-    createSubView: function (View) {
-      return new View();
-    },
-
-    renderSubView: function () {
-    },
-
-    showSubView: function () {
+    getViewOptions: function (options) {
+      return _.extend({}, this.opts, options);
     }
   });
 

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -24,6 +24,7 @@ define([
   'models/auth_brokers/iframe',
   'models/auth_brokers/redirect',
   'models/auth_brokers/web-channel',
+  'models/notifications',
   'models/reliers/base',
   'models/reliers/sync',
   'models/reliers/oauth',
@@ -39,8 +40,8 @@ define([
 function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
   Url, OAuthErrors, AuthErrors, Storage, BaseBroker, FirstrunBroker,
   FxDesktopV1Broker, FxDesktopV2Broker, FxFennecV1Broker, FxiOSV1Broker,
-  IframeBroker, RedirectBroker, WebChannelBroker, BaseRelier, SyncRelier,
-  OAuthRelier, Relier, User, Metrics, StorageMetrics, WindowMock,
+  IframeBroker, RedirectBroker, WebChannelBroker, Notifications, BaseRelier,
+  SyncRelier, OAuthRelier, Relier, User, Metrics, StorageMetrics, WindowMock,
   RouterMock, HistoryMock, TestHelpers) {
   'use strict';
 
@@ -49,21 +50,23 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
   var HELLO_ORIGIN = 'https://hello.firefox.com';
 
   describe('lib/app-start', function () {
-    var windowMock;
-    var routerMock;
-    var historyMock;
-    var brokerMock;
-    var userMock;
     var appStart;
+    var brokerMock;
+    var historyMock;
+    var notifications;
+    var routerMock;
+    var userMock;
+    var windowMock;
 
     beforeEach(function () {
+      brokerMock = new BaseBroker();
+      historyMock = new HistoryMock();
+      notifications = new Notifications();
+      routerMock = new RouterMock();
+      userMock = new User();
+
       windowMock = new WindowMock();
       windowMock.parent = new WindowMock();
-
-      routerMock = new RouterMock();
-      historyMock = new HistoryMock();
-      userMock = new User();
-      brokerMock = new BaseBroker();
     });
 
     afterEach(function () {
@@ -490,6 +493,7 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
         appStart = new AppStart({
           broker: brokerMock,
           history: historyMock,
+          notifications: notifications,
           window: windowMock
         });
         appStart.useConfig({});

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -45,20 +45,20 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
   Cocktail.mixin(SettingsPanelView, SettingsPanelMixin);
 
   describe('views/settings', function () {
-    var view;
-    var routerMock;
+    var able;
+    var account;
     var formPrefill;
     var fxaClient;
-    var profileClient;
-    var relier;
-    var user;
-    var account;
+    var initialSubView;
     var metrics;
-    var able;
     var notifications;
     var panelViews;
-    var initialSubView;
+    var profileClient;
+    var relier;
+    var routerMock;
     var subPanels;
+    var user;
+    var view;
 
     var ACCESS_TOKEN = 'access token';
     var UID = 'uid';
@@ -211,15 +211,15 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
       });
 
       it('on navigate from subview', function () {
-        var spy1 = sinon.spy(view, 'showEphemeralMessages');
-        var spy2 = sinon.spy(view, 'logScreen');
+        sinon.spy(view, 'showEphemeralMessages');
+        sinon.spy(view, 'logScreen');
         sinon.stub($.modal, 'isActive', function () {
           return true;
         });
         sinon.stub($.modal, 'close', function () { });
-        routerMock.trigger(routerMock.NAVIGATE_FROM_SUBVIEW);
-        assert.isTrue(spy1.called);
-        assert.isTrue(spy2.called);
+        notifications.trigger('navigate-from-subview');
+        assert.isTrue(view.showEphemeralMessages.called);
+        assert.isTrue(view.logScreen.called);
         assert.isTrue($.modal.isActive.called);
         assert.isTrue($.modal.close.called);
         $.modal.isActive.restore();
@@ -487,6 +487,7 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
           assert.isTrue(SubPanels.prototype.initialize.calledWith({
             initialSubView: SettingsPanelView,
             panelViews: panelViews,
+            parent: view,
             router: routerMock
           }));
         });
@@ -503,6 +504,7 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
           assert.isTrue(SubPanels.prototype.initialize.calledWith({
             initialSubView: SettingsPanelView,
             panelViews: [SettingsPanelView],
+            parent: view,
             router: routerMock
           }));
         });
@@ -516,6 +518,7 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
           assert.isTrue(SubPanels.prototype.initialize.calledWith({
             initialSubView: SettingsPanelView,
             panelViews: [SettingsPanelView],
+            parent: view,
             router: routerMock
           }));
         });


### PR DESCRIPTION
Router was out of control. With the new AppView, it makes sense to have it
take care of drawing new Views and SubViews. SubView creation logic was moved
to sub_panels.js, the only place it's used. Not a complete removal of View
logic from router.js, but moving in the right direction.

@philbooth, your it!