### PR TITLE
feat(metric): Add metric to track password change success

### DIFF
--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -45,6 +45,7 @@ define(function (require, exports, module) {
           self.relier
         )
         .then(function () {
+          self.logViewEvent('success');
           return self.invokeBrokerMethod('afterChangePassword', account);
         })
         .then(function () {

--- a/app/tests/spec/views/settings/change_password.js
+++ b/app/tests/spec/views/settings/change_password.js
@@ -180,6 +180,7 @@ define(function (require, exports, module) {
 
           it('displays a success message', function () {
             assert.isTrue(view.displaySuccess.called);
+            assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.change-password.success'));
           });
         });
 

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -101,9 +101,11 @@ The event stream is a log of events and the time they occurred while the user is
 #### cannot_create_account
 
 #### change_password
-* error.change-password.auth.121 - account locked
-* change-password.unlock-email.send - user attempted to send unlock email
-* change-password.unlock-email.send.success - unlock email successfully sent
+* error.change_password.auth.103 - incorrect password
+* error.change_password.auth.121 - account locked
+* change_password.unlock-email.send - user attempted to send unlock email
+* change_password.unlock-email.send.success - unlock email successfully sent
+* change_password.success - password changed successfully
 
 #### choose_what_to_sync
 * choose-what-to-sync.engine-unchecked.`<engine_name>` - a Sync engine was unselected.


### PR DESCRIPTION
This PR adds the metric `fxa.content.settings.change_password.success`, which tracks when a user successfully changes their password.

fixes #3396 

@vladikoff r?