### PR TITLE
fix(devices): rename lastConnected to lastAccessTime

### DIFF
--- a/app/scripts/models/device.js
+++ b/app/scripts/models/device.js
@@ -15,7 +15,7 @@ define(function (require, exports, module) {
     defaults: {
       id: null,
       isCurrentDevice: null,
-      lastConnected: null,
+      lastAccessTime: null,
       name: null,
       type: null
     },

--- a/app/scripts/templates/settings/devices.mustache
+++ b/app/scripts/templates/settings/devices.mustache
@@ -23,7 +23,7 @@
               {{name}} {{#isCurrentDevice}}<span class="device-current">{{#t}}(current){{/t}}</span>{{/isCurrentDevice}}
             </div>
             <div class="last-connected">
-              {{lastConnected}}
+              {{lastAccessTime}}
             </div>
             <button class="settings-button warning device-disconnect" data-id="{{id}}">{{#t}}Disconnect{{/t}}</button>
           </li>


### PR DESCRIPTION
@shane-tomlinson, as per https://github.com/mozilla/fxa-auth-server/pull/1131, the field name from the auth server has been changed to `lastAccessTime`. This changes the content server to match.