### PR TITLE
chore(nsp): Add grunt-nsp to check for suspicious modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ install:
 
 # now run the tests!
 script:
+  - grunt nsp --force # check for vulnerable modules via nodesecurity.io
   - grunt selectconfig:dist l10n-generate-pages &> /dev/null
   - grunt htmllint:dist
   - travis_retry npm run test-travis

--- a/grunttasks/nsp.js
+++ b/grunttasks/nsp.js
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (grunt) {
+  grunt.config('nsp', {
+    package: grunt.file.readJSON('package.json'),
+    shrinkwrap: grunt.file.readJSON('npm-shrinkwrap.json')
+  });
+};

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "grunt-jscs": "2.0.0",
     "grunt-jsonlint": "1.0.4",
     "grunt-newer": "1.1.1",
+    "grunt-nsp": "2.0.1",
     "grunt-todo": "0.5.0",
     "husky": "0.9.2",
     "intern": "3.0.0",


### PR DESCRIPTION
Current output: "Warning: (+) 16 vulnerabilities found"
Output is also pretty verbose. Filed https://github.com/nodesecurity/grunt-nsp/issues/4 (support for custom/summary reporter) and https://github.com/nodesecurity/grunt-nsp/issues/5 (ability to mute certain advisories) upstream.

Fixes #3241 