### PR TITLE
chore(teamcity): use fxdownload version that downloads from moz cdn

### DIFF
--- a/tests/teamcity/update-builds.sh
+++ b/tests/teamcity/update-builds.sh
@@ -63,7 +63,7 @@ fi
 cd $FXDOWNLOAD_DIR && npm install
 
 for d in beta release esr; do
-  ./index.js --install-dir $CHANNELS_DIR --channel $d
+  ./fetch.js --install-dir $CHANNELS_DIR --channel $d
 done
 
 show_firefox_versions


### PR DESCRIPTION
r? - @vladikoff 

Changes to use s3 for storage mean that downloads from the archive are broken, so switch to use the CDN for downloads.