### PR TITLE
fix(client): Fix the "back" button in CWTS when used in about:accounts.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -599,6 +599,30 @@ define(function (require, exports, module) {
       // immediately redirected
       var startPage = this._selectStartPage();
       var isSilent = !! startPage;
+
+      if (usePushState) {
+        // There was a change in Firefox where the initial page in
+        // about:accounts does not create a history entry and the
+        // previous history entry is `about:blank`. If the user signs up,
+        // goes to choose what to sync and then clicks "back",
+        // the screen does not transition.
+        //
+        // This replaces the `about:blank` entry with the current page when
+        // embedded in about:accounts, and if the user just loads
+        // accounts.firefox.com, it should effectively be a noOp.
+        //
+        // See #3329
+        try {
+          This._window.history.replaceState(
+              {}, document.title, this._window.location.href);
+        } catch (e) {
+          // This happens if the user refreshes
+          // about:accounts?action=signup. History is now botched. Should
+          // we present a message to the user "No way Jose"
+          // See #3335
+        }
+      }
+
       this._history.start({ pushState: usePushState, silent: isSilent });
       if (startPage) {
         this._router.navigate(startPage);


### PR DESCRIPTION
### DO NOT MERGE YET!

I think a Firefox patch is the proper solution for this, at least it would make fewer assumptions. CWTS on the web is only enabled in Fx 45, which is currently in Aurora. We still have time to fix this problem in Fx 45 and avoid this content server work around.

---------------------------

about:accounts loads FxA but prevents the first page from being added to
history. When the user clicks "back" in CWTS, the page goes to "about:blank",
which is interpreted as "/", which is then redirected to "/settings". The
call to history.pushState excepts w/ a SecurityError because "about:blank"
is a different domain to "/settings".

This PR seeds history to ensure the first page is available to go back to.

fixes #3329