### PR TITLE
fix(tests): Fix functional tests when run against a remote server.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -33,12 +33,21 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
 
   function displaySuccess(displayStrategy, msg) {
     this.hideError();
+    var $success = this.$('.success');
 
     if (msg) {
-      this.$('.success')[displayStrategy](this.translator.get(msg));
+      $success[displayStrategy](this.translator.get(msg));
     }
 
-    this.$('.success').slideDown(EPHEMERAL_MESSAGE_ANIMATION_MS);
+    // the 'data-shown' attribute value is added so the functional tests
+    // can find out if the success message was successfully shown, even
+    // if the element is then hidden. In the functional tests,
+    // testSuccessWasShown removes the attribute so multiple checks for the
+    // element can take place in the same test.
+    $success
+      .slideDown(EPHEMERAL_MESSAGE_ANIMATION_MS)
+      .attr('data-shown', 'true');
+
     this.trigger('success', msg);
     this._isSuccessVisible = true;
   }
@@ -58,11 +67,20 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
     this.logError(err);
     var translated = this.translateError(err);
 
+    var $error = this.$('.error');
     if (translated) {
-      this.$('.error')[displayStrategy](translated);
+      $error[displayStrategy](translated);
     }
 
-    this.$('.error').slideDown(EPHEMERAL_MESSAGE_ANIMATION_MS);
+    // the 'data-shown' attribute value is added so the functional tests
+    // can find out if the error message was successfully shown, even
+    // if the element is then hidden. In the functional tests,
+    // testErrorWasShown removes the attribute so multiple checks for the
+    // element can take place in the same test.
+    $error
+      .slideDown(EPHEMERAL_MESSAGE_ANIMATION_MS)
+      .attr('data-shown', 'true');
+
     this.trigger('error', translated);
 
     this._isErrorVisible = true;

