### PR TITLE
fix(client): Fix the browser back button in the firstrun flow.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -589,23 +589,13 @@ define(function (require, exports, module) {
     },
 
     allResourcesReady: function () {
-      // The IFrame cannot use pushState or else a page transition
-      // would cause the parent frame to redirect.
-      var usePushState = ! this._isInAnIframe();
-
-      if (! usePushState) {
-        // If pushState cannot be used, Backbone falls back to using
-        // the hashchange. Put the initial pathname onto the hash
-        // so the correct page loads.
-        this._window.location.hash = this._window.location.pathname;
-      }
-
       // If a new start page is specified, do not attempt to render
       // the route displayed in the URL because the user is
       // immediately redirected
       var startPage = this._selectStartPage();
       var isSilent = !! startPage;
-      this._history.start({ pushState: usePushState, silent: isSilent });
+      // pushState must be specified or else no screen transitions occur.
+      this._history.start({ pushState: true, silent: isSilent });
       if (startPage) {
         this._router.navigate(startPage);
       }

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -740,6 +740,8 @@ define(function (require, exports, module) {
 
     describe('allResourcesReady', function () {
       beforeEach(function () {
+        sinon.spy(historyMock, 'start');
+
         appStart = new AppStart({
           broker: brokerMock,
           history: historyMock,
@@ -747,15 +749,15 @@ define(function (require, exports, module) {
           user: userMock,
           window: windowMock
         });
+
+        appStart.allResourcesReady();
       });
 
-      it('should set the window hash if in an iframe', function () {
-        sinon.stub(appStart, '_isInAnIframe', function () {
-          return true;
-        });
-        windowMock.location.pathname = 'signup';
-        appStart.allResourcesReady();
-        assert.equal(windowMock.location.hash, 'signup');
+      it('should start history', function () {
+        assert.isTrue(historyMock.start.calledWith({
+          pushState: true,
+          silent: false
+        }));
       });
     });
 


### PR DESCRIPTION
The combination of using hashchange events and a browser bug caused
the browser back button to be enabled as soon as the user loaded
the firstrun flow. pushState does not suffer from this problem.
Use pushState instead of hashchange.

This fix has some repercussions on Fx <= 43. Read the table in the
referenced bug to find out more.

fixes #3296

I have not yet tested this in Fx for iOS or Fx for Android's firstrun flows.

@vladikoff - mind an r?