### PR TITLE
fix(client): Ensure `/signin` is visible when users sign out after verification

### DIFF
--- a/app/scripts/views/app.js
+++ b/app/scripts/views/app.js
@@ -91,7 +91,15 @@ define([
             // automatically redirected.
             if (! isShown) {
               viewToShow.destroy();
-              self._currentView = null;
+
+              // If viewToShow calls `navigate` in its `beforeRender` function,
+              // the new view will be created and self._currentView will
+              // reference the second view before the first view's render
+              // promise chain completes. Ensure self._currentView is the same
+              // as viewToShow before destroying the reference. Ref #3187
+              if (viewToShow === self._currentView) {
+                self._currentView = null;
+              }
 
               return p(null);
             }

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -82,7 +82,7 @@ define([
         .then(FunctionalHelpers.testSuccessWasShown(this));
     },
 
-    'sign up, verify same browser with original tab closed': function () {
+    'sign up, verify same browser with original tab closed, sign out': function () {
       var self = this;
       return fillOutSignUp(this, email, PASSWORD, OLD_ENOUGH_YEAR)
         .then(function () {
@@ -100,6 +100,21 @@ define([
         .end()
 
         .then(FunctionalHelpers.testSuccessWasShown(this))
+
+        // Ref https://github.com/mozilla/fxa-content-server/issues/3187
+        // Ensure the signin screen shows if the user signs out after
+        // verification.
+        .findByCssSelector('#signout')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        // `visibleByQSA` is used to ensure visibility. With the bug in #3187
+        // referenced above, the signin screen is drawn, but invisible
+        .then(FunctionalHelpers.visibleByQSA('#fxa-signin-header'))
+        .end()
 
         .closeCurrentWindow()
 


### PR DESCRIPTION
In views/app.js->render:
If `viewToShow` calls `navigate` in its `beforeRender` function,
a new view will be created and `self._currentView` will
reference the second view before the first view's `render`
promise chain completes. Ensure `self._currentView` is the same
as `viewToShow` before destroying the reference.

fixes #3187

@philbooth - r?