### PR TITLE
refactor(client): Convert `app` to the Simplified CommonJS wrapper.

### DIFF
--- a/app/scripts/head/startup-styles.js
+++ b/app/scripts/head/startup-styles.js
@@ -15,7 +15,6 @@
 
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    /* exceptsPaths: lib/environment */
     define(['lib/environment'], factory);
   } else {
     // Browser globals

--- a/app/scripts/lib/able.js
+++ b/app/scripts/lib/able.js
@@ -11,8 +11,9 @@
  * will always return `undefined` and `report` will return an empty array.
  */
 
-define([], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   function AbleWrapper() {
     // nothing to do here.
@@ -34,5 +35,5 @@ define([], function () {
     }
   };
 
-  return AbleWrapper;
+  module.exports = AbleWrapper;
 });

--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -15,111 +15,59 @@
  * 6) Start the app if cookies are enabled.
  */
 
-define([
-  'underscore',
-  'backbone',
-  'lib/promise',
-  'lib/router',
-  'lib/translator',
-  'lib/session',
-  'lib/url',
-  'lib/config-loader',
-  'lib/screen-info',
-  'lib/metrics',
-  'lib/sentry',
-  'lib/storage-metrics',
-  'lib/fxa-client',
-  'lib/assertion',
-  'lib/constants',
-  'lib/oauth-client',
-  'lib/oauth-errors',
-  'lib/auth-errors',
-  'lib/profile-client',
-  'lib/marketing-email-client',
-  'lib/channels/inter-tab',
-  'lib/channels/iframe',
-  'lib/channels/null',
-  'lib/channels/web',
-  'lib/storage',
-  'lib/able',
-  'lib/environment',
-  'lib/origin-check',
-  'lib/height-observer',
-  'models/reliers/relier',
-  'models/reliers/oauth',
-  'models/reliers/sync',
-  'models/auth_brokers/base',
-  'models/auth_brokers/fx-desktop-v1',
-  'models/auth_brokers/fx-desktop-v2',
-  'models/auth_brokers/fx-fennec-v1',
-  'models/auth_brokers/fx-ios-v1',
-  'models/auth_brokers/fx-ios-v2',
-  'models/auth_brokers/first-run',
-  'models/auth_brokers/web-channel',
-  'models/auth_brokers/redirect',
-  'models/auth_brokers/iframe',
-  'models/unique-user-id',
-  'models/user',
-  'models/verification/same-browser',
-  'models/form-prefill',
-  'lib/channels/notifier',
-  'models/refresh-observer',
-  'views/app',
-  'views/close_button'
-],
-function (
-  _,
-  Backbone,
-  p,
-  Router,
-  Translator,
-  Session,
-  Url,
-  ConfigLoader,
-  ScreenInfo,
-  Metrics,
-  SentryMetrics,
-  StorageMetrics,
-  FxaClient,
-  Assertion,
-  Constants,
-  OAuthClient,
-  OAuthErrors,
-  AuthErrors,
-  ProfileClient,
-  MarketingEmailClient,
-  InterTabChannel,
-  IframeChannel,
-  NullChannel,
-  WebChannel,
-  Storage,
-  Able,
-  Environment,
-  OriginCheck,
-  HeightObserver,
-  Relier,
-  OAuthRelier,
-  SyncRelier,
-  BaseAuthenticationBroker,
-  FxDesktopV1AuthenticationBroker,
-  FxDesktopV2AuthenticationBroker,
-  FxFennecV1AuthenticationBroker,
-  FxiOSV1AuthenticationBroker,
-  FxiOSV2AuthenticationBroker,
-  FirstRunAuthenticationBroker,
-  WebChannelAuthenticationBroker,
-  RedirectAuthenticationBroker,
-  IframeAuthenticationBroker,
-  UniqueUserId,
-  User,
-  SameBrowserVerificationModel,
-  FormPrefill,
-  Notifier,
-  RefreshObserver,
-  AppView,
-  CloseButtonView
-) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Able = require('lib/able');
+  var AppView = require('views/app');
+  var Assertion = require('lib/assertion');
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
+  var BaseAuthenticationBroker = require('models/auth_brokers/base');
+  var CloseButtonView = require('views/close_button');
+  var ConfigLoader = require('lib/config-loader');
+  var Constants = require('lib/constants');
+  var Environment = require('lib/environment');
+  var FirstRunAuthenticationBroker = require('models/auth_brokers/first-run');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var FxDesktopV1AuthenticationBroker = require('models/auth_brokers/fx-desktop-v1');
+  var FxDesktopV2AuthenticationBroker = require('models/auth_brokers/fx-desktop-v2');
+  var FxFennecV1AuthenticationBroker = require('models/auth_brokers/fx-fennec-v1');
+  var FxiOSV1AuthenticationBroker = require('models/auth_brokers/fx-ios-v1');
+  var FxiOSV2AuthenticationBroker = require('models/auth_brokers/fx-ios-v2');
+  var HeightObserver = require('lib/height-observer');
+  var IframeAuthenticationBroker = require('models/auth_brokers/iframe');
+  var IframeChannel = require('lib/channels/iframe');
+  var InterTabChannel = require('lib/channels/inter-tab');
+  var MarketingEmailClient = require('lib/marketing-email-client');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var NullChannel = require('lib/channels/null');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthErrors = require('lib/oauth-errors');
+  var OAuthRelier = require('models/reliers/oauth');
+  var OriginCheck = require('lib/origin-check');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var RedirectAuthenticationBroker = require('models/auth_brokers/redirect');
+  var RefreshObserver = require('models/refresh-observer');
+  var Relier = require('models/reliers/relier');
+  var Router = require('lib/router');
+  var SameBrowserVerificationModel = require('models/verification/same-browser');
+  var ScreenInfo = require('lib/screen-info');
+  var SentryMetrics = require('lib/sentry');
+  var Session = require('lib/session');
+  var Storage = require('lib/storage');
+  var StorageMetrics = require('lib/storage-metrics');
+  var SyncRelier = require('models/reliers/sync');
+  var Translator = require('lib/translator');
+  var UniqueUserId = require('models/unique-user-id');
+  var Url = require('lib/url');
+  var User = require('models/user');
+  var WebChannel = require('lib/channels/web');
+  var WebChannelAuthenticationBroker = require('models/auth_brokers/web-channel');
 
   function Start(options) {
     options = options || {};
@@ -825,5 +773,5 @@ function (
     }
   };
 
-  return Start;
+  module.exports = Start;
 });

--- a/app/scripts/lib/assertion.js
+++ b/app/scripts/lib/assertion.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/promise',
-  'vendor/jwcrypto'
-],
-function (P, jwcrypto) {
+define(function (require, exports, module) {
   'use strict';
+
+  var jwcrypto = require('vendor/jwcrypto');
+  var P = require('lib/promise');
 
   var CERT_DURATION_MS = 1000 * 60 * 60 * 6; // 6hrs
   var ASSERTION_DURATION_MS = 1000 * 3600 * 24 * 365 * 25; // 25 years
@@ -88,5 +87,5 @@ function (P, jwcrypto) {
     generate: bundle
   };
 
-  return Assertion;
+  module.exports = Assertion;
 });

--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -4,12 +4,11 @@
 
 // provides functions to work with errors returned by the auth server.
 
-define([
-  'underscore',
-  'lib/errors'
-],
-function (_, Errors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Errors = require('lib/errors');
 
   var t = function (msg) {
     return msg;
@@ -248,7 +247,7 @@ function (_, Errors) {
   };
   /*eslint-enable sorting/sort-object-props*/
 
-  return _.extend({}, Errors, {
+  module.exports = _.extend({}, Errors, {
     ERRORS: ERRORS,
     NAMESPACE: 'auth',
 

--- a/app/scripts/lib/base64url.js
+++ b/app/scripts/lib/base64url.js
@@ -9,12 +9,12 @@
  * variant, which is needed for JWTs.
  */
 
-define([
-  'sjcl'
-], function (sjcl) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var sjcl = require('sjcl');
+
+  module.exports = {
 
     encode: function (bits) {
       return sjcl.codec.base64.fromBits(bits)

--- a/app/scripts/lib/channels/base.js
+++ b/app/scripts/lib/channels/base.js
@@ -4,12 +4,11 @@
 
 // A channel interface.
 
-define([
-  'underscore',
-  'backbone'
-],
-function (_, Backbone) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   function BaseChannel() {
     // nothing to do.
@@ -29,5 +28,5 @@ function (_, Backbone) {
     }
   });
 
-  return BaseChannel;
+  module.exports = BaseChannel;
 });

--- a/app/scripts/lib/channels/duplex.js
+++ b/app/scripts/lib/channels/duplex.js
@@ -10,12 +10,12 @@
  * receive messages via a postMessage (Fx Desktop Sync v1).
  */
 
-define([
-  'underscore',
-  'lib/promise',
-  'lib/channels/base'
-], function (_, p, BaseChannel) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var BaseChannel = require('lib/channels/base');
+  var p = require('lib/promise');
 
   var DEFAULT_SEND_TIMEOUT_LENGTH_MS = 90 * 1000;
 
@@ -200,5 +200,5 @@ define([
     }
   });
 
-  return DuplexChannel;
+  module.exports = DuplexChannel;
 });

--- a/app/scripts/lib/channels/fx-desktop-v1.js
+++ b/app/scripts/lib/channels/fx-desktop-v1.js
@@ -6,13 +6,13 @@
 // a CustomEvent sender and a postMessage receiver. This is
 // the v1 way of communicating with the browser for Sync.
 
-define([
-  'underscore',
-  'lib/channels/duplex',
-  'lib/channels/senders/fx-desktop-v1',
-  'lib/channels/receivers/postmessage'
-], function (_, DuplexChannel, FxDesktopV1Sender, PostMessageReceiver) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var DuplexChannel = require('lib/channels/duplex');
+  var FxDesktopV1Sender = require('lib/channels/senders/fx-desktop-v1');
+  var PostMessageReceiver = require('lib/channels/receivers/postmessage');
 
   function FxDesktopV1Channel() {
   }
@@ -69,7 +69,7 @@ define([
     }
   });
 
-  return FxDesktopV1Channel;
+  module.exports = FxDesktopV1Channel;
 });
 
 

--- a/app/scripts/lib/channels/iframe.js
+++ b/app/scripts/lib/channels/iframe.js
@@ -9,13 +9,13 @@
  * on the URL.
  */
 
-define([
-  'underscore',
-  'lib/channels/duplex',
-  'lib/channels/receivers/postmessage',
-  'lib/channels/senders/postmessage'
-], function (_, DuplexChannel, PostMessageReceiver, PostMessageSender) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var DuplexChannel = require('lib/channels/duplex');
+  var PostMessageReceiver = require('lib/channels/receivers/postmessage');
+  var PostMessageSender = require('lib/channels/senders/postmessage');
 
   function IFrameChannel() {
     // constructor, nothing to do.
@@ -75,6 +75,6 @@ define([
     return parsed;
   };
 
-  return IFrameChannel;
+  module.exports = IFrameChannel;
 });
 

--- a/app/scripts/lib/channels/inter-tab.js
+++ b/app/scripts/lib/channels/inter-tab.js
@@ -20,12 +20,12 @@
  * sensitive data is erased as soon as it is consumed by the receiving tab.
  */
 
-define([
-  'backbone',
-  'crosstab',
-  'underscore'
-], function (Backbone, crosstab, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var crosstab = require('crosstab');
 
   var BROADCAST_CHANNEL_ID = 'firefox_accounts';
 
@@ -211,5 +211,5 @@ define([
   InterTabChannel.LocalStorageAdapter = LocalStorageAdapter;
 
 
-  return InterTabChannel;
+  module.exports = InterTabChannel;
 });

--- a/app/scripts/lib/channels/notifier.js
+++ b/app/scripts/lib/channels/notifier.js
@@ -6,11 +6,11 @@
  * The notifier triggers events on multiple channels (iframe, tabs, browsers, etc).
  */
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   // Events that have the 'internal:' namespace should only be
   // handled by the content server. Other events may be handled
@@ -71,5 +71,5 @@ define([
     }
   }, EVENTS);
 
-  return Notifer;
+  module.exports = Notifer;
 });

--- a/app/scripts/lib/channels/null.js
+++ b/app/scripts/lib/channels/null.js
@@ -4,12 +4,11 @@
 
 // A shell of a channel. Doesn't do anything yet, but is a useful standin.
 
-define([
-  'underscore',
-  'lib/channels/base'
-],
-function (_, BaseChannel) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var BaseChannel = require('lib/channels/base');
 
   function NullChannel() {
     // nothing to do.
@@ -17,5 +16,5 @@ function (_, BaseChannel) {
 
   _.extend(NullChannel.prototype, new BaseChannel());
 
-  return NullChannel;
+  module.exports = NullChannel;
 });

--- a/app/scripts/lib/channels/receivers/null.js
+++ b/app/scripts/lib/channels/receivers/null.js
@@ -6,11 +6,11 @@
  * A null receiver. Doesn't actually receive any messages
  */
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   function NullReceiver() {
     // nothing to do
@@ -23,6 +23,6 @@ define([
     }
   });
 
-  return NullReceiver;
+  module.exports = NullReceiver;
 });
 

--- a/app/scripts/lib/channels/receivers/postmessage.js
+++ b/app/scripts/lib/channels/receivers/postmessage.js
@@ -6,12 +6,12 @@
  * Receive a message over postMessage.
  */
 
-define([
-  'backbone',
-  'underscore',
-  'lib/auth-errors'
-], function (Backbone, _, AuthErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
 
 
   function PostMessageReceiver() {
@@ -75,6 +75,6 @@ define([
     }
   });
 
-  return PostMessageReceiver;
+  module.exports = PostMessageReceiver;
 });
 

--- a/app/scripts/lib/channels/receivers/web-channel.js
+++ b/app/scripts/lib/channels/receivers/web-channel.js
@@ -8,11 +8,11 @@
  */
 
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   function WebChannelReceiver() {
     // nothing to do
@@ -57,6 +57,6 @@ define([
     }
   });
 
-  return WebChannelReceiver;
+  module.exports = WebChannelReceiver;
 });
 

--- a/app/scripts/lib/channels/senders/fx-desktop-v1.js
+++ b/app/scripts/lib/channels/senders/fx-desktop-v1.js
@@ -6,10 +6,10 @@
  * Send a message to the browser using a FirefoxAccountsCommand.
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   function FxDesktopV1Sender() {
     // nothing to do here.
@@ -51,7 +51,7 @@ define([
     });
   }
 
-  return FxDesktopV1Sender;
+  module.exports = FxDesktopV1Sender;
 });
 
 

--- a/app/scripts/lib/channels/senders/null.js
+++ b/app/scripts/lib/channels/senders/null.js
@@ -6,10 +6,10 @@
  * A null sender. Sends messages nowhere.
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   function NullSender() {
     // nothing to do here.
@@ -27,7 +27,7 @@ define([
     }
   };
 
-  return NullSender;
+  module.exports = NullSender;
 });
 
 

--- a/app/scripts/lib/channels/senders/postmessage.js
+++ b/app/scripts/lib/channels/senders/postmessage.js
@@ -20,10 +20,10 @@
  * `data` is an object with any extra data.
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   function PostMessageSender() {
     // nothing to do here.
@@ -57,7 +57,7 @@ define([
     });
   }
 
-  return PostMessageSender;
+  module.exports = PostMessageSender;
 });
 
 

--- a/app/scripts/lib/channels/senders/web-channel.js
+++ b/app/scripts/lib/channels/senders/web-channel.js
@@ -7,10 +7,10 @@
  * https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   function WebChannelSender() {
     // nothing to do here.
@@ -50,7 +50,7 @@ define([
     });
   }
 
-  return WebChannelSender;
+  module.exports = WebChannelSender;
 });
 
 

--- a/app/scripts/lib/channels/web.js
+++ b/app/scripts/lib/channels/web.js
@@ -6,13 +6,13 @@
 // https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
 // https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/FxAccountsOAuthClient.jsm
 
-define([
-  'underscore',
-  'lib/channels/duplex',
-  'lib/channels/senders/web-channel',
-  'lib/channels/receivers/web-channel'
-], function (_, DuplexChannel, WebChannelSender, WebChannelReceiver) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var DuplexChannel = require('lib/channels/duplex');
+  var WebChannelReceiver = require('lib/channels/receivers/web-channel');
+  var WebChannelSender = require('lib/channels/senders/web-channel');
 
   function WebChannel(id) {
     if (! id) {
@@ -49,5 +49,5 @@ define([
     }
   });
 
-  return WebChannel;
+  module.exports = WebChannel;
 });

--- a/app/scripts/lib/config-loader.js
+++ b/app/scripts/lib/config-loader.js
@@ -4,18 +4,13 @@
 
 // fetch config from the backend and provide some helper functions.
 
-define([
-  'lib/errors',
-  'lib/promise',
-  'lib/xhr',
-  'underscore'
-], function (
-  Errors,
-  p,
-  xhr,
-  _
-) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Errors = require('lib/errors');
+  var p = require('lib/promise');
+  var xhr = require('lib/xhr');
 
   function ConfigLoader(options) {
     options = options || {};
@@ -85,6 +80,6 @@ define([
     NAMESPACE: 'config'
   });
 
-  return ConfigLoader;
+  module.exports = ConfigLoader;
 });
 

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([], function () {
+define(function (require, exports, module) {
   'use strict';
 
+
   /*eslint-disable sorting/sort-object-props*/
-  return {
+  module.exports = {
     // All browsers have a max length of URI that they can handle.
     // IE9 has the shortest total length at 2083 bytes and 2048 characters
     // for GET requests.

--- a/app/scripts/lib/cropper.js
+++ b/app/scripts/lib/cropper.js
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore'
-],
-function (_) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
 
   var DEFAULT_DISPLAY_LENGTH = 240;
   var DEFAULT_EXPORT_LENGTH = 480;
@@ -304,6 +303,6 @@ function (_) {
     return this.canvas.toBlob(cb, type, quality);
   };
 
-  return Cropper;
+  module.exports = Cropper;
 });
 

--- a/app/scripts/lib/ephemeral-messages.js
+++ b/app/scripts/lib/ephemeral-messages.js
@@ -5,10 +5,10 @@
 // an ephemeral messages model. Ephemeral messages are allowed
 // a single `get` and no more.
 
-define([
-  'backbone'
-], function (Backbone) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
 
   var Model = Backbone.Model.extend({
     get: function (attribute) {
@@ -21,6 +21,6 @@ define([
     }
   });
 
-  return Model;
+  module.exports = Model;
 });
 

--- a/app/scripts/lib/errors.js
+++ b/app/scripts/lib/errors.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore',
-  'lib/strings'
-], function (_, Strings) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var _ = require('underscore');
+  var Strings = require('lib/strings');
+
+  module.exports = {
     /**
      * Find an error in this.ERRORS. Searches by string, number,
      * or if searchFor contains errno, the errno.

--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore',
-  'lib/experiments/mailcheck',
-  'lib/experiments/open-gmail',
-  'lib/experiments/sync-checkbox',
-  'lib/url'
-], function (_, MailcheckExperiment, OpenGmailExperiment,
-  SyncCheckboxExperiment, Url) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var MailcheckExperiment = require('lib/experiments/mailcheck');
+  var OpenGmailExperiment = require('lib/experiments/open-gmail');
+  var SyncCheckboxExperiment = require('lib/experiments/sync-checkbox');
+  var Url = require('lib/url');
 
   var CHOOSE_ABLE_EXPERIMENT = 'chooseAbExperiment';
   var FORCE_EXPERIMENT_PARAM = 'forceExperiment';
@@ -134,5 +133,5 @@ define([
     }
   });
 
-  return ExperimentInterface;
+  module.exports = ExperimentInterface;
 });

--- a/app/scripts/lib/experiments/base.js
+++ b/app/scripts/lib/experiments/base.js
@@ -7,14 +7,13 @@
   It helps keep the state, organize testing groups and log experiment metrics.
  */
 
-define([
-  'backbone',
-  'underscore',
-  'lib/storage',
-  'lib/url'
-],
-function (Backbone, _, Storage, Url) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var Storage = require('lib/storage');
+  var Url = require('lib/url');
 
   var FORCE_GROUP_TYPE = 'forceExperimentGroup';
   var storage = Storage.factory('localStorage');
@@ -207,5 +206,5 @@ function (Backbone, _, Storage, Url) {
 
   BaseExperiment.extend = Backbone.Model.extend;
 
-  return BaseExperiment;
+  module.exports = BaseExperiment;
 });

--- a/app/scripts/lib/experiments/mailcheck.js
+++ b/app/scripts/lib/experiments/mailcheck.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/experiments/base'
-], function (BaseExperiment) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseExperiment = require('lib/experiments/base');
 
   var createSaveStateDelegate = BaseExperiment.createSaveStateDelegate;
 
@@ -42,5 +42,5 @@ define([
     }
   });
 
-  return MailCheckExperiment;
+  module.exports = MailCheckExperiment;
 });

--- a/app/scripts/lib/experiments/open-gmail.js
+++ b/app/scripts/lib/experiments/open-gmail.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/experiments/base'
-], function (BaseExperiment) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseExperiment = require('lib/experiments/base');
 
   var createSaveStateDelegate = BaseExperiment.createSaveStateDelegate;
 
@@ -41,5 +41,5 @@ define([
     }
   });
 
-  return OpenGmailExperiment;
+  module.exports = OpenGmailExperiment;
 });

--- a/app/scripts/lib/experiments/sync-checkbox.js
+++ b/app/scripts/lib/experiments/sync-checkbox.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/experiments/base'
-], function (BaseExperiment) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseExperiment = require('lib/experiments/base');
 
   var createSaveStateDelegate = BaseExperiment.createSaveStateDelegate;
 
@@ -29,5 +29,5 @@ define([
     }
   });
 
-  return SyncCheckboxExperiment;
+  module.exports = SyncCheckboxExperiment;
 });

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -6,16 +6,15 @@
 // and to allow us to develop to features that are not yet present in the real
 // client.
 
-define([
-  'fxaClient',
-  'jquery',
-  'lib/constants',
-  'lib/promise',
-  'lib/session',
-  'lib/auth-errors'
-],
-function (FxaClient, $, Constants, p, Session, AuthErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var Constants = require('lib/constants');
+  var FxaClient = require('fxaClient');
+  var p = require('lib/promise');
+  var Session = require('lib/session');
 
   function trim(str) {
     return $.trim(str);
@@ -474,6 +473,6 @@ function (FxaClient, $, Constants, p, Session, AuthErrors) {
     }
   };
 
-  return FxaClientWrapper;
+  module.exports = FxaClientWrapper;
 });
 

--- a/app/scripts/lib/height-observer.js
+++ b/app/scripts/lib/height-observer.js
@@ -7,11 +7,11 @@
  * if the element's height changes.
  */
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   function HeightObserver (options) {
     options = options || {};
@@ -77,6 +77,6 @@ define([
     }
   });
 
-  return HeightObserver;
+  module.exports = HeightObserver;
 });
 

