### PR TITLE
refactor(client): Use the Account's isSignedIn method in base.js

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -282,13 +282,11 @@ define(function (require, exports, module) {
      */
     isUserAuthorized: function () {
       var self = this;
-      var sessionToken;
 
       return p()
         .then(function () {
           if (self.mustAuth || self.mustVerify) {
-            sessionToken = self.getSignedInAccount().get('sessionToken');
-            return !! sessionToken && self.fxaClient.isSignedIn(sessionToken);
+            return self.getSignedInAccount().isSignedIn();
           }
           return true;
         });

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -12,7 +12,6 @@ define(function (require, exports, module) {
   var chai = require('chai');
   var DOMEventMock = require('../../mocks/dom-event');
   var EphemeralMessages = require('lib/ephemeral-messages');
-  var FxaClient = require('lib/fxa-client');
   var Metrics = require('lib/metrics');
   var Notifier = require('lib/channels/notifier');
   var p = require('lib/promise');
@@ -31,7 +30,6 @@ define(function (require, exports, module) {
   describe('views/base', function () {
     var broker;
     var ephemeralMessages;
-    var fxaClient;
     var metrics;
     var notifier;
     var viewName = 'view';
@@ -56,7 +54,6 @@ define(function (require, exports, module) {
 
       broker = new BaseBroker();
       ephemeralMessages = new EphemeralMessages();
-      fxaClient = new FxaClient();
       metrics = new Metrics();
       notifier = new Notifier();
       user = new User();
@@ -65,7 +62,6 @@ define(function (require, exports, module) {
       view = new View({
         broker: broker,
         ephemeralMessages: ephemeralMessages,
-        fxaClient: fxaClient,
         metrics: metrics,
         notifier: notifier,
         translator: translator,
@@ -219,7 +215,7 @@ define(function (require, exports, module) {
           sessionToken: 'abc123',
           uid: 'uid'
         });
-        sinon.stub(fxaClient, 'sessionStatus', function () {
+        sinon.stub(account, 'isSignedIn', function () {
           return p(true);
         });
         sinon.stub(account, 'isVerified', function () {
@@ -242,7 +238,7 @@ define(function (require, exports, module) {
           sessionToken: 'abc123',
           uid: 'uid'
         });
-        sinon.stub(fxaClient, 'sessionStatus', function () {
+        sinon.stub(account, 'isSignedIn', function () {
           return p(true);
         });
         sinon.stub(account, 'isVerified', function () {
@@ -269,7 +265,7 @@ define(function (require, exports, module) {
           uid: 'uid',
           verified: true
         });
-        sinon.stub(fxaClient, 'sessionStatus', function () {
+        sinon.stub(account, 'isSignedIn', function () {
           return p(true);
         });
         sinon.stub(view, 'getSignedInAccount', function () {

--- a/app/tests/spec/views/settings/change_password.js
+++ b/app/tests/spec/views/settings/change_password.js
@@ -10,7 +10,6 @@ define(function (require, exports, module) {
   var Broker = require('models/auth_brokers/base');
   var chai = require('chai');
   var EphemeralMessages = require('lib/ephemeral-messages');
-  var FxaClient = require('lib/fxa-client');
   var Metrics = require('lib/metrics');
   var p = require('lib/promise');
   var Relier = require('models/reliers/relier');
@@ -22,11 +21,10 @@ define(function (require, exports, module) {
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
 
-  describe('views/change_password', function () {
+  describe('views/settings/change_password', function () {
     var account;
     var broker;
     var ephemeralMessages;
-    var fxaClient;
     var metrics;
     var relier;
     var user;
@@ -41,18 +39,11 @@ define(function (require, exports, module) {
         relier: relier
       });
 
-      fxaClient = new FxaClient({
-        broker: broker
-      });
-
-      user = new User({
-        fxaClient: fxaClient
-      });
+      user = new User({});
 
       view = new View({
         broker: broker,
         ephemeralMessages: ephemeralMessages,
-        fxaClient: fxaClient,
         metrics: metrics,
         relier: relier,
         user: user
@@ -67,13 +58,13 @@ define(function (require, exports, module) {
 
     describe('with session', function () {
       beforeEach(function () {
-        sinon.stub(view.fxaClient, 'isSignedIn', function () {
-          return true;
-        });
         account = user.initAccount({
           email: 'a@a.com',
           sessionToken: 'abc123',
           verified: true
+        });
+        sinon.stub(account, 'isSignedIn', function () {
+          return p(true);
         });
 
         sinon.stub(view, 'getSignedInAccount', function () {

--- a/app/tests/spec/views/settings/delete_account.js
+++ b/app/tests/spec/views/settings/delete_account.js
@@ -72,16 +72,16 @@ define(function (require, exports, module) {
     describe('with session', function () {
       beforeEach(function () {
         email = TestHelpers.createEmail();
-        sinon.stub(view.fxaClient, 'isSignedIn', function () {
-          return true;
-        });
 
         account = user.initAccount({
           email: email,
           sessionToken: 'abc123',
+          uid: UID,
           verified: true
         });
-        account.set('uid', UID);
+        sinon.stub(account, 'isSignedIn', function () {
+          return p(true);
+        });
 
         sinon.stub(view, 'getSignedInAccount', function () {
           return account;


### PR DESCRIPTION
* Remove the inline variant, duplicate code, causes extra dependencies in tests.
* A couple of tests were cleaned up as a result.

@philbooth and @zaach - mind an r?

This is part of the long-running drive to remove fxaClient calls from the views.