### PR TITLE
fix(client): clear relier uid on sign-out

### DIFF
--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -158,16 +158,15 @@ function (
     },
 
     navigate: function (url, options) {
-      // Only add search parameters if they do not already exist.
-      // Search parameters are added to the URLs because they are sometimes
-      // used to pass state from the browser to the screens. Perhaps we should
-      // take the search parameters on startup, toss them into Session, and
-      // forget about this malarky?
-      if (! /\?/.test(url)) {
+      options = options || { trigger: true };
+
+      // If the caller has not asked us to clear the query params
+      // and the new URL does not contain query params, propagate
+      // the current query params to the next view.
+      if (! options.clearQueryParams && ! /\?/.test(url)) {
         url = url + this.window.location.search;
       }
 
-      options = options || { trigger: true };
       return Backbone.Router.prototype.navigate.call(this, url, options);
     },
 

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -649,7 +649,10 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
         this.ephemeralMessages.set('data', options.data);
       }
 
-      this.router.navigate(page, { trigger: true });
+      this.router.navigate(page, {
+        clearQueryParams: options.clearQueryParams,
+        trigger: true
+      });
     },
 
     /**

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -206,6 +206,11 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
         })
         .fin(function () {
           self.logViewEvent('signout.success');
+          // Unset uid otherwise it will henceforth be impossible
+          // to sign in to different accounts inside this tab.
+          self.relier.unset('uid');
+          self.relier.unset('email');
+          self.relier.unset('preVerifyToken');
           self.user.clearSignedInAccount();
           // The user has manually signed out, a pretty strong indicator
           // the user does not want any of their information pre-filled

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -214,6 +214,7 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
           self._formPrefill.clear();
           Session.clear();
           self.navigate('signin', {
+            clearQueryParams: true,
             success: t('Signed out successfully')
           });
         });

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -97,13 +97,35 @@ function (chai, sinon, Backbone, Router, BaseView, DisplayNameView,
         assert.equal(navigateUrl, '/signin');
         assert.deepEqual(navigateOptions, { trigger: true });
       });
+    });
 
-      it('preserves window search parameters across screen transition', function () {
+    describe('set query params', function () {
+      beforeEach(function () {
         windowMock.location.search = '?context=' + Constants.FX_DESKTOP_V1_CONTEXT;
-        router.navigate('/forgot');
-        assert.equal(navigateUrl, '/forgot?context=' + Constants.FX_DESKTOP_V1_CONTEXT);
-        assert.deepEqual(navigateOptions, { trigger: true });
       });
+
+      describe('navigate with default options', function () {
+        beforeEach(function () {
+          router.navigate('/forgot');
+        });
+
+        it('preserves query params', function () {
+          assert.equal(navigateUrl, '/forgot?context=' + Constants.FX_DESKTOP_V1_CONTEXT);
+          assert.deepEqual(navigateOptions, { trigger: true });
+        });
+      });
+
+      describe('navigate with clearQueryParams option set', function () {
+        beforeEach(function () {
+          router.navigate('/forgot', { clearQueryParams: true });
+        });
+
+        it('clears the query params if clearQueryString option is set', function () {
+          assert.equal(navigateUrl, '/forgot');
+          assert.deepEqual(navigateOptions, { clearQueryParams: true });
+        });
+      });
+
     });
 
     describe('redirectToSignupOrSettings', function () {

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -478,6 +478,15 @@ function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
 
         assert.equal(view.ephemeralData(), 'foo');
       });
+
+      it('propagates the clearQueryParams option', function () {
+        sinon.spy(view.router, 'navigate');
+        view.navigate('signin', { clearQueryParams: true });
+        assert.equal(view.router.navigate.callCount, 1);
+        var args = view.router.navigate.args[0];
+        assert.deepEqual(args[1], { clearQueryParams: true, trigger: true });
+        view.router.navigate.restore();
+      });
     });
 
     describe('focus', function () {

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -356,6 +356,7 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
             return p();
           });
           sinon.spy(user, 'clearSignedInAccount');
+          sinon.spy(relier, 'unset');
           sinon.spy(view, 'navigate');
 
           formPrefill.set('email', 'testuser@testuser.com');
@@ -365,8 +366,19 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
             .then(function () {
               assert.isTrue(user.clearSignedInAccount.called);
 
+              assert.equal(relier.unset.callCount, 3);
+              var args = relier.unset.args[0];
+              assert.lengthOf(args, 1);
+              assert.equal(args[0], 'uid');
+              args = relier.unset.args[1];
+              assert.lengthOf(args, 1);
+              assert.equal(args[0], 'email');
+              args = relier.unset.args[2];
+              assert.lengthOf(args, 1);
+              assert.equal(args[0], 'preVerifyToken');
+
               assert.equal(view.navigate.callCount, 1);
-              var args = view.navigate.args[0];
+              args = view.navigate.args[0];
               assert.lengthOf(args, 2);
               assert.equal(args[0], 'signin');
               assert.deepEqual(args[1], {

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -356,6 +356,7 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
             return p();
           });
           sinon.spy(user, 'clearSignedInAccount');
+          sinon.spy(view, 'navigate');
 
           formPrefill.set('email', 'testuser@testuser.com');
           formPrefill.set('password', 'password');
@@ -363,6 +364,16 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
           return view.signOut()
             .then(function () {
               assert.isTrue(user.clearSignedInAccount.called);
+
+              assert.equal(view.navigate.callCount, 1);
+              var args = view.navigate.args[0];
+              assert.lengthOf(args, 2);
+              assert.equal(args[0], 'signin');
+              assert.deepEqual(args[1], {
+                clearQueryParams: true,
+                success: 'Signed out successfully'
+              });
+
               assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.signout.submit'));
               assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.signout.success'));
               assert.isFalse(TestHelpers.isEventLogged(metrics, 'settings.signout.error'));

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -120,6 +120,66 @@ define([
         .end();
     },
 
+    'sign up, verify and sign out of two accounts, all in the same tab, then sign in to the first account': function () {
+      // https://github.com/mozilla/fxa-content-server/issues/2209
+      var secondEmail = TestHelpers.createEmail();
+      var self = this;
+      return fillOutSignUp(this, email, PASSWORD)
+        .then(function () {
+          return testAtConfirmScreen(self, email);
+        })
+        .then(function () {
+          return FunctionalHelpers.getVerificationLink(email, 0);
+        })
+        .then(function (verificationLink) {
+          return self.remote.get(require.toUrl(verificationLink));
+        })
+
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+
+        .then(FunctionalHelpers.testSuccessWasShown(self))
+
+        .findByCssSelector('#signout')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        .then(function () {
+          return fillOutSignUp(self, secondEmail, PASSWORD);
+        })
+        .then(function () {
+          return testAtConfirmScreen(self, secondEmail);
+        })
+        .then(function () {
+          return FunctionalHelpers.getVerificationLink(secondEmail, 0);
+        })
+        .then(function (verificationLink) {
+          return self.remote.get(require.toUrl(verificationLink));
+        })
+
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+
+        .then(FunctionalHelpers.testSuccessWasShown(self))
+
+        .findByCssSelector('#signout')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        .then(function () {
+          return fillOutSignIn(self, email, PASSWORD);
+        })
+
+        .findByCssSelector('#fxa-settings-header')
+        .end();
+    },
+
     'sign up, verify same browser by replacing the original tab': function () {
       var self = this;
       return fillOutSignUp(this, email, PASSWORD)


### PR DESCRIPTION
Fixes #2209.

The fix is contained in commit `01f443d` ("clear relier uid on sign-out"). The other commit ("clear query params on sign-out") is purely a cosmetic change. I left them as two commits so that it's easier to ditch the cosmetic change if we decide not to keep it. If we do want to keep it though, I'm happy to squash the commits or leave them separate, whichever is preferred.

@shane-tomlinson r?