### PR TITLE
refactor(client): Move some view based reset password logic to mixins/models.

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -465,6 +465,48 @@ define(function (require, exports, module) {
         .then(function () {
           device.destroy();
         });
+    },
+
+    /**
+     * Initiate a password reset
+     *
+     * @param {object} relier
+     * @param {object} [options]
+     * @param {string} [options.resume] resume token
+     * @returns {promise}
+     */
+    resetPassword: function (relier, options) {
+      options = options || {};
+
+      return this._fxaClient.passwordReset(
+        this.get('email'),
+        relier,
+        {
+          resume: options.resume
+        }
+      );
+    },
+
+    /**
+     * Retry a password reset
+     *
+     * @param {string} passwordForgotToken
+     * @param {object} relier
+     * @param {object} [options]
+     * @param {string} [options.resume] resume token
+     * @returns {promise}
+     */
+    retryResetPassword: function (passwordForgotToken, relier, options) {
+      options = options || {};
+
+      return this._fxaClient.passwordResetResend(
+        this.get('email'),
+        passwordForgotToken,
+        relier,
+        {
+          resume: options.resume
+        }
+      );
     }
   });
 

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
   var FormView = require('views/form');
   var Notifier = require('lib/channels/notifier');
   var PasswordMixin = require('views/mixins/password-mixin');
-  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  var PasswordResetMixin = require('views/mixins/password-reset-mixin');
   var ServiceMixin = require('views/mixins/service-mixin');
   var Template = require('stache!templates/complete_reset_password');
   var Url = require('lib/url');
@@ -159,22 +159,8 @@ define(function (require, exports, module) {
       var self = this;
       self.logViewEvent('resend');
       var email = self._verificationInfo.get('email');
-      return self.fxaClient.passwordReset(
-        email,
-        self.relier,
-        {
-          resume: self.getStringifiedResumeToken()
-        }
-      )
-      .then(function (result) {
-        self.navigate('confirm_reset_password', {
-          data: {
-            email: email,
-            passwordForgotToken: result.passwordForgotToken
-          }
-        });
-      })
-      .fail(self.displayError.bind(self));
+      return self.resetPassword(email)
+        .fail(self.displayError.bind(self));
     }
   });
 
@@ -182,7 +168,7 @@ define(function (require, exports, module) {
     View,
     FloatingPlaceholderMixin,
     PasswordMixin,
-    ResumeTokenMixin,
+    PasswordResetMixin,
     ServiceMixin
   );
 

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -11,8 +11,8 @@ define(function (require, exports, module) {
   var ConfirmView = require('views/confirm');
   var Notifier = require('lib/channels/notifier');
   var p = require('lib/promise');
+  var PasswordResetMixin = require('views/mixins/password-reset-mixin');
   var ResendMixin = require('views/mixins/resend-mixin');
-  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
   var ServiceMixin = require('views/mixins/service-mixin');
   var Session = require('lib/session');
   var Template = require('stache!templates/confirm_reset_password');
@@ -244,13 +244,9 @@ define(function (require, exports, module) {
       var self = this;
       self.logViewEvent('resend');
 
-      return self.fxaClient.passwordResetResend(
+      return self.retryResetPassword(
         self._email,
-        self._passwordForgotToken,
-        self.relier,
-        {
-          resume: self.getStringifiedResumeToken()
-        }
+        self._passwordForgotToken
       )
       .then(function () {
         self.displaySuccess();
@@ -274,8 +270,8 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     View,
+    PasswordResetMixin,
     ResendMixin,
-    ResumeTokenMixin,
     ServiceMixin
   );
 

--- a/app/scripts/views/mixins/password-reset-mixin.js
+++ b/app/scripts/views/mixins/password-reset-mixin.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+/**
+ * Provides reset password helper methods.
+ *
+ * Dependent on the ResumeTokenMixin which is automatically mixed-in.
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var _ = require('underscore');
+  var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+
+  module.exports = _.extend({
+    /**
+     * Initiate a password reset. If successful, redirects to
+     * `confirm_reset_password`.
+     *
+     * @param {email}
+     * @return {promise} - resolves with auth server response if successful.
+     */
+    resetPassword: function (email) {
+      var self = this;
+
+      var account = this.user.initAccount({ email: email });
+      return account.resetPassword(
+        self.relier,
+        {
+          resume: self.getStringifiedResumeToken()
+        }
+      )
+      .then(function (result) {
+        self.navigate('confirm_reset_password', {
+          clearQueryParams: true,
+          data: {
+            email: email,
+            passwordForgotToken: result.passwordForgotToken
+          }
+        });
+
+        return result;
+      });
+    },
+
+    /**
+     * Retry a password reset
+     *
+     * @param {string} email
+     * @param {string} passwordForgotToken
+     * @return {promise} - resolves with auth server response if successful.
+     */
+    retryResetPassword: function (email, passwordForgotToken) {
+      var self = this;
+
+      var account = this.user.initAccount({ email: email });
+      return account.retryResetPassword(
+        passwordForgotToken,
+        self.relier,
+        {
+          resume: self.getStringifiedResumeToken()
+        }
+      );
+    }
+  }, ResumeTokenMixin);
+});

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -1084,5 +1084,64 @@ define(function (require, exports, module) {
           fxaClient.deviceDestroy.calledWith(SESSION_TOKEN, 'device-1'));
       });
     });
