### PR TITLE
chore(tests): openVerificationLinkSameBrowser => openVerificationLinkInNewTab

### DIFF
--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -164,7 +164,7 @@ define([
       var self = this;
       return initiateLockedAccountChangePassword(this)
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -212,7 +212,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 

--- a/tests/functional/delete_account.js
+++ b/tests/functional/delete_account.js
@@ -122,7 +122,7 @@ define([
 
       return initiateLockedAccountDeleteAccount(self)
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -156,7 +156,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 

--- a/tests/functional/firstrun_sign_up.js
+++ b/tests/functional/firstrun_sign_up.js
@@ -66,7 +66,7 @@ define([
 
         // verify the user
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                 self, email, 0);
         })
         .switchToWindow('newwindow')

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -96,7 +96,7 @@ define([
 
         // verify the user
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                 self, email, 0);
         })
         .switchToWindow('newwindow')

--- a/tests/functional/fx_ios_v1_sign_up.js
+++ b/tests/functional/fx_ios_v1_sign_up.js
@@ -63,7 +63,7 @@ define([
 
         // verify the user
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                 self, email, 0);
         })
         .switchToWindow('newwindow')

--- a/tests/functional/fx_ios_v2_sign_up.js
+++ b/tests/functional/fx_ios_v2_sign_up.js
@@ -90,7 +90,7 @@ define([
 
         // verify the user
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                 self, email, 0);
         })
         .switchToWindow('newwindow')

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -241,7 +241,7 @@ define([
     };
   }
 
-  function openVerificationLinkSameBrowser(context, email, index, windowName) {
+  function openVerificationLinkInNewTab(context, email, index, windowName) {
     var user = TestHelpers.emailToUser(email);
     windowName = windowName || 'newwindow';
 
@@ -774,7 +774,7 @@ define([
     openPasswordResetLinkDifferentBrowser: openPasswordResetLinkDifferentBrowser,
     openUnlockLinkDifferentBrowser: openUnlockLinkDifferentBrowser,
     openVerificationLinkDifferentBrowser: openVerificationLinkDifferentBrowser,
-    openVerificationLinkSameBrowser: openVerificationLinkSameBrowser,
+    openVerificationLinkInNewTab: openVerificationLinkInNewTab,
     pollUntil: pollUntil,
     respondToWebChannelMessage: respondToWebChannelMessage,
     testAreEventsLogged: testAreEventsLogged,

--- a/tests/functional/oauth_iframe.js
+++ b/tests/functional/oauth_iframe.js
@@ -117,7 +117,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
         .switchToWindow('newwindow')
@@ -158,7 +158,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -270,7 +270,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -331,7 +331,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -189,7 +189,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -285,7 +285,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 

--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -79,7 +79,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -135,7 +135,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -232,7 +232,7 @@ define([
       var self = this;
       return initiateLockedAccountSignIn(self)
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -267,7 +267,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -80,7 +80,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -124,7 +124,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -266,7 +266,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 

--- a/tests/functional/oauth_sign_up_verification_redirect.js
+++ b/tests/functional/oauth_sign_up_verification_redirect.js
@@ -74,7 +74,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+          return FunctionalHelpers.openVerificationLinkInNewTab(self, email, 0);
         })
 
         .switchToWindow('newwindow')
@@ -105,7 +105,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
             self, email, 0);
         })
 

--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -103,7 +103,7 @@ define([
             .end()
 
             .then(function () {
-              return FunctionalHelpers.openVerificationLinkSameBrowser(
+              return FunctionalHelpers.openVerificationLinkInNewTab(
                           self, email2, 0);
             })
 

--- a/tests/functional/oauth_webchannel.js
+++ b/tests/functional/oauth_webchannel.js
@@ -105,7 +105,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
         .switchToWindow('newwindow')
@@ -158,7 +158,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+          return FunctionalHelpers.openVerificationLinkInNewTab(self, email, 0);
         })
 
         .switchToWindow('newwindow')
@@ -282,7 +282,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
             self, email, 0);
         })
 
@@ -358,7 +358,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+          return FunctionalHelpers.openVerificationLinkInNewTab(self, email, 0);
         })
 
         .switchToWindow('newwindow')

--- a/tests/functional/oauth_webchannel_keys.js
+++ b/tests/functional/oauth_webchannel_keys.js
@@ -74,7 +74,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
         .switchToWindow('newwindow')
@@ -126,7 +126,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+          return FunctionalHelpers.openVerificationLinkInNewTab(self, email, 0);
         })
 
         .switchToWindow('newwindow')
@@ -218,7 +218,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -296,7 +296,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+          return FunctionalHelpers.openVerificationLinkInNewTab(self, email, 0);
         })
 
         .switchToWindow('newwindow')

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -329,7 +329,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -369,7 +369,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 
@@ -500,7 +500,7 @@ define([
             .end()
 
             .then(function () {
-              return FunctionalHelpers.openVerificationLinkSameBrowser(
+              return FunctionalHelpers.openVerificationLinkInNewTab(
                           self, email, 0);
             })
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -61,7 +61,7 @@ define([
           return testAtConfirmScreen(self, email);
         })
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+          return FunctionalHelpers.openVerificationLinkInNewTab(self, email, 0);
         })
         .switchToWindow('newwindow')
 
@@ -89,7 +89,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(self, email, 0);
+          return FunctionalHelpers.openVerificationLinkInNewTab(self, email, 0);
         })
 
         .switchToWindow('newwindow')

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -76,7 +76,7 @@ define([
         .end()
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                 self, email, 0);
         })
         .switchToWindow('newwindow')
@@ -131,7 +131,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -85,7 +85,7 @@ define([
 
         // verify the user
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                 self, email, 0);
         })
         .switchToWindow('newwindow')
@@ -135,7 +135,7 @@ define([
         .then(FunctionalHelpers.openExternalSite(self))
 
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                       self, email, 0);
         })
 

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -98,7 +98,7 @@ define([
         }))
         // verify the user
         .then(function () {
-          return FunctionalHelpers.openVerificationLinkSameBrowser(
+          return FunctionalHelpers.openVerificationLinkInNewTab(
                 self, email, 0);
         })
         .switchToWindow('newwindow')


### PR DESCRIPTION
@shane-tomlinson, not sure if you remember us chatting about this recently? We agreed that the `...SameBrowser` suffix doesn't make it clear enough that a matching call to `closeCurrentWindow` is required.

Initially I did the work on my pre-mergepocalypse branch, but as I'm pulling things over from there bit-by-bit anyway, it occurred to me that this should be reviewed separately.