### PR TITLE
fix(metrics): Fix the refresh metrics when refreshing a settings subpanel.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -61,6 +61,7 @@ define([
   'models/user',
   'models/form-prefill',
   'models/notifications',
+  'models/refresh-observer',
   'views/app',
   'views/close_button'
 ],
@@ -110,6 +111,7 @@ function (
   User,
   FormPrefill,
   Notifications,
+  RefreshObserver,
   AppView,
   CloseButtonView
 ) {
@@ -122,6 +124,7 @@ function (
     this._configLoader = new ConfigLoader();
     this._history = options.history || Backbone.history;
     this._notifications = options.notifications;
+    this._refreshObserver = options.refreshObserver;
     this._relier = options.relier;
     this._router = options.router;
     this._storage = options.storage || Storage;
@@ -223,6 +226,8 @@ function (
                     .then(_.bind(this.initializeFormPrefill, this))
                     // depends on iframeChannel and interTabChannel
                     .then(_.bind(this.initializeNotifications, this))
+                    // depends on notifications, metrics
+                    .then(_.bind(this.initializeRefreshObserver, this))
                     // router depends on all of the above
                     .then(_.bind(this.initializeRouter, this))
                     // appView depends on the router
@@ -536,6 +541,16 @@ function (
           iframeChannel: this._iframeChannel,
           tabChannel: this._interTabChannel,
           webChannel: notificationWebChannel
+        });
+      }
+    },
+
+    initializeRefreshObserver: function () {
+      if (! this._refreshObserver) {
+        this._refreshObserver = new RefreshObserver({
+          metrics: this._metrics,
+          notifications: this._notifications,
+          window: this._window
         });
       }
     },

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -337,6 +337,21 @@ define([
     },
 
     /**
+     * Log an event with the screen name as a prefix
+     *
+     * @param {string} screenName
+     * @param {string} eventName
+     */
+    logScreenEvent: function (screenName, eventName) {
+      var event = Strings.interpolate('%(screenName)s.%(eventName)s', {
+        eventName: eventName,
+        screenName: screenName,
+      });
+
+      this.logEvent(event);
+    },
+
+    /**
      * Convert a screenName an identifier
      */
     screenToId: function (screenName) {

--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -153,7 +153,6 @@ function (
       this.window = options.window || window;
 
       this.notifications.once('view-shown', this._afterFirstViewHasRendered.bind(this));
-      this.notifications.on('view-shown', this._checkForRefresh.bind(this));
 
       this.storage = Storage.factory('sessionStorage', this.window);
     },
@@ -226,22 +225,6 @@ function (
       }, options || {});
 
       return viewOptions;
-    },
-
-    _checkForRefresh: function (currentView) {
-      var refreshMetrics = this.storage.get('last_page_loaded');
-      var screenName = currentView.getScreenName();
-
-      if (refreshMetrics && refreshMetrics.view === screenName && this.metrics) {
-        currentView.logScreenEvent('refresh');
-      }
-
-      refreshMetrics = {
-        timestamp: Date.now(),
-        view: screenName
-      };
-
-      this.storage.set('last_page_loaded', refreshMetrics);
     },
 
     _afterFirstViewHasRendered: function () {

--- a/app/scripts/models/refresh-observer.js
+++ b/app/scripts/models/refresh-observer.js
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Watch for page refreshes.
+ *
+ * Listen for `show-view` and `show-sub-view` messages and check if the user
+ * has refreshed the page. If so, a `<view_name>.refresh` event is
+ * logged to metrics.
+ */
+
+define([
+  'backbone',
+  'lib/storage'
+], function (Backbone, Storage) {
+  'use strict';
+
+  function isRefresh (refreshMetrics, screenName) {
+    return refreshMetrics && refreshMetrics.view === screenName;
+  }
+
+  return Backbone.Model.extend({
+    initialize: function (options) {
+      options = options || {};
+
+      this._metrics = options.metrics;
+      this._notifications = options.notifications;
+      this._window = options.window || window;
+
+      this._storage = Storage.factory('sessionStorage', this._window);
+
+      this._notifications.on('show-view', this._onShowView.bind(this));
+      this._notifications.on('show-sub-view', this._onShowSubView.bind(this));
+    },
+
+    _onShowView: function (View, viewOptions) {
+      this.logIfRefresh(viewOptions.screenName);
+    },
+
+    _onShowSubView: function (SubView, ParentView, viewOptions) {
+      this.logIfRefresh(viewOptions.screenName);
+    },
+
+    /**
+     * Log a `<screen_name>.refresh` event if `screenName` matches the
+     * previous screen name. This works across page reloads.
+     *
+     * @param {string} screenName
+     */
+    logIfRefresh: function (screenName) {
+      var refreshMetrics = this._storage.get('last_page_loaded');
+
+      if (isRefresh(refreshMetrics, screenName)) {
+        this._metrics.logScreenEvent(screenName, 'refresh');
+      }
+
+      refreshMetrics = {
+        timestamp: Date.now(),
+        view: screenName
+      };
+
+      this._storage.set('last_page_loaded', refreshMetrics);
+    }
+  });
+});

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -10,13 +10,12 @@ define([
   'jquery',
   'lib/promise',
   'lib/auth-errors',
-  'lib/strings',
   'lib/ephemeral-messages',
   'lib/null-metrics',
   'views/mixins/timer-mixin'
 ],
 function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
-      Strings, EphemeralMessages, NullMetrics, TimerMixin) {
+      EphemeralMessages, NullMetrics, TimerMixin) {
   'use strict';
 
   var DEFAULT_TITLE = window.document.title;
@@ -611,14 +610,11 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
 
     /**
      * Log an event with the screen name as a prefix
+     *
+     * @param {string} eventName
      */
     logScreenEvent: function (eventName) {
-      var event = Strings.interpolate('%(screenName)s.%(eventName)s', {
-        eventName: eventName,
-        screenName: this.getScreenName()
-      });
-
-      this.metrics.logEvent(event);
+      this.metrics.logScreenEvent(this.getScreenName(), eventName);
     },
 
     hideError: function () {

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -25,6 +25,7 @@ define([
   'models/auth_brokers/redirect',
   'models/auth_brokers/web-channel',
   'models/notifications',
+  'models/refresh-observer',
   'models/reliers/base',
   'models/reliers/sync',
   'models/reliers/oauth',
@@ -40,9 +41,9 @@ define([
 function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
   Url, OAuthErrors, AuthErrors, Storage, BaseBroker, FirstrunBroker,
   FxDesktopV1Broker, FxDesktopV2Broker, FxFennecV1Broker, FxiOSV1Broker,
-  IframeBroker, RedirectBroker, WebChannelBroker, Notifications, BaseRelier,
-  SyncRelier, OAuthRelier, Relier, User, Metrics, StorageMetrics, WindowMock,
-  RouterMock, HistoryMock, TestHelpers) {
+  IframeBroker, RedirectBroker, WebChannelBroker, Notifications,
+  RefreshObserver, BaseRelier, SyncRelier, OAuthRelier, Relier, User,
+  Metrics, StorageMetrics, WindowMock, RouterMock, HistoryMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -705,6 +706,20 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
         };
 
         appStart.initializeHeightObserver();
+      });
+    });
+
+    describe('initializeRefreshObserver', function () {
+      beforeEach(function () {
+        appStart = new AppStart({
+          notifications: notifications,
+          window: windowMock
+        });
+      });
+
+      it('creates a RefreshObserver instance', function () {
+        appStart.initializeRefreshObserver();
+        assert.instanceOf(appStart._refreshObserver, RefreshObserver);
       });
     });
 

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -552,6 +552,16 @@ function (chai, $, p, Metrics, AuthErrors, Environment, sinon, _, WindowMock, Te
       });
     });
 
