### PR TITLE
WIP feat(client): Enable the `Sync preferences` button for context=fx_desktop_v2

### DIFF
--- a/app/scripts/models/auth_brokers/first-run.js
+++ b/app/scripts/models/auth_brokers/first-run.js
@@ -26,7 +26,8 @@ define([
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       chooseWhatToSyncCheckbox: true,
-      chooseWhatToSyncWebV1: false
+      chooseWhatToSyncWebV1: false,
+      syncPreferencesNotification: false
     }),
 
     initialize: function (options) {

--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -47,7 +47,8 @@ define([
           'desktop-addons',
           'desktop-preferences'
         ]
-      }
+      },
+      syncPreferencesNotification: true
     }),
 
     type: 'fx-desktop-v2',
@@ -57,7 +58,8 @@ define([
       CHANGE_PASSWORD: 'fxaccounts:change_password',
       DELETE_ACCOUNT: 'fxaccounts:delete_account',
       LOADED: 'fxaccounts:loaded',
-      LOGIN: 'fxaccounts:login'
+      LOGIN: 'fxaccounts:login',
+      SYNC_PREFERENCES: 'fxaccounts:sync_preferences'
     },
 
     createChannel: function () {

--- a/app/scripts/models/auth_brokers/fx-fennec-v1.js
+++ b/app/scripts/models/auth_brokers/fx-fennec-v1.js
@@ -20,10 +20,6 @@ define([
   var FxFennecV1AuthenticationBroker = FxDesktopV2AuthenticationBroker.extend({
     type: 'fx-fennec-v1',
 
-    commands: _.extend({}, proto.commands, {
-      SYNC_PREFERENCES: 'fxaccounts:sync_preferences'
-    }),
-
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       chooseWhatToSyncCheckbox: false,
       chooseWhatToSyncWebV1: {
@@ -34,8 +30,7 @@ define([
           'tabs'
         ]
       },
-      emailVerificationMarketingSnippet: false,
-      syncPreferencesNotification: true
+      emailVerificationMarketingSnippet: false
     }),
 
     defaultBehaviors: _.extend({}, proto.defaultBehaviors, {
@@ -55,16 +50,6 @@ define([
           });
         }
       });
-    },
-
-    /**
-     * Notify the browser that it should open sync preferences
-     *
-     * @method openSyncPreferences
-     * @returns {promise} resolves when notification is sent.
-     */
-    openSyncPreferences: function () {
-      return this.send(this.getCommand('SYNC_PREFERENCES'));
     }
   });
 

--- a/app/scripts/models/auth_brokers/fx-sync.js
+++ b/app/scripts/models/auth_brokers/fx-sync.js
@@ -162,6 +162,16 @@ define([
     },
 
     /**
+     * Notify the browser that it should open sync preferences
+     *
+     * @method openSyncPreferences
+     * @returns {promise} resolves when notification is sent.
+     */
+    openSyncPreferences: function () {
+      return this.send(this.getCommand('SYNC_PREFERENCES'));
+    },
+
+    /**
      * Get a reference to a channel. If a channel has already been created,
      * the cached channel will be returned. Used by the ChannelMixin.
      *

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -55,8 +55,8 @@ define([
       assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
     });
 
-    it('does not have the `syncPreferencesNotification` capability by default', function () {
-      assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+    it('has the `syncPreferencesNotification` capability by default', function () {
+      assert.isTrue(broker.hasCapability('syncPreferencesNotification'));
     });
 
     describe('createChannel', function () {

--- a/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -131,15 +131,6 @@ function (chai, NullChannel, FxFennecV1AuthenticationBroker, Relier,
           });
       });
     });
-
-    describe('openSyncPreferences', function () {
-      it('sends the `fxaccounts:sync_preferences` message', function () {
-        return broker.openSyncPreferences()
-          .then(function () {
-            assert.isTrue(broker.send.calledWith('fxaccounts:sync_preferences'));
-          });
-      });
-    });
   });
 });
 

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -35,7 +35,8 @@ define([
           CHANGE_PASSWORD: 'change_password',
           DELETE_ACCOUNT: 'delete_account',
           LOADED: 'loaded',
-          LOGIN: 'login'
+          LOGIN: 'login',
+          SYNC_PREFERENCES: 'sync_preferences'
         },
         window: windowMock
       }, options));
@@ -292,6 +293,15 @@ define([
             assert.equal(args[0], 'delete_account');
             assert.equal(args[1].email, 'testuser@testuser.com');
             assert.equal(args[1].uid, 'uid');
+          });
+      });
+    });
+
+    describe('openSyncPreferences', function () {
+      it('sends the `sync_preferences` message', function () {
+        return broker.openSyncPreferences()
+          .then(function () {
+            assert.isTrue(channelMock.send.calledWith('sync_preferences'));
           });
       });
     });

--- a/docs/relier-communication-protocols/fx-webchannel.md
+++ b/docs/relier-communication-protocols/fx-webchannel.md
@@ -96,6 +96,11 @@ Sent after the user successfully deletes their account. No response is expected.
 
 Sent after the user successfully changes their password. No response is expected. A change password causes a user's `unwrapBKey` to change, all data that is sent with `fxaccounts:login` is sent with `fxaccounts:change_password`.
 
+
+#### fxaccounts:sync_preferences
+Sent after the user clicks the `Sync preferences` button after the user
+verifies their email address. No data is sent. No response is expected.
+
 #### profile:change
 
 Sent after the user changes their avatar or display name. No response is

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -111,12 +111,24 @@ define([
         .end()
 
         .findByCssSelector('.account-ready-service')
-        .getVisibleText()
-        .then(function (text) {
-          assert.ok(text.indexOf('Firefox Sync') > -1);
-        })
-
+          .getVisibleText()
+          .then(function (text) {
+            assert.ok(text.indexOf('Firefox Sync') > -1);
+          })
         .end()
+
+          // user can open sync preferences in new tab.
+        .then(FunctionalHelpers.noSuchBrowserNotification(self, 'fxaccounts:sync_preferences'))
+
+        // user should be able to open sync preferences
+        .findByCssSelector('#sync-preferences')
+          // user wants to open sync preferences.
+          .click()
+        .end()
+
+        // browser is notified of desire to open Sync preferences
+        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:sync_preferences'))
+
         .closeCurrentWindow()
 
         // switch to the original window, it should not transition.


### PR DESCRIPTION
The user will see the `Sync preferences` button, and if it is clicked,
a `fxaccounts:sync_preferences` WebChannel message will be sent to
the browser.

issue #3079

Labeling WIP until the questions in #3079 are resolved.