### PR TITLE
fix(client): enforce validation of notifier event data

### DIFF
--- a/app/scripts/lib/channels/notifier.js
+++ b/app/scripts/lib/channels/notifier.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * The notifier triggers events on multiple channels (iframe, tabs, browsers, etc).
+ * The notifier triggers commands on multiple channels (iframe, tabs, browsers, etc).
  */
 
 define(function (require, exports, module) {
@@ -11,20 +11,49 @@ define(function (require, exports, module) {
 
   var _ = require('underscore');
   var Backbone = require('backbone');
+  var Validate = require('lib/validate');
 
-  // Events that have the 'internal:' namespace should only be
-  // handled by the content server. Other events may be handled
+  // Commands that have the 'internal:' namespace should only be
+  // handled by the content server. Other commands may be handled
   // both externally and internally to the content server.
-  var EVENTS = {
-    COMPLETE_RESET_PASSWORD_TAB_OPEN: 'fxaccounts:complete_reset_password_tab_open',
-    DELETE: 'fxaccounts:delete',
-    PROFILE_CHANGE: 'profile:change',
-    SIGNED_IN: 'internal:signed_in',
-    SIGNED_OUT: 'fxaccounts:logout'
+  var COMMANDS = {
+    COMPLETE_RESET_PASSWORD_TAB_OPEN: {
+      name: 'fxaccounts:complete_reset_password_tab_open',
+      schema: null
+    },
+    DELETE: {
+      name: 'fxaccounts:delete',
+      schema: { uid: 'String' }
+    },
+    PROFILE_CHANGE: {
+      name: 'profile:change',
+      schema: { uid: 'String' }
+    },
+    SIGNED_IN: {
+      name: 'internal:signed_in',
+      schema: {
+        keyFetchToken: '?String',
+        uid: 'String',
+        unwrapBKey: '?String'
+      }
+    },
+    SIGNED_OUT: {
+      name: 'fxaccounts:logout',
+      schema: { uid: '?String' }
+    }
   };
 
+  var COMMAND_NAMES = {};
+  var SCHEMATA = {};
+
+  Object.keys(COMMANDS).forEach(function (key) {
+    var command = COMMANDS[key];
+    COMMAND_NAMES[key] = command.name;
+    SCHEMATA[command.name] = command.schema;
+  });
+
   var Notifer = Backbone.Model.extend({
-    EVENTS: EVENTS,
+    COMMANDS: COMMAND_NAMES,
 
     initialize: function (options) {
       options = options || {};
@@ -51,22 +80,35 @@ define(function (require, exports, module) {
       }
     },
 
-    triggerAll: function (event, data, context) {
-      this.triggerRemote(event, data);
-      this.trigger(event, data, context);
+    triggerAll: function (command, data, context) {
+      this.triggerRemote(command, data);
+      this.trigger(command, data, context);
     },
 
-    triggerRemote: function (event, data) {
+    triggerRemote: function (command, data) {
+      // Validation distinguishes between undefined values and values that are
+      // set to undefined. And some channels don't serialise their payloads, so
+      // values that are set to undefined get sent with the message. Mitigate
+      // by explicitly removing those values before processing the data.
+      data = eliminateUndefinedProperties(data);
+
+      if (SCHEMATA[command]) {
+        if (! Validate.isDataValid(data, SCHEMATA[command])) {
+          throw new Error('Invalid data for command ' + command);
+        }
+      } else if (! _.isNull(data) && ! _.isUndefined(data)) {
+        throw new Error('Unexpected data for command ' + command);
+      }
 
       // internal:* messages are never sent outside of FxA. Ensure
       // only internal channels receive internal:* messages.
-      if (/^internal:/.test(event)) {
+      if (/^internal:/.test(command)) {
         this._internalChannels.forEach(function (channel) {
-          channel.send(event, data);
+          channel.send(command, data);
         });
       } else {
         this._channels.forEach(function (channel) {
-          channel.send(event, data);
+          channel.send(command, data);
         });
       }
     },
@@ -74,7 +116,7 @@ define(function (require, exports, module) {
     // Listen for notifications from other fxa tabs or frames
     _listen: function (tabChannel) {
       var self = this;
-      _.each(EVENTS, function (name) {
+      _.each(COMMAND_NAMES, function (name) {
         tabChannel.on(name, self.trigger.bind(self, name));
       });
     },
@@ -84,7 +126,15 @@ define(function (require, exports, module) {
         this._tabChannel.clear();
       }
     }
-  }, EVENTS);
+  }, COMMAND_NAMES);
 
   module.exports = Notifer;
+
+  function eliminateUndefinedProperties (data) {
+    if (! data) {
+      return data;
+    }
+
+    return _.omit(data, _.isUndefined);
+  }
 });

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -162,7 +162,7 @@ define(function (require, exports, module) {
     clearSignedInAccount: function () {
       var uid = this.getSignedInAccount().get('uid');
       this.clearSignedInAccountUid();
-      this._notifier.triggerRemote(this._notifier.EVENTS.SIGNED_OUT, {
+      this._notifier.triggerRemote(this._notifier.COMMANDS.SIGNED_OUT, {
         uid: uid
       });
     },
@@ -207,7 +207,7 @@ define(function (require, exports, module) {
       return account.destroy(password)
         .then(function () {
           self.removeAccount(account);
-          self._notifier.triggerAll(self._notifier.EVENTS.DELETE, {
+          self._notifier.triggerAll(self._notifier.COMMANDS.DELETE, {
             uid: account.get('uid')
           });
         });
@@ -415,7 +415,7 @@ define(function (require, exports, module) {
       // Other tabs only need to know the account `uid` to load any
       // necessary info from localStorage
       this._notifier.triggerRemote(
-        this._notifier.EVENTS.SIGNED_IN, account.pick('uid', 'unwrapBKey', 'keyFetchToken'));
+        this._notifier.COMMANDS.SIGNED_IN, account.pick('uid', 'unwrapBKey', 'keyFetchToken'));
     },
 
     /**

--- a/app/tests/spec/lib/validate.js
+++ b/app/tests/spec/lib/validate.js
@@ -134,5 +134,112 @@ define(function (require, exports, module) {
         assert.isTrue(Validate.isPasswordValid(createRandomHexString(Constants.PASSWORD_MIN_LENGTH)));
       });
     });
+
+    describe('isDataValid', function () {
+      /*eslint-disable sorting/sort-object-props */
+
+      it('is defined', function () {
+        assert.isFunction(Validate.isDataValid);
+      });
+
+      it('expects two arguments', function () {
+        assert.lengthOf(Validate.isDataValid, 2);
+      });
+
+      it('returns true when simple type matches the schema', function () {
+        assert.isTrue(Validate.isDataValid('foo', 'String'));
+      });
+
+      it('returns false when simple type does not match the schema', function () {
+        assert.isFalse(Validate.isDataValid('foo', 'Number'));
+      });
+
+      it('handles null', function () {
+        assert.isTrue(Validate.isDataValid(null, 'Null'));
+      });
+
+      it('handles undefined', function () {
+        assert.isTrue(Validate.isDataValid(undefined, 'Undefined'));
+      });
+
+      it('handles false', function () {
+        assert.isTrue(Validate.isDataValid(false, 'Boolean'));
+      });
+
+      it('handles zero', function () {
+        assert.isTrue(Validate.isDataValid(0, 'Number'));
+      });
+
+      it('handles empty string', function () {
+        assert.isTrue(Validate.isDataValid('', 'String'));
+      });
+
+      it('returns true when complex type matches the schema', function () {
+        assert.isTrue(Validate.isDataValid(
+          [ 'foo', 3.14159265359, {} ],
+          [ 'String', 'Number', 'Object' ]
+        ));
+      });
+
+      it('returns false when complex type does not match the schema', function () {
+        assert.isFalse(Validate.isDataValid(
+          [ 'foo', 3.14159265359, [] ],
+          [ 'String', 'Number', 'Object' ]
+        ));
+      });
+
+      it('handles different key order', function () {
+        assert.isTrue(Validate.isDataValid(
+          { foo: 'bar', baz: 'qux' },
+          { baz: 'String', foo: 'String' }
+        ));
+      });
+
+      it('handles nested objects', function () {
+        assert.isTrue(Validate.isDataValid(
+          { foo: { bar: [ 'baz', 'qux' ] } },
+          { foo: { bar: [ 'String', 'String' ] } }
+        ));
+        assert.isFalse(Validate.isDataValid(
+          { foo: { bar: [ 'baz', 'qux' ] } },
+          { foo: { bar: [ 'String', 'Number' ] } }
+        ));
+      });
+
+      it('does not ignore undefined properties if schema property is undefined', function () {
+        assert.isFalse(Validate.isDataValid(
+          { foo: 'bar', baz: undefined },
+          { foo: 'String' }
+        ));
+      });
+
+      it('does not ignore undefined properties if schema property is defined', function () {
+        assert.isFalse(Validate.isDataValid(
+          { foo: 'bar', baz: undefined },
+          { foo: 'String', baz: 'String' }
+        ));
+      });
+
+      it('returns false if a property is not in the schema', function () {
+        assert.isFalse(Validate.isDataValid(
+          { foo: 'bar', baz: 'qux' },
+          { foo: 'String' }
+        ));
+      });
+
+      it('leading ? in schema property indicates optional', function () {
+        assert.isTrue(Validate.isDataValid(null, '?String'));
+        assert.isTrue(Validate.isDataValid(undefined, '?String'));
+        assert.isFalse(Validate.isDataValid(false, '?String'));
+        assert.isFalse(Validate.isDataValid(0, '?String'));
+        assert.isTrue(Validate.isDataValid('', '?String'));
+        assert.isTrue(Validate.isDataValid(
+          { foo: 'bar', baz: undefined },
+          { foo: 'String', baz: '?String' }
+        ));
+      });
+
+      /*eslint-enable sorting/sort-object-props */
+    });
   });
 });

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
       assert.equal(notifier.triggerRemote.callCount, 1);
       var args = notifier.triggerRemote.args[0];
       assert.lengthOf(args, 2);
-      assert.equal(args[0], notifier.EVENTS.SIGNED_IN);
+      assert.equal(args[0], notifier.COMMANDS.SIGNED_IN);
 
       // unwrapBKey and keyFetchToken are used in password reset
       // to enable the original tab to send encryption keys
@@ -142,7 +142,7 @@ define(function (require, exports, module) {
           assert.equal(notifier.triggerRemote.callCount, 1);
           var args = notifier.triggerRemote.args[0];
           assert.lengthOf(args, 2);
-          assert.equal(args[0], notifier.EVENTS.SIGNED_OUT);
+          assert.equal(args[0], notifier.COMMANDS.SIGNED_OUT);
         });
     });
 
@@ -198,7 +198,7 @@ define(function (require, exports, module) {
       });
 
       it('should trigger a notification', function () {
-        assert.isTrue(notifier.triggerAll.calledWith(notifier.EVENTS.DELETE, {
+        assert.isTrue(notifier.triggerAll.calledWith(notifier.COMMANDS.DELETE, {
           uid: account.get('uid')
         }));
       });

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -40,6 +40,7 @@ define(function (require, exports, module) {
       user = new User({
         notifier: notifier
       });
+      user.getSignedInAccount().set('uid', 'foo');
       windowMock = new WindowMock();
 
       view = new View({

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -266,7 +266,7 @@ define(function (require, exports, module) {
       });
 
       it('call onProfileUpdate after notification', function () {
-        notifier.trigger(notifier.EVENTS.PROFILE_CHANGE, {});
+        notifier.trigger(notifier.COMMANDS.PROFILE_CHANGE, {});
         assert.isTrue(spy.called);
       });
     });

--- a/app/tests/spec/views/mixins/notifier-mixin.js
+++ b/app/tests/spec/views/mixins/notifier-mixin.js
@@ -15,7 +15,7 @@ define(function (require, exports, module) {
   var assert = chai.assert;
 
   describe('views/mixins/notifier-mixin', function () {
-    var data = { token: 'token' };
+    var data = { uid: 'foo' };
     var functionHandlerSpy;
     var notifier;
     var view;
@@ -137,33 +137,33 @@ define(function (require, exports, module) {
     describe('notifier.trigger', function () {
       beforeEach(function () {
         sinon.spy(notifier, 'trigger');
-        view.notifier.trigger('message1', data);
+        view.notifier.trigger('fxaccounts:logout', data);
       });
 
       it('delegates to notifier.trigger', function () {
-        assert.isTrue(notifier.trigger.calledWith('message1', data, view));
+        assert.isTrue(notifier.trigger.calledWith('fxaccounts:logout', data, view));
       });
     });
 
     describe('notifier.triggerAll', function () {
       beforeEach(function () {
         sinon.spy(notifier, 'triggerAll');
-        view.notifier.triggerAll('message1', data);
+        view.notifier.triggerAll('fxaccounts:logout', data);
       });
 
       it('delegates to notifier.triggerAll', function () {
-        assert.isTrue(notifier.triggerAll.calledWith('message1', data, view));
+        assert.isTrue(notifier.triggerAll.calledWith('fxaccounts:logout', data, view));
       });
     });
 
     describe('notifier.triggerRemote', function () {
       beforeEach(function () {
         sinon.spy(notifier, 'triggerRemote');
-        view.notifier.triggerRemote('message1', data);
+        view.notifier.triggerRemote('fxaccounts:logout', data);
       });
 
       it('delegates to notifier.triggerRemote', function () {
-        assert.isTrue(notifier.triggerRemote.calledWith('message1', data));
+        assert.isTrue(notifier.triggerRemote.calledWith('fxaccounts:logout', data));
       });
     });
 

--- a/app/tests/spec/views/mixins/settings-mixin.js
+++ b/app/tests/spec/views/mixins/settings-mixin.js
@@ -43,6 +43,7 @@ define(function (require, exports, module) {
       user = new User({
         notifier: notifier
       });
+      user.getSignedInAccount().set('uid', 'foo');
 
       sandbox = new sinon.sandbox.create();
       sandbox.spy(user, 'setSignedInAccountByUid');

--- a/app/tests/spec/views/mixins/signed-in-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-in-notification-mixin.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
         assert.equal(notifier.on.callCount, 1);
         var args = notifier.on.args[0];
         assert.lengthOf(args, 2);
-        assert.equal(args[0], notifier.EVENTS.SIGNED_IN);
+        assert.equal(args[0], notifier.COMMANDS.SIGNED_IN);
         assert.isFunction(args[1]);
       });
 
@@ -171,7 +171,7 @@ define(function (require, exports, module) {
           assert.equal(notifier.off.callCount, 1);
           var args = notifier.off.args[0];
           assert.lengthOf(args, 2);
-          assert.equal(args[0], notifier.EVENTS.SIGNED_IN);
+          assert.equal(args[0], notifier.COMMANDS.SIGNED_IN);
           assert.equal(args[1], notifier.on.args[0][1]);
         });
       });

--- a/app/tests/spec/views/openid/login.js
+++ b/app/tests/spec/views/openid/login.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
         fxaClient: fxaClient,
         notifier: notifier
       });
+      user.getSignedInAccount().set('uid', 'foo');
 
       view = new View({
         broker: broker,

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -516,7 +516,8 @@ define(function (require, exports, module) {
         sinon.stub(view, 'getAccount', function () {
           return user.initAccount({
             email: 'a@a.com',
-            sessionToken: 'abc123'
+            sessionToken: 'abc123',
+            uid: 'foo'
           });
         });
 
@@ -558,7 +559,8 @@ define(function (require, exports, module) {
       it('can switch to signin with the useDifferentAccount button', function () {
         var account = user.initAccount({
           email: 'a@a.com',
-          sessionToken: 'abc123'
+          sessionToken: 'abc123',
+          uid: 'foo'
         });
         sinon.stub(view, 'getAccount', function () {
           return account;


### PR DESCRIPTION
This is my first attempt to fix #3354, validation of notification payloads.

Note that this change doesn't cover the elimination of particular fields, it is purely to implement safeguards for ensuring we don't expose anything unintentionally.

The 3rd-party validation libraries I found were all pretty heavyweight and, as our requirements are simple, I added a new function to `app/scripts/lib/validate.js` to handle the checking.

@shane-tomlinson & @vladikoff, feedback wanted. :grin: 