### PR TITLE
feat(client): Show the  button on verification tab in Fennec

### DIFF
--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -138,7 +138,7 @@ function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
         });
     },
 
-    persist: function () {
+    persistVerificationData: function (account) {
       var self = this;
       return p().then(function () {
         var relier = self.relier;
@@ -151,6 +151,8 @@ function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
           state: relier.get('state'),
           webChannelId: self.get('webChannelId')
         });
+
+        return proto.persistVerificationData.call(self, account);
       });
     },
 

--- a/app/scripts/models/auth_brokers/web-channel.js
+++ b/app/scripts/models/auth_brokers/web-channel.js
@@ -158,17 +158,21 @@ function (_, OAuthAuthenticationBroker, ChannelMixin, p,
       // The slight delay here is to allow the functional tests time to
       // bind event handlers before the flow completes.
       var self = this;
-      return p().delay(100).then(function () {
-        if (self.hasPendingOAuthFlow()) {
-          // This tab won't have access to key-fetching material, so
-          // retreive it from the session if necessary.
-          if (self.relier.wantsKeys()) {
-            account.set('keyFetchToken', self.session.oauth.keyFetchToken);
-            account.set('unwrapBKey', self.session.oauth.unwrapBKey);
+      return proto.afterCompleteSignUp.call(self, account)
+        .delay(100)
+        .then(function (behavior) {
+          if (self.hasPendingOAuthFlow()) {
+            // This tab won't have access to key-fetching material, so
+            // retreive it from the session if necessary.
+            if (self.relier.wantsKeys()) {
+              account.set('keyFetchToken', self.session.oauth.keyFetchToken);
+              account.set('unwrapBKey', self.session.oauth.unwrapBKey);
+            }
+            return self.finishOAuthSignUpFlow(account);
           }
-          return self.finishOAuthSignUpFlow(account);
-        }
-      });
+
+          return behavior;
+        });
     },
 
     afterResetPasswordConfirmationPoll: function (account) {
@@ -185,11 +189,15 @@ function (_, OAuthAuthenticationBroker, ChannelMixin, p,
       // The slight delay here is to allow the functional tests time to
       // bind event handlers before the flow completes.
       var self = this;
-      return p().delay(100).then(function () {
-        if (self.hasPendingOAuthFlow()) {
-          return self.finishOAuthSignInFlow(account);
-        }
-      });
+      return proto.afterCompleteResetPassword.call(self, account)
+        .delay(100)
+        .then(function (behavior) {
+          if (self.hasPendingOAuthFlow()) {
+            return self.finishOAuthSignInFlow(account);
+          }
+
+          return behavior;
+        });
     },
 
     // used by the ChannelMixin to get a channel.

--- a/app/scripts/models/verification/same-browser.js
+++ b/app/scripts/models/verification/same-browser.js
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Verification info that is stored locally in case the user verifies
+ * in the same browser. This allows information like `context`
+ * to be re-used if the user verifies in the same browser, but not
+ * in a different browser.
+ *
+ * Information is persisted into localStorage. Either an `email` or `uid`
+ * is required for the verification info to be fetched.
+ *
+ * `uid` is used in signup and account unlock verifications
+ * `email` is used in password reset verifications.
+ */
+
+define([
+  'backbone',
+  'lib/storage'
+], function (Backbone, Storage) {
+  'use strict';
+
+  var STORAGE_KEY = 'verificationInfo';
+
+  var proto = Backbone.Model.prototype;
+
+  var SameBrowserVerificationModel = Backbone.Model.extend({
+    initialize: function (attributes, options) {
+      proto.initialize.call(this, attributes, options);
+
+      this._email = options.email;
+      this._namespace = options.namespace;
+      this._uid = options.uid;
+      this._window = options.window || window;
+
+      this._storage = options.storage || new Storage(this._window.localStorage);
+    },
+
+    _STORAGE_KEY: STORAGE_KEY,
+
+    /**
+     * Get the user's storage ID. `uid` is used for signup/account unlock,
+     * `email` for password reset.
+     *
+     * @returns {string}
+     * @private
+     */
+    _getUsersStorageId: function () {
+      return this._uid || this._email;
+    },
+
+    /**
+     * Persist verification info to localStorage. Info will be loaded on
+     * verification in verification occurs in the same browser.
+     */
+    persist: function () {
+      var id = this._getUsersStorageId();
+      if (id) {
+        var verificationInfo = this._storage.get(STORAGE_KEY) || {};
+        verificationInfo[id] = verificationInfo[id] || {};
+        verificationInfo[id][this._namespace] = this.toJSON();
+        this._storage.set(STORAGE_KEY, verificationInfo);
+      }
+    },
+
+    /**
+     * Load verification info for the current user from localStorage
+     */
+    load: function () {
+      var id = this._getUsersStorageId();
+      if (id) {
+        var usersStoredInfo = (this._storage.get(STORAGE_KEY) || {})[id];
+        if (usersStoredInfo) {
+          this.set(usersStoredInfo[this._namespace] || {});
+        }
+      }
+    },
+
+    /**
+     * Clear verification info from localStorage
+     */
+    clear: function () {
+      var id = this._getUsersStorageId();
+      if (id) {
+        var verificationInfo = this._storage.get(STORAGE_KEY) || {};
+        if (verificationInfo[id]) {
+          delete verificationInfo[id][this._namespace];
+          if (! Object.keys(verificationInfo[id]).length) {
+            delete verificationInfo[id];
+          }
+          this._storage.set(STORAGE_KEY, verificationInfo);
+        }
+      }
+    }
+  });
+
+  return SameBrowserVerificationModel;
+});

--- a/app/scripts/views/complete_account_unlock.js
+++ b/app/scripts/views/complete_account_unlock.js
@@ -38,6 +38,15 @@ function (FormView, CompleteAccountUnlockTemplate, AuthErrors,
       return this.fxaClient.completeAccountUnlock(uid, code)
         .then(function () {
           self.logViewEvent('verification.success');
+          var account = self.user.initAccount({
+            code: code,
+            uid: uid
+          });
+
+          return self.invokeBrokerMethod(
+                    'afterCompleteAccountUnlock', account);
+        })
+        .then(function () {
           self.navigate('account_unlock_complete');
           return false;
         })

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -96,7 +96,7 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
       // prevented by the broker. An example is Firefox Desktop where the
       // browser is already performing a poll, so a second poll is not needed.
 
-      return self.broker.persist()
+      return self.broker.persistVerificationData(self.getAccount())
         .then(function () {
           return self.invokeBrokerMethod(
                     'beforeSignUpConfirmationPoll', self.getAccount());

--- a/app/scripts/views/confirm_account_unlock.js
+++ b/app/scripts/views/confirm_account_unlock.js
@@ -79,7 +79,7 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
 
     afterVisible: function () {
       var self = this;
-      return self.broker.persist()
+      return self.broker.persistVerificationData(self.getAccount())
         .then(function () {
           return self._waitForConfirmation();
         })

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -58,7 +58,7 @@ function (Cocktail, ConfirmView, BaseView, Template, p, Session, AuthErrors,
     afterVisible: function () {
       var self = this;
 
-      return self.broker.persist()
+      return self.broker.persistVerificationData(this.user.initAccount({ email: this._email }))
         .then(function () {
           return self._waitForConfirmation()
             .then(function (sessionInfo) {

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -38,12 +38,12 @@ function (chai, sinon, Session, p, Constants, OAuthClient, Assertion, AuthErrors
   var INVALID_OAUTH_CODE_REDIRECT_URL = 'https://127.0.0.1:8080?code=code&state=state';
 
   describe('models/auth_brokers/oauth', function () {
+    var account;
+    var assertionLibrary;
     var broker;
     var oAuthClient;
-    var assertionLibrary;
     var relier;
     var user;
-    var account;
 
     beforeEach(function () {
       oAuthClient = new OAuthClient();
@@ -140,9 +140,9 @@ function (chai, sinon, Session, p, Constants, OAuthClient, Assertion, AuthErrors
       });
     });
 
-    describe('persist', function () {
+    describe('persistVerificationData', function () {
       it('saves OAuth params to session', function () {
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             assert.ok(!! Session.oauth);
           });

--- a/app/tests/spec/models/auth_brokers/redirect.js
+++ b/app/tests/spec/models/auth_brokers/redirect.js
@@ -21,23 +21,22 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
   var REDIRECT_TO = 'https://redirect.here';
 
   describe('models/auth_brokers/redirect', function () {
-    var relier;
-    var broker;
-    var windowMock;
-    var user;
     var account;
+    var broker;
     var metrics;
+    var relier;
+    var user;
+    var windowMock;
 
     beforeEach(function () {
-      windowMock = new WindowMock();
+      metrics = { flush: sinon.spy(p) };
       relier = new Relier();
       user = new User();
+      windowMock = new WindowMock();
+
       account = user.initAccount({
         sessionToken: 'abc123'
       });
-
-      metrics = { flush: sinon.spy(p) };
-
       broker = new RedirectAuthenticationBroker({
         metrics: metrics,
         relier: relier,
@@ -128,9 +127,9 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
       });
     });
 
-    describe('persist', function () {
+    describe('persistVerificationData', function () {
       it('sets the Original Tab marker', function () {
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             assert.isTrue(broker.isOriginalTab());
           });
@@ -149,7 +148,7 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
           return p();
         });
 
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             return broker.finishOAuthFlow(account);
           })
@@ -162,7 +161,7 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
 
     describe('afterCompleteSignUp', function () {
       it('finishes the oauth flow if the user verifies in the original tab', function () {
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             return broker.afterCompleteSignUp(account);
           })
@@ -183,7 +182,7 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
 
     describe('afterCompleteResetPassword', function () {
       it('finishes the oauth flow if the user verifies in the original tab', function () {
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             return broker.afterCompleteResetPassword(account);
           })

--- a/app/tests/spec/models/auth_brokers/web-channel.js
+++ b/app/tests/spec/models/auth_brokers/web-channel.js
@@ -23,26 +23,26 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
   var assert = chai.assert;
 
   describe('models/auth_brokers/web-channel', function () {
+    var account;
     var broker;
-    var windowMock;
-    var relierMock;
     var channelMock;
     var fxaClientMock;
-    var view;
+    var relierMock;
     var user;
-    var account;
+    var view;
+    var windowMock;
 
     beforeEach(function () {
-      windowMock = new WindowMock();
+      channelMock = new NullChannel();
       relierMock = new Relier();
       user = new User();
+      windowMock = new WindowMock();
 
       account = user.initAccount({
         sessionToken: 'abc123',
         uid: 'uid'
       });
 
-      channelMock = new NullChannel();
       sinon.spy(channelMock, 'send');
 
       fxaClientMock = new FxaClientWrapper({
@@ -214,7 +214,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
         account.set('keyFetchToken', 'keyFetchToken');
         account.set('unwrapBKey', 'unwrapBKey');
 
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             return broker.beforeSignUpConfirmationPoll(account);
           })
@@ -230,7 +230,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
           return true;
         });
 
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             account.set('keyFetchToken', 'keyFetchToken');
             account.set('unwrapBKey', 'unwrapBKey');
@@ -246,7 +246,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
     describe('afterCompleteSignUp', function () {
       it('calls sendOAuthResultToRelier if there is session data present', function () {
         setupCompletesOAuthTest();
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             return broker.afterCompleteSignUp(account);
           })
@@ -260,7 +260,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
 
       it('doesn\'t call sendOAuthResultToRelier if there is no session data', function () {
         setupCompletesOAuthTest();
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             broker.session.clear('oauth');
             return broker.afterCompleteSignUp(account);
@@ -276,7 +276,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
           return true;
         });
 
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             account.set('keyFetchToken', 'keyFetchToken');
             account.set('unwrapBKey', 'unwrapBKey');
@@ -298,7 +298,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
     describe('afterSignUpConfirmationPoll', function () {
       it('calls sendOAuthResultToRelier if there is session data present', function () {
         setupCompletesOAuthTest();
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             return broker.afterSignUpConfirmationPoll(account);
           })
@@ -312,7 +312,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
 
       it('doesn\'t call sendOAuthResultToRelier if there is no session data', function () {
         setupCompletesOAuthTest();
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             broker.session.clear('oauth');
             return broker.afterSignUpConfirmationPoll(account);
@@ -327,7 +327,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
       it('calls sendOAuthResultToRelier if there is session data present', function () {
         setupCompletesOAuthTest();
 
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             return broker.afterCompleteResetPassword(account);
           })
@@ -341,7 +341,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
 
       it('doesn\'t call sendOAuthResultToRelier if there is no session data', function () {
         setupCompletesOAuthTest();
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             broker.session.clear('oauth');
             return broker.afterCompleteResetPassword(account);
@@ -356,7 +356,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
       it('calls sendOAuthResultToRelier if there is session data present', function () {
         setupCompletesOAuthTest();
 
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             return broker.afterResetPasswordConfirmationPoll(account);
           })
@@ -370,7 +370,7 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
 
       it('doesn\'t call sendOAuthResultToRelier if there is no session data', function () {
         setupCompletesOAuthTest();
-        return broker.persist()
+        return broker.persistVerificationData(account)
           .then(function () {
             broker.session.clear('oauth');
             return broker.afterResetPasswordConfirmationPoll(account);

--- a/app/tests/spec/models/verification/base.js
+++ b/app/tests/spec/models/verification/base.js
@@ -50,8 +50,8 @@ define([
     describe('isValid', function () {
       it('returns false if model is marked as damaged', function () {
         var model = new Model({
-          code: 'ho',
-          uid: 'hi'
+          code: 'a-code',
+          uid: 'a-uid'
         });
         model.markDamaged();
         assert.isFalse(model.isValid());
@@ -60,15 +60,15 @@ define([
       it('returns false if `validate` explodes', function () {
         var model = new Model({
           code: null,
-          uid: 'hi'
+          uid: 'a-uid'
         });
         assert.isFalse(model.isValid());
       });
 
       it('returns true otherwise', function () {
         var model = new Model({
-          code: 'ho',
-          uid: 'hi'
+          code: 'a-code',
+          uid: 'a-uid'
         });
         assert.isTrue(model.isValid());
       });
@@ -77,8 +77,8 @@ define([
     describe('markExpired/isExpired', function () {
       it('marks the link as expired', function () {
         var model = new Model({
-          code: 'ho',
-          uid: 'hi'
+          code: 'a-code',
+          uid: 'a-uid'
         });
 
         assert.isFalse(model.isExpired());
@@ -90,8 +90,8 @@ define([
     describe('markDamaged/isDamaged', function () {
       it('marks the link as damaged', function () {
         var model = new Model({
-          code: 'ho',
-          uid: 'hi'
+          code: 'a-code',
+          uid: 'a-uid'
         });
 
         assert.isFalse(model.isDamaged());
@@ -101,4 +101,3 @@ define([
     });
   });
 });
-

--- a/app/tests/spec/models/verification/same-browser.js
+++ b/app/tests/spec/models/verification/same-browser.js
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'lib/storage',
+  'models/verification/same-browser',
+  'sinon'
+], function (chai, Storage, SameBrowserVerificationModel, sinon) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  describe('models/verification/same-browser', function () {
+    describe('_getUsersStorageId', function () {
+      var model;
+
+      describe('with a model that has a `uid', function () {
+        beforeEach(function () {
+          model = new SameBrowserVerificationModel({}, {
+            code: 'a-code',
+            namespace: 'context',
+            uid: 'a-uid'
+          });
+        });
+
+        it('returns the `uid`', function () {
+          assert.equal(model._getUsersStorageId(), 'a-uid');
+        });
+      });
+
+      describe('with a model that has an `email`', function () {
+        beforeEach(function () {
+          model = new SameBrowserVerificationModel({}, {
+            code: 'a-code',
+            email: 'testuser@testuser.com',
+            namespace: 'context'
+          });
+        });
+
+        it('returns the `email`', function () {
+          assert.equal(model._getUsersStorageId(), 'testuser@testuser.com');
+        });
+      });
+    });
+
+    describe('model persistence', function () {
+      var model;
+      var storage;
+
+      beforeEach(function () {
+        storage = new Storage();
+
+        model = new SameBrowserVerificationModel({
+          context: 'fx_desktop_v1'
+        }, {
+          code: 'a-code',
+          namespace: 'context',
+          storage: storage,
+          uid: 'a-uid',
+        });
+
+        sinon.spy(storage, 'get');
+        sinon.spy(storage, 'set');
+      });
+
+      describe('persist', function () {
+        beforeEach(function () {
+          model.persist();
+        });
+
+        it('persists the verification info to loca lStorage', function () {
+          assert.isTrue(storage.set.calledWith(model._STORAGE_KEY));
+        });
+      });
+
+      describe('load', function () {
+        beforeEach(function () {
+          model.persist();
+
+          model.unset('context');
+          sinon.spy(model, 'set');
+          model.load();
+        });
+
+        it('loads verification info from localStorage', function () {
+          assert.isTrue(storage.get.calledWith(model._STORAGE_KEY));
+          assert.equal(model.get('context'), 'fx_desktop_v1');
+        });
+      });
+
+      describe('clear', function () {
+        beforeEach(function () {
+          model.persist();
+          model.unset('context');
+          model.clear();
+          model.load();
+        });
+
+        it('clears the verification info for the user/context combination from localStorage', function () {
+          assert.isTrue(storage.get.calledWith(model._STORAGE_KEY));
+          assert.isTrue(storage.set.calledWith(model._STORAGE_KEY));
+        });
+
+        it('does not reload erased data', function () {
+          assert.isFalse(model.has('context'));
+        });
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/complete_account_unlock.js
+++ b/app/tests/spec/views/complete_account_unlock.js
@@ -26,15 +26,15 @@ function (chai, sinon, p, View, AuthErrors, Metrics, Constants, FxaClient,
   var assert = chai.assert;
 
   describe('views/complete_account_unlock', function () {
-    var view;
-    var routerMock;
-    var windowMock;
     var accountUnlockError;
-    var metrics;
-    var fxaClient;
-    var relier;
     var broker;
+    var fxaClient;
+    var metrics;
+    var relier;
+    var routerMock;
     var user;
+    var view;
+    var windowMock;
     var validCode = TestHelpers.createRandomHexString(Constants.CODE_LENGTH);
     var invalidCode = TestHelpers.createRandomHexString(Constants.CODE_LENGTH - 1);
     var validUid = TestHelpers.createRandomHexString(Constants.UID_LENGTH);
@@ -79,13 +79,13 @@ function (chai, sinon, p, View, AuthErrors, Metrics, Constants, FxaClient,
     }
 
     beforeEach(function () {
-      routerMock = new RouterMock();
-      windowMock = new WindowMock();
-      metrics = new Metrics();
-      relier = new Relier();
       broker = new Broker();
       fxaClient = new FxaClient();
+      metrics = new Metrics();
+      relier = new Relier();
+      routerMock = new RouterMock();
       user = new User();
+      windowMock = new WindowMock();
 
       accountUnlockError = null;
       sinon.stub(fxaClient, 'completeAccountUnlock', function () {
@@ -95,6 +95,8 @@ function (chai, sinon, p, View, AuthErrors, Metrics, Constants, FxaClient,
           return p();
         }
       });
+
+      sinon.spy(broker, 'afterCompleteAccountUnlock');
 
       initView();
     });
@@ -208,6 +210,7 @@ function (chai, sinon, p, View, AuthErrors, Metrics, Constants, FxaClient,
         return view.render()
           .then(function () {
             assert.isTrue(view.fxaClient.completeAccountUnlock.calledWith(validUid, validCode));
+            assert.isTrue(broker.afterCompleteAccountUnlock.called);
             assert.equal(routerMock.page, 'account_unlock_complete');
             assert.isTrue(TestHelpers.isEventLogged(
                     metrics, 'complete-account-unlock.verification.success'));

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -132,7 +132,7 @@ function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient,
 
     describe('afterVisible', function () {
       it('notifies the broker before the confirmation', function () {
-        sinon.spy(broker, 'persist');
+        sinon.spy(broker, 'persistVerificationData');
 
         sinon.stub(broker, 'beforeSignUpConfirmationPoll', function (account) {
           assert.isTrue(account.get('customizeSync'));
@@ -141,7 +141,7 @@ function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient,
 
         return view.afterVisible()
           .then(function () {
-            assert.isTrue(broker.persist.called);
+            assert.isTrue(broker.persistVerificationData.called);
             assert.isTrue(
                 broker.beforeSignUpConfirmationPoll.calledWith(account));
           });

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -119,7 +119,7 @@ function (Backbone, chai, sinon, p, AuthErrors, View, Metrics,
       beforeEach(function () {
         createDeps();
 
-        sinon.spy(broker, 'persist');
+        sinon.spy(broker, 'persistVerificationData');
 
         return view.render()
           .then(function () {
@@ -197,7 +197,7 @@ function (Backbone, chai, sinon, p, AuthErrors, View, Metrics,
       beforeEach(function () {
         createDeps();
 
-        sinon.spy(broker, 'persist');
+        sinon.spy(broker, 'persistVerificationData');
       });
 
       afterEach(function () {
@@ -217,7 +217,7 @@ function (Backbone, chai, sinon, p, AuthErrors, View, Metrics,
 
         return view.afterVisible()
           .then(function () {
-            assert.isTrue(broker.persist.called);
+            assert.isTrue(broker.persistVerificationData.called);
             assert.isTrue(
               view._finishPasswordResetSameBrowser.calledWith(sessionInfo));
             assert.isTrue(TestHelpers.isEventLogged(
@@ -237,7 +237,7 @@ function (Backbone, chai, sinon, p, AuthErrors, View, Metrics,
 
         return view.afterVisible()
           .then(function () {
-            assert.isTrue(broker.persist.called);
+            assert.isTrue(broker.persistVerificationData.called);
             assert.isTrue(
               view._finishPasswordResetDifferentBrowser.called);
             assert.isTrue(TestHelpers.isEventLogged(
@@ -257,7 +257,7 @@ function (Backbone, chai, sinon, p, AuthErrors, View, Metrics,
             var err = view.displayError.args[0][0];
             assert.isTrue(AuthErrors.is(err, 'UNEXPECTED_ERROR'));
 
-            assert.isTrue(broker.persist.called);
+            assert.isTrue(broker.persistVerificationData.called);
             assert.isFalse(TestHelpers.isEventLogged(
               metrics, 'confirm_reset_password.verification.success'));
           });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -160,8 +160,9 @@ function (Translator, Session) {
     '../tests/spec/models/auth_brokers/redirect',
     '../tests/spec/models/auth_brokers/web-channel',
     '../tests/spec/models/verification/base',
+    '../tests/spec/models/verification/reset-password',
+    '../tests/spec/models/verification/same-browser',
     '../tests/spec/models/verification/sign-up',
-    '../tests/spec/models/verification/reset-password'
   ];
 
   // The translator is expected to be on the window object.

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -111,6 +111,19 @@ define([
           })
         .end()
 
+          // user can open sync preferences in new tab.
+        .then(FunctionalHelpers.noSuchBrowserNotification(self, 'fxaccounts:sync_preferences'))
+
+        // user should be able to open sync preferences
+        .findByCssSelector('#sync-preferences')
+          // user wants to open sync preferences.
+          .click()
+        .end()
+
+        // browser is notified of desire to open Sync preferences
+        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:sync_preferences'))
+
+
         .closeCurrentWindow()
         .switchToWindow('')
         .end()
@@ -120,7 +133,7 @@ define([
 
         .then(FunctionalHelpers.noSuchBrowserNotification(self, 'fxaccounts:sync_preferences'))
 
-        // user should be able to open sync preferences
+        // user can open sync preferences in original tab.
         .findByCssSelector('#sync-preferences')
           // user wants to open sync preferences.
           .click()


### PR DESCRIPTION
Save verification info into localStorage that says what broker was used
during sign up. If the user verifies in the same browser, use the same
broker.

fixes #3140