### PR TITLE
fix(tests): allow unset value of GIT_COMMIT

### DIFF
--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -4,7 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-set -o nounset
 set -o errexit # exit on first command with non-zero status
 
 BASENAME=$(basename $0)

--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -4,7 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-set -o nounset
 set -o errexit # exit on first command with non-zero status
 
 BASENAME=$(basename $0)


### PR DESCRIPTION
r? - @vladikoff - oops, sorry. My previous change broke latest where GIT_COMMIT was unset. So this just removes the `nounset` directive. (I could fix this more "correctly" than just removing that restriction, but I don't think that directive added a lot of value anyways).

p.s., I might just merge this anyways, since tests on latest are broken now o_O