### PR TITLE
fix(metrics): Send an error's context as a Sentry report tag.

### DIFF
--- a/app/scripts/lib/sentry.js
+++ b/app/scripts/lib/sentry.js
@@ -147,6 +147,7 @@ define(function (require, exports, module) {
      */
     _exceptionTags: [
       'code',
+      'context',
       'errno',
       'namespace',
       'status'

--- a/app/tests/spec/lib/sentry.js
+++ b/app/tests/spec/lib/sentry.js
@@ -233,6 +233,7 @@ define(function (require, exports, module) {
 
         var err = new Error('uh oh');
         err.code = 400;
+        err.context = '/signup';
         err.errno = 998;
         err.namespace = 'config';
         err.status = 401;
@@ -243,6 +244,7 @@ define(function (require, exports, module) {
         assert.isTrue(Raven.captureException.calledWith(err, {
           tags: {
             code: 400,
+            context: '/signup',
             errno: 998,
             namespace: 'config',
             status: 401


### PR DESCRIPTION
fixes #3470

@vladikoff, @jrgm - r?