--- a/app/scripts/views/legal_copy.js
+++ b/app/scripts/views/legal_copy.js
@@ -29,7 +29,9 @@ function (Cocktail, xhr, BaseView, BackMixin) {
         url: self.copyUrl
       })
       .then(function (template) {
-        self.$('#legal-copy').html(template);
+        var $legalCopy = self.$('#legal-copy');
+
+        $legalCopy.html(template);
 
         // data-visible-url is used to display the href in
         // brackets next to the original text.
@@ -52,6 +54,12 @@ function (Cocktail, xhr, BaseView, BackMixin) {
         });
 
         self.$('.hidden').removeClass('hidden');
+
+        // The `data-shown` attribute is searched for by the functional
+        // tests. The legal copy HTML has unstable markup, so the functional
+        // tests need some stable identifier to look for to know the copy is
+        // ready.
+        $legalCopy.attr('data-shown', 'true');
 
         // Set a session cookie that informs the server
         // the user can go back if they refresh the page.

--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -155,14 +155,7 @@ define([
           .click()
         .end()
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-
-        .findByCssSelector('.success')
-          .getVisibleText()
-          .then(function (val) {
-            assert.ok(val, 'has success text');
-          })
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         .then(testIsBrowserNotifiedOfAvatarChange(self))
 

--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -144,13 +144,7 @@ define([
         .findByCssSelector('#fxa-settings-header')
         .end()
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-
-        .findByClassName('success').isDisplayed()
-          .then(function (isDisplayed) {
-            assert.equal(isDisplayed, true);
-          })
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         .get(require.toUrl(SIGNIN_URL))
 
@@ -183,8 +177,7 @@ define([
         .closeCurrentWindow()
         .switchToWindow('')
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         // account is unlocked, re-try the password change
         .then(function () {
@@ -254,8 +247,7 @@ define([
           return FunctionalHelpers.openUnlockLinkDifferentBrowser(client, email, 'x-unlock-code');
         })
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         // account is unlocked, re-try the password change
         .then(function () {

--- a/tests/functional/complete_sign_up.js
+++ b/tests/functional/complete_sign_up.js
@@ -5,7 +5,6 @@
 define([
   'intern',
   'intern!object',
-  'intern/chai!assert',
   'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
@@ -13,7 +12,7 @@ define([
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest, FxaClient, Constants, restmail, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, require, nodeXMLHttpRequest, FxaClient, Constants, restmail, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
@@ -216,32 +215,19 @@ define([
               .click()
             .end()
 
-            .findByClassName('success')
-            .end()
-
-            .then(FunctionalHelpers.visibleByQSA('.success'))
-
-            // Success is showing the success message
-            .findByCssSelector('.success').isDisplayed()
-              .then(function (isDisplayed) {
-                assert.isTrue(isDisplayed);
-              })
-            .end()
+            .then(FunctionalHelpers.testSuccessWasShown(self))
 
             .findById('resend')
               .click()
-            .end()
-
-            .findById('resend')
               .click()
             .end()
 
             // Stills shows success message
-            .findByCssSelector('.success').isDisplayed()
-              .then(function (isDisplayed) {
-                assert.isTrue(isDisplayed);
-              })
-            .end();
+            //
+            // this uses .visibleByQSA instead of testSuccessWasShown because
+            // the element is not re-shown, but rather should continue to
+            // be visible.
+            .then(FunctionalHelpers.visibleByQSA('.success'));
         });
     }
   });

--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -75,16 +75,9 @@ define([
         .end()
 
         // the test below depends on the speed of the email resent XHR
-        // we have to wait until the resent request completes and the success notification is visible
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-
-        .then(function (result) {
-          assert.ok(result);
-        }, function (error) {
-          // success was never displayed
-          assert.fail(error);
-        })
-        .end();
+        // we have to wait until the resent request completes and the
+        // success notification is visible
+        .then(FunctionalHelpers.testSuccessWasShown(this));
     }
   });
 });

--- a/tests/functional/delete_account.js
+++ b/tests/functional/delete_account.js
@@ -135,8 +135,7 @@ define([
         .closeCurrentWindow()
         .switchToWindow('')
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         // account is unlocked, re-try the delete account
         .then(function () {
@@ -192,8 +191,7 @@ define([
           return FunctionalHelpers.openUnlockLinkDifferentBrowser(client, email, 'x-unlock-code');
         })
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         // account is unlocked, re-try the delete account
         .then(function () {

--- a/tests/functional/email_opt_in.js
+++ b/tests/functional/email_opt_in.js
@@ -152,8 +152,7 @@ define([
           .click()
         .end()
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         // ensure the opt-out sticks across refreshes
         .refresh()
@@ -207,8 +206,7 @@ define([
           .click()
         .end()
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         .then(function () {
           return waitForBasket(email);

--- a/tests/functional/legal.js
+++ b/tests/functional/legal.js
@@ -6,9 +6,8 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
-  'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, FunctionalHelpers) {
+  'tests/functional/lib/helpers',
+], function (intern, registerSuite, assert, FunctionalHelpers) {
   var url = intern.config.fxaContentRoot + 'legal';
 
   registerSuite({
@@ -16,9 +15,8 @@ define([
 
     'start at legal page': function () {
 
-      return this.remote
-        .get(require.toUrl(url))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+      return FunctionalHelpers.openPage(this, url, '#fxa-legal-header')
+
         .findByCssSelector('a[href="/legal/terms"]')
           .click()
         .end()
@@ -43,15 +41,11 @@ define([
 
     'start at terms page': function () {
 
-      return this.remote
-        .setFindTimeout(intern.config.pageLoadTimeout)
-        .get(require.toUrl(url + '/terms'))
+      return FunctionalHelpers.openPage(this, url + '/terms', '#fxa-tos-header')
 
-        .findByCssSelector('#main-content')
-        .end()
+        .then(FunctionalHelpers.visibleByQSA('#legal-copy[data-shown]'))
+        .findByCssSelector('#legal-copy[data-shown]')
 
-        .then(FunctionalHelpers.visibleByQSA('#legal-copy'))
-        .findById('legal-copy')
           .getVisibleText()
           .then(function (resultText) {
             // the legal text shouldn't be empty
@@ -62,15 +56,10 @@ define([
 
     'start at privacy page': function () {
 
-      return this.remote
-        .setFindTimeout(intern.config.pageLoadTimeout)
-        .get(require.toUrl(url + '/privacy'))
+      return FunctionalHelpers.openPage(this, url + '/privacy', '#fxa-pp-header')
 
-        .findByCssSelector('#main-content')
-        .end()
-
-        .then(FunctionalHelpers.visibleByQSA('#legal-copy'))
-        .findById('legal-copy')
+        .then(FunctionalHelpers.visibleByQSA('#legal-copy[data-shown]'))
+        .findByCssSelector('#legal-copy[data-shown]')
           .getVisibleText()
           .then(function (resultText) {
             // the legal text shouldn't be empty

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -694,6 +694,32 @@ define([
       });
   }
 
+  function testSuccessWasShown(context, selector) {
+    selector = selector || '.success[data-shown]';
+    return testElementWasShown(context, selector);
+  }
+
+  function testErrorWasShown(context, selector) {
+    selector = selector || '.error[data-shown]';
+    return testElementWasShown(context, selector);
+  }
+
+  function testElementWasShown(context, selector) {
+    return function () {
+      return context.remote
+        .findByCssSelector(selector)
+        .end()
+
+        .executeAsync(function (selector, done) {
+          // remove the attribute so subsequent checks can be made
+          // against the same element. displaySuccess and displayError
+          // will re-add the 'data-shown' attribute.
+          $(selector).removeAttr('data-shown');
+          done();
+        }, [selector]);
+    };
+  }
+
   return {
     clearBrowserState: clearBrowserState,
     clearSessionStorage: clearSessionStorage,
@@ -722,8 +748,10 @@ define([
     pollUntil: pollUntil,
     respondToWebChannelMessage: respondToWebChannelMessage,
     testAreEventsLogged: testAreEventsLogged,
+    testErrorWasShown: testErrorWasShown,
     testIsBrowserNotified: testIsBrowserNotified,
     testIsEventLogged: testIsEventLogged,
+    testSuccessWasShown: testSuccessWasShown,
     visibleByQSA: visibleByQSA
   };
 });

--- a/tests/functional/oauth_iframe.js
+++ b/tests/functional/oauth_iframe.js
@@ -420,7 +420,7 @@ define([
         .findByCssSelector('#fxa-signin-header')
         .end()
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         .findByCssSelector('#password')
           .type(PASSWORD)

--- a/tests/functional/oauth_webchannel.js
+++ b/tests/functional/oauth_webchannel.js
@@ -455,8 +455,7 @@ define([
         .findByCssSelector('#fxa-signin-header')
         .end()
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         .findByCssSelector('#password')
           .type(PASSWORD)

--- a/tests/functional/oauth_webchannel_keys.js
+++ b/tests/functional/oauth_webchannel_keys.js
@@ -393,8 +393,7 @@ define([
         .findByCssSelector('#fxa-signin-header')
         .end()
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         .findByCssSelector('#password')
           .type(PASSWORD)

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -82,20 +82,6 @@ define([
       .setFindTimeout(intern.config.pageLoadTimeout);
   }
 
-  function testSuccessMessageVisible(context, message) {
-    return context.remote
-      .setFindTimeout(intern.config.pageLoadTimeout)
-
-      .then(FunctionalHelpers.visibleByQSA('.success'))
-      .findByCssSelector('.success')
-        .getVisibleText()
-        .then(function (text) {
-          var searchFor = new RegExp(message, 'i');
-          assert.isTrue(searchFor.test(text));
-        })
-      .end();
-  }
-
   function testAtSettingsWithVerifiedMessage(context) {
     return context.remote
       .setFindTimeout(intern.config.pageLoadTimeout)
@@ -112,9 +98,7 @@ define([
       })
       .end()
 
-      .then(function () {
-        return testSuccessMessageVisible(context, 'verified');
-      });
+      .then(FunctionalHelpers.testSuccessWasShown(context));
   }
 
   registerSuite({
@@ -242,20 +226,19 @@ define([
         .then(restmail(EMAIL_SERVER_ROOT + '/mail/' + user, 2))
 
         // Success is showing the success message
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(this))
 
         .findById('resend')
           .click()
-        .end()
-
-        .findById('resend')
           .click()
         .end()
 
         // Stills shows success message
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end();
+        //
+        // this uses .visibleByQSA instead of testSuccessWasShown because
+        // the element is not re-shown, but rather should continue to
+        // be visible.
+        .then(FunctionalHelpers.visibleByQSA('.success'));
     },
 
     'open complete page with missing token shows damaged screen': function () {
@@ -455,9 +438,7 @@ define([
         .findByCssSelector('#fxa-signin-header')
         .end()
 
-        .then(function () {
-          return testSuccessMessageVisible(self, 'reset');
-        })
+        .then(FunctionalHelpers.testSuccessWasShown(self))
 
         .findByCssSelector('#password')
           .type(PASSWORD)
@@ -545,8 +526,7 @@ define([
             .findByCssSelector('#fxa-settings-header')
             .end()
 
-            .then(FunctionalHelpers.visibleByQSA('.success'))
-            .end()
+            .then(FunctionalHelpers.testSuccessWasShown(self))
 
             .findByCssSelector('#signout')
               .click()

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -42,17 +42,6 @@ define([
       .end();
   }
 
-  function testVerifiedMessageVisible(context) {
-    return context.remote
-      .then(FunctionalHelpers.visibleByQSA('.success'))
-      .findByCssSelector('.success')
-        .getVisibleText()
-        .then(function (text) {
-          assert.ok(/verified/i.test(text));
-        })
-      .end();
-  }
-
   registerSuite({
     name: 'sign_up',
 
@@ -82,9 +71,7 @@ define([
         .findByCssSelector('#fxa-settings-header')
         .end()
 
-        .then(function () {
-          return testVerifiedMessageVisible(self);
-        })
+        .then(FunctionalHelpers.testSuccessWasShown(this))
 
         .closeCurrentWindow()
 
@@ -92,9 +79,7 @@ define([
         .switchToWindow('')
         .end()
 
-        .then(function () {
-          return testVerifiedMessageVisible(self);
-        });
+        .then(FunctionalHelpers.testSuccessWasShown(this));
     },
 
     'sign up, verify same browser with original tab closed': function () {
@@ -114,9 +99,7 @@ define([
         .findByCssSelector('#fxa-settings-header')
         .end()
 
-        .then(function () {
-          return testVerifiedMessageVisible(self);
-        })
+        .then(FunctionalHelpers.testSuccessWasShown(this))
 
         .closeCurrentWindow()
 
@@ -142,9 +125,7 @@ define([
         .findByCssSelector('#fxa-settings-header')
         .end()
 
-        .then(function () {
-          return testVerifiedMessageVisible(self);
-        });
+        .then(FunctionalHelpers.testSuccessWasShown(this));
     },
 
     'signup, verify different browser - from original tab\'s P.O.V.': function () {
@@ -163,9 +144,7 @@ define([
         .findByCssSelector('#fxa-settings-header')
         .end()
 
-        .then(function () {
-          return testVerifiedMessageVisible(self);
-        });
+        .then(FunctionalHelpers.testSuccessWasShown(this));
     },
 
     'signup, verify different browser - from new browser\'s P.O.V.': function () {

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -105,8 +105,7 @@ define([
         .switchToWindow('')
         .end()
 
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(this))
 
         .then(function () {
           return testIsBrowserNotifiedOfLogin(self, email, { checkVerified: true });
@@ -214,10 +213,7 @@ define([
         .findByCssSelector('#fxa-signin-header')
         .end()
 
-        // user verified in a new browser, they have to enter
-        // their updated credentials in the original tab.
-        .then(FunctionalHelpers.visibleByQSA('.success'))
-        .end()
+        .then(FunctionalHelpers.testSuccessWasShown(this))
 
         .findByCssSelector('#password')
           .type(PASSWORD)


### PR DESCRIPTION
* The `.success` and `.error` messages on the `/settings` page are hidden after
  a short period. This caused the functional tests to frequently fail when
  looking for the .success message. Instead of checking whether the .success
  and `.error` messages are still visible, check if they *were visible*. The
  client code will add a `[data-shown]` attribute to the elements. This
  attribute is searched for by the functional tests, and then removed, so
  subsequent messages can be displayed and checked for in the same test.
* The legal pages load their content using XHR requests, which can take time.
  The tests were sometimes failing because the `#legal-copy` contents were
  empty. The new sequence is add a `[data-shown]` attribute to `#legal-copy`
  after the contents are written, and search for the `data-shown` attribute in
  the functional tests.

fixes #3174
fixes #3182