### PR TITLE
fix(client): No more redirect to `signin_complete` w/ fx_desktop_v2

### DIFF
--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -34,6 +34,15 @@ define(function (require, exports, module) {
     },
 
     defaultBehaviors: _.extend({}, proto.defaultBehaviors, {
+      // about:accounts displays its own screen after sign in, no need
+      // to show anything.
+      afterForceAuth: new HaltBehavior(),
+      // about:accounts displays its own screen after password reset, no
+      // need to show anything.
+      afterResetPasswordConfirmationPoll: new HaltBehavior(),
+      // about:accounts displays its own screen after sign in, no need
+      // to show anything.
+      afterSignIn: new HaltBehavior(),
       // the browser is already polling, no need for the content server
       // code to poll as well, otherwise two sets of polls are going on
       // for the same user.

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -42,19 +42,19 @@ define(function (require, exports, module) {
       });
     });
 
-    it('has the `signup` capability by default', function () {
+    it('has the `signup` capability', function () {
       assert.isTrue(broker.hasCapability('signup'));
     });
 
-    it('has the `handleSignedInNotification` capability by default', function () {
+    it('has the `handleSignedInNotification` capability', function () {
       assert.isTrue(broker.hasCapability('handleSignedInNotification'));
     });
 
-    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
+    it('has the `emailVerificationMarketingSnippet` capability', function () {
       assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
     });
 
-    it('does not have the `syncPreferencesNotification` capability by default', function () {
+    it('does not have the `syncPreferencesNotification` capability', function () {
       assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
     });
 
@@ -73,18 +73,28 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('afterForceAuth', function () {
+      it('notifies the channel with `fxaccounts:login`, halts', function () {
+        return broker.afterForceAuth(account)
+          .then(function (result) {
+            assert.isTrue(channelMock.send.calledWith('fxaccounts:login'));
+            assert.isTrue(result.halt);
+          });
+      });
+    });
+
     describe('afterSignIn', function () {
-      it('notifies the channel with `fxaccounts:login`, does not halt', function () {
+      it('notifies the channel with `fxaccounts:login`, halts', function () {
         return broker.afterSignIn(account)
           .then(function (result) {
             assert.isTrue(channelMock.send.calledWith('fxaccounts:login'));
-            assert.isUndefined(result.halt);
+            assert.isTrue(result.halt);
           });
       });
     });
 
     describe('beforeSignUpConfirmationPoll', function () {
-      it('notifies the channel with `fxaccounts:login`, halts by default', function () {
+      it('notifies the channel with `fxaccounts:login`, halts', function () {
         return broker.beforeSignUpConfirmationPoll(account)
           .then(function (result) {
             assert.isTrue(channelMock.send.calledWith('fxaccounts:login'));
@@ -94,11 +104,11 @@ define(function (require, exports, module) {
     });
 
     describe('afterResetPasswordConfirmationPoll', function () {
-      it('notifies the channel with `fxaccounts:login`, halts by default', function () {
+      it('notifies the channel with `fxaccounts:login`, halts', function () {
         return broker.afterResetPasswordConfirmationPoll(account)
           .then(function (result) {
             assert.isTrue(channelMock.send.calledWith('fxaccounts:login'));
-            assert.isUndefined(result.halt);
+            assert.isTrue(result.halt);
           });
       });
     });

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -11,6 +11,8 @@ define([
   './functional/complete_sign_up',
   './functional/sync_sign_up',
   './functional/sync_v2_sign_up',
+  './functional/sync_v2_sign_in',
+  './functional/sync_v2_force_auth',
   './functional/sync_v3_sign_up',
   './functional/fx_firstrun_v1_sign_up',
   './functional/fx_firstrun_v1_sign_in',

--- a/tests/functional/sync_v2_force_auth.js
+++ b/tests/functional/sync_v2_force_auth.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'app/bower_components/fxa-js-client/fxa-client',
+  'intern',
+  'intern!object',
+  'intern/node_modules/dojo/node!xmlhttprequest',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers'
+], function (FxaClient, intern, registerSuite, nodeXMLHttpRequest,
+  TestHelpers, FunctionalHelpers) {
+  var config = intern.config;
+
+  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+  var FORCE_AUTH_URL = config.fxaContentRoot + 'force_auth?context=fx_desktop_v2&service=sync';
+
+  var client;
+  var email;
+  var PASSWORD = '12345678';
+  var url;
+
+  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
+  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+
+  registerSuite({
+    name: 'Firefox Desktop Sync v2 force_auth',
+
+    beforeEach: function () {
+      email = TestHelpers.createEmail();
+      url = FORCE_AUTH_URL + '&email=' + encodeURIComponent(email);
+
+      client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'verified': function () {
+      var self = this;
+
+      return client.signUp(email, PASSWORD, { preVerified: true })
+        .then(function () {
+          return FunctionalHelpers.openPage(self, url, '#fxa-force-auth-header')
+            .execute(listenForFxaCommands)
+            .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
+
+            .then(function () {
+              return FunctionalHelpers.fillOutForceAuth(self, PASSWORD);
+            })
+
+            // add a slight delay to ensure the page does not transition
+            .sleep(2000)
+
+            // the page does not transition.
+            .findByCssSelector('#fxa-force-auth-header')
+            .end()
+
+            .then(testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
+            .then(testIsBrowserNotified(self, 'fxaccounts:login'));
+        });
+    }
+  });
+});

--- a/tests/functional/sync_v2_sign_in.js
+++ b/tests/functional/sync_v2_sign_in.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/node_modules/dojo/node!xmlhttprequest',
+  'app/bower_components/fxa-js-client/fxa-client',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, nodeXMLHttpRequest, FxaClient,
+        TestHelpers, FunctionalHelpers) {
+  var config = intern.config;
+  var PAGE_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v2&service=sync';
+
+  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+
+  var client;
+  var email;
+  var PASSWORD = '12345678';
+
+  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
+  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+
+  registerSuite({
+    name: 'Firefox Desktop Sync v2 sign_in',
+
+    beforeEach: function () {
+      email = TestHelpers.createEmail();
+      client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+      var self = this;
+      return client.signUp(email, PASSWORD, { preVerified: true })
+        .then(function () {
+          // clear localStorage to avoid pollution from other tests.
+          return FunctionalHelpers.clearBrowserState(self);
+        });
+    },
+
+    afterEach: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'sign in verified': function () {
+      var self = this;
+      return FunctionalHelpers.openPage(self, PAGE_URL, '#fxa-signin-header')
+        .execute(listenForFxaCommands)
+        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
+
+        .then(function () {
+          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
+        })
+
+        // add a slight delay to ensure the page does not transition
+        .sleep(2000)
+
+        // the page does not transition
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        // browser should have been notified.
+        .then(testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified(self, 'fxaccounts:login'));
+    }
+  });
+});

--- a/tests/intern_functional_circle.js
+++ b/tests/intern_functional_circle.js
@@ -14,6 +14,8 @@ define([
     'tests/functional/complete_sign_up',
     'tests/functional/sync_sign_up',
     'tests/functional/sync_v2_sign_up',
+    'tests/functional/sync_v2_sign_in',
+    'tests/functional/sync_v2_force_auth',
     'tests/functional/verification_experiments',
     'tests/functional/bounced_email',
     'tests/functional/fx_firstrun_v1_sign_up',


### PR DESCRIPTION
To fix #3330, a new base authentication broker was created
for all WebChannel based brokers. The new broker did not
define any behaviors.

FxDesktopV2AuthenticationBroker is based off of this
new broker, wheras it used to be based off of
FxDesktopV1AuthenticationBroker. DesktopV1 had all
the correct behaviors defined. DesktopV2 did not
define behaviors for afterForceAuth, afterSignIn
and afterResetPasswordConfirmationPoll

This PR defines those behaviors, and adds functional tests
to ensure we do not regress.

fixes #3353