### PR TITLE
fix(tests): Fix the communication preferences tests.

### DIFF
--- a/tests/functional/email_opt_in.js
+++ b/tests/functional/email_opt_in.js
@@ -141,6 +141,9 @@ define([
         // ensure the changes stick across refreshes
         .refresh()
 
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+
         .then(FunctionalHelpers.visibleByQSA('#communication-preferences .settings-unit-details'))
 
         .then(testOptedIn(self))
@@ -154,6 +157,9 @@ define([
 
         // ensure the opt-out sticks across refreshes
         .refresh()
+
+        .findByCssSelector('#fxa-settings-header')
+        .end()
 
         .findByCssSelector('#communication-preferences .settings-unit-toggle')
           .click()
@@ -210,6 +216,9 @@ define([
 
         // ensure the opt-in sticks across refreshes
         .refresh()
+
+        .findByCssSelector('#fxa-settings-header')
+        .end()
 
         .findByCssSelector('#communication-preferences .settings-unit-toggle')
           .click()


### PR DESCRIPTION
The tests were frequently stalling after a page refresh when it tried to click
on the communication preferences button. This adds
a `findByCssSelector('#fxa-settings-header')` after the page refresh and
through some Selenium magic, the problem goes away.

fixes #3176