+
+    describe('resetPassword', function () {
+      var relier;
+
+      beforeEach(function () {
+        account.set('email', EMAIL);
+
+        relier = {};
+
+        sinon.stub(fxaClient, 'passwordReset', function () {
+          return p();
+        });
+
+        return account.resetPassword(relier, {
+          resume: 'resume token'
+        });
+      });
+
+      it('delegates to the fxaClient', function () {
+        assert.isTrue(fxaClient.passwordReset.calledOnce);
+        assert.isTrue(fxaClient.passwordReset.calledWith(
+          EMAIL,
+          relier,
+          {
+            resume: 'resume token'
+          }
+        ));
+      });
+    });
+
+    describe('retryResetPassword', function () {
+      var relier;
+
+      beforeEach(function () {
+        account.set('email', EMAIL);
+
+        relier = {};
+
+        sinon.stub(fxaClient, 'passwordResetResend', function () {
+          return p();
+        });
+
+        return account.retryResetPassword('password forgot token', relier, {
+          resume: 'resume token'
+        });
+      });
+
+      it('delegates to the fxaClient', function () {
+        assert.isTrue(fxaClient.passwordResetResend.calledOnce);
+        assert.isTrue(fxaClient.passwordResetResend.calledWith(
+          EMAIL,
+          'password forgot token',
+          relier,
+          {
+            resume: 'resume token'
+          }
+        ));
+      });
+    });
   });
 });

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -374,39 +374,27 @@ define(function (require, exports, module) {
     });
 
     describe('resendResetEmail', function () {
-      it('redirects to /confirm_reset_password if auth server is happy', function () {
-        sinon.stub(view.fxaClient, 'passwordReset', function () {
-          return p(true);
+      it('delegates to the `resetPassword` method', function () {
+        sinon.stub(view, 'resetPassword', function () {
+          return p();
         });
-
-        sinon.stub(view, 'getStringifiedResumeToken', function () {
-          return 'resume token';
-        });
-
-        sinon.spy(view, 'navigate');
 
         return view.resendResetEmail()
-            .then(function () {
-              assert.isTrue(view.navigate.calledWith('confirm_reset_password'));
-              assert.isTrue(view.fxaClient.passwordReset.calledWith(
-                EMAIL,
-                relier,
-                {
-                  resume: 'resume token'
-                }
-              ));
-            });
+          .then(function () {
+            assert.isTrue(view.resetPassword.calledOnce);
+            assert.isTrue(view.resetPassword.calledWith(EMAIL));
+          });
       });
 
       it('shows server response as an error otherwise', function () {
-        sinon.stub(view.fxaClient, 'passwordReset', function () {
+        sinon.stub(view, 'resetPassword', function () {
           return p.reject(new Error('server error'));
         });
 
         return view.resendResetEmail()
-            .then(function () {
-              assert.equal(view.$('.error').text(), 'server error');
-            });
+          .then(function () {
+            assert.equal(view.$('.error').text(), 'server error');
+          });
       });
     });
   });

--- a/app/tests/spec/views/mixins/password-reset-mixin.js
+++ b/app/tests/spec/views/mixins/password-reset-mixin.js
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var assert = require('chai').assert;
+  var p = require('lib/promise');
+  var PasswordResetMixin = require('views/mixins/password-reset-mixin');
+  var sinon = require('sinon');
+
+  describe('views/mixins/password-reset-mixin', function () {
+    describe('interface', function () {
+      it('exports the `resetPassword` method', function () {
+        assert.isFunction(PasswordResetMixin.resetPassword);
+      });
+    });
+
+    describe('resetPassword', function () {
+      var account;
+      var email;
+      var relier;
+      var view;
+
+      beforeEach(function () {
+        account = {
+          resetPassword: sinon.spy(function () {
+            return p({ passwordForgotToken: 'password forgot token' });
+          })
+        };
+        email = 'testuser@testuser.com';
+
+        relier = {};
+
+        view = {
+          getStringifiedResumeToken: sinon.spy(function () {
+            return 'resume token';
+          }),
+          navigate: sinon.spy(),
+          relier: relier,
+          user: {
+            initAccount: sinon.spy(function (accountData) {
+              return account;
+            })
+          }
+        };
+
+        return PasswordResetMixin.resetPassword.call(view, email);
+      });
+
+      it('initiates an account and calls the expected account method', function () {
+        assert.isTrue(view.user.initAccount.calledWith({ email: email }));
+        assert.isTrue(account.resetPassword.calledWith(
+          relier,
+          {
+            resume: 'resume token'
+          }
+        ));
+      });
+
+      it('redirects to /confirm_reset_password if auth server is happy', function () {
+        assert.isTrue(view.navigate.calledWith('confirm_reset_password', {
+          clearQueryParams: true,
+          data: {
+            email: 'testuser@testuser.com',
+            passwordForgotToken: 'password forgot token'
+          }
+        }));
+      });
+    });
+
+    describe('retryResetPassword', function () {
+      var account;
+      var email;
+      var passwordForgotToken;
+      var relier;
+      var view;
+
+      beforeEach(function () {
+        account = {
+          retryResetPassword: sinon.spy(function () {
+            return p();
+          })
+        };
+        email = 'testuser@testuser.com';
+        passwordForgotToken = 'password forgot token';
+
+        relier = {};
+
+        view = {
+          getStringifiedResumeToken: sinon.spy(function () {
+            return 'resume token';
+          }),
+          navigate: sinon.spy(),
+          relier: relier,
+          user: {
+            initAccount: sinon.spy(function (accountData) {
+              return account;
+            })
+          }
+        };
+
+        return PasswordResetMixin.retryResetPassword.call(
+          view, email, passwordForgotToken);
+      });
+
+      it('initiates an account and calls the expected account method', function () {
+        assert.isTrue(view.user.initAccount.calledWith({ email: email }));
+        assert.isTrue(account.retryResetPassword.calledWith(
+          passwordForgotToken,
+          relier,
+          {
+            resume: 'resume token'
+          }
+        ));
+      });
+    });
+  });
+});

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -117,6 +117,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/service-mixin',
     '../tests/spec/views/mixins/settings-mixin',
     '../tests/spec/views/mixins/password-mixin',
+    '../tests/spec/views/mixins/password-reset-mixin',
     '../tests/spec/views/mixins/password-strength-mixin',
     '../tests/spec/views/mixins/avatar-mixin',
     '../tests/spec/views/mixins/back-mixin',


### PR DESCRIPTION
@philbooth - here's one of the refactors from the plane ride that I mentioned!

I'm not convinced a PasswordResetMixin is the best way to go, but it seemed like a reasonable step to consolidate code.

---------------------------------

* Part of the slow process of removing fxaClient interaction from views into the Account model.
* Create a PasswordResetMixin to extract password reset initiation logic so it can be shared.