### PR TITLE
refactor(client): Extract `accountKeys`, `relierKeys` to the Account model.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -390,7 +390,6 @@ define(function (require, exports, module) {
         } else if (this._isWebChannel()) {
           this._authenticationBroker = new WebChannelAuthenticationBroker({
             assertionLibrary: this._assertionLibrary,
-            fxaClient: this._fxaClient,
             oAuthClient: this._oAuthClient,
             relier: this._relier,
             session: Session,

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -614,6 +614,41 @@ define(function (require, exports, module) {
           resume: options.resume
         }
       );
+    },
+
+    /**
+     * Fetch keys for the account. Requires account to have
+     * `keyFetchToken` and `unwrapBKey`
+     *
+     * @returns {promise} that resolves with the account keys, if they
+     *   can be generated, resolves with null otherwise.
+     */
+    accountKeys: function () {
+      if (! this.has('keyFetchToken') || ! this.has('unwrapBKey')) {
+        return p(null);
+      }
+
+      return this._fxaClient.accountKeys(
+          this.get('keyFetchToken'), this.get('unwrapBKey'));
+    },
+
+    /**
+     * Fetch keys that can be used by a relier.
+     *
+     * @param {object} relier
+     * @returns {promise} that resolves with the relier keys, if they
+     *   can be generated, resolves with null otherwise.
+     */
+    relierKeys: function (relier) {
+      var self = this;
+      return this.accountKeys()
+        .then(function (accountKeys) {
+          if (! accountKeys) {
+            return null;
+          }
+
+          return relier.deriveRelierKeys(accountKeys, self.get('uid'));
+        });
     }
   });
 

--- a/app/scripts/models/auth_brokers/web-channel.js
+++ b/app/scripts/models/auth_brokers/web-channel.js
@@ -27,7 +27,6 @@ define(function (require, exports, module) {
     initialize: function (options) {
       options = options || {};
 
-      this._fxaClient = options.fxaClient;
       // channel can be passed in for testing.
       this._channel = options.channel;
 
@@ -75,19 +74,10 @@ define(function (require, exports, module) {
           if (! self.relier.wantsKeys()) {
             return result;
           }
-          var uid = account.get('uid');
-          var keyFetchToken = account.get('keyFetchToken');
-          var unwrapBKey = account.get('unwrapBKey');
-          if (! keyFetchToken || ! unwrapBKey) {
-            result.keys = null;
-            return result;
-          }
-          return self._fxaClient.accountKeys(keyFetchToken, unwrapBKey)
-            .then(function (keys) {
-              return self.relier.deriveRelierKeys(keys, uid);
-            })
-            .then(function (keys) {
-              result.keys = keys;
+
+          return account.relierKeys(self.relier)
+            .then(function (relierKeys) {
+              result.keys = relierKeys;
               return result;
             });
         });


### PR DESCRIPTION
Ripped these methods out of the WebchannelAuthenticationBroker.
The WebChannelAuthenticationBroker no longer needs an fxaClient.

@rfk - you wrote the original keys code, mind an r?
@vbudhram - r? Time to introduce you to some of the hairy content server concepts - the AuthenticationBrokers and Account. Have a read over the [architecture doc](https://github.com/mozilla/fxa-content-server/blob/master/docs/architecture.md) to get an overview of what those entities do.

This is an opportunistic refactor that came from investigating #3431 and #3415.