### PR TITLE
refactor(client): Further data sandboxing

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -202,11 +202,20 @@ define(function (require, exports, module) {
     },
 
     toJSON: function () {
-      return _.pick(this.attributes, ALLOWED_KEYS);
+      /*
+       * toJSON is explicitly disabled because it fetches all attributes
+       * on the model, making accidental data exposure easier than it
+       * should be. Use the [pick](http:*underscorejs.org/#pick) method
+       * instead, which requires a list of attributes to get.
+       *
+       * e.g.:
+       * var accountData = account.pick('email', 'uid');
+       */
+      throw new Error('toJSON is explicitly disabled, use `.pick` instead');
     },
 
     toPersistentJSON: function () {
-      return _.pick(this.attributes, ALLOWED_PERSISTENT_KEYS);
+      return this.pick(ALLOWED_PERSISTENT_KEYS);
     },
 
     setProfileImage: function (profileImage) {
@@ -375,6 +384,8 @@ define(function (require, exports, module) {
         code
       )
       .then(function () {
+        self.set('verified', true);
+
         if (self.get('needsOptedInToMarketingEmail')) {
           self.unset('needsOptedInToMarketingEmail');
           var emailPrefs = self.getMarketingEmailPrefs();

--- a/app/scripts/models/auth_brokers/fx-sync.js
+++ b/app/scripts/models/auth_brokers/fx-sync.js
@@ -11,7 +11,6 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var _ = require('underscore');
   var AuthErrors = require('lib/auth-errors');
   var BaseAuthenticationBroker = require('models/auth_brokers/base');
   var ChannelMixin = require('models/auth_brokers/mixins/channel');
@@ -216,11 +215,7 @@ define(function (require, exports, module) {
         'verified'
       ];
 
-      var loginData = {};
-      _.each(ALLOWED_FIELDS, function (field) {
-        loginData[field] = account.get(field);
-      });
-
+      var loginData = account.pick(ALLOWED_FIELDS);
       loginData.verified = !! loginData.verified;
       loginData.verifiedCanLinkAccount = !! this._verifiedCanLinkAccount;
       return loginData;

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -116,8 +116,6 @@ define(function (require, exports, module) {
           self.relier
         )
         .then(function (updatedAccount) {
-          self.notifier.triggerRemote(
-              Notifier.SIGNED_IN, updatedAccount.toJSON());
           // See the above note about notifying the original tab.
           self.logViewEvent('verification.success');
           return self.invokeBrokerMethod(

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -13,7 +13,6 @@ define(function (require, exports, module) {
   var FormView = require('views/form');
   var LoadingMixin = require('views/mixins/loading-mixin');
   var MarketingEmailErrors = require('lib/marketing-email-errors');
-  var Notifier = require('lib/channels/notifier');
   var ResendMixin = require('views/mixins/resend-mixin');
   var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
   var Url = require('lib/url');
@@ -67,7 +66,7 @@ define(function (require, exports, module) {
       }
 
       var code = verificationInfo.get('code');
-      return self.getAccount().verifySignUp(code)
+      return self.user.completeAccountSignUp(self.getAccount(), code)
           .fail(function (err) {
             if (MarketingEmailErrors.created(err)) {
               // A basket error should not prevent the
@@ -91,8 +90,6 @@ define(function (require, exports, module) {
           })
           .then(function () {
             var account = self.getAccount();
-
-            self.notifier.triggerRemote(Notifier.SIGNED_IN, account.toJSON());
 
             if (! self.relier.isDirectAccess()) {
               self.navigate('signup_complete');

--- a/app/scripts/views/mixins/signed-in-notification-mixin.js
+++ b/app/scripts/views/mixins/signed-in-notification-mixin.js
@@ -17,11 +17,8 @@ define(function (require, exports, module) {
 
     _navigateToSignedInView: function (event) {
       if (this.broker.hasCapability('handleSignedInNotification')) {
-        var self = this;
-        return this.user.setSignedInAccount(event)
-          .then(function () {
-            self.navigate(self._redirectTo || 'settings');
-          });
+        this.user.setSignedInAccountByUid(event.uid);
+        this.navigate(this._redirectTo || 'settings');
       }
 
       return p();

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -433,6 +433,10 @@ define(function (require, exports, module) {
         it('delegates to the fxaClient', function () {
           assert.isTrue(fxaClient.verifyCode.calledWith(UID, 'CODE'));
         });
+
+        it('sets the `verified` flag', function () {
+          assert.isTrue(account.get('verified'));
+        });
       });
 
       describe('with email opt-in', function () {
@@ -961,21 +965,13 @@ define(function (require, exports, module) {
       });
     });
 
-    it('toJSON returns data for the right keys', function () {
-      account = new Account({
-        email: EMAIL,
-        sessionToken: SESSION_TOKEN,
-        uid: UID
-      }, {
-        assertion: 'test'
+    describe('toJSON', function () {
+      it('is disabled and throws', function () {
+        // toJSOn is disabled to avoid unintentional data leaks. Use pick
+        assert.throws(function () {
+          account.toJSON();
+        });
       });
-
-      var data = account.toJSON();
-
-      assert.isUndefined(data.accountData);
-      assert.isUndefined(data.assertion);
-      assert.isUndefined(data.foo);
-      assert.ok(data.email);
     });
 
     it('toPersistentJSON returns data for the right keys', function () {

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -81,7 +81,9 @@ define(function (require, exports, module) {
       metrics = new Metrics();
       notifier = new Notifier();
       relier = new Relier();
-      user = new User();
+      user = new User({
+        notifier: notifier
+      });
       verificationError = null;
       windowMock = new WindowMock();
 

--- a/app/tests/spec/views/mixins/signed-in-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-in-notification-mixin.js
@@ -57,14 +57,14 @@ define(function (require, exports, module) {
             })
           };
           view.user = {
-            setSignedInAccount: sinon.spy(function () {
+            setSignedInAccountByUid: sinon.spy(function () {
               return p();
             })
           };
           view.navigate = sinon.spy();
           notifier.triggerAll = sinon.spy();
           return notifier.on.args[0][1]({
-            data: 'foo'
+            uid: 'uid'
           });
         });
 
@@ -76,18 +76,16 @@ define(function (require, exports, module) {
           assert.equal(args[0], 'handleSignedInNotification');
         });
 
-        it('calls user.setSignedInAccount correctly', function () {
-          assert.equal(view.user.setSignedInAccount.callCount, 1);
-          assert.isTrue(view.user.setSignedInAccount.alwaysCalledOn(view.user));
-          var args = view.user.setSignedInAccount.args[0];
-          assert.lengthOf(args, 1);
-          assert.deepEqual(args[0], { data: 'foo' });
+        it('calls user.setSignedInAccountByUid correctly', function () {
+          assert.equal(view.user.setSignedInAccountByUid.callCount, 1);
+          assert.isTrue(view.user.setSignedInAccountByUid.alwaysCalledOn(view.user));
+          assert.isTrue(view.user.setSignedInAccountByUid.calledWith('uid'));
         });
 
         it('calls navigate correctly', function () {
           assert.equal(view.navigate.callCount, 1);
           assert.isTrue(view.navigate.alwaysCalledOn(view));
-          assert.isTrue(view.navigate.calledAfter(view.user.setSignedInAccount));
+          assert.isTrue(view.navigate.calledAfter(view.user.setSignedInAccountByUid));
           var args = view.navigate.args[0];
           assert.lengthOf(args, 1);
           assert.equal(args[0], 'settings');
@@ -106,13 +104,13 @@ define(function (require, exports, module) {
             })
           };
           view.user = {
-            setSignedInAccount: sinon.spy(function () {
+            setSignedInAccountByUid: sinon.spy(function () {
               return p();
             })
           };
           view.navigate = sinon.spy();
           notifier.on.args[0][1]({
-            data: 'foo'
+            uid: 'uid'
           });
         });
 
@@ -120,8 +118,8 @@ define(function (require, exports, module) {
           assert.equal(view.broker.hasCapability.callCount, 1);
         });
 
-        it('does not call user.setSignedInAccount', function () {
-          assert.equal(view.user.setSignedInAccount.callCount, 0);
+        it('does not call user.setSignedInAccountByUid', function () {
+          assert.isFalse(view.user.setSignedInAccountByUid.called);
         });
 
         it('does not call navigate', function () {
@@ -137,14 +135,14 @@ define(function (require, exports, module) {
             })
           };
           view.user = {
-            setSignedInAccount: sinon.spy(function () {
+            setSignedInAccountByUid: sinon.spy(function () {
               return p();
             })
           };
           view.navigate = sinon.spy();
           view._redirectTo = 'foo';
           return notifier.on.args[0][1]({
-            data: 'bar'
+            uid: 'uid'
           });
         });
 
@@ -152,9 +150,9 @@ define(function (require, exports, module) {
           assert.equal(view.broker.hasCapability.callCount, 1);
         });
 
-        it('calls user.setSignedInAccount correctly', function () {
-          assert.equal(view.user.setSignedInAccount.callCount, 1);
-          assert.deepEqual(view.user.setSignedInAccount.args[0][0], { data: 'bar' });
+        it('calls user.setSignedInAccountByUid correctly', function () {
+          assert.equal(view.user.setSignedInAccountByUid.callCount, 1);
+          assert.isTrue(view.user.setSignedInAccountByUid.calledWith('uid'));
         });
 
         it('calls navigate correctly', function () {


### PR DESCRIPTION
* Consolidate sending the Notifier.EVENTS.SIGNED_IN message from user.js
  * Only send `uid`, `unwrapBKey`, and `keyFetchToken`, not the entire account
  * Requires moving some logic from views to user.js
  * Receivers of the SIGNED_IN message must load account data from user.js
    using the passed `uid`
* Disable account.toJSON, use pick instead which requires that fields be specified.
* Add user.completeAccountSignUp

issue #3366

@philbooth - Another one for you!