### PR TITLE
fix(test): Fix the `attempt to use webcam for avatar` functional test.

### DIFF
--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -254,9 +254,7 @@ define([
       return this.remote
         .get(require.toUrl(AVATAR_CHANGE_URL_AUTOMATED))
 
-        // go to change avatar - click the span inside the element
-        // to ensure the click handlers are hooked up properly.
-        .findByCssSelector('#camera span')
+        .findByCssSelector('#camera')
           .click()
         .end()
 


### PR DESCRIPTION
The `#camera span` element was removed with #3379.
Look for the `#camera` element only.

fixes #3455 
