### PR TITLE
fix(tests): add config to run latest with node 4.x as latest4.dev.lcip.org

### DIFF
--- a/tests/teamcity/latest4
+++ b/tests/teamcity/latest4
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+FXA_CONTENT_ROOT="https://latest4.dev.lcip.org/"
+FXA_AUTH_ROOT="https://latest4.dev.lcip.org/auth/v1"
+FXA_OAUTH_APP_ROOT="https://123done-latest4.dev.lcip.org/"
+FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done-latest4.dev.lcip.org/"


### PR DESCRIPTION
Just a config file for a server yet to be built (working on that). Going to skip r= for this.