### PR TITLE
fix(client): Do not use the OAuth Redirect broker to verify Sync sign ups.

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -26,6 +26,7 @@ define([], function () {
     // set of users to disconnect from Sync.
     SESSION_TOKEN_USED_FOR_SYNC: 'fx_desktop_v1',
 
+    DIRECT_CONTEXT: 'direct',
     FX_DESKTOP_V1_CONTEXT: 'fx_desktop_v1',
     FX_DESKTOP_V2_CONTEXT: 'fx_desktop_v2',
     FX_FENNEC_V1_CONTEXT: 'fx_fennec_v1',

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -270,7 +270,8 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
 
           windowMock.location.search = Url.objToSearchString({
             code: 'code',
-            service: 'client id'
+            service: 'client id',
+            uid: 'users id'
           });
 
           return testExpectedBrokerCreated(WebChannelBroker);
@@ -310,7 +311,8 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
         it('returns a Redirect broker if both `code` and `service` are available - for verification flows', function () {
           windowMock.location.search = Url.objToSearchString({
             code: 'the code',
-            service: 'the service'
+            service: 'the service',
+            uid: 'users id'
           });
 
           return testExpectedBrokerCreated(RedirectBroker);
@@ -332,6 +334,16 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
       describe('base', function () {
         it('returns a Base broker if the user directly browses to any other page', function () {
           windowMock.location.href = '/settings';
+
+          return testExpectedBrokerCreated(BaseBroker);
+        });
+
+        it('returns a BaseBroker if verifying a Sync signup', function () {
+          windowMock.location.search = Url.objToSearchString({
+            code: 'the code',
+            service: Constants.SYNC_SERVICE,
+            uid: 'users id'
+          });
 
           return testExpectedBrokerCreated(BaseBroker);
         });
@@ -362,7 +374,7 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
       });
 
       it('creates an SyncRelier if Sync', function () {
-        sinon.stub(appStart, '_isSync', function () {
+        sinon.stub(appStart, '_isServiceSync', function () {
           return true;
         });
 
@@ -622,7 +634,7 @@ function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
           return true;
         });
 
-        sinon.stub(appStart, '_isSync', function () {
+        sinon.stub(appStart, '_isServiceSync', function () {
           return true;
         });
 


### PR DESCRIPTION
Use the direct access authentication broker instead. In the future,
verifications in the same browser will use the same authentication broker used
for signup.

fixes #3215