### PR TITLE
feat(client): notify other tabs of successful sign in/out

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -77,7 +77,12 @@ define([], function () {
     ACCESS_TYPE_ONLINE: 'online',
     ACCESS_TYPE_OFFLINE: 'offline',
 
-    DEFAULT_XHR_TIMEOUT_MS: 2500
+    DEFAULT_XHR_TIMEOUT_MS: 2500,
+
+    EVENTS: {
+      SIGNIN_SUCCESS: 'signin.success',
+      SIGNOUT_SUCCESS: 'signout.success'
+    }
   };
   /*eslint-enable sorting/sort-object-props*/
 });

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -267,6 +267,10 @@ define([
        */
       emailVerificationMarketingSnippet: true,
       /**
+       * Should the view try to synchronise sign-in state across tabs?
+       */
+      interTabSignIn: true,
+      /**
        * Is signup supported? the fx_ios_v1 broker can disable it.
        */
       signup: true,

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -61,6 +61,12 @@ function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
       afterSignIn: new HaltBehavior()
     }),
 
+    defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
+      // Disable inter-tab sign-in for OAuth due to the potential for unintended
+      // consequences from redirecting to a relier URL more than once.
+      interTabSignIn: false
+    }),
+
     initialize: function (options) {
       options = options || {};
 

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -9,6 +9,7 @@ define([
   'stache!templates/complete_sign_up',
   'lib/auth-errors',
   'views/mixins/experiment-mixin',
+  'views/mixins/inter-tab-channel-mixin',
   'views/mixins/resend-mixin',
   'views/mixins/loading-mixin',
   'views/mixins/resume-token-mixin',
@@ -16,12 +17,13 @@ define([
   'lib/url',
   'lib/constants'
 ],
-function (Cocktail, FormView, BaseView, CompleteSignUpTemplate,
-  AuthErrors, ExperimentMixin, ResendMixin, LoadingMixin, ResumeTokenMixin, VerificationInfo,
-  Url, Constants) {
+function (Cocktail, FormView, BaseView, CompleteSignUpTemplate, AuthErrors,
+  ExperimentMixin, InterTabChannelMixin, ResendMixin, LoadingMixin,
+  ResumeTokenMixin, VerificationInfo, Url, Constants) {
   'use strict';
 
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;
+  var EVENTS = Constants.EVENTS;
   var t = BaseView.t;
 
   var CompleteSignUpView = FormView.extend({
@@ -94,9 +96,11 @@ function (Cocktail, FormView, BaseView, CompleteSignUpTemplate,
               return false;
             }
 
-            return self.getAccount().isSignedIn()
+            var account = self.getAccount();
+            return account.isSignedIn()
               .then(function (isSignedIn) {
                 if (isSignedIn) {
+                  self.interTabSend(EVENTS.SIGNIN_SUCCESS, account);
                   self.navigate('settings', {
                     success: t('Account verified successfully')
                   });
@@ -189,6 +193,7 @@ function (Cocktail, FormView, BaseView, CompleteSignUpTemplate,
   Cocktail.mixin(
     CompleteSignUpView,
     ExperimentMixin,
+    InterTabChannelMixin,
     LoadingMixin,
     ResendMixin,
     ResumeTokenMixin

--- a/app/scripts/views/mixins/inter-tab-signin-mixin.js
+++ b/app/scripts/views/mixins/inter-tab-signin-mixin.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'cocktail',
+  'lib/constants',
+  'lib/promise',
+  'views/mixins/inter-tab-channel-mixin'
+],
+function (Cocktail, Constants, p, InterTabChannelMixin) {
+  'use strict';
+
+  var EVENTS = Constants.EVENTS;
+
+  return Cocktail.mixin({
+    afterVisible: function () {
+      this.navigateToSignedInView = navigateToSignedInView.bind(this);
+      this.interTabOn(EVENTS.SIGNIN_SUCCESS, this.navigateToSignedInView);
+    },
+
+    onSignInSuccess: function (account) {
+      this.interTabOff(EVENTS.SIGNIN_SUCCESS, this.navigateToSignedInView);
+      this.interTabSend(EVENTS.SIGNIN_SUCCESS, account);
+    }
+  }, InterTabChannelMixin);
+
+  function navigateToSignedInView (event) {
+    if (this.broker.hasCapability('interTabSignIn')) {
+      var self = this;
+      return this.user.setSignedInAccount(event.data)
+        .then(function () {
+          self.navigate(self._redirectTo || 'settings');
+        });
+    }
+
+    return p();
+  }
+});

--- a/app/scripts/views/mixins/inter-tab-signout-mixin.js
+++ b/app/scripts/views/mixins/inter-tab-signout-mixin.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'cocktail',
+  'lib/constants',
+  'lib/session',
+  'views/base',
+  'views/mixins/inter-tab-channel-mixin'
+],
+function (Cocktail, Constants, Session, BaseView, InterTabChannelMixin) {
+  'use strict';
+
+  var EVENTS = Constants.EVENTS;
+  var t = BaseView.t;
+
+  return Cocktail.mixin({
+    afterVisible: function () {
+      this.clearSessionAndNavigateToSignIn = clearSessionAndNavigateToSignIn.bind(this);
+      this.interTabOn(EVENTS.SIGNOUT_SUCCESS, this.clearSessionAndNavigateToSignIn);
+    },
+
+    onSignOutSuccess: function () {
+      this.interTabOff(EVENTS.SIGNOUT_SUCCESS, this.clearSessionAndNavigateToSignIn);
+      this.interTabSend(EVENTS.SIGNOUT_SUCCESS);
+      this.clearSessionAndNavigateToSignIn();
+    }
+  }, InterTabChannelMixin);
+
+  function clearSessionAndNavigateToSignIn () {
+    this.logScreenEvent(EVENTS.SIGNOUT_SUCCESS);
+    this.user.removeAllAccounts();
+    this._formPrefill.clear();
+    Session.clear();
+    this.navigate('signin', {
+      success: t('Signed out successfully')
+    });
+  }
+});

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -7,9 +7,9 @@ define([
   'jquery',
   'modal',
   'cocktail',
-  'lib/session',
   'views/base',
   'views/mixins/avatar-mixin',
+  'views/mixins/inter-tab-signout-mixin',
   'views/settings/avatar',
   'views/settings/avatar_change',
   'views/settings/avatar_crop',
@@ -26,14 +26,12 @@ define([
   'views/decorators/allow_only_one_submit',
   'stache!templates/settings'
 ],
-function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
+function ($, modal, Cocktail, BaseView, AvatarMixin, InterTabSignoutMixin,
   AvatarView, AvatarChangeView, AvatarCropView, AvatarCameraView, GravatarView,
   GravatarPermissionsView, CommunicationPreferencesView, ChangePasswordView,
   DeleteAccountView, DisplayNameView, SubPanels, SettingsMixin, LoadingMixin,
   allowOnlyOneSubmit, Template) {
   'use strict';
-
-  var t = BaseView.t;
 
   var PANEL_VIEWS = [
     AvatarView,
@@ -205,17 +203,7 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
           self.logScreenEvent('signout.error');
         })
         .fin(function () {
-          self.logScreenEvent('signout.success');
-          self.user.clearSignedInAccount();
-          // The user has manually signed out, a pretty strong indicator
-          // the user does not want any of their information pre-filled
-          // on the signin page. Clear any remaining formPrefill info
-          // to ensure their data isn't sticking around in memory.
-          self._formPrefill.clear();
-          Session.clear();
-          self.navigate('signin', {
-            success: t('Signed out successfully')
-          });
+          self.onSignOutSuccess();
         });
     }),
 
@@ -243,6 +231,7 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
   Cocktail.mixin(
     View,
     AvatarMixin,
+    InterTabSignoutMixin,
     LoadingMixin,
     SettingsMixin
   );

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -4,26 +4,27 @@
 
 define([
   'cocktail',
+  'lib/auth-errors',
   'lib/promise',
+  'lib/session',
+  'stache!templates/sign_in',
   'views/base',
   'views/form',
-  'stache!templates/sign_in',
-  'lib/session',
-  'lib/auth-errors',
+  'views/decorators/allow_only_one_submit',
+  'views/decorators/progress_indicator',
+  'views/mixins/avatar-mixin',
+  'views/mixins/account-locked-mixin',
+  'views/mixins/inter-tab-signin-mixin',
+  'views/mixins/migration-mixin',
   'views/mixins/password-mixin',
   'views/mixins/resume-token-mixin',
   'views/mixins/service-mixin',
-  'views/mixins/signup-disabled-mixin',
-  'views/mixins/avatar-mixin',
-  'views/mixins/account-locked-mixin',
-  'views/mixins/migration-mixin',
-  'views/decorators/allow_only_one_submit',
-  'views/decorators/progress_indicator'
+  'views/mixins/signup-disabled-mixin'
 ],
-function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
-  AuthErrors, PasswordMixin, ResumeTokenMixin, ServiceMixin,
-  SignupDisabledMixin, AvatarMixin, AccountLockedMixin, MigrationMixin,
-  allowOnlyOneSubmit, showProgressIndicator) {
+function (Cocktail, AuthErrors, p, Session, SignInTemplate, BaseView, FormView,
+  allowOnlyOneSubmit, showProgressIndicator, AvatarMixin, AccountLockedMixin,
+  InterTabSignInMixin, MigrationMixin, PasswordMixin, ResumeTokenMixin,
+  ServiceMixin, SignupDisabledMixin) {
 
   'use strict';
 
@@ -302,6 +303,7 @@ function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
     View,
     AccountLockedMixin,
     AvatarMixin,
+    InterTabSignInMixin,
     MigrationMixin,
     PasswordMixin,
     ResumeTokenMixin,

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -3,28 +3,29 @@
 
 define([
   'cocktail',
-  'lib/promise',
-  'views/base',
-  'views/form',
-  'stache!templates/sign_up',
   'lib/auth-errors',
   'lib/mailcheck',
+  'lib/promise',
+  'stache!templates/sign_up',
+  'views/base',
+  'views/form',
+  'views/coppa/coppa-date-picker',
+  'views/coppa/coppa-age-input',
+  'views/mixins/checkbox-mixin',
   'views/mixins/experiment-mixin',
+  'views/mixins/inter-tab-signin-mixin',
+  'views/mixins/migration-mixin',
   'views/mixins/password-mixin',
   'views/mixins/password-strength-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/checkbox-mixin',
   'views/mixins/resume-token-mixin',
-  'views/mixins/migration-mixin',
+  'views/mixins/service-mixin',
   'views/mixins/signup-disabled-mixin',
-  'views/mixins/signup-success-mixin',
-  'views/coppa/coppa-date-picker',
-  'views/coppa/coppa-age-input'
+  'views/mixins/signup-success-mixin'
 ],
-function (Cocktail, p, BaseView, FormView, Template, AuthErrors, mailcheck,
-  ExperimentMixin, PasswordMixin, PasswordStrengthMixin, ServiceMixin,
-  CheckboxMixin, ResumeTokenMixin, MigrationMixin, SignupDisabledMixin,
-  SignupSuccessMixin, CoppaDatePicker, CoppaAgeInput) {
+function (Cocktail, AuthErrors, mailcheck, p, Template, BaseView, FormView,
+  CoppaDatePicker, CoppaAgeInput, CheckboxMixin, ExperimentMixin,
+  InterTabSignInMixin, MigrationMixin, PasswordMixin, PasswordStrengthMixin,
+  ResumeTokenMixin, ServiceMixin, SignupDisabledMixin, SignupSuccessMixin) {
   'use strict';
 
   var t = BaseView.t;
@@ -326,6 +327,7 @@ function (Cocktail, p, BaseView, FormView, Template, AuthErrors, mailcheck,
 
           if (preVerifyToken && account.get('verified')) {
             self.logScreenEvent('preverified.success');
+            self.onSignInSuccess();
           }
           self.logScreenEvent('success');
           return self.invokeBrokerMethod('afterSignUp', account);
@@ -367,6 +369,7 @@ function (Cocktail, p, BaseView, FormView, Template, AuthErrors, mailcheck,
     View,
     CheckboxMixin,
     ExperimentMixin,
+    InterTabSignInMixin,
     MigrationMixin,
     PasswordMixin,
     PasswordStrengthMixin,

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -21,7 +21,7 @@ function (chai, Relier, BaseAuthenticationBroker,
     var view;
     var windowMock;
 
-    beforeEach(function () {
+    before(function () {
       view = new BaseView();
       windowMock = new WindowMock();
       relier = new Relier();
@@ -196,6 +196,18 @@ function (chai, Relier, BaseAuthenticationBroker,
 
         it('returns `true` for `signup` by default', function () {
           assert.isTrue(broker.hasCapability('signup'));
+        });
+
+        it('returns `true` for `interTabSignIn` by default', function () {
+          assert.isTrue(broker.hasCapability('interTabSignIn'));
+        });
+
+        it('returns `true` for `emailVerificationMarketingSnippet` by default', function () {
+          assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+        });
+
+        it('returns `false` for `syncPreferencesNotification` by default', function () {
+          assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
         });
       });
 

--- a/app/tests/spec/models/auth_brokers/first-run.js
+++ b/app/tests/spec/models/auth_brokers/first-run.js
@@ -35,6 +35,22 @@ function (chai, sinon, NullChannel, Account, FirstRunAuthenticationBroker, Relie
       });
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `interTabSignIn` capability by default', function () {
+      assert.isTrue(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('afterLoaded', function () {
       it('notifies the iframe channel', function () {
         sinon.spy(iframeChannel, 'send');

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
@@ -43,6 +43,22 @@ define([
       });
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `interTabSignIn` capability by default', function () {
+      assert.isTrue(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('createChannel', function () {
       it('creates a channel', function () {
         assert.ok(broker.createChannel());

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -23,7 +23,7 @@ define([
     var user;
     var windowMock;
 
-    beforeEach(function () {
+    before(function () {
       windowMock = new WindowMock();
       channelMock = new NullChannel();
       channelMock.send = sinon.spy(function () {
@@ -41,6 +41,22 @@ define([
         channel: channelMock,
         window: windowMock
       });
+    });
+
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `interTabSignIn` capability by default', function () {
+      assert.isTrue(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
     });
 
     describe('createChannel', function () {

--- a/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -46,6 +46,22 @@ function (chai, NullChannel, FxFennecV1AuthenticationBroker, Relier,
       sinon.spy(broker, 'send');
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `interTabSignIn` capability by default', function () {
+      assert.isTrue(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('does not have the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isFalse(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('has the `syncPreferencesNotification` capability by default', function () {
+      assert.isTrue(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     it('disables the `chooseWhatToSyncCheckbox` capability', function () {
       return broker.fetch()
         .then(function () {

--- a/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -15,54 +15,107 @@ function (chai, NullChannel, FxiOSAuthenticationBroker, Relier, WindowMock) {
   var assert = chai.assert;
 
   describe('models/auth_brokers/fx-ios-v1', function () {
-    var broker;
     var channel;
     var relier;
     var windowMock;
 
     function createBroker () {
-      broker = new FxiOSAuthenticationBroker({
+      return new FxiOSAuthenticationBroker({
         channel: channel,
         relier: relier,
         window: windowMock
       });
     }
 
-    beforeEach(function () {
+    before(function () {
       channel = new NullChannel();
       relier = new Relier();
       windowMock = new WindowMock();
     });
 
-    describe('`signup` capability', function () {
-      it('returns `false` if `exclude_signup=1` is specified, a reason is provided', function () {
-        windowMock.location.search = '?exclude_signup=1';
-        createBroker();
+    describe('`exclude_signup` parameter is set', function () {
+      var broker;
 
-        return broker.fetch()
-          .then(function () {
-            assert.isFalse(broker.hasCapability('signup'));
-            assert.ok(broker.SIGNUP_DISABLED_REASON);
-          });
+      before(function () {
+        windowMock.location.search = '?exclude_signup=1';
+        broker = createBroker();
       });
 
-      it('returns `true` otherwise', function () {
+      after(function () {
         windowMock.location.search = '';
-        createBroker();
+      });
 
-        return broker.fetch()
-          .then(function () {
-            assert.isTrue(broker.hasCapability('signup'));
-          });
+      it('has the `signup` capability by default', function () {
+        assert.isTrue(broker.hasCapability('signup'));
+      });
+
+      it('has the `interTabSignIn` capability by default', function () {
+        assert.isTrue(broker.hasCapability('interTabSignIn'));
+      });
+
+      it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+        assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+      });
+
+      it('does not have the `syncPreferencesNotification` capability by default', function () {
+        assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+      });
+
+      describe('`broker.fetch` is called', function () {
+        before(function () {
+          return broker.fetch();
+        });
+
+        it('does not have the `signup` capability', function () {
+          assert.isFalse(broker.hasCapability('signup'));
+        });
+
+        it('`broker.SIGNUP_DISABLED_REASON` is set', function () {
+          assert.instanceOf(broker.SIGNUP_DISABLED_REASON, Error);
+        });
       });
     });
 
-    it('disables the `chooseWhatToSyncCheckbox` capability', function () {
-      createBroker();
-      return broker.fetch()
-        .then(function () {
+    describe('`exclude_signup` parameter is not set', function () {
+      var broker;
+
+      before(function () {
+        broker = createBroker();
+      });
+
+      it('has the `signup` capability by default', function () {
+        assert.isTrue(broker.hasCapability('signup'));
+      });
+
+      it('has the `interTabSignIn` capability by default', function () {
+        assert.isTrue(broker.hasCapability('interTabSignIn'));
+      });
+
+      it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+        assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+      });
+
+      it('does not have the `syncPreferencesNotification` capability by default', function () {
+        assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+      });
+
+      describe('`broker.fetch` is called', function () {
+        before(function () {
+          return broker.fetch();
+        });
+
+        it('has the `signup` capability', function () {
+          assert.isTrue(broker.hasCapability('signup'));
+        });
+
+        it('`broker.SIGNUP_DISABLED_REASON` is not set', function () {
+          assert.isUndefined(broker.SIGNUP_DISABLED_REASON);
+        });
+
+        it('does not have the `chooseWhatToSyncCheckbox` capability', function () {
           assert.isFalse(broker.hasCapability('chooseWhatToSyncCheckbox'));
         });
+      });
     });
   });
 });

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -58,6 +58,22 @@ define([
       createAuthBroker();
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `interTabSignIn` capability by default', function () {
+      assert.isTrue(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('afterLoaded', function () {
       it('sends a `loaded` message', function () {
         return broker.afterLoaded()

--- a/app/tests/spec/models/auth_brokers/iframe.js
+++ b/app/tests/spec/models/auth_brokers/iframe.js
@@ -46,6 +46,22 @@ function (chai, sinon, $, IframeAuthenticationBroker, Relier, p, NullChannel,
       }
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `interTabSignIn` capability by default', function () {
+      assert.isFalse(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('sendOAuthResultToRelier', function () {
       it('sends an `oauth_complete` message', function () {
         sinon.stub(broker, 'send', function () {

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -83,6 +83,22 @@ function (chai, sinon, Session, p, Constants, OAuthClient, Assertion, AuthErrors
       sinon.spy(broker, 'finishOAuthFlow');
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `interTabSignIn` capability by default', function () {
+      assert.isFalse(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('sendOAuthResultToRelier', function () {
       it('must be overridden', function () {
         return broker.sendOAuthResultToRelier()

--- a/app/tests/spec/models/auth_brokers/redirect.js
+++ b/app/tests/spec/models/auth_brokers/redirect.js
@@ -50,6 +50,22 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
       });
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `interTabSignIn` capability by default', function () {
+      assert.isFalse(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('sendOAuthResultToRelier', function () {
       describe('with no error', function () {
         it('prepares window to be closed', function () {

--- a/app/tests/spec/models/auth_brokers/web-channel.js
+++ b/app/tests/spec/models/auth_brokers/web-channel.js
@@ -91,6 +91,21 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
       };
     }
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `interTabSignIn` capability by default', function () {
+      assert.isFalse(broker.hasCapability('interTabSignIn'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
 
     describe('fetch', function () {
       describe('for the signin/signup flow', function () {

--- a/app/tests/spec/views/mixins/inter-tab-signin-mixin.js
+++ b/app/tests/spec/views/mixins/inter-tab-signin-mixin.js
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'cocktail',
+  'sinon',
+  'lib/promise',
+  'views/base',
+  'views/mixins/inter-tab-signin-mixin'
+], function (chai, Cocktail, sinon, p, BaseView, InterTabSignInMixin) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  var View = BaseView.extend({});
+  Cocktail.mixin(View, InterTabSignInMixin);
+
+  describe('views/mixins/inter-tab-signin-mixin', function () {
+    var view;
+
+    before(function () {
+      view = new View();
+    });
+
+    after(function () {
+      view.destroy();
+    });
+
+    it('exports correct interface', function () {
+      var methods = [
+        'afterVisible',
+        'initialize',
+        'interTabOn',
+        'interTabOff',
+        'interTabOffAll',
+        'interTabSend',
+        'interTabClear',
+        'onSignInSuccess'
+      ];
+      assert.lengthOf(Object.keys(InterTabSignInMixin), methods.length);
+      methods.forEach(function (methodName) {
+        assert.isFunction(InterTabSignInMixin[methodName]);
+        assert.isFunction(view[methodName]);
+      });
+      assert.isUndefined(view.navigateToSignedInView);
+    });
+
+    describe('afterVisible', function () {
+      before(function () {
+        view.interTabOn = sinon.spy();
+        view.afterVisible();
+      });
+
+      it('defines the navigateToSignedInView method', function () {
+        assert.isFunction(view.navigateToSignedInView);
+        assert.lengthOf(view.navigateToSignedInView, 1);
+      });
+
+      it('calls interTabOn correctly', function () {
+        assert.equal(view.interTabOn.callCount, 1);
+        assert.isTrue(view.interTabOn.alwaysCalledOn(view));
+        var args = view.interTabOn.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], 'signin.success');
+        assert.equal(args[1], view.navigateToSignedInView);
+      });
+
+      describe('navigateToSignedInView', function () {
+        before(function () {
+          view.broker = {
+            hasCapability: sinon.spy(function () {
+              return true;
+            })
+          };
+          view.user = {
+            setSignedInAccount: sinon.spy(function () {
+              return p();
+            })
+          };
+          view.navigate = sinon.spy();
+          return view.navigateToSignedInView({
+            data: 'foo'
+          });
+        });
+
+        it('calls broker.hasCapability correctly', function () {
+          assert.equal(view.broker.hasCapability.callCount, 1);
+          assert.isTrue(view.broker.hasCapability.alwaysCalledOn(view.broker));
+          var args = view.broker.hasCapability.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'interTabSignIn');
+        });
+
+        it('calls user.setSignedInAccount correctly', function () {
+          assert.equal(view.user.setSignedInAccount.callCount, 1);
+          assert.isTrue(view.user.setSignedInAccount.alwaysCalledOn(view.user));
+          var args = view.user.setSignedInAccount.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'foo');
+        });
+
+        it('calls navigate correctly', function () {
+          assert.equal(view.navigate.callCount, 1);
+          assert.isTrue(view.navigate.alwaysCalledOn(view));
+          assert.isTrue(view.navigate.calledAfter(view.user.setSignedInAccount));
+          var args = view.navigate.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'settings');
+        });
+      });
+
+      describe('navigateToSignedInView without interTabSignIn capability', function () {
+        before(function () {
+          view.broker = {
+            hasCapability: sinon.spy(function () {
+              return false;
+            })
+          };
+          view.user = {
+            setSignedInAccount: sinon.spy(function () {
+              return p();
+            })
+          };
+          view.navigate = sinon.spy();
+          view.navigateToSignedInView({
+            data: 'foo'
+          });
+        });
+
+        it('calls broker.hasCapability', function () {
+          assert.equal(view.broker.hasCapability.callCount, 1);
+        });
+
+        it('does not call user.setSignedInAccount', function () {
+          assert.equal(view.user.setSignedInAccount.callCount, 0);
+        });
+
+        it('does not call navigate', function () {
+          assert.equal(view.navigate.callCount, 0);
+        });
+      });
+
+      describe('navigateToSignedInView with OAuth redirect URL', function () {
+        before(function () {
+          view.broker = {
+            hasCapability: sinon.spy(function () {
+              return true;
+            })
+          };
+          view.user = {
+            setSignedInAccount: sinon.spy(function () {
+              return p();
+            })
+          };
+          view.navigate = sinon.spy();
+          view._redirectTo = 'foo';
+          return view.navigateToSignedInView({
+            data: 'bar'
+          });
+        });
+
+        it('calls broker.hasCapability', function () {
+          assert.equal(view.broker.hasCapability.callCount, 1);
+        });
+
+        it('calls user.setSignedInAccount correctly', function () {
+          assert.equal(view.user.setSignedInAccount.callCount, 1);
+          assert.equal(view.user.setSignedInAccount.args[0][0], 'bar');
+        });
+
+        it('calls navigate correctly', function () {
+          assert.equal(view.navigate.callCount, 1);
+          assert.equal(view.navigate.args[0][0], 'foo');
+        });
+      });
+
+      describe('onSignInSuccess', function () {
+        before(function () {
+          view.interTabOff = sinon.spy();
+          view.interTabSend = sinon.spy();
+          view.navigateToSignedInView = sinon.spy();
+          view.onSignInSuccess('foo');
+        });
+
+        it('calls interTabOff correctly', function () {
+          assert.equal(view.interTabOff.callCount, 1);
+          assert.isTrue(view.interTabOff.alwaysCalledOn(view));
+          var args = view.interTabOff.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'signin.success');
+          assert.equal(args[1], view.navigateToSignedInView);
+        });
+
+        it('calls interTabSend correctly', function () {
+          assert.equal(view.interTabSend.callCount, 1);
+          assert.isTrue(view.interTabSend.alwaysCalledOn(view));
+          assert.isTrue(view.interTabSend.calledAfter(view.interTabOff));
+          var args = view.interTabSend.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'signin.success');
+          assert.equal(args[1], 'foo');
+        });
+
+        it('does not call navigateToSignedInView', function () {
+          assert.equal(view.navigateToSignedInView.callCount, 0);
+        });
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/mixins/inter-tab-signout-mixin.js
+++ b/app/tests/spec/views/mixins/inter-tab-signout-mixin.js
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'cocktail',
+  'sinon',
+  'views/base',
+  'views/mixins/inter-tab-signout-mixin'
+], function (chai, Cocktail, sinon, BaseView, InterTabSignoutMixin) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  var View = BaseView.extend({});
+  Cocktail.mixin(View, InterTabSignoutMixin);
+
+  describe('views/mixins/inter-tab-signout-mixin', function () {
+    var view;
+
+    before(function () {
+      view = new View();
+    });
+
+    afterEach(function () {
+      view.destroy();
+    });
+
+    it('exports correct interface', function () {
+      var methods = [
+        'afterVisible',
+        'initialize',
+        'interTabOn',
+        'interTabOff',
+        'interTabOffAll',
+        'interTabSend',
+        'interTabClear',
+        'onSignOutSuccess'
+      ];
+      assert.lengthOf(Object.keys(InterTabSignoutMixin), methods.length);
+      methods.forEach(function (methodName) {
+        assert.isFunction(InterTabSignoutMixin[methodName]);
+        assert.isFunction(view[methodName]);
+      });
+      assert.isUndefined(view.clearSessionAndNavigateToSignIn);
+    });
+
+    describe('afterVisible', function () {
+      before(function () {
+        view.interTabOn = sinon.spy();
+        view.afterVisible();
+      });
+
+      it('defines the clearSessionAndNavigateToSignIn method', function () {
+        assert.isFunction(view.clearSessionAndNavigateToSignIn);
+        assert.lengthOf(view.clearSessionAndNavigateToSignIn, 0);
+      });
+
+      it('calls interTabOn correctly', function () {
+        assert.equal(view.interTabOn.callCount, 1);
+        assert.isTrue(view.interTabOn.alwaysCalledOn(view));
+        var args = view.interTabOn.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], 'signout.success');
+        assert.equal(args[1], view.clearSessionAndNavigateToSignIn);
+      });
+
+      describe('clearSessionAndNavigateToSignIn', function () {
+        before(function () {
+          view.logScreenEvent = sinon.spy();
+          view.user = {
+            removeAllAccounts: sinon.spy()
+          };
+          view._formPrefill = {
+            clear: sinon.spy()
+          };
+          view.navigate = sinon.spy();
+          view.clearSessionAndNavigateToSignIn();
+        });
+
+        it('calls logScreenEvent correctly', function () {
+          assert.equal(view.logScreenEvent.callCount, 1);
+          assert.isTrue(view.logScreenEvent.alwaysCalledOn(view));
+          var args = view.logScreenEvent.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'signout.success');
+        });
+
+        it('calls user.removeAllAccounts correctly', function () {
+          assert.equal(view.user.removeAllAccounts.callCount, 1);
+          assert.isTrue(view.user.removeAllAccounts.alwaysCalledOn(view.user));
+          assert.lengthOf(view.user.removeAllAccounts.args[0], 0);
+        });
+
+        it('calls _formPrefill.clear correctly', function () {
+          assert.equal(view._formPrefill.clear.callCount, 1);
+          assert.isTrue(view._formPrefill.clear.alwaysCalledOn(view._formPrefill));
+          assert.lengthOf(view._formPrefill.clear.args[0], 0);
+        });
+
+        it('calls navigate correctly', function () {
+          assert.equal(view.navigate.callCount, 1);
+          assert.isTrue(view.navigate.alwaysCalledOn(view));
+          assert.isTrue(view.navigate.calledAfter(view.user.removeAllAccounts));
+          assert.isTrue(view.navigate.calledAfter(view._formPrefill.clear));
+          var args = view.navigate.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'signin');
+          assert.isObject(args[1]);
+          assert.lengthOf(Object.keys(args[1]), 1);
+          assert.equal(args[1].success, 'Signed out successfully');
+        });
+      });
+
+      describe('onSignOutSuccess', function () {
+        before(function () {
+          view.interTabOff = sinon.spy();
+          view.interTabSend = sinon.spy();
+          view.clearSessionAndNavigateToSignIn = sinon.spy();
+          view.onSignOutSuccess();
+        });
+
+        it('calls interTabOff correctly', function () {
+          assert.equal(view.interTabOff.callCount, 1);
+          assert.isTrue(view.interTabOff.alwaysCalledOn(view));
+          var args = view.interTabOff.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'signout.success');
+          assert.equal(args[1], view.clearSessionAndNavigateToSignIn);
+        });
+
+        it('calls interTabSend correctly', function () {
+          assert.equal(view.interTabSend.callCount, 1);
+          assert.isTrue(view.interTabSend.alwaysCalledOn(view));
+          assert.isTrue(view.interTabSend.calledAfter(view.interTabOff));
+          var args = view.interTabSend.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'signout.success');
+        });
+
+        it('calls clearSessionAndNavigateToSignIn correctly', function () {
+          assert.equal(view.clearSessionAndNavigateToSignIn.callCount, 1);
+          assert.isTrue(view.clearSessionAndNavigateToSignIn.alwaysCalledOn(view));
+          assert.lengthOf(view.clearSessionAndNavigateToSignIn.args[0], 0);
+        });
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -14,6 +14,7 @@ define([
   'lib/oauth-client',
   'lib/assertion',
   'lib/able',
+  'lib/channels/inter-tab',
   'models/reliers/oauth',
   'models/auth_brokers/oauth',
   'models/user',
@@ -24,8 +25,8 @@ define([
   '../../lib/helpers'
 ],
 function (chai, $, sinon, View, p, Session, FxaClient, Metrics, OAuthClient,
-      Assertion, Able, OAuthRelier, OAuthBroker, User, FormPrefill, Notifications, WindowMock,
-      RouterMock, TestHelpers) {
+      Assertion, Able, InterTabChannel, OAuthRelier, OAuthBroker, User,
+      FormPrefill, Notifications, WindowMock, RouterMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -69,6 +70,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, OAuthClient,
     var formPrefill;
     var able;
     var notifications;
+    var interTabChannel;
 
     beforeEach(function () {
       Session.clear();
@@ -112,6 +114,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, OAuthClient,
       formPrefill = new FormPrefill();
       able = new Able();
       notifications = new Notifications();
+      interTabChannel = new InterTabChannel();
 
       view = new View({
         able: able,
@@ -119,6 +122,7 @@ function (chai, $, sinon, View, p, Session, FxaClient, Metrics, OAuthClient,
         broker: broker,
         formPrefill: formPrefill,
         fxaClient: fxaClient,
+        interTabChannel: interTabChannel,
         metrics: metrics,
         notifications: notifications,
         oAuthClient: oAuthClient,

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -16,6 +16,7 @@ define([
   'lib/fxa-client',
   'lib/ephemeral-messages',
   'lib/able',
+  'lib/channels/inter-tab',
   'models/reliers/sync',
   'models/auth_brokers/base',
   'models/user',
@@ -26,7 +27,7 @@ define([
   '../../lib/helpers'
 ],
 function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, ExperimentInterface, Metrics,
-      FxaClient, EphemeralMessages, Able, Relier, Broker, User, FormPrefill,
+      FxaClient, EphemeralMessages, Able, InterTabChannel, Relier, Broker, User, FormPrefill,
       Notifications, RouterMock, WindowMock, TestHelpers) {
   'use strict';
 
@@ -46,6 +47,7 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
     var coppa;
     var able;
     var notifications;
+    var interTabChannel;
 
     function fillOutSignUp(email, password, isCoppaValid) {
       view.$('[type=email]').val(email);
@@ -68,6 +70,7 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
         ephemeralMessages: ephemeralMessages,
         formPrefill: formPrefill,
         fxaClient: fxaClient,
+        interTabChannel: interTabChannel,
         metrics: metrics,
         notifications: notifications,
         relier: relier,
@@ -101,6 +104,7 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
       coppa = new CoppaDatePicker();
       able = new Able();
       notifications = new Notifications();
+      interTabChannel = new InterTabChannel();
 
       createView();
 
@@ -618,10 +622,14 @@ function (chai, $, sinon, p, View, CoppaDatePicker, Session, AuthErrors, Experim
           return true;
         });
 
+        sinon.stub(view, 'onSignInSuccess', function () {});
+
         return view.submit()
             .then(function () {
               assert.isTrue(user.signUpAccount.called);
               assert.isTrue(broker.afterSignIn.called);
+              assert.equal(view.onSignInSuccess.callCount, 1);
+              assert.lengthOf(view.onSignInSuccess.args[0], 0);
             });
       });
 

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -123,6 +123,8 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/account-locked-mixin',
     '../tests/spec/views/mixins/checkbox-mixin',
     '../tests/spec/views/mixins/inter-tab-channel-mixin',
+    '../tests/spec/views/mixins/inter-tab-signin-mixin',
+    '../tests/spec/views/mixins/inter-tab-signout-mixin',
     '../tests/spec/views/mixins/loading-mixin',
     '../tests/spec/views/mixins/migration-mixin',
     '../tests/spec/views/mixins/modal-settings-panel-mixin',

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -22,6 +22,7 @@ define([
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
   var SIGNUP_URL = config.fxaContentRoot + 'signup';
   var RESET_PASSWORD_URL = config.fxaContentRoot + 'reset_password';
+  var SETTINGS_URL = config.fxaContentRoot + 'settings';
 
   var EXTERNAL_SITE_URL = 'http://example.com';
   var EXTERNAL_SITE_LINK_TEXT = 'More information';
@@ -247,39 +248,40 @@ define([
 
     return getVerificationLink(user, index)
       .then(function (verificationLink) {
-        return context.remote
-          .execute(function (verificationLink, windowName) {
-            var newWindow = window.open(verificationLink, windowName);
-
-            // Hook up the new window to listen for WebChannel messages.
-            // XXX TODO: this is pretty gross to do universally like this...
-            // XXX TODO: it will go away if we can make the original tab
-            //           reliably be the one to complete the oauth flow.
-            newWindow.addEventListener('WebChannelMessageToChrome', function (e) {
-              var command = e.detail.message.command;
-              var data = e.detail.message.data;
-              var element = newWindow.document.createElement('div');
-              element.setAttribute('id', 'message-' + command.replace(/:/g, '-'));
-              element.innerText = JSON.stringify(data);
-              newWindow.document.body.appendChild(element);
-            });
-
-            // from http://dev.w3.org/html5/webstorage/
-            // When a new top-level browsing context is created by a script in
-            // an existing browsing context, then the session storage area of
-            // the origin of that Document must be copied into the new
-            // browsing context when it is created. From that point on,
-            // however, the two session storage areas must be considered
-            // separate, not affecting each other in any way.
-            //
-            // We want to pretend this is a new tab that the user opened using
-            // CTRL-T, which does NOT copy sessionStorage over. Wipe
-            // sessionStorage in this new context;
-            newWindow.sessionStorage.clear();
-
-            return true;
-          }, [ verificationLink, windowName ]);
+        return context.remote.execute(openWindow, [ verificationLink, windowName ]);
       });
+  }
+
+  function openWindow (url, name) {
+    var newWindow = window.open(url, name);
+
+    // Hook up the new window to listen for WebChannel messages.
+    // XXX TODO: this is pretty gross to do universally like this...
+    // XXX TODO: it will go away if we can make the original tab
+    //           reliably be the one to complete the oauth flow.
+    newWindow.addEventListener('WebChannelMessageToChrome', function (e) {
+      var command = e.detail.message.command;
+      var data = e.detail.message.data;
+      var element = newWindow.document.createElement('div');
+      element.setAttribute('id', 'message-' + command.replace(/:/g, '-'));
+      element.innerText = JSON.stringify(data);
+      newWindow.document.body.appendChild(element);
+    });
+
+    // from http://dev.w3.org/html5/webstorage/
+    // When a new top-level browsing context is created by a script in
+    // an existing browsing context, then the session storage area of
+    // the origin of that Document must be copied into the new
+    // browsing context when it is created. From that point on,
+    // however, the two session storage areas must be considered
+    // separate, not affecting each other in any way.
+    //
+    // We want to pretend this is a new tab that the user opened using
+    // CTRL-T, which does NOT copy sessionStorage over. Wipe
+    // sessionStorage in this new context;
+    newWindow.sessionStorage.clear();
+
+    return true;
   }
 
   function openVerificationLinkDifferentBrowser(client, email) {
@@ -312,6 +314,18 @@ define([
       .then(function (result) {
         return client.accountReset(email, password, result.accountResetToken);
       });
+  }
+
+  function openSettingsSameBrowser(context, windowName) {
+    return context.remote.execute(openWindow, [ SETTINGS_URL, windowName ]);
+  }
+
+  function openSignInSameBrowser(context, windowName) {
+    return context.remote.execute(openWindow, [ SIGNIN_URL, windowName ]);
+  }
+
+  function openSignUpSameBrowser(context, windowName) {
+    return context.remote.execute(openWindow, [ SIGNUP_URL, windowName ]);
   }
 
   function openUnlockLinkDifferentBrowser(client, email) {
@@ -742,6 +756,9 @@ define([
     openFxaFromUntrustedRp: openFxaFromUntrustedRp,
     openPage: openPage,
     openPasswordResetLinkDifferentBrowser: openPasswordResetLinkDifferentBrowser,
+    openSettingsSameBrowser: openSettingsSameBrowser,
+    openSignInSameBrowser: openSignInSameBrowser,
+    openSignUpSameBrowser: openSignUpSameBrowser,
     openUnlockLinkDifferentBrowser: openUnlockLinkDifferentBrowser,
     openVerificationLinkDifferentBrowser: openVerificationLinkDifferentBrowser,
     openVerificationLinkSameBrowser: openVerificationLinkSameBrowser,

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -189,8 +189,28 @@ define([
         })
         .findById('avatar-options')
         .end();
-    }
+    },
 
+    'sign in, open settings in a second tab, sign out': function () {
+      var windowName = 'sign-out inter-tab functional test';
+      var self = this;
+      return FunctionalHelpers.fillOutSignIn(this, email, FIRST_PASSWORD)
+        .then(function () {
+          return FunctionalHelpers.openSettingsSameBrowser(self, windowName);
+        })
+        .switchToWindow(windowName)
+        .findById('fxa-settings-header')
+        .end()
+        .findById('signout')
+          .click()
+        .end()
+        .findById('fxa-signin-header')
+        .end()
+        .closeCurrentWindow()
+        .switchToWindow('')
+        .findById('fxa-signin-header')
+        .end();
+    }
   });
 
   registerSuite({

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -217,6 +217,62 @@ define([
               })
             .end();
         });
+    },
+
+    'sign in with a second sign-in tab open': function () {
+      var windowName = 'sign-in inter-tab functional test';
+      var self = this;
+      return verifyUser(email, 0)
+        .then(function () {
+          return FunctionalHelpers.openSignInSameBrowser(self, windowName);
+        })
+        .then(function () {
+          return self.remote
+            .switchToWindow(windowName)
+            .findById('fxa-signin-header')
+            .end();
+        })
+        .then(function () {
+          return fillOutSignIn(self, email, PASSWORD);
+        })
+        .then(function () {
+          return self.remote
+            .findById('fxa-settings-header')
+            .end()
+            .closeCurrentWindow()
+            .switchToWindow('')
+            .findById('fxa-settings-header')
+            .end();
+        });
+    },
+
+    'sign in with a second sign-up tab open': function () {
+      var windowName = 'sign-in inter-tab functional test';
+      var self = this;
+      return verifyUser(email, 0)
+        .then(function () {
+          return FunctionalHelpers.openSignUpSameBrowser(self, windowName);
+        })
+        .then(function () {
+          return self.remote
+            .switchToWindow(windowName)
+            .findById('fxa-signup-header')
+            .end()
+            .switchToWindow('');
+        })
+        .then(function () {
+          return fillOutSignIn(self, email, PASSWORD);
+        })
+        .then(function () {
+          return self.remote
+            .switchToWindow(windowName)
+            .findById('fxa-settings-header')
+            .end()
+            .closeCurrentWindow()
+            .switchToWindow('')
+            .findById('fxa-settings-header')
+            .end();
+        });
     }
   });
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -411,6 +411,67 @@ define([
             assert.equal(resultText, '');
           })
         .end();
+    },
+
+    'sign up, open sign-in in second tab, verify in third tab': function () {
+      var windowName = 'sign-up inter-tab functional test';
+      var self = this;
+      return fillOutSignUp(this, email, PASSWORD, OLD_ENOUGH_YEAR)
+        .then(function () {
+          return testAtConfirmScreen(self, email);
+        })
+        .then(function () {
+          return FunctionalHelpers.openSignInSameBrowser(self, windowName);
+        })
+        .switchToWindow(windowName)
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+        })
+        .switchToWindow('newwindow')
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+        .closeCurrentWindow()
+        .switchToWindow(windowName)
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+        .closeCurrentWindow()
+        .switchToWindow('')
+        .findByCssSelector('#fxa-settings-header')
+        .end();
+    },
+
+    'sign up, open sign-up in second tab, verify in original tab': function () {
+      var windowName = 'sign-up inter-tab functional test';
+      var self = this;
+      return fillOutSignUp(this, email, PASSWORD, OLD_ENOUGH_YEAR)
+        .then(function () {
+          return testAtConfirmScreen(self, email);
+        })
+        .then(function () {
+          return FunctionalHelpers.openSignUpSameBrowser(self, windowName);
+        })
+        .switchToWindow(windowName)
+        .findByCssSelector('#fxa-signup-header')
+        .end()
+        .switchToWindow('')
+        .then(function () {
+          return FunctionalHelpers.getVerificationLink(email, 0);
+        })
+        .then(function (verificationLink) {
+          return self.remote.get(require.toUrl(verificationLink));
+        })
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+        })
+        .switchToWindow(windowName)
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+        .closeCurrentWindow()
+        .switchToWindow('')
+        .findByCssSelector('#fxa-settings-header')
+        .end();
     }
   });
 


### PR DESCRIPTION
Fixes #3024, synchronising the sign-in state from `/signin`, `/signup` and `/settings`.

This change is broadly similar to my previous attempt, #3144, except with saner handling of the sign-up flow.

No attempt is made to handle password resets, so it is still possible for a user to get into a funny state if they're signed in and specify a different account's email address. Presumably that's a rare occurrence in the wild.