### PR TITLE
feat(client): synchronise signed-in state across tabs

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -206,13 +206,16 @@ function (
                     // fxaClient depends on the relier and
                     // inter tab communication.
                     .then(_.bind(this.initializeFxaClient, this))
+                    // depends on iframeChannel and interTabChannel
+                    .then(_.bind(this.initializeNotifications, this))
                     // assertionLibrary depends on fxaClient
                     .then(_.bind(this.initializeAssertionLibrary, this))
                     // profileClient depends on fxaClient and assertionLibrary
                     .then(_.bind(this.initializeProfileClient, this))
                     // marketingEmailClient depends on config
                     .then(_.bind(this.initializeMarketingEmailClient, this))
-                    // user depends on the profileClient, oAuthClient, and assertionLibrary.
+                    // user depends on the profileClient, oAuthClient,
+                    // assertionLibrary and notifications.
                     .then(_.bind(this.initializeUser, this))
                     // broker relies on the user, relier, fxaClient,
                     // assertionLibrary, and metrics
@@ -226,8 +229,6 @@ function (
 
                     // depends on nothing
                     .then(_.bind(this.initializeFormPrefill, this))
-                    // depends on iframeChannel and interTabChannel
-                    .then(_.bind(this.initializeNotifications, this))
                     // depends on notifications, metrics
                     .then(_.bind(this.initializeRefreshObserver, this))
                     // router depends on all of the above
@@ -529,6 +530,7 @@ function (
           assertion: this._assertionLibrary,
           fxaClient: this._fxaClient,
           marketingEmailClient: this._marketingEmailClient,
+          notifications: this._notifications,
           oAuthClient: this._oAuthClient,
           oAuthClientId: this._config.oAuthClientId,
           profileClient: this._profileClient,

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -286,6 +286,10 @@ define([
        */
       emailVerificationMarketingSnippet: true,
       /**
+       * Should the view handle signed-in notifications from other tabs?
+       */
+      handleSignedInNotification: true,
+      /**
        * Is signup supported? the fx_ios_v1 broker can disable it.
        */
       signup: true,

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -61,6 +61,13 @@ function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
       afterSignIn: new HaltBehavior()
     }),
 
+    defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
+      // Disable signed-in notifications for OAuth due to the potential for
+      // unintended consequences from redirecting to a relier URL more than
+      // once.
+      handleSignedInNotification: false
+    }),
+
     initialize: function (options) {
       options = options || {};
 

--- a/app/scripts/models/notifications.js
+++ b/app/scripts/models/notifications.js
@@ -14,8 +14,9 @@ define([
 
   var EVENTS = {
     DELETE: 'fxaccounts:delete',
-    LOGOUT: 'fxaccounts:logout',
-    PROFILE_CHANGE: 'profile:change'
+    PROFILE_CHANGE: 'profile:change',
+    SIGNED_IN: 'fxaccounts:login',
+    SIGNED_OUT: 'fxaccounts:logout'
   };
 
   var Notifications = Backbone.Model.extend({
@@ -40,18 +41,18 @@ define([
     },
 
     broadcast: function (event, data) {
+      this.triggerRemote(event, data);
+      this.trigger(event, data);
+    },
+
+    triggerRemote: function (event, data) {
       this._channels.forEach(function (channel) {
         channel.send(event, data);
       });
-      this.trigger(event, data);
     },
 
     profileUpdated: function (data) {
       this.broadcast(EVENTS.PROFILE_CHANGE, data);
-    },
-
-    loggedOut: function (data) {
-      this.broadcast(EVENTS.LOGOUT, data);
     },
 
     accountDeleted: function (data) {
@@ -62,12 +63,8 @@ define([
     _listen: function (tabChannel) {
       var self = this;
       _.each(EVENTS, function (name) {
-        tabChannel.on(name, self._handleNotification.bind(self));
+        tabChannel.on(name, self.trigger.bind(self, name));
       });
-    },
-
-    _handleNotification: function (message) {
-      this.trigger(message.event, message.data);
     }
   }, Backbone.Events);
 

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -45,6 +45,8 @@ function (Cocktail, FormView, BaseView, CompleteSignUpTemplate,
       // cache the email in case we need to attempt to resend the
       // verification link
       this._email = this._account.get('email');
+
+      this._notifications = options.notifications;
     },
 
     getAccount: function () {
@@ -89,12 +91,16 @@ function (Cocktail, FormView, BaseView, CompleteSignUpTemplate,
                       'afterCompleteSignUp', self.getAccount());
           })
           .then(function () {
+            var account = self.getAccount();
+
+            self._notifications.triggerRemote(self._notifications.EVENTS.SIGNED_IN, account.toJSON());
+
             if (! self.relier.isDirectAccess()) {
               self.navigate('signup_complete');
               return false;
             }
 
-            return self.getAccount().isSignedIn()
+            return account.isSignedIn()
               .then(function (isSignedIn) {
                 if (isSignedIn) {
                   self.navigate('settings', {

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -4,18 +4,19 @@
 
 define([
   'cocktail',
+  'lib/auth-errors',
   'lib/promise',
+  'lib/session',
+  'stache!templates/force_auth',
   'views/base',
   'views/form',
   'views/sign_in',
   'views/mixins/password-mixin',
   'views/mixins/resume-token-mixin',
-  'stache!templates/force_auth',
-  'lib/session',
-  'lib/auth-errors'
+  'views/mixins/signed-in-notification-mixin'
 ],
-function (Cocktail, p, BaseView, FormView, SignInView, PasswordMixin,
-    ResumeTokenMixin, Template, Session, AuthErrors) {
+function (Cocktail, AuthErrors, p, Session, Template, BaseView, FormView,
+  SignInView, PasswordMixin, ResumeTokenMixin, SignedInNotificationMixin) {
   'use strict';
 
   function getFatalErrorMessage(self, fatalError) {
@@ -149,7 +150,8 @@ function (Cocktail, p, BaseView, FormView, SignInView, PasswordMixin,
   Cocktail.mixin(
     View,
     PasswordMixin,
-    ResumeTokenMixin
+    ResumeTokenMixin,
+    SignedInNotificationMixin
   );
 
   return View;

--- a/app/scripts/views/mixins/signed-in-notification-mixin.js
+++ b/app/scripts/views/mixins/signed-in-notification-mixin.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Handle signed-in notifications.
+
+define([
+  'lib/promise'
+],
+function (p) {
+  'use strict';
+
+  function navigateToSignedInView (event) {
+    if (this.broker.hasCapability('handleSignedInNotification')) {
+      var self = this;
+      return this.user.setSignedInAccount(event)
+        .then(function () {
+          self.navigate(self._redirectTo || 'settings');
+        });
+    }
+
+    return p();
+  }
+
+  return {
+    initialize: function (options) {
+      this._notifications = options.notifications;
+      this._navigateToSignedInView = navigateToSignedInView.bind(this);
+      this._notifications.on(
+        this._notifications.EVENTS.SIGNED_IN,
+        this._navigateToSignedInView
+      );
+    },
+
+    destroy: function () {
+      this._notifications.off(
+        this._notifications.EVENTS.SIGNED_IN,
+        this._navigateToSignedInView
+      );
+    }
+  };
+});

--- a/app/scripts/views/mixins/signed-out-notification-mixin.js
+++ b/app/scripts/views/mixins/signed-out-notification-mixin.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Handle signed-out notifications.
+
+define([
+  'lib/session',
+  'views/base'
+],
+function (Session, BaseView) {
+  'use strict';
+
+  function clearSessionAndNavigateToSignIn () {
+    // Unset uid otherwise it will henceforth be impossible
+    // to sign in to different accounts inside this tab.
+    this.relier.unset('uid');
+    this.relier.unset('email');
+    this.relier.unset('preVerifyToken');
+    this.user.clearSignedInAccountUid();
+    // The user has manually signed out, a pretty strong indicator
+    // the user does not want any of their information pre-filled
+    // on the signin page. Clear any remaining formPrefill info
+    // to ensure their data isn't sticking around in memory.
+    this._formPrefill.clear();
+    Session.clear();
+    this.navigate('signin', {
+      clearQueryParams: true,
+      success: BaseView.t('Signed out successfully')
+    });
+  }
+
+  return {
+    initialize: function (options) {
+      this._notifications = options.notifications;
+      this.clearSessionAndNavigateToSignIn = clearSessionAndNavigateToSignIn.bind(this);
+      this._notifications.on(
+        this._notifications.EVENTS.SIGNED_OUT,
+        this.clearSessionAndNavigateToSignIn
+      );
+    },
+
+    destroy: function () {
+      this._notifications.off(
+        this._notifications.EVENTS.SIGNED_OUT,
+        this.clearSessionAndNavigateToSignIn
+      );
+    }
+  };
+});

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -4,12 +4,16 @@
 
 /* exceptsPaths: modal */
 define([
+  'cocktail',
   'jquery',
   'modal',
-  'cocktail',
-  'lib/session',
+  'stache!templates/settings',
   'views/base',
+  'views/decorators/allow_only_one_submit',
   'views/mixins/avatar-mixin',
+  'views/mixins/loading-mixin',
+  'views/mixins/settings-mixin',
+  'views/mixins/signed-out-notification-mixin',
   'views/settings/avatar',
   'views/settings/avatar_change',
   'views/settings/avatar_crop',
@@ -20,20 +24,14 @@ define([
   'views/settings/change_password',
   'views/settings/delete_account',
   'views/settings/display_name',
-  'views/sub_panels',
-  'views/mixins/settings-mixin',
-  'views/mixins/loading-mixin',
-  'views/decorators/allow_only_one_submit',
-  'stache!templates/settings'
+  'views/sub_panels'
 ],
-function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
-  AvatarView, AvatarChangeView, AvatarCropView, AvatarCameraView, GravatarView,
-  GravatarPermissionsView, CommunicationPreferencesView, ChangePasswordView,
-  DeleteAccountView, DisplayNameView, SubPanels, SettingsMixin, LoadingMixin,
-  allowOnlyOneSubmit, Template) {
+function (Cocktail, $, modal, Template, BaseView, allowOnlyOneSubmit, AvatarMixin,
+  LoadingMixin, SettingsMixin, SignedOutNotificationMixin, AvatarView, AvatarChangeView,
+  AvatarCropView, AvatarCameraView, GravatarView, GravatarPermissionsView,
+  CommunicationPreferencesView, ChangePasswordView, DeleteAccountView,
+  DisplayNameView, SubPanels) {
   'use strict';
-
-  var t = BaseView.t;
 
   var PANEL_VIEWS = [
     AvatarView,
@@ -206,22 +204,8 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
         })
         .fin(function () {
           self.logViewEvent('signout.success');
-          // Unset uid otherwise it will henceforth be impossible
-          // to sign in to different accounts inside this tab.
-          self.relier.unset('uid');
-          self.relier.unset('email');
-          self.relier.unset('preVerifyToken');
           self.user.clearSignedInAccount();
-          // The user has manually signed out, a pretty strong indicator
-          // the user does not want any of their information pre-filled
-          // on the signin page. Clear any remaining formPrefill info
-          // to ensure their data isn't sticking around in memory.
-          self._formPrefill.clear();
-          Session.clear();
-          self.navigate('signin', {
-            clearQueryParams: true,
-            success: t('Signed out successfully')
-          });
+          self.clearSessionAndNavigateToSignIn();
         });
     }),
 
@@ -250,7 +234,8 @@ function ($, modal, Cocktail, Session, BaseView, AvatarMixin,
     View,
     AvatarMixin,
     LoadingMixin,
-    SettingsMixin
+    SettingsMixin,
+    SignedOutNotificationMixin
   );
 
   return View;

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -4,26 +4,27 @@
 
 define([
   'cocktail',
+  'lib/auth-errors',
   'lib/promise',
+  'lib/session',
+  'stache!templates/sign_in',
   'views/base',
   'views/form',
-  'stache!templates/sign_in',
-  'lib/session',
-  'lib/auth-errors',
+  'views/decorators/allow_only_one_submit',
+  'views/decorators/progress_indicator',
+  'views/mixins/account-locked-mixin',
+  'views/mixins/avatar-mixin',
+  'views/mixins/migration-mixin',
   'views/mixins/password-mixin',
   'views/mixins/resume-token-mixin',
   'views/mixins/service-mixin',
-  'views/mixins/signup-disabled-mixin',
-  'views/mixins/avatar-mixin',
-  'views/mixins/account-locked-mixin',
-  'views/mixins/migration-mixin',
-  'views/decorators/allow_only_one_submit',
-  'views/decorators/progress_indicator'
+  'views/mixins/signed-in-notification-mixin',
+  'views/mixins/signup-disabled-mixin'
 ],
-function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
-  AuthErrors, PasswordMixin, ResumeTokenMixin, ServiceMixin,
-  SignupDisabledMixin, AvatarMixin, AccountLockedMixin, MigrationMixin,
-  allowOnlyOneSubmit, showProgressIndicator) {
+function (Cocktail, AuthErrors, p, Session, SignInTemplate, BaseView, FormView,
+  allowOnlyOneSubmit, showProgressIndicator, AccountLockedMixin, AvatarMixin,
+  MigrationMixin, PasswordMixin, ResumeTokenMixin, ServiceMixin,
+  SignedInNotificationMixin, SignupDisabledMixin) {
 
   'use strict';
 
@@ -306,6 +307,7 @@ function (Cocktail, p, BaseView, FormView, SignInTemplate, Session,
     PasswordMixin,
     ResumeTokenMixin,
     ServiceMixin,
+    SignedInNotificationMixin,
     SignupDisabledMixin
   );
 

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -3,27 +3,28 @@
 
 define([
   'cocktail',
+  'lib/auth-errors',
   'lib/promise',
+  'lib/mailcheck',
+  'stache!templates/sign_up',
   'views/base',
   'views/form',
-  'stache!templates/sign_up',
-  'lib/auth-errors',
-  'lib/mailcheck',
+  'views/coppa/coppa-age-input',
+  'views/mixins/checkbox-mixin',
   'views/mixins/experiment-mixin',
+  'views/mixins/migration-mixin',
   'views/mixins/password-mixin',
   'views/mixins/password-strength-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/checkbox-mixin',
   'views/mixins/resume-token-mixin',
-  'views/mixins/migration-mixin',
+  'views/mixins/service-mixin',
+  'views/mixins/signed-in-notification-mixin',
   'views/mixins/signup-disabled-mixin',
-  'views/mixins/signup-success-mixin',
-  'views/coppa/coppa-age-input'
+  'views/mixins/signup-success-mixin'
 ],
-function (Cocktail, p, BaseView, FormView, Template, AuthErrors, mailcheck,
-  ExperimentMixin, PasswordMixin, PasswordStrengthMixin, ServiceMixin,
-  CheckboxMixin, ResumeTokenMixin, MigrationMixin, SignupDisabledMixin,
-  SignupSuccessMixin, CoppaAgeInput) {
+function (Cocktail, AuthErrors, p, mailcheck, Template, BaseView, FormView,
+  CoppaAgeInput, CheckboxMixin, ExperimentMixin, MigrationMixin, PasswordMixin,
+  PasswordStrengthMixin, ResumeTokenMixin, ServiceMixin, SignedInNotificationMixin,
+  SignupDisabledMixin, SignupSuccessMixin) {
   'use strict';
 
   var t = BaseView.t;
@@ -360,6 +361,7 @@ function (Cocktail, p, BaseView, FormView, Template, AuthErrors, mailcheck,
     PasswordStrengthMixin,
     ResumeTokenMixin,
     ServiceMixin,
+    SignedInNotificationMixin,
     SignupDisabledMixin,
     SignupSuccessMixin
   );

--- a/app/tests/spec/lib/channels/inter-tab.js
+++ b/app/tests/spec/lib/channels/inter-tab.js
@@ -232,14 +232,43 @@ define([
       });
 
       describe('on', function () {
-        var callback = function () {};
+        var handler;
+
         beforeEach(function () {
+          sinon.stub(crossTabMock.util, 'tabCount', function () {
+            return 2;
+          });
+          sinon.stub(crossTabMock.util, 'generateId', function () {
+            return 'wibble';
+          });
           sinon.spy(crossTabMock.util.events, 'on');
-          localStorageAdapter.on('message', callback);
+          sinon.spy(crossTabMock.util.events, 'off');
+          sinon.spy(crossTabMock, 'broadcast');
+          handler = function () {};
+          localStorageAdapter.on('message', handler);
         });
 
-        it('register a callback to be called when a message is sent', function () {
-          assert.isTrue(crossTabMock.util.events.on.calledWith('message'));
+        it('calls crosstab.util.events.on correctly', function () {
+          assert.equal(crossTabMock.util.events.on.callCount, 1);
+          var args = crossTabMock.util.events.on.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'message');
+          assert.isFunction(args[1]);
+        });
+
+        describe('send', function () {
+          beforeEach(function () {
+            localStorageAdapter.send('message', 'data');
+          });
+
+          it('calls crosstab.broadcast correctly', function () {
+            assert.equal(crossTabMock.broadcast.callCount, 1);
+            var args = crossTabMock.broadcast.args[0];
+            assert.lengthOf(args, 3);
+            assert.equal(args[0], 'message');
+            assert.deepEqual(args[1], { data: 'data', id: 'wibble' });
+            assert.isNull(args[2]);
+          });
         });
       });
 

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -21,7 +21,7 @@ function (chai, Relier, BaseAuthenticationBroker,
     var view;
     var windowMock;
 
-    beforeEach(function () {
+    before(function () {
       view = new BaseView();
       windowMock = new WindowMock();
       relier = new Relier();
@@ -196,6 +196,18 @@ function (chai, Relier, BaseAuthenticationBroker,
 
         it('returns `true` for `signup` by default', function () {
           assert.isTrue(broker.hasCapability('signup'));
+        });
+
+        it('returns `true` for `handleSignedInNotification` by default', function () {
+          assert.isTrue(broker.hasCapability('handleSignedInNotification'));
+        });
+
+        it('returns `true` for `emailVerificationMarketingSnippet` by default', function () {
+          assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+        });
+
+        it('returns `false` for `syncPreferencesNotification` by default', function () {
+          assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
         });
       });
 

--- a/app/tests/spec/models/auth_brokers/first-run.js
+++ b/app/tests/spec/models/auth_brokers/first-run.js
@@ -35,6 +35,22 @@ function (chai, sinon, NullChannel, Account, FirstRunAuthenticationBroker, Relie
       });
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `handleSignedInNotification` capability by default', function () {
+      assert.isTrue(broker.hasCapability('handleSignedInNotification'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('afterLoaded', function () {
       it('notifies the iframe channel', function () {
         sinon.spy(iframeChannel, 'send');

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
@@ -43,6 +43,22 @@ define([
       });
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `handleSignedInNotification` capability by default', function () {
+      assert.isTrue(broker.hasCapability('handleSignedInNotification'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('createChannel', function () {
       it('creates a channel', function () {
         assert.ok(broker.createChannel());

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -23,7 +23,7 @@ define([
     var user;
     var windowMock;
 
-    beforeEach(function () {
+    before(function () {
       windowMock = new WindowMock();
       channelMock = new NullChannel();
       channelMock.send = sinon.spy(function () {
@@ -41,6 +41,22 @@ define([
         channel: channelMock,
         window: windowMock
       });
+    });
+
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `handleSignedInNotification` capability by default', function () {
+      assert.isTrue(broker.hasCapability('handleSignedInNotification'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
     });
 
     describe('createChannel', function () {
@@ -116,6 +132,10 @@ define([
     });
 
     describe('afterSignUp', function () {
+      afterEach(function () {
+        broker.hasCapability.restore();
+      });
+
       it('causes a redirect to `/choose_what_to_sync` if `chooseWhatToSyncWebV1` capability is supported', function () {
         sinon.stub(broker, 'hasCapability', function (capabilityName) {
           return capabilityName === 'chooseWhatToSyncWebV1';
@@ -128,7 +148,7 @@ define([
       });
 
       it('does nothing if `chooseWhatToSyncWebV1` capability is unsupported', function () {
-        sinon.stub(broker, 'hasCapability', function (capabilityName) {
+        sinon.stub(broker, 'hasCapability', function () {
           return false;
         });
 

--- a/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -46,6 +46,22 @@ function (chai, NullChannel, FxFennecV1AuthenticationBroker, Relier,
       sinon.spy(broker, 'send');
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `handleSignedInNotification` capability by default', function () {
+      assert.isTrue(broker.hasCapability('handleSignedInNotification'));
+    });
+
+    it('does not have the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isFalse(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('has the `syncPreferencesNotification` capability by default', function () {
+      assert.isTrue(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     it('disables the `chooseWhatToSyncCheckbox` capability', function () {
       return broker.fetch()
         .then(function () {

--- a/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -15,54 +15,107 @@ function (chai, NullChannel, FxiOSAuthenticationBroker, Relier, WindowMock) {
   var assert = chai.assert;
 
   describe('models/auth_brokers/fx-ios-v1', function () {
-    var broker;
     var channel;
     var relier;
     var windowMock;
 
     function createBroker () {
-      broker = new FxiOSAuthenticationBroker({
+      return new FxiOSAuthenticationBroker({
         channel: channel,
         relier: relier,
         window: windowMock
       });
     }
 
-    beforeEach(function () {
+    before(function () {
       channel = new NullChannel();
       relier = new Relier();
       windowMock = new WindowMock();
     });
 
-    describe('`signup` capability', function () {
-      it('returns `false` if `exclude_signup=1` is specified, a reason is provided', function () {
-        windowMock.location.search = '?exclude_signup=1';
-        createBroker();
+    describe('`exclude_signup` parameter is set', function () {
+      var broker;
 
-        return broker.fetch()
-          .then(function () {
-            assert.isFalse(broker.hasCapability('signup'));
-            assert.ok(broker.SIGNUP_DISABLED_REASON);
-          });
+      before(function () {
+        windowMock.location.search = '?exclude_signup=1';
+        broker = createBroker();
       });
 
-      it('returns `true` otherwise', function () {
+      after(function () {
         windowMock.location.search = '';
-        createBroker();
+      });
 
-        return broker.fetch()
-          .then(function () {
-            assert.isTrue(broker.hasCapability('signup'));
-          });
+      it('has the `signup` capability by default', function () {
+        assert.isTrue(broker.hasCapability('signup'));
+      });
+
+      it('has the `handleSignedInNotification` capability by default', function () {
+        assert.isTrue(broker.hasCapability('handleSignedInNotification'));
+      });
+
+      it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+        assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+      });
+
+      it('does not have the `syncPreferencesNotification` capability by default', function () {
+        assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+      });
+
+      describe('`broker.fetch` is called', function () {
+        before(function () {
+          return broker.fetch();
+        });
+
+        it('does not have the `signup` capability', function () {
+          assert.isFalse(broker.hasCapability('signup'));
+        });
+
+        it('`broker.SIGNUP_DISABLED_REASON` is set', function () {
+          assert.instanceOf(broker.SIGNUP_DISABLED_REASON, Error);
+        });
       });
     });
 
-    it('disables the `chooseWhatToSyncCheckbox` capability', function () {
-      createBroker();
-      return broker.fetch()
-        .then(function () {
+    describe('`exclude_signup` parameter is not set', function () {
+      var broker;
+
+      before(function () {
+        broker = createBroker();
+      });
+
+      it('has the `signup` capability by default', function () {
+        assert.isTrue(broker.hasCapability('signup'));
+      });
+
+      it('has the `handleSignedInNotification` capability by default', function () {
+        assert.isTrue(broker.hasCapability('handleSignedInNotification'));
+      });
+
+      it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+        assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+      });
+
+      it('does not have the `syncPreferencesNotification` capability by default', function () {
+        assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+      });
+
+      describe('`broker.fetch` is called', function () {
+        before(function () {
+          return broker.fetch();
+        });
+
+        it('has the `signup` capability', function () {
+          assert.isTrue(broker.hasCapability('signup'));
+        });
+
+        it('`broker.SIGNUP_DISABLED_REASON` is not set', function () {
+          assert.isUndefined(broker.SIGNUP_DISABLED_REASON);
+        });
+
+        it('does not have the `chooseWhatToSyncCheckbox` capability', function () {
           assert.isFalse(broker.hasCapability('chooseWhatToSyncCheckbox'));
         });
+      });
     });
   });
 });

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -58,6 +58,22 @@ define([
       createAuthBroker();
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('has the `handleSignedInNotification` capability by default', function () {
+      assert.isTrue(broker.hasCapability('handleSignedInNotification'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('afterLoaded', function () {
       it('sends a `loaded` message', function () {
         return broker.afterLoaded()

--- a/app/tests/spec/models/auth_brokers/iframe.js
+++ b/app/tests/spec/models/auth_brokers/iframe.js
@@ -46,6 +46,22 @@ function (chai, sinon, $, IframeAuthenticationBroker, Relier, p, NullChannel,
       }
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `handleSignedInNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('handleSignedInNotification'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('sendOAuthResultToRelier', function () {
       it('sends an `oauth_complete` message', function () {
         sinon.stub(broker, 'send', function () {

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -83,6 +83,22 @@ function (chai, sinon, Session, p, Constants, OAuthClient, Assertion, AuthErrors
       sinon.spy(broker, 'finishOAuthFlow');
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `handleSignedInNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('handleSignedInNotification'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('sendOAuthResultToRelier', function () {
       it('must be overridden', function () {
         return broker.sendOAuthResultToRelier()

--- a/app/tests/spec/models/auth_brokers/redirect.js
+++ b/app/tests/spec/models/auth_brokers/redirect.js
@@ -50,6 +50,22 @@ function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
       });
     });
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `handleSignedInNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('handleSignedInNotification'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
+
     describe('sendOAuthResultToRelier', function () {
       describe('with no error', function () {
         it('prepares window to be closed', function () {

--- a/app/tests/spec/models/auth_brokers/web-channel.js
+++ b/app/tests/spec/models/auth_brokers/web-channel.js
@@ -91,6 +91,21 @@ function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWr
       };
     }
 
+    it('has the `signup` capability by default', function () {
+      assert.isTrue(broker.hasCapability('signup'));
+    });
+
+    it('does not have the `handleSignedInNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('handleSignedInNotification'));
+    });
+
+    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+      assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
+    });
+
+    it('does not have the `syncPreferencesNotification` capability by default', function () {
+      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    });
 
     describe('fetch', function () {
       describe('for the signin/signup flow', function () {

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -307,7 +307,13 @@ function (chai, sinon, p, AuthErrors, Metrics, FxaClient, InterTabChannel,
                   { reason: view.fxaClient.SIGNIN_REASON.PASSWORD_RESET }
               ));
               assert.equal(routerMock.page, 'reset_password_complete');
-              assert.isTrue(interTabChannel.send.calledWith('login'));
+
+              assert.equal(interTabChannel.send.callCount, 1);
+              var args = interTabChannel.send.args[0];
+              assert.lengthOf(args, 2);
+              assert.equal(args[0], 'login');
+              assert.isObject(args[1]);
+
               assert.isTrue(TestHelpers.isEventLogged(
                       metrics, 'complete_reset_password.verification.success'));
               return user.setSignedInAccount.returnValues[0].then(function (returnValue) {

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -13,14 +13,15 @@ define([
   'lib/auth-errors',
   'models/reliers/relier',
   'models/auth_brokers/base',
-  'models/user',
   'models/form-prefill',
+  'models/notifications',
+  'models/user',
   '../../mocks/window',
   '../../mocks/router',
   '../../lib/helpers'
 ],
 function (chai, $, sinon, View, SignInView, FxaClient, p, AuthErrors, Relier,
-  Broker, User, FormPrefill, WindowMock, RouterMock, TestHelpers) {
+  Broker, FormPrefill, Notifications, User, WindowMock, RouterMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -30,6 +31,7 @@ function (chai, $, sinon, View, SignInView, FxaClient, p, AuthErrors, Relier,
     var email;
     var formPrefill;
     var fxaClient;
+    var notifications;
     var relier;
     var router;
     var user;
@@ -40,15 +42,19 @@ function (chai, $, sinon, View, SignInView, FxaClient, p, AuthErrors, Relier,
       broker = new Broker();
       formPrefill = new FormPrefill();
       fxaClient = new FxaClient();
+      notifications = new Notifications();
       relier = new Relier();
       router = new RouterMock();
-      user = new User();
+      user = new User({
+        notifications: notifications
+      });
       windowMock = new WindowMock();
 
       view = new View({
         broker: broker,
         formPrefill: formPrefill,
         fxaClient: fxaClient,
+        notifications: notifications,
         relier: relier,
         router: router,
         user: user,

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -189,8 +189,7 @@ define([
       });
 
       it('call onProfileUpdate after notification', function () {
-        notifications.profileUpdated.restore();
-        notifications.profileUpdated({});
+        notifications.trigger(notifications.EVENTS.PROFILE_CHANGE, {});
         assert.isTrue(spy.called);
       });
     });

--- a/app/tests/spec/views/mixins/settings-mixin.js
+++ b/app/tests/spec/views/mixins/settings-mixin.js
@@ -5,13 +5,14 @@
 define([
   'chai',
   'cocktail',
-  'models/reliers/relier',
-  'models/user',
   'sinon',
+  'models/notifications',
+  'models/user',
+  'models/reliers/relier',
   'stache!templates/test_template',
   'views/base',
   'views/mixins/settings-mixin'
-], function (chai, Cocktail, Relier, User, sinon, TestTemplate,
+], function (chai, Cocktail, sinon, Notifications, User, Relier, TestTemplate,
   BaseView, SettingsMixin) {
   'use strict';
 
@@ -28,6 +29,7 @@ define([
     var sandbox;
     var user;
     var view;
+    var notifications;
 
     function createView() {
       view = new SettingsView({
@@ -38,7 +40,10 @@ define([
 
     beforeEach(function () {
       relier = new Relier();
-      user = new User();
+      notifications = new Notifications();
+      user = new User({
+        notifications: notifications
+      });
 
       sandbox = new sinon.sandbox.create();
       sandbox.spy(user, 'setSignedInAccountByUid');

--- a/app/tests/spec/views/mixins/signed-in-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-in-notification-mixin.js
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'cocktail',
+  'sinon',
+  'lib/promise',
+  'models/notifications',
+  'views/base',
+  'views/mixins/signed-in-notification-mixin'
+], function (chai, Cocktail, sinon, p, Notifications, BaseView,
+  SignedInNotificationMixin) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  var View = BaseView.extend({});
+  Cocktail.mixin(View, SignedInNotificationMixin);
+
+  describe('views/mixins/signed-in-notification-mixin', function () {
+    it('exports correct interface', function () {
+      assert.lengthOf(Object.keys(SignedInNotificationMixin), 2);
+      assert.isFunction(SignedInNotificationMixin.initialize);
+      assert.isFunction(SignedInNotificationMixin.destroy);
+    });
+
+    describe('new View', function () {
+      var notifications;
+      var view;
+
+      before(function () {
+        notifications = new Notifications();
+        notifications.on = sinon.spy();
+        view = new View({
+          notifications: notifications
+        });
+      });
+
+      after(function () {
+        view.destroy();
+      });
+
+      it('calls notifications.on correctly', function () {
+        assert.equal(notifications.on.callCount, 1);
+        var args = notifications.on.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], notifications.EVENTS.SIGNED_IN);
+        assert.isFunction(args[1]);
+      });
+
+      describe('navigateToSignedInView', function () {
+        before(function () {
+          view.broker = {
+            hasCapability: sinon.spy(function () {
+              return true;
+            })
+          };
+          view.user = {
+            setSignedInAccount: sinon.spy(function () {
+              return p();
+            })
+          };
+          view.navigate = sinon.spy();
+          notifications.broadcast = sinon.spy();
+          return notifications.on.args[0][1]({
+            data: 'foo'
+          });
+        });
+
+        it('calls broker.hasCapability correctly', function () {
+          assert.equal(view.broker.hasCapability.callCount, 1);
+          assert.isTrue(view.broker.hasCapability.alwaysCalledOn(view.broker));
+          var args = view.broker.hasCapability.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'handleSignedInNotification');
+        });
+
+        it('calls user.setSignedInAccount correctly', function () {
+          assert.equal(view.user.setSignedInAccount.callCount, 1);
+          assert.isTrue(view.user.setSignedInAccount.alwaysCalledOn(view.user));
+          var args = view.user.setSignedInAccount.args[0];
+          assert.lengthOf(args, 1);
+          assert.deepEqual(args[0], { data: 'foo' });
+        });
+
+        it('calls navigate correctly', function () {
+          assert.equal(view.navigate.callCount, 1);
+          assert.isTrue(view.navigate.alwaysCalledOn(view));
+          assert.isTrue(view.navigate.calledAfter(view.user.setSignedInAccount));
+          var args = view.navigate.args[0];
+          assert.lengthOf(args, 1);
+          assert.equal(args[0], 'settings');
+        });
+
+        it('does not call notifications.broadcast', function () {
+          assert.equal(notifications.broadcast.callCount, 0);
+        });
+      });
+
+      describe('navigateToSignedInView without handleSignedInNotification capability', function () {
+        before(function () {
+          view.broker = {
+            hasCapability: sinon.spy(function () {
+              return false;
+            })
+          };
+          view.user = {
+            setSignedInAccount: sinon.spy(function () {
+              return p();
+            })
+          };
+          view.navigate = sinon.spy();
+          notifications.on.args[0][1]({
+            data: 'foo'
+          });
+        });
+
+        it('calls broker.hasCapability', function () {
+          assert.equal(view.broker.hasCapability.callCount, 1);
+        });
+
+        it('does not call user.setSignedInAccount', function () {
+          assert.equal(view.user.setSignedInAccount.callCount, 0);
+        });
+
+        it('does not call navigate', function () {
+          assert.equal(view.navigate.callCount, 0);
+        });
+      });
+
+      describe('navigateToSignedInView with OAuth redirect URL', function () {
+        before(function () {
+          view.broker = {
+            hasCapability: sinon.spy(function () {
+              return true;
+            })
+          };
+          view.user = {
+            setSignedInAccount: sinon.spy(function () {
+              return p();
+            })
+          };
+          view.navigate = sinon.spy();
+          view._redirectTo = 'foo';
+          return notifications.on.args[0][1]({
+            data: 'bar'
+          });
+        });
+
+        it('calls broker.hasCapability', function () {
+          assert.equal(view.broker.hasCapability.callCount, 1);
+        });
+
+        it('calls user.setSignedInAccount correctly', function () {
+          assert.equal(view.user.setSignedInAccount.callCount, 1);
+          assert.deepEqual(view.user.setSignedInAccount.args[0][0], { data: 'bar' });
+        });
+
+        it('calls navigate correctly', function () {
+          assert.equal(view.navigate.callCount, 1);
+          assert.equal(view.navigate.args[0][0], 'foo');
+        });
+      });
+
+      describe('destroy', function () {
+        beforeEach(function () {
+          notifications.off = sinon.spy();
+          view.destroy();
+        });
+
+        it('calls notifications.off correctly', function () {
+          assert.equal(notifications.off.callCount, 1);
+          var args = notifications.off.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], notifications.EVENTS.SIGNED_IN);
+          assert.equal(args[1], notifications.on.args[0][1]);
+        });
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/mixins/signed-out-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-out-notification-mixin.js
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'chai',
+  'cocktail',
+  'sinon',
+  'models/notifications',
+  'views/base',
+  'views/mixins/signed-out-notification-mixin'
+], function (chai, Cocktail, sinon, Notifications, BaseView,
+  SignedOutNotificationMixin) {
+  'use strict';
+
+  var assert = chai.assert;
+
+  var View = BaseView.extend({});
+  Cocktail.mixin(View, SignedOutNotificationMixin);
+
+  describe('views/mixins/signed-out-notification-mixin', function () {
+    it('exports correct interface', function () {
+      assert.lengthOf(Object.keys(SignedOutNotificationMixin), 2);
+      assert.isFunction(SignedOutNotificationMixin.initialize);
+      assert.isFunction(SignedOutNotificationMixin.destroy);
+    });
+
+    describe('new View', function () {
+      var notifications;
+      var view;
+
+      before(function () {
+        notifications = new Notifications();
+        notifications.on = sinon.spy();
+        view = new View({
+          notifications: notifications
+        });
+      });
+
+      afterEach(function () {
+        view.destroy();
+      });
+
+      it('calls notifications.on correctly', function () {
+        assert.equal(notifications.on.callCount, 1);
+        var args = notifications.on.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], 'fxaccounts:logout');
+        assert.isFunction(args[1]);
+      });
+
+      describe('clearSessionAndNavigateToSignIn', function () {
+        before(function () {
+          view.relier = {
+            unset: sinon.spy()
+          };
+          view.user = {
+            clearSignedInAccountUid: sinon.spy()
+          };
+          view._formPrefill = {
+            clear: sinon.spy()
+          };
+          view.navigate = sinon.spy();
+          notifications.on.args[0][1]();
+        });
+
+        it('calls relier.unset correctly', function () {
+          assert.equal(view.relier.unset.callCount, 3);
+
+          assert.lengthOf(view.relier.unset.args[0], 1);
+          assert.equal(view.relier.unset.args[0][0], 'uid');
+
+          assert.lengthOf(view.relier.unset.args[1], 1);
+          assert.equal(view.relier.unset.args[1][0], 'email');
+
+          assert.lengthOf(view.relier.unset.args[2], 1);
+          assert.equal(view.relier.unset.args[2][0], 'preVerifyToken');
+        });
+
+        it('calls user.clearSignedInAccountUid correctly', function () {
+          assert.equal(view.user.clearSignedInAccountUid.callCount, 1);
+          assert.lengthOf(view.user.clearSignedInAccountUid.args[0], 0);
+        });
+
+        it('calls _formPrefill.clear correctly', function () {
+          assert.equal(view._formPrefill.clear.callCount, 1);
+          assert.lengthOf(view._formPrefill.clear.args[0], 0);
+        });
+
+        it('calls navigate correctly', function () {
+          assert.equal(view.navigate.callCount, 1);
+          assert.isTrue(view.navigate.calledAfter(view.user.clearSignedInAccountUid));
+          assert.isTrue(view.navigate.calledAfter(view._formPrefill.clear));
+          var args = view.navigate.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'signin');
+          assert.isObject(args[1]);
+          assert.lengthOf(Object.keys(args[1]), 2);
+          assert.isTrue(args[1].clearQueryParams);
+          assert.equal(args[1].success, 'Signed out successfully');
+        });
+      });
+
+      describe('destroy', function () {
+        beforeEach(function () {
+          notifications.off = sinon.spy();
+          view.destroy();
+        });
+
+        it('calls notifications.off correctly', function () {
+          assert.equal(notifications.off.callCount, 1);
+          var args = notifications.off.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], notifications.EVENTS.SIGNED_OUT);
+          assert.equal(args[1], notifications.on.args[0][1]);
+        });
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/oauth_sign_in.js
+++ b/app/tests/spec/views/oauth_sign_in.js
@@ -13,14 +13,16 @@ define([
   'lib/metrics',
   'models/reliers/oauth',
   'models/auth_brokers/oauth',
-  'models/user',
   'models/form-prefill',
+  'models/notifications',
+  'models/user',
   '../../mocks/window',
   '../../mocks/router',
   '../../lib/helpers'
 ],
 function (chai, $, sinon, View, Session, FxaClient, p, Metrics, OAuthRelier,
-      OAuthBroker, User, FormPrefill, WindowMock, RouterMock, TestHelpers) {
+  OAuthBroker, FormPrefill, Notifications, User, WindowMock, RouterMock,
+  TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -37,6 +39,7 @@ function (chai, $, sinon, View, Session, FxaClient, p, Metrics, OAuthRelier,
     var profileClientMock;
     var user;
     var formPrefill;
+    var notifications;
 
     var CLIENT_ID = 'dcdb5ae7add825d2';
     var STATE = '123';
@@ -59,11 +62,13 @@ function (chai, $, sinon, View, Session, FxaClient, p, Metrics, OAuthRelier,
       });
       fxaClient = new FxaClient();
       user = new User({
-        fxaClient: fxaClient
+        fxaClient: fxaClient,
+        notifications: notifications
       });
       metrics = new Metrics();
       profileClientMock = TestHelpers.stubbedProfileClient();
       formPrefill = new FormPrefill();
+      notifications = new Notifications();
 
       initView();
       return view.render()
@@ -84,6 +89,7 @@ function (chai, $, sinon, View, Session, FxaClient, p, Metrics, OAuthRelier,
         formPrefill: formPrefill,
         fxaClient: fxaClient,
         metrics: metrics,
+        notifications: notifications,
         profileClient: profileClientMock,
         relier: relier,
         router: router,

--- a/app/tests/spec/views/openid/login.js
+++ b/app/tests/spec/views/openid/login.js
@@ -7,13 +7,15 @@ define([
   'sinon',
   'lib/promise',
   'lib/fxa-client',
+  'models/notifications',
   'models/user',
   'models/auth_brokers/base',
   'views/openid/login',
   '../../../mocks/window',
   '../../../mocks/router',
 ],
-function (chai, sinon, p, FxaClient, User, Broker, View, WindowMock, RouterMock) {
+function (chai, sinon, p, FxaClient, Notifications, User, Broker, View,
+  WindowMock, RouterMock) {
   'use strict';
 
   var assert = chai.assert;
@@ -23,6 +25,7 @@ function (chai, sinon, p, FxaClient, User, Broker, View, WindowMock, RouterMock)
     var windowMock;
     var routerMock;
     var fxaClient;
+    var notifications;
     var user;
     var broker;
 
@@ -31,8 +34,10 @@ function (chai, sinon, p, FxaClient, User, Broker, View, WindowMock, RouterMock)
       windowMock = new WindowMock();
       routerMock = new RouterMock();
       fxaClient = new FxaClient();
+      notifications = new Notifications();
       user = new User({
-        fxaClient: fxaClient
+        fxaClient: fxaClient,
+        notifications: notifications
       });
       broker = new Broker();
 

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -87,11 +87,12 @@ function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
       fxaClient = new FxaClient();
       profileClient = new ProfileClient();
 
+      notifications = new Notifications();
       user = new User({
         fxaClient: fxaClient,
+        notifications: notifications,
         profileClient: profileClient
       });
-      notifications = new Notifications();
 
       formPrefill = new FormPrefill();
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -15,17 +15,18 @@ define([
   'lib/fxa-client',
   'lib/constants',
   'lib/ephemeral-messages',
+  'models/auth_brokers/base',
+  'models/form-prefill',
+  'models/notifications',
   'models/reliers/relier',
   'models/user',
-  'models/form-prefill',
-  'models/auth_brokers/base',
   '../../mocks/window',
   '../../mocks/router',
   '../../lib/helpers'
 ],
 function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
-      FxaClient, Constants, EphemeralMessages, Relier, User, FormPrefill, Broker,
-      WindowMock, RouterMock, TestHelpers) {
+  FxaClient, Constants, EphemeralMessages, Broker, FormPrefill, Notifications,
+  Relier, User, WindowMock, RouterMock, TestHelpers) {
   'use strict';
 
   var assert = chai.assert;
@@ -43,6 +44,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
     var user;
     var formPrefill;
     var ephemeralMessages;
+    var notifications;
 
     beforeEach(function () {
       email = TestHelpers.createEmail();
@@ -58,10 +60,12 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
       });
       fxaClient = new FxaClient();
       user = new User({
-        fxaClient: fxaClient
+        fxaClient: fxaClient,
+        notifications: notifications
       });
       formPrefill = new FormPrefill();
       ephemeralMessages = new EphemeralMessages();
+      notifications = new Notifications();
 
       initView();
 
@@ -87,6 +91,7 @@ function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
         formPrefill: formPrefill,
         fxaClient: fxaClient,
         metrics: metrics,
+        notifications: notifications,
         relier: relier,
         router: routerMock,
         user: user,

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -618,6 +618,7 @@ function (chai, $, sinon, p, View, CoppaAgeInput, Session, AuthErrors, Experimen
         var revisitView = new View({
           able: able,
           fxaClient: fxaClient,
+          notifications: notifications,
           relier: relier,
           router: revisitRouter
         });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -125,6 +125,8 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/migration-mixin',
     '../tests/spec/views/mixins/modal-settings-panel-mixin',
     '../tests/spec/views/mixins/settings-panel-mixin',
+    '../tests/spec/views/mixins/signed-in-notification-mixin',
+    '../tests/spec/views/mixins/signed-out-notification-mixin',
     '../tests/spec/views/mixins/signup-enabled-mixin',
     '../tests/spec/views/openid/login',
     '../tests/spec/views/openid/start',

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -189,8 +189,33 @@ define([
         })
         .findById('avatar-options')
         .end();
-    }
+    },
 
+    'sign in, open settings in a second tab, sign out': function () {
+      var windowName = 'sign-out inter-tab functional test';
+      var self = this;
+      return FunctionalHelpers.fillOutSignIn(this, email, FIRST_PASSWORD)
+        .then(function () {
+          return FunctionalHelpers.openSettingsInNewTab(self, windowName);
+        })
+        .switchToWindow(windowName)
+
+        .findById('fxa-settings-header')
+        .end()
+
+        .findById('signout')
+          .click()
+        .end()
+
+        .findById('fxa-signin-header')
+        .end()
+
+        .closeCurrentWindow()
+        .switchToWindow('')
+
+        .findById('fxa-signin-header')
+        .end();
+    }
   });
 
   registerSuite({

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -217,6 +217,69 @@ define([
               })
             .end();
         });
+    },
+
+    'sign in with a second sign-in tab open': function () {
+      var windowName = 'sign-in inter-tab functional test';
+      var self = this;
+      return verifyUser(email, 0)
+        .then(function () {
+          return FunctionalHelpers.openSignInInNewTab(self, windowName);
+        })
+        .then(function () {
+          return self.remote
+            .switchToWindow(windowName)
+            .findById('fxa-signin-header')
+            .end();
+        })
+        .then(function () {
+          return fillOutSignIn(self, email, PASSWORD);
+        })
+        .then(function () {
+          return self.remote
+            .findById('fxa-settings-header')
+            .end()
+
+            .closeCurrentWindow()
+            .switchToWindow('')
+
+            .findById('fxa-settings-header')
+            .end();
+        });
+    },
+
+    'sign in with a second sign-up tab open': function () {
+      var windowName = 'sign-in inter-tab functional test';
+      var self = this;
+      return verifyUser(email, 0)
+        .then(function () {
+          return FunctionalHelpers.openSignUpInNewTab(self, windowName);
+        })
+        .then(function () {
+          return self.remote
+            .switchToWindow(windowName)
+
+            .findById('fxa-signup-header')
+            .end()
+
+            .switchToWindow('');
+        })
+        .then(function () {
+          return fillOutSignIn(self, email, PASSWORD);
+        })
+        .then(function () {
+          return self.remote
+            .switchToWindow(windowName)
+
+            .findById('fxa-settings-header')
+            .end()
+
+            .closeCurrentWindow()
+            .switchToWindow('')
+
+            .findById('fxa-settings-header')
+            .end();
+        });
     }
   });
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -74,6 +74,8 @@ define([
 
         // back to the original window
         .switchToWindow('')
+
+        .findByCssSelector('#fxa-settings-header')
         .end()
 
         .then(FunctionalHelpers.testSuccessWasShown(this));
@@ -389,6 +391,76 @@ define([
             // check the password address was cleared
             assert.equal(resultText, '');
           })
+        .end();
+    },
+
+    'sign up, open sign-in in second tab, verify in third tab': function () {
+      var windowName = 'sign-up inter-tab functional test';
+      var self = this;
+      return fillOutSignUp(this, email, PASSWORD)
+        .then(function () {
+          return testAtConfirmScreen(self, email);
+        })
+        .then(function () {
+          return FunctionalHelpers.openSignInInNewTab(self, windowName);
+        })
+        .switchToWindow(windowName)
+
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkInNewTab(self, email, 0);
+        })
+        .switchToWindow('newwindow')
+
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+
+        .closeCurrentWindow()
+        .switchToWindow(windowName)
+
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+
+        .closeCurrentWindow()
+        .switchToWindow('')
+
+        .findByCssSelector('#fxa-settings-header')
+        .end();
+    },
+
+    'sign up, open sign-up in second tab, verify in original tab': function () {
+      var windowName = 'sign-up inter-tab functional test';
+      var self = this;
+      return fillOutSignUp(this, email, PASSWORD)
+        .then(function () {
+          return testAtConfirmScreen(self, email);
+        })
+        .then(function () {
+          return FunctionalHelpers.openSignUpInNewTab(self, windowName);
+        })
+        .switchToWindow(windowName)
+
+        .findByCssSelector('#fxa-signup-header')
+        .end()
+
+        .switchToWindow('')
+        .then(function () {
+          return FunctionalHelpers.getVerificationLink(email, 0);
+        })
+        .then(function (verificationLink) {
+          return self.remote.get(require.toUrl(verificationLink));
+        })
+        .switchToWindow(windowName)
+
+        .findByCssSelector('#fxa-settings-header')
+        .end()
+
+        .closeCurrentWindow()
+        .switchToWindow('')
+
+        .findByCssSelector('#fxa-settings-header')
         .end();
     }
   });


### PR DESCRIPTION
This is my third (and final :grin:) attempt to fix #3024. Previous code review comments can be found in #3144 and #3206.

This approach sacrifices using the inter-tab channel directly in favour of using the notifications abstraction. To make that possible, a minor tweak was made to the `notifications.broadcast` logic (removing the call to `this.trigger`) but it's a safe change because nothing was calling that function until now.

The other difference from the previous two attempts is pushing the responsibility for broadcasting events from the views into the user object, which makes the code *so* much nicer. One view is left with a call to `notifications.broadcast`, `complete_sign_up`.

@shane-tomlinson r?