### PR TITLE
chore(client): Remove `submit` from ForceAuthView.

### DIFF
--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -63,16 +63,6 @@ define(function (require, exports, module) {
       this._formPrefill.set('password', this.getElementValue('.password'));
     },
 
-    submit: function () {
-      var account = this.user.initAccount({
-        email:  this.relier.get('email')
-      });
-
-      var password = this.getElementValue('.password');
-
-      return this._signIn(account, password);
-    },
-
     onSignInError: function (account, password, err) {
       if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
         // dead end, do not allow the user to sign up.


### PR DESCRIPTION
`submit` duplicated logic already found in the SignInView's `submit` function.

fixes #3438 

@philbooth - one more for you!