### PR TITLE
feat(client): Expand the permissions screen.

### DIFF
--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -19,7 +19,11 @@ define(function (require, exports, module) {
   var RELIER_FIELDS_IN_RESUME_TOKEN = ['state', 'verificationRedirect'];
   // We only grant permissions that our UI currently prompts for. Others
   // will be stripped.
-  var PERMISSION_WHITE_LIST = ['profile:uid', 'profile:email'];
+  var PERMISSION_WHITE_LIST = [
+    'profile:display_name',
+    'profile:email',
+    'profile:uid'
+  ];
 
   var OAuthRelier = Relier.extend({
     defaults: _.extend({}, Relier.prototype.defaults, {
@@ -27,11 +31,14 @@ define(function (require, exports, module) {
       clientId: null,
       // whether to fetch and derive relier-specific keys
       keys: false,
+      // permissions are individual scopes
+      permissions: null,
       // redirectTo is for future use by the oauth flow. redirectTo
       // would have redirectUri as its base.
       redirectTo: null,
       // redirectUri is used by the oauth flow
       redirectUri: null,
+      // a rollup of all the permissions
       scope: null,
       // standard oauth parameters.
       state: null,
@@ -194,7 +201,12 @@ define(function (require, exports, module) {
         return false;
       }
 
-      return ! account.hasGrantedPermissions(this.get('clientId'), this.get('permissions'));
+      // only check permissions for which the account has a value.
+      var applicableProfilePermissions =
+        account.getPermissionsWithValues(this.get('permissions'));
+
+      return ! account.hasSeenPermissions(
+          this.get('clientId'), applicableProfilePermissions);
     }
   });
 

--- a/app/scripts/templates/partial/permission.mustache
+++ b/app/scripts/templates/partial/permission.mustache
@@ -1,0 +1,15 @@
+<fieldset class="checkbox-row {{^visible}}hidden{{/visible}}" {{#required}}disabled{{/required}}>
+  <label class="fxa-checkbox">
+    <input class="permission" name="{{ name }}" type="checkbox" checked="checked" value="{{ name }}" {{#required}}disabled{{/required}}/>
+
+    {{#valueVisible}}
+      <div class="fxa-checkbox__value">{{ value }}</div>
+      <div class="fxa-checkbox__label">{{ label }}</div>
+    {{/valueVisible}}
+
+    {{^valueVisible}}
+      <div class="fxa-checkbox__value">{{ label }}</div>
+    {{/valueVisible}}
+  </label>
+</fieldset>
+

--- a/app/scripts/templates/permissions.mustache
+++ b/app/scripts/templates/permissions.mustache
@@ -10,10 +10,7 @@
     <p id="permission-request">{{#t}}%(serviceName)s wants the following information from your account:{{/t}}</p>
 
     <form id="permissions" novalidate>
-      <div class="input-row">
-        <label class="small-label">{{#t}}Email{{/t}}</label>
-        <input type="email" class="email" value="{{ email }}" disabled/>
-      </div>
+      {{{ unsafePermissionsHTML }}}
 
       <div class="button-row">
         <button id="accept" type="submit">{{#t}}Accept{{/t}}</button>

--- a/app/scripts/views/permissions.js
+++ b/app/scripts/views/permissions.js
@@ -5,11 +5,49 @@
 define(function (require, exports, module) {
   'use strict';
 
+  var _ = require('underscore');
+  var Account = require('models/account');
   var BackMixin = require('views/mixins/back-mixin');
+  var BaseView = require('views/base');
+  var CheckboxMixin = require('views/mixins/checkbox-mixin');
   var Cocktail = require('cocktail');
   var FormView = require('views/form');
+  var OAuthErrors = require('lib/oauth-errors');
+  var PermissionTemplate = require('stache!templates/partial/permission');
   var ServiceMixin = require('views/mixins/service-mixin');
+  var Strings = require('lib/strings');
   var Template = require('stache!templates/permissions');
+
+  var t = BaseView.t;
+
+  // Reduce the number of strings to translate by interpolating
+  // to create the required variant of a label.
+  var requiredPermissionLabel = t('%(permissionName)s (required)');
+
+  // Permissions are in the array in the order they should
+  // appear on the screen.
+  var PERMISSIONS = [
+    {
+      label: t('Email address'),
+      name: 'profile:email',
+      required: true
+    },
+    {
+      label: t('Display name'),
+      name: 'profile:display_name'
+    },
+    {
+      label: t('Account picture'),
+      name: 'profile:avatar',
+      valueVisible: false
+    },
+    {
+      label: 'uid',
+      name: 'profile:uid',
+      required: true,
+      visible: false
+    }
+  ];
 
   var View = FormView.extend({
     template: Template,
@@ -25,6 +63,7 @@ define(function (require, exports, module) {
       // a continuation function is passed in that should be called
       // when submit has completed.
       this.onSubmitComplete = this.model.get('onSubmitComplete');
+      this._validatePermissions(this.relier.get('permissions') || []);
     },
 
     getAccount: function () {
@@ -33,12 +72,179 @@ define(function (require, exports, module) {
 
     context: function () {
       var account = this.getAccount();
+      var requestedPermissions = this.relier.get('permissions');
+      var applicablePermissions =
+        this._getApplicablePermissions(account, requestedPermissions);
+      var permissionsHTML = this._getPermissionsHTML(account, applicablePermissions);
+
       return {
-        email: account.get('email'),
         privacyUri: this.relier.get('privacyUri'),
         serviceName: this.relier.get('serviceName'),
-        termsUri: this.relier.get('termsUri')
+        termsUri: this.relier.get('termsUri'),
+        unsafePermissionsHTML: permissionsHTML,
       };
+    },
+
+    /**
+     * Validate the requested permissions. Logs an INVALID_SCOPES error
+     * if any invalid permissions found. Does not throw.
+     *
+     * @private
+     * @param {string} requestedPermissionNames
+     */
+    _validatePermissions: function (requestedPermissionNames) {
+      requestedPermissionNames.forEach(function (permissionName) {
+        var permission = this._getPermissionConfig(permissionName);
+        // log the invalid scope instead of throwing an error
+        // to see if any reliers are specifying invalid scopes. We
+        // will be more strict in the future. Ref #2508
+        if (! permission) {
+          this.logError(OAuthErrors.toError('INVALID_SCOPES', permissionName));
+        }
+      }, this);
+    },
+
+    /**
+     * Get configuration for a permission
+     *
+     * @private
+     * @param {string} permissionName
+     * @returns {object} permission, if found.
+     * @throws if permission is invalid
+     */
+    _getPermissionConfig: function (permissionName) {
+      var permission = _.findWhere(PERMISSIONS, { name: permissionName });
+
+      if (! permission) {
+        return null;
+      }
+
+      return _.clone(permission);
+    },
+
+    /**
+     * Get the applicable permissions. A permission is applicable
+     * if both requested and the account has a corresponding value
+     *
+     * @private
+     * @param {object} account
+     * @param {array of strings} requestedPermissionNames
+     * @returns {array of objects} applicable permissions
+     */
+    _getApplicablePermissions: function (account, requestedPermissionNames) {
+      var self = this;
+
+      // only show permissions that have corresponding values.
+      var permissionsWithValues =
+        account.getPermissionsWithValues(requestedPermissionNames);
+
+      return permissionsWithValues.map(function (permissionName) {
+        var permission = self._getPermissionConfig(permissionName);
+
+        // filter out permissions we do not know about
+        if (! permission) {
+          return null;
+        }
+
+        return permissionName;
+      }).filter(function (permissionName) {
+        return permissionName !== null;
+      });
+    },
+
+    /**
+     * Get the index of a permission
+     *
+     * @private
+     * @param {string} permissionName
+     * @returns {number} permission index if found, -1 otw.
+     */
+    _getPermissionIndex: function (permissionName) {
+      return _.findIndex(PERMISSIONS, function (permission) {
+        return permission.name === permissionName;
+      });
+    },
+
+    /**
+     * Sort permissions to match the sort order in the PERMISSIONS array
+     *
+     * @private
+     * @param {array of strings} permissionNames
+     * @returns {array of strings} sorted permissionNames
+     */
+    _sortPermissions: function (permissionNames) {
+      var self = this;
+      return [].concat(permissionNames).sort(function (a, b) {
+        var aIndex = self._getPermissionIndex(a);
+        var bIndex = self._getPermissionIndex(b);
+        return aIndex - bIndex;
+      });
+    },
+
+    /**
+     * Get HTML for the set of permissions
+     *
+     * @private
+     * @param {array of strings} permissionNames
+     * @returns {string} HTML
+     */
+    _getPermissionsHTML: function (account, permissionNames) {
+      var self = this;
+
+      var sortedPermissionNames = self._sortPermissions(permissionNames);
+
+      // convert the permission names to HTML
+      return sortedPermissionNames.map(function (permissionName) {
+        var permission = self._getPermissionConfig(permissionName);
+        if (permission.required !== true) {
+          permission.required = false;
+        }
+
+        // convert label to the required label
+        if (permission.required) {
+          permission.label = Strings.interpolate(requiredPermissionLabel, {
+            permissionName: permission.label
+          });
+        }
+
+        // value is visible unless overridden
+        if (permission.valueVisible !== false) {
+          permission.valueVisible = true;
+        }
+
+        // permission as a whole is visible unless overridden
+        if (permission.visible !== false) {
+          permission.visible = true;
+        }
+
+        var accountKey = Account.PERMISSIONS_TO_KEYS[permissionName];
+        permission.value = account.get(accountKey);
+
+        return permission;
+      }).map(PermissionTemplate).join('\n');
+    },
+
+    /**
+     * Get the permission values from the form
+     *
+     * Returned object has the following format:
+     * {
+     *   'profile:display_name': false,
+     *   'profile:email': true
+     * }
+     *
+     * @private
+     * @returns {object}
+     */
+    _getFormPermissions: function () {
+      var $permissionEls = this.$('.permission');
+      var clientPermissions = {};
+
+      $permissionEls.each(function (index, el) {
+        clientPermissions[el.name] = !! el.checked;
+      });
+
+      return clientPermissions;
     },
 
     beforeRender: function () {
@@ -46,6 +252,11 @@ define(function (require, exports, module) {
       if (! this.getAccount().get('sessionToken')) {
         this.navigate(this._previousView());
         return false;
+      }
+
+      var account = this.getAccount();
+      if (account.get('verified')) {
+        return account.fetchProfile();
       }
     },
 
@@ -55,7 +266,9 @@ define(function (require, exports, module) {
 
       self.logViewEvent('accept');
 
-      account.saveGrantedPermissions(self.relier.get('clientId'), self.relier.get('permissions'));
+      account.setClientPermissions(
+          self.relier.get('clientId'), self._getFormPermissions());
+
       return self.user.setAccount(account)
         .then(self.onSubmitComplete);
     },
@@ -68,11 +281,14 @@ define(function (require, exports, module) {
     is: function (type) {
       return this.type === type;
     }
+  }, {
+    PERMISSIONS: PERMISSIONS
   });
 
   Cocktail.mixin(
     View,
     BackMixin,
+    CheckboxMixin,
     ServiceMixin
   );
 

--- a/app/scripts/views/settings/gravatar_permissions.js
+++ b/app/scripts/views/settings/gravatar_permissions.js
@@ -12,6 +12,9 @@ define(function (require, exports, module) {
   var ServiceMixin = require('views/mixins/service-mixin');
   var Template = require('stache!templates/settings/gravatar_permissions');
 
+  var GRAVATAR_MOCK_CLIENT_ID = 'gravatar';
+  var GRAVATAR_PERMISSION = 'profile:email';
+
   var View = FormView.extend({
     template: Template,
     className: 'gravatar-permissions',
@@ -28,7 +31,7 @@ define(function (require, exports, module) {
 
     beforeRender: function () {
       var account = this.getSignedInAccount();
-      if (account.hasGrantedPermissions(View.GRAVATAR_MOCK_CLIENT_ID, View.PERMISSIONS)) {
+      if (account.getClientPermission(GRAVATAR_MOCK_CLIENT_ID, GRAVATAR_PERMISSION)) {
         this.logViewEvent('already-accepted');
         this.navigate('settings/avatar/gravatar');
         return false;
@@ -41,16 +44,18 @@ define(function (require, exports, module) {
       self.logViewEvent('accept');
 
       return p().then(function () {
-        account.saveGrantedPermissions(View.GRAVATAR_MOCK_CLIENT_ID, View.PERMISSIONS);
+        var permissions = {};
+        permissions[GRAVATAR_PERMISSION] = true;
+        account.setClientPermissions(GRAVATAR_MOCK_CLIENT_ID, permissions);
         self.user.setAccount(account);
         self.navigate('settings/avatar/gravatar');
       });
     }
-
+  }, {
+    GRAVATAR_MOCK_CLIENT_ID: GRAVATAR_MOCK_CLIENT_ID,
+    GRAVATAR_PERMISSION: GRAVATAR_PERMISSION
   });
 
-  View.PERMISSIONS = ['profile:email'];
-  View.GRAVATAR_MOCK_CLIENT_ID = 'gravatar';
 
   Cocktail.mixin(
     View,

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -85,7 +85,7 @@ ul.links {
   }
 }
 
-.choose-what-to-sync-row {
+.choose-what-to-sync-row, .checkbox-row {
 
   label {
     display: block;
@@ -171,15 +171,32 @@ ul.links {
 }
 
 #permissions {
-  .input-row {
-    text-align: left;
-    margin: 30px 0;
+  fieldset {
+    border: none;
   }
 
-  input[disabled] {
-    background-color: $input-background-disabled-color;
-    border-color: $input-border-disabled-color;
-    color: $input-disabled-color;
+  .avatar-wrapper {
+    height: 50px;
+    width: 50px;
+  }
+
+  .fxa-checkbox {
+    color: #8a9ba8;
+    height: auto;
+
+    .fxa-checkbox__label {
+      color: #8a9ba8;
+      font-size: 14px;
+      margin-top: auto;
+    }
+
+    .fxa-checkbox__value {
+      font-size: 18px;
+      line-height: 18px;
+      // email addresses can overflow the label and cause
+      // the screen to be very wide. Break the addresses.
+      word-break: break-all;
+    }
   }
 }
 

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -108,13 +108,11 @@ define(function (require, exports, module) {
     it('getSignedInAccount', function () {
       var account = user.initAccount({
         email: 'email',
-        grantedPermissions: { 'someClientId': ['profile:email'] },
         uid: 'uid'
       });
       return user.setSignedInAccount(account)
         .then(function () {
           assert.equal(user.getSignedInAccount().get('uid'), account.get('uid'));
-          assert.deepEqual(user.getSignedInAccount().get('grantedPermissions')['someClientId'], ['profile:email']);
         });
     });
 
@@ -504,7 +502,7 @@ define(function (require, exports, module) {
 
           var oldAccount = user.initAccount({
             email: 'email',
-            grantedPermissions: { foo: ['bar'] },
+            permissions: { foo: { bar: true } },
             uid: 'uid2'
           });
 
@@ -526,7 +524,9 @@ define(function (require, exports, module) {
         it('merges data with old and new account', function () {
           var updatedAccount = user.setSignedInAccount.args[0][0];
           assert.deepEqual(
-            updatedAccount.get('grantedPermissions').foo, ['bar']);
+            updatedAccount.getClientPermissions('foo'), {
+              bar: true
+            });
           assert.equal(updatedAccount.get('displayName'), 'fx user');
         });
       });

--- a/app/tests/spec/views/permissions.js
+++ b/app/tests/spec/views/permissions.js
@@ -10,6 +10,7 @@ define(function (require, exports, module) {
   var Broker = require('models/auth_brokers/base');
   var chai = require('chai');
   var Metrics = require('lib/metrics');
+  var OAuthErrors = require('lib/oauth-errors');
   var p = require('lib/promise');
   var Relier = require('models/reliers/relier');
   var Notifier = require('lib/channels/notifier');
@@ -55,12 +56,23 @@ define(function (require, exports, module) {
         serviceName: SERVICE_NAME,
         serviceUri: SERVICE_URI
       });
+
       user = new User({});
+
       account = user.initAccount({
         email: email,
         sessionToken: 'fake session token',
         uid: 'uid'
       });
+
+      sinon.stub(user, 'setAccount', function () {
+        return p(account);
+      });
+
+      sinon.stub(account, 'fetchProfile', function () {
+        return p();
+      });
+
       model.set({
         account: account,
         onSubmitComplete: onSubmitComplete
@@ -98,40 +110,51 @@ define(function (require, exports, module) {
     }
 
     describe('renders', function () {
-      it('coming from sign in, redirects to /signin when session token missing', function () {
-        account.clear('sessionToken');
-        return initView('sign_in')
-          .then(function () {
+      describe('with a sessionToken', function () {
+        beforeEach(function () {
+          return initView('sign_up');
+        });
+
+        it('renders relier info', function () {
+          assert.include(view.$('#permission-request').text(), SERVICE_NAME,
+            'service name shows in paragraph');
+        });
+
+        it('renders some permissions', function () {
+          assert.ok(view.$('.permission').length);
+        });
+      });
+
+      describe('without a sessionToken', function () {
+        beforeEach(function () {
+          account.clear('sessionToken');
+        });
+
+        describe('coming from signin', function () {
+          beforeEach(function () {
+            return initView('sign_in');
+          });
+
+          it('redirects to /signin', function () {
             assert.isTrue(view.navigate.calledWith('/signin'));
           });
-      });
+        });
 
-      it('coming from sign up, redirects to /signup when session token missing', function () {
-        account.clear('sessionToken');
-        return initView('sign_up')
-          .then(function () {
+        describe('coming from signup', function () {
+          beforeEach(function () {
+            return initView('sign_up');
+          });
+
+          it('redirects to /signup', function () {
             assert.isTrue(view.navigate.calledWith('/signup'));
           });
-      });
-
-      it('renders relier info', function () {
-        return initView('sign_up')
-          .then(function () {
-            assert.include(view.$('#permission-request').text(), SERVICE_NAME,
-              'service name shows in paragraph');
-
-            assert.equal(view.$('.email').val(), email,
-              'shows email in permissions list');
-          });
+        });
       });
     });
 
     describe('submit', function () {
       beforeEach(function () {
-        sinon.spy(account, 'saveGrantedPermissions');
-        sinon.stub(user, 'setAccount', function (account) {
-          return p(account);
-        });
+        sinon.spy(account, 'setClientPermissions');
 
         return initView('sign_in')
           .then(function () {
@@ -142,7 +165,10 @@ define(function (require, exports, module) {
 
       it('saves the granted permissions', function () {
         assert.isTrue(
-          account.saveGrantedPermissions.calledWith(CLIENT_ID, PERMISSIONS));
+          account.setClientPermissions.calledWith(CLIENT_ID, {
+            'profile:email': true,
+            'profile:uid': true
+          }));
       });
 
       it('sets the account', function () {
@@ -154,5 +180,215 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('_getPermissionConfig', function () {
+      var permission;
+
+      describe('with a valid permission', function () {
+        beforeEach(function () {
+          return initView('sign_up')
+            .then(function () {
+              permission = view._getPermissionConfig('profile:email');
+            });
+        });
+
+        it('returns the permission', function () {
+          assert.equal(permission.name, 'profile:email');
+        });
+      });
+
+      describe('with an invalid permission', function () {
+        beforeEach(function () {
+          return initView('sign_up')
+            .then(function () {
+              permission = view._getPermissionConfig('invalid');
+            });
+        });
+
+        it('returns null', function () {
+          assert.isNull(permission);
+        });
+      });
+    });
+
+    describe('_validatePermissions', function () {
+      beforeEach(function () {
+        return initView('sign_up')
+          .then(function () {
+            sinon.spy(view, 'logError');
+            view._validatePermissions(['profile:invalid', 'profile:email']);
+          });
+      });
+
+      it('logs an error for invalid permissions', function () {
+        assert.isTrue(view.logError.calledOnce);
+
+        var error = view.logError.args[0][0];
+
+        assert.isTrue(OAuthErrors.is(error, 'INVALID_SCOPES'));
+        assert.equal(error.context, 'profile:invalid');
+      });
+    });
+
+    describe('_getApplicablePermissions', function () {
+      var permissions;
+
+      beforeEach(function () {
+        account.clear();
+        account.set({
+          displayName: 'Test user',
+          email: 'testuser@testuser.com',
+          uid: 'users id'
+        });
+
+        return initView('sign_up')
+          .then(function () {
+            sinon.spy(view, 'logError');
+          });
+      });
+
+      describe('with valid permissions', function () {
+        beforeEach(function () {
+          permissions = view._getApplicablePermissions(account, [
+            'profile:email',
+            'profile:display_name',
+            'profile:avatar',
+            'profile:uid'
+          ]);
+        });
+
+        it('returns requested permissions if the account has a value', function () {
+          assert.equal(permissions.length, 3);
+
+          assert.equal(permissions[0], 'profile:email');
+          assert.equal(permissions[1], 'profile:display_name');
+          assert.equal(permissions[2], 'profile:uid');
+        });
+      });
+
+      describe('with an invalid permission', function () {
+        beforeEach(function () {
+          permissions =
+            view._getApplicablePermissions(account, [
+              'profile:email',
+              'profile:invalid'
+            ]);
+        });
+
+        it('filters the invalid permission', function () {
+          assert.lengthOf(permissions, 1);
+          assert.equal(permissions[0], 'profile:email');
+        });
+      });
+    });
+
+    describe('_sortPermissions', function () {
+      var sortedPermissions;
+      beforeEach(function () {
+        var requestedPermissions = ['profile:display_name', 'profile:email'];
+
+        return initView('sign_up')
+          .then(function () {
+            sortedPermissions = view._sortPermissions(requestedPermissions);
+          });
+      });
+
+      it('sorts the permissions', function () {
+        var expectedSortedPermissions =
+            ['profile:email', 'profile:display_name'];
+
+        assert.deepEqual(sortedPermissions, expectedSortedPermissions);
+      });
+    });
+
+    describe('_getPermissionsHTML', function () {
+      beforeEach(function () {
+        account.clear();
+        account.set({
+          displayName: 'Test user',
+          email: 'testuser@testuser.com',
+          uid: 'users id'
+        });
+
+        // permissions are passed in unsorted
+        var permissionNames = ['profile:display_name', 'profile:email', 'profile:uid'];
+
+        return initView('sign_up')
+          .then(function () {
+            var html = view._getPermissionsHTML(account, permissionNames);
+            $('#container').html(html);
+          });
+      });
+
+      it('correctly sorts and renders required permission', function () {
+        var permissionContainer = $('#container fieldset:nth(0)');
+        assert.equal(permissionContainer.attr('disabled'), 'disabled');
+        assert.include(permissionContainer.find('.fxa-checkbox__label').text(), 'required');
+        assert.equal(permissionContainer.find('input[type=checkbox]').attr('disabled'), 'disabled');
+
+        var html = permissionContainer.html();
+        assert.include(html, 'testuser@testuser.com');
+        assert.include(html, 'value="profile:email"');
+      });
+
+      it('correctly renders non-required permission', function () {
+        var permissionContainer = $('#container fieldset:nth(1)');
+        assert.isUndefined(permissionContainer.attr('disabled'));
+        assert.isUndefined(permissionContainer.find('input[type=checkbox]').attr('disabled'));
+
+        var html = permissionContainer.html();
+        assert.include(html, 'Test user');
+        assert.include(html, 'value="profile:display_name"');
+      });
+
+      it('correctly renders hidden permission', function () {
+        var permissionContainer = $('#container fieldset:nth(2)');
+
+        assert.equal(permissionContainer.find('input[type=checkbox]').attr('disabled'), 'disabled');
+        assert.isTrue(permissionContainer.hasClass('hidden'));
+
+        var html = permissionContainer.html();
+        assert.include(html, 'value="profile:uid"');
+      });
+
+      it('adds `required` text to `required` permissions', function () {
+        var permissionContainer = $('#container fieldset:nth(0)');
+        var html = permissionContainer.html();
+        console.log('permissionLabel', html);
+        assert.include(html, 'required');
+      });
+    });
+
+    describe('_getFormPermissions', function () {
+      var clientPermissions;
+
+      beforeEach(function () {
+        account.set({
+          displayName: 'Test user',
+          email: 'testuser@testuser.com',
+          uid: 'user id'
+        });
+
+        // only profile:email and profile:display_name should be displayed
+        // profile:avatar is not applicable since user does not yet have one
+        relier.set('permissions',
+          ['profile:email', 'profile:display_name', 'profile:avatar', 'profile:uid']);
+
+        return initView('sign_up')
+          .then(function () {
+            // profile:email is the only visible item left after this.
+            $('#container').find('.permission[name="profile:display_name"]')
+              .removeAttr('checked');
+
+            clientPermissions = view._getFormPermissions();
+          });
+      });
+
+      it('returns permissions that are selected', function () {
+        assert.lengthOf(Object.keys(clientPermissions), 3);
+        assert.isFalse(clientPermissions['profile:display_name']);
+        assert.isTrue(clientPermissions['profile:email']);
+        assert.isTrue(clientPermissions['profile:uid']);
+      });
+    });
   });
 });

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "chai": "1.8.1",
     "cocktail": "0.5.9",
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
-    "fxa-checkbox": "mozilla/fxa-checkbox#96575e301a4d1d43efc8b2de0149aaafcbb3b37b",
+    "fxa-checkbox": "mozilla/fxa-checkbox#76be01b4919dc09f591f46b015d43fc0576fc212",
     "fxa-content-server-l10n": "https://github.com/mozilla/fxa-content-server-l10n.git",
     "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.33",
     "fxa-password-strength-checker": "https://github.com/mozilla/fxa-password-strength-checker.git#d73b3ade374607e2749ee375301b0a168008b16f",

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -319,8 +319,12 @@ define([
       });
   }
 
-  function openSettingsInNewTab(context, windowName) {
-    return context.remote.execute(openWindow, [ SETTINGS_URL, windowName ]);
+  function openSettingsInNewTab(context, windowName, panel) {
+    var url = SETTINGS_URL;
+    if (panel) {
+      url += '/' + panel;
+    }
+    return context.remote.execute(openWindow, [ url, windowName ]);
   }
 
   function openSignInInNewTab(context, windowName) {
@@ -909,6 +913,14 @@ define([
     };
   }
 
+  function testElementExists(selector) {
+    return function () {
+      return this.parent
+        .findByCssSelector(selector)
+        .end();
+    };
+  }
+
   return {
     clearBrowserState: clearBrowserState,
     clearSessionStorage: clearSessionStorage,
@@ -942,6 +954,7 @@ define([
     pollUntil: pollUntil,
     respondToWebChannelMessage: respondToWebChannelMessage,
     testAreEventsLogged: testAreEventsLogged,
+    testElementExists: testElementExists,
     testElementValueEquals: testElementValueEquals,
     testErrorWasShown: testErrorWasShown,
     testIsBrowserNotified: testIsBrowserNotified,

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -24,11 +24,15 @@ define([
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
+  var noSuchElement = FunctionalHelpers.noSuchElement;
   var openFxaFromUntrustedRp = FunctionalHelpers.openFxaFromUntrustedRp;
   var openPage = FunctionalHelpers.openPage;
+  var openSettingsInNewTab = thenify(FunctionalHelpers.openSettingsInNewTab);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
+  var testElementExists = FunctionalHelpers.testElementExists;
   var testUrlEquals = FunctionalHelpers.testUrlEquals;
   var type = FunctionalHelpers.type;
+  var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   registerSuite({
     name: 'oauth permissions',
@@ -51,17 +55,16 @@ define([
 
         .then(fillOutSignIn(self, email, PASSWORD))
 
-        .findByCssSelector('#fxa-permissions-header')
-        .end()
+        .then(testElementExists('#fxa-permissions-header'))
 
         .then(click('#accept'))
 
-        .findByCssSelector('#loggedin')
+        .then(testElementExists('#loggedin'))
 
         .then(testUrlEquals(OAUTH_APP));
     },
 
-    're-signin verified': function () {
+    're-signin verified, no additional permissions': function () {
       var self = this;
 
       return openFxaFromUntrustedRp(self, 'signin')
@@ -69,13 +72,10 @@ define([
 
         .then(fillOutSignIn(self, email, PASSWORD))
 
-        .findByCssSelector('#fxa-permissions-header')
-        .end()
-
+        .then(testElementExists('#fxa-permissions-header'))
         .then(click('#accept'))
 
-        .findByCssSelector('#loggedin')
-        .end()
+        .then(testElementExists('#loggedin'))
 
         .then(testUrlEquals(OAUTH_APP))
 
@@ -85,10 +85,10 @@ define([
         // user signed in previously and should not need to enter
         // their email address.
         .then(type('input[type=password]', PASSWORD))
-
         .then(click('button[type=submit]'))
 
-        .findByCssSelector('#loggedin')
+        // no permissions additional asked for
+        .then(testElementExists('#loggedin'))
 
         // redirected back to the App without seeing the permissions screen.
         .then(testUrlEquals(OAUTH_APP));
@@ -102,13 +102,10 @@ define([
 
         .then(fillOutSignIn(self, email, PASSWORD))
 
-        .findByCssSelector('#fxa-permissions-header')
-        .end()
-
+        .then(testElementExists('#fxa-permissions-header'))
         .then(click('#accept'))
 
-        .findByCssSelector('#fxa-confirm-header')
-        .end()
+        .then(testElementExists('#fxa-confirm-header'))
 
         // get the second email, the first was sent on client.signUp w/
         // preVerified: false above. The second email has the `service` and
@@ -120,7 +117,6 @@ define([
           return openPage(self, verifyUrl, '#loggedin');
         });
     },
-
 
     'signup, verify same browser': function () {
       var self = this;
@@ -138,13 +134,11 @@ define([
 
         .then(fillOutSignUp(self, email, PASSWORD))
 
-        .findByCssSelector('#fxa-permissions-header')
-        .end()
+        .then(testElementExists('#fxa-permissions-header'))
 
         .then(click('#accept'))
 
-        .findByCssSelector('#fxa-confirm-header')
-        .end()
+        .then(testElementExists('#fxa-confirm-header'))
 
         .then(openVerificationLinkInNewTab(self, email, 0))
 
@@ -167,8 +161,7 @@ define([
         .closeCurrentWindow()
         .switchToWindow('')
 
-        .findByCssSelector('#loggedin')
-        .end();
+        .then(testElementExists('#loggedin'));
     },
 
     'preverified signup': function () {
@@ -182,8 +175,7 @@ define([
         .then(type('#age', 24))
         .then(click('button[type="submit"]'))
 
-        .findByCssSelector('#fxa-permissions-header')
-        .end()
+        .then(testElementExists('#fxa-permissions-header'))
 
         .then(click('#accept'))
 
@@ -192,12 +184,10 @@ define([
         // straight for the loggedin user, visibleByQSA blows up
         // because 123done isn't loaded yet and it complains about
         // the unload event of the content server.
-        .findByCssSelector('#footer-main')
-        .end()
+        .then(testElementExists('#footer-main'))
 
         // user is pre-verified and sent directly to the RP.
-        .then(FunctionalHelpers.visibleByQSA('#loggedin'))
-        .end()
+        .then(visibleByQSA('#loggedin'))
 
         .findByCssSelector('#loggedin')
         .getVisibleText()
@@ -208,25 +198,21 @@ define([
         .end();
     },
 
-    'signup, then signin': function () {
+    'signup, then signin with no additional permissions': function () {
       var self = this;
       return openFxaFromUntrustedRp(self, 'signup')
         .then(fillOutSignUp(self, email, PASSWORD))
 
-        .findByCssSelector('#fxa-permissions-header')
-        .end()
-
+        .then(testElementExists('#fxa-permissions-header'))
         .then(click('#accept'))
 
-        .findByCssSelector('#fxa-confirm-header')
-        .end()
+        .then(testElementExists('#fxa-confirm-header'))
 
         .then(openVerificationLinkInNewTab(self, email, 0))
 
         .switchToWindow('newwindow')
         // wait for the verified window in the new tab
-        .findById('fxa-sign-up-complete-header')
-        .end()
+        .then(testElementExists('#fxa-sign-up-complete-header'))
 
         .sleep(5000)
         .findByCssSelector('.account-ready-service')
@@ -242,8 +228,7 @@ define([
         .closeCurrentWindow()
         .switchToWindow('')
 
-        .findByCssSelector('#loggedin')
-        .end()
+        .then(testElementExists('#loggedin'))
 
         .then(click('#logout'))
 
@@ -252,11 +237,9 @@ define([
         // user signed in previously and should not need to enter
         // their email address.
         .then(type('input[type=password]', PASSWORD))
-
         .then(click('button[type=submit]'))
 
-        .findByCssSelector('#loggedin')
-        .end()
+        .then(testElementExists('#loggedin'))
 
         .then(testUrlEquals(OAUTH_APP));
     },
@@ -272,16 +255,149 @@ define([
         // age not filled in, submit works anyways.
         .then(click('button[type=submit]'))
 
-        .findByCssSelector('#fxa-permissions-header')
-        .end()
+        .then(testElementExists('#fxa-permissions-header'))
 
         .then(click('#accept'))
 
-        .findByCssSelector('#loggedin')
-        .end()
+        .then(testElementExists('#loggedin'))
 
         .then(testUrlEquals(OAUTH_APP));
     },
-  });
 
+    'signin with new permission available b/c of new account information': function () {
+      var self = this;
+
+      return openFxaFromUntrustedRp(self, 'signin')
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+
+        .then(fillOutSignIn(self, email, PASSWORD))
+
+        .then(testElementExists('#fxa-permissions-header'))
+
+        // display name is not available because user has not set their name
+        .then(noSuchElement(self, 'input[name="profile:display_name"]'))
+
+        .then(click('#accept'))
+
+        .then(testElementExists('#loggedin'))
+        .then(testUrlEquals(OAUTH_APP))
+
+        .then(click('#logout'))
+
+        .then(openSettingsInNewTab(self, 'settings', 'display_name'))
+        .switchToWindow('settings')
+
+        .then(type('#display-name input[type=text]', 'test user'))
+        .then(click('#display-name button[type=submit]'))
+
+        .then(visibleByQSA('.settings-success'))
+
+        .closeCurrentWindow()
+        .switchToWindow('')
+
+        .then(click('.signin'))
+
+        .then(type('input[type=password', PASSWORD))
+        .then(click('button[type=submit]'))
+
+        // display name is now available
+        .then(testElementExists('input[name="profile:display_name"]'))
+
+        .then(click('#accept'))
+        .then(testElementExists('#loggedin'));
+    },
+
+    'signin with additional requested permission': function () {
+      var self = this;
+
+      return self.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+
+        .then(fillOutSignIn(self, email, PASSWORD))
+
+        // make display_name available from the start
+        .then(click('#display-name button.settings-unit-toggle'))
+
+        .then(type('#display-name input[type=text]', 'test user'))
+        .then(click('#display-name button[type=submit]'))
+
+        .then(visibleByQSA('.settings-success'))
+
+        .then(function () {
+          // the first time through, only request email and uid
+          return openFxaFromUntrustedRp(self, 'signin', '?scope=profile%3Aemail profile%3Auid');
+        })
+
+        .then(type('input[type=password', PASSWORD))
+        .then(click('button[type=submit]'))
+
+        .then(testElementExists('#fxa-permissions-header'))
+
+        // display name is not available because it's not requested
+        .then(noSuchElement(self, 'input[name="profile:display_name"]'))
+
+        .then(click('#accept'))
+
+        .then(testElementExists('#loggedin'))
+        .then(testUrlEquals(OAUTH_APP))
+
+        .then(click('#logout'))
+        .then(click('.signin'))
+
+        .then(type('input[type=password', PASSWORD))
+        .then(click('button[type=submit]'))
+
+        // the second time through, profile:email, profile:uid, and
+        // profile:display_name will be asked for, so display_name is
+        // available
+        .then(testElementExists('input[name="profile:display_name"]'))
+        .then(click('#accept'))
+
+        .then(testElementExists('#loggedin'));
+    },
+
+    'signin after de-selecting a requested permission': function () {
+      var self = this;
+
+      return self.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+
+        .then(fillOutSignIn(self, email, PASSWORD))
+
+        // make display_name available from the start
+        .then(click('#display-name button.settings-unit-toggle'))
+
+        .then(type('#display-name input[type=text]', 'test user'))
+        .then(click('#display-name button[type=submit]'))
+
+        .then(visibleByQSA('.settings-success'))
+
+        .then(function () {
+          return openFxaFromUntrustedRp(self, 'signin');
+        })
+
+        .then(type('input[type=password', PASSWORD))
+        .then(click('button[type=submit]'))
+
+        .then(testElementExists('input[name="profile:display_name"]'))
+
+        // deselect display name to ensure permission state is
+        // saved correctly.
+        .then(click('input[name="profile:display_name"]'))
+
+        .then(click('#accept'))
+        .then(testElementExists('#loggedin'))
+
+        .then(click('#logout'))
+
+        // signin again, no permissions should be asked for even though
+        // display_name was de-selected last time.
+        .then(click('.signin'))
+
+        .then(type('input[type=password', PASSWORD))
+        .then(click('button[type=submit]'))
+
+        .then(testElementExists('#loggedin'));
+    }
+  });
 });


### PR DESCRIPTION
Add separate fields for "email", "display name" and "profile image"

fixes #2477