### PR TITLE
Additional Dockerfile for self-hosting

### DIFF
--- a/docs/self-host.docker
+++ b/docs/self-host.docker
@@ -1,0 +1,16 @@
+FROM vladikoff/fxa-slim-image:latest
+
+RUN adduser --disabled-password --gecos '' fxa && adduser fxa sudo && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+COPY . /home/fxa/fxa-content-server
+WORKDIR /home/fxa/fxa-content-server
+RUN chown -R fxa .
+USER fxa
+RUN npm install --production \
+  && cp server/config/local.json-dist server/config/local.json \
+  && npm cache clear
+
+CMD npm run start-production
+
+# Expose ports
+EXPOSE 3030


### PR DESCRIPTION
The existing Dockerfile in this repo leads to the following error when you build and then run it:

> npm ERR! Error: EACCES, open 'npm-debug.log'

Despite https://github.com/mozilla/fxa-content-server/commit/4487573d2bdee55cfb50040d02aac6df1cf18a01#diff-04c6e90faac2675aa89e2176d2eec7d8 and https://github.com/mozilla/fxa-content-server/commit/4b2446441b6da3805cc7a03d98c1f0d7268a5b58#diff-04c6e90faac2675aa89e2176d2eec7d8R87 I assume that Dockerfile should stay in place for people who are using it for development, so I added the Dockerfile for self-hosting in the docs/ folder in this PR.