### PR TITLE
fix(teamcity): record content,oauth,profile,auth __version__

### DIFF
--- a/tests/teamcity/latest
+++ b/tests/teamcity/latest
@@ -6,3 +6,8 @@ FXA_CONTENT_ROOT="https://latest.dev.lcip.org/"
 FXA_AUTH_ROOT="https://latest.dev.lcip.org/auth/v1"
 FXA_OAUTH_APP_ROOT="https://123done-latest.dev.lcip.org/"
 FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done-latest.dev.lcip.org/"
+
+FXA_CONTENT_VERSION="https://latest.dev.lcip.org/__version__"
+FXA_OAUTH_VERSION="https://oauth-latest.dev.lcip.org/__version__"
+FXA_PROFILE_VERSION="https://latest.dev.lcip.org/profile/__version__"
+FXA_AUTH_VERSION="https://latest.dev.lcip.org/auth/__version__"

--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -25,12 +25,26 @@ else
   echo "Using GIT_COMMIT from the environment $GIT_COMMIT"
 fi
 
-echo "FXA_TEST_NAME      $FXA_TEST_NAME"
-echo "FXA_CONTENT_ROOT   $FXA_CONTENT_ROOT"
-echo "FXA_AUTH_ROOT      $FXA_AUTH_ROOT"
-echo "FXA_OAUTH_APP_ROOT $FXA_OAUTH_APP_ROOT"
-echo "FXA_FIREFOX_BINARY $FXA_FIREFOX_BINARY"
-echo "GIT_COMMIT         $GIT_COMMIT"
+echo "FXA_TEST_NAME       $FXA_TEST_NAME"
+echo "FXA_CONTENT_ROOT    $FXA_CONTENT_ROOT"
+echo "FXA_AUTH_ROOT       $FXA_AUTH_ROOT"
+echo "FXA_OAUTH_APP_ROOT  $FXA_OAUTH_APP_ROOT"
+echo "FXA_FIREFOX_BINARY  $FXA_FIREFOX_BINARY"
+echo "GIT_COMMIT          $GIT_COMMIT"
+
+echo "FXA_CONTENT_VERSION $FXA_CONTENT_VERSION"
+echo "FXA_OAUTH_VERSION   $FXA_OAUTH_VERSION"
+echo "FXA_PROFILE_VERSION $FXA_PROFILE_VERSION"
+echo "FXA_AUTH_VERSION    $FXA_AUTH_VERSION"
+
+
+echo ""
+echo "Server versions:"
+curl -s $FXA_CONTENT_VERSION
+curl -s $FXA_OAUTH_VERSION
+curl -s $FXA_PROFILE_VERSION
+curl -s $FXA_AUTH_VERSION
+echo ""
 
 rm -rf fxa-content-server-"$FXA_TEST_NAME"
 git clone https://github.com/mozilla/fxa-content-server.git -b master fxa-content-server-"$FXA_TEST_NAME"

--- a/tests/teamcity/stable
+++ b/tests/teamcity/stable
@@ -6,3 +6,8 @@ FXA_CONTENT_ROOT="https://stable.dev.lcip.org/"
 FXA_AUTH_ROOT="https://stable.dev.lcip.org/auth/v1"
 FXA_OAUTH_APP_ROOT="https://123done-stable.dev.lcip.org/"
 FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done-stable.dev.lcip.org/"
+
+FXA_CONTENT_VERSION="https://stable.dev.lcip.org/__version__"
+FXA_OAUTH_VERSION="https://oauth-stable.dev.lcip.org/__version__"
+FXA_PROFILE_VERSION="https://stable.dev.lcip.org/profile/__version__"
+FXA_AUTH_VERSION="https://stable.dev.lcip.org/auth/__version__"

--- a/tests/teamcity/stage
+++ b/tests/teamcity/stage
@@ -6,3 +6,8 @@ FXA_CONTENT_ROOT="https://accounts.stage.mozaws.net/"
 FXA_AUTH_ROOT="https://api-accounts.stage.mozaws.net/v1"
 FXA_OAUTH_APP_ROOT="https://123done-stage.dev.lcip.org/"
 FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done-stage.dev.lcip.org/"
+
+FXA_CONTENT_VERSION="https://accounts.stage.mozaws.net/__version__"
+FXA_OAUTH_VERSION="https://oauth.stage.mozaws.net/__version__"
+FXA_PROFILE_VERSION="https://profile.stage.mozaws.net/__version__"
+FXA_AUTH_VERSION="https://api-accounts.stage.mozaws.net/__version__"


### PR DESCRIPTION
r? - @vladikoff or @vbudhram or @shane-tomlinson (whoever wants to look)

Don't merge this before https://github.com/mozilla/fxa-content-server/issues/3453 gets sorted out (since all tests are failing on latest at the moment), but it would be useful going forward to record the server versions on each test run. (Maybe some kind of autodiscovery would be better, but explicit is okay too).