### PR TITLE
fix(test): Fix the 'sign in with a second sign-in tab open' test.

### DIFF
--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -224,6 +224,9 @@ define([
       var self = this;
       return verifyUser(email, 0)
         .then(function () {
+          return FunctionalHelpers.openPage(self, PAGE_URL, '#fxa-signin-header');
+        })
+        .then(function () {
           return FunctionalHelpers.openSignInInNewTab(self, windowName);
         })
         .then(function () {


### PR DESCRIPTION
The 'sign in with a second sign-in tab open' functional test fails when run by
itself. The test assumes the first open tab is at the signin page, but when run
in standalone mode, it's not.

This fix opens the original tab to `/signin` to fulfill the assumption

fixes #3380

@philbooth - This is the fix we just worked out, mind an r?