### PR TITLE
refactor(client): Unify callback data in InterTabChannel and Backbone.Events

### DIFF
--- a/app/scripts/lib/channels/inter-tab.js
+++ b/app/scripts/lib/channels/inter-tab.js
@@ -40,10 +40,7 @@ define([
   BroadcastChannelAdapter.prototype = {
     onMessage: function (event) {
       var envelope = JSON.parse(event.data);
-      this.trigger(envelope.name, {
-        data: envelope.data,
-        event: envelope.name
-      });
+      this.trigger(envelope.name, envelope.data);
     },
 
     send: function (name, data) {
@@ -142,10 +139,7 @@ define([
       var id = envelope.id;
 
       if (! sentMessageIds[id]) {
-        callback({
-          data: envelope.data,
-          event: event.event
-        });
+        callback(envelope.data);
       } else {
         // The event is only triggered once, no need to continue to keep
         // track of the sent message ids.

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -223,9 +223,7 @@ function (Cocktail, ConfirmView, BaseView, Template, p, Session, AuthErrors,
       var deferred = p.defer();
 
       this._isWaitingForLoginMessage = true;
-      this.interTabOn('login', function (event) {
-        deferred.resolve(event && event.data);
-      });
+      this.interTabOn('login', deferred.resolve.bind(deferred));
 
       return deferred.promise;
     },

--- a/app/tests/spec/lib/channels/inter-tab.js
+++ b/app/tests/spec/lib/channels/inter-tab.js
@@ -207,10 +207,7 @@ define([
 
             it('triggers the callback for this tab', function () {
               assert.isTrue(handler.calledWith({
-                data: {
-                  field: 'value'
-                },
-                event: 'message'
+                field: 'value'
               }));
             });
           });
@@ -321,10 +318,7 @@ define([
         it('triggers a message with the event and data', function () {
           assert.isTrue(
             broadcastChannelAdapter.trigger.calledWith('message', {
-              data: {
-                key: 'value'
-              },
-              event: 'message'
+              key: 'value'
             }));
         });
       });

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -312,10 +312,7 @@ function (Backbone, chai, sinon, p, AuthErrors, View, Metrics,
 
         setTimeout(function () {
           interTabChannel.send('login', {
-            data: {
-              sessionToken: 'sessiontoken'
-            },
-            event: 'login'
+            sessionToken: 'sessiontoken'
           });
         }, VERIFICATION_POLL_TIMEOUT_MS * 4);
 
@@ -340,10 +337,7 @@ function (Backbone, chai, sinon, p, AuthErrors, View, Metrics,
 
         setTimeout(function () {
           interTabChannel.send('login', {
-            data: {
-              sessionToken: 'sessiontoken'
-            },
-            event: 'login'
+            sessionToken: 'sessiontoken'
           });
         }, VERIFICATION_POLL_TIMEOUT_MS * 4);
 


### PR DESCRIPTION
InterTabChannel returned an `event` object which contained `event` and
`data` fields. Backbone.Events just passed the `data`.

This standardizes on the Backbone style.

fixes #3229