### PR TITLE
fix(client): tolerate missing _formPrefill in signed-out-notification-mixin

### DIFF
--- a/app/scripts/views/mixins/signed-out-notification-mixin.js
+++ b/app/scripts/views/mixins/signed-out-notification-mixin.js
@@ -23,11 +23,13 @@ define(function (require, exports, module) {
       this.relier.unset('email');
       this.relier.unset('preVerifyToken');
       this.user.clearSignedInAccountUid();
-      // The user has manually signed out, a pretty strong indicator
-      // the user does not want any of their information pre-filled
-      // on the signin page. Clear any remaining formPrefill info
-      // to ensure their data isn't sticking around in memory.
-      this._formPrefill.clear();
+      if (this._formPrefill) {
+        // The user has manually signed out, a pretty strong indicator
+        // the user does not want any of their information pre-filled
+        // on the signin page. Clear any remaining formPrefill info
+        // to ensure their data isn't sticking around in memory.
+        this._formPrefill.clear();
+      }
       Session.clear();
       this.navigateToSignIn();
     },

--- a/app/tests/spec/views/mixins/signed-out-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-out-notification-mixin.js
@@ -28,12 +28,23 @@ define(function (require, exports, module) {
       var notifier;
       var view;
 
-      before(function () {
+      beforeEach(function () {
         notifier = new Notifier();
         notifier.on = sinon.spy();
         view = new View({
           notifier: notifier
         });
+        view.relier = {
+          unset: sinon.spy()
+        };
+        view.user = {
+          clearSignedInAccountUid: sinon.spy()
+        };
+        view._formPrefill = {
+          clear: sinon.spy()
+        };
+        view.navigate = sinon.spy();
+        notifier.triggerAll = sinon.spy();
       });
 
       afterEach(function () {
@@ -49,18 +60,7 @@ define(function (require, exports, module) {
       });
 
       describe('clearSessionAndNavigateToSignIn', function () {
-        before(function () {
-          view.relier = {
-            unset: sinon.spy()
-          };
-          view.user = {
-            clearSignedInAccountUid: sinon.spy()
-          };
-          view._formPrefill = {
-            clear: sinon.spy()
-          };
-          view.navigate = sinon.spy();
-          notifier.triggerAll = sinon.spy();
+        beforeEach(function () {
           notifier.on.args[0][1]();
         });
 
@@ -102,6 +102,18 @@ define(function (require, exports, module) {
 
         it('does not call notifier.triggerAll', function () {
           assert.equal(notifier.triggerAll.callCount, 0);
+        });
+      });
+
+      describe('delete _formPrefill', function () {
+        beforeEach(function () {
+          view._formPrefill = null;
+        });
+
+        it('clearSessionAndNavigateToSignIn does not throw', function () {
+          assert.doesNotThrow(function () {
+            notifier.on.args[0][1]();
+          });
         });
       });
     });


### PR DESCRIPTION
Fixes #3404.

Just made the most obvious fix, checking _formPrefill before dereferencing it.