### PR TITLE
fix(client): Do not sign out of Sync when visiting /force_auth

### DIFF
--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -11,7 +11,6 @@ define(function (require, exports, module) {
   var Cocktail = require('cocktail');
   var FormView = require('views/form');
   var PasswordResetMixin = require('views/mixins/password-reset-mixin');
-  var Session = require('lib/session');
   var SignInView = require('views/sign_in');
   var Template = require('stache!templates/force_auth');
 
@@ -23,21 +22,9 @@ define(function (require, exports, module) {
     return '';
   }
 
-
   var View = SignInView.extend({
     template: Template,
-    className: 'sign-in',
-
-    initialize: function (options) {
-      options = options || {};
-
-      this._formPrefill = options.formPrefill;
-
-      // forceAuth means a user must sign in as a specific user.
-      // kill the user's local session.
-      Session.clear();
-      this.user.clearSignedInAccount();
-    },
+    className: 'force-auth',
 
     context: function () {
       var fatalError = '';

--- a/tests/functional/sync_v2_force_auth.js
+++ b/tests/functional/sync_v2_force_auth.js
@@ -21,7 +21,7 @@ define([
   var PASSWORD = '12345678';
   var url;
 
-  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
+  var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
 
@@ -45,7 +45,8 @@ define([
       return client.signUp(email, PASSWORD, { preVerified: true })
         .then(function () {
           return FunctionalHelpers.openPage(self, url, '#fxa-force-auth-header')
-            .execute(listenForFxaCommands)
+            .then(noSuchBrowserNotification(self, 'fxaccounts:logout'))
+
             .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
 
             .then(function () {


### PR DESCRIPTION
We were erroneously clearing the signed in user, which sent an
`fxaccounts:logout` message over the WebChannel.

fixes #3431