### PR TITLE
feat(client): Report email opt-in status to firstrun page.

### DIFF
--- a/app/scripts/models/auth_brokers/first-run.js
+++ b/app/scripts/models/auth_brokers/first-run.js
@@ -69,8 +69,10 @@ define(function (require, exports, module) {
       return proto.afterResetPasswordConfirmationPoll.apply(this, arguments);
     },
 
-    beforeSignUpConfirmationPoll: function () {
-      this._iframeChannel.send(this._iframeCommands.SIGNUP_MUST_VERIFY);
+    beforeSignUpConfirmationPoll: function (account) {
+      this._iframeChannel.send(this._iframeCommands.SIGNUP_MUST_VERIFY, {
+        emailOptIn: !! account.get('needsOptedInToMarketingEmail')
+      });
 
       return proto.beforeSignUpConfirmationPoll.apply(this, arguments);
     },

--- a/app/tests/spec/models/auth_brokers/first-run.js
+++ b/app/tests/spec/models/auth_brokers/first-run.js
@@ -97,14 +97,26 @@ define(function (require, exports, module) {
     });
 
     describe('beforeSignUpConfirmationPoll', function () {
-      it('notifies the iframe channel, does not halt', function () {
+      var result;
+      beforeEach(function () {
         sinon.spy(iframeChannel, 'send');
 
+        account.set('needsOptedInToMarketingEmail', true);
+
         return broker.beforeSignUpConfirmationPoll(account)
-          .then(function (result) {
-            assert.isTrue(iframeChannel.send.calledWith(broker._iframeCommands.SIGNUP_MUST_VERIFY));
-            assert.isUndefined(result.halt);
+          .then(function (_result) {
+            result = _result;
           });
+      });
+
+      it('notifies the iframe channel', function () {
+        assert.isTrue(
+          iframeChannel.send.calledWith(
+            broker._iframeCommands.SIGNUP_MUST_VERIFY, { emailOptIn: true }));
+      });
+
+      it('does not halt', function () {
+        assert.isUndefined(result.halt);
       });
     });
 

--- a/docs/relier-communication-protocols/firstrun.md
+++ b/docs/relier-communication-protocols/firstrun.md
@@ -19,6 +19,9 @@ their email after an account unlock.
 The user has successfully completed the signup form and must verify
 their email address.
 
+The `data` field contains:
+* `emailOptIn` {Boolean} - whether the user has opted in to receiving marketing email
+
 #### verification_complete
 The user has successfully verified their email address.
 


### PR DESCRIPTION
Send `emailOptIn` with the `signup_must_verify` message.

`emailOptIn` can be `true` or `false`

fixes #3411

@vbudhram, @vladikoff and @jpetto - r?

@jpetto - rebuilding https://stomlinson.dev.lcip.org now with this change.