### PR TITLE
feat(metrics): send flow events with entrypoint metadata

### DIFF
--- a/server/lib/metrics-collector-stderr.js
+++ b/server/lib/metrics-collector-stderr.js
@@ -13,6 +13,13 @@ var METRICS_OP = 'client.metrics';
 var MARKETING_OP = 'client.marketing';
 var VERSION = 1;
 
+var FLOW_EVENTS = {
+  'screen.confirm': 'flow.signup.success',
+  'screen.signin': 'flow.signin',
+  'screen.signup': 'flow.signup',
+  'verify-email.verification.success': 'flow.signup.verify'
+};
+
 function addTime(loggableEvent) {
   // round the date to the nearest hour.
   var today = new Date();
@@ -116,6 +123,7 @@ function toLoggableEvent(event) {
 }
 
 function writeEntry(entry) {
+  entry.events = addFlowEvents(entry);
   // Heka listens on stderr.
   // process.stderr.write is synchronous unlike most stream operations.
   // See http://nodejs.org/api/process.html#process_process_stderr
@@ -124,6 +132,20 @@ function writeEntry(entry) {
   process.stderr.write(JSON.stringify(entry) + '\n');
 }
 
+function addFlowEvents(entry) {
+  var events = entry.events;
+  var entrypoint = entry.entrypoint;
+
+  if (Array.isArray(events)) {
+    return events.concat(events.filter(function (event) {
+      return !! FLOW_EVENTS[event];
+    }).map(function (event) {
+      return FLOW_EVENTS[event] + ':' + entrypoint;
+    }));
+  }
+
+  return events;
+}
 
 function processMarketingImpressions(event) {
   if (! (event && event.marketing && event.marketing.forEach)) {

--- a/tests/server/metrics-collector-stderr.js
+++ b/tests/server/metrics-collector-stderr.js
@@ -48,11 +48,31 @@ define([
         assert.isUndefined(loggedMetrics['nt.notIncludedUndefined']);
         assert.isUndefined(loggedMetrics['nt.notIncludedNull']);
 
+        assert.lengthOf(loggedMetrics.events, 10);
+        assert.lengthOf(loggedMetrics.event_durations, 6);
+
         assert.equal(loggedMetrics.events[0], 'firstEvent');
         assert.equal(loggedMetrics.event_durations[0], 1235);
 
         assert.equal(loggedMetrics.events[1], 'secondEvent');
         assert.equal(loggedMetrics.event_durations[1], 3512);
+
+        assert.equal(loggedMetrics.events[2], 'screen.signup');
+        assert.equal(loggedMetrics.event_durations[2], 3513);
+
+        assert.equal(loggedMetrics.events[3], 'screen.signin');
+        assert.equal(loggedMetrics.event_durations[3], 3514);
+
+        assert.equal(loggedMetrics.events[4], 'screen.confirm');
+        assert.equal(loggedMetrics.event_durations[4], 3515);
+
+        assert.equal(loggedMetrics.events[5], 'verify-email.verification.success');
+        assert.equal(loggedMetrics.event_durations[5], 3516);
+
+        assert.equal(loggedMetrics.events[6], 'flow.signup:menupanel');
+        assert.equal(loggedMetrics.events[7], 'flow.signin:menupanel');
+        assert.equal(loggedMetrics.events[8], 'flow.signup.success:menupanel');
+        assert.equal(loggedMetrics.events[9], 'flow.signup.verify:menupanel');
 
         assert.equal(loggedMetrics.service, 'sync');
         assert.equal(loggedMetrics.context, 'fx_desktop_v1');
@@ -94,6 +114,22 @@ define([
         {
           offset: 3512,
           type: 'secondEvent'
+        },
+        {
+          offset: 3513,
+          type: 'screen.signup'
+        },
+        {
+          offset: 3514,
+          type: 'screen.signin'
+        },
+        {
+          offset: 3515,
+          type: 'screen.confirm'
+        },
+        {
+          offset: 3516,
+          type: 'verify-email.verification.success'
         }
       ],
       lang: 'db_LB',


### PR DESCRIPTION
This is another step towards fixing #3002, to better differentiate between entrypoints in the flow dashboard.

In order to implement @rfk's suggestion from https://github.com/mozilla/fxa-content-server/issues/3002#issuecomment-149457560, we need to include the entrypoint in the event name so that it can be processed by Heka. Rather than changing the existing events, which could affect other graphs and would leave the flow dashboard in a broken state, this changeset takes the approach of injecting new events alongside the current ones.

After the new events have been deployed, we'll then need to add a new Heka filter to process them. Again, my plan is to avoid editing the existing Heka filter so that we don't force the flow dashboard into an interim broken state. You can see my proposed changes for the new filter in [this branch](https://github.com/mozilla-services/puppet-config/compare/mozilla-services:master...philbooth:fxa-new-flow-events).

Once the new filter is in place, we can leave it running for a bit before updating the dashboard js to match. That way, the dashboard will immediately have some historical data when we switch it over, rather than displaying initially-empty graphs.

@shane-tomlinson / @vladikoff r?