+    describe('logScreenEvent', function () {
+      beforeEach(function () {
+        metrics.logScreenEvent('screen', 'event1');
+      });
+
+      it('logs an event with the screen name as a prefix to the event stream', function () {
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen.event1'));
+      });
+    });
+
     describe('setBrokerType', function () {
       it('sets the broker name', function () {
         metrics.setBrokerType('fx-desktop-v2');

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -9,7 +9,6 @@ define([
   'lib/router',
   'views/base',
   'views/settings/display_name',
-  'views/sign_in',
   'views/settings',
   'lib/able',
   'lib/constants',
@@ -24,9 +23,8 @@ define([
   '../../lib/helpers'
 ],
 function (chai, sinon, Backbone, Router, BaseView, DisplayNameView,
-  SignInView, SettingsView, Able, Constants, Environment, Metrics,
-  Notifications, Relier, User, FormPrefill, NullBroker, WindowMock,
-  TestHelpers) {
+  SettingsView, Able, Constants, Environment, Metrics, Notifications,
+  Relier, User, FormPrefill, NullBroker, WindowMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -147,32 +145,6 @@ function (chai, sinon, Backbone, Router, BaseView, DisplayNameView,
         router.redirectToBestOAuthChoice();
         assert.equal(navigateUrl, '/oauth/signin');
         assert.deepEqual(navigateOptions, { replace: true, trigger: true });
-      });
-    });
-
-    describe('_checkForRefresh', function () {
-      var view;
-      before(function () {
-        view = new SignInView({
-          broker: broker,
-          formPrefill: formPrefill,
-          metrics: metrics,
-          relier: relier,
-          router: router,
-          screenName: 'signin',
-          user: user,
-          window: windowMock
-        });
-
-        sinon.spy(view, 'logScreenEvent');
-      });
-
-      it('logs a `refresh` if the same view is displayed twice in a row', function () {
-        router._checkForRefresh(view);
-        assert.isFalse(view.logScreenEvent.calledWith('refresh'));
-
-        router._checkForRefresh(view);
-        assert.isTrue(view.logScreenEvent.calledWith('refresh'));
       });
     });
 

--- a/app/tests/spec/models/refresh-observer.js
+++ b/app/tests/spec/models/refresh-observer.js
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'lib/metrics',
+  '../../mocks/window',
+  'models/notifications',
+  'models/refresh-observer',
+  'sinon'
+],
+function (chai, Metrics, WindowMock, Notifications, RefreshObserver, sinon) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  describe('models/refresh-observer', function () {
+    var metrics;
+    var notifications;
+    var refreshObserver;
+    var windowMock;
+
+    var ViewMock = function () {};
+
+    function createDeps () {
+      metrics = new Metrics();
+      notifications = new Notifications();
+      windowMock = new WindowMock();
+
+      refreshObserver = new RefreshObserver({
+        metrics: metrics,
+        notifications: notifications,
+        window: windowMock
+      });
+    }
+
+    beforeEach(function () {
+      createDeps();
+    });
+
+    describe('logIfRefresh', function () {
+      beforeEach(function () {
+        sinon.spy(metrics, 'logScreenEvent');
+      });
+
+      describe('with two consecutive views with different names', function () {
+        beforeEach(function () {
+          refreshObserver.logIfRefresh('screen1');
+          refreshObserver.logIfRefresh('screen2');
+        });
+
+        it('does not log a page refresh', function () {
+          assert.isFalse(metrics.logScreenEvent.called);
+        });
+      });
+
+      describe('with two consecutive views with the same name', function () {
+        beforeEach(function () {
+          refreshObserver.logIfRefresh('screen1');
+          refreshObserver.logIfRefresh('screen1');
+        });
+
+        it('logs a page refresh', function () {
+          assert.isTrue(
+              metrics.logScreenEvent.calledWith('screen1', 'refresh'));
+        });
+      });
+    });
+
+    describe('notifications', function () {
+      beforeEach(function () {
+        sinon.spy(refreshObserver, 'logIfRefresh');
+      });
+
+      describe('show-view', function () {
+        beforeEach(function () {
+          notifications.trigger('show-view', ViewMock, { screenName: 'screen1' });
+        });
+
+        it('calls `logIfRefresh', function () {
+          assert.isTrue(refreshObserver.logIfRefresh.calledWith('screen1'));
+        });
+      });
+
+      describe('show-sub-view', function () {
+        beforeEach(function () {
+          notifications.trigger('show-sub-view', ViewMock, ViewMock, { screenName: 'screen1' });
+        });
+
+        it('calls `logIfRefresh', function () {
+          assert.isTrue(refreshObserver.logIfRefresh.calledWith('screen1'));
+        });
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -589,6 +589,16 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
       });
     });
 
+    describe('logScreenEvent', function () {
+      beforeEach(function () {
+        view.logScreenEvent('event1');
+      });
+
+      it('logs an event with the screen name as a prefix to the event stream', function () {
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen.event1'));
+      });
+    });
+
     describe('logError', function () {
       it('logs an error to the event stream', function () {
         var err = AuthErrors.toError('INVALID_TOKEN', screenName);

--- a/app/tests/spec/views/mixins/password-strength-mixin.js
+++ b/app/tests/spec/views/mixins/password-strength-mixin.js
@@ -40,7 +40,7 @@ define([
             isCollectionEnabled: function () {
               return true;
             },
-            logEvent: sinon.spy()
+            logScreenEvent: sinon.spy()
           },
           user: {
             get: function () {

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -139,6 +139,7 @@ function (Translator, Session) {
     '../tests/spec/models/marketing-email-prefs',
     '../tests/spec/models/notifications',
     '../tests/spec/models/oauth-token',
+    '../tests/spec/models/refresh-observer',
     '../tests/spec/models/resume-token',
     '../tests/spec/models/mixins/resume-token',
     '../tests/spec/models/mixins/search-param',


### PR DESCRIPTION
Create the `PageRefreshWatch` model that listens for `show-view`
and `show-sub-view` messages, where a screen name is passed that
can be used to check for refreshes.

fixes #3172

@philbooth - Furthering the cause to split up the router, plus fixing a bug. Mind an r?