### PR TITLE
feat(client): Better handling of deleted accounts on /force_auth

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -243,6 +243,10 @@ define(function (require, exports, module) {
     INVALID_CAMERA_DIMENSIONS: {
       errno: 1033,
       message: UNEXPECTED_ERROR_MESSAGE
+    },
+    DELETED_ACCOUNT: {
+      errno: 1034,
+      message: t('Account no longer exists.')
     }
   };
   /*eslint-enable sorting/sort-object-props*/

--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -175,7 +175,7 @@ define(function (require, exports, module) {
           // Attempt to get account status of email and navigate
           // to correct signin/signup page if exists.
           var account = self.user.initAccount({ email: email });
-          return account.checkAccountEmailExists()
+          return self.user.checkAccountEmailExists(account)
             .then(function (exists) {
               if (exists) {
                 return '/oauth/signin';

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -406,13 +406,23 @@ define(function (require, exports, module) {
     },
 
     /**
-     * Check if user exists by stored email.
+     * Check whether the account's email is registered.
      *
-     * @returns {promise} - resolves when complete
+     * @returns {promise} resolves to `true` if email is registered,
+     * `false` otw.
      */
-    checkAccountEmailExists: function () {
-      var email = this.get('email');
-      return this._fxaClient.checkAccountExistsByEmail(email);
+    checkEmailExists: function () {
+      return this._fxaClient.checkAccountExistsByEmail(this.get('email'));
+    },
+
+    /**
+     * Check whether the account's UID is registered.
+     *
+     * @returns {promise} resolves to `true` if the uid is registered,
+     * `false` otw.
+     */
+    checkUidExists: function () {
+      return this._fxaClient.checkAccountExists(this.get('uid'));
     },
 
     /**

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -332,6 +332,12 @@ define(function (require, exports, module) {
      */
     defaultCapabilities: {
       /**
+       * If the provided UID no longer exists on the auth server, can
+       * the user sign up/in with the same email address but a different
+       * uid?
+       */
+      allowUidChange: false,
+      /**
        * Should the signup page show the `Choose what to sync` checkbox
        */
       chooseWhatToSyncCheckbox: true,

--- a/app/scripts/models/auth_brokers/fx-desktop-v3.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v3.js
@@ -18,6 +18,7 @@ define(function (require, exports, module) {
 
   var FxDesktopV3AuthenticationBroker = FxDesktopV2AuthenticationBroker.extend({
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
+      allowUidChange: true,
       syncPreferencesNotification: true
     }),
 

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -179,6 +179,10 @@ define(function (require, exports, module) {
     },
 
     transformLink: function (link) {
+      if (link[0] !== '/') {
+        link = '/' + link;
+      }
+
       return '/oauth' + link;
     }
   });

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -488,6 +488,42 @@ define(function (require, exports, module) {
             self.clearSignedInAccount();
           }
         });
+    },
+
+    /**
+     * Check whether an Account's `uid` is registered. Removes the account
+     * from storage if account no longer exists on the server.
+     *
+     * @param {object} account - account to check
+     * @returns {promise} resolves to `true` if an account exists, `false` otw.
+     */
+    checkAccountUidExists: function (account) {
+      var self = this;
+      return account.checkUidExists()
+        .then(function (exists) {
+          if (! exists) {
+            self.removeAccount(account);
+          }
+          return exists;
+        });
+    },
+
+    /**
+     * Check whether an Account's `email` is registered. Removes the account
+     * from storage if account no longer exists on the server.
+     *
+     * @param {object} account - account to check
+     * @returns {promise} resolves to `true` if an account exists, `false` otw.
+     */
+    checkAccountEmailExists: function (account) {
+      var self = this;
+      return account.checkEmailExists()
+        .then(function (exists) {
+          if (! exists) {
+            self.removeAccount(account);
+          }
+          return exists;
+        });
     }
   });
 

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -29,7 +29,13 @@
 
     <form novalidate>
       <div class="input-row">
-        <input type="email" class="email" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" {{#shouldFocusEmail}}autofocus{{/shouldFocusEmail}} required />
+        {{#forceEmail}}
+          <p class="prefillEmail">{{ forceEmail }}</p>
+          <input type="email" class="email hidden" value="{{ forceEmail }}" disabled />
+        {{/forceEmail}}
+        {{^forceEmail}}
+          <input type="email" class="email" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" {{#shouldFocusEmail}}autofocus{{/shouldFocusEmail}} required />
+        {{/forceEmail}}
       </div>
 
       <div class="input-row password-row">
@@ -80,7 +86,9 @@
     </form>
 
     <div class="links">
-      <a href="/signin" class="sign-in">{{#t}}Have an account? Sign in.{{/t}}</a>
+      {{#isSignInEnabled}}
+        <a href="/signin" class="sign-in">{{#t}}Have an account? Sign in.{{/t}}</a>
+      {{/isSignInEnabled}}
     </div>
 
     {{/error}}

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -11,6 +11,8 @@ define(function (require, exports, module) {
   var BaseView = require('views/base');
   var Cocktail = require('cocktail');
   var FormView = require('views/form');
+  var NullBehavior = require('views/behaviors/null');
+  var p = require('lib/promise');
   var PasswordResetMixin = require('views/mixins/password-reset-mixin');
   var SignInView = require('views/sign_in');
   var Template = require('stache!templates/force_auth');
@@ -23,6 +25,8 @@ define(function (require, exports, module) {
     return '';
   }
 
+  var proto = SignInView.prototype;
+
   var View = SignInView.extend({
     template: Template,
     className: 'force-auth',
@@ -32,17 +36,102 @@ define(function (require, exports, module) {
     afterSignInBrokerMethod: 'afterForceAuth',
     afterSignInNavigateData: { clearQueryParams: true },
 
-    context: function () {
-      var fatalError = '';
-      var email = this.relier.get('email');
+    _fatalError: null,
 
-      if (! email) {
-        fatalError = AuthErrors.toError('FORCE_AUTH_EMAIL_REQUIRED');
+    beforeRender: function () {
+      var self = this;
+      var relier = this.relier;
+
+      if (! relier.has('email')) {
+        this._fatalError = AuthErrors.toError('FORCE_AUTH_EMAIL_REQUIRED');
+        return;
       }
 
+      /**
+       * If the relier specifies a UID, check whether the UID is still
+       * registered. If the uid is not registered, the account
+       * was probably deleted. If the broker supports UID changes,
+       * the user will still be allowed to signup or in, depending on
+       * whether the email is registered. If not, show a useful error
+       * and do not allow the user to continue.
+       */
+      var account = this.user.initAccount({
+        email: relier.get('email'),
+        uid: relier.get('uid')
+      });
+
+      if (relier.has('uid')) {
+        return p.all([
+          this.user.checkAccountEmailExists(account),
+          this.user.checkAccountUidExists(account)
+        ]).spread(function (emailExists, uidExists) {
+          /*
+           * uidExists: false, emailExists: false
+           *   Let user sign up w/ email.
+           * uidExists: true, emailExists: false
+           *   Uid exists but doesn't match email, how'd this happen?
+           *   Let the user sign up.
+           * uidExists: false, emailExists: true
+           *   Sign in w/ new uid.
+           * uidExists: true, emailExists: true
+           *   Assume for the same account, try to sign in
+           */
+          if (! emailExists) {
+            return self._signUpIfUidChangeSupported(account);
+          } if (! uidExists) {
+            return self._signInIfUidChangeSupported(account);
+          }
+
+          // email and uid are both registered, continue as normal
+        });
+      } else {
+        // relier did not specify a uid, there's a bit more flexibility.
+        // If the email no longer exists, sign up the user.
+        return this.user.checkAccountEmailExists(account)
+          .then(function (emailExists) {
+            if (! emailExists) {
+              return self._navigateToForceSignUp(account);
+            }
+          });
+      }
+    },
+
+    _signUpIfUidChangeSupported: function (account) {
+      if (this.broker.hasCapability('allowUidChange')) {
+        return this._navigateToForceSignUp(account);
+      } else {
+        this._fatalError = AuthErrors.toError('DELETED_ACCOUNT');
+      }
+    },
+
+    _signInIfUidChangeSupported: function (account) {
+      // if the broker supports a UID change, use force_auth to sign in,
+      // otherwise print a big error message.
+      if (! this.broker.hasCapability('allowUidChange')) {
+        this._fatalError = AuthErrors.toError('DELETED_ACCOUNT');
+      }
+    },
+
+    _navigateToForceSignUp: function (account) {
+      // The default behavior of FxDesktop brokers is to halt before
+      // the signup confirmation poll because about:accounts takes care
+      // of polling and updating the UI. /force_auth is not opened in
+      // about:accounts and unless beforeSignUpConfirmationPoll is
+      // overridden, the user receives no visual feedback in this
+      // tab once the verification is complete.
+      this.broker.setBehavior(
+          'beforeSignUpConfirmationPoll', new NullBehavior());
+
+      return this.navigate(this.broker.transformLink('signup'), {
+        error: AuthErrors.toError('DELETED_ACCOUNT'),
+        forceEmail: account.get('email')
+      });
+    },
+
+    context: function () {
       return {
-        email: email,
-        fatalError: getFatalErrorMessage(this, fatalError),
+        email: this.relier.get('email'),
+        fatalError: getFatalErrorMessage(this, this._fatalError),
         isPasswordAutoCompleteDisabled: this.isPasswordAutoCompleteDisabled(),
         password: this._formPrefill.get('password')
       };
@@ -56,14 +145,20 @@ define(function (require, exports, module) {
       this._formPrefill.set('password', this.getElementValue('.password'));
     },
 
-    onSignInError: function (account, password, err) {
-      if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
-        // dead end, do not allow the user to sign up.
-        this.displayError(err);
-      } else {
-        return SignInView.prototype.onSignInError.call(
-            this, account, password, err);
+    onSignInError: function (account, password, error) {
+      if (AuthErrors.is(error, 'UNKNOWN_ACCOUNT')) {
+        if (this.relier.has('uid')) {
+          if (this.broker.hasCapability('allowUidChange')) {
+            return this._navigateToForceSignUp(account);
+          } else {
+            this.displayError(AuthErrors.toError('DELETED_ACCOUNT'));
+          }
+        } else {
+          return this._navigateToForceSignUp(account);
+        }
       }
+
+      return proto.onSignInError.call(this, account, password, error);
     },
 
     resetPasswordNow: allowOnlyOneSubmit(function () {
@@ -71,8 +166,12 @@ define(function (require, exports, module) {
       var email = self.relier.get('email');
 
       return self.resetPassword(email)
-        .fail(function (err) {
-          self.displayError(err);
+        .fail(function (error) {
+          if (AuthErrors.is(error, 'UNKNOWN_ACCOUNT')) {
+            error = AuthErrors.toError('DELETED_ACCOUNT');
+          }
+
+          self.displayError(error);
         });
     }),
 

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -60,6 +60,11 @@ define(function (require, exports, module) {
         return p(false);
       }
 
+      var error = this.model.get('error');
+      if (error && AuthErrors.is(error, 'DELETED_ACCOUNT')) {
+        error.forceMessage = t('Account no longer exists. Recreate it?');
+      }
+
       return FormView.prototype.beforeRender.call(this);
     },
 
@@ -141,7 +146,7 @@ define(function (require, exports, module) {
     },
 
     _selectAutoFocusEl: function () {
-      var prefillEmail = this.getPrefillEmail();
+      var prefillEmail = this.model.get('forceEmail') || this.getPrefillEmail();
       var prefillPassword = this._formPrefill.get('password');
 
       return selectAutoFocusEl(
@@ -149,20 +154,24 @@ define(function (require, exports, module) {
     },
 
     context: function () {
+      var autofocusEl = this._selectAutoFocusEl();
+      var forceEmail = this.model.get('forceEmail');
       var prefillEmail = this.getPrefillEmail();
       var prefillPassword = this._formPrefill.get('password');
-      var autofocusEl = this._selectAutoFocusEl();
 
       var relier = this.relier;
       var isSync = relier.isSync();
+
       var context = {
         chooseWhatToSyncCheckbox: this.broker.hasCapability('chooseWhatToSyncCheckbox'),
         email: prefillEmail,
         error: this.error,
+        forceEmail: forceEmail,
         isAmoMigration: this.isAmoMigration(),
         isCustomizeSyncChecked: relier.isCustomizeSyncChecked(),
         isEmailOptInVisible: this._isEmailOptInEnabled(),
         isPasswordAutoCompleteDisabled: this.isPasswordAutoCompleteDisabled(),
+        isSignInEnabled: ! forceEmail,
         isSync: isSync,
         isSyncMigration: this.isSyncMigration(),
         password: prefillPassword,

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -215,20 +215,12 @@ define(function (require, exports, module) {
         beforeEach(function () {
           accountExists = false;
 
-          sinon.stub(user, 'initAccount', function () {
-            var account = new Account({
-              sessionToken: 'abc123'
-            });
-
-            account.checkAccountEmailExists = function () {
-              if (accountExists instanceof Error) {
-                return p.reject(accountExists);
-              } else {
-                return p(accountExists);
-              }
-            };
-
-            return account;
+          sinon.stub(user, 'checkAccountEmailExists', function () {
+            if (accountExists instanceof Error) {
+              return p.reject(accountExists);
+            } else {
+              return p(accountExists);
+            }
           });
 
           relier.set('email', 'test@email.com');

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -1628,5 +1628,38 @@ define(function (require, exports, module) {
         assert.isFalse(account.has('grantedPermissions'));
       });
     });
+
+    describe('checkUidExists', function () {
+      beforeEach(function () {
+        account.set('uid', UID);
+
+        sinon.stub(fxaClient, 'checkAccountExists', function () {
+          return p();
+        });
+
+        return account.checkUidExists();
+      });
+
+      it('delegates to the fxaClient', function () {
+        assert.isTrue(fxaClient.checkAccountExists.calledWith(UID));
+      });
+    });
+
+    describe('checkEmailExists', function () {
+      beforeEach(function () {
+        account.set('email', EMAIL);
+
+        sinon.stub(fxaClient, 'checkAccountExistsByEmail', function () {
+          return p();
+        });
+
+        return account.checkEmailExists();
+      });
+
+      it('delegates to the fxaClient', function () {
+        assert.isTrue(
+            fxaClient.checkAccountExistsByEmail.calledWith(EMAIL));
+      });
+    });
   });
 });

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v3.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v3.js
@@ -27,6 +27,10 @@ define(function (require, exports, module) {
       it('has the `syncPreferencesNotification` capability', function () {
         assert.isTrue(broker.hasCapability('syncPreferencesNotification'));
       });
+
+      it('has the `allowUidChange` capability', function () {
+        assert.isTrue(broker.hasCapability('allowUidChange'));
+      });
     });
   });
 });

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -282,6 +282,11 @@ define(function (require, exports, module) {
         var transformed = broker.transformLink('/signin');
         assert.equal(transformed, '/oauth/signin');
       });
+
+      it('adds necessary separator', function () {
+        var transformed = broker.transformLink('signin');
+        assert.equal(transformed, '/oauth/signin');
+      });
     });
 
   });

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -20,7 +20,10 @@ define(function (require, exports, module) {
   var User = require('models/user');
 
   var assert = chai.assert;
+
   var CODE = 'verification code';
+  var EMAIL = 'a@a.com';
+  var SESSION_TOKEN = 'session token';
   var UUID = 'a mock uuid';
 
   describe('models/user', function () {
@@ -904,6 +907,78 @@ define(function (require, exports, module) {
         it('signs out the current account', function () {
           assert.isTrue(user.clearSignedInAccount.called);
         });
+      });
+    });
+
+    describe('checkAccountUidExists', function () {
+      var account;
+      var exists;
+
+      beforeEach(function () {
+        account = user.initAccount({
+          email: EMAIL,
+          sessionToken: SESSION_TOKEN,
+          uid: UUID
+        });
+
+        sinon.stub(account, 'checkUidExists', function () {
+          return p(false);
+        });
+
+        sinon.spy(user, 'removeAccount');
+
+        return user.checkAccountUidExists(account)
+          .then(function (_exists) {
+            exists = _exists;
+          });
+      });
+
+      it('delegates to the account model', function () {
+        assert.isTrue(account.checkUidExists.called);
+      });
+
+      it('removes the account if it does not exist', function () {
+        assert.isTrue(user.removeAccount.calledWith(account));
+      });
+
+      it('returns a promise that resolves to whether the account exists', function () {
+        assert.isFalse(exists);
+      });
+    });
+
+    describe('checkAccountEmailExists', function () {
+      var account;
+      var exists;
+
+      beforeEach(function () {
+        account = user.initAccount({
+          email: EMAIL,
+          sessionToken: SESSION_TOKEN,
+          uid: UUID
+        });
+
+        sinon.stub(account, 'checkEmailExists', function () {
+          return p(false);
+        });
+
+        sinon.spy(user, 'removeAccount');
+
+        return user.checkAccountEmailExists(account)
+          .then(function (_exists) {
+            exists = _exists;
+          });
+      });
+
+      it('delegates to the account model', function () {
+        assert.isTrue(account.checkEmailExists.called);
+      });
+
+      it('removes the account if it does not exist', function () {
+        assert.isTrue(user.removeAccount.calledWith(account));
+      });
+
+      it('returns a promise that resolves to whether the account exists', function () {
+        assert.isFalse(exists);
       });
     });
   });

--- a/app/tests/spec/views/mixins/signin-mixin.js
+++ b/app/tests/spec/views/mixins/signin-mixin.js
@@ -8,6 +8,7 @@ define(function (require, exports, module) {
   var Account = require('models/account');
   var assert = require('chai').assert;
   var Backbone = require('backbone');
+  var AuthBroker = require('models/auth_brokers/base');
   var p = require('lib/promise');
   var Relier = require('models/reliers/relier');
   var SignInMixin = require('views/mixins/signin-mixin');
@@ -23,6 +24,7 @@ define(function (require, exports, module) {
 
     describe('signIn', function () {
       var account;
+      var broker;
       var model;
       var relier;
       var view;
@@ -32,6 +34,7 @@ define(function (require, exports, module) {
           email: 'testuser@testuser.com',
           verified: true
         });
+        broker = new AuthBroker();
         model = new Backbone.Model();
 
         relier = new Relier();
@@ -39,6 +42,7 @@ define(function (require, exports, module) {
           _formPrefill: {
             clear: sinon.spy()
           },
+          broker: broker,
           getStringifiedResumeToken: sinon.spy(),
           invokeBrokerMethod: sinon.spy(function () {
             return p();

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -143,6 +143,26 @@ define(function (require, exports, module) {
           });
       });
 
+      describe('with model.forceEmail', function () {
+        beforeEach(function () {
+          model.set('forceEmail', 'testuser@testuser.com');
+
+          return view.render();
+        });
+
+        it('shows a readonly email', function () {
+          var $emailInputEl = view.$('[type=email]');
+          assert.equal($emailInputEl.val(), 'testuser@testuser.com');
+          assert.isTrue($emailInputEl.hasClass('hidden'));
+
+          assert.equal(view.$('.prefillEmail').text(), 'testuser@testuser.com');
+        });
+
+        it('does not allow `signin`', function () {
+          assert.equal(view.$('.sign-in').length, 0);
+        });
+      });
+
       it('prefills email with email from the relier if formPrefill.email is not set', function () {
         relier.set('email', 'testuser@testuser.com');
 

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -15,6 +15,7 @@ define([
   './functional/sync_v2_reset_password',
   './functional/sync_v2_force_auth',
   './functional/sync_v3_sign_up',
+  './functional/sync_v3_force_auth',
   './functional/fx_firstrun_v1_sign_up',
   './functional/fx_firstrun_v1_sign_in',
   './functional/fx_firstrun_v2_sign_up',

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -9,40 +9,151 @@ define([
 ], function (registerSuite, TestHelpers, FunctionalHelpers) {
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
+  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
   var openForceAuth = FunctionalHelpers.openForceAuth;
+  var testElementDisabled = FunctionalHelpers.testElementDisabled;
   var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   var type = FunctionalHelpers.type;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
+
+  function testAccountNoLongerExistsErrorShown() {
+    return this.parent
+      .then(testElementTextInclude('.error', 'no longer exists'));
+  }
 
   var PASSWORD = 'password';
   var email;
 
   registerSuite({
-    name: 'force_auth with an existing user',
+    name: 'force_auth',
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
 
-      return this.remote
-        .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this));
+      return FunctionalHelpers.clearBrowserState(this);
     },
 
-    'sign in via force_auth': function () {
+    'with an invalid email': function () {
       return this.remote
+        .then(openForceAuth({
+          // TODO - this is a discrepancy and should go to the 400 page,
+          // but that's for another PR.
+          header: '#fxa-unexpected-error-header',
+          query: {
+            email: 'invalid'
+          }
+        }));
+    },
+
+    'with a registered email, no uid': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(openForceAuth({ query: { email: email }}))
         .then(fillOutForceAuth(PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'));
     },
 
+    'with a registered email, invalid uid': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(function (accountInfo) {
+          return openForceAuth({
+            // TODO - this is a discrepancy and should go to the 400 page,
+            // but that's for another PR.
+            header: '#fxa-unexpected-error-header',
+            query: {
+              email: email,
+              uid: 'a' + accountInfo.uid
+            }
+          }).call(this);
+        });
+    },
+
+    'with a registered email, registered uid': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(function (accountInfo) {
+          return openForceAuth({
+            query: {
+              email: email,
+              uid: accountInfo.uid
+            }
+          }).call(this);
+        })
+        .then(fillOutForceAuth(PASSWORD))
+
+        .then(testElementExists('#fxa-settings-header'));
+    },
+
+    'with a registered email, unregistered uid': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openForceAuth({
+          query: {
+            email: email,
+            uid: TestHelpers.createUID()
+          }
+        }))
+        .then(testAccountNoLongerExistsErrorShown);
+    },
+
+    'with an unregistered email, no uid': function () {
+      return this.remote
+        .then(openForceAuth({
+          header: '#fxa-signup-header',
+          query: { email: email }
+        }))
+        .then(visibleByQSA('.error'))
+        .then(testElementTextInclude('.error', 'recreate'))
+
+        // ensure the email is filled in, and not editible.
+        .then(testElementValueEquals('input[type=email]', email))
+        .then(testElementDisabled('input[type=email]'))
+
+        .then(fillOutSignUp(this, email, PASSWORD, { enterEmail: false }))
+        .then(testElementExists('#fxa-confirm-header'));
+    },
+
+    'with an unregistered email, registered uid': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(function (accountInfo) {
+          return openForceAuth({
+            query: {
+              email: 'a' + email,
+              uid: accountInfo.uid
+            }
+          }).call(this);
+        })
+
+        // user stays on the force_auth page but cannot continue, broker
+        // does not support uid change
+        .then(testAccountNoLongerExistsErrorShown);
+    },
+
+    'with an unregistered email, unregistered uid': function () {
+      return this.remote
+        .then(openForceAuth({
+          query: {
+            email: email,
+            uid: TestHelpers.createUID()
+          }
+        }))
+
+        // user stays on the force_auth page but cannot continue, broker
+        // does not support uid change
+        .then(testAccountNoLongerExistsErrorShown);
+    },
+
     'forgot password flow via force-auth goes directly to confirm email screen': function () {
       return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(openForceAuth({ query: { email: email }}))
         .then(click('.reset-password'))
 
@@ -56,12 +167,14 @@ define([
 
     'visiting the tos/pp links saves information for return': function () {
       return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(testRepopulateFields('/legal/terms', 'fxa-tos-header'))
         .then(testRepopulateFields('/legal/privacy', 'fxa-pp-header'));
     },
 
     'form prefill information is cleared after sign in->sign out': function () {
       return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(openForceAuth({ query: { email: email }}))
         .then(fillOutForceAuth(PASSWORD))
 
@@ -72,33 +185,6 @@ define([
         .then(testElementValueEquals('input[type=password]', ''));
     }
   });
-
-  registerSuite({
-    name: 'force_auth with an unregistered user',
-
-    beforeEach: function () {
-      email = TestHelpers.createEmail();
-
-      return this.remote
-        .then(clearBrowserState(this));
-    },
-
-    'sign in shows an error message': function () {
-      var self = this;
-      return this.remote
-        .then(openForceAuth({ query: { email: email }}))
-        .then(fillOutForceAuth(self, PASSWORD))
-        .then(visibleByQSA('.error'));
-    },
-
-    'reset password shows an error message': function () {
-      return this.remote
-        .then(openForceAuth({ query: { email: email }}))
-        .then(click('a[href="/confirm_reset_password"]'))
-        .then(visibleByQSA('.error'));
-    }
-  });
-
 
   function testRepopulateFields(dest, header) {
     return function () {

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -840,6 +840,39 @@ define([
   }
 
   /**
+   * Check to ensure an element has a `disabled` attribute.
+   *
+   * @param {string} selector
+   * @returns {promise} rejects if test fails
+   */
+  function testElementDisabled(selector) {
+    return function () {
+      return this.parent
+        .findByCssSelector(selector)
+          .getAttribute('disabled')
+          .then(function (disabledValue) {
+            // attribute value is null if it does not exist
+            assert.notStrictEqual(disabledValue, null);
+          })
+        .end();
+    };
+  }
+
+  /**
+   * Check to ensure an element exists
+   *
+   * @param {string} selector
+   * @returns {promise} rejects if element does not exist
+   */
+  function testElementExists(selector) {
+    return function () {
+      return this.parent
+        .findByCssSelector(selector)
+        .end();
+    };
+  }
+
+  /**
    * Check whether an input element's text includes the expected value.
    * Comparison is case insensitive
    *
@@ -1084,14 +1117,6 @@ define([
     return testAttribute(elementSelector, attributeName, 'match', regex);
   }
 
-  function testElementExists(selector) {
-    return function () {
-      return this.parent
-        .findByCssSelector(selector)
-        .end();
-    };
-  }
-
   function verifyUser(user, index, client, accountData) {
     return getVerificationHeaders(user, index)
       .then(function (headers) {
@@ -1138,6 +1163,7 @@ define([
     testAttribute: testAttribute,
     testAttributeEquals: testAttributeEquals,
     testAttributeMatches: testAttributeMatches,
+    testElementDisabled: testElementDisabled,
     testElementExists: testElementExists,
     testElementTextInclude: testElementTextInclude,
     testElementValueEquals: testElementValueEquals,

--- a/tests/functional/oauth_force_auth.js
+++ b/tests/functional/oauth_force_auth.js
@@ -14,66 +14,74 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
-  var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
+  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
+  var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
+  var testElementDisabled = FunctionalHelpers.testElementDisabled;
   var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
+  var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   var testUrlEquals = FunctionalHelpers.testUrlEquals;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   var PASSWORD = 'password';
   var email;
 
-
   registerSuite({
-    name: 'oauth force_auth with a registered force_email',
+    name: 'oauth force_auth',
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
       return this.remote
-        .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(clearBrowserState(this, {
           '123done': true,
           contentServer: true
         }));
     },
 
-    'allows the user to sign in': function () {
+    'with a registered email': function () {
       return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(openFxaFromRp(this, 'force_auth', { query: { email: email }}))
         .then(fillOutForceAuth(PASSWORD))
 
         .then(testElementExists('#loggedin'))
+        // redirected back to the App
         .then(testUrlEquals(OAUTH_APP));
-    }
-  });
-
-  registerSuite({
-    name: 'oauth force_auth with an unregistered force_mail',
-
-    beforeEach: function () {
-      email = TestHelpers.createEmail();
-      // clear localStorage to avoid polluting other tests.
-      return this.remote
-        .then(clearBrowserState(this, {
-          '123done': true,
-          contentServer: true
-        }));
     },
 
-    'sign in shows an error message': function () {
+    'with an unregistered email': function () {
       return this.remote
-        .then(openFxaFromRp(this, 'force_auth', { query: { email: email }}))
-        .then(fillOutForceAuth(PASSWORD))
-        .then(visibleByQSA('.error'));
-    },
+        .then(openFxaFromRp(this, 'force_auth', {
+          header: '#fxa-signup-header',
+          query: { email: email }
+        }))
+        .then(visibleByQSA('.error'))
+        .then(testElementTextInclude('.error', 'recreate'))
+        // ensure the email is filled in, and not editible.
+        .then(testElementValueEquals('input[type=email]', email))
+        .then(testElementDisabled('input[type=email]'))
+        .then(fillOutSignUp(this, email, PASSWORD, { enterEmail: false }))
 
-    'reset password shows an error message': function () {
-      return this.remote
-        .then(openFxaFromRp(this, 'force_auth', { query: { email: email }}))
-        .then(click('a[href="/confirm_reset_password"]'))
-        .then(visibleByQSA('.error'));
+        .then(testElementExists('#fxa-confirm-header'))
+        .then(openVerificationLinkInNewTab(this, email, 0))
+
+        .switchToWindow('newwindow')
+        // wait for the verified window in the new tab
+        .then(testElementExists('#fxa-sign-up-complete-header'))
+        // user sees the name of the RP,
+        // but cannot redirect
+        .then(testElementTextInclude('.account-ready-service', '123done'))
+
+        // switch to the original window
+        .closeCurrentWindow()
+        .switchToWindow('')
+
+        .then(testElementExists('#loggedin'))
+        // redirected back to the App
+        .then(testUrlEquals(OAUTH_APP));
     }
   });
 });

--- a/tests/functional/sync_v3_force_auth.js
+++ b/tests/functional/sync_v3_force_auth.js
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers'
+], function (registerSuite, TestHelpers, FunctionalHelpers) {
+  var email;
+  var PASSWORD = '12345678';
+  var POST_SIGNIN_DELAY = 2000;
+
+  var thenify = FunctionalHelpers.thenify;
+
+  var click = FunctionalHelpers.click;
+  var createUser = FunctionalHelpers.createUser;
+  var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
+  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
+  var openForceAuth = FunctionalHelpers.openForceAuth;
+  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testElementDisabled = FunctionalHelpers.testElementDisabled;
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
+  var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  var visibleByQSA = FunctionalHelpers.visibleByQSA;
+
+  registerSuite({
+    name: 'Firefox Desktop Sync v3 force_auth',
+
+    beforeEach: function () {
+      email = TestHelpers.createEmail();
+
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'with a registered email, no uid': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openForceAuth( {
+          query: {
+            context: 'fx_desktop_v3',
+            email: email,
+            service: 'sync'
+          }
+        }))
+        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(fillOutForceAuth(PASSWORD))
+        // add a slight delay to ensure the page does not transition
+        .sleep(POST_SIGNIN_DELAY)
+        // the page does not transition.
+        .then(testElementExists('#fxa-force-auth-header'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:login'));
+    },
+
+    'with a registered email, registered uid': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(function (accountInfo) {
+          return openForceAuth({
+            query: {
+              context: 'fx_desktop_v3',
+              email: email,
+              service: 'sync',
+              uid: accountInfo.uid
+            }
+          }).call(this);
+        })
+        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(fillOutForceAuth(PASSWORD))
+        // add a slight delay to ensure the page does not transition
+        .sleep(POST_SIGNIN_DELAY)
+        // the page does not transition.
+        .then(testElementExists('#fxa-force-auth-header'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:login'));
+    },
+
+    'with a registered email, unregistered uid': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openForceAuth({
+          query: {
+            context: 'fx_desktop_v3',
+            email: email,
+            service: 'sync',
+            uid: TestHelpers.createUID()
+          }
+        }))
+        .then(noSuchBrowserNotification(this, 'fxaccounts:logout'))
+        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(fillOutForceAuth(PASSWORD))
+        // add a slight delay to ensure the page does not transition
+        .sleep(POST_SIGNIN_DELAY)
+        // the page does not transition.
+        .then(testElementExists('#fxa-force-auth-header'))
+        // user is able to sign in, browser notified of new uid
+        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:login'));
+    },
+
+    'with an unregistered email, no uid': function () {
+      return this.remote
+        .then(openForceAuth({
+          // user should be automatically redirected to the
+          // signup page where they can signup with the
+          // specified email
+          header: '#fxa-signup-header',
+          query: {
+            context: 'fx_desktop_v3',
+            email: email,
+            service: 'sync'
+          }
+        }))
+        .then(noSuchBrowserNotification(this, 'fxaccounts:logout'))
+        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(visibleByQSA('.error'))
+        .then(testElementTextInclude('.error', 'recreate'))
+        // ensure the email is filled in, and not editible.
+        .then(testElementValueEquals('input[type=email]', email))
+        .then(testElementDisabled('input[type=email]'))
+        .then(fillOutSignUp(this, email, PASSWORD, { enterEmail: false }))
+
+        .then(testElementExists('#fxa-choose-what-to-sync-header'))
+        .then(click('button[type=submit]'))
+
+        // the default behavior of not transitioning to the confirm
+        // screen is overridden because the user is signing up outside
+        // of about:accounts.
+        .then(testElementExists('#fxa-confirm-header'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:login'));
+    },
+
+    'with an unregistered email, registered uid': function () {
+      var unregisteredEmail = 'a' + email;
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(function (accountInfo) {
+          return openForceAuth({
+            // user should be automatically redirected to the
+            // signup page where they can signup with the
+            // specified email
+            header: '#fxa-signup-header',
+            query: {
+              context: 'fx_desktop_v3',
+              email: unregisteredEmail,
+              service: 'sync',
+              uid: accountInfo.uid
+            }
+          }).call(this);
+        })
+        .then(visibleByQSA('.error'))
+        .then(testElementTextInclude('.error', 'recreate'))
+        // ensure the email is filled in, and not editible.
+        .then(testElementValueEquals('input[type=email]', unregisteredEmail))
+        .then(testElementDisabled('input[type=email]'));
+    },
+
+    'with an unregistered email, unregistered uid': function () {
+      return this.remote
+        .then(openForceAuth({
+          // user should be automatically redirected to the
+          // signup page where they can signup with the
+          // specified email
+          header: '#fxa-signup-header',
+          query: {
+            context: 'fx_desktop_v3',
+            email: email,
+            service: 'sync',
+            uid: TestHelpers.createUID()
+          }
+        }))
+        .then(visibleByQSA('.error'))
+        .then(testElementTextInclude('.error', 'recreate'))
+        // ensure the email is filled in, and not editible.
+        .then(testElementValueEquals('input[type=email]', email))
+        .then(testElementDisabled('input[type=email]'));
+    }
+  });
+});

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define([], function () {
+define([
+  'app/scripts/lib/constants'
+], function (Constants) {
 
   function createRandomHexString(length) {
     var str = '';
@@ -15,6 +17,10 @@ define([], function () {
     }
 
     return str;
+  }
+
+  function createUID () {
+    return createRandomHexString(Constants.UID_LENGTH);
   }
 
   function createEmail(template) {
@@ -31,6 +37,7 @@ define([], function () {
   return {
     createEmail: createEmail,
     createRandomHexString: createRandomHexString,
+    createUID: createUID,
     emailToUser: emailToUser
   };
 });


### PR DESCRIPTION
Sync users who click "Manage account" are sent to the `/settings` page. A
user may have to sign in via force_auth if their sessionToken is no longer
valid. If the user deleted their account, they may have to re-sign up, or
if they have already re-signed up, they may have to sign in.

This PR checks whether the passed in email and uid are still registered
before allowing the user to sign in.

If no uid is passed:
* If the email is no longer registered, allow the user to sign up again.

If a uid is passed:
* If the email is no longer registered and the broker supports a UID change,
    allow the user to sign up again.
* If the uid is no longer registered but the email is, allow the user to sign
  in if the broker supports a UID change.
* If the broker does not support a UID change, dead end for either case.

Currently the only broker that allows a UID change is fx_desktop_v3. We can
expand this functionality to other brokers once we verify support.

fixes #3057 
fixes #3283