### PR TITLE
feat(client): Log localStorage errors on startup.

### DIFF
--- a/tests/functional/cookies_disabled.js
+++ b/tests/functional/cookies_disabled.js
@@ -5,9 +5,8 @@
 define([
   'intern',
   'intern!object',
-  'intern/chai!assert',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, FunctionalHelpers) {
+], function (intern, registerSuite, FunctionalHelpers) {
   // there is no way to disable cookies using wd. Add `disable_cookies`
   // to the URL to synthesize cookies being disabled.
   var config = intern.config;
@@ -24,6 +23,7 @@ define([
     name: 'cookies_disabled',
 
     'visit signup page with localStorage disabled': function () {
+      var self = this;
       return FunctionalHelpers.openPage(
             this, SIGNUP_COOKIES_DISABLED_URL, '#fxa-cookies-disabled-header')
         // try again, cookies are still disabled.
@@ -32,11 +32,7 @@ define([
         .end()
 
         // show an error message after second try
-        .then(FunctionalHelpers.visibleByQSA('#stage .error'))
-        .findByCssSelector('#stage .error').isDisplayed()
-        .then(function (isDisplayed) {
-          assert.equal(isDisplayed, true);
-        });
+        .then(FunctionalHelpers.testErrorWasShown(self));
     },
 
     'synthesize enabling cookies by visiting the sign up page, then cookies_disabled, then clicking "try again"': function () {
@@ -45,6 +41,7 @@ define([
       // manually seed history.
       return FunctionalHelpers.openPage(
             self, SIGNUP_COOKIES_ENABLED_URL, '#fxa-signup-header')
+
         .then(function () {
           return FunctionalHelpers.openPage(
               self, COOKIES_DISABLED_URL, '#fxa-cookies-disabled-header');
@@ -56,7 +53,8 @@ define([
         .end()
 
         // Should be redirected back to the signup page.
-        .findById('fxa-signup-header');
+        .findById('fxa-signup-header')
+        .end();
     },
 
     'visit verify page with localStorage disabled': function () {

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -691,7 +691,26 @@ define([
 
       // Wait until the `readySelector` element is found to return.
       .findByCssSelector(readySelector)
-      .end();
+      .end()
+
+      .then(null, function (err) {
+        return context.remote
+          .getCurrentUrl()
+            .then(function (resultUrl) {
+              console.log('Error fetching %s, now at %s', url, resultUrl);
+            })
+          .end()
+
+          .then(function () {
+            return context.remote.takeScreenshot();
+          })
+          .then(function (buffer) {
+            console.error('Error occurred, capturing base64 screenshot:');
+            console.error(buffer.toString('base64'));
+
+            throw err;
+          });
+      });
   }
 
   function fetchAllMetrics(context) {


### PR DESCRIPTION
Follow on for #3416 

Send error reports to both Sentry and our internal metrics.

A localStorage check is done on app start to see if localStorage
is enabled. If not, the browser will return an error. The error
object has a context of `storage`, a type of `localStorage` or
`sessionStorage` and an errno of the `name` field generated
by the browser.

issue #3414 