### PR TITLE
refactor(client): Move deleteAccount logic from view to user.js/account.js

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -332,6 +332,20 @@ define(function (require, exports, module) {
       return this._fxaClient.signOut(this.get('sessionToken'));
     },
 
+    /**
+     * Destroy the account, remove it from the server
+     */
+    destroy: function () {
+      var self = this;
+      return self._fxaClient.deleteAccount(
+        self.get('email'),
+        self.get('password')
+      )
+      .then(function () {
+        self.trigger('destroy', self);
+      });
+    },
+
     saveGrantedPermissions: function (clientId, clientPermissions) {
       var permissions = this.get('grantedPermissions') || {};
       permissions[clientId] = clientPermissions;

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -183,6 +183,26 @@ define(function (require, exports, module) {
       this._storage.set('accounts', accounts);
     },
 
+    /**
+     * Delete the account from the server, notify all interested parties,
+     * delete the account from storage.
+     *
+     * @param {object} accountData
+     * @return {promise}
+     */
+    deleteAccount: function (accountData) {
+      var self = this;
+      var account = self.initAccount(accountData);
+
+      return account.destroy()
+        .then(function () {
+          self.removeAccount(account);
+          self._notifier.triggerAll(self._notifier.EVENTS.DELETE, {
+            uid: account.get('uid')
+          });
+        });
+    },
+
     // Stores a new account and sets it as the current account.
     setSignedInAccount: function (accountData) {
       var self = this;

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -298,6 +298,48 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('signOut', function () {
+      beforeEach(function () {
+        sinon.stub(fxaClient, 'signOut', function () {
+          return p();
+        });
+
+        account.set('sessionToken', SESSION_TOKEN);
+
+        return account.signOut();
+      });
+
+      it('calls the correct fxaClient method', function () {
+        assert.isTrue(fxaClient.signOut.calledOnce);
+        assert.isTrue(fxaClient.signOut.calledWith(SESSION_TOKEN));
+      });
+    });
+
+    describe('destroy', function () {
+      beforeEach(function () {
+        sinon.stub(fxaClient, 'deleteAccount', function () {
+          return p();
+        });
+
+        sinon.spy(account, 'trigger');
+
+        account.set({
+          email: EMAIL,
+          password: PASSWORD
+        });
+
+        return account.destroy();
+      });
+
+      it('calls the correct fxaClient method', function () {
+        assert.isTrue(fxaClient.deleteAccount.calledWith(EMAIL, PASSWORD));
+      });
+
+      it('triggers a `destroy` message when complete', function () {
+        assert.isTrue(account.trigger.calledWith('destroy', account));
+      });
+    });
+
     describe('createOAuthToken', function () {
       var accessToken = 'access token';
 


### PR DESCRIPTION
Builds on https://github.com/mozilla/fxa-content-server/pull/3317 and should be reviewed afterwards.

@philbooth, @zaach - r?