### PR TITLE
feat(sass): show a spinner while loading a ProfileImage

### DIFF
--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -10,8 +10,11 @@ define(function (require, exports, module) {
   var _ = require('underscore');
   var AuthErrors = require('lib/auth-errors');
   var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
   var ProfileErrors = require('lib/profile-errors');
   var ProfileImage = require('models/profile-image');
+
+  var MAX_SPINNER_COMPLETE_TIME = 400; // ms
 
   var Mixin = {
     notifications: {
@@ -22,16 +25,30 @@ define(function (require, exports, module) {
       // implement in view
     },
 
-    displayAccountProfileImage: function (account, wrapperClass) {
+    /**
+     * Adds a profile image for the account to the view, or a default image
+     * if none is available.
+     *
+     * @param {object} account - The account whose profile image will be shown.
+     * @param {object} [options]
+     *   @param {string} [options.wrapperClass] - The class for the element into
+     *                 which the profile image will be inserted.
+     *   @param {boolean} [options.spinner] - When true, show a spinner while
+     *                    the profile image is loading.
+     */
+    displayAccountProfileImage: function (account, options) {
+      options = options || {};
+
+      var avatarWrapperEl = this.$(options.wrapperClass || '.avatar-wrapper');
       var self = this;
-      if (! wrapperClass) {
-        wrapperClass = '.avatar-wrapper';
-      }
+      var spinnerEl;
 
       // We'll optimize the UI for the case that the account
       // doesn't have a profile image if it's not cached
       if (self._shouldShowDefaultProfileImage(account)) {
-        self.$(wrapperClass).addClass('with-default');
+        avatarWrapperEl.addClass('with-default');
+      } else if (options.spinner) {
+        spinnerEl = self._addLoadingSpinner(avatarWrapperEl);
       }
 
       return account.fetchCurrentProfileImage()
@@ -49,16 +66,24 @@ define(function (require, exports, module) {
           // default image if displayed
           return new ProfileImage();
         })
+        .fin(function () {
+          if (typeof spinnerEl !== 'undefined') {
+            return self._completeLoadingSpinner(spinnerEl);
+          }
+        })
         .then(function (profileImage) {
           self._displayedProfileImage = profileImage;
+          avatarWrapperEl.find(':not(.avatar-spinner)').remove();
 
           if (profileImage.isDefault()) {
-            self.$(wrapperClass).addClass('with-default');
-            self.$(wrapperClass).html('<span></span>');
+            avatarWrapperEl
+              .addClass('with-default')
+              .append('<span></span>');
             self.logViewEvent('profile_image_not_shown');
           } else {
-            self.$(wrapperClass).removeClass('with-default');
-            self.$(wrapperClass).html(profileImage.get('img'));
+            avatarWrapperEl
+              .removeClass('with-default')
+              .append($(profileImage.get('img')).addClass('profile-image'));
             self.logViewEvent('profile_image_shown');
           }
         });
@@ -79,6 +104,38 @@ define(function (require, exports, module) {
 
     _shouldShowDefaultProfileImage: function (account) {
       return ! account.has('profileImageUrl');
+    },
+
+    _addLoadingSpinner: function (spinnerWrapperEl) {
+      return $('<span class="avatar-spinner"></span>').appendTo(spinnerWrapperEl.addClass('with-spinner'));
+    },
+
+    // "Completes" the spinner, transitioning the semi-circle to a circle, and
+    // then removes the spinner element.
+    _completeLoadingSpinner: function (spinnerEl) {
+      var deferred = p.defer();
+      spinnerEl
+        .addClass('completed')
+        .on('transitionend', function (event) {
+          // The first transitionend event will resolve the promise, but the spinner will have
+          // subsequent transitions, so we'll also hook on the transitionend event of the
+          // ::after pseudoelement, which "expands" to hide the spinner.
+          deferred.resolve();
+
+          if (event.originalEvent && event.originalEvent.pseudoElement === '::after') {
+            spinnerEl.remove();
+          }
+        });
+
+      // Always resolve and remove the spinner after MAX_SPINNER_COMPLETE_TIME,
+      // in case we don't receive the expected transitionend events, such as in
+      // the case of IE.
+      this.setTimeout(function transitionMaxTime () {
+        deferred.resolve();
+        spinnerEl.remove();
+      }, MAX_SPINNER_COMPLETE_TIME);
+
+      return deferred.promise;
     },
 
     logAccountImageChange: function (account) {

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
 
     afterVisible: function () {
       FormView.prototype.afterVisible.call(this);
-      return this.displayAccountProfileImage(this.getAccount());
+      return this.displayAccountProfileImage(this.getAccount(), { spinner: true });
     },
 
     beforeDestroy: function () {

--- a/app/styles/_modules.scss
+++ b/app/styles/_modules.scss
@@ -12,6 +12,7 @@
 @import 'modules/legal';
 @import 'modules/spinner';
 @import 'modules/avatar';
+@import 'modules/avatar_spinner';
 @import 'modules/cropper';
 @import 'modules/graphic';
 @import 'modules/marketing';

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -63,6 +63,8 @@ $settings-ui-height: 630px;
 
 //Avatar Variables
 $avatar-size: 240px;
+$avatar-spinner-color: #c3cfd8;
+$profile-image-fade-in-duration: 150ms;
 
 // The Firefox logo
 $fox-logo-zindex: 999;

--- a/app/styles/modules/_avatar_spinner.scss
+++ b/app/styles/modules/_avatar_spinner.scss
@@ -1,0 +1,107 @@
+.avatar-spinner {
+  $arc-width: 3%; // Percent that the center overlay should be shrunk by, revealing the spinner band.
+  $center-expand-delay: 200ms;
+  $center-expand-duration: 200ms;
+  $complete-duration: 200ms;
+  $fade-in-delay: 200ms;
+  $fade-in-duration: 200ms;
+  $rotation-period: 2s; // Time for the spinner to make a single rotation
+  $solid-part-width: 75%;
+
+  @extend %fill-avatar;
+
+  // Fade in the spinner, to try to reduce flash, in addition to its
+  // continual rotation.
+  animation: $rotation-period linear infinite spin,
+    $fade-in-duration linear 1 $fade-in-delay both fadein;
+
+  // The spinner is comprised of a background section covering the left portion
+  // of the element, and an inset box shadow emanating from the bottom left.
+  background: {
+    color: $content-background-color;
+    image: linear-gradient($avatar-spinner-color, $avatar-spinner-color);
+    position: left;
+    repeat: no-repeat;
+    size: $solid-part-width 100%;
+  }
+  box-shadow: inset $avatar-size/8 $avatar-size/-8 $avatar-size/16 $avatar-spinner-color;
+  left: 0;
+  opacity: 1;
+  position: absolute;
+  top: 0;
+
+  // Hack: Some browsers (IE most notably) don't trigger transitionend events on
+  // pseudoelements, so we need a transition on the "base" element, which will
+  // emit the necessary transitionend event.
+  transition: {
+    duration: $complete-duration;
+    property: opacity;
+  }
+
+  &.completed {
+    // Keep the spinner spinning, but don't let it fade out again
+    animation-play-state: running, paused;
+    opacity: 0.999;
+  }
+
+  &::before {
+    @extend %fill-avatar;
+
+    // A second solid background, comprised of the left 75% of the element,
+    // overlaid upon the top of the underlying first, used to advance the "head"
+    // of the spinner when it completes.
+    background: {
+      image: linear-gradient($avatar-spinner-color, $avatar-spinner-color);
+      position: left;
+      repeat: no-repeat;
+      size: $solid-part-width 100%;
+    }
+    content: '';
+    position: relative;
+    // When the spinner completes, this pseudoelement spins clockwise,
+    // making the ring 100% solid
+    transform: rotate(0.001deg);
+    transition: {
+      duration: $complete-duration;
+      property: transform;
+      timing-function: cubic-bezier(0.6, 0.04, 0.98, 0.335); // easeInCirc
+    }
+  }
+  &.completed::before {
+    transform: rotate(90deg);
+  }
+
+  &::after {
+    // Overlay a slightly-smaller circle of the background color over the
+    // element, so it appears as a ring
+    @extend %fill-avatar;
+    background-color: $content-background-color;
+    content: '';
+    left: 0;
+    position: absolute;
+    top: 0;
+    transform: scale(1 - $arc-width / 100%);
+    transition: {
+      delay: $center-expand-delay;
+      duration: $center-expand-duration;
+      property: transform;
+      timing-function: ease-in-out;
+    }
+  }
+  &.completed::after {
+    transform: scale(1.001);
+  }
+}
+
+%fill-avatar {
+  border-radius: 50%;
+  display: inline-block;
+  height: 100%;
+  width: 100%;
+}
+
+.with-spinner .profile-image {
+  @extend %fill-avatar;
+  animation: $profile-image-fade-in-duration ease-in-out 1 both fadein;
+  position: relative;
+}


### PR DESCRIPTION
Fixes #3277 . When the SignIn view is waiting for a ProfileImage to load, fade in an `avatar-spinner` element. When the image is done loading, "complete" the spinner, and remove it.

Although the AvatarMixin is used in a number of places, to keep the scope small for this, I've only enabled this for the SignIn view (by way of the `showSpinner` argument in `displayAccountProfileImage`).

![spinner](https://cloud.githubusercontent.com/assets/47222/11804367/1d277ff4-a2b8-11e5-8e24-dc8a373ae508.gif)

@ryanfeeley r?