### PR TITLE
feat(l10n): Add translatable string for a "Help" link.

### DIFF
--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -26,6 +26,13 @@ define(function (require, exports, module) {
   t('Desktop Add-ons');
   t('Desktop Preferences');
 
+  // Allow translators to include "help" links in additional contexts.
+  // Including the string here means translators are free to use it
+  // without triggering errors from our l10n linting procedure.
+  // See e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=1131472
+  // for why this could be necessary.
+  t('<a href="https://support.mozilla.org/kb/im-having-problems-with-my-firefox-account">Help</a>');
+
   /**
    * Replace instances of %s and %(name)s with their corresponding values in
    * the context


### PR DESCRIPTION
For the background on this, see https://bugzilla.mozilla.org/show_bug.cgi?id=1131472

Mozilla China run a fork of FxA with various tweaks to better serve their local userbase, at https://accounts.firefox.com.cn/.   Sometimes users can get confused about whether they're logging into the .com or .com.cn version, so Bug 1131472 added some additional "help" links in the zh-CN translation of our error messages to guide them in the right direction.

This was backed out because it triggered our l10n XSS linter, which found unexpected outgoing links in the translation.  But users in China still face this problem, so I'd like to be able to bring back the help affordances in some form.

This PR adds a "help" link as a translatable string.  We don't use it anywhere be default, but its presence here allows translators to use it without triggering linter errors.  It's a bit of a hack, but will help our friends at Mozilla China to deliver a better experience for their users.

@vladikoff, what do you think?  