### PR TITLE
fix(client): rename broadcast to triggerAll

### DIFF
--- a/app/scripts/models/notifications.js
+++ b/app/scripts/models/notifications.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * The notifier broadcasts messages across multiple channels (iframe, tabs, browsers, etc).
+ * The notifier triggers events on multiple channels (iframe, tabs, browsers, etc).
  */
 
 define([
@@ -40,7 +40,7 @@ define([
       }
     },
 
-    broadcast: function (event, data) {
+    triggerAll: function (event, data) {
       this.triggerRemote(event, data);
       this.trigger(event, data);
     },
@@ -52,11 +52,11 @@ define([
     },
 
     profileUpdated: function (data) {
-      this.broadcast(EVENTS.PROFILE_CHANGE, data);
+      this.triggerAll(EVENTS.PROFILE_CHANGE, data);
     },
 
     accountDeleted: function (data) {
-      this.broadcast(EVENTS.DELETE, data);
+      this.triggerAll(EVENTS.DELETE, data);
     },
 
     // Listen for notifications from other fxa tabs or frames

--- a/app/tests/spec/models/notifications.js
+++ b/app/tests/spec/models/notifications.js
@@ -60,14 +60,14 @@ function (chai, sinon, Notifications, NullChannel) {
       callback(message);
     });
 
-    describe('broadcast', function () {
-      it('broadcasts to all channels and triggers self', function () {
+    describe('triggerAll', function () {
+      it('triggers events on all channels and self', function () {
         var ev = 'some event';
         var data = { foo: 'bar' };
         var spy = sinon.spy();
 
         notifications.on(ev, spy);
-        notifications.broadcast(ev, data);
+        notifications.triggerAll(ev, data);
 
         assert.isTrue(webChannelMock.send.calledWith(ev, data));
         assert.isTrue(tabChannelMock.send.calledWith(ev, data));
@@ -98,7 +98,7 @@ function (chai, sinon, Notifications, NullChannel) {
       });
     });
 
-    it('triggerRemote sends to all channels but does not trigger self', function () {
+    it('triggerRemote triggers events on remote channels but not self', function () {
       var ev = 'some other event';
       var data = { baz: 'qux' };
       var spy = sinon.spy();

--- a/app/tests/spec/views/mixins/signed-in-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-in-notification-mixin.js
@@ -63,7 +63,7 @@ define([
             })
           };
           view.navigate = sinon.spy();
-          notifications.broadcast = sinon.spy();
+          notifications.triggerAll = sinon.spy();
           return notifications.on.args[0][1]({
             data: 'foo'
           });
@@ -94,8 +94,8 @@ define([
           assert.equal(args[0], 'settings');
         });
 
-        it('does not call notifications.broadcast', function () {
-          assert.equal(notifications.broadcast.callCount, 0);
+        it('does not call notifications.triggerAll', function () {
+          assert.equal(notifications.triggerAll.callCount, 0);
         });
       });
 

--- a/app/tests/spec/views/mixins/signed-out-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-out-notification-mixin.js
@@ -61,6 +61,7 @@ define([
             clear: sinon.spy()
           };
           view.navigate = sinon.spy();
+          notifications.triggerAll = sinon.spy();
           notifications.on.args[0][1]();
         });
 
@@ -98,6 +99,10 @@ define([
           assert.lengthOf(Object.keys(args[1]), 2);
           assert.isTrue(args[1].clearQueryParams);
           assert.equal(args[1].success, 'Signed out successfully');
+        });
+
+        it('does not call notifications.triggerAll', function () {
+          assert.equal(notifications.triggerAll.callCount, 0);
         });
       });
 


### PR DESCRIPTION
This change just makes the `notifications` interface a bit more uniform. My original plan to sort out #3228 at the same time failed but I thought this bit was worth keeping.

@shane-tomlinson r?