### PR TITLE
refactor(client): Better Account field sandboxing

### DIFF
--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -92,8 +92,7 @@ define(function (require, exports, module) {
         return accountData;
       }
 
-      return new Account({
-        accountData: accountData,
+      return new Account(accountData, {
         assertion: this._assertion,
         fxaClient: this._fxaClient,
         marketingEmailClient: this._marketingEmailClient,
@@ -188,13 +187,14 @@ define(function (require, exports, module) {
      * delete the account from storage.
      *
      * @param {object} accountData
-     * @return {promise}
+     * @param {string} password - the user's password
+     * @return {promise} - resolves when complete
      */
-    deleteAccount: function (accountData) {
+    deleteAccount: function (accountData, password) {
       var self = this;
       var account = self.initAccount(accountData);
 
-      return account.destroy()
+      return account.destroy(password)
         .then(function () {
           self.removeAccount(account);
           self._notifier.triggerAll(self._notifier.EVENTS.DELETE, {
@@ -288,9 +288,18 @@ define(function (require, exports, module) {
         Session.cachedCredentials.email !== Session.email));
     },
 
-    signInAccount: function (account, relier, options) {
+    /**
+     * Sign in an account
+     *
+     * @param {object} account - account to sign in
+     * @param {string} password - the user's password
+     * @param {object} relier - relier being signed in to
+     * @param {object} [options] - options
+     * @returns {promise} - resolves when complete
+     */
+    signInAccount: function (account, password, relier, options) {
       var self = this;
-      return account.signIn(relier, options)
+      return account.signIn(password, relier, options)
         .then(function () {
           // If there's an account with the same uid in localStorage we merge
           // its attributes with the new account instance to retain state
@@ -311,9 +320,18 @@ define(function (require, exports, module) {
         });
     },
 
-    signUpAccount: function (account, relier, options) {
+    /**
+     * Sign up a new account
+     *
+     * @param {object} account - account to sign up
+     * @param {string} password - the user's password
+     * @param {object} relier - relier being signed in to
+     * @param {object} [options] - options
+     * @returns {promise} - resolves when complete
+     */
+    signUpAccount: function (account, password, relier, options) {
       var self = this;
-      return account.signUp(relier, options)
+      return account.signUp(password, relier, options)
         .then(function () {
           return self.setSignedInAccount(account);
         });
@@ -340,9 +358,19 @@ define(function (require, exports, module) {
         });
     },
 
-    completeAccountPasswordReset: function (account, token, code, relier) {
+    /**
+     * Complete a password reset for the account
+     *
+     * @param {object} account - account to sign up
+     * @param {string} password - the user's new password
+     * @param {string} token - email verification token
+     * @param {string} code - email verification code
+     * @param {object} relier - relier being signed in to
+     * @returns {promise} - resolves when complete
+     */
+    completeAccountPasswordReset: function (account, password, token, code, relier) {
       var self = this;
-      return account.completePasswordReset(token, code, relier)
+      return account.completePasswordReset(password, token, code, relier)
         .then(function () {
           return self.setSignedInAccount(account);
         });

--- a/app/scripts/views/complete_account_unlock.js
+++ b/app/scripts/views/complete_account_unlock.js
@@ -37,7 +37,6 @@ define(function (require, exports, module) {
         .then(function () {
           self.logViewEvent('verification.success');
           var account = self.user.initAccount({
-            code: code,
             uid: uid
           });
 

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -105,12 +105,12 @@ define(function (require, exports, module) {
       // reset password complete poll completes in the original tab,
       // it will fetch the sessionToken from localStorage and go to town.
       var account = self.user.initAccount({
-        email: email,
-        password: password
+        email: email
       });
 
       return self.user.completeAccountPasswordReset(
           account,
+          password,
           token,
           code,
           self.relier

--- a/app/scripts/views/confirm_account_unlock.js
+++ b/app/scripts/views/confirm_account_unlock.js
@@ -43,6 +43,12 @@ define(function (require, exports, module) {
         if (data.account) {
           accountData = data.account;
         }
+
+        // The password is needed to poll whether the user has
+        // unlocked their account.
+        if (data.password) {
+          this._password = data.password;
+        }
       }
 
       this._account = this.user.initAccount(accountData);
@@ -119,7 +125,7 @@ define(function (require, exports, module) {
       var self = this;
       var account = self.getAccount();
       var email = account.get('email');
-      var password = account.get('password');
+      var password = this._password;
 
       // try to sign the user in using the email/password that caused the
       // account to be locked. If the user has verified their email address,

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -67,19 +67,21 @@ define(function (require, exports, module) {
 
     submit: function () {
       var account = this.user.initAccount({
-        email:  this.relier.get('email'),
-        password: this.$('.password').val()
+        email:  this.relier.get('email')
       });
 
-      return this._signIn(account);
+      var password = this.getElementValue('.password');
+
+      return this._signIn(account, password);
     },
 
-    onSignInError: function (account, err) {
+    onSignInError: function (account, password, err) {
       if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
         // dead end, do not allow the user to sign up.
         this.displayError(err);
       } else {
-        return SignInView.prototype.onSignInError.call(this, account, err);
+        return SignInView.prototype.onSignInError.call(
+            this, account, password, err);
       }
     },
 

--- a/app/scripts/views/mixins/account-locked-mixin.js
+++ b/app/scripts/views/mixins/account-locked-mixin.js
@@ -24,8 +24,16 @@ define(function (require, exports, module) {
             BaseView.preventDefaultThen('sendAccountLockedEmail')
     },
 
-    notifyOfLockedAccount: function (account) {
+    /**
+     * Notify the user their account has been locked
+     *
+     * @param {object} account - account that has been locked
+     * @param {string} password - the user's password, used to poll if the
+     *   account has been unlocked
+     */
+    notifyOfLockedAccount: function (account, password) {
       this._lockedAccount = account;
+      this._password = password;
 
       var err = AuthErrors.toError('ACCOUNT_LOCKED');
       err.forceMessage = t('Account locked. <a href="/confirm_account_unlock">Send unlock email</a>');
@@ -33,9 +41,16 @@ define(function (require, exports, module) {
       return this.displayErrorUnsafe(err);
     },
 
+    /**
+     * Send the account locked email
+     *
+     * @returns {promise} - resolves when complete
+     */
     sendAccountLockedEmail: function () {
       var self = this;
       var account = self._lockedAccount;
+      var password = self._password;
+
       var email = account.get('email');
       self.logViewEvent('unlock-email.send');
       return self.fxaClient.sendAccountUnlockEmail(
@@ -50,7 +65,10 @@ define(function (require, exports, module) {
         self.navigate('confirm_account_unlock', {
           data: {
             account: account,
-            lockoutSource: self.getViewName()
+            lockoutSource: self.getViewName(),
+            // the password is used by the confirm_account_unlock screen
+            // to determine whether the account has been unlocked.
+            password: password
           }
         });
       }, function (err) {

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -54,10 +54,7 @@ define(function (require, exports, module) {
           return self.render();
         }, function (err) {
           if (AuthErrors.is(err, 'ACCOUNT_LOCKED')) {
-            // the password is needed to poll whether the account has
-            // been unlocked.
-            account.set('password', oldPassword);
-            return self.notifyOfLockedAccount(account);
+            return self.notifyOfLockedAccount(account, oldPassword);
           }
 
           throw err;

--- a/app/scripts/views/settings/delete_account.js
+++ b/app/scripts/views/settings/delete_account.js
@@ -34,9 +34,8 @@ define(function (require, exports, module) {
       var self = this;
       var account = self.getSignedInAccount();
       var password = self.getElementValue('.password');
-      account.set('password', password);
 
-      return self.user.deleteAccount(account)
+      return self.user.deleteAccount(account, password)
         .then(function () {
           Session.clear();
           return self.invokeBrokerMethod('afterDeleteAccount', account);
@@ -51,7 +50,7 @@ define(function (require, exports, module) {
           });
         }, function (err) {
           if (AuthErrors.is(err, 'ACCOUNT_LOCKED')) {
-            return self.notifyOfLockedAccount(account);
+            return self.notifyOfLockedAccount(account, password);
           }
 
           // re-throw error, it will be handled at a lower level.

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -282,12 +282,12 @@ define(function (require, exports, module) {
     _initAccount: function () {
       var self = this;
 
+      var password = self.getElementValue('.password');
       var preVerifyToken = self.relier.get('preVerifyToken');
       var account = self.user.initAccount({
         customizeSync: self.$('.customize-sync').is(':checked'),
         email: self.getElementValue('.email'),
-        needsOptedInToMarketingEmail: self.$('.marketing-email-optin').is(':checked'),
-        password: self.getElementValue('.password')
+        needsOptedInToMarketingEmail: self.$('.marketing-email-optin').is(':checked')
       });
 
       if (preVerifyToken) {
@@ -305,7 +305,7 @@ define(function (require, exports, module) {
 
       return self.invokeBrokerMethod('beforeSignIn', account.get('email'))
         .then(function () {
-          return self.user.signUpAccount(account, self.relier, {
+          return self.user.signUpAccount(account, password, self.relier, {
             resume: self.getStringifiedResumeToken()
           });
         })

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -205,7 +205,6 @@ define(function (require, exports, module) {
           customizeSync: true,
           declinedSyncEngines: ['bookmarks', 'passwords'],
           keyFetchToken: 'key_fetch_token',
-          notSent: 'not_sent',
           sessionToken: 'session_token',
           sessionTokenContext: 'sync',
           uid: 'uid',
@@ -258,7 +257,6 @@ define(function (require, exports, module) {
         account.set({
           customizeSync: true,
           keyFetchToken: 'key_fetch_token',
-          notSent: 'not_sent',
           sessionToken: 'session_token',
           sessionTokenContext: 'sync',
           uid: 'uid',
@@ -276,7 +274,6 @@ define(function (require, exports, module) {
             assert.equal(args[1].unwrapBKey, 'unwrap_b_key');
             assert.equal(args[1].customizeSync, true);
             assert.equal(args[1].verified, true);
-            assert.isFalse('notSent' in args[1]);
             assert.isUndefined(args[1].sessionTokenContext);
           });
       });

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -317,27 +317,34 @@ define(function (require, exports, module) {
             });
       });
 
-      it('direct access signs the user in and redirects to `/settings` if broker does not say halt', function () {
-        view.$('[type=password]').val(PASSWORD);
+      describe('direct access', function () {
+        var account;
 
-        sinon.stub(fxaClient, 'signIn', function () {
-          return p(ACCOUNT_DATA);
-        });
-        sinon.stub(fxaClient, 'completePasswordReset', function () {
-          return p(true);
-        });
-        sinon.stub(user, 'setSignedInAccount', function (newAccount) {
-          return p(newAccount);
-        });
-        sinon.stub(relier, 'isDirectAccess', function () {
-          return true;
-        });
-        sinon.spy(view, 'navigate');
+        beforeEach(function () {
+          view.$('[type=password]').val(PASSWORD);
 
-        return view.validateAndSubmit()
-          .then(function () {
-            assert.isTrue(view.navigate.calledWith('settings'));
+          sinon.stub(user, 'completeAccountPasswordReset', function (_account) {
+            account = _account;
+            return p(account);
           });
+
+          sinon.stub(relier, 'isDirectAccess', function () {
+            return true;
+          });
+
+          sinon.spy(view, 'navigate');
+
+          return view.validateAndSubmit();
+        });
+
+        it('delegates to the user model', function () {
+          assert.isTrue(user.completeAccountPasswordReset.calledWith(
+            account, PASSWORD, TOKEN, CODE, relier));
+        });
+
+        it('redirects the user to `/settings`', function () {
+          assert.isTrue(view.navigate.calledWith('settings'));
+        });
       });
 
       it('reload view to allow user to resend an email on INVALID_TOKEN error', function () {

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
         return view.submit()
           .then(function () {
             assert.equal(user.signUpAccount.args[0][0].get('email'), email);
-            assert.equal(user.signUpAccount.args[0][0].get('password'), 'password');
+            assert.equal(user.signUpAccount.args[0][1], 'password');
             assert.isTrue(view.navigate.calledWith('confirm'));
             assert.isTrue(TestHelpers.isEventLogged(metrics,
                               'oauth.signup.success'));
@@ -220,7 +220,7 @@ define(function (require, exports, module) {
           .then(function () {
             assert.isTrue(view.navigate.calledWith('confirm'));
             assert.equal(user.signUpAccount.args[0][0].get('email'), email);
-            assert.equal(user.signUpAccount.args[0][0].get('password'), password);
+            assert.equal(user.signUpAccount.args[0][1], password);
           });
       });
     });

--- a/app/tests/spec/views/settings/delete_account.js
+++ b/app/tests/spec/views/settings/delete_account.js
@@ -148,9 +148,9 @@ define(function (require, exports, module) {
             return view.submit();
           });
 
-          it('deletes the users account', function () {
+          it('delegates to the user model', function () {
             assert.isTrue(user.deleteAccount.calledOnce);
-            assert.isTrue(user.deleteAccount.calledWith(account));
+            assert.isTrue(user.deleteAccount.calledWith(account, password));
           });
 
           it('notifies the broker', function () {
@@ -177,21 +177,14 @@ define(function (require, exports, module) {
               return p.reject(AuthErrors.toError('ACCOUNT_LOCKED'));
             });
 
+            sinon.spy(view, 'notifyOfLockedAccount');
+
             return view.submit();
           });
 
-          it('shows error message to locked out users', function () {
-            assert.isTrue(view.isErrorVisible());
-            assert.include(view.$('.error').text().toLowerCase(), 'locked');
-          });
-
-          it('logs the error', function () {
-            var err = view._normalizeError(AuthErrors.toError('ACCOUNT_LOCKED'));
-            assert.isTrue(TestHelpers.isErrorLogged(metrics, err));
-          });
-
-          it('retains the password in the account to poll for account unlock', function () {
-            assert.isTrue(account.has('password'));
+          it('notifies the user of the locked account', function () {
+            assert.isTrue(
+              view.notifyOfLockedAccount.calledWith(account, password));
           });
         });
 

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -572,7 +572,7 @@ define(function (require, exports, module) {
 
             assert.equal(view.navigate.args[0][0], 'confirm');
             assert.isTrue(view.navigate.args[0][1].data.account.get('customizeSync'));
-            assert.isTrue(user.signUpAccount.calledWith(account, relier));
+            assert.isTrue(user.signUpAccount.calledWith(account, password, relier));
             assert.isTrue(TestHelpers.isEventLogged(metrics,
                               'signup.success'));
           });


### PR DESCRIPTION
* Only allow expected fields in the Accounts model
 * Unexpected fields cause a loud failure.
* Do not allow the password to be set on the Account to ensure it never leaks.
  * Instead pass the password into functions that require one.
* Convert the constructor to be called the Backbone way, with two parameters
  * The first parameter is the attributes, the second options.


I'd like to the same with the unwrapBKey and any other sensitive info.

issue #3366