### PR TITLE
fix(tests): Fix the communication preferences tests.

### DIFF
--- a/app/scripts/templates/settings/communication_preferences.mustache
+++ b/app/scripts/templates/settings/communication_preferences.mustache
@@ -1,4 +1,4 @@
-<div id="communication-preferences" class="settings-unit{{#isPanelOpen}} open{{/isPanelOpen}}">
+<div id="communication-preferences" class="settings-unit{{#isPanelOpen}} open{{/isPanelOpen}} {{#isBasketReady}}basket-ready{{/isBasketReady}}">
   <div class="settings-unit-stub">
     <header class="settings-unit-summary">
       <h2 class="settings-unit-title">{{#t}}Communication preferences{{/t}}</h2>

--- a/app/tests/spec/views/settings/communication_preferences.js
+++ b/app/tests/spec/views/settings/communication_preferences.js
@@ -92,7 +92,11 @@ define(function (require, exports, module) {
     });
 
     describe('render', function () {
-      it('renders opted-in user corrected', function () {
+      it('adds the `basket-ready` class to the `#communications-preferences` element', function () {
+        assert.lengthOf(view.$('#communication-preferences.basket-ready'), 1);
+      });
+
+      it('renders opted-in user correctly', function () {
         sinon.stub(emailPrefsModel, 'isOptedIn', function () {
           return true;
         });

--- a/tests/functional/email_opt_in.js
+++ b/tests/functional/email_opt_in.js
@@ -87,7 +87,7 @@ define([
           return self.remote.get(require.toUrl(verificationLink));
         })
 
-        .findByCssSelector('#fxa-settings-header')
+        .findByCssSelector('#communication-preferences.basket-ready')
         .end()
 
         .then(waitForBasket(email))
@@ -119,7 +119,7 @@ define([
           return self.remote.get(require.toUrl(verificationLink));
         })
 
-        .findByCssSelector('#fxa-settings-header')
+        .findByCssSelector('#communication-preferences.basket-ready')
         .end()
 
         .then(waitForBasket(email))
@@ -139,7 +139,7 @@ define([
         // ensure the changes stick across refreshes
         .refresh()
 
-        .findByCssSelector('#fxa-settings-header')
+        .findByCssSelector('#communication-preferences.basket-ready')
         .end()
 
         .then(FunctionalHelpers.visibleByQSA('#communication-preferences .settings-unit-details'))
@@ -155,7 +155,7 @@ define([
         // ensure the opt-out sticks across refreshes
         .refresh()
 
-        .findByCssSelector('#fxa-settings-header')
+        .findByCssSelector('#communication-preferences.basket-ready')
         .end()
 
         .findByCssSelector('#communication-preferences .settings-unit-toggle')
@@ -184,7 +184,7 @@ define([
           return self.remote.get(require.toUrl(verificationLink));
         })
 
-        .findByCssSelector('#fxa-settings-header')
+        .findByCssSelector('#communication-preferences.basket-ready')
         .end()
 
         .findByCssSelector('#communication-preferences .settings-unit-toggle')
@@ -213,7 +213,7 @@ define([
         // ensure the opt-in sticks across refreshes
         .refresh()
 
-        .findByCssSelector('#fxa-settings-header')
+        .findByCssSelector('#communication-preferences.basket-ready')
         .end()
 
         .findByCssSelector('#communication-preferences .settings-unit-toggle')


### PR DESCRIPTION
PR #3088 sped up the rendering of the settings page but introduced
a regression in the communication preferences tests. Communication
preferences are re-rendered after an XHR request to Basket is made
to check whether the user has opted in to email communcations. The
Selenium tests moved to quickly and clicked the "open panel" button
using an element that was sometimes no longer in the DOM (sometimes meaning
sometimes the response to basket took a while and the prefs opened,
other times basket finished early and Selenium's reference was stale).

This PR fixes this by adding a `basket-ready` class to the
`#communication-preferences` element when rendering is complete.
Selenium looks for this class name, and then continues.

fixes #3357

@philbooth or @vladikoff - r?