### PR TITLE
fix(client): fix name clash with web-channel events

### DIFF
--- a/app/scripts/models/notifications.js
+++ b/app/scripts/models/notifications.js
@@ -12,11 +12,14 @@ define([
 ], function (Backbone, _) {
   'use strict';
 
+  // Events that have the 'internal:' namespace should only be
+  // handled by the content server. Other events may be handled
+  // both externally and internally to the content server.
   var EVENTS = {
     DELETE: 'fxaccounts:delete',
     PROFILE_CHANGE: 'profile:change',
-    SIGNED_IN: 'fxaccounts:login',
-    SIGNED_OUT: 'fxaccounts:logout'
+    SIGNED_IN: 'internal:signedIn',
+    SIGNED_OUT: 'internal:signedOut'
   };
 
   var Notifications = Backbone.Model.extend({

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -120,7 +120,7 @@ function (chai, sinon, p, Constants, Session, FxaClient, AuthErrors,
           assert.equal(notifications.triggerRemote.callCount, 1);
           var args = notifications.triggerRemote.args[0];
           assert.lengthOf(args, 1);
-          assert.equal(args[0], 'fxaccounts:logout');
+          assert.equal(args[0], notifications.EVENTS.SIGNED_OUT);
         });
     });
 
@@ -418,7 +418,7 @@ function (chai, sinon, p, Constants, Session, FxaClient, AuthErrors,
           assert.equal(notifications.triggerRemote.callCount, 1);
           var args = notifications.triggerRemote.args[0];
           assert.lengthOf(args, 2);
-          assert.equal(args[0], 'fxaccounts:login');
+          assert.equal(args[0], notifications.EVENTS.SIGNED_IN);
           assert.deepEqual(args[1], account.toJSON());
         });
     });

--- a/app/tests/spec/views/mixins/signed-out-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-out-notification-mixin.js
@@ -45,7 +45,7 @@ define([
         assert.equal(notifications.on.callCount, 1);
         var args = notifications.on.args[0];
         assert.lengthOf(args, 2);
-        assert.equal(args[0], 'fxaccounts:logout');
+        assert.equal(args[0], notifications.EVENTS.SIGNED_OUT);
         assert.isFunction(args[1]);
       });
 


### PR DESCRIPTION
Fixes #3267.

Because `master` has changed in a conflicting way since train 49 was tagged, this PR is open against the tag commit and therefore won't merge cleanly to `master`. It also means the change can't be cleanly cherry-picked between the two. Presumably we want to create a `train-49` branch to merge this into, but this is the diff for now. I have [another PR open for the change against `master`](https://github.com/mozilla/fxa-content-server/pull/3270).

This is the simplest of the possible fixes, which is just to revert to the original event names proposed for this feature. Doing so avoids clashing with listeners for the web channel event. An alternative approach might be to keep the clashing names and not send these events over the web channel, but that means messing with the new `notifier` stuff which I assume we don't want to do.