### PR TITLE
feat(config): Add a /.well-known/fxa-client-configuration endpoint

### DIFF
--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -34,7 +34,8 @@ module.exports = function (config, i18n) {
     require('./routes/get-metrics-errors')(),
     require('./routes/get-openid-login')(config),
     require('./routes/get-openid-authenticate')(config),
-    require('./routes/get-openid-configuration')(config)
+    require('./routes/get-openid-configuration')(config),
+    require('./routes/get-fxa-client-configuration')(config)
   ];
 
   function addVersionPrefix(unversionedUrl) {

--- a/server/lib/routes/get-fxa-client-configuration.js
+++ b/server/lib/routes/get-fxa-client-configuration.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (config) {
+  var route = {};
+  route.method = 'get';
+  route.path = '/.well-known/fxa-client-configuration';
+
+  var fxaClientConfig = {
+    /*eslint-disable camelcase */
+    auth_server_endpoint: config.get('fxaccount_url') + '/v1',
+    oauth_server_endpoint: config.get('oauth_url') + '/v1',
+    profile_server_endpoint: config.get('profile_url') + '/v1',
+  };
+
+  route.process = function (req, res) {
+
+    // These values houldn't change often, but might occasionally.
+    res.header('Cache-Control', 'public, max-age=3600');
+
+    // charset must be set on json responses.
+    res.charset = 'utf-8';
+
+    res.json(fxaClientConfig);
+  };
+
+  return route;
+};

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -24,6 +24,7 @@ define([
   };
 
   var routes = {
+    '/.well-known/fxa-client-configuration': { statusCode: 200 },
     '/.well-known/openid-configuration': { statusCode: 200 },
     '/account_unlock_complete': { statusCode: 200 },
     '/cannot_create_account': { statusCode: 200 },


### PR DESCRIPTION
The new `/.well-known/openid-configuration` has proven a big hit with client implements [1] but it doesn't include all the endpoints necessary for a Firefox device to bootstrap itself into talking to our servers.  Rather than add additional fxa-specific keys in an otherwise spec-driven config document, what if we added a parallel config file that's specifically for rich clients that talk our various custom protocols?

It might look like this:

```
$ wget -q -O - https://accounts.firefox.com/.well-known/fxa-client-configuration
{
  "auth_server_endpoint": "https://api.accounts.firefox.com/v1",
  "oauth_server_endpoint": "https://oauth.accounts.firefox.com/v1",
  "profile_server_endpoint": "https://profile.accounts.firefox.com/v1"
}
```

Like the OIDC discovery document, it would allow you to specify a single base URL of "my FxA instance is at https://accounts.firefox.com" and discover all the other endpoints you need to know from there.  Also like the OIDC discovery document, it doesn't contain any provisions for namespacing or versioning or discovery of other arbitrary services or any of the other rabbit-holes that have prevented us from shipping this sort of thing in the past.  It's a simple JSON blob to make a small but real difference to easy of client implementations.

Unlike the OIDC discovery document, it hands out server root URLs and lets the client construct sub-paths that it needs, rather than including a separate key for each possible operation within the protocol.  Our clients do this already, so it matches their behaviour, so meh.

It also doesn't specify the sync tokenserver URL or the location of any other identity-attached services.  The fxa-content-server doesn't currently need to know these locations and I'd prefer it to stay that way, but might be talked out of it in the specific case of sync.

/cc @ncalexan; @shane-tomlinson r?

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1237406