### PR TITLE
fix(validation): Add validation to optional params in models and reliers

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -636,7 +636,7 @@ define(function (require, exports, module) {
 
     _getErrorPage: function (err) {
       if (OAuthErrors.is(err, 'MISSING_PARAMETER') ||
-          OAuthErrors.is(err, 'INVALID_REQUEST_PARAMETER') ||
+          OAuthErrors.is(err, 'INVALID_PARAMETER') ||
           OAuthErrors.is(err, 'UNKNOWN_CLIENT')) {
         var queryString = Url.objToSearchString({
           client_id: err.client_id, //eslint-disable-line camelcase

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
       errno: 108,
       message: t('Invalid token')
     },
-    INVALID_REQUEST_PARAMETER: {
+    INVALID_PARAMETER: {
       errno: 109,
       message: t('Invalid OAuth parameter: %(param)s')
     },
@@ -123,7 +123,7 @@ define(function (require, exports, module) {
           return {
             param: err.param
           };
-        } else if (this.is(err, 'INVALID_REQUEST_PARAMETER')) {
+        } else if (this.is(err, 'INVALID_PARAMETER')) {
           return {
             param: err.param || err.validation.keys.join(',')
           };

--- a/app/scripts/lib/url.js
+++ b/app/scripts/lib/url.js
@@ -20,7 +20,7 @@ define(function (require, exports, module) {
 
     _.each(pairs, function (pair) {
       var keyValue = pair.split('=');
-      terms[keyValue[0]] = decodeURIComponent(keyValue[1]);
+      terms[keyValue[0]] = decodeURIComponent(keyValue[1]).trim();
     });
 
     if (! whitelist) {
@@ -63,6 +63,10 @@ define(function (require, exports, module) {
     },
 
     getOrigin: function (url) {
+      if (! url) {
+        return '';
+      }
+
       // The URL API is only supported by new browsers, a workaround is used.
       var anchor = document.createElement('a');
 

--- a/app/scripts/models/mixins/search-param.js
+++ b/app/scripts/models/mixins/search-param.js
@@ -45,9 +45,10 @@ define(function (require, exports, module) {
      * @param {String} paramName - name of the search parameter
      * @param {String} [modelName] - name to set in model. If not specified,
      *      use the same value as `paramName`
-     * @throws {TypeError} if paramName is neither `true` nor `false`
+     * @param {Errors} Errors - corresponding Errors object
+     * @throws {error}
      */
-    importBooleanSearchParam: function (paramName, modelName) {
+    importBooleanSearchParam: function (paramName, modelName, Errors) {
       modelName = modelName || paramName;
       var self = this;
 
@@ -58,8 +59,31 @@ define(function (require, exports, module) {
         } else if (textValue === 'false') {
           self.set(modelName, false);
         } else {
-          throw new TypeError(paramName + ' must be `true` or `false`');
+          var err = Errors.toError('INVALID_PARAMETER');
+          err.param = paramName;
+          throw err;
         }
+      }
+    },
+
+    /**
+     * Set a value based on a value in window.location.search. Throws error
+     * if paramName param is not in window.location.search.
+     *
+     * Throws Error mapped to `MISSING_PARAMETER` in Errors object.
+     *
+     * @param {string} paramName - name of the search parameter
+     * @param {string} modelName - name to set in model
+     * @param {Errors} Errors - corresponding Errors object
+     * @throws {error}
+     */
+    importRequiredSearchParam: function (paramName, modelName, Errors) {
+      var self = this;
+      self.importSearchParam(paramName, modelName);
+      if (! self.has(modelName || paramName)) {
+        var err = Errors.toError('MISSING_PARAMETER');
+        err.param = paramName;
+        throw err;
       }
     }
   };

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -96,8 +96,8 @@ define(function (require, exports, module) {
 
           // A relier can indicate they do not want to allow
           // cached credentials if they set email === 'blank'
-          if (self.getSearchParam('email') ===
-              Constants.DISALLOW_CACHED_CREDENTIALS) {
+          var email = self.getSearchParam('email');
+          if (email === Constants.DISALLOW_CACHED_CREDENTIALS) {
             self.set('allowCachedCredentials', false);
           } else {
             self.importSearchParam('email');

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -540,8 +540,8 @@ define(function (require, exports, module) {
         assert.include(errorUrl, Constants.BAD_REQUEST_PAGE);
       });
 
-      it('returns BAD_REQUEST_PAGE for an invalid OAuth client', function () {
-        var errorUrl = appStart._getErrorPage(OAuthErrors.toError('INVALID_REQUEST_PARAMETER'));
+      it('returns BAD_REQUEST_PAGE for an invalid OAuth parameter', function () {
+        var errorUrl = appStart._getErrorPage(OAuthErrors.toError('INVALID_PARAMETER'));
         assert.include(errorUrl, Constants.BAD_REQUEST_PAGE);
       });
 

--- a/app/tests/spec/lib/oauth-errors.js
+++ b/app/tests/spec/lib/oauth-errors.js
@@ -70,16 +70,23 @@ define(function (require, exports, module) {
         assert.equal(OAuthErrors.toInterpolationContext(err).param, 'param');
       });
 
-      it('`INVALID_REQUEST_PARAMETER` returns object w/ `param`', function () {
-        var err = OAuthErrors.toError('INVALID_REQUEST_PARAMETER');
+      it('`INVALID_PARAMETER` w/ server error returns object w/ param', function () {
+        var err = OAuthErrors.toError('INVALID_PARAMETER');
         err.validation = {
           keys: ['param']
         };
         assert.equal(OAuthErrors.toInterpolationContext(err).param, 'param');
       });
 
+      it('`INVALID_PARAMETER` w/ client error returns object w/ param', function () {
+        var err = OAuthErrors.toError('INVALID_PARAMETER');
+        err.param = 'param';
+
+        assert.equal(OAuthErrors.toInterpolationContext(err).param, 'param');
+      });
+
       it('malformed server responses are handled gracefully', function () {
-        var err = OAuthErrors.toError('INVALID_REQUEST_PARAMETER');
+        var err = OAuthErrors.toError('INVALID_PARAMETER');
         // validation should have a keys field that is an array.
         err.validation = {};
         assert.equal(Object.keys(OAuthErrors.toInterpolationContext(err)).length, 0);

--- a/app/tests/spec/lib/url.js
+++ b/app/tests/spec/lib/url.js
@@ -17,6 +17,14 @@ define(function (require, exports, module) {
             assert.equal(Url.searchParam('color', '?color=green'), 'green');
           });
 
+      it('returns empty if parameter is empty', function () {
+        assert.equal(Url.searchParam('color', '?color='), '');
+      });
+
+      it('returns empty if parameter is a space', function () {
+        assert.equal(Url.searchParam('color', '?color= '), '');
+      });
+
       it('returns undefined if parameter does not exist', function () {
         assert.isUndefined(Url.searchParam('animal', '?color=green'));
       });

--- a/app/tests/spec/lib/validate.js
+++ b/app/tests/spec/lib/validate.js
@@ -243,12 +243,6 @@ define(function (require, exports, module) {
     });
 
     describe('isPromptValid', function () {
-      describe('no value', function () {
-        it('returns true', function () {
-          assert.isTrue(Validate.isPromptValid());
-        });
-      });
-
       describe('consent', function () {
         it('returns true', function () {
           assert.isTrue(Validate.isPromptValid('consent'));
@@ -258,6 +252,147 @@ define(function (require, exports, module) {
       describe('other values', function () {
         it('returns false', function () {
           assert.isFalse(Validate.isPromptValid('unrecognized'));
+        });
+      });
+    });
+
+    describe('isUrlValid', function () {
+      it('is defined', function () {
+        assert.isFunction(Validate.isUrlValid);
+      });
+
+      var invalidURLs = ['', {}, true, 1, 'asdf', 'http:://invalid.url'];
+      invalidURLs.forEach( function (item) {
+        it('returns false for ' + item, function () {
+          assert.isFalse(Validate.isUrlValid(item));
+        });
+      });
+
+      var validURLs = ['http://imgur.com/gallery/OeEaX', 'https://bugzilla.mozilla.org/', 'https://ex.am.ple/path', 'www.firefox.com'];
+      validURLs.forEach( function (item) {
+        it('returns true for ' + item, function () {
+          assert.isTrue(Validate.isUrlValid(item));
+        });
+      });
+    });
+
+    describe('isUrnValid', function () {
+      it('is defined', function () {
+        assert.isFunction(Validate.isUrnValid);
+      });
+
+      var invalidUrns = ['', 'asdf', 'urn::asdf'];
+      invalidUrns.forEach( function (item) {
+        it('returns false for ' + item, function () {
+          assert.isFalse(Validate.isUrlValid(item));
+        });
+      });
+
+      var validUrns = ['urn:ietf:wg:oauth:2.0:fx:webchannel'];
+      validUrns.forEach( function (item) {
+        it('returns true for ' + item, function () {
+          assert.isTrue(Validate.isUrlValid(item));
+        });
+      });
+    });
+
+    describe('isUriValid', function () {
+      it('is defined', function () {
+        assert.isFunction(Validate.isUriValid);
+      });
+
+      // Subset of test cases used from https://github.com/DavidTPate/isuri/blob/master/test/test.js
+      var validUris = [
+        'ftp://ftp.is.co.za/rfc/rfc1808.txt',
+        'http://www.ietf.org/rfc/rfc2396.txt',
+        'mailto:John.Doe@example.com',
+        'news:comp.infosystems.www.servers.unix',
+        'telnet://192.0.2.16:80/',
+        'urn:oasis:names:specification:docbook:dtd:xml:4.1.2',
+        'http://asdf:qw%20er@localhost:8000?asdf=12345&asda=fc%2F#bacon',
+        'http://asdf@localhost:8000',
+        'coap://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]',
+        'http://127.0.0.1:8000/foo?bar',
+        'http://asdf:qwer@localhost:8000',
+        'http://127.0.0.1:8080/api/oauth',
+        'http://user:pass%3A@localhost:80',
+        'http://localhost:123',
+        'https://localhost:123',
+        'mailto:asdf@asdf.com',
+        'ftp://www.example.com',
+        'xmpp:isaacschlueter@jabber.org',
+        'http://localhost:18/asdf',
+        'http://localhost:42/asdf?qwer=zxcv',
+        'HTTP://www.example.com/',
+        'HTTP://www.example.com',
+        'http://www.ExAmPlE.com/',
+        'http://user:pw@www.ExAmPlE.com/',
+        'http://USER:PW@www.ExAmPlE.com/',
+        'http://user@www.example.com/',
+        'http://user%3Apw@www.example.com/',
+        'http://x.com/path?that%27s#all,%20folks',
+        'HTTP://X.COM/Y',
+        'http://www.narwhaljs.org/blog/categories?id=news',
+        'http://mt0.google.com/vt/lyrs=m@114&hl=en&src=api&x=2&y=2&z=3&s=',
+        'http://mt0.google.com/vt/lyrs=m@114???&hl=en&src=api&x=2&y=2&z=3&s='
+      ];
+
+      validUris.forEach( function (item) {
+        it('returns true for ' + item, function (){
+          assert.isTrue(Validate.isUriValid(item));
+        });
+      });
+
+      var invalidUris = [
+        'file:/asda',
+        'qwerty',
+        '',
+        'https:://ex.am.ple/path'
+      ];
+
+      invalidUris.forEach( function (item) {
+        it('returns false for ' + item, function (){
+          assert.isFalse(Validate.isUriValid(item));
+        });
+      });
+    });
+
+    describe('isAccessTypeValid', function () {
+      it('is defined', function () {
+        assert.isFunction(Validate.isAccessTypeValid);
+      });
+
+      var invalidTypes = ['', 'word', 'crazyType'];
+      invalidTypes.forEach( function (item) {
+        it('returns false for ' + item, function () {
+          assert.isFalse(Validate.isAccessTypeValid(item));
+        });
+      });
+
+      var validTypes = ['online', 'offline'];
+      validTypes.forEach( function (item) {
+        it('returns true for ' + item, function () {
+          assert.isTrue(Validate.isAccessTypeValid(item));
+        });
+      });
+    });
+
+    describe('isVerificationRedirectValid', function () {
+      it('is defined', function () {
+        assert.isFunction(Validate.isVerificationRedirectValid);
+      });
+
+      var invalidTypes = ['', 'word', 'crazyType'];
+      invalidTypes.forEach( function (item) {
+        it('returns false for ' + item, function () {
+          assert.isFalse(Validate.isVerificationRedirectValid(item));
+        });
+      });
+
+      var validTypes = ['always', 'no'];
+      validTypes.forEach( function (item) {
+        it('returns true for ' + item, function () {
+          assert.isTrue(Validate.isVerificationRedirectValid(item));
         });
       });
     });

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -20,7 +20,7 @@ define(function (require, exports, module) {
 
     var SERVICE = 'service';
     var PREVERIFY_TOKEN = 'abigtoken';
-    var EMAIL = 'email';
+    var EMAIL = 'email@moz.org';
     var UID = 'uid';
     var ENTRYPOINT = 'preferences';
     var CAMPAIGN = 'fennec';

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -753,6 +753,26 @@ define([
   }
 
   /**
+   * Check whether an input element's text includes the expected value.
+   * Comparison is case insensitive
+   *
+   * @param {string} selector
+   * @param {string} expected
+   * @returns {promise} rejects if test fails.
+   */
+  function testElementTextInclude(selector, expected) {
+    return function () {
+      return this.parent
+        .findByCssSelector(selector)
+        .getVisibleText()
+        .then(function (resultText) {
+          assert.include(resultText.toLowerCase(), expected.toLowerCase());
+        })
+        .end();
+    };
+  }
+
+  /**
    * Check whether an input element's value equals the expected value
    *
    * @param {string} selector
@@ -974,6 +994,7 @@ define([
     respondToWebChannelMessage: respondToWebChannelMessage,
     testAreEventsLogged: testAreEventsLogged,
     testElementExists: testElementExists,
+    testElementTextInclude: testElementTextInclude,
     testElementValueEquals: testElementValueEquals,
     testErrorWasShown: testErrorWasShown,
     testIsBrowserNotified: testIsBrowserNotified,

--- a/tests/functional/oauth_query_param_validation.js
+++ b/tests/functional/oauth_query_param_validation.js
@@ -1,0 +1,388 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/node_modules/dojo/node!querystring',
+  'intern/node_modules/dojo/node!url',
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, Querystring, Url, FunctionalHelpers) {
+  var config = intern.config;
+
+  var SIGNUP_ROOT = config.fxaContentRoot + 'oauth/signup';
+
+  var TRUSTED_CLIENT_ID;
+  var TRUSTED_SCOPE = 'profile';
+  var UNTRUSTED_CLIENT_ID;
+  var UNTRUSTED_SCOPE = 'profile:uid profile:email';
+  var UNTRUSTED_NO_VALID_SCOPES = 'profile';
+
+
+  var thenify = FunctionalHelpers.thenify;
+  var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
+  var openFxaFromUntrustedRp = thenify(FunctionalHelpers.openFxaFromUntrustedRp);
+  var openPage = FunctionalHelpers.openPage;
+  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
+
+  var openPageWithQueryParams = function (context, queryParams, expectedHeader) {
+    var queryParamsString = '?' + Querystring.stringify(queryParams || {});
+
+    return openPage(context, SIGNUP_ROOT + queryParamsString, expectedHeader);
+  };
+
+  var openSignUpExpect200 = function (context, queryParams) {
+    return openPageWithQueryParams(context, queryParams, '#fxa-signup-header');
+  };
+
+  var openSignUpExpect400 = function (context, queryParams) {
+    return openPageWithQueryParams(context, queryParams, '#fxa-400-header');
+  };
+
+  var testErrorInclude = function (expected) {
+    return testElementTextInclude('.error', expected);
+  };
+
+  var getClientId = function () {
+    return function () {
+      return this.parent
+        .getCurrentUrl()
+        .then(function (url) {
+          var parsedUrl = Url.parse(url);
+          var parsedQueryString = Querystring.parse(parsedUrl.query);
+          return parsedQueryString.client_id;
+        });
+    };
+  };
+
+  /*eslint-disable camelcase */
+  registerSuite({
+    name: 'oauth query parameter validation',
+
+    before: function () {
+      // get the trusted and untrusted client IDs by opening
+      // FxA from the reliers. This is done instead of hard coding
+      // the values because the client_ids change depending on
+      // the environment.
+      var self = this;
+      return this.remote
+        .then(openFxaFromRp(this, 'signup'))
+        .then(getClientId())
+        .then(function (clientId) {
+          TRUSTED_CLIENT_ID = clientId;
+        })
+        .then(openFxaFromUntrustedRp(self, 'signup'))
+        .then(getClientId())
+        .then(function (clientId) {
+          UNTRUSTED_CLIENT_ID = clientId;
+        });
+    },
+
+    beforeEach: function () {
+      return FunctionalHelpers.clearBrowserState(this, {
+        contentServer: true
+      });
+    },
+
+    'invalid access_type': function () {
+      return openSignUpExpect400(this, {
+        access_type: 'invalid',
+        client_id: TRUSTED_CLIENT_ID,
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('access_type'));
+    },
+
+    'valid access_type (offline)': function () {
+      return openSignUpExpect200(this, {
+        access_type: 'offline',
+        client_id: TRUSTED_CLIENT_ID,
+        scope: TRUSTED_SCOPE
+      });
+    },
+
+    'valid access_type (online)': function () {
+      return openSignUpExpect200(this, {
+        access_type: 'online',
+        client_id: TRUSTED_CLIENT_ID,
+        scope: TRUSTED_SCOPE
+      });
+    },
+
+    'missing client_id': function () {
+      return openSignUpExpect400(this, {
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('missing'))
+      .then(testErrorInclude('client_id'));
+    },
+
+    'empty client_id': function () {
+      return openSignUpExpect400(this, {
+        client_id: '',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('client_id'));
+    },
+
+    'space client_id': function () {
+      return openSignUpExpect400(this, {
+        client_id: ' ',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('client_id'));
+    },
+
+    'invalid client_id': function () {
+      return openSignUpExpect400(this, {
+        client_id: 'invalid_client_id',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('client_id'));
+    },
+
+    'unknown client_id': function () {
+      return openSignUpExpect400(this, {
+        client_id: 'deadbeef',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('unknown client'));
+    },
+
+    'missing keys': function () {
+      return openSignUpExpect200(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        scope: TRUSTED_SCOPE
+      });
+    },
+
+    'empty keys': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        keys: '',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('keys'));
+    },
+
+    'space keys': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        keys: ' ',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('keys'));
+    },
+
+    'invalid keys': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        keys: 'asdf',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('keys'));
+    },
+
+    'valid keys (true)': function () {
+      return openSignUpExpect200(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        keys: 'true',
+        scope: TRUSTED_SCOPE
+      });
+    },
+
+    'valid keys (false)': function () {
+      return openSignUpExpect200(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        keys: 'false',
+        scope: TRUSTED_SCOPE
+      });
+    },
+
+    'empty prompt': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        prompt: '',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('prompt'));
+    },
+
+    'space prompt': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        prompt: ' ',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('prompt'));
+    },
+
+    'invalid prompt': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        prompt: 'invalid',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('prompt'));
+    },
+
+    'valid prompt (consent)': function () {
+      return openSignUpExpect200(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        prompt: 'consent',
+        scope: TRUSTED_SCOPE
+      });
+    },
+
+    'invalid redirectTo (url)': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        redirectTo: '127.0.0.1',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('redirectTo'));
+    },
+
+    'invalid redirectTo (urn)': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        redirectTo: 'urn::asdf',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('redirectTo'));
+    },
+
+    'valid redirectTo (url)': function () {
+      return openSignUpExpect200(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        redirectTo: 'http://127.0.0.1',
+        scope: TRUSTED_SCOPE
+      });
+    },
+
+    'valid redirect_uri (urn)': function () {
+      return openSignUpExpect200(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: 'urn:ietf:wg:oauth:2.0:fx:webchannel',
+        scope: TRUSTED_SCOPE
+      });
+    },
+
+    'invalid redirect_uri (url)': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: '127.0.0.1',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('redirect_uri'));
+    },
+
+    'invalid redirect_uri (urn)': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: 'urn::asdf',
+        scope: TRUSTED_SCOPE
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('redirect_uri'));
+    },
+
+    'valid redirect_uri (url)': function () {
+      return openSignUpExpect200(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: 'http://127.0.0.1',
+        scope: TRUSTED_SCOPE
+      });
+    },
+
+    'missing scope': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID
+      })
+      .then(testErrorInclude('missing'))
+      .then(testErrorInclude('scope'));
+    },
+
+    'empty scope': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        scope: ''
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('scope'));
+    },
+
+    'space scope': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        scope: ' '
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('scope'));
+    },
+
+    'no valid scopes (untrusted)': function () {
+      return openSignUpExpect400(this, {
+        client_id: UNTRUSTED_CLIENT_ID,
+        scope: UNTRUSTED_NO_VALID_SCOPES
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('scope'));
+    },
+
+    'valid scope (trusted)': function () {
+      return openSignUpExpect200(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        scope: TRUSTED_SCOPE
+      });
+    },
+
+    'valid scope (untrusted)': function () {
+      return openSignUpExpect200(this, {
+        client_id: UNTRUSTED_CLIENT_ID,
+        scope: UNTRUSTED_SCOPE
+      });
+    },
+
+    'invalid verification_redirect': function () {
+      return openSignUpExpect400(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        scope: TRUSTED_SCOPE,
+        verification_redirect: 'invalid'
+      })
+      .then(testErrorInclude('invalid'))
+      .then(testErrorInclude('verification_redirect'));
+    },
+
+    'valid verification_redirect (always)': function () {
+      return openSignUpExpect200(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        scope: TRUSTED_SCOPE,
+        verification_redirect: 'always'
+      });
+    },
+
+    'valid verification_redirect (no)': function () {
+      return openSignUpExpect200(this, {
+        client_id: TRUSTED_CLIENT_ID,
+        scope: TRUSTED_SCOPE,
+        verification_redirect: 'no'
+      });
+    }
+  });
+  /*eslint-enable camelcase */
+});

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -13,7 +13,6 @@ define([
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, TestHelpers, Test, FunctionalHelpers) {
   var config = intern.config;
-  var SIGNUP_ROOT = config.fxaContentRoot + 'oauth/signup';
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
 
   var PASSWORD = 'password';
@@ -63,18 +62,6 @@ define([
           '123done': true,
           contentServer: true
         }));
-    },
-
-    'with missing client_id': function () {
-      return openPage(this, SIGNUP_ROOT + '?scope=profile', '#fxa-400-header');
-    },
-
-    'with invalid client_id': function () {
-      return openPage(this, SIGNUP_ROOT + '?client_id=invalid_client_id&scope=profile', '#fxa-400-header');
-    },
-
-    'with missing scope': function () {
-      return openPage(this, SIGNUP_ROOT + '?client_id=client_id', '#fxa-400-header');
     },
 
     'signup, verify same browser': function () {

--- a/tests/functional_oauth.js
+++ b/tests/functional_oauth.js
@@ -4,6 +4,7 @@
 
 define([
   './functional/amo_sign_up',
+  './functional/oauth_query_param_validation',
   './functional/oauth_sign_in',
   './functional/oauth_sign_up',
   './functional/oauth_sign_up_verification_redirect',


### PR DESCRIPTION
This PR adds extra validation to oauth and relier models. It guards against invalid emails and urls used in parameters.

Fixes #3452, Fixes #2025, Fixes #3490  

@vladikoff @shane-tomlinson r?