### PR TITLE
fix(client): focus first input in choose_what_to_sync

### DIFF
--- a/app/scripts/templates/choose_what_to_sync.mustache
+++ b/app/scripts/templates/choose_what_to_sync.mustache
@@ -18,7 +18,7 @@
             {{#hasTabSupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="tabs">
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="tabs" autofocus>
               <span class="fxa-checkbox__label">
                 {{#t}}Tabs{{/t}}
               </span>
@@ -29,7 +29,7 @@
             {{#hasBookmarkSupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="bookmarks">
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="bookmarks"{{^hasTabSupport}} autofocus{{/hasTabSupport}}>
               <span class="fxa-checkbox__label">
                 {{#t}}Bookmarks{{/t}}
               </span>
@@ -40,7 +40,7 @@
             {{#hasDesktopAddonSupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="addons">
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="addons"{{^hasTabSupport}}{{^hasBookmarkSupport}} autofocus{{/hasBookmarkSupport}}{{/hasTabSupport}}>
                 <span class="fxa-checkbox__label">
                   {{#t}}Add-ons{{/t}}
                 </span>
@@ -52,7 +52,7 @@
             {{#hasPasswordSupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="passwords">
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="passwords"{{^hasTabSupport}}{{^hasBookmarkSupport}}{{^hasDesktopAddonSupport}} autofocus{{/hasDesktopAddonSupport}}{{/hasBookmarkSupport}}{{/hasTabSupport}}>
               <span class="fxa-checkbox__label">
                 {{#t}}Passwords{{/t}}
               </span>
@@ -63,7 +63,7 @@
             {{#hasHistorySupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="history">
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="history"{{^hasTabSupport}}{{^hasBookmarkSupport}}{{^hasDesktopAddonSupport}}{{^hasPasswordSupport}} autofocus{{/hasPasswordSupport}}{{/hasDesktopAddonSupport}}{{/hasBookmarkSupport}}{{/hasTabSupport}}>
               <span class="fxa-checkbox__label">
                 {{#t}}History{{/t}}
               </span>
@@ -74,7 +74,7 @@
             {{#hasDesktopPreferencesSupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="prefs">
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="prefs"{{^hasTabSupport}}{{^hasBookmarkSupport}}{{^hasDesktopAddonSupport}}{{^hasPasswordSupport}}{{^hasDesktopPreferencesSupport}} autofocus{{/hasDesktopPreferencesSupport}}{{/hasPasswordSupport}}{{/hasDesktopAddonSupport}}{{/hasBookmarkSupport}}{{/hasTabSupport}}>
                 <span class="fxa-checkbox__label">
                   {{#t}}Preferences{{/t}}
                 </span>

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -66,6 +66,22 @@ define([
         .findByCssSelector('#fxa-choose-what-to-sync-header')
         .end()
 
+        // test that autofocus attribute has been applied sanely
+        .findByTagName('input')
+          .getAttribute('autofocus')
+          .then(function (value) {
+            assert.strictEqual(value, '');
+          })
+        .end()
+        .findAllByXpath('(//input)[position()>1]')
+          .getAttribute('autofocus')
+          .then(function (values) {
+            values.forEach(function (value) {
+              assert.isNull(value);
+            });
+          })
+        .end()
+
         // uncheck the passwords and history engines
         .findByCssSelector('input[value="passwords"]')
           .click()


### PR DESCRIPTION
Fixes #3339.

I took the approach of adding an `autofocus` attribute to the first input in the form as it felt like a problem that should be fixed in the template rather than in the view script. However, because of all the conditions in that form, doing so has led to an ugly string of nested `{{^condition}}` thingies as the form progresses. So maybe there's a cleaner way to tackle this?

@vladikoff, r?