### PR TITLE
fix(client): fx-desktop-v2 broker halts before signup confirmation poll.

### DIFF
--- a/app/scripts/models/auth_brokers/first-run.js
+++ b/app/scripts/models/auth_brokers/first-run.js
@@ -11,12 +11,12 @@ define(function (require, exports, module) {
   'use strict';
 
   var _ = require('underscore');
-  var FxDesktopV2AuthenticationBroker = require('models/auth_brokers/fx-desktop-v2');
+  var FxSyncWebChannelAuthenticationBroker = require('models/auth_brokers/fx-sync-web-channel');
   var HaltBehavior = require('views/behaviors/halt');
 
-  var proto = FxDesktopV2AuthenticationBroker.prototype;
+  var proto = FxSyncWebChannelAuthenticationBroker.prototype;
 
-  var FirstRunAuthenticationBroker = FxDesktopV2AuthenticationBroker.extend({
+  var FirstRunAuthenticationBroker = FxSyncWebChannelAuthenticationBroker.extend({
     _iframeCommands: {
       LOADED: 'loaded',
       LOGIN: 'login',

--- a/app/scripts/models/auth_brokers/fx-fennec-v1.js
+++ b/app/scripts/models/auth_brokers/fx-fennec-v1.js
@@ -11,13 +11,13 @@ define(function (require, exports, module) {
   'use strict';
 
   var _ = require('underscore');
-  var FxDesktopV2AuthenticationBroker = require('models/auth_brokers/fx-desktop-v2');
+  var FxSyncWebChannelAuthenticationBroker = require('models/auth_brokers/fx-sync-web-channel');
   var NavigateBehavior = require('views/behaviors/navigate');
   var p = require('lib/promise');
 
-  var proto = FxDesktopV2AuthenticationBroker.prototype;
+  var proto = FxSyncWebChannelAuthenticationBroker.prototype;
 
-  var FxFennecV1AuthenticationBroker = FxDesktopV2AuthenticationBroker.extend({
+  var FxFennecV1AuthenticationBroker = FxSyncWebChannelAuthenticationBroker.extend({
     type: 'fx-fennec-v1',
 
     commands: _.extend({}, proto.commands, {

--- a/app/scripts/models/auth_brokers/fx-sync-web-channel.js
+++ b/app/scripts/models/auth_brokers/fx-sync-web-channel.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A variant of the FxSync broker that communicates with the
+ * browser via WebChannels. Each command is prefixed with `fxaccounts:`
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var Constants = require('lib/constants');
+  var FxSyncAuthenticationBroker = require('./fx-sync');
+  var WebChannel = require('lib/channels/web');
+
+  var FxSyncWebChannelAuthenticationBroker = FxSyncAuthenticationBroker.extend({
+    type: 'fx-sync-web-channel',
+
+    commands: {
+      CAN_LINK_ACCOUNT: 'fxaccounts:can_link_account',
+      CHANGE_PASSWORD: 'fxaccounts:change_password',
+      DELETE_ACCOUNT: 'fxaccounts:delete_account',
+      LOADED: 'fxaccounts:loaded',
+      LOGIN: 'fxaccounts:login'
+    },
+
+    createChannel: function () {
+      var channel = new WebChannel(Constants.ACCOUNT_UPDATES_WEBCHANNEL_ID);
+      channel.initialize({
+        window: this.window
+      });
+
+      return channel;
+    }
+  });
+
+  module.exports = FxSyncWebChannelAuthenticationBroker;
+});
+

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -84,11 +84,11 @@ define(function (require, exports, module) {
     });
 
     describe('beforeSignUpConfirmationPoll', function () {
-      it('notifies the channel with `fxaccounts:login`, does not halt', function () {
+      it('notifies the channel with `fxaccounts:login`, halts by default', function () {
         return broker.beforeSignUpConfirmationPoll(account)
           .then(function (result) {
             assert.isTrue(channelMock.send.calledWith('fxaccounts:login'));
-            assert.isUndefined(result.halt);
+            assert.isTrue(result.halt);
           });
       });
     });

--- a/tests/functional/firstrun_sign_up.js
+++ b/tests/functional/firstrun_sign_up.js
@@ -87,7 +87,7 @@ define([
         .end()
         .closeCurrentWindow()
 
-        // switch back to the original window, it should not transition.
+        // switch back to the original window, it should transition.
         .switchToWindow('')
         .end()
 

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -110,7 +110,12 @@ define([
         .switchToWindow('')
         .end()
 
-        .findByCssSelector('#fxa-confirm-header')
+        // We do not expect the verification poll to occur. The poll
+        // will take a few seconds to complete if it erroneously occurs.
+        // Add an affordance just in case the poll happens unexpectedly.
+        .sleep(5000)
+
+        .then(FunctionalHelpers.visibleByQSA('#fxa-confirm-header'))
         .end();
     },
 

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -139,7 +139,12 @@ define([
         .switchToWindow('')
         .end()
 
-        .findByCssSelector('#fxa-confirm-header')
+        // We do not expect the verification poll to occur. The poll
+        // will take a few seconds to complete if it erroneously occurs.
+        // Add an affordance just in case the poll happens unexpectedly.
+        .sleep(5000)
+
+        .then(FunctionalHelpers.visibleByQSA('#fxa-confirm-header'))
         .end();
     }
   });


### PR DESCRIPTION
The FxDesktopV2 auth broker was used as the superclass to both the
firstrun and Fennec auth brokers, when all these brokers really
needed was a Sync auth broker that communicated via WebChannels.
When the FxDesktopV2 started to be used as a standalone broker,
its default behavior of doing the confirmation poll caused
incorrect behavior if the user signed up for Sync from
`about:preferences#sync` - the original tab would redirect to
`/signup_complete` briefly before the browser re-displayed
`about:preferences#sync`.

This work extracts an FxSyncWebChannel authentication broker that
defines no behaviors. FxDesktopV2, FxFennecV1 and Firstrun all
extend from this new module and set any expected behaviors.
FxDesktopV2 now halts before the signup confirmation poll.

fixes #3330

@vladikoff - mind an r?