### PR TITLE
fix(client): fix name clash with web-channel events

### DIFF
--- a/app/scripts/lib/channels/notifier.js
+++ b/app/scripts/lib/channels/notifier.js
@@ -12,12 +12,15 @@ define([
 ], function (Backbone, _) {
   'use strict';
 
+  // Events that have the 'internal:' namespace should only be
+  // handled by the content server. Other events may be handled
+  // both externally and internally to the content server.
   var EVENTS = {
     COMPLETE_RESET_PASSWORD_TAB_OPEN: 'fxaccounts:complete_reset_password_tab_open',
     DELETE: 'fxaccounts:delete',
     PROFILE_CHANGE: 'profile:change',
-    SIGNED_IN: 'fxaccounts:login',
-    SIGNED_OUT: 'fxaccounts:logout'
+    SIGNED_IN: 'internal:signed_in',
+    SIGNED_OUT: 'internal:signed_out'
   };
 
   var Notifer = Backbone.Model.extend({

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -120,7 +120,7 @@ function (chai, sinon, p, Constants, Session, FxaClient, AuthErrors,
           assert.equal(notifier.triggerRemote.callCount, 1);
           var args = notifier.triggerRemote.args[0];
           assert.lengthOf(args, 1);
-          assert.equal(args[0], 'fxaccounts:logout');
+          assert.equal(args[0], notifier.EVENTS.SIGNED_OUT);
         });
     });
 
@@ -418,7 +418,7 @@ function (chai, sinon, p, Constants, Session, FxaClient, AuthErrors,
           assert.equal(notifier.triggerRemote.callCount, 1);
           var args = notifier.triggerRemote.args[0];
           assert.lengthOf(args, 2);
-          assert.equal(args[0], 'fxaccounts:login');
+          assert.equal(args[0], notifier.EVENTS.SIGNED_IN);
           assert.deepEqual(args[1], account.toJSON());
         });
     });


### PR DESCRIPTION
Fixes #3267.

Because `master` has changed in a conflicting way since train 49 was tagged, there is [another PR open against the tag commit](https://github.com/mozilla/fxa-content-server/pull/3269), which won't merge cleanly to `master`. It also means the change can't be cleanly cherry-picked between the two.

This is the simplest of the possible fixes, which is just to revert to the original event names proposed for this feature. Doing so avoids clashing with listeners for the web channel event. An alternative approach might be to keep the clashing names and not send these events over the web channel, but that means messing with the new `notifier` stuff which I assume we don't want to do.