--- a/app/scripts/lib/hkdf.js
+++ b/app/scripts/lib/hkdf.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'sjcl',
-  'lib/promise'
-],
-function (sjcl, p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
+  var sjcl = require('sjcl');
 
   /**
    * hkdf - The HMAC-based Key Derivation Function
@@ -53,6 +52,6 @@ function (sjcl, p) {
     return p(truncated);
   }
 
-  return hkdf;
+  module.exports = hkdf;
 
 });

--- a/app/scripts/lib/image-loader.js
+++ b/app/scripts/lib/image-loader.js
@@ -4,9 +4,11 @@
 
 // A utility for pre-loading images
 
-define(['underscore', 'lib/promise'],
-function (_, p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var p = require('lib/promise');
 
   /**
    * Returns true if given "uri" has HTTP or HTTPS scheme
@@ -25,7 +27,7 @@ function (_, p) {
     return defer.promise;
   }
 
-  return {
+  module.exports = {
     load: load
   };
 });

--- a/app/scripts/lib/key-codes.js
+++ b/app/scripts/lib/key-codes.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- define(function () {
-   'use strict';
+define(function (require, exports, module) {
+  'use strict';
 
-   return {
-     DOWN_ARROW: 40,
-     ENTER: 13,
-     LEFT_ARROW: 37,
-     RIGHT_ARROW: 39,
-     TAB: 9,
-     UP_ARROW: 38
-   };
- });
+  module.exports = {
+    DOWN_ARROW: 40,
+    ENTER: 13,
+    LEFT_ARROW: 37,
+    RIGHT_ARROW: 39,
+    TAB: 9,
+    UP_ARROW: 38
+  };
+});

--- a/app/scripts/lib/mailcheck.js
+++ b/app/scripts/lib/mailcheck.js
@@ -4,14 +4,12 @@
 
 // A ux utility to suggest correct spelling of email domains
 
-/* exceptsPaths: mailcheck */
-define([
-  'views/tooltip',
-  'lib/key-codes',
-  'mailcheck'
-],
-function (Tooltip, KeyCodes) {
+define(function (require, exports, module) {
   'use strict';
+
+  var KeyCodes = require('lib/key-codes');
+  var mailcheck = require('mailcheck'); //eslint-disable-line no-unused-vars
+  var Tooltip = require('views/tooltip');
 
   var DOMAINS = [];
   var SECOND_LEVEL_DOMAINS = [ // domains that get suggested, i.e gnail => gmail
@@ -33,7 +31,7 @@ function (Tooltip, KeyCodes) {
    * @param {Object} translator Translator object passed by the view
    * @param {Object} view View mailcheck is used with
    */
-  return function checkMailInput(target, metrics, translator, view) {
+  module.exports = function checkMailInput(target, metrics, translator, view) {
     var element = $(target);
     if (! element.length || ! view) {
       return;

--- a/app/scripts/lib/marketing-email-client.js
+++ b/app/scripts/lib/marketing-email-client.js
@@ -6,12 +6,12 @@
  * A client to talk to the basket marketing email server
  */
 
-define([
-  'lib/constants',
-  'lib/xhr',
-  'lib/marketing-email-errors'
-], function (Constants, xhr, MarketingEmailErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Constants = require('lib/constants');
+  var MarketingEmailErrors = require('lib/marketing-email-errors');
+  var xhr = require('lib/xhr');
 
   function MarketingEmailClient(options) {
     options = options || {};
@@ -67,6 +67,6 @@ define([
     }
   };
 
-  return MarketingEmailClient;
+  module.exports = MarketingEmailClient;
 });
 

--- a/app/scripts/lib/marketing-email-errors.js
+++ b/app/scripts/lib/marketing-email-errors.js
@@ -4,12 +4,11 @@
 
 // provides functions to work with errors returned by the auth server.
 
-define([
-  'underscore',
-  'lib/errors'
-],
-function (_, Errors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Errors = require('lib/errors');
 
   var t = function (msg) {
     return msg;
@@ -86,7 +85,7 @@ function (_, Errors) {
   };
   /*eslint-enable sorting/sort-object-props*/
 
-  return _.extend({}, Errors, {
+  module.exports = _.extend({}, Errors, {
     ERRORS: ERRORS,
     NAMESPACE: 'basket-errors',
     normalizeXHRError: function (xhr) {

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -14,17 +14,17 @@
  * but can also be sent by calling metrics.flush();
  */
 
-define([
-  'backbone',
-  'jquery',
-  'lib/environment',
-  'lib/promise',
-  'lib/strings',
-  'lib/xhr',
-  'speedTrap',
-  'underscore'
-], function (Backbone, $, Environment, p, Strings, xhr, speedTrap, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var Environment = require('lib/environment');
+  var p = require('lib/promise');
+  var speedTrap = require('speedTrap');
+  var Strings = require('lib/strings');
+  var xhr = require('lib/xhr');
 
   // Speed trap is a singleton, convert it
   // to an instantiable function.
@@ -416,7 +416,7 @@ define([
     }
   });
 
-  return Metrics;
+  module.exports = Metrics;
 });
 
 

--- a/app/scripts/lib/null-metrics.js
+++ b/app/scripts/lib/null-metrics.js
@@ -7,12 +7,12 @@
  * or for unit tests.
  */
 
-define([
-  'underscore',
-  'lib/promise',
-  'lib/metrics'
-], function (_, p, Metrics) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
 
   function NullMetrics () {
     // do nothing
@@ -33,7 +33,7 @@ define([
     return false;
   };
 
-  return NullMetrics;
+  module.exports = NullMetrics;
 });
 
 

--- a/app/scripts/lib/null-storage.js
+++ b/app/scripts/lib/null-storage.js
@@ -5,9 +5,9 @@
 // This is a memory store that's api compatible with localStorage/sessionStorage.
 // It's used for testing lib/storage.
 
-define([
-], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   function NullStorage () {
     this._storage = {};
@@ -35,5 +35,5 @@ define([
     this._storage = {};
   };
 
-  return NullStorage;
+  module.exports = NullStorage;
 });

--- a/app/scripts/lib/oauth-client.js
+++ b/app/scripts/lib/oauth-client.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/xhr',
-  'lib/oauth-errors'
-],
-function (xhr, OAuthErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var OAuthErrors = require('lib/oauth-errors');
+  var xhr = require('lib/xhr');
 
   var GET_CLIENT = '/v1/client/';
   var GET_CODE = '/v1/authorization';
@@ -55,6 +54,6 @@ function (xhr, OAuthErrors) {
     }
   };
 
-  return OAuthClient;
+  module.exports = OAuthClient;
 });
 

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -4,13 +4,12 @@
 
 // provides functions to work with errors returned by the auth server.
 
-define([
-  'underscore',
-  'lib/errors',
-  'lib/strings'
-],
-function (_, Errors, Strings) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Errors = require('lib/errors');
+  var Strings = require('lib/strings');
 
   var t = function (msg) {
     return msg;
@@ -109,7 +108,7 @@ function (_, Errors, Strings) {
   };
   /*eslint-enable sorting/sort-object-props*/
 
-  return _.extend({}, Errors, {
+  module.exports = _.extend({}, Errors, {
     ERRORS: ERRORS,
     NAMESPACE: 'oauth',
 

--- a/app/scripts/lib/origin-check.js
+++ b/app/scripts/lib/origin-check.js
@@ -23,12 +23,12 @@
  * is found after a short period, return `null`.
  */
 
-define([
-  'lib/promise',
-  'lib/channels/iframe',
-  'raven'
-], function (p, IFrameChannel, Raven) {
+define(function (require, exports, module) {
   'use strict';
+
+  var IFrameChannel = require('lib/channels/iframe');
+  var p = require('lib/promise');
+  var Raven = require('raven');
 
   // This timeout needs to be long enough for slow machines to able to respond to
   // See https://github.com/mozilla/fxa-content-server/issues/2946 for details
@@ -116,7 +116,7 @@ define([
     }
   };
 
-  return OriginCheck;
+  module.exports = OriginCheck;
 });
 
 

--- a/app/scripts/lib/profile-client.js
+++ b/app/scripts/lib/profile-client.js
@@ -4,12 +4,11 @@
 
 // This module handles communication with the fxa-profile-server.
 
-define([
-  'lib/xhr',
-  'lib/profile-errors'
-],
-function (xhr, ProfileErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var ProfileErrors = require('lib/profile-errors');
+  var xhr = require('lib/xhr');
 
   function ProfileClient(options) {
     options = options || {};
@@ -79,6 +78,6 @@ function (xhr, ProfileErrors) {
 
   ProfileClient.Errors = ProfileErrors;
 
-  return ProfileClient;
+  module.exports = ProfileClient;
 });
 

--- a/app/scripts/lib/profile-errors.js
+++ b/app/scripts/lib/profile-errors.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore',
-  'lib/errors'
-], function (_, Errors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Errors = require('lib/errors');
 
   var t = function (msg) {
     return msg;
@@ -45,7 +45,7 @@ define([
   };
   /*eslint-enable sorting/sort-object-props*/
 
-  return _.extend({}, Errors, {
+  module.exports = _.extend({}, Errors, {
     ERRORS: ERRORS,
     NAMESPACE: 'profile'
   });

--- a/app/scripts/lib/promise.js
+++ b/app/scripts/lib/promise.js
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // monkey patch p to be able to convert jQuery XHR promises to our promises.
-define([
-  'p-promise'
-], function (p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('p-promise');
 
   // for more background, read
   // https://github.com/kriskowal/q/wiki/Coming-from-jQuery
@@ -23,7 +23,7 @@ define([
     return defer.promise;
   };
 
-  return p;
+  module.exports = p;
 });
 
 

--- a/app/scripts/lib/relier-keys.js
+++ b/app/scripts/lib/relier-keys.js
@@ -6,14 +6,14 @@
  * Derive relier-specific encryption keys from account master keys.
  */
 
-define([
-  'sjcl',
-  'p-promise',
-  'lib/hkdf',
-  'lib/base64url',
-  'lib/constants'
-], function (sjcl, p, hkdf, base64url, Constants) {
+define(function (require, exports, module) {
   'use strict';
+
+  var base64url = require('lib/base64url');
+  var Constants = require('lib/constants');
+  var hkdf = require('lib/hkdf');
+  var p = require('p-promise');
+  var sjcl = require('sjcl');
 
   var KEY_CLASS_TAG_A = 'kAr';
   var KEY_CLASS_TAG_B = 'kBr';
@@ -115,7 +115,7 @@ define([
       });
   }
 
-  return {
+  module.exports = {
     deriveRelierKeys: deriveRelierKeys,
     generateDerivedKey: generateDerivedKey
   };

--- a/app/scripts/lib/require-on-demand.js
+++ b/app/scripts/lib/require-on-demand.js
@@ -14,12 +14,12 @@
  *   });
  */
 
-define([
-  'lib/errors',
-  'lib/promise',
-  'underscore'
-], function (Errors, p, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Errors = require('lib/errors');
+  var p = require('lib/promise');
 
   var t = function (msg) {
     return msg;
@@ -79,6 +79,6 @@ define([
 
   requireOnDemand.Errors = RODErrors;
 
-  return requireOnDemand;
+  module.exports = requireOnDemand;
 });
 

--- a/app/scripts/lib/requirejs-plugin-nocache.js
+++ b/app/scripts/lib/requirejs-plugin-nocache.js
@@ -3,8 +3,9 @@
  * Available via the MIT or new BSD license.
  */
 
-define([], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   function defaultBuster() {
     return Date.now();
@@ -31,5 +32,5 @@ define([], function () {
     }
   };
 
-  return nocache;
+  module.exports = nocache;
 });

--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -2,81 +2,44 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'backbone',
-  './storage',
-  'underscore',
-  '../views/cannot_create_account',
-  '../views/choose_what_to_sync',
-  '../views/clear_storage',
-  '../views/complete_account_unlock',
-  '../views/complete_reset_password',
-  '../views/complete_sign_up',
-  '../views/confirm',
-  '../views/confirm_account_unlock',
-  '../views/confirm_reset_password',
-  '../views/cookies_disabled',
-  '../views/force_auth',
-  '../views/legal',
-  '../views/openid/login',
-  '../views/openid/start',
-  '../views/permissions',
-  '../views/pp',
-  '../views/ready',
-  '../views/reset_password',
-  '../views/settings',
-  '../views/settings/avatar_camera',
-  '../views/settings/avatar_change',
-  '../views/settings/avatar_crop',
-  '../views/settings/avatar_gravatar',
-  '../views/settings/change_password',
-  '../views/settings/communication_preferences',
-  '../views/settings/delete_account',
-  '../views/settings/display_name',
-  '../views/settings/gravatar_permissions',
-  '../views/sign_in',
-  '../views/sign_up',
-  '../views/tos',
-  '../views/unexpected_error'
-],
-function (
-  Backbone,
-  Storage,
-  _,
-  CannotCreateAccountView,
-  ChooseWhatToSyncView,
-  ClearStorageView,
-  CompleteAccountUnlockView,
-  CompleteResetPasswordView,
-  CompleteSignUpView,
-  ConfirmView,
-  ConfirmAccountUnlockView,
-  ConfirmResetPasswordView,
-  CookiesDisabledView,
-  ForceAuthView,
-  LegalView,
-  OpenIdLoginView,
-  OpenIdStartView,
-  PermissionsView,
-  PpView,
-  ReadyView,
-  ResetPasswordView,
-  SettingsView,
-  AvatarCameraView,
-  AvatarChangeView,
-  AvatarCropView,
-  AvatarGravatarView,
-  ChangePasswordView,
-  CommunicationPreferencesView,
-  DeleteAccountView,
-  DisplayNameView,
-  GravatarPermissionsView,
-  SignInView,
-  SignUpView,
-  TosView,
-  UnexpectedErrorView
-) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AvatarCameraView = require('../views/settings/avatar_camera');
+  var AvatarChangeView = require('../views/settings/avatar_change');
+  var AvatarCropView = require('../views/settings/avatar_crop');
+  var AvatarGravatarView = require('../views/settings/avatar_gravatar');
+  var Backbone = require('backbone');
+  var CannotCreateAccountView = require('../views/cannot_create_account');
+  var ChangePasswordView = require('../views/settings/change_password');
+  var ChooseWhatToSyncView = require('../views/choose_what_to_sync');
+  var ClearStorageView = require('../views/clear_storage');
+  var CommunicationPreferencesView = require('../views/settings/communication_preferences');
+  var CompleteAccountUnlockView = require('../views/complete_account_unlock');
+  var CompleteResetPasswordView = require('../views/complete_reset_password');
+  var CompleteSignUpView = require('../views/complete_sign_up');
+  var ConfirmAccountUnlockView = require('../views/confirm_account_unlock');
+  var ConfirmResetPasswordView = require('../views/confirm_reset_password');
+  var ConfirmView = require('../views/confirm');
+  var CookiesDisabledView = require('../views/cookies_disabled');
+  var DeleteAccountView = require('../views/settings/delete_account');
+  var DisplayNameView = require('../views/settings/display_name');
+  var ForceAuthView = require('../views/force_auth');
+  var GravatarPermissionsView = require('../views/settings/gravatar_permissions');
+  var LegalView = require('../views/legal');
+  var OpenIdLoginView = require('../views/openid/login');
+  var OpenIdStartView = require('../views/openid/start');
+  var PermissionsView = require('../views/permissions');
+  var PpView = require('../views/pp');
+  var ReadyView = require('../views/ready');
+  var ResetPasswordView = require('../views/reset_password');
+  var SettingsView = require('../views/settings');
+  var SignInView = require('../views/sign_in');
+  var SignUpView = require('../views/sign_up');
+  var Storage = require('./storage');
+  var TosView = require('../views/tos');
+  var UnexpectedErrorView = require('../views/unexpected_error');
 
   function createViewHandler(View, options) {
     return function () {
@@ -311,5 +274,5 @@ function (
     createChildViewHandler: createChildViewHandler
   });
 
-  return Router;
+  module.exports = Router;
 });

--- a/app/scripts/lib/screen-info.js
+++ b/app/scripts/lib/screen-info.js
@@ -4,9 +4,9 @@
 
 // module to calculate screen dimentions given a window.
 
-define([
-], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   var NOT_REPORTED_VALUE = 'none';
 
@@ -24,6 +24,6 @@ define([
     this.screenWidth = screen.width || NOT_REPORTED_VALUE;
   }
 
-  return ScreenInfo;
+  module.exports = ScreenInfo;
 });
 

--- a/app/scripts/lib/sentry.js
+++ b/app/scripts/lib/sentry.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore',
-  'raven',
-  'lib/url'
-], function (_, Raven, Url) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Raven = require('raven');
+  var Url = require('lib/url');
 
   var ALLOWED_QUERY_PARAMETERS = [
     'automatedBrowser',
@@ -169,6 +169,6 @@ define([
     __cleanUpQueryParam: cleanUpQueryParam
   };
 
-  return SentryMetrics;
+  module.exports = SentryMetrics;
 });
 

--- a/app/scripts/lib/service-name.js
+++ b/app/scripts/lib/service-name.js
@@ -4,9 +4,9 @@
 
 // Look up friendly service names by their 'slug'
 
-define([],
-function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   function t(str) {
     return str;
@@ -24,5 +24,5 @@ function () {
     return this.translator.get(serviceNames[service] || '');
   };
 
-  return ServiceName;
+  module.exports = ServiceName;
 });

--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -5,10 +5,10 @@
 // Session saves session information about the user. Data is automatically
 // saved to sessionStorage and automatically loaded from sessionStorage on startup.
 
-define([
-  'underscore'
-], function (_) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
 
   var NAMESPACE = '__fxa_session';
 
@@ -185,5 +185,5 @@ define([
 
 
   // session is a singleton
-  return new Session();
+  module.exports = new Session();
 });

--- a/app/scripts/lib/storage-metrics.js
+++ b/app/scripts/lib/storage-metrics.js
@@ -7,13 +7,13 @@
  * tests
  */
 
-define([
-  'underscore',
-  'lib/promise',
-  'lib/metrics',
-  'lib/storage'
-], function (_, p, Metrics, Storage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Storage = require('lib/storage');
 
   var storage = Storage.factory('localStorage');
 
@@ -41,6 +41,6 @@ define([
     }
   });
 
-  return StorageMetrics;
+  module.exports = StorageMetrics;
 
 });

--- a/app/scripts/lib/storage.js
+++ b/app/scripts/lib/storage.js
@@ -5,11 +5,11 @@
 // This module abstracts interaction with storage backends such as localStorage
 // or sessionStorage.
 
-define([
-  'lib/null-storage',
-  'lib/url'
-], function (NullStorage, Url) {
+define(function (require, exports, module) {
   'use strict';
+
+  var NullStorage = require('lib/null-storage');
+  var Url = require('lib/url');
 
   var NAMESPACE = '__fxa_storage';
 
@@ -94,5 +94,5 @@ define([
     return storage;
   };
 
-  return Storage;
+  module.exports = Storage;
 });

--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-],
-function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   var t = function (msg) {
     return msg;
@@ -52,7 +51,7 @@ function () {
     return interpolated;
   }
 
-  return {
+  module.exports = {
     interpolate: interpolate
   };
 

--- a/app/scripts/lib/translator.js
+++ b/app/scripts/lib/translator.js
@@ -7,14 +7,13 @@
 // is chosen on the backend based on the user's `Accept-Language`
 // headers.
 
-define([
-  'underscore',
-  'jquery',
-  'lib/promise',
-  'lib/strings'
-],
-function (_, $, p, Strings) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var p = require('lib/promise');
+  var Strings = require('lib/strings');
 
   var Translator = function () {
     this.translations = {};
@@ -88,5 +87,5 @@ function (_, $, p, Strings) {
     interpolate: Strings.interpolate
   };
 
-  return Translator;
+  module.exports = Translator;
 });

--- a/app/scripts/lib/url.js
+++ b/app/scripts/lib/url.js
@@ -4,9 +4,10 @@
 
 // utilities to deal with urls
 
-define(['underscore'],
-function (_) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
 
   function searchParams (str, whitelist) {
     var search = (typeof str === 'string' ? str : window.location.search).replace(/^\?/, '');
@@ -38,7 +39,7 @@ function (_) {
     return allowedTerms;
   }
 
-  return {
+  module.exports = {
     searchParams: searchParams,
     searchParam: function (name, str) {
       var terms = searchParams(str);

--- a/app/scripts/lib/validate.js
+++ b/app/scripts/lib/validate.js
@@ -4,15 +4,15 @@
 
 // Do some validation.
 
-define([
-  'lib/constants'
-], function (Constants) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Constants = require('lib/constants');
 
   // taken from the fxa-auth-server
   var HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;
 
-  return {
+  module.exports = {
     /**
      * Check if an email address is valid
      *

--- a/app/scripts/lib/xhr.js
+++ b/app/scripts/lib/xhr.js
@@ -12,16 +12,16 @@
  *    a default data type. See issue #1786.
  */
 
-define([
-  'underscore',
-  'jquery',
-  'lib/promise'
-], function (_, $, p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var p = require('lib/promise');
 
   var DEFAULT_DATA_TYPE = 'json';
 
-  return {
+  module.exports = {
     /**
      * Low level ajax functionality, does not set a default data type.
      *

--- a/app/scripts/lib/xss.js
+++ b/app/scripts/lib/xss.js
@@ -4,14 +4,13 @@
 
 // Basic XSS protection
 
-define([
-  'underscore',
-  'lib/constants'
-],
-function (_, Constants) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var _ = require('underscore');
+  var Constants = require('lib/constants');
+
+  module.exports = {
     // only allow http or https URLs, encoding the URL.
     href: function (text) {
       if (! _.isString(text)) {

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -5,19 +5,18 @@
 // This model abstracts interaction between the user's account
 // and the profile server and also handles (de)serialization.
 
-define([
-  'backbone',
-  'underscore',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/profile-client',
-  'lib/constants',
-  'models/profile-image',
-  'models/oauth-token',
-  'models/marketing-email-prefs'
-], function (Backbone, _, p, AuthErrors, ProfileClient, Constants,
-  ProfileImage, OAuthToken, MarketingEmailPrefs) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
+  var Constants = require('lib/constants');
+  var MarketingEmailPrefs = require('models/marketing-email-prefs');
+  var OAuthToken = require('models/oauth-token');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var ProfileImage = require('models/profile-image');
 
   // Account attributes that can be persisted
   var PERSISTENT = {
@@ -460,5 +459,5 @@ define([
       };
     });
 
-  return Account;
+  module.exports = Account;
 });

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -7,16 +7,15 @@
  * the outside world.
  */
 
-define([
-  'backbone',
-  'lib/promise',
-  'models/mixins/search-param',
-  'models/verification/same-browser',
-  'views/behaviors/null',
-  'underscore',
-], function (Backbone, p, SearchParamMixin, SameBrowserVerificationModel,
-  NullBehavior, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var NullBehavior = require('views/behaviors/null');
+  var p = require('lib/promise');
+  var SameBrowserVerificationModel = require('models/verification/same-browser');
+  var SearchParamMixin = require('models/mixins/search-param');
 
   var BaseAuthenticationBroker = Backbone.Model.extend({
     type: 'base',
@@ -412,5 +411,5 @@ define([
 
   _.extend(BaseAuthenticationBroker.prototype, SearchParamMixin);
 
-  return BaseAuthenticationBroker;
+  module.exports = BaseAuthenticationBroker;
 });

--- a/app/scripts/models/auth_brokers/first-run.js
+++ b/app/scripts/models/auth_brokers/first-run.js
@@ -7,12 +7,12 @@
  * embedded in the Firefox firstrun flow.
  */
 
-define([
-  'models/auth_brokers/fx-desktop-v2',
-  'views/behaviors/halt',
-  'underscore'
-], function (FxDesktopV2AuthenticationBroker, HaltBehavior, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var FxDesktopV2AuthenticationBroker = require('models/auth_brokers/fx-desktop-v2');
+  var HaltBehavior = require('views/behaviors/halt');
 
   var proto = FxDesktopV2AuthenticationBroker.prototype;
 
@@ -82,5 +82,5 @@ define([
     }
   });
 
-  return FirstRunAuthenticationBroker;
+  module.exports = FirstRunAuthenticationBroker;
 });

--- a/app/scripts/models/auth_brokers/fx-desktop-v1.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v1.js
@@ -6,15 +6,14 @@
  * V1 of the broker to communicate with Fx Desktop when signing in to Sync.
  */
 
-define([
-  'lib/channels/fx-desktop-v1',
-  'lib/url',
-  'models/auth_brokers/fx-sync',
-  'underscore',
-  'views/behaviors/halt'
-], function (FxDesktopChannel, Url, FxSyncAuthenticationBroker, _,
-  HaltBehavior) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var FxDesktopChannel = require('lib/channels/fx-desktop-v1');
+  var FxSyncAuthenticationBroker = require('models/auth_brokers/fx-sync');
+  var HaltBehavior = require('views/behaviors/halt');
+  var Url = require('lib/url');
 
   var proto = FxSyncAuthenticationBroker.prototype;
 
@@ -66,6 +65,6 @@ define([
     }
   });
 
-  return FxDesktopV1AuthenticationBroker;
+  module.exports = FxDesktopV1AuthenticationBroker;
 });
 

--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -10,15 +10,15 @@
  * If Sync is iframed by web content, v2 of the protocol is assumed.
  */
 
-define([
-  './fx-sync',
-  'lib/channels/web',
-  'lib/constants',
-  'lib/promise',
-  'underscore',
-  'views/behaviors/navigate'
-], function (FxSyncAuthenticationBroker, WebChannel, Constants, p, _, NavigateBehavior) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Constants = require('lib/constants');
+  var FxSyncAuthenticationBroker = require('./fx-sync');
+  var NavigateBehavior = require('views/behaviors/navigate');
+  var p = require('lib/promise');
+  var WebChannel = require('lib/channels/web');
 
   var proto = FxSyncAuthenticationBroker.prototype;
 
@@ -70,6 +70,6 @@ define([
     }
   });
 
-  return FxDesktopV2AuthenticationBroker;
+  module.exports = FxDesktopV2AuthenticationBroker;
 });
 

--- a/app/scripts/models/auth_brokers/fx-fennec-v1.js
+++ b/app/scripts/models/auth_brokers/fx-fennec-v1.js
@@ -7,13 +7,13 @@
  * embedded in Firefox for Android.
  */
 
-define([
-  'lib/promise',
-  'models/auth_brokers/fx-desktop-v2',
-  'underscore',
-  'views/behaviors/navigate'
-], function (p, FxDesktopV2AuthenticationBroker, _, NavigateBehavior) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var FxDesktopV2AuthenticationBroker = require('models/auth_brokers/fx-desktop-v2');
+  var NavigateBehavior = require('views/behaviors/navigate');
+  var p = require('lib/promise');
 
   var proto = FxDesktopV2AuthenticationBroker.prototype;
 
@@ -68,5 +68,5 @@ define([
     }
   });
 
-  return FxFennecV1AuthenticationBroker;
+  module.exports = FxFennecV1AuthenticationBroker;
 });

--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -7,12 +7,12 @@
  * embedded in the Firefox for iOS 1.0 ... < 2.0.
  */
 
-define([
-  'lib/auth-errors',
-  'models/auth_brokers/fx-desktop-v1',
-  'underscore'
-], function (AuthErrors, FxDesktopV1AuthenticationBroker, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var FxDesktopV1AuthenticationBroker = require('models/auth_brokers/fx-desktop-v1');
 
   var proto = FxDesktopV1AuthenticationBroker.prototype;
 
@@ -35,5 +35,5 @@ define([
     }
   });
 
-  return FxiOSV1AuthenticationBroker;
+  module.exports = FxiOSV1AuthenticationBroker;
 });

--- a/app/scripts/models/auth_brokers/fx-ios-v2.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v2.js
@@ -7,13 +7,13 @@
  * embedded in the Firefox for iOS 2.0.
  */
 
-define([
-  'lib/promise',
-  'models/auth_brokers/fx-desktop-v1',
-  'underscore',
-  'views/behaviors/navigate'
-], function (p, FxDesktopV1AuthenticationBroker, _, NavigateBehavior) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var FxDesktopV1AuthenticationBroker = require('models/auth_brokers/fx-desktop-v1');
+  var NavigateBehavior = require('views/behaviors/navigate');
+  var p = require('lib/promise');
 
   var proto = FxDesktopV1AuthenticationBroker.prototype;
 
@@ -49,5 +49,5 @@ define([
     type: 'fx-ios-v2'
   });
 
-  return FxiOSV2AuthenticationBroker;
+  module.exports = FxiOSV2AuthenticationBroker;
 });

--- a/app/scripts/models/auth_brokers/fx-sync.js
+++ b/app/scripts/models/auth_brokers/fx-sync.js
@@ -8,15 +8,15 @@
  * and a `commands` object.
  */
 
-define([
-  'cocktail',
-  'underscore',
-  'models/auth_brokers/base',
-  'models/auth_brokers/mixins/channel',
-  'lib/auth-errors',
-  'lib/promise'
-], function (Cocktail, _, BaseAuthenticationBroker, ChannelMixin, AuthErrors, p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseAuthenticationBroker = require('models/auth_brokers/base');
+  var ChannelMixin = require('models/auth_brokers/mixins/channel');
+  var Cocktail = require('cocktail');
+  var p = require('lib/promise');
 
   var proto = BaseAuthenticationBroker.prototype;
 
@@ -232,6 +232,6 @@ define([
     ChannelMixin
   );
 
-  return FxSyncAuthenticationBroker;
+  module.exports = FxSyncAuthenticationBroker;
 });
 

--- a/app/scripts/models/auth_brokers/iframe.js
+++ b/app/scripts/models/auth_brokers/iframe.js
@@ -4,12 +4,12 @@
 
 // Finishes the OAuth flow by redirecting the window.
 
-define([
-  'underscore',
-  'models/auth_brokers/oauth',
-  'models/auth_brokers/mixins/channel'
-], function (_, OAuthAuthenticationBroker, ChannelMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var ChannelMixin = require('models/auth_brokers/mixins/channel');
+  var OAuthAuthenticationBroker = require('models/auth_brokers/oauth');
 
   var IframeAuthenticationBroker = OAuthAuthenticationBroker.extend({
     type: 'iframe',
@@ -48,5 +48,5 @@ define([
 
   _.extend(IframeAuthenticationBroker.prototype, ChannelMixin);
 
-  return IframeAuthenticationBroker;
+  module.exports = IframeAuthenticationBroker;
 });

--- a/app/scripts/models/auth_brokers/mixins/channel.js
+++ b/app/scripts/models/auth_brokers/mixins/channel.js
@@ -12,10 +12,10 @@
  * instance
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   // normalize the channel action. New channels return promises, old
   // channels use NodeJS style callbacks. Convert the old channel style
@@ -65,6 +65,6 @@ define([
     }
   };
 
-  return ChannelMixin;
+  module.exports = ChannelMixin;
 });
 

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -7,21 +7,19 @@
  * to override `sendOAuthResultToRelier`
  */
 
-define([
-  'underscore',
-  'lib/constants',
-  'lib/url',
-  'lib/oauth-errors',
-  'lib/auth-errors',
-  'lib/promise',
-  'lib/validate',
-  'models/auth_brokers/base',
-  'views/behaviors/halt',
-  'views/behaviors/navigate'
-],
-function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
-      BaseAuthenticationBroker, HaltBehavior, NavigateBehavior) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseAuthenticationBroker = require('models/auth_brokers/base');
+  var Constants = require('lib/constants');
+  var HaltBehavior = require('views/behaviors/halt');
+  var NavigateBehavior = require('views/behaviors/navigate');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var Url = require('lib/url');
+  var Validate = require('lib/validate');
 
   /**
    * Formats the OAuth "result.redirect" url into a {code, state} object
@@ -199,5 +197,5 @@ function (_, Constants, Url, OAuthErrors, AuthErrors, p, Validate,
     }
   });
 
-  return OAuthAuthenticationBroker;
+  module.exports = OAuthAuthenticationBroker;
 });

--- a/app/scripts/models/auth_brokers/redirect.js
+++ b/app/scripts/models/auth_brokers/redirect.js
@@ -4,14 +4,14 @@
 
 // Finishes the OAuth flow by redirecting the window.
 
-define([
-  'lib/promise',
-  'lib/constants',
-  'lib/url',
-  'models/auth_brokers/oauth',
-  'views/behaviors/halt'
-], function (p, Constants, Url, OAuthAuthenticationBroker, HaltBehavior) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Constants = require('lib/constants');
+  var HaltBehavior = require('views/behaviors/halt');
+  var OAuthAuthenticationBroker = require('models/auth_brokers/oauth');
+  var p = require('lib/promise');
+  var Url = require('lib/url');
 
   var proto = OAuthAuthenticationBroker.prototype;
 
@@ -126,5 +126,5 @@ define([
     }
   });
 
-  return RedirectAuthenticationBroker;
+  module.exports = RedirectAuthenticationBroker;
 });

--- a/app/scripts/models/auth_brokers/web-channel.js
+++ b/app/scripts/models/auth_brokers/web-channel.js
@@ -7,16 +7,14 @@
  * with the browser
  */
 
-define([
-  'underscore',
-  'models/auth_brokers/oauth',
-  'models/auth_brokers/mixins/channel',
-  'lib/promise',
-  'lib/channels/web'
-],
-function (_, OAuthAuthenticationBroker, ChannelMixin, p,
-      WebChannel) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var ChannelMixin = require('models/auth_brokers/mixins/channel');
+  var OAuthAuthenticationBroker = require('models/auth_brokers/oauth');
+  var p = require('lib/promise');
+  var WebChannel = require('lib/channels/web');
 
   var proto = OAuthAuthenticationBroker.prototype;
 
@@ -236,5 +234,5 @@ function (_, OAuthAuthenticationBroker, ChannelMixin, p,
   });
 
   _.extend(WebChannelAuthenticationBroker.prototype, ChannelMixin);
-  return WebChannelAuthenticationBroker;
+  module.exports = WebChannelAuthenticationBroker;
 });

--- a/app/scripts/models/cropper-image.js
+++ b/app/scripts/models/cropper-image.js
@@ -4,12 +4,12 @@
 
 // This model abstracts images used by the cropper view
 
-define([
-  'backbone',
-  'lib/constants',
-  'lib/auth-errors'
-], function (Backbone, Constants, AuthErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
+  var Constants = require('lib/constants');
 
   // a 1x1 jpeg
   var jpegSrc = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsM' +
@@ -37,5 +37,5 @@ define([
     }
   });
 
-  return CropperImage;
+  module.exports = CropperImage;
 });

--- a/app/scripts/models/email-resend.js
+++ b/app/scripts/models/email-resend.js
@@ -4,11 +4,11 @@
 
 // This model limits the number of emails a component can send
 
-define([
-  'backbone',
-  'lib/constants'
-], function (Backbone, Constants) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var Constants = require('lib/constants');
 
   function shouldResend (tries, maxTries) {
     return tries === 1 || tries === maxTries;
@@ -42,5 +42,5 @@ define([
     }
   });
 
-  return EmailResend;
+  module.exports = EmailResend;
 });

--- a/app/scripts/models/form-prefill.js
+++ b/app/scripts/models/form-prefill.js
@@ -9,10 +9,10 @@
 //
 // These values are not persisted across browser sessions.
 
-define([
-  'backbone'
-], function (Backbone) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
 
   var FormPrefill = Backbone.Model.extend({
     defaults: {
@@ -22,7 +22,7 @@ define([
     }
   });
 
-  return FormPrefill;
+  module.exports = FormPrefill;
 });
 
 

--- a/app/scripts/models/marketing-email-prefs.js
+++ b/app/scripts/models/marketing-email-prefs.js
@@ -8,12 +8,12 @@
  * loaded on demand, independently of account information.
  */
 
-define([
-  'underscore',
-  'backbone',
-  'lib/promise'
-], function (_, Backbone, p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var p = require('lib/promise');
 
   var SCOPES = 'basket:write profile:email';
 
@@ -130,5 +130,5 @@ define([
     }
   });
 
-  return MarketingEmailPrefs;
+  module.exports = MarketingEmailPrefs;
 });

--- a/app/scripts/models/mixins/resume-token.js
+++ b/app/scripts/models/mixins/resume-token.js
@@ -9,12 +9,12 @@
  * fields that are saved to and populated from the ResumeToken.
  */
 
-define([
-  'models/resume-token'
-], function (ResumeToken) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var ResumeToken = require('models/resume-token');
+
+  module.exports = {
     /**
      * Get an object of values that should be stored in a ResumeToken
      *

--- a/app/scripts/models/mixins/search-param.js
+++ b/app/scripts/models/mixins/search-param.js
@@ -6,12 +6,12 @@
  * A mixin that allows models to get/import search parameters
  */
 
-define([
-  'lib/url'
-], function (Url) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var Url = require('lib/url');
+
+  module.exports = {
     /**
      * Get a value from the URL search parameter
      *

--- a/app/scripts/models/oauth-token.js
+++ b/app/scripts/models/oauth-token.js
@@ -8,10 +8,10 @@
  * with an Account model.
  */
 
-define([
-  'backbone'
-], function (Backbone) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
 
   var Model = Backbone.Model.extend({
     defaults: {
@@ -30,7 +30,7 @@ define([
     }
   });
 
-  return Model;
+  module.exports = Model;
 });
 
 

--- a/app/scripts/models/profile-image.js
+++ b/app/scripts/models/profile-image.js
@@ -4,13 +4,13 @@
 
 // This model abstracts profile images
 
-define([
-  'backbone',
-  'lib/promise',
-  'lib/image-loader',
-  'lib/profile-errors'
-], function (Backbone, p, ImageLoader, ProfileErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var ImageLoader = require('lib/image-loader');
+  var p = require('lib/promise');
+  var ProfileErrors = require('lib/profile-errors');
 
   var ProfileImage = Backbone.Model.extend({
     defaults: {
@@ -40,5 +40,5 @@ define([
     }
   });
 
-  return ProfileImage;
+  module.exports = ProfileImage;
 });

--- a/app/scripts/models/refresh-observer.js
+++ b/app/scripts/models/refresh-observer.js
@@ -10,17 +10,17 @@
  * logged to metrics.
  */
 
-define([
-  'backbone',
-  'lib/storage'
-], function (Backbone, Storage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var Storage = require('lib/storage');
 
   function isRefresh (refreshMetrics, viewName) {
     return refreshMetrics && refreshMetrics.view === viewName;
   }
 
-  return Backbone.Model.extend({
+  module.exports = Backbone.Model.extend({
     initialize: function (options) {
       options = options || {};
 

--- a/app/scripts/models/reliers/base.js
+++ b/app/scripts/models/reliers/base.js
@@ -7,11 +7,11 @@
  * depending on how you want to use it.
  */
 
-define([
-  'backbone',
-  'lib/promise'
-], function (Backbone, p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var p = require('lib/promise');
 
   var Relier = Backbone.Model.extend({
     defaults: {},
@@ -105,5 +105,5 @@ define([
     }
   });
 
-  return Relier;
+  module.exports = Relier;
 });

--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -6,15 +6,15 @@
  * An OAuth Relier - holds OAuth information.
  */
 
-define([
-  'underscore',
-  'models/reliers/relier',
-  'lib/oauth-errors',
-  'lib/relier-keys',
-  'lib/url',
-  'lib/constants'
-], function (_, Relier, OAuthErrors, RelierKeys, Url, Constants) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Constants = require('lib/constants');
+  var OAuthErrors = require('lib/oauth-errors');
+  var Relier = require('models/reliers/relier');
+  var RelierKeys = require('lib/relier-keys');
+  var Url = require('lib/url');
 
   var RELIER_FIELDS_IN_RESUME_TOKEN = ['state', 'verificationRedirect'];
   // We only grant permissions that our UI currently prompts for. Others
@@ -208,5 +208,5 @@ define([
     });
   }
 
-  return OAuthRelier;
+  module.exports = OAuthRelier;
 });

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -10,16 +10,15 @@
  * query parameter.
  */
 
-define([
-  'cocktail',
-  'models/reliers/base',
-  'models/mixins/resume-token',
-  'models/mixins/search-param',
-  'lib/promise',
-  'lib/constants'
-], function (Cocktail, BaseRelier, ResumeTokenMixin, SearchParamMixin, p,
-  Constants) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseRelier = require('models/reliers/base');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var p = require('lib/promise');
+  var ResumeTokenMixin = require('models/mixins/resume-token');
+  var SearchParamMixin = require('models/mixins/search-param');
 
   var RELIER_FIELDS_IN_RESUME_TOKEN = [
     'utmTerm',
@@ -123,5 +122,5 @@ define([
     SearchParamMixin
   );
 
-  return Relier;
+  module.exports = Relier;
 });

--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -10,12 +10,12 @@
  * - migration
  */
 
-define([
-  'underscore',
-  'models/reliers/relier',
-  'lib/service-name'
-], function (_, Relier, ServiceNameTranslator) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Relier = require('models/reliers/relier');
+  var ServiceNameTranslator = require('lib/service-name');
 
   var SyncRelier = Relier.extend({
     defaults: _.extend({}, Relier.prototype.defaults, {
@@ -82,5 +82,5 @@ define([
     }
   });
 
-  return SyncRelier;
+  module.exports = SyncRelier;
 });

--- a/app/scripts/models/resume-token.js
+++ b/app/scripts/models/resume-token.js
@@ -7,11 +7,11 @@
  * search parameters post-verification in the OAuth flow
  */
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   var ResumeToken = Backbone.Model.extend({
     defaults: {
@@ -68,6 +68,6 @@ define([
     stringify: stringify
   });
 
-  return ResumeToken;
+  module.exports = ResumeToken;
 });
 

--- a/app/scripts/models/unique-user-id.js
+++ b/app/scripts/models/unique-user-id.js
@@ -17,16 +17,15 @@
  * If not in localStorage either, create a new uniqueUserId.
  */
 
-define([
-  'backbone',
-  'cocktail',
-  'lib/storage',
-  'models/mixins/resume-token',
-  'models/mixins/search-param',
-  'uuid'
-], function (Backbone, Cocktail, Storage, ResumeTokenMixin, SearchParamMixin,
-  uuid) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var Cocktail = require('cocktail');
+  var ResumeTokenMixin = require('models/mixins/resume-token');
+  var SearchParamMixin = require('models/mixins/search-param');
+  var Storage = require('lib/storage');
+  var uuid = require('uuid');
 
   var Model = Backbone.Model.extend({
     initialize: function (options) {
@@ -79,5 +78,5 @@ define([
     SearchParamMixin
   );
 
-  return Model;
+  module.exports = Model;
 });

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -8,16 +8,16 @@
 //
 // i.e. User hasMany Accounts.
 
-define([
-  'backbone',
-  'cocktail',
-  'underscore',
-  'lib/promise',
-  'lib/storage',
-  'models/account',
-  'models/mixins/resume-token'
-], function (Backbone, Cocktail, _, p, Storage, Account, ResumeTokenMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Account = require('models/account');
+  var Backbone = require('backbone');
+  var Cocktail = require('cocktail');
+  var p = require('lib/promise');
+  var ResumeTokenMixin = require('models/mixins/resume-token');
+  var Storage = require('lib/storage');
 
   var User = Backbone.Model.extend({
     initialize: function (options) {
@@ -313,5 +313,5 @@ define([
     ResumeTokenMixin
   );
 
-  return User;
+  module.exports = User;
 });

--- a/app/scripts/models/verification/account-unlock.js
+++ b/app/scripts/models/verification/account-unlock.js
@@ -7,13 +7,13 @@
  * A model to hold account unlock verification data
  */
 
-define([
-  './base',
-  'lib/validate'
-], function (VerificationInfo, Validate) {
+define(function (require, exports, module) {
   'use strict';
 
-  return VerificationInfo.extend({
+  var Validate = require('lib/validate');
+  var VerificationInfo = require('./base');
+
+  module.exports = VerificationInfo.extend({
     defaults: {
       code: null,
       uid: null

--- a/app/scripts/models/verification/base.js
+++ b/app/scripts/models/verification/base.js
@@ -12,11 +12,11 @@
  * whose values are validation functions.
  */
 
-define([
-  'backbone',
-  'underscore'
-], function (Backbone, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   var proto = Backbone.Model.prototype;
 
@@ -118,6 +118,6 @@ define([
     }
   });
 
-  return VerificationInfo;
+  module.exports = VerificationInfo;
 });
 

--- a/app/scripts/models/verification/reset-password.js
+++ b/app/scripts/models/verification/reset-password.js
@@ -6,13 +6,13 @@
  * A model to hold reset password verification data
  */
 
-define([
-  './base',
-  'lib/validate'
-], function (VerificationInfo, Validate) {
+define(function (require, exports, module) {
   'use strict';
 
-  return VerificationInfo.extend({
+  var Validate = require('lib/validate');
+  var VerificationInfo = require('./base');
+
+  module.exports = VerificationInfo.extend({
     defaults: {
       code: null,
       email: null,

--- a/app/scripts/models/verification/same-browser.js
+++ b/app/scripts/models/verification/same-browser.js
@@ -15,11 +15,11 @@
  * `email` is used in password reset verifications.
  */
 
-define([
-  'backbone',
-  'lib/storage'
-], function (Backbone, Storage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var Storage = require('lib/storage');
 
   var STORAGE_KEY = 'verificationInfo';
 
@@ -95,5 +95,5 @@ define([
     }
   });
 
-  return SameBrowserVerificationModel;
+  module.exports = SameBrowserVerificationModel;
 });

--- a/app/scripts/models/verification/sign-up.js
+++ b/app/scripts/models/verification/sign-up.js
@@ -6,13 +6,13 @@
  * A model to hold sign up verification data
  */
 
-define([
-  './base',
-  'lib/validate'
-], function (VerificationInfo, Validate) {
+define(function (require, exports, module) {
   'use strict';
 
-  return VerificationInfo.extend({
+  var Validate = require('lib/validate');
+  var VerificationInfo = require('./base');
+
+  module.exports = VerificationInfo.extend({
     defaults: {
       code: null,
       uid: null

--- a/app/scripts/views/app.js
+++ b/app/scripts/views/app.js
@@ -6,12 +6,12 @@
  * The outermost view of the system. Handles window level interactions.
  */
 
-define([
-  'jquery',
-  'lib/promise',
-  'views/base'
-], function ($, p, BaseView) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var BaseView = require('views/base');
+  var p = require('lib/promise');
 
   var AppView = BaseView.extend({
     initialize: function (options) {
@@ -174,6 +174,6 @@ define([
 
   });
 
-  return AppView;
+  module.exports = AppView;
 });
 

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'underscore',
-  'backbone',
-  'raven',
-  'jquery',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/ephemeral-messages',
-  'lib/null-metrics',
-  'views/mixins/notifier-mixin',
-  'views/mixins/timer-mixin'
-],
-function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
-      EphemeralMessages, NullMetrics, NotifierMixin, TimerMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
+  var Cocktail = require('cocktail');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var NotifierMixin = require('views/mixins/notifier-mixin');
+  var NullMetrics = require('lib/null-metrics');
+  var p = require('lib/promise');
+  var Raven = require('raven');
+  var TimerMixin = require('views/mixins/timer-mixin');
 
   var DEFAULT_TITLE = window.document.title;
   var EPHEMERAL_MESSAGE_ANIMATION_MS = 150;
@@ -827,5 +825,5 @@ function (Cocktail, _, Backbone, Raven, $, p, AuthErrors,
     TimerMixin
   );
 
-  return BaseView;
+  module.exports = BaseView;
 });

--- a/app/scripts/views/behaviors/halt.js
+++ b/app/scripts/views/behaviors/halt.js
@@ -6,10 +6,10 @@
  * A behavior that halts the view flow.
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   var HaltBehavior = function () {
     var behavior = function (view) {
@@ -23,6 +23,6 @@ define([
     return behavior;
   };
 
-  return HaltBehavior;
+  module.exports = HaltBehavior;
 });
 

--- a/app/scripts/views/behaviors/navigate.js
+++ b/app/scripts/views/behaviors/navigate.js
@@ -6,10 +6,10 @@
  * A behavior that navigates to a new view.
  */
 
-define([
-  'lib/promise'
-], function (p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   var NavigationBehavior = function (endpoint, options) {
     options = options || {};
@@ -32,6 +32,6 @@ define([
     return behavior;
   };
 
-  return NavigationBehavior;
+  module.exports = NavigationBehavior;
 });
 

--- a/app/scripts/views/behaviors/null.js
+++ b/app/scripts/views/behaviors/null.js
@@ -6,8 +6,9 @@
  * A placeholder behavior, does nothing.
  */
 
-define([], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   var NullBehavior = function () {
     var behavior = function (/*view*/) {
@@ -17,6 +18,6 @@ define([], function () {
     return behavior;
   };
 
-  return NullBehavior;
+  module.exports = NullBehavior;
 });
 

--- a/app/scripts/views/cannot_create_account.js
+++ b/app/scripts/views/cannot_create_account.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/base',
-  'stache!templates/cannot_create_account'
-],
-function (BaseView, CannotCreateAccountTemplate) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var CannotCreateAccountTemplate = require('stache!templates/cannot_create_account');
 
   var CannotCreateAccountView = BaseView.extend({
     template: CannotCreateAccountTemplate,
@@ -22,6 +21,6 @@ function (BaseView, CannotCreateAccountTemplate) {
 
   });
 
-  return CannotCreateAccountView;
+  module.exports = CannotCreateAccountView;
 });
 

--- a/app/scripts/views/choose_what_to_sync.js
+++ b/app/scripts/views/choose_what_to_sync.js
@@ -2,19 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/promise',
-  'stache!templates/choose_what_to_sync',
-  'views/form',
-  'views/mixins/back-mixin',
-  'views/mixins/checkbox-mixin',
-  'views/mixins/signup-success-mixin',
-  'underscore'
-],
-function (Cocktail, p, Template, FormView, BackMixin, CheckboxMixin,
-  SignupSuccessMixin, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var BackMixin = require('views/mixins/back-mixin');
+  var CheckboxMixin = require('views/mixins/checkbox-mixin');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var SignupSuccessMixin = require('views/mixins/signup-success-mixin');
+  var Template = require('stache!templates/choose_what_to_sync');
 
   var View = FormView.extend({
     template: Template,
@@ -122,5 +120,5 @@ function (Cocktail, p, Template, FormView, BackMixin, CheckboxMixin,
     SignupSuccessMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/clear_storage.js
+++ b/app/scripts/views/clear_storage.js
@@ -7,12 +7,11 @@
  * to clear browser storage state between tests.
  */
 
-define([
-  'views/base',
-  'stache!templates/clear_storage'
-],
-function (BaseView, Template) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Template = require('stache!templates/clear_storage');
 
   var View = BaseView.extend({
     template: Template,
@@ -28,6 +27,6 @@ function (BaseView, Template) {
     }
   });
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/scripts/views/close_button.js
+++ b/app/scripts/views/close_button.js
@@ -8,14 +8,13 @@
  * to the parent that indicates "close me!"
  */
 
-define([
-  'views/base',
-  'lib/promise',
-  'lib/oauth-errors',
-  'stache!templates/partial/close-button'
-],
-function (BaseView, p, OAuthErrors, CloseTemplate) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var CloseTemplate = require('stache!templates/partial/close-button');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
 
   var View = BaseView.extend({
     template: CloseTemplate,
@@ -44,6 +43,6 @@ function (BaseView, p, OAuthErrors, CloseTemplate) {
     }
   });
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/scripts/views/complete_account_unlock.js
+++ b/app/scripts/views/complete_account_unlock.js
@@ -2,16 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/form',
-  'stache!templates/complete_account_unlock',
-  'lib/auth-errors',
-  'lib/url',
-  'models/verification/account-unlock'
-],
-function (FormView, CompleteAccountUnlockTemplate, AuthErrors,
-    Url, VerificationInfo) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var CompleteAccountUnlockTemplate = require('stache!templates/complete_account_unlock');
+  var FormView = require('views/form');
+  var Url = require('lib/url');
+  var VerificationInfo = require('models/verification/account-unlock');
 
   var CompleteAccountUnlockView = FormView.extend({
     template: CompleteAccountUnlockTemplate,
@@ -81,5 +79,5 @@ function (FormView, CompleteAccountUnlockTemplate, AuthErrors,
     }
   });
 
-  return CompleteAccountUnlockView;
+  module.exports = CompleteAccountUnlockView;
 });

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -2,25 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'views/form',
-  'stache!templates/complete_reset_password',
-  'views/mixins/floating-placeholder-mixin',
-  'views/mixins/password-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin',
-  'lib/channels/notifier',
-  'models/verification/reset-password',
-  'lib/auth-errors',
-  'lib/url'
-],
-function (Cocktail, BaseView, FormView, Template, FloatingPlaceholderMixin,
-  PasswordMixin, ResumeTokenMixin, ServiceMixin,
-  Notifier, VerificationInfo, AuthErrors, Url) {
-
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  var FormView = require('views/form');
+  var Notifier = require('lib/channels/notifier');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/complete_reset_password');
+  var Url = require('lib/url');
+  var VerificationInfo = require('models/verification/reset-password');
 
   var t = BaseView.t;
   var View = FormView.extend({
@@ -190,5 +186,5 @@ function (Cocktail, BaseView, FormView, Template, FloatingPlaceholderMixin,
     ServiceMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -2,25 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'views/base',
-  'stache!templates/complete_sign_up',
-  'lib/auth-errors',
-  'views/mixins/experiment-mixin',
-  'views/mixins/resend-mixin',
-  'views/mixins/loading-mixin',
-  'views/mixins/resume-token-mixin',
-  'lib/channels/notifier',
-  'models/verification/sign-up',
-  'lib/url',
-  'lib/constants'
-],
-function (Cocktail, FormView, BaseView, CompleteSignUpTemplate,
-  AuthErrors, ExperimentMixin, ResendMixin, LoadingMixin, ResumeTokenMixin,
-  Notifier, VerificationInfo, Url, Constants) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var CompleteSignUpTemplate = require('stache!templates/complete_sign_up');
+  var Constants = require('lib/constants');
+  var ExperimentMixin = require('views/mixins/experiment-mixin');
+  var FormView = require('views/form');
+  var LoadingMixin = require('views/mixins/loading-mixin');
+  var Notifier = require('lib/channels/notifier');
+  var ResendMixin = require('views/mixins/resend-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var Url = require('lib/url');
+  var VerificationInfo = require('models/verification/sign-up');
 
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;
   var t = BaseView.t;
@@ -199,5 +196,5 @@ function (Cocktail, FormView, BaseView, CompleteSignUpTemplate,
     ResumeTokenMixin
   );
 
-  return CompleteSignUpView;
+  module.exports = CompleteSignUpView;
 });

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'views/base',
-  'stache!templates/confirm',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/constants',
-  'views/mixins/experiment-mixin',
-  'views/mixins/resend-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin'
-],
-function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
-  ExperimentMixin, ResendMixin, ResumeTokenMixin, ServiceMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var ExperimentMixin = require('views/mixins/experiment-mixin');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var ResendMixin = require('views/mixins/resend-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/confirm');
 
   var t = BaseView.t;
 
@@ -193,5 +191,5 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
     ServiceMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/confirm_account_unlock.js
+++ b/app/scripts/views/confirm_account_unlock.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'views/base',
-  'stache!templates/confirm_account_unlock',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/constants',
-  'views/mixins/back-mixin',
-  'views/mixins/resend-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin'
-],
-function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
-    BackMixin, ResendMixin, ResumeTokenMixin, ServiceMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var ResendMixin = require('views/mixins/resend-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/confirm_account_unlock');
 
   var t = BaseView.t;
 
@@ -176,5 +174,5 @@ function (Cocktail, FormView, BaseView, Template, p, AuthErrors, Constants,
     ServiceMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/confirm',
-  'views/base',
-  'stache!templates/confirm_reset_password',
-  'lib/promise',
-  'lib/session',
-  'lib/auth-errors',
-  'lib/channels/notifier',
-  'views/mixins/resend-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin'
-],
-function (Cocktail, ConfirmView, BaseView, Template, p, Session, AuthErrors,
-  Notifier, ResendMixin, ResumeTokenMixin, ServiceMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var ConfirmView = require('views/confirm');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var ResendMixin = require('views/mixins/resend-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Session = require('lib/session');
+  var Template = require('stache!templates/confirm_reset_password');
 
   var t = BaseView.t;
 
@@ -281,5 +279,5 @@ function (Cocktail, ConfirmView, BaseView, Template, p, Session, AuthErrors,
     ServiceMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/cookies_disabled.js
+++ b/app/scripts/views/cookies_disabled.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'lib/config-loader',
-  'lib/auth-errors',
-  'lib/storage',
-  'stache!templates/cookies_disabled',
-  'views/mixins/back-mixin'
-],
-function (Cocktail, BaseView, ConfigLoader, AuthErrors, Storage, Template, BackMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var ConfigLoader = require('lib/config-loader');
+  var Storage = require('lib/storage');
+  var Template = require('stache!templates/cookies_disabled');
 
   var View = BaseView.extend({
     constructor: function (options) {
@@ -43,5 +42,5 @@ function (Cocktail, BaseView, ConfigLoader, AuthErrors, Storage, Template, BackM
     BackMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/coppa/coppa-age-input.js
+++ b/app/scripts/views/coppa/coppa-age-input.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/auth-errors',
-  'stache!templates/partial/coppa-age-input',
-  'views/form',
-  'views/mixins/floating-placeholder-mixin',
-  'lib/key-codes'
-], function (Cocktail, AuthErrors, Template, FormView, FloatingPlaceholderMixin, KeyCodes) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Cocktail = require('cocktail');
+  var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  var FormView = require('views/form');
+  var KeyCodes = require('lib/key-codes');
+  var Template = require('stache!templates/partial/coppa-age-input');
 
   var CUTOFF_AGE = 13;
   var View = FormView.extend({
@@ -102,5 +102,5 @@ define([
     FloatingPlaceholderMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/decorators/allow_only_one_submit.js
+++ b/app/scripts/views/decorators/allow_only_one_submit.js
@@ -8,11 +8,10 @@
  * Requires the invokeHandler function.
  */
 
-define([
-  'lib/promise'
-],
-function (p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
 
   function allowOnlyOneSubmit(handler) {
     return function () {
@@ -42,5 +41,5 @@ function (p) {
     };
   }
 
-  return allowOnlyOneSubmit;
+  module.exports = allowOnlyOneSubmit;
 });

--- a/app/scripts/views/decorators/notify_delayed_request.js
+++ b/app/scripts/views/decorators/notify_delayed_request.js
@@ -7,12 +7,11 @@
  * longer than expected
  */
 
-define([
-  'lib/promise',
-  'lib/auth-errors'
-],
-function (p, AuthErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var p = require('lib/promise');
 
   function notifyDelayedRequest(handler) {
     return function () {
@@ -44,5 +43,5 @@ function (p, AuthErrors) {
     };
   }
 
-  return notifyDelayedRequest;
+  module.exports = notifyDelayedRequest;
 });

--- a/app/scripts/views/decorators/progress_indicator.js
+++ b/app/scripts/views/decorators/progress_indicator.js
@@ -12,12 +12,11 @@
  * Requires the invokeHandler function.
  */
 
-define([
-  'lib/promise',
-  'views/progress_indicator'
-],
-function (p, ProgressIndicator) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
+  var ProgressIndicator = require('views/progress_indicator');
 
   function showProgressIndicator(handler, _el) {
     var el = _el || 'button[type=submit]';
@@ -64,5 +63,5 @@ function (p, ProgressIndicator) {
     return progressIndicator;
   }
 
-  return showProgressIndicator;
+  module.exports = showProgressIndicator;
 });

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/auth-errors',
-  'lib/promise',
-  'lib/session',
-  'stache!templates/force_auth',
-  'views/base',
-  'views/form',
-  'views/sign_in',
-  'views/mixins/password-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/signed-in-notification-mixin'
-],
-function (Cocktail, AuthErrors, p, Session, Template, BaseView, FormView,
-  SignInView, PasswordMixin, ResumeTokenMixin, SignedInNotificationMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var Session = require('lib/session');
+  var SignedInNotificationMixin = require('views/mixins/signed-in-notification-mixin');
+  var SignInView = require('views/sign_in');
+  var Template = require('stache!templates/force_auth');
 
   function getFatalErrorMessage(self, fatalError) {
     if (fatalError) {
@@ -154,5 +152,5 @@ function (Cocktail, AuthErrors, p, Session, Template, BaseView, FormView,
     SignedInNotificationMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -17,21 +17,19 @@
  * See documentation for an explanation of each.
  */
 
-define([
-  'underscore',
-  'jquery',
-  'lib/promise',
-  'lib/validate',
-  'lib/auth-errors',
-  'views/base',
-  'views/tooltip',
-  'views/decorators/progress_indicator',
-  'views/decorators/notify_delayed_request',
-  'views/decorators/allow_only_one_submit'
-],
-function (_, $, p, Validate, AuthErrors, BaseView, Tooltip,
-    showButtonProgressIndicator, notifyDelayedRequest, allowOnlyOneSubmit) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var notifyDelayedRequest = require('views/decorators/notify_delayed_request');
+  var p = require('lib/promise');
+  var showButtonProgressIndicator = require('views/decorators/progress_indicator');
+  var Tooltip = require('views/tooltip');
+  var Validate = require('lib/validate');
 
   /**
    * Decorator that checks whether the form has changed, and if so, call
@@ -567,5 +565,5 @@ function (_, $, p, Validate, AuthErrors, BaseView, Tooltip,
     }
   });
 
-  return FormView;
+  module.exports = FormView;
 });

--- a/app/scripts/views/legal.js
+++ b/app/scripts/views/legal.js
@@ -2,18 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/base',
-  'stache!templates/legal'
-],
-function (BaseView, Template) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Template = require('stache!templates/legal');
 
   var View = BaseView.extend({
     className: 'legal',
     template: Template
   });
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/scripts/views/legal_copy.js
+++ b/app/scripts/views/legal_copy.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/xhr',
-  'views/base',
-  'views/mixins/back-mixin'
-],
-function (Cocktail, xhr, BaseView, BackMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var xhr = require('lib/xhr');
 
   // A view to fetch and render legal copy. Sub-classes must provide
   // a `copyUrl` where the copy template can be fetched, as well a
@@ -87,6 +86,6 @@ function (Cocktail, xhr, BaseView, BackMixin) {
     BackMixin
   );
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/scripts/views/marketing_snippet.js
+++ b/app/scripts/views/marketing_snippet.js
@@ -9,14 +9,14 @@
  * signup for sync in Firefox Desktop.
  */
 
-define([
-  'cocktail',
-  'views/base',
-  'lib/constants',
-  'views/mixins/marketing-mixin',
-  'stache!templates/marketing_snippet'
-], function (Cocktail, BaseView, Constants, MarketingMixin, Template) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var MarketingMixin = require('views/mixins/marketing-mixin');
+  var Template = require('stache!templates/marketing_snippet');
 
   var View = BaseView.extend({
     template: Template,
@@ -65,7 +65,7 @@ define([
     MarketingMixin
   );
 
-  return View;
+  module.exports = View;
 });
 
 

--- a/app/scripts/views/marketing_snippet_ios.js
+++ b/app/scripts/views/marketing_snippet_ios.js
@@ -9,12 +9,12 @@
  * signup for sync in Firefox Desktop.
  */
 
-define([
-  'underscore',
-  'views/marketing_snippet',
-  'stache!templates/marketing_snippet_ios'
-], function (_, MarketingSnippetView, Template) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var MarketingSnippetView = require('views/marketing_snippet');
+  var Template = require('stache!templates/marketing_snippet_ios');
 
   var playStoreImageLanguages = [
     'ca',
@@ -100,5 +100,5 @@ define([
     }
   });
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/mixins/account-locked-mixin.js
+++ b/app/scripts/views/mixins/account-locked-mixin.js
@@ -8,13 +8,13 @@
  * @class AccountLockedMixin
  */
 
-define([
-  'underscore',
-  'lib/auth-errors',
-  'views/base',
-  'views/mixins/resume-token-mixin'
-], function (_, AuthErrors, BaseView, ResumeTokenMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
 
   var t = BaseView.t;
 
@@ -67,6 +67,6 @@ define([
     // because the AccountLockedMixin depends on the ResumeTokenMixin.
   }, ResumeTokenMixin);
 
-  return AccountLockedMixin;
+  module.exports = AccountLockedMixin;
 });
 

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -4,14 +4,14 @@
 
 // helper functions for views with a profile image. Meant to be mixed into views.
 
-define([
-  'underscore',
-  'lib/auth-errors',
-  'lib/profile-errors',
-  'lib/channels/notifier',
-  'models/profile-image'
-], function (_, AuthErrors, ProfileErrors, Notifier, ProfileImage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var Notifier = require('lib/channels/notifier');
+  var ProfileErrors = require('lib/profile-errors');
+  var ProfileImage = require('models/profile-image');
 
   var Mixin = {
     notifications: {
@@ -123,5 +123,5 @@ define([
 
   Mixin.notifications[Notifier.PROFILE_CHANGE] = 'onProfileUpdate';
 
-  return Mixin;
+  module.exports = Mixin;
 });

--- a/app/scripts/views/mixins/back-mixin.js
+++ b/app/scripts/views/mixins/back-mixin.js
@@ -8,11 +8,11 @@
  * @class BackMixin
  */
 
-define([
-  'views/base',
-  'lib/key-codes'
-], function (BaseView, KeyCodes) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var KeyCodes = require('lib/key-codes');
 
   var BackMixin = {
     _canGoBack: false,
@@ -77,5 +77,5 @@ define([
     }
   };
 
-  return BackMixin;
+  module.exports = BackMixin;
 });

--- a/app/scripts/views/mixins/checkbox-mixin.js
+++ b/app/scripts/views/mixins/checkbox-mixin.js
@@ -6,14 +6,14 @@
  * Log when checkbox values are changed, if the checkbox has an id.
  */
 
-define([
-  'fxaCheckbox',
-  'jquery',
-  'lib/strings'
-], function (FxaCheckbox, $, Strings) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var $ = require('jquery');
+  var FxaCheckbox = require('fxaCheckbox');
+  var Strings = require('lib/strings');
+
+  module.exports = {
     events: {
       'change input[type=checkbox]': 'logCheckboxChange'
     },

--- a/app/scripts/views/mixins/experiment-mixin.js
+++ b/app/scripts/views/mixins/experiment-mixin.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/experiment'
-], function (ExperimentInterface) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var ExperimentInterface = require('lib/experiment');
+
+  module.exports = {
     initialize: function (options) {
       options = options || {};
 

--- a/app/scripts/views/mixins/floating-placeholder-mixin.js
+++ b/app/scripts/views/mixins/floating-placeholder-mixin.js
@@ -8,12 +8,12 @@
  * hooked up in `afterRender`
  */
 
-define([
-  'jquery'
-], function ($) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var $ = require('jquery');
+
+  module.exports = {
     events: {
       'input input[placeholder]': 'floatingPlaceholderMixinOnInput'
     },

--- a/app/scripts/views/mixins/loading-mixin.js
+++ b/app/scripts/views/mixins/loading-mixin.js
@@ -7,13 +7,13 @@
  * the View's normal template is rendered.
  */
 
-define([
-  'jquery',
-  'stache!templates/loading'
-], function ($, loadingTemplate) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var $ = require('jquery');
+  var loadingTemplate = require('stache!templates/loading');
+
+  module.exports = {
     initialize: function () {
       var self = this;
       var loadingHTML = loadingTemplate({});

--- a/app/scripts/views/mixins/marketing-mixin.js
+++ b/app/scripts/views/mixins/marketing-mixin.js
@@ -7,10 +7,10 @@
  * and clicks.
  */
 
-define([
-  'jquery'
-], function ($) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
 
   var MarketingMixin = {
     events: {
@@ -48,6 +48,6 @@ define([
     }
   };
 
-  return MarketingMixin;
+  module.exports = MarketingMixin;
 });
 

--- a/app/scripts/views/mixins/migration-mixin.js
+++ b/app/scripts/views/mixins/migration-mixin.js
@@ -5,10 +5,11 @@
 // Helper functions for views with migration-specific behaviour.
 // Meant to be mixed into views.
 
-define([], function () {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+
+  module.exports = {
     isMigration: function () {
       return this.relier.has('migration');
     }

--- a/app/scripts/views/mixins/modal-settings-panel-mixin.js
+++ b/app/scripts/views/mixins/modal-settings-panel-mixin.js
@@ -6,13 +6,13 @@
 // This is a mixin used by Modal views that are childViews of Settings
 // Non-modal childViews of Settings use settings-panel-mixin instead.
 
-define([
-  'jquery',
-  'views/base'
-], function ($, BaseView) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var $ = require('jquery');
+  var BaseView = require('views/base');
+
+  module.exports = {
     isModal: true,
 
     initialize: function (options) {

--- a/app/scripts/views/mixins/notifier-mixin.js
+++ b/app/scripts/views/mixins/notifier-mixin.js
@@ -29,10 +29,10 @@
  * when the module is destroyed.
  */
 
-define([
-  'underscore'
-], function (_) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
 
   function NotifierProxy(options) {
     options = options || {};
@@ -163,6 +163,6 @@ define([
     }
   };
 
-  return NotifierMixin;
+  module.exports = NotifierMixin;
 });
 

--- a/app/scripts/views/mixins/password-mixin.js
+++ b/app/scripts/views/mixins/password-mixin.js
@@ -4,11 +4,11 @@
 
 // helper functions for views with passwords. Meant to be mixed into views.
 
-define([
-], function () {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+
+  module.exports = {
     events: {
       'change .show-password': 'onPasswordVisibilityChange'
     },

--- a/app/scripts/views/mixins/password-strength-mixin.js
+++ b/app/scripts/views/mixins/password-strength-mixin.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/promise',
-  'lib/require-on-demand',
-  'lib/url',
-  'underscore'
-], function (p, requireOnDemand, Url, _) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var p = require('lib/promise');
+  var requireOnDemand = require('lib/require-on-demand');
+  var Url = require('lib/url');
 
   var PasswordStrengthMixin = {
     initialize: function (options) {
@@ -96,5 +96,5 @@ define([
       this.logViewEvent(eventName);
     }
   };
-  return PasswordStrengthMixin;
+  module.exports = PasswordStrengthMixin;
 });

--- a/app/scripts/views/mixins/resend-mixin.js
+++ b/app/scripts/views/mixins/resend-mixin.js
@@ -5,14 +5,14 @@
 // helper functions for views with passwords. Meant to be mixed into views.
 // Note, this mixin overrides beforeSubmit and is incompatible with Cocktail.
 
-define([
-  'models/email-resend'
-], function (EmailResend) {
+define(function (require, exports, module) {
   'use strict';
+
+  var EmailResend = require('models/email-resend');
 
   var SHOW_RESEND_IN_MS = 5 * 60 * 1000; // 5 minutes.
 
-  return {
+  module.exports = {
 
     initialize: function () {
       this._emailResend = new EmailResend();

--- a/app/scripts/views/mixins/resume-token-mixin.js
+++ b/app/scripts/views/mixins/resume-token-mixin.js
@@ -4,13 +4,13 @@
 
 // View mixin to get a ResumeToken model in a consistent fashion.
 
-define([
-  'models/resume-token',
-  'underscore'
-], function (ResumeToken, _) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var _ = require('underscore');
+  var ResumeToken = require('models/resume-token');
+
+  module.exports = {
     /**
      * Get a ResumeToken model.
      *

--- a/app/scripts/views/mixins/service-mixin.js
+++ b/app/scripts/views/mixins/service-mixin.js
@@ -5,12 +5,12 @@
 // The service-mixin is used in views that know about services, which is mostly
 // OAuth services but also Sync.
 
-define([
-  'views/base'
-], function (BaseView) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var BaseView = require('views/base');
+
+  module.exports = {
     transformLinks: function () {
       this.$('a[href~="/signin"]').attr('href',
           this.broker.transformLink('/signin'));

--- a/app/scripts/views/mixins/settings-mixin.js
+++ b/app/scripts/views/mixins/settings-mixin.js
@@ -5,12 +5,12 @@
 // View mixin the checks whether the uid specified by the relier is
 // is cached and valid.
 
-define([
-  'lib/session'
-], function (Session) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var Session = require('lib/session');
+
+  module.exports = {
     // user must be authenticated and verified to see Settings pages
     mustVerify: true,
 

--- a/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/app/scripts/views/mixins/settings-panel-mixin.js
@@ -5,13 +5,13 @@
 // This is a mixin used by views that are childViews of Settings
 // Modal childViews of Settings use modal-settings-panel-mixin instead.
 
-define([
-  'jquery',
-  'views/base'
-], function ($, BaseView) {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+  var $ = require('jquery');
+  var BaseView = require('views/base');
+
+  module.exports = {
     initialize: function (options) {
       this.parentView = options.parentView;
     },

--- a/app/scripts/views/mixins/signed-in-notification-mixin.js
+++ b/app/scripts/views/mixins/signed-in-notification-mixin.js
@@ -4,12 +4,11 @@
 
 // Handle signed-in notifications.
 
-define([
-  'lib/promise',
-  'lib/channels/notifier'
-],
-function (p, Notifier) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
 
   var Mixin = {
     notifications: {
@@ -32,5 +31,5 @@ function (p, Notifier) {
   Mixin.notifications[Notifier.SIGNED_IN] =
               '_navigateToSignedInView';
 
-  return Mixin;
+  module.exports = Mixin;
 });

--- a/app/scripts/views/mixins/signed-out-notification-mixin.js
+++ b/app/scripts/views/mixins/signed-out-notification-mixin.js
@@ -4,13 +4,12 @@
 
 // Handle signed-out notifications.
 
-define([
-  'lib/session',
-  'lib/channels/notifier',
-  'views/base'
-],
-function (Session, Notifier, BaseView) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Notifier = require('lib/channels/notifier');
+  var Session = require('lib/session');
 
   var Mixin = {
     notifications: {
@@ -40,5 +39,5 @@ function (Session, Notifier, BaseView) {
   Mixin.notifications[Notifier.SIGNED_OUT] =
               'clearSessionAndNavigateToSignIn';
 
-  return Mixin;
+  module.exports = Mixin;
 });

--- a/app/scripts/views/mixins/signup-disabled-mixin.js
+++ b/app/scripts/views/mixins/signup-disabled-mixin.js
@@ -4,10 +4,11 @@
 
 // View mixin with signup enabled/disabled behaviors.
 
-define([], function () {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+
+  module.exports = {
     isSignupDisabled: function () {
       return ! this.broker.hasCapability('signup');
     },

--- a/app/scripts/views/mixins/signup-success-mixin.js
+++ b/app/scripts/views/mixins/signup-success-mixin.js
@@ -4,10 +4,11 @@
 
 // `onSignUpSuccess` is shared amongst several views. This is the shared source.
 
-define([], function () {
+define(function (require, exports, module) {
   'use strict';
 
-  return {
+
+  module.exports = {
     onSignUpSuccess: function (account) {
       var self = this;
       if (account.get('verified')) {

--- a/app/scripts/views/mixins/timer-mixin.js
+++ b/app/scripts/views/mixins/timer-mixin.js
@@ -10,11 +10,10 @@
  * the view.
  */
 
-define([
-  'underscore'
-],
-function (_) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
 
   var Mixin = {
     setTimeout: function (callback, timeoutMS) {
@@ -55,6 +54,6 @@ function (_) {
     this._timeouts = null;
   }
 
-  return Mixin;
+  module.exports = Mixin;
 });
 

--- a/app/scripts/views/openid/login.js
+++ b/app/scripts/views/openid/login.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/base',
-  'stache!templates/openid/login',
-  'lib/session'
-],
-function (BaseView, Template, Session) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Session = require('lib/session');
+  var Template = require('stache!templates/openid/login');
 
   var View = BaseView.extend({
     template: Template,
@@ -54,5 +53,5 @@ function (BaseView, Template, Session) {
     }
   });
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/openid/start.js
+++ b/app/scripts/views/openid/start.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/base',
-  'views/form',
-  'stache!templates/openid/start'
-],
-function (BaseView, FormView, Template) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var FormView = require('views/form');
+  var Template = require('stache!templates/openid/start');
 
   var View = FormView.extend({
     template: Template,
@@ -32,6 +31,6 @@ function (BaseView, FormView, Template) {
 
   });
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/scripts/views/permissions.js
+++ b/app/scripts/views/permissions.js
@@ -2,18 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'stache!templates/permissions',
-  'lib/promise',
-  'views/mixins/back-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/signup-success-mixin'
-],
-function (Cocktail, FormView, Template, p, BackMixin, ServiceMixin,
-  SignupSuccessMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BackMixin = require('views/mixins/back-mixin');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var p = require('lib/promise');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var SignupSuccessMixin = require('views/mixins/signup-success-mixin');
+  var Template = require('stache!templates/permissions');
 
   var View = FormView.extend({
     template: Template,
@@ -102,5 +100,5 @@ function (Cocktail, FormView, Template, p, BackMixin, ServiceMixin,
     SignupSuccessMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/pp.js
+++ b/app/scripts/views/pp.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/legal_copy',
-  'stache!templates/pp',
-  'lib/auth-errors'
-],
-function (LegalCopyView, Template, AuthErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var LegalCopyView = require('views/legal_copy');
+  var Template = require('stache!templates/pp');
 
   var View = LegalCopyView.extend({
     className: 'pp',
@@ -21,6 +20,6 @@ function (LegalCopyView, Template, AuthErrors) {
     template: Template
   });
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/scripts/views/progress_indicator.js
+++ b/app/scripts/views/progress_indicator.js
@@ -16,13 +16,13 @@
 // is never shown. If `done` then `start` are called within HIDE_DELAY_MS, then
 // the progress indicator is not hidden.
 
-define([
-  'underscore',
-  'jquery',
-  'backbone',
-  'views/mixins/timer-mixin'
-], function (_, $, Backbone, TimerMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var TimerMixin = require('views/mixins/timer-mixin');
 
   // The show and hide delays are to minimize flash.
   var SHOW_DELAY_MS = 100;
@@ -147,6 +147,6 @@ define([
 
   _.extend(View.prototype, TimerMixin);
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -7,19 +7,17 @@
  * "All ready! You can go visit {{ service }}"
  */
 
-define([
-  'cocktail',
-  'lib/constants',
-  'lib/url',
-  'stache!templates/ready',
-  'views/form',
-  'views/marketing_snippet',
-  'views/marketing_snippet_ios',
-  'views/mixins/service-mixin'
-],
-function (Cocktail, Constants, Url, Template, FormView, MarketingSnippet,
-  MarketingSnippetiOS, ServiceMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var MarketingSnippet = require('views/marketing_snippet');
+  var MarketingSnippetiOS = require('views/marketing_snippet_ios');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/ready');
+  var Url = require('lib/url');
 
   function t(msg) {
     return msg;
@@ -197,5 +195,5 @@ function (Cocktail, Constants, Url, Template, FormView, MarketingSnippet,
     ServiceMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'views/form',
-  'stache!templates/reset_password',
-  'lib/session',
-  'lib/auth-errors',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/back-mixin'
-],
-function (Cocktail, BaseView, FormView, Template, Session,
-  AuthErrors, ResumeTokenMixin, ServiceMixin, BackMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Session = require('lib/session');
+  var Template = require('stache!templates/reset_password');
 
   var t = BaseView.t;
 
@@ -99,5 +97,5 @@ function (Cocktail, BaseView, FormView, Template, Session,
     ServiceMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -2,36 +2,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* exceptsPaths: modal */
-define([
-  'cocktail',
-  'jquery',
-  'modal',
-  'stache!templates/settings',
-  'views/base',
-  'views/decorators/allow_only_one_submit',
-  'views/mixins/avatar-mixin',
-  'views/mixins/loading-mixin',
-  'views/mixins/settings-mixin',
-  'views/mixins/signed-out-notification-mixin',
-  'views/settings/avatar',
-  'views/settings/avatar_change',
-  'views/settings/avatar_crop',
-  'views/settings/avatar_camera',
-  'views/settings/avatar_gravatar',
-  'views/settings/gravatar_permissions',
-  'views/settings/communication_preferences',
-  'views/settings/change_password',
-  'views/settings/delete_account',
-  'views/settings/display_name',
-  'views/sub_panels'
-],
-function (Cocktail, $, modal, Template, BaseView, allowOnlyOneSubmit, AvatarMixin,
-  LoadingMixin, SettingsMixin, SignedOutNotificationMixin, AvatarView, AvatarChangeView,
-  AvatarCropView, AvatarCameraView, GravatarView, GravatarPermissionsView,
-  CommunicationPreferencesView, ChangePasswordView, DeleteAccountView,
-  DisplayNameView, SubPanels) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
+  var AvatarCameraView = require('views/settings/avatar_camera');
+  var AvatarChangeView = require('views/settings/avatar_change');
+  var AvatarCropView = require('views/settings/avatar_crop');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var AvatarView = require('views/settings/avatar');
+  var BaseView = require('views/base');
+  var ChangePasswordView = require('views/settings/change_password');
+  var Cocktail = require('cocktail');
+  var CommunicationPreferencesView = require('views/settings/communication_preferences');
+  var DeleteAccountView = require('views/settings/delete_account');
+  var DisplayNameView = require('views/settings/display_name');
+  var GravatarPermissionsView = require('views/settings/gravatar_permissions');
+  var GravatarView = require('views/settings/avatar_gravatar');
+  var LoadingMixin = require('views/mixins/loading-mixin');
+  var modal = require('modal'); //eslint-disable-line no-unused-vars
+  var SettingsMixin = require('views/mixins/settings-mixin');
+  var SignedOutNotificationMixin = require('views/mixins/signed-out-notification-mixin');
+  var SubPanels = require('views/sub_panels');
+  var Template = require('stache!templates/settings');
 
   var PANEL_VIEWS = [
     AvatarView,
@@ -239,5 +233,5 @@ function (Cocktail, $, modal, Template, BaseView, allowOnlyOneSubmit, AvatarMixi
     SignedOutNotificationMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/settings/avatar.js
+++ b/app/scripts/views/settings/avatar.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'stache!templates/settings/avatar',
-  'views/mixins/avatar-mixin',
-  'views/mixins/settings-panel-mixin'
-],
-function (Cocktail, FormView, Template, AvatarMixin, SettingsPanelMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var SettingsPanelMixin = require('views/mixins/settings-panel-mixin');
+  var Template = require('stache!templates/settings/avatar');
 
   var View = FormView.extend({
     template: Template,
@@ -32,5 +31,5 @@ function (Cocktail, FormView, Template, AvatarMixin, SettingsPanelMixin) {
 
   Cocktail.mixin(View, AvatarMixin, SettingsPanelMixin);
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -2,26 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* exceptsPaths: canvasToBlob */
-define([
-  'underscore',
-  'cocktail',
-  'canvasToBlob',
-  'views/form',
-  'views/progress_indicator',
-  'views/mixins/avatar-mixin',
-  'views/mixins/modal-settings-panel-mixin',
-  'stache!templates/settings/avatar_camera',
-  'lib/constants',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/environment',
-  'models/profile-image'
-],
-function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
-    AvatarMixin, ModalSettingsPanelMixin, Template, Constants, p,
-    AuthErrors, Environment, ProfileImage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var canvasToBlob = require('canvasToBlob'); //eslint-disable-line no-unused-vars
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var Environment = require('lib/environment');
+  var FormView = require('views/form');
+  var ModalSettingsPanelMixin = require('views/mixins/modal-settings-panel-mixin');
+  var p = require('lib/promise');
+  var ProfileImage = require('models/profile-image');
+  var ProgressIndicator = require('views/progress_indicator');
+  var Template = require('stache!templates/settings/avatar_camera');
 
   // a blank 1x1 png
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
@@ -239,5 +235,5 @@ function (_, Cocktail, canvasToBlob, FormView, ProgressIndicator,
     ModalSettingsPanelMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'cocktail',
-  'views/form',
-  'views/mixins/avatar-mixin',
-  'views/mixins/modal-settings-panel-mixin',
-  'stache!templates/settings/avatar_change',
-  'lib/auth-errors',
-  'lib/image-loader',
-  'lib/promise',
-  'models/cropper-image'
-],
-function ($, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
-  Template, AuthErrors, ImageLoader, p, CropperImage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var Cocktail = require('cocktail');
+  var CropperImage = require('models/cropper-image');
+  var FormView = require('views/form');
+  var ImageLoader = require('lib/image-loader');
+  var ModalSettingsPanelMixin = require('views/mixins/modal-settings-panel-mixin');
+  var p = require('lib/promise');
+  var Template = require('stache!templates/settings/avatar_change');
 
   var View = FormView.extend({
     template: Template,
@@ -151,5 +149,5 @@ function ($, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
     ModalSettingsPanelMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'p-promise',
-  'cocktail',
-  'views/form',
-  'views/mixins/avatar-mixin',
-  'views/mixins/modal-settings-panel-mixin',
-  'stache!templates/settings/avatar_crop',
-  'lib/constants',
-  'lib/cropper',
-  'lib/auth-errors',
-  'models/cropper-image',
-  'models/profile-image'
-],
-function (p, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
-    Template, Constants, Cropper, AuthErrors, CropperImage, ProfileImage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var Cropper = require('lib/cropper');
+  var CropperImage = require('models/cropper-image');
+  var FormView = require('views/form');
+  var ModalSettingsPanelMixin = require('views/mixins/modal-settings-panel-mixin');
+  var p = require('p-promise');
+  var ProfileImage = require('models/profile-image');
+  var Template = require('stache!templates/settings/avatar_crop');
 
   var HORIZONTAL_GUTTER = 90;
   var VERTICAL_GUTTER = 0;
@@ -143,5 +141,5 @@ function (p, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
     ModalSettingsPanelMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -2,24 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'underscore',
-  'md5',
-  'cocktail',
-  'views/form',
-  'views/mixins/avatar-mixin',
-  'views/mixins/modal-settings-panel-mixin',
-  'stache!templates/settings/avatar_gravatar',
-  'lib/auth-errors',
-  'lib/constants',
-  'lib/image-loader',
-  'views/decorators/progress_indicator',
-  'models/profile-image'
-],
-function ($, _, md5, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
-    Template, AuthErrors, Constants, ImageLoader, showProgressIndicator, ProfileImage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var ImageLoader = require('lib/image-loader');
+  var md5 = require('md5');
+  var ModalSettingsPanelMixin = require('views/mixins/modal-settings-panel-mixin');
+  var ProfileImage = require('models/profile-image');
+  var showProgressIndicator = require('views/decorators/progress_indicator');
+  var Template = require('stache!templates/settings/avatar_gravatar');
 
   function t (s) { return s; }
 
@@ -101,5 +99,5 @@ function ($, _, md5, Cocktail, FormView, AvatarMixin, ModalSettingsPanelMixin,
     ModalSettingsPanelMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -2,23 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'views/form',
-  'lib/auth-errors',
-  'stache!templates/settings/change_password',
-  'views/mixins/password-mixin',
-  'views/mixins/floating-placeholder-mixin',
-  'views/mixins/settings-panel-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/back-mixin',
-  'views/mixins/account-locked-mixin'
-],
-function (Cocktail, BaseView, FormView, AuthErrors, Template, PasswordMixin,
-  FloatingPlaceholderMixin, SettingsPanelMixin, ServiceMixin,
-  BackMixin, AccountLockedMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AccountLockedMixin = require('views/mixins/account-locked-mixin');
+  var AuthErrors = require('lib/auth-errors');
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  var FormView = require('views/form');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var SettingsPanelMixin = require('views/mixins/settings-panel-mixin');
+  var Template = require('stache!templates/settings/change_password');
 
   var t = BaseView.t;
 
@@ -78,5 +75,5 @@ function (Cocktail, BaseView, FormView, AuthErrors, Template, PasswordMixin,
     AccountLockedMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/settings/communication_preferences.js
+++ b/app/scripts/views/settings/communication_preferences.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/xss',
-  'lib/constants',
-  'lib/marketing-email-errors',
-  'lib/metrics',
-  'views/base',
-  'views/form',
-  'views/mixins/settings-panel-mixin',
-  'stache!templates/settings/communication_preferences'
-],
-function (Cocktail, Xss, Constants, MarketingEmailErrors, Metrics, BaseView, FormView,
-  SettingsPanelMixin, Template) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var MarketingEmailErrors = require('lib/marketing-email-errors');
+  var Metrics = require('lib/metrics');
+  var SettingsPanelMixin = require('views/mixins/settings-panel-mixin');
+  var Template = require('stache!templates/settings/communication_preferences');
+  var Xss = require('lib/xss');
 
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;
   var t = BaseView.t;
@@ -124,6 +122,6 @@ function (Cocktail, Xss, Constants, MarketingEmailErrors, Metrics, BaseView, For
     SettingsPanelMixin
   );
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/scripts/views/settings/delete_account.js
+++ b/app/scripts/views/settings/delete_account.js
@@ -2,24 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'views/form',
-  'stache!templates/settings/delete_account',
-  'lib/session',
-  'lib/auth-errors',
-  'lib/channels/notifier',
-  'views/mixins/password-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/settings-panel-mixin',
-  'views/mixins/account-locked-mixin',
-  'views/mixins/floating-placeholder-mixin'
-],
-function (Cocktail, BaseView, FormView, Template, Session, AuthErrors,
-      Notifier, PasswordMixin, SettingsPanelMixin, ServiceMixin,
-      AccountLockedMixin, FloatingPlaceholderMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AccountLockedMixin = require('views/mixins/account-locked-mixin');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  var FormView = require('views/form');
+  var Notifier = require('lib/channels/notifier');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ServiceMixin = require('views/mixins/settings-panel-mixin');
+  var Session = require('lib/session');
+  var SettingsPanelMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/settings/delete_account');
 
   var t = BaseView.t;
 
@@ -79,6 +76,6 @@ function (Cocktail, BaseView, FormView, Template, Session, AuthErrors,
     FloatingPlaceholderMixin
   );
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/scripts/views/settings/display_name.js
+++ b/app/scripts/views/settings/display_name.js
@@ -2,18 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/base',
-  'views/form',
-  'stache!templates/settings/display_name',
-  'views/mixins/settings-panel-mixin',
-  'views/mixins/avatar-mixin',
-  'views/mixins/floating-placeholder-mixin'
-],
-function (Cocktail, BaseView, FormView, Template,
-  SettingsPanelMixin, AvatarMixin, FloatingPlaceholderMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  var FormView = require('views/form');
+  var SettingsPanelMixin = require('views/mixins/settings-panel-mixin');
+  var Template = require('stache!templates/settings/display_name');
 
   var t = BaseView.t;
 
@@ -64,5 +62,5 @@ function (Cocktail, BaseView, FormView, Template,
     FloatingPlaceholderMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/settings/gravatar_permissions.js
+++ b/app/scripts/views/settings/gravatar_permissions.js
@@ -2,17 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'views/form',
-  'stache!templates/settings/gravatar_permissions',
-  'lib/promise',
-  'views/mixins/modal-settings-panel-mixin',
-  'views/mixins/service-mixin'
-],
-function (Cocktail, FormView, Template, p,
-  ModalSettingsPanelMixin, ServiceMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var ModalSettingsPanelMixin = require('views/mixins/modal-settings-panel-mixin');
+  var p = require('lib/promise');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Template = require('stache!templates/settings/gravatar_permissions');
 
   var View = FormView.extend({
     template: Template,
@@ -60,5 +58,5 @@ function (Cocktail, FormView, Template, p,
     ServiceMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -2,31 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/auth-errors',
-  'lib/promise',
-  'lib/session',
-  'stache!templates/sign_in',
-  'views/base',
-  'views/form',
-  'views/decorators/allow_only_one_submit',
-  'views/decorators/progress_indicator',
-  'views/mixins/account-locked-mixin',
-  'views/mixins/avatar-mixin',
-  'views/mixins/migration-mixin',
-  'views/mixins/password-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/signed-in-notification-mixin',
-  'views/mixins/signup-disabled-mixin'
-],
-function (Cocktail, AuthErrors, p, Session, SignInTemplate, BaseView, FormView,
-  allowOnlyOneSubmit, showProgressIndicator, AccountLockedMixin, AvatarMixin,
-  MigrationMixin, PasswordMixin, ResumeTokenMixin, ServiceMixin,
-  SignedInNotificationMixin, SignupDisabledMixin) {
-
+define(function (require, exports, module) {
   'use strict';
+
+  var AccountLockedMixin = require('views/mixins/account-locked-mixin');
+  var allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
+  var AuthErrors = require('lib/auth-errors');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var FormView = require('views/form');
+  var MigrationMixin = require('views/mixins/migration-mixin');
+  var p = require('lib/promise');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Session = require('lib/session');
+  var showProgressIndicator = require('views/decorators/progress_indicator');
+  var SignedInNotificationMixin = require('views/mixins/signed-in-notification-mixin');
+  var SignInTemplate = require('stache!templates/sign_in');
+  var SignupDisabledMixin = require('views/mixins/signup-disabled-mixin');
 
   var t = BaseView.t;
 
@@ -311,5 +306,5 @@ function (Cocktail, AuthErrors, p, Session, SignInTemplate, BaseView, FormView,
     SignupDisabledMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -1,31 +1,27 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'lib/auth-errors',
-  'lib/promise',
-  'lib/mailcheck',
-  'stache!templates/sign_up',
-  'views/base',
-  'views/form',
-  'views/coppa/coppa-age-input',
-  'views/mixins/checkbox-mixin',
-  'views/mixins/experiment-mixin',
-  'views/mixins/migration-mixin',
-  'views/mixins/password-mixin',
-  'views/mixins/password-strength-mixin',
-  'views/mixins/resume-token-mixin',
-  'views/mixins/service-mixin',
-  'views/mixins/signed-in-notification-mixin',
-  'views/mixins/signup-disabled-mixin',
-  'views/mixins/signup-success-mixin'
-],
-function (Cocktail, AuthErrors, p, mailcheck, Template, BaseView, FormView,
-  CoppaAgeInput, CheckboxMixin, ExperimentMixin, MigrationMixin, PasswordMixin,
-  PasswordStrengthMixin, ResumeTokenMixin, ServiceMixin, SignedInNotificationMixin,
-  SignupDisabledMixin, SignupSuccessMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var CheckboxMixin = require('views/mixins/checkbox-mixin');
+  var Cocktail = require('cocktail');
+  var CoppaAgeInput = require('views/coppa/coppa-age-input');
+  var ExperimentMixin = require('views/mixins/experiment-mixin');
+  var FormView = require('views/form');
+  var mailcheck = require('lib/mailcheck');
+  var MigrationMixin = require('views/mixins/migration-mixin');
+  var p = require('lib/promise');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var PasswordStrengthMixin = require('views/mixins/password-strength-mixin');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var SignedInNotificationMixin = require('views/mixins/signed-in-notification-mixin');
+  var SignupDisabledMixin = require('views/mixins/signup-disabled-mixin');
+  var SignupSuccessMixin = require('views/mixins/signup-success-mixin');
+  var Template = require('stache!templates/sign_up');
 
   var t = BaseView.t;
 
@@ -366,5 +362,5 @@ function (Cocktail, AuthErrors, p, mailcheck, Template, BaseView, FormView,
     SignupSuccessMixin
   );
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/sub_panels.js
+++ b/app/scripts/views/sub_panels.js
@@ -3,13 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // This component renders multiple childViews
-define([
-  'lib/promise',
-  'views/base',
-  'stache!templates/sub_panels'
-],
-function (p, BaseView, Template) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var p = require('lib/promise');
+  var Template = require('stache!templates/sub_panels');
 
   var View = BaseView.extend({
     template: Template,
@@ -112,5 +111,5 @@ function (p, BaseView, Template) {
     }
   });
 
-  return View;
+  module.exports = View;
 });

--- a/app/scripts/views/tooltip.js
+++ b/app/scripts/views/tooltip.js
@@ -4,13 +4,13 @@
 
 // It's a tooltip!
 
-define([
-  'underscore',
-  'jquery',
-  'views/base',
-  'lib/key-codes'
-], function (_, $, BaseView, KeyCodes) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var BaseView = require('views/base');
+  var KeyCodes = require('lib/key-codes');
 
   var displayedTooltip;
   var PADDING_BELOW_TOOLTIP_PX = 2;
@@ -125,5 +125,5 @@ define([
     }
   });
 
-  return Tooltip;
+  module.exports = Tooltip;
 });

--- a/app/scripts/views/tos.js
+++ b/app/scripts/views/tos.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/legal_copy',
-  'stache!templates/tos',
-  'lib/auth-errors'
-],
-function (LegalCopyView, Template, AuthErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var LegalCopyView = require('views/legal_copy');
+  var Template = require('stache!templates/tos');
 
   var View = LegalCopyView.extend({
     className: 'tos',
@@ -21,6 +20,6 @@ function (LegalCopyView, Template, AuthErrors) {
     template: Template
   });
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/scripts/views/unexpected_error.js
+++ b/app/scripts/views/unexpected_error.js
@@ -7,18 +7,17 @@
  * to clear browser storage state between tests.
  */
 
-define([
-  'views/base',
-  'stache!templates/unexpected_error'
-],
-function (BaseView, Template) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Template = require('stache!templates/unexpected_error');
 
   var View = BaseView.extend({
     className: 'unexpected-error',
     template: Template
   });
 
-  return View;
+  module.exports = View;
 });
 

--- a/app/tests/lib/helpers.js
+++ b/app/tests/lib/helpers.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'sinon',
-  'lib/promise',
-  '../mocks/profile.js'
-], function (sinon, p, ProfileMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var p = require('lib/promise');
+  var ProfileMock = require('../mocks/profile.js');
+  var sinon = require('sinon');
 
   function requiresFocus(callback, done) {
     // Give the document focus
@@ -136,7 +136,7 @@ define([
     return profileClientMock;
   }
 
-  return {
+  module.exports = {
     addFxaClientSpy: addFxaClientSpy,
     createEmail: createEmail,
     createRandomHexString: createRandomHexString,

--- a/app/tests/mocks/broadcast-channel.js
+++ b/app/tests/mocks/broadcast-channel.js
@@ -5,11 +5,10 @@
 // stub out the BroadcastChannel object for testing.
 // See https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API
 
-define([
-  'sinon'
-],
-function (sinon) {
+define(function (require, exports, module) {
   'use strict';
+
+  var sinon = require('sinon');
 
   function BroadcastChannelMock (name) {
     this._name = name;
@@ -19,6 +18,6 @@ function (sinon) {
     postMessage: sinon.spy()
   };
 
-  return BroadcastChannelMock;
+  module.exports = BroadcastChannelMock;
 });
 

--- a/app/tests/mocks/canvas.js
+++ b/app/tests/mocks/canvas.js
@@ -4,9 +4,9 @@
 
 // stub out the router object for testing.
 
-define([
-], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   function CanvasMock() {
     // nothing to do here.
@@ -36,5 +36,5 @@ define([
     }
   };
 
-  return CanvasMock;
+  module.exports = CanvasMock;
 });

--- a/app/tests/mocks/crosstab.js
+++ b/app/tests/mocks/crosstab.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'crosstab'
-], function (crosstab) {
+define(function (require, exports, module) {
   'use strict';
+
+  var crosstab = require('crosstab');
 
   function deepStub(target, source) {
     for (var key in source) {
@@ -23,7 +23,7 @@ define([
   }
 
 
-  return function () {
+  module.exports = function () {
     // create a complete new copy of the tree
     // every time a mock is created so that we
     // can stub functions out and forget about

--- a/app/tests/mocks/dom-event.js
+++ b/app/tests/mocks/dom-event.js
@@ -4,9 +4,9 @@
 
 // mock out a DOM event
 
-define([
-], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   function DOMEventMock() {
     // nothing to do
@@ -30,6 +30,6 @@ define([
     }
   };
 
-  return DOMEventMock;
+  module.exports = DOMEventMock;
 });
 

--- a/app/tests/mocks/file-reader.js
+++ b/app/tests/mocks/file-reader.js
@@ -4,9 +4,9 @@
 
 // mock out a FileReader
 
-define([
-], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAACZJREFUeNrtwQEBAAAAgiD' +
                '/r25IQAEAAAAAAAAAAAAAAAAAAADvBkCAAAEehacTAAAAAElFTkSuQmCC';
@@ -55,6 +55,6 @@ define([
     }
   };
 
-  return FileReaderMock;
+  module.exports = FileReaderMock;
 });
 

--- a/app/tests/mocks/fxa-client.js
+++ b/app/tests/mocks/fxa-client.js
@@ -4,11 +4,11 @@
 
 // stub out the fxa-client object for testing.
 
-define([
-  'lib/promise',
-  'lib/fxa-client'
-], function (p, FxaClientWrapper) {
+define(function (require, exports, module) {
   'use strict';
+
+  var FxaClientWrapper = require('lib/fxa-client');
+  var p = require('lib/promise');
 
   function FxaClientWrapperMock() {
   }
@@ -19,5 +19,5 @@ define([
     };
   });
 
-  return FxaClientWrapperMock;
+  module.exports = FxaClientWrapperMock;
 });

--- a/app/tests/mocks/history.js
+++ b/app/tests/mocks/history.js
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // A mock for Backbone.history
-define([
-], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   function History() {}
 
@@ -14,5 +14,5 @@ define([
     }
   };
 
-  return History;
+  module.exports = History;
 });

--- a/app/tests/mocks/oauth_servers.js
+++ b/app/tests/mocks/oauth_servers.js
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'sinon'
-], function (sinon) {
+define(function (require, exports, module) {
   'use strict';
+
+  var sinon = require('sinon');
 
   /**
    * Create a fake set of OAuth servers through instantiation.
@@ -48,7 +48,7 @@ define([
     }
   };
 
-  return MockOAuthServers;
+  module.exports = MockOAuthServers;
 
 });
 

--- a/app/tests/mocks/profile.js
+++ b/app/tests/mocks/profile.js
@@ -4,9 +4,9 @@
 
 // stub out the router object for testing.
 
-define([
-], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   function Profile() {
   }
@@ -24,5 +24,5 @@ define([
     Profile.prototype[method] = function () { };
   });
 
-  return Profile;
+  module.exports = Profile;
 });

--- a/app/tests/mocks/router.js
+++ b/app/tests/mocks/router.js
@@ -4,11 +4,11 @@
 
 // stub out the router object for testing.
 
-define([
-  'underscore',
-  'backbone'
-], function (_, Backbone) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
 
   function RouterMock() {
     // nothing to do here.
@@ -30,5 +30,5 @@ define([
     }
   });
 
-  return RouterMock;
+  module.exports = RouterMock;
 });

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -4,14 +4,13 @@
 
 // stub out the window object for testing.
 
-define([
-  'backbone',
-  'sinon',
-  'underscore',
-  'lib/null-storage'
-],
-function (Backbone, sinon, _, NullStorage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var NullStorage = require('lib/null-storage');
+  var sinon = require('sinon');
 
   function MutationObserver (notifier) {
     return {
@@ -165,5 +164,5 @@ function (Backbone, sinon, _, NullStorage) {
     }
   });
 
-  return WindowMock;
+  module.exports = WindowMock;
 });

--- a/app/tests/setup.js
+++ b/app/tests/setup.js
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([], function () {
+define(function (require, exports, module) {
   'use strict';
+
 
   mocha.setup('bdd');
   mocha.timeout(20000);

--- a/app/tests/spec/head/startup-styles.js
+++ b/app/tests/spec/head/startup-styles.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'head/startup-styles',
-  'lib/environment',
-  '../../mocks/window'
-], function (chai, sinon, StartupStyles, Environment, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Environment = require('lib/environment');
+  var sinon = require('sinon');
+  var StartupStyles = require('head/startup-styles');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/able.js
+++ b/app/tests/spec/lib/able.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/able'
-],
-function (chai, sinon, Able) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var chai = require('chai');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -2,52 +2,45 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'raven',
-  'lib/app-start',
-  'lib/session',
-  'lib/channels/null',
-  'lib/constants',
-  'lib/promise',
-  'lib/url',
-  'lib/oauth-errors',
-  'lib/auth-errors',
-  'lib/storage',
-  'models/auth_brokers/base',
-  'models/auth_brokers/first-run',
-  'models/auth_brokers/fx-desktop-v1',
-  'models/auth_brokers/fx-desktop-v2',
-  'models/auth_brokers/fx-fennec-v1',
-  'models/auth_brokers/fx-ios-v1',
-  'models/auth_brokers/fx-ios-v2',
-  'models/auth_brokers/iframe',
-  'models/auth_brokers/redirect',
-  'models/auth_brokers/web-channel',
-  'lib/channels/notifier',
-  'models/refresh-observer',
-  'models/reliers/base',
-  'models/reliers/sync',
-  'models/reliers/oauth',
-  'models/reliers/relier',
-  'models/verification/same-browser',
-  'models/user',
-  'lib/metrics',
-  'lib/storage-metrics',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../mocks/history',
-  '../../lib/helpers'
-],
-function (chai, sinon, Raven, AppStart, Session, NullChannel, Constants, p,
-  Url, OAuthErrors, AuthErrors, Storage, BaseBroker, FirstrunBroker,
-  FxDesktopV1Broker, FxDesktopV2Broker, FxFennecV1Broker, FxiOSV1Broker,
-  FxiOSV2Broker, IframeBroker, RedirectBroker, WebChannelBroker, Notifier,
-  RefreshObserver, BaseRelier, SyncRelier, OAuthRelier, Relier,
-  SameBrowserVerificationModel, User, Metrics, StorageMetrics, WindowMock,
-  RouterMock, HistoryMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AppStart = require('lib/app-start');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseBroker = require('models/auth_brokers/base');
+  var BaseRelier = require('models/reliers/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FirstrunBroker = require('models/auth_brokers/first-run');
+  var FxDesktopV1Broker = require('models/auth_brokers/fx-desktop-v1');
+  var FxDesktopV2Broker = require('models/auth_brokers/fx-desktop-v2');
+  var FxFennecV1Broker = require('models/auth_brokers/fx-fennec-v1');
+  var FxiOSV1Broker = require('models/auth_brokers/fx-ios-v1');
+  var FxiOSV2Broker = require('models/auth_brokers/fx-ios-v2');
+  var HistoryMock = require('../../mocks/history');
+  var IframeBroker = require('models/auth_brokers/iframe');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var NullChannel = require('lib/channels/null');
+  var OAuthErrors = require('lib/oauth-errors');
+  var OAuthRelier = require('models/reliers/oauth');
+  var p = require('lib/promise');
+  var Raven = require('raven');
+  var RedirectBroker = require('models/auth_brokers/redirect');
+  var RefreshObserver = require('models/refresh-observer');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var SameBrowserVerificationModel = require('models/verification/same-browser');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var StorageMetrics = require('lib/storage-metrics');
+  var SyncRelier = require('models/reliers/sync');
+  var TestHelpers = require('../../lib/helpers');
+  var Url = require('lib/url');
+  var User = require('models/user');
+  var WebChannelBroker = require('models/auth_brokers/web-channel');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
   var FIRSTRUN_ORIGIN = 'https://firstrun.firefox.com';

--- a/app/tests/spec/lib/assertion.js
+++ b/app/tests/spec/lib/assertion.js
@@ -2,25 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* exceptsPaths: vendor/jwcrypto/lib/algs/rs */
-define([
-  'chai',
-  'jquery',
-  '../../lib/helpers',
-  'lib/promise',
-  'lib/config-loader',
-  'lib/assertion',
-  'lib/fxa-client',
-  'models/reliers/relier',
-  'vendor/jwcrypto',
-  'vendor/jwcrypto/lib/algs/rs'
-],
-// FxaClientWrapper is the object that is used in
-// fxa-content-server views. It wraps FxaClient to
-// take care of some app-specific housekeeping.
-function (chai, $, TestHelpers, p, ConfigLoader, Assertion, FxaClientWrapper,
-      Relier, jwcrypto) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Assertion = require('lib/assertion');
+  var chai = require('chai');
+  var ConfigLoader = require('lib/config-loader');
+  var FxaClientWrapper = require('lib/fxa-client');
+  var jwcrypto = require('vendor/jwcrypto');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var rs = require('vendor/jwcrypto/lib/algs/rs'); //eslint-disable-line no-unused-vars
+  var TestHelpers = require('../../lib/helpers');
 
   var assert = chai.assert;
   var AUDIENCE = 'http://123done.org';

--- a/app/tests/spec/lib/auth-errors.js
+++ b/app/tests/spec/lib/auth-errors.js
@@ -4,12 +4,11 @@
 
 // test the interpolated library
 
-define([
-  'chai',
-  'lib/auth-errors'
-],
-function (chai, AuthErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/base64url.js
+++ b/app/tests/spec/lib/base64url.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sjcl',
-  'lib/base64url'
-], function (chai, sjcl, base64url) {
+define(function (require, exports, module) {
   'use strict';
+
+  var base64url = require('lib/base64url');
+  var chai = require('chai');
+  var sjcl = require('sjcl');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/channels/duplex.js
+++ b/app/tests/spec/lib/channels/duplex.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/duplex',
-  'lib/channels/senders/null',
-  'lib/channels/receivers/null',
-  '../../../mocks/window'
-],
-function (chai, sinon, DuplexChannel, NullSender, NullReceiver, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var DuplexChannel = require('lib/channels/duplex');
+  var NullReceiver = require('lib/channels/receivers/null');
+  var NullSender = require('lib/channels/senders/null');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var channel;
   var windowMock;

--- a/app/tests/spec/lib/channels/fx-desktop-v1.js
+++ b/app/tests/spec/lib/channels/fx-desktop-v1.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/channels/fx-desktop-v1',
-  '../../../mocks/window'
-],
-function (chai, FxDesktopV1Channel, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FxDesktopV1Channel = require('lib/channels/fx-desktop-v1');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/channels/iframe.js
+++ b/app/tests/spec/lib/channels/iframe.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/auth-errors',
-  'lib/channels/iframe',
-  '../../../mocks/window'
-],
-function (chai, sinon, AuthErrors, IFrameChannel, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var IFrameChannel = require('lib/channels/iframe');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var channel;
   var windowMock;

--- a/app/tests/spec/lib/channels/inter-tab.js
+++ b/app/tests/spec/lib/channels/inter-tab.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  '../../../mocks/broadcast-channel',
-  '../../../mocks/crosstab',
-  '../../../mocks/window',
-  'lib/channels/inter-tab'
-], function (chai, sinon, BroadcastChannelMock, CrossTabMock, WindowMock,
-  InterTabChannel) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BroadcastChannelMock = require('../../../mocks/broadcast-channel');
+  var chai = require('chai');
+  var CrossTabMock = require('../../../mocks/crosstab');
+  var InterTabChannel = require('lib/channels/inter-tab');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/channels/notifier.js
+++ b/app/tests/spec/lib/channels/notifier.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'backbone',
-  'chai',
-  'lib/channels/null',
-  'lib/channels/notifier',
-  'sinon'
-],
-function (Backbone, chai, NullChannel, Notifier, sinon) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var chai = require('chai');
+  var Notifier = require('lib/channels/notifier');
+  var NullChannel = require('lib/channels/null');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/channels/null.js
+++ b/app/tests/spec/lib/channels/null.js
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'lib/channels/null'
-],
-function (NullChannel) {
+define(function (require, exports, module) {
   'use strict';
+
+  var NullChannel = require('lib/channels/null');
 
   var channel;
 

--- a/app/tests/spec/lib/channels/receivers/postmessage.js
+++ b/app/tests/spec/lib/channels/receivers/postmessage.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/auth-errors',
-  'lib/channels/receivers/postmessage',
-  '../../../../mocks/window'
-],
-function (chai, sinon, AuthErrors, PostMessageReceiver, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var PostMessageReceiver = require('lib/channels/receivers/postmessage');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../../mocks/window');
 
   var windowMock;
   var receiver;

--- a/app/tests/spec/lib/channels/receivers/web-channel.js
+++ b/app/tests/spec/lib/channels/receivers/web-channel.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/receivers/web-channel',
-  '../../../../mocks/window'
-],
-function (chai, sinon, WebChannelReceiver, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var sinon = require('sinon');
+  var WebChannelReceiver = require('lib/channels/receivers/web-channel');
+  var WindowMock = require('../../../../mocks/window');
 
   var windowMock;
   var receiver;

--- a/app/tests/spec/lib/channels/senders/fx-desktop-v1.js
+++ b/app/tests/spec/lib/channels/senders/fx-desktop-v1.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/senders/fx-desktop-v1',
-  '../../../../mocks/window'
-],
-function (chai, sinon, FxDesktopV1Sender, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FxDesktopV1Sender = require('lib/channels/senders/fx-desktop-v1');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../../mocks/window');
 
   var windowMock;
   var sender;

--- a/app/tests/spec/lib/channels/senders/web-channel.js
+++ b/app/tests/spec/lib/channels/senders/web-channel.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/senders/web-channel',
-  '../../../../mocks/window'
-],
-function (chai, sinon, WebChannelSender, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var sinon = require('sinon');
+  var WebChannelSender = require('lib/channels/senders/web-channel');
+  var WindowMock = require('../../../../mocks/window');
 
   var windowMock;
   var sender;

--- a/app/tests/spec/lib/channels/web.js
+++ b/app/tests/spec/lib/channels/web.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/web',
-  '/tests/mocks/window.js'
-],
-function (chai, sinon, WebChannel, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var sinon = require('sinon');
+  var WebChannel = require('lib/channels/web');
+  var WindowMock = require('/tests/mocks/window.js');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/config-loader.js
+++ b/app/tests/spec/lib/config-loader.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/config-loader',
-  'lib/promise',
-  'lib/xhr',
-  'sinon',
-],
-function (chai, ConfigLoader, p, Xhr, sinon) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ConfigLoader = require('lib/config-loader');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var Xhr = require('lib/xhr');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/cropper.js
+++ b/app/tests/spec/lib/cropper.js
@@ -2,25 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* exceptsPaths: jquery-simulate */
-define([
-  'chai',
-  'sinon',
-  'jquery-simulate',
-  '../../mocks/router',
-  '../../mocks/canvas',
-  'lib/promise',
-  'lib/cropper',
-  'lib/ephemeral-messages',
-  'views/settings/avatar_crop',
-  'models/cropper-image',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/user'
-],
-function (chai, sinon, jQuerySimulate, RouterMock, CanvasMock, p, Cropper,
-  EphemeralMessages, View, CropperImage, Notifier, Relier, User) {
+define(function (require, exports, module) {
   'use strict';
+
+  var CanvasMock = require('../../mocks/canvas');
+  var chai = require('chai');
+  var Cropper = require('lib/cropper');
+  var CropperImage = require('models/cropper-image');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var jQuerySimulate = require('jquery-simulate'); //eslint-disable-line no-unused-vars
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var View = require('views/settings/avatar_crop');
 
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';

--- a/app/tests/spec/lib/environment.js
+++ b/app/tests/spec/lib/environment.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/environment',
-  '../../mocks/window'
-], function (chai, sinon, Environment, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Environment = require('lib/environment');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/experiment.js
+++ b/app/tests/spec/lib/experiment.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  '../../mocks/window',
-  'lib/session',
-  'lib/able',
-  'lib/metrics',
-  'models/user',
-  'lib/channels/notifier',
-  'lib/experiment'
-],
-function (chai, sinon, WindowMock, Session, Able,
-          Metrics, User, Notifier, ExperimentInterface) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var chai = require('chai');
+  var ExperimentInterface = require('lib/experiment');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
   var expInt;

--- a/app/tests/spec/lib/experiments/base.js
+++ b/app/tests/spec/lib/experiments/base.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/able',
-  'lib/experiments/base',
-  'lib/metrics',
-  'lib/storage',
-  'lib/channels/notifier',
-  'models/user',
-  'sinon',
-  '../../../mocks/window'
-],
-function (chai, Able, Experiment, Metrics, Storage, Notifier,
-  User, sinon, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var chai = require('chai');
+  var Experiment = require('lib/experiments/base');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var able;
   var assert = chai.assert;

--- a/app/tests/spec/lib/experiments/mailcheck.js
+++ b/app/tests/spec/lib/experiments/mailcheck.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/able',
-  'lib/experiments/mailcheck',
-  'lib/metrics',
-  'lib/storage',
-  'lib/channels/notifier',
-  'models/user',
-  'sinon',
-  '../../../lib/helpers',
-  '../../../mocks/window'
-],
-function (chai, Able, Experiment, Metrics, Storage, Notifier, User,
-  sinon, TestHelpers, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var chai = require('chai');
+  var Experiment = require('lib/experiments/mailcheck');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var able;
   var assert = chai.assert;

--- a/app/tests/spec/lib/experiments/open-gmail.js
+++ b/app/tests/spec/lib/experiments/open-gmail.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/able',
-  'lib/experiments/open-gmail',
-  'lib/metrics',
-  'lib/storage',
-  'models/account',
-  'lib/channels/notifier',
-  'models/user',
-  'sinon',
-  '../../../lib/helpers',
-  '../../../mocks/window'
-],
-function (chai, Able, Experiment, Metrics, Storage, Account, Notifier,
-  User, sinon, TestHelpers, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var Account = require('models/account');
+  var chai = require('chai');
+  var Experiment = require('lib/experiments/open-gmail');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var able;
   var account;

--- a/app/tests/spec/lib/experiments/sync-checkbox.js
+++ b/app/tests/spec/lib/experiments/sync-checkbox.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/able',
-  'lib/experiments/sync-checkbox',
-  'lib/metrics',
-  'lib/storage',
-  'lib/channels/notifier',
-  'models/user',
-  'sinon',
-  '../../../lib/helpers',
-  '../../../mocks/window'
-],
-function (chai, Able, Experiment, Metrics, Storage, Notifier, User,
-  sinon, TestHelpers, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var chai = require('chai');
+  var Experiment = require('lib/experiments/sync-checkbox');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var able;
   var assert = chai.assert;

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -2,25 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'fxaClient',
-  'lib/promise',
-  '../../lib/helpers',
-  'lib/fxa-client',
-  'lib/auth-errors',
-  'lib/constants',
-  'models/resume-token',
-  'models/reliers/oauth'
-],
-// FxaClientWrapper is the object that is used in
-// fxa-content-server views. It wraps FxaClient to
-// take care of some app-specific housekeeping.
-function (chai, $, sinon, FxaClient, p, testHelpers, FxaClientWrapper, AuthErrors,
-      Constants, ResumeToken, OAuthRelier) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClient = require('fxaClient');
+  var FxaClientWrapper = require('lib/fxa-client');
+  var OAuthRelier = require('models/reliers/oauth');
+  var p = require('lib/promise');
+  var ResumeToken = require('models/resume-token');
+  var sinon = require('sinon');
+  var testHelpers = require('../../lib/helpers');
 
   var STATE = 'state';
   var SERVICE = 'sync';

--- a/app/tests/spec/lib/height-observer.js
+++ b/app/tests/spec/lib/height-observer.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  '../../mocks/window',
-  'lib/height-observer'
-],
-function (chai, sinon, WindowMock, HeightObserver) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var HeightObserver = require('lib/height-observer');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/image-loader.js
+++ b/app/tests/spec/lib/image-loader.js
@@ -4,12 +4,11 @@
 
 // test the metrics library
 
-define([
-  'chai',
-  'lib/image-loader'
-],
-function (chai, ImageLoader) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ImageLoader = require('lib/image-loader');
 
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';

--- a/app/tests/spec/lib/mailcheck.js
+++ b/app/tests/spec/lib/mailcheck.js
@@ -4,14 +4,13 @@
 
 // test the metrics library
 
-define([
-  'sinon',
-  'chai',
-  'jquery',
-  'lib/mailcheck'
-],
-function (sinon, chai, $, mailcheck) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var mailcheck = require('lib/mailcheck');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
   var MAILCHECK_ID = 'mailcheck-test';

--- a/app/tests/spec/lib/marketing-email-client.js
+++ b/app/tests/spec/lib/marketing-email-client.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/marketing-email-client',
-  'lib/marketing-email-errors',
-  'lib/promise',
-  'lib/xhr'
-],
-function (chai, sinon, MarketingEmailClient, MarketingEmailErrors, p, xhr) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var MarketingEmailClient = require('lib/marketing-email-client');
+  var MarketingEmailErrors = require('lib/marketing-email-errors');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var xhr = require('lib/xhr');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -4,20 +4,19 @@
 
 // test the metrics library
 
-define([
-  'chai',
-  'jquery',
-  'lib/promise',
-  'lib/metrics',
-  'lib/auth-errors',
-  'lib/environment',
-  'sinon',
-  'underscore',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, $, p, Metrics, AuthErrors, Environment, sinon, _, WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Environment = require('lib/environment');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/null-metrics.js
+++ b/app/tests/spec/lib/null-metrics.js
@@ -4,13 +4,12 @@
 
 // test the metrics library
 
-define([
-  'chai',
-  'lib/null-metrics',
-  'lib/metrics'
-],
-function (chai, NullMetrics, Metrics) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var NullMetrics = require('lib/null-metrics');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/null-storage.js
+++ b/app/tests/spec/lib/null-storage.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/null-storage'
-],
-function (chai, NullStorage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var NullStorage = require('lib/null-storage');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/oauth-client.js
+++ b/app/tests/spec/lib/oauth-client.js
@@ -2,19 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/oauth-client',
-  'lib/oauth-errors',
-  'lib/xhr',
-  'lib/promise'
-],
-// FxaClientWrapper is the object that is used in
-// fxa-content-server views. It wraps FxaClient to
-// take care of some app-specific housekeeping.
-function (chai, sinon, OAuthClient, OAuthErrors, Xhr, p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var Xhr = require('lib/xhr');
 
   var OAUTH_URL = 'http://127.0.0.1:9010';
   var RP_URL = 'http://127.0.0.1:8080/api/oauth';

--- a/app/tests/spec/lib/oauth-errors.js
+++ b/app/tests/spec/lib/oauth-errors.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/oauth-errors'
-],
-function (chai, OAuthErrors) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var OAuthErrors = require('lib/oauth-errors');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/origin-check.js
+++ b/app/tests/spec/lib/origin-check.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/origin-check',
-  '../../mocks/window'
-],
-function (chai, sinon, OriginCheck, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var OriginCheck = require('lib/origin-check');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/profile-client.js
+++ b/app/tests/spec/lib/profile-client.js
@@ -2,17 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/session',
-  'lib/profile-client'
-],
-// FxaClientWrapper is the object that is used in
-// fxa-content-server views. It wraps FxaClient to
-// take care of some app-specific housekeeping.
-function (chai, sinon, Session, ProfileClient) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ProfileClient = require('lib/profile-client');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
 
   var PROFILE_URL = 'http://127.0.0.1:1111';
   var assert = chai.assert;

--- a/app/tests/spec/lib/relier-keys.js
+++ b/app/tests/spec/lib/relier-keys.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/relier-keys'
-], function (chai, RelierKeys) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var RelierKeys = require('lib/relier-keys');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/require-on-demand.js
+++ b/app/tests/spec/lib/require-on-demand.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/promise',
-  'lib/require-on-demand',
-  'sinon'
-], function (chai, p, requireOnDemand, sinon) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var p = require('lib/promise');
+  var requireOnDemand = require('lib/require-on-demand');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -2,30 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'backbone',
-  'lib/router',
-  'views/base',
-  'views/settings/display_name',
-  'views/settings',
-  'lib/able',
-  'lib/constants',
-  'lib/environment',
-  'lib/metrics',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/user',
-  'models/form-prefill',
-  'models/auth_brokers/base',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, Backbone, Router, BaseView, DisplayNameView,
-  SettingsView, Able, Constants, Environment, Metrics, Notifier,
-  Relier, User, FormPrefill, NullBroker, WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var Backbone = require('backbone');
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var DisplayNameView = require('views/settings/display_name');
+  var Environment = require('lib/environment');
+  var FormPrefill = require('models/form-prefill');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var NullBroker = require('models/auth_brokers/base');
+  var Relier = require('models/reliers/relier');
+  var Router = require('lib/router');
+  var SettingsView = require('views/settings');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/screen-info.js
+++ b/app/tests/spec/lib/screen-info.js
@@ -4,13 +4,12 @@
 
 // test the screen-info module
 
-define([
-  'chai',
-  'lib/screen-info',
-  '../../mocks/window'
-],
-function (chai, ScreenInfo, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ScreenInfo = require('lib/screen-info');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/sentry.js
+++ b/app/tests/spec/lib/sentry.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/sentry',
-  'raven',
-  '../../mocks/window'
-], function (chai, sinon, SentryMetrics, Raven, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Raven = require('raven');
+  var SentryMetrics = require('lib/sentry');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
   var windowMock;

--- a/app/tests/spec/lib/service-name.js
+++ b/app/tests/spec/lib/service-name.js
@@ -4,13 +4,12 @@
 
 // test the service-name library
 
-define([
-  'chai',
-  'lib/translator',
-  'lib/service-name'
-],
-function (chai, Translator, ServiceName) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ServiceName = require('lib/service-name');
+  var Translator = require('lib/translator');
 
   var assert = chai.assert;
   var serviceName;

--- a/app/tests/spec/lib/session.js
+++ b/app/tests/spec/lib/session.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/session'
-],
-function (chai, Session) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Session = require('lib/session');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/storage-metrics.js
+++ b/app/tests/spec/lib/storage-metrics.js
@@ -4,15 +4,14 @@
 
 // test the metrics library
 
-define([
-  'chai',
-  'lib/storage-metrics',
-  'lib/metrics',
-  'lib/storage',
-  '../../mocks/window'
-],
-function (chai, StorageMetrics, Metrics, Storage, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var Storage = require('lib/storage');
+  var StorageMetrics = require('lib/storage-metrics');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/storage.js
+++ b/app/tests/spec/lib/storage.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/storage',
-  'lib/null-storage',
-  '../../mocks/window'
-],
-function (chai, sinon, Storage, NullStorage, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var NullStorage = require('lib/null-storage');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/strings.js
+++ b/app/tests/spec/lib/strings.js
@@ -4,12 +4,11 @@
 
 // test the interpolated library
 
-define([
-  'chai',
-  'lib/strings'
-],
-function (chai, Strings) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Strings = require('lib/strings');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/translator.js
+++ b/app/tests/spec/lib/translator.js
@@ -4,12 +4,11 @@
 
 // test the translation library
 
-define([
-  'chai',
-  'lib/translator'
-],
-function (chai, Translator) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Translator = require('lib/translator');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/url.js
+++ b/app/tests/spec/lib/url.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/url'
-],
-function (chai, Url) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Url = require('lib/url');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/validate.js
+++ b/app/tests/spec/lib/validate.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/validate',
-  'lib/constants',
-  '../../lib/helpers'
-],
-function (chai, Validate, Constants, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var TestHelpers = require('../../lib/helpers');
+  var Validate = require('lib/validate');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/xhr.js
+++ b/app/tests/spec/lib/xhr.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  'underscore',
-  'lib/xhr',
-  'lib/promise'
-],
-function (chai, sinon, $, _, Xhr, p) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var chai = require('chai');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var Xhr = require('lib/xhr');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/lib/xss.js
+++ b/app/tests/spec/lib/xss.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'underscore',
-  'lib/xss',
-  'lib/constants'
-],
-function (chai, _, XSS, Constants) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var XSS = require('lib/xss');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -2,26 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/constants',
-  'lib/assertion',
-  'lib/profile-client',
-  'lib/oauth-client',
-  'lib/fxa-client',
-  'lib/auth-errors',
-  'lib/profile-errors',
-  'lib/marketing-email-client',
-  'models/account',
-  'models/oauth-token',
-  'models/reliers/relier'
-],
-function (chai, sinon, p, Constants, Assertion, ProfileClient,
-    OAuthClient, FxaClientWrapper, AuthErrors, ProfileErrors,
-    MarketingEmailClient, Account, OAuthToken, Relier) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Account = require('models/account');
+  var Assertion = require('lib/assertion');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClientWrapper = require('lib/fxa-client');
+  var MarketingEmailClient = require('lib/marketing-email-client');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthToken = require('models/oauth-token');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var ProfileErrors = require('lib/profile-errors');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -2,18 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/account',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/verification/same-browser',
-  '../../../mocks/window',
-  'sinon'
-],
-function (chai, Account, Relier, BaseAuthenticationBroker,
-  SameBrowserVerificationModel, WindowMock, sinon) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Account = require('models/account');
+  var BaseAuthenticationBroker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var Relier = require('models/reliers/relier');
+  var SameBrowserVerificationModel = require('models/verification/same-browser');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/first-run.js
+++ b/app/tests/spec/models/auth_brokers/first-run.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/channels/null',
-  'models/account',
-  'models/auth_brokers/first-run',
-  'models/reliers/relier',
-  '../../../mocks/window'
-],
-function (chai, sinon, NullChannel, Account, FirstRunAuthenticationBroker, Relier, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Account = require('models/account');
+  var chai = require('chai');
+  var FirstRunAuthenticationBroker = require('models/auth_brokers/first-run');
+  var NullChannel = require('lib/channels/null');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/channels/null',
-  'lib/promise',
-  '../../../mocks/window',
-  'models/auth_brokers/fx-desktop-v1',
-  'models/user',
-  'sinon'
-], function (chai, NullChannel, p, WindowMock, FxDesktopV1AuthenticationBroker,
-  User, sinon) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FxDesktopV1AuthenticationBroker = require('models/auth_brokers/fx-desktop-v1');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/channels/null',
-  'lib/promise',
-  '../../../mocks/window',
-  'models/auth_brokers/fx-desktop-v2',
-  'models/user',
-  'sinon'
-], function (chai, NullChannel, p, WindowMock, FxDesktopV2AuthenticationBroker,
-  User, sinon) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FxDesktopV2AuthenticationBroker = require('models/auth_brokers/fx-desktop-v2');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -2,18 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/channels/null',
-  'models/auth_brokers/fx-fennec-v1',
-  'models/reliers/relier',
-  'models/user',
-  'sinon',
-  '../../../mocks/window'
-],
-function (chai, NullChannel, FxFennecV1AuthenticationBroker, Relier,
-  User, sinon, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FxFennecV1AuthenticationBroker = require('models/auth_brokers/fx-fennec-v1');
+  var NullChannel = require('lib/channels/null');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/channels/null',
-  'models/auth_brokers/fx-ios-v1',
-  'models/reliers/relier',
-  '../../../mocks/window'
-],
-function (chai, NullChannel, FxiOSAuthenticationBroker, Relier, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FxiOSAuthenticationBroker = require('models/auth_brokers/fx-ios-v1');
+  var NullChannel = require('lib/channels/null');
+  var Relier = require('models/reliers/relier');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/fx-ios-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v2.js
@@ -2,18 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/channels/null',
-  'models/auth_brokers/fx-ios-v2',
-  'models/reliers/relier',
-  'models/user',
-  'sinon',
-  '../../../mocks/window'
-],
-function (chai, NullChannel, FxiOSV2AuthenticationBroker, Relier,
-  User, sinon, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FxiOSV2AuthenticationBroker = require('models/auth_brokers/fx-ios-v2');
+  var NullChannel = require('lib/channels/null');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -2,19 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/auth-errors',
-  'lib/channels/null',
-  'lib/promise',
-  'models/auth_brokers/fx-sync',
-  'models/user',
-  'sinon',
-  'underscore',
-  '../../../mocks/window'
-], function (chai, AuthErrors, NullChannel, p, FxSyncAuthenticationBroker,
-  User, sinon, _, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var FxSyncAuthenticationBroker = require('models/auth_brokers/fx-sync');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/iframe.js
+++ b/app/tests/spec/models/auth_brokers/iframe.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  'models/auth_brokers/iframe',
-  'models/reliers/relier',
-  'lib/promise',
-  'lib/channels/null',
-  'lib/session',
-  '../../../mocks/window'
-],
-function (chai, sinon, $, IframeAuthenticationBroker, Relier, p, NullChannel,
-      Session, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var IframeAuthenticationBroker = require('models/auth_brokers/iframe');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -2,23 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/session',
-  'lib/promise',
-  'lib/constants',
-  'lib/oauth-client',
-  'lib/assertion',
-  'lib/auth-errors',
-  'lib/oauth-errors',
-  'models/reliers/relier',
-  'models/user',
-  'models/auth_brokers/oauth'
-],
-function (chai, sinon, Session, p, Constants, OAuthClient, Assertion, AuthErrors,
-      OAuthErrors, Relier, User, OAuthAuthenticationBroker) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Assertion = require('lib/assertion');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var OAuthAuthenticationBroker = require('models/auth_brokers/oauth');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var User = require('models/user');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/auth_brokers/redirect.js
+++ b/app/tests/spec/models/auth_brokers/redirect.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/constants',
-  'lib/session',
-  'models/auth_brokers/redirect',
-  'models/reliers/base',
-  'models/user',
-  '../../../mocks/window'
-],
-function (chai, sinon, p, Constants, Session, RedirectAuthenticationBroker,
-    Relier, User, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var p = require('lib/promise');
+  var RedirectAuthenticationBroker = require('models/auth_brokers/redirect');
+  var Relier = require('models/reliers/base');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
   var REDIRECT_TO = 'https://redirect.here';

--- a/app/tests/spec/models/auth_brokers/web-channel.js
+++ b/app/tests/spec/models/auth_brokers/web-channel.js
@@ -2,23 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'models/auth_brokers/web-channel',
-  'models/reliers/relier',
-  'models/user',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/constants',
-  'lib/channels/null',
-  'lib/session',
-  'views/base',
-  '../../../mocks/window'
-],
-function (chai, sinon, WebChannelAuthenticationBroker, Relier, User, FxaClientWrapper,
-      p, Constants, NullChannel, Session, BaseView, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClientWrapper = require('lib/fxa-client');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var WebChannelAuthenticationBroker = require('models/auth_brokers/web-channel');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/email-resend.js
+++ b/app/tests/spec/models/email-resend.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'models/email-resend',
-  'lib/constants'
-],
-function (chai, sinon, EmailResend, Constants) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var EmailResend = require('models/email-resend');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/form-prefill.js
+++ b/app/tests/spec/models/form-prefill.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/form-prefill'
-], function (chai, FormPrefill) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/marketing-email-prefs.js
+++ b/app/tests/spec/models/marketing-email-prefs.js
@@ -2,19 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/constants',
-  'lib/marketing-email-client',
-  'models/marketing-email-prefs',
-  'models/account',
-  'models/oauth-token'
-],
-function (chai, sinon, p, Constants, MarketingEmailClient,
-  MarketingEmailPrefs, Account, OAuthToken) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Account = require('models/account');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var MarketingEmailClient = require('lib/marketing-email-client');
+  var MarketingEmailPrefs = require('models/marketing-email-prefs');
+  var OAuthToken = require('models/oauth-token');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/mixins/resume-token.js
+++ b/app/tests/spec/models/mixins/resume-token.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'backbone',
-  'chai',
-  'cocktail',
-  'models/mixins/resume-token',
-  'models/resume-token'
-], function (Backbone, chai, Cocktail, ResumeTokenMixin, ResumeToken) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var ResumeToken = require('models/resume-token');
+  var ResumeTokenMixin = require('models/mixins/resume-token');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/mixins/search-param.js
+++ b/app/tests/spec/models/mixins/search-param.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'backbone',
-  'cocktail',
-  'models/mixins/search-param',
-  '../../../mocks/window',
-  '../../../lib/helpers'
-], function (chai, Backbone, Cocktail, SearchParamMixin, WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Backbone = require('backbone');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var SearchParamMixin = require('models/mixins/search-param');
+  var TestHelpers = require('../../../lib/helpers');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/oauth-token.js
+++ b/app/tests/spec/models/oauth-token.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'models/oauth-token'
-],
-function (chai, sinon, p, OAuthToken) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var OAuthToken = require('models/oauth-token');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/profile-image.js
+++ b/app/tests/spec/models/profile-image.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/profile-errors',
-  'models/profile-image'
-],
-function (chai, ProfileErrors, ProfileImage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ProfileErrors = require('lib/profile-errors');
+  var ProfileImage = require('models/profile-image');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/refresh-observer.js
+++ b/app/tests/spec/models/refresh-observer.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/metrics',
-  '../../mocks/window',
-  'lib/channels/notifier',
-  'models/refresh-observer',
-  'sinon'
-],
-function (chai, Metrics, WindowMock, Notifier, RefreshObserver, sinon) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var RefreshObserver = require('models/refresh-observer');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/reliers/base.js
+++ b/app/tests/spec/models/reliers/base.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/reliers/base'
-], function (chai, BaseRelier) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseRelier = require('models/reliers/base');
+  var chai = require('chai');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -2,22 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'models/reliers/oauth',
-  'models/user',
-  'lib/session',
-  'lib/oauth-client',
-  'lib/oauth-errors',
-  'lib/promise',
-  'lib/relier-keys',
-  'lib/url',
-  '../../../mocks/window',
-  '../../../lib/helpers'
-], function (chai, sinon, OAuthRelier, User, Session, OAuthClient, OAuthErrors,
-      p, RelierKeys, Url, WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthErrors = require('lib/oauth-errors');
+  var OAuthRelier = require('models/reliers/oauth');
+  var p = require('lib/promise');
+  var RelierKeys = require('lib/relier-keys');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var Url = require('lib/url');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   /*eslint-disable camelcase */
   var assert = chai.assert;

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/constants',
-  'models/reliers/relier',
-  'models/resume-token',
-  '../../../mocks/window',
-  '../../../lib/helpers'
-], function (chai, Constants, Relier, ResumeToken, WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var Relier = require('models/reliers/relier');
+  var ResumeToken = require('models/resume-token');
+  var TestHelpers = require('../../../lib/helpers');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/reliers/sync.js
+++ b/app/tests/spec/models/reliers/sync.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/reliers/sync',
-  'lib/translator',
-  '../../../mocks/window',
-  '../../../lib/helpers'
-], function (chai, Relier, Translator, WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Relier = require('models/reliers/sync');
+  var TestHelpers = require('../../../lib/helpers');
+  var Translator = require('lib/translator');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/resume-token.js
+++ b/app/tests/spec/models/resume-token.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/resume-token'
-],
-function (chai, ResumeToken) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ResumeToken = require('models/resume-token');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/unique-user-id.js
+++ b/app/tests/spec/models/unique-user-id.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/storage',
-  'lib/url',
-  'models/resume-token',
-  'models/unique-user-id',
-  '../../mocks/window'
-],
-function (chai, Storage, Url, ResumeToken, UniqueUserId, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var ResumeToken = require('models/resume-token');
+  var Storage = require('lib/storage');
+  var UniqueUserId = require('models/unique-user-id');
+  var Url = require('lib/url');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/constants',
-  'lib/session',
-  'lib/fxa-client',
-  'lib/auth-errors',
-  'lib/channels/notifier',
-  'models/user'
-],
-function (chai, sinon, p, Constants, Session, FxaClient, AuthErrors,
-  Notifier, User) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClient = require('lib/fxa-client');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var User = require('models/user');
 
   var assert = chai.assert;
   var UUID = 'a mock uuid';

--- a/app/tests/spec/models/verification/base.js
+++ b/app/tests/spec/models/verification/base.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'models/verification/base'
-], function (chai, BaseModel) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseModel = require('models/verification/base');
+  var chai = require('chai');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/verification/reset-password.js
+++ b/app/tests/spec/models/verification/reset-password.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/constants',
-  'models/verification/reset-password',
-  '../../../lib/helpers'
-], function (chai, Constants, Model, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var Model = require('models/verification/reset-password');
+  var TestHelpers = require('../../../lib/helpers');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/verification/same-browser.js
+++ b/app/tests/spec/models/verification/same-browser.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/storage',
-  'models/verification/same-browser',
-  'sinon'
-], function (chai, Storage, SameBrowserVerificationModel, sinon) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var SameBrowserVerificationModel = require('models/verification/same-browser');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/models/verification/sign-up.js
+++ b/app/tests/spec/models/verification/sign-up.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/constants',
-  'models/verification/sign-up',
-  '../../../lib/helpers'
-], function (chai, Constants, Model, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var Model = require('models/verification/sign-up');
+  var TestHelpers = require('../../../lib/helpers');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/app.js
+++ b/app/tests/spec/views/app.js
@@ -2,21 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'backbone',
-  'chai',
-  'jquery',
-  'lib/auth-errors',
-  'lib/environment',
-  'lib/promise',
-  '../../mocks/router',
-  '../../mocks/window',
-  'lib/channels/notifier',
-  'sinon',
-  'views/app'
-], function (Backbone, chai, $, AuthErrors, Environment, p, RouterMock,
-  WindowMock, Notifier, sinon, AppView) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AppView = require('views/app');
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
+  var chai = require('chai');
+  var Environment = require('lib/environment');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -2,29 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/base',
-  'lib/promise',
-  'lib/translator',
-  'lib/ephemeral-messages',
-  'lib/metrics',
-  'lib/auth-errors',
-  'lib/fxa-client',
-  'models/auth_brokers/base',
-  'models/user',
-  'stache!templates/test_template',
-  '../../mocks/dom-event',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, BaseView, p, Translator, EphemeralMessages, Metrics,
-  AuthErrors, FxaClient, BaseBroker, User, Template, DOMEventMock, RouterMock,
-  WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseBroker = require('models/auth_brokers/base');
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var DOMEventMock = require('../../mocks/dom-event');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var Template = require('stache!templates/test_template');
+  var TestHelpers = require('../../lib/helpers');
+  var Translator = require('lib/translator');
+  var User = require('models/user');
+  var WindowMock = require('../../mocks/window');
 
   var requiresFocus = TestHelpers.requiresFocus;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/behaviors/halt.js
+++ b/app/tests/spec/views/behaviors/halt.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'views/behaviors/halt'
-],
-function (chai, HaltBehavior) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var HaltBehavior = require('views/behaviors/halt');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/behaviors/navigate.js
+++ b/app/tests/spec/views/behaviors/navigate.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/behaviors/navigate'
-],
-function (chai, sinon, NavigateBehavior) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var NavigateBehavior = require('views/behaviors/navigate');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/behaviors/null.js
+++ b/app/tests/spec/views/behaviors/null.js
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'views/behaviors/null'
-],
-function (NullBehavior) {
+define(function (require, exports, module) {
   'use strict';
+
+  var NullBehavior = require('views/behaviors/null');
 
   describe('views/behaviors/null', function () {
     it('does nothing', function () {

--- a/app/tests/spec/views/cannot_create_account.js
+++ b/app/tests/spec/views/cannot_create_account.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/cannot_create_account',
-  'models/auth_brokers/base',
-  'models/reliers/relier'
-],
-function (chai, sinon, View, Broker, Relier) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var View = require('views/cannot_create_account');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/choose_what_to_sync.js
+++ b/app/tests/spec/views/choose_what_to_sync.js
@@ -2,24 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/promise',
-  'views/choose_what_to_sync',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/ephemeral-messages',
-  'models/user',
-  'models/auth_brokers/fx-fennec-v1',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, p, View, Metrics, FxaClient, EphemeralMessages,
-          User, Broker, WindowMock, RouterMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Broker = require('models/auth_brokers/fx-fennec-v1');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/choose_what_to_sync');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/clear_storage.js
+++ b/app/tests/spec/views/clear_storage.js
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'views/clear_storage'
-],
-function (chai, View) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var View = require('views/clear_storage');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/close_button.js
+++ b/app/tests/spec/views/close_button.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  '../../mocks/window',
-  '../../lib/helpers',
-  'lib/promise',
-  'lib/metrics',
-  'lib/oauth-errors',
-  'views/close_button',
-  'models/auth_brokers/oauth'
-],
-function (chai, sinon, $, WindowMock, TestHelpers, p, Metrics,
-      OAuthErrors, View, OAuthBroker) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var OAuthBroker = require('models/auth_brokers/oauth');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var View = require('views/close_button');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/complete_account_unlock.js
+++ b/app/tests/spec/views/complete_account_unlock.js
@@ -2,26 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'views/complete_account_unlock',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/constants',
-  'lib/fxa-client',
-  'lib/url',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, View, AuthErrors, Metrics, Constants, FxaClient,
-      Url, Relier, Broker, User, RouterMock, WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var Url = require('lib/url');
+  var User = require('models/user');
+  var View = require('views/complete_account_unlock');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -2,25 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'views/complete_reset_password',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, AuthErrors, Metrics, FxaClient, View, Notifier,
-  Relier, Broker, User, RouterMock, WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/complete_reset_password');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -2,28 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'views/complete_sign_up',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/constants',
-  'lib/fxa-client',
-  'lib/marketing-email-errors',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  'lib/channels/notifier',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, View, AuthErrors, Metrics, Constants, FxaClient,
-      MarketingEmailErrors, Relier, Broker, User, Notifier, RouterMock,
-      WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FxaClient = require('lib/fxa-client');
+  var MarketingEmailErrors = require('lib/marketing-email-errors');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/complete_sign_up');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -2,28 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/session',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/ephemeral-messages',
-  'views/confirm',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient,
-  EphemeralMessages, View, Notifier, Relier, BaseBroker, User,
-  WindowMock, RouterMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseBroker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/confirm');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/confirm_account_unlock.js
+++ b/app/tests/spec/views/confirm_account_unlock.js
@@ -2,27 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/session',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/ephemeral-messages',
-  'views/confirm_account_unlock',
-  'models/reliers/relier',
-  'models/user',
-  'models/auth_brokers/oauth',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, Session, AuthErrors, Metrics, FxaClient,
-      EphemeralMessages, View, Relier, User, OAuthBroker, RouterMock,
-      WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var OAuthBroker = require('models/auth_brokers/oauth');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/confirm_account_unlock');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -2,28 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/auth-errors',
-  'views/confirm_reset_password',
-  'lib/metrics',
-  'lib/ephemeral-messages',
-  'lib/storage',
-  '../../mocks/fxa-client',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, sinon, p, AuthErrors, View, Metrics, EphemeralMessages,
-  Storage, FxaClient, Notifier, Relier, Broker, User, RouterMock,
-  WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('../../mocks/fxa-client');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/confirm_reset_password');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/cookies_disabled.js
+++ b/app/tests/spec/views/cookies_disabled.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'chai',
-  'sinon',
-  'views/cookies_disabled',
-  '../../mocks/window',
-  'lib/storage'
-],
-function ($, chai, sinon, View, WindowMock, Storage) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var sinon = require('sinon');
+  var Storage = require('lib/storage');
+  var View = require('views/cookies_disabled');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/coppa/coppa-age-input.js
+++ b/app/tests/spec/views/coppa/coppa-age-input.js
@@ -2,18 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'lib/auth-errors',
-  'lib/metrics',
-  'models/form-prefill',
-  'sinon',
-  'views/coppa/coppa-age-input',
-  '../../../lib/helpers'
-],
-function (chai, $, AuthErrors, Metrics, FormPrefill, sinon, View, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
+  var Metrics = require('lib/metrics');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var View = require('views/coppa/coppa-age-input');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/decorators/progress_indicator.js
+++ b/app/tests/spec/views/decorators/progress_indicator.js
@@ -3,17 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  'lib/promise',
-  'views/base',
-  'views/progress_indicator',
-  'views/decorators/progress_indicator'
-],
-function (chai, sinon, $, p, BaseView, ProgressIndicator, showProgressIndicator) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var p = require('lib/promise');
+  var ProgressIndicator = require('views/progress_indicator');
+  var showProgressIndicator = require('views/decorators/progress_indicator');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -2,27 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/force_auth',
-  'views/sign_in',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/auth-errors',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/form-prefill',
-  'lib/channels/notifier',
-  'models/user',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, View, SignInView, FxaClient, p, AuthErrors, Relier,
-  Broker, FormPrefill, Notifier, User, WindowMock, RouterMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var SignInView = require('views/sign_in');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/force_auth');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -2,22 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  'lib/promise',
-  'views/behaviors/halt',
-  'views/form',
-  'stache!templates/test_template',
-  'lib/constants',
-  'lib/metrics',
-  'lib/auth-errors',
-  '../../lib/helpers'
-],
-function (chai, sinon, $, p, HaltBehavior, FormView, Template, Constants, Metrics, AuthErrors,
-      TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var FormView = require('views/form');
+  var HaltBehavior = require('views/behaviors/halt');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var Template = require('stache!templates/test_template');
+  var TestHelpers = require('../../lib/helpers');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/marketing_snippet.js
+++ b/app/tests/spec/views/marketing_snippet.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'views/marketing_snippet',
-  'lib/metrics',
-  '../../mocks/window'
-],
-function (chai, View, Metrics, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var View = require('views/marketing_snippet');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/marketing_snippet_ios.js
+++ b/app/tests/spec/views/marketing_snippet_ios.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/marketing_snippet_ios',
-  'lib/able',
-  'lib/metrics',
-  '../../mocks/window'
-],
-function (chai, sinon, View, Able, Metrics, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var sinon = require('sinon');
+  var View = require('views/marketing_snippet_ios');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/account-locked-mixin.js
+++ b/app/tests/spec/views/mixins/account-locked-mixin.js
@@ -2,24 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'cocktail',
-  'sinon',
-  'models/reliers/base',
-  'models/user',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics',
-  'views/mixins/account-locked-mixin',
-  'views/base',
-  'stache!templates/test_template',
-  '../../../mocks/router',
-  '../../../lib/helpers'
-], function (Chai, Cocktail, sinon, Relier, User, FxaClient, p, AuthErrors,
-    Metrics, AccountLockedMixin, BaseView, Template, RouterMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AccountLockedMixin = require('views/mixins/account-locked-mixin');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/base');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var Template = require('stache!templates/test_template');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -2,27 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'cocktail',
-  'views/mixins/avatar-mixin',
-  'views/base',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/user',
-  'models/account',
-  'models/profile-image',
-  'lib/metrics',
-  'lib/auth-errors',
-  'lib/profile-errors',
-  'lib/promise',
-  'lib/channels/null',
-  '../../../lib/helpers'
-], function (Chai, sinon, Cocktail, AvatarMixin, BaseView, Notifier, Relier,
-    User, Account, ProfileImage, Metrics, AuthErrors, ProfileErrors, p, NullChannel,
-    TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Account = require('models/account');
+  var AuthErrors = require('lib/auth-errors');
+  var AvatarMixin = require('views/mixins/avatar-mixin');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var ProfileErrors = require('lib/profile-errors');
+  var ProfileImage = require('models/profile-image');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/back-mixin.js
+++ b/app/tests/spec/views/mixins/back-mixin.js
@@ -2,18 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'chai',
-  'sinon',
-  '../../../mocks/window',
-  'views/mixins/back-mixin',
-  'views/base',
-  'stache!templates/test_template',
-  'lib/key-codes'
-], function (Cocktail, Chai, sinon, WindowMock,
-        BackMixin, BaseView, TestTemplate, KeyCodes) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var KeyCodes = require('lib/key-codes');
+  var sinon = require('sinon');
+  var TestTemplate = require('stache!templates/test_template');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/checkbox-mixin.js
+++ b/app/tests/spec/views/mixins/checkbox-mixin.js
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'chai',
-  'sinon',
-  'views/mixins/checkbox-mixin',
-  'views/base',
-  'stache!templates/test_template'
-], function (Cocktail, Chai, sinon, CheckboxMixin, BaseView, Template) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var CheckboxMixin = require('views/mixins/checkbox-mixin');
+  var Cocktail = require('cocktail');
+  var sinon = require('sinon');
+  var Template = require('stache!templates/test_template');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/experiment-mixin.js
+++ b/app/tests/spec/views/mixins/experiment-mixin.js
@@ -2,20 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'cocktail',
-  'chai',
-  '../../../mocks/window',
-  'views/mixins/experiment-mixin',
-  'views/base',
-  'stache!templates/test_template',
-  'models/user',
-  'lib/channels/notifier',
-  'lib/able',
-  'lib/metrics'
-], function (Cocktail, Chai, WindowMock, Mixin, BaseView, TestTemplate, User,
-  Notifier, Able, Metrics) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Metrics = require('lib/metrics');
+  var Mixin = require('views/mixins/experiment-mixin');
+  var Notifier = require('lib/channels/notifier');
+  var TestTemplate = require('stache!templates/test_template');
+  var User = require('models/user');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = Chai.assert;
   var View = BaseView.extend({

--- a/app/tests/spec/views/mixins/floating-placeholder-mixin.js
+++ b/app/tests/spec/views/mixins/floating-placeholder-mixin.js
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'cocktail',
-  'jquery',
-  'stache!templates/test_template',
-  'views/form',
-  'views/mixins/floating-placeholder-mixin',
-  'lib/key-codes'
-], function (chai, Cocktail, $, Template, FormView, FloatingPlaceholderMixin, KeyCodes) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  var FormView = require('views/form');
+  var KeyCodes = require('lib/key-codes');
+  var Template = require('stache!templates/test_template');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/loading-mixin.js
+++ b/app/tests/spec/views/mixins/loading-mixin.js
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'cocktail',
-  'chai',
-  'views/mixins/loading-mixin',
-  'views/base',
-  'stache!templates/test_template',
-  '../../../mocks/window'
-], function ($, Cocktail, Chai, LoadingMixin, BaseView, Template, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var LoadingMixin = require('views/mixins/loading-mixin');
+  var Template = require('stache!templates/test_template');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/migration-mixin.js
+++ b/app/tests/spec/views/mixins/migration-mixin.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/mixins/migration-mixin',
-], function (chai, sinon, MigrationMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var MigrationMixin = require('views/mixins/migration-mixin');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/modal-settings-panel-mixin.js
+++ b/app/tests/spec/views/mixins/modal-settings-panel-mixin.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'cocktail',
-  'views/mixins/modal-settings-panel-mixin',
-  'views/base',
-  'lib/metrics',
-  'stache!templates/test_template'
-], function (chai, sinon, Cocktail, ModalSettingsPanelMixin, BaseView,
-    Metrics, TestTemplate) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Metrics = require('lib/metrics');
+  var ModalSettingsPanelMixin = require('views/mixins/modal-settings-panel-mixin');
+  var sinon = require('sinon');
+  var TestTemplate = require('stache!templates/test_template');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/notifier-mixin.js
+++ b/app/tests/spec/views/mixins/notifier-mixin.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'cocktail',
-  'lib/channels/notifier',
-  'sinon',
-  'views/base',
-  'views/mixins/notifier-mixin'
-], function (chai, Cocktail, Notifier, sinon, BaseView,
-  NotifierMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Notifier = require('lib/channels/notifier');
+  var NotifierMixin = require('views/mixins/notifier-mixin');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/password-mixin.js
+++ b/app/tests/spec/views/mixins/password-mixin.js
@@ -2,20 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'jquery',
-  'chai',
-  'sinon',
-  'underscore',
-  'lib/metrics',
-  'views/mixins/password-mixin',
-  'views/base',
-  'models/reliers/relier',
-  'stache!templates/test_template',
-  '../../../lib/helpers'
-], function ($, chai, sinon, _, Metrics, PasswordMixin, BaseView, Relier,
-  TestTemplate, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var PasswordMixin = require('views/mixins/password-mixin');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var TestTemplate = require('stache!templates/test_template');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/password-strength-mixin.js
+++ b/app/tests/spec/views/mixins/password-strength-mixin.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'cocktail',
-  'sinon',
-  'views/mixins/password-strength-mixin',
-  'views/base'
-], function (chai, Cocktail, sinon, PasswordStrengthMixin, BaseView) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var PasswordStrengthMixin = require('views/mixins/password-strength-mixin');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/resume-token-mixin.js
+++ b/app/tests/spec/views/mixins/resume-token-mixin.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'cocktail',
-  'models/reliers/relier',
-  'models/resume-token',
-  'stache!templates/test_template',
-  'views/base',
-  'views/mixins/resume-token-mixin',
-], function (chai, Cocktail, Relier, ResumeToken, TestTemplate,
-  BaseView, ResumeTokenMixin ) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Relier = require('models/reliers/relier');
+  var ResumeToken = require('models/resume-token');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var TestTemplate = require('stache!templates/test_template');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/service-mixin.js
+++ b/app/tests/spec/views/mixins/service-mixin.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'underscore',
-  '../../../mocks/window',
-  'views/mixins/service-mixin',
-  'views/base',
-  'lib/session',
-  'stache!templates/test_template',
-  'models/reliers/oauth',
-  'models/auth_brokers/base'
-], function (Chai, sinon, _, WindowMock,
-        ServiceMixin, BaseView, Session,
-        TestTemplate, OAuthRelier, NullBroker) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var NullBroker = require('models/auth_brokers/base');
+  var OAuthRelier = require('models/reliers/oauth');
+  var ServiceMixin = require('views/mixins/service-mixin');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestTemplate = require('stache!templates/test_template');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/mixins/settings-mixin.js
+++ b/app/tests/spec/views/mixins/settings-mixin.js
@@ -2,19 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'cocktail',
-  'sinon',
-  'lib/channels/notifier',
-  'models/user',
-  'models/reliers/relier',
-  'stache!templates/test_template',
-  'views/base',
-  'views/mixins/settings-mixin'
-], function (chai, Cocktail, sinon, Notifier, User, Relier, TestTemplate,
-  BaseView, SettingsMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Notifier = require('lib/channels/notifier');
+  var Relier = require('models/reliers/relier');
+  var SettingsMixin = require('views/mixins/settings-mixin');
+  var sinon = require('sinon');
+  var TestTemplate = require('stache!templates/test_template');
+  var User = require('models/user');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/settings-panel-mixin.js
+++ b/app/tests/spec/views/mixins/settings-panel-mixin.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'cocktail',
-  'views/mixins/settings-panel-mixin',
-  'views/base',
-  'lib/metrics',
-  'stache!templates/test_template'
-], function (chai, sinon, Cocktail, SettingsPanelMixin, BaseView,
-    Metrics, TestTemplate) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Metrics = require('lib/metrics');
+  var SettingsPanelMixin = require('views/mixins/settings-panel-mixin');
+  var sinon = require('sinon');
+  var TestTemplate = require('stache!templates/test_template');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/signed-in-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-in-notification-mixin.js
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'cocktail',
-  'sinon',
-  'lib/promise',
-  'lib/channels/notifier',
-  'views/base',
-  'views/mixins/signed-in-notification-mixin'
-], function (chai, Cocktail, sinon, p, Notifier, BaseView,
-  SignedInNotificationMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var SignedInNotificationMixin = require('views/mixins/signed-in-notification-mixin');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/signed-out-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-out-notification-mixin.js
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'cocktail',
-  'sinon',
-  'lib/channels/notifier',
-  'views/base',
-  'views/mixins/signed-out-notification-mixin'
-], function (chai, Cocktail, sinon, Notifier, BaseView,
-  SignedOutNotificationMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Notifier = require('lib/channels/notifier');
+  var SignedOutNotificationMixin = require('views/mixins/signed-out-notification-mixin');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/signup-enabled-mixin.js
+++ b/app/tests/spec/views/mixins/signup-enabled-mixin.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/auth-errors',
-  'views/mixins/signup-disabled-mixin',
-], function (chai, sinon, AuthErrors, SignupDisabledMixin) {
+define(function (require, exports, module) {
   'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var SignupDisabledMixin = require('views/mixins/signup-disabled-mixin');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/mixins/timer-mixin.js
+++ b/app/tests/spec/views/mixins/timer-mixin.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'underscore',
-  '../../../lib/helpers',
-  'views/mixins/timer-mixin',
-  'views/base'
-], function (Chai, _, TestHelpers, TimerMixin, BaseView) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var TestHelpers = require('../../../lib/helpers');
+  var TimerMixin = require('views/mixins/timer-mixin');
 
   var assert = Chai.assert;
 

--- a/app/tests/spec/views/oauth_sign_in.js
+++ b/app/tests/spec/views/oauth_sign_in.js
@@ -2,28 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/sign_in',
-  'lib/session',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/metrics',
-  'models/reliers/oauth',
-  'models/auth_brokers/oauth',
-  'models/form-prefill',
-  'lib/channels/notifier',
-  'models/user',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, View, Session, FxaClient, p, Metrics, OAuthRelier,
-  OAuthBroker, FormPrefill, Notifier, User, WindowMock, RouterMock,
-  TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var OAuthBroker = require('models/auth_brokers/oauth');
+  var OAuthRelier = require('models/reliers/oauth');
+  var p = require('lib/promise');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/sign_in');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -2,31 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/sign_up',
-  'lib/promise',
-  'lib/session',
-  'lib/fxa-client',
-  'lib/metrics',
-  'lib/oauth-client',
-  'lib/assertion',
-  'lib/able',
-  'models/reliers/oauth',
-  'models/auth_brokers/oauth',
-  'models/user',
-  'models/form-prefill',
-  'lib/channels/notifier',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, View, p, Session, FxaClient, Metrics, OAuthClient,
-      Assertion, Able, OAuthRelier, OAuthBroker, User, FormPrefill, Notifier, WindowMock,
-      RouterMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Able = require('lib/able');
+  var Assertion = require('lib/assertion');
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var OAuthBroker = require('models/auth_brokers/oauth');
+  var OAuthClient = require('lib/oauth-client');
+  var OAuthRelier = require('models/reliers/oauth');
+  var p = require('lib/promise');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/sign_up');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/openid/login.js
+++ b/app/tests/spec/views/openid/login.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/fxa-client',
-  'lib/channels/notifier',
-  'models/user',
-  'models/auth_brokers/base',
-  'views/openid/login',
-  '../../../mocks/window',
-  '../../../mocks/router',
-],
-function (chai, sinon, p, FxaClient, Notifier, User, Broker, View,
-  WindowMock, RouterMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var FxaClient = require('lib/fxa-client');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var View = require('views/openid/login');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/openid/start.js
+++ b/app/tests/spec/views/openid/start.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/openid/start',
-  '../../../mocks/window'
-],
-function (chai, sinon, View, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var sinon = require('sinon');
+  var View = require('views/openid/start');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/permissions.js
+++ b/app/tests/spec/views/permissions.js
@@ -2,25 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/promise',
-  'views/permissions',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/ephemeral-messages',
-  'models/reliers/relier',
-  'models/user',
-  'models/auth_brokers/base',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, p, View, Metrics, FxaClient, EphemeralMessages,
-      Relier, User, Broker, WindowMock, RouterMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/permissions');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/pp.js
+++ b/app/tests/spec/views/pp.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/pp',
-  'lib/promise',
-  '../../mocks/window'
-],
-function (chai, sinon, View, p, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var View = require('views/pp');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/progress_indicator.js
+++ b/app/tests/spec/views/progress_indicator.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'jquery',
-  'views/progress_indicator'
-],
-function (chai, sinon, $, ProgressIndicator) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var ProgressIndicator = require('views/progress_indicator');
+  var sinon = require('sinon');
 
   var assert = chai.assert;
   var progressIndicator;

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/ready',
-  'lib/session',
-  'lib/fxa-client',
-  'lib/able',
-  'lib/promise',
-  'models/reliers/sync',
-  'models/auth_brokers/oauth',
-  '../../mocks/window'
-],
-function (chai, sinon, View, Session, FxaClient, Able, p, SyncRelier,
-      OAuthBroker, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var Able = require('lib/able');
+  var chai = require('chai');
+  var FxaClient = require('lib/fxa-client');
+  var OAuthBroker = require('models/auth_brokers/oauth');
+  var p = require('lib/promise');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var SyncRelier = require('models/reliers/sync');
+  var View = require('views/ready');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -2,24 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'underscore',
-  'chai',
-  'sinon',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'views/reset_password',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/form-prefill',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (_, chai, sinon, p, AuthErrors, Metrics, FxaClient, View, Relier,
-      Broker, FormPrefill, RouterMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var _ = require('underscore');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var View = require('views/reset_password');
 
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -2,38 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'cocktail',
-  'underscore',
-  'views/settings',
-  'views/base',
-  'views/sub_panels',
-  'views/settings/communication_preferences',
-  'views/mixins/settings-panel-mixin',
-  '../../mocks/router',
-  '../../lib/helpers',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/profile-client',
-  'lib/profile-errors',
-  'lib/auth-errors',
-  'lib/able',
-  'lib/metrics',
-  'models/form-prefill',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/profile-image',
-  'models/user',
-  'stache!templates/test_template'
-],
-function (chai, $, sinon, Cocktail, _, View, BaseView, SubPanels,
-  CommunicationPreferencesView, SettingsPanelMixin, RouterMock, TestHelpers,
-  FxaClient, p, ProfileClient, ProfileErrors, AuthErrors, Able, Metrics,
-  FormPrefill, Notifier, Relier, ProfileImage, User, TestTemplate) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var Able = require('lib/able');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var CommunicationPreferencesView = require('views/settings/communication_preferences');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var ProfileErrors = require('lib/profile-errors');
+  var ProfileImage = require('models/profile-image');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var SettingsPanelMixin = require('views/mixins/settings-panel-mixin');
+  var sinon = require('sinon');
+  var SubPanels = require('views/sub_panels');
+  var TestHelpers = require('../../lib/helpers');
+  var TestTemplate = require('stache!templates/test_template');
+  var User = require('models/user');
+  var View = require('views/settings');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/settings/avatar.js
+++ b/app/tests/spec/views/settings/avatar.js
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/avatar',
-  '../../../mocks/router',
-  '../../../mocks/fxa-client',
-  'lib/promise',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/user'
-],
-function (chai, $, sinon, View, RouterMock, FxaClientMock,
-    p, Notifier, Relier, User) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var FxaClientMock = require('../../../mocks/fxa-client');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var User = require('models/user');
+  var View = require('views/settings/avatar');
 
   var assert = chai.assert;
   var IMG_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';

--- a/app/tests/spec/views/settings/avatar_camera.js
+++ b/app/tests/spec/views/settings/avatar_camera.js
@@ -2,28 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/avatar_camera',
-  '../../../mocks/router',
-  '../../../mocks/window',
-  '../../../mocks/canvas',
-  '../../../mocks/profile',
-  '../../../lib/helpers',
-  'lib/channels/notifier',
-  'models/user',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics'
-],
-function (chai, $, sinon, View, RouterMock, WindowMock, CanvasMock,
-    ProfileMock, TestHelpers, Notifier, User, Relier, AuthBroker, p,
-    AuthErrors, Metrics) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthBroker = require('models/auth_brokers/base');
+  var AuthErrors = require('lib/auth-errors');
+  var CanvasMock = require('../../../mocks/canvas');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var ProfileMock = require('../../../mocks/profile');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/avatar_camera');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/settings/avatar_change.js
+++ b/app/tests/spec/views/settings/avatar_change.js
@@ -2,27 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/avatar_change',
-  '../../../mocks/router',
-  '../../../mocks/file-reader',
-  '../../../mocks/profile',
-  '../../../mocks/window',
-  '../../../lib/helpers',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/user',
-  'lib/profile-client',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics'
-],
-function (chai, $, sinon, View, RouterMock, FileReaderMock, ProfileMock,
-            WindowMock, TestHelpers, Notifier, Relier, User, ProfileClient, p, AuthErrors, Metrics) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var FileReaderMock = require('../../../mocks/file-reader');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var ProfileMock = require('../../../mocks/profile');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/avatar_change');
+  var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAACZJREFUeNrtwQEBAAAAgiD' +

--- a/app/tests/spec/views/settings/avatar_crop.js
+++ b/app/tests/spec/views/settings/avatar_crop.js
@@ -2,31 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* exceptsPaths: draggable, jquery-simulate */
-define([
-  'chai',
-  'jquery',
-  'draggable',
-  'sinon',
-  'jquery-simulate',
-  'views/settings/avatar_crop',
-  '../../../mocks/router',
-  '../../../mocks/profile',
-  'lib/channels/notifier',
-  'models/user',
-  'models/cropper-image',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'lib/promise',
-  'lib/ephemeral-messages',
-  'lib/auth-errors',
-  'lib/metrics',
-  '../../../lib/helpers'
-],
-function (chai, $, ui, sinon, jQuerySimulate, View, RouterMock, ProfileMock,
-  Notifier, User, CropperImage, Relier, AuthBroker, p,
-  EphemeralMessages, AuthErrors, Metrics, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthBroker = require('models/auth_brokers/base');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var CropperImage = require('models/cropper-image');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var jQuerySimulate = require('jquery-simulate'); //eslint-disable-line no-unused-vars
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var ProfileMock = require('../../../mocks/profile');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var ui = require('draggable'); //eslint-disable-line no-unused-vars
+  var User = require('models/user');
+  var View = require('views/settings/avatar_crop');
 
   var assert = chai.assert;
   var pngSrc = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAACZJREFUeNrtwQEBAAAAgiD' +

--- a/app/tests/spec/views/settings/avatar_gravatar.js
+++ b/app/tests/spec/views/settings/avatar_gravatar.js
@@ -2,27 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/avatar_gravatar',
-  '../../../mocks/router',
-  '../../../mocks/profile',
-  '../../../lib/helpers',
-  'lib/channels/notifier',
-  'models/user',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'lib/auth-errors',
-  'lib/promise',
-  'lib/metrics',
-  'lib/profile-client'
-],
-function (chai, $, sinon, View, RouterMock, ProfileMock, TestHelpers,
-  Notifier, User, Relier, AuthBroker, AuthErrors, p, Metrics,
-  ProfileClient) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthBroker = require('models/auth_brokers/base');
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var ProfileClient = require('lib/profile-client');
+  var ProfileMock = require('../../../mocks/profile');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/avatar_gravatar');
 
   var assert = chai.assert;
   var GRAVATAR_URL = 'https://secure.gravatar.com/avatar/';

--- a/app/tests/spec/views/settings/change_password.js
+++ b/app/tests/spec/views/settings/change_password.js
@@ -2,25 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/auth-errors',
-  'lib/fxa-client',
-  'lib/metrics',
-  'lib/promise',
-  'lib/ephemeral-messages',
-  'views/settings/change_password',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  '../../../mocks/router',
-  '../../../lib/helpers'
-],
-function (chai, $, sinon, AuthErrors, FxaClient, Metrics, p,
-    EphemeralMessages, View, Relier, Broker, User, RouterMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/change_password');
 
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/settings/communication_preferences.js
+++ b/app/tests/spec/views/settings/communication_preferences.js
@@ -2,24 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/communication_preferences',
-  'models/user',
-  'models/account',
-  'models/marketing-email-prefs',
-  'models/reliers/relier',
-  'lib/promise',
-  'lib/constants',
-  'lib/marketing-email-errors',
-  'lib/metrics',
-  '../../../lib/helpers'
-],
-function (chai, $, sinon, View, User, Account, MarketingEmailPrefs, Relier,
-  p, Constants, MarketingEmailErrors, Metrics, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Account = require('models/account');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var MarketingEmailErrors = require('lib/marketing-email-errors');
+  var MarketingEmailPrefs = require('models/marketing-email-prefs');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/communication_preferences');
 
   var assert = chai.assert;
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;

--- a/app/tests/spec/views/settings/delete_account.js
+++ b/app/tests/spec/views/settings/delete_account.js
@@ -2,27 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'views/settings/delete_account',
-  'lib/fxa-client',
-  'lib/promise',
-  'lib/auth-errors',
-  'lib/metrics',
-  'lib/channels/null',
-  'models/reliers/relier',
-  'models/auth_brokers/base',
-  'models/user',
-  'lib/channels/notifier',
-  '../../../mocks/router',
-  '../../../lib/helpers',
-  'lib/key-codes'
-],
-function (chai, $, sinon, View, FxaClient, p, AuthErrors, Metrics, NullChannel,
-    Relier, Broker, User, Notifier, RouterMock, TestHelpers, KeyCodes) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var FxaClient = require('lib/fxa-client');
+  var KeyCodes = require('lib/key-codes');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var NullChannel = require('lib/channels/null');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/delete_account');
 
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/settings/display_name.js
+++ b/app/tests/spec/views/settings/display_name.js
@@ -2,22 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/promise',
-  'views/settings/display_name',
-  'lib/metrics',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/user',
-  '../../../mocks/router',
-  '../../../lib/helpers',
-  'lib/key-codes'
-],
-function (chai, $, sinon, p, View, Metrics, Notifier, Relier, User, RouterMock, TestHelpers, KeyCodes) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var KeyCodes = require('lib/key-codes');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/display_name');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/settings/gravatar_permissions.js
+++ b/app/tests/spec/views/settings/gravatar_permissions.js
@@ -2,20 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/promise',
-  'views/settings/gravatar_permissions',
-  'lib/metrics',
-  'models/reliers/relier',
-  'models/user',
-  '../../../mocks/router',
-  '../../../lib/helpers'
-],
-function (chai, $, sinon, p, View, Metrics, Relier, User, RouterMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var Metrics = require('lib/metrics');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../../mocks/router');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/settings/gravatar_permissions');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -2,32 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/promise',
-  'views/sign_in',
-  'lib/session',
-  'lib/auth-errors',
-  'lib/oauth-errors',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/constants',
-  'lib/ephemeral-messages',
-  'models/auth_brokers/base',
-  'models/form-prefill',
-  'lib/channels/notifier',
-  'models/reliers/relier',
-  'models/user',
-  '../../mocks/window',
-  '../../mocks/router',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, p, View, Session, AuthErrors, OAuthErrors, Metrics,
-  FxaClient, Constants, EphemeralMessages, Broker, FormPrefill, Notifier,
-  Relier, User, WindowMock, RouterMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/relier');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/sign_in');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -2,33 +2,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'lib/promise',
-  'views/sign_up',
-  'views/coppa/coppa-age-input',
-  'lib/session',
-  'lib/auth-errors',
-  'lib/experiment',
-  'lib/metrics',
-  'lib/fxa-client',
-  'lib/ephemeral-messages',
-  'lib/able',
-  'models/reliers/sync',
-  'models/auth_brokers/base',
-  'models/user',
-  'models/form-prefill',
-  'lib/channels/notifier',
-  '../../mocks/router',
-  '../../mocks/window',
-  '../../lib/helpers'
-],
-function (chai, $, sinon, p, View, CoppaAgeInput, Session, AuthErrors, ExperimentInterface, Metrics,
-      FxaClient, EphemeralMessages, Able, Relier, Broker, User, FormPrefill,
-      Notifier, RouterMock, WindowMock, TestHelpers) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var Able = require('lib/able');
+  var AuthErrors = require('lib/auth-errors');
+  var Broker = require('models/auth_brokers/base');
+  var chai = require('chai');
+  var CoppaAgeInput = require('views/coppa/coppa-age-input');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var ExperimentInterface = require('lib/experiment');
+  var FormPrefill = require('models/form-prefill');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/sync');
+  var RouterMock = require('../../mocks/router');
+  var Session = require('lib/session');
+  var sinon = require('sinon');
+  var TestHelpers = require('../../lib/helpers');
+  var User = require('models/user');
+  var View = require('views/sign_up');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/sub_panels.js
+++ b/app/tests/spec/views/sub_panels.js
@@ -2,24 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'sinon',
-  'cocktail',
-  'views/sub_panels',
-  'views/base',
-  'views/mixins/modal-settings-panel-mixin',
-  'views/mixins/settings-panel-mixin',
-  '../../mocks/router',
-  'lib/promise',
-  'lib/metrics',
-  'stache!templates/test_template',
-],
-function (chai, $, sinon, Cocktail, View, BaseView,
-  ModalSettingsPanelMixin, SettingsPanelMixin, RouterMock, p,
-  Metrics, TestTemplate) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var BaseView = require('views/base');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var Metrics = require('lib/metrics');
+  var ModalSettingsPanelMixin = require('views/mixins/modal-settings-panel-mixin');
+  var p = require('lib/promise');
+  var RouterMock = require('../../mocks/router');
+  var SettingsPanelMixin = require('views/mixins/settings-panel-mixin');
+  var sinon = require('sinon');
+  var TestTemplate = require('stache!templates/test_template');
+  var View = require('views/sub_panels');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/tooltip.js
+++ b/app/tests/spec/views/tooltip.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'jquery',
-  'views/tooltip',
-  'lib/key-codes'
-],
-function (chai, $, Tooltip, KeyCodes) {
+define(function (require, exports, module) {
   'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var KeyCodes = require('lib/key-codes');
+  var Tooltip = require('views/tooltip');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/tos.js
+++ b/app/tests/spec/views/tos.js
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'sinon',
-  'views/tos',
-  'lib/promise',
-  '../../mocks/window'
-],
-function (chai, sinon, View, p, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var p = require('lib/promise');
+  var sinon = require('sinon');
+  var View = require('views/tos');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/app/tests/spec/views/unexpected_error.js
+++ b/app/tests/spec/views/unexpected_error.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([
-  'chai',
-  'lib/ephemeral-messages',
-  'views/unexpected_error',
-  '../../mocks/window'
-],
-function (chai, EphemeralMessages, View, WindowMock) {
+define(function (require, exports, module) {
   'use strict';
+
+  var chai = require('chai');
+  var EphemeralMessages = require('lib/ephemeral-messages');
+  var View = require('views/unexpected_error');
+  var WindowMock = require('../../mocks/window');
 
   var assert = chai.assert;
 

--- a/grunttasks/amdcheck.js
+++ b/grunttasks/amdcheck.js
@@ -4,12 +4,10 @@
 
 module.exports = function (grunt) {
   grunt.config('amdcheck', {
-    app: {
+    tests: {
       files: [{
         expand: true,
         src: [
-          'app/{scripts,tests}/**/*.js',
-          'app/!scripts/vendor/**',
           'tests/functional/**/*.js'
         ]
       }],


### PR DESCRIPTION
I have only done the `app` directory because `use strict` is forbidden
in `tests` and I do not remember why. Before converting `tests`, I want
to find out whethere `use strict` is OK to use there or not.