### PR TITLE
fix(tests): Disable `grunt validate-shrinkwrap` for now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ install:
 
 # now run the tests!
 script:
-  - grunt validate-shrinkwrap --force # check for vulnerable modules via nodesecurity.io
   - grunt selectconfig:dist l10n-generate-pages &> /dev/null
   - grunt htmllint:dist
   - travis_retry npm run test-travis

--- a/grunttasks/validate-shrinkwrap.js
+++ b/grunttasks/validate-shrinkwrap.js
@@ -1,9 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-module.exports = function (grunt) {
-  grunt.config('validate-shrinkwrap', {
-    // no options.
-  });
-};

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "grunt-jscs": "2.0.0",
     "grunt-jsonlint": "1.0.4",
     "grunt-newer": "1.1.1",
-    "grunt-nsp-shrinkwrap": "0.0.3",
     "grunt-todo": "0.5.0",
     "husky": "0.9.2",
     "intern": "3.0.0",


### PR DESCRIPTION
`grunt validate-shrinkwrap` has been deprecated and replaced by `grunt nsp`.
Unfortunately, continued use of `grunt validate-shrinkwrap` causes an XHR
request to be made that blows up. Upgrading to `grunt nsp` causes issues of its
own. Disabling until we have this figured out.

fixes #3237