### PR TITLE
feat(migration): Updated views to support AMO migration

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -41,6 +41,8 @@ define(function (require, exports, module) {
 
     SYNC_SERVICE: 'sync',
 
+    SYNC11_MIGRATION: 'sync11',
+    AMO_MIGRATION: 'amo',
 
     VERIFICATION_POLL_IN_MS: 4000,
 

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -102,6 +102,9 @@ define(function (require, exports, module) {
           } else {
             self.importSearchParam('email');
           }
+
+          self.importSearchParam('migration');
+
         });
     },
 

--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -36,7 +36,6 @@ define(function (require, exports, module) {
       return Relier.prototype.fetch.call(self)
         .then(function () {
           self.importSearchParam('context');
-          self.importSearchParam('migration');
 
           try {
             self.importBooleanSearchParam('customizeSync');

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -19,9 +19,9 @@
     {{^error}}
       <div class="error"></div>
       <div class="success"></div>
-        {{#isMigration}}
+      {{#isSyncMigration}}
           <div class="info nudge">{{#t}}Migrate your sync data by signing in to your Firefox&nbsp;Account.{{/t}}</div>
-        {{/isMigration}}
+      {{/isSyncMigration}}
 
       {{#suggestedAccount}}
           <div class="avatar-wrapper avatar-view">

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -19,9 +19,13 @@
     {{^error}}
     <div class="error"></div>
     <div class="success"></div>
-    {{#isMigration}}
+    {{#isSyncMigration}}
       <div class="info nudge">{{#t}}Migrate your sync data by creating a new Firefox&nbsp;Account.{{/t}}</div>
-    {{/isMigration}}
+    {{/isSyncMigration}}
+
+    {{#isAmoMigration}}
+        <div class="info nudge pad" id="amo-migration">{{#t}}Have an account with a different email? <a href="%(signinUri)s">Sign in</a>{{/t}}</div>
+    {{/isAmoMigration}}
 
     <form novalidate>
       <div class="input-row">

--- a/app/scripts/views/mixins/migration-mixin.js
+++ b/app/scripts/views/mixins/migration-mixin.js
@@ -8,10 +8,15 @@
 define(function (require, exports, module) {
   'use strict';
 
+  var Constants = require('lib/constants');
 
   module.exports = {
-    isMigration: function () {
-      return this.relier.has('migration');
+    isSyncMigration: function isSyncMigration () {
+      return this.relier.get('migration') === Constants.SYNC11_MIGRATION;
+    },
+
+    isAmoMigration: function isAmoMigration () {
+      return this.relier.get('migration') === Constants.AMO_MIGRATION;
     }
   };
 });

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -60,9 +60,9 @@ define(function (require, exports, module) {
         chooserAskForPassword: this._suggestedAccountAskPassword(suggestedAccount),
         email: email,
         error: this.error,
-        isMigration: this.isMigration(),
         isPasswordAutoCompleteDisabled: this.isPasswordAutoCompleteDisabled(),
         isSignupDisabled: this.isSignupDisabled(),
+        isSyncMigration: this.isSyncMigration(),
         password: this._formPrefill.get('password'),
         serviceName: this.relier.get('serviceName'),
         suggestedAccount: hasSuggestedAccount

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -128,7 +128,8 @@ define(function (require, exports, module) {
 
     events: {
       'blur input.email': 'onEmailBlur',
-      'blur input.password': 'onPasswordBlur'
+      'blur input.password': 'onPasswordBlur',
+      'click #amo-migration a': 'onAmoSignIn'
     },
 
     getPrefillEmail: function () {
@@ -157,15 +158,17 @@ define(function (require, exports, module) {
         chooseWhatToSyncCheckbox: this.broker.hasCapability('chooseWhatToSyncCheckbox'),
         email: prefillEmail,
         error: this.error,
+        isAmoMigration: this.isAmoMigration(),
         isCustomizeSyncChecked: relier.isCustomizeSyncChecked(),
         isEmailOptInVisible: this._isEmailOptInEnabled(),
-        isMigration: this.isMigration(),
         isPasswordAutoCompleteDisabled: this.isPasswordAutoCompleteDisabled(),
         isSync: isSync,
+        isSyncMigration: this.isSyncMigration(),
         password: prefillPassword,
         serviceName: relier.get('serviceName'),
         shouldFocusEmail: autofocusEl === 'email',
-        shouldFocusPassword: autofocusEl === 'password'
+        shouldFocusPassword: autofocusEl === 'password',
+        signinUri: this.broker.transformLink('/signin')
       };
 
       if (isSync && this.isInExperiment('syncCheckbox')) {
@@ -237,6 +240,13 @@ define(function (require, exports, module) {
       if (this.isInExperiment('mailcheck')) {
         mailcheck(this.$el.find('.email'), this.metrics, this.translator, this);
       }
+    },
+
+    onAmoSignIn: function () {
+      // The user has chosen to sign in with a different email, clear the
+      // email from the relier so it's not used again on the signin page.
+      this.relier.unset('email');
+      this.$('input[type=email]').val('');
     },
 
     _isEmailSameAsBouncedEmail: function () {

--- a/app/styles/_state.scss
+++ b/app/styles/_state.scss
@@ -29,6 +29,10 @@
   /*Pull the message up to bring it closer to the header*/
   &.nudge {
     top: -10px;
+
+      &.pad {
+          padding: 10px;
+      }
   }
 }
 

--- a/app/tests/spec/models/reliers/sync.js
+++ b/app/tests/spec/models/reliers/sync.js
@@ -33,14 +33,14 @@ define(function (require, exports, module) {
         windowMock.location.search = TestHelpers.toSearchString({
           context: 'fx_desktop_v1',
           customizeSync: 'true',
-          migration: 'sync1.5',
+          migration: 'sync11',
           service: 'sync'
         });
 
         return relier.fetch()
           .then(function () {
             assert.equal(relier.get('context'), 'fx_desktop_v1');
-            assert.equal(relier.get('migration'), 'sync1.5');
+            assert.equal(relier.get('migration'), 'sync11');
             assert.equal(relier.get('service'), 'sync');
             assert.isTrue(relier.get('customizeSync'));
           });

--- a/app/tests/spec/views/mixins/migration-mixin.js
+++ b/app/tests/spec/views/mixins/migration-mixin.js
@@ -13,32 +13,63 @@ define(function (require, exports, module) {
 
   describe('views/mixins/migration-mixin', function () {
     it('exports correct interface', function () {
-      assert.lengthOf(Object.keys(MigrationMixin), 1);
-      assert.isFunction(MigrationMixin.isMigration);
+      assert.lengthOf(Object.keys(MigrationMixin), 2);
+      assert.isFunction(MigrationMixin.isSyncMigration);
+      assert.isFunction(MigrationMixin.isAmoMigration);
     });
 
-    describe('call isMigration', function () {
+    describe('call isSyncMigration', function () {
       var relier, result;
 
       beforeEach(function () {
         relier = {
+          get: sinon.spy(function () {
+            return 'sync11';
+          }),
           has: sinon.spy(function () {
             return 'foo';
           })
         };
-        result = MigrationMixin.isMigration.call({ relier: relier });
+        result = MigrationMixin.isSyncMigration.call({ relier: relier });
       });
 
-      it('calls this.relier.has correctly', function () {
-        assert.equal(relier.has.callCount, 1);
-
-        var args = relier.has.getCall(0).args;
+      it('calls isSyncMigration correctly', function () {
+        assert.equal(relier.get.callCount, 1);
+        var args = relier.get.getCall(0).args;
         assert.lengthOf(args, 1);
         assert.equal(args[0], 'migration');
       });
 
-      it('returns this.relier.has result', function () {
-        assert.equal(result, 'foo');
+      it('returns this.isSyncMigration result', function () {
+        assert.equal(result, true);
+      });
+    });
+
+    describe('call isAmoMigration', function () {
+      var relier, result;
+
+      beforeEach(function () {
+        relier = {
+          get: sinon.spy(function () {
+            return 'amo';
+          }),
+          has: sinon.spy(function () {
+            return 'foo';
+
+          })
+        };
+        result = MigrationMixin.isAmoMigration.call({ relier: relier });
+      });
+
+      it('calls isAmoMigration correctly', function () {
+        assert.equal(relier.get.callCount, 1);
+        var args = relier.get.getCall(0).args;
+        assert.lengthOf(args, 1);
+        assert.equal(args[0], 'migration');
+      });
+
+      it('returns this.isAmoMigration result', function () {
+        assert.equal(result, true);
       });
     });
   });

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -150,30 +150,41 @@ define(function (require, exports, module) {
               assert.equal(view.$('[type=email]').val(), 'testuser@testuser.com');
             });
       });
+    });
 
-      it('displays a message if isMigration returns true', function () {
+    describe('migration', function () {
+      it('does not display migration message if no migration', function () {
         initView();
-        sinon.stub(view, 'isMigration', function (arg) {
+
+        return view.render()
+          .then(function () {
+            assert.lengthOf(view.$('.info.nudge'), 0);
+          });
+      });
+
+      it('displays migration message if isSyncMigration returns true', function () {
+        initView();
+        sinon.stub(view, 'isSyncMigration', function () {
           return true;
         });
 
         return view.render()
           .then(function () {
             assert.equal(view.$('.info.nudge').html(), 'Migrate your sync data by signing in to your Firefox&nbsp;Account.');
-            view.isMigration.restore();
+            view.isSyncMigration.restore();
           });
       });
 
-      it('does not display a message if isMigration returns false', function () {
+      it('does not display migration message if isSyncMigration returns false', function () {
         initView();
-        sinon.stub(view, 'isMigration', function (arg) {
+        sinon.stub(view, 'isSyncMigration', function () {
           return false;
         });
 
         return view.render()
           .then(function () {
             assert.lengthOf(view.$('.info.nudge'), 0);
-            view.isMigration.restore();
+            view.isSyncMigration.restore();
           });
       });
     });

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -224,46 +224,61 @@ define(function (require, exports, module) {
             });
         });
       });
+    });
 
-      it('displays a message if isMigration returns true', function () {
-        sinon.stub(view, 'isMigration', function (arg) {
+    describe('migration', function () {
+      it('does not display migration message if no migration', function () {
+        return view.render()
+          .then(function () {
+            assert.lengthOf(view.$('.info.nudge'), 0);
+          });
+      });
+
+      it('displays migration message if isSyncMigration returns true', function () {
+        sinon.stub(view, 'isSyncMigration', function () {
           return true;
         });
 
         return view.render()
           .then(function () {
             assert.equal(view.$('.info.nudge').html(), 'Migrate your sync data by creating a new Firefox&nbsp;Account.');
-            view.isMigration.restore();
+            view.isSyncMigration.restore();
           });
       });
 
-      it('does not display a message if isMigration returns false', function () {
-        sinon.stub(view, 'isMigration', function (arg) {
+      it('does not display migration message if isSyncMigration returns false', function () {
+        sinon.stub(view, 'isSyncMigration', function () {
           return false;
         });
 
         return view.render()
           .then(function () {
             assert.lengthOf(view.$('.info.nudge'), 0);
-            view.isMigration.restore();
+            view.isSyncMigration.restore();
           });
       });
 
-      it('sends users to /signin if signup is disabled', function () {
-        sinon.stub(view, 'isSignupDisabled', function () {
+      it('displays migration message if isAmoMigration returns true', function () {
+        sinon.stub(view, 'isAmoMigration', function () {
           return true;
-        });
-
-        sinon.stub(view, 'navigate', sinon.spy());
-        sinon.stub(view, 'getSignupDisabledReason', function () {
-          return AuthErrors.toError('IOS_SIGNUP_DISABLED');
         });
 
         return view.render()
           .then(function () {
-            assert.isTrue(view.navigate.calledWith('signin'));
-            var err = view.navigate.args[0][1].error;
-            assert.isTrue(AuthErrors.is(err, 'IOS_SIGNUP_DISABLED'));
+            assert.equal(view.$('.info.nudge').html(), 'Have an account with a different email? <a href="/signin">Sign in</a>');
+            view.isAmoMigration.restore();
+          });
+      });
+
+      it('does not display migration message if isAmoMigration returns false', function () {
+        sinon.stub(view, 'isAmoMigration', function () {
+          return false;
+        });
+
+        return view.render()
+          .then(function () {
+            assert.lengthOf(view.$('.info.nudge'), 0);
+            view.isAmoMigration.restore();
           });
       });
     });

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -1022,6 +1022,26 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('onAmoSignIn', function () {
+      beforeEach(function () {
+        relier.set('email', email);
+        view.$('input[type=email]').val(email);
+
+        // simulate what happens when the user clicks the AMO sign in link
+        view.onAmoSignIn();
+        view.beforeDestroy();
+      });
+
+      // these two fields are cleared to prevent the email
+      // from being displayed on the signin screen.
+      it('unsets the email on the relier', function () {
+        assert.isFalse(relier.has('email'));
+      });
+
+      it('sets an empty email on formPrefill', function () {
+        assert.equal(formPrefill.get('email'), '');
+      });
+    });
   });
 });
 

--- a/docs/query-params.md
+++ b/docs/query-params.md
@@ -13,6 +13,17 @@ When authenticating a user for OAuth.
 * /oauth/signup
 * /oauth/force_auth
 
+### `migration`
+If the user is migrating their account, specify which service they are migrating from.
+
+#### When to specify
+When signing up a user.
+
+* /signup
+
+#### Options
+* `amo`
+
 ### `keys`
 Set to true to receive derived kA and kB keys that can be used to encrypt data.
 
@@ -79,6 +90,7 @@ The button provides a link to the relier using the `redirect_uri` without extra 
 
 #### When to specify
 When the relier supports being linked to its `redirect_uri` without extra OAuth parameters.
+
 
 ## Firefox/Sync parameters
 

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -49,5 +49,5 @@ define([
   './functional/avatar',
   './functional/alternative_styles',
   './functional/email_opt_in',
-  './functional/refreshes_metrics',
+  './functional/refreshes_metrics'
 ], function () {});

--- a/tests/functional/amo_sign_up.js
+++ b/tests/functional/amo_sign_up.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'tests/functional/lib/helpers'
+], function (registerSuite, assert, FunctionalHelpers) {
+
+  var MIGRATE_PARAMS = 'state=state&migration=amo&scope=profile&email=fakeemail@restmail.com';
+
+  registerSuite({
+    name: 'oauth amo sign up',
+
+    beforeEach: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'as a migrating user': function () {
+      return FunctionalHelpers.openFxaFromRp(this, 'signup', MIGRATE_PARAMS)
+        .then(FunctionalHelpers.visibleByQSA('.info.nudge'))
+        .findByCssSelector('.info.nudge a')
+          .click()
+        .end()
+
+        .findByCssSelector('#fxa-signin-header')
+        .end()
+
+        .findByCssSelector('input[type="email"]')
+        .getAttribute('value')
+        .then(function (resultText) {
+          // check the email address is empty
+          assert.equal(resultText, '');
+        })
+        .end();
+    }
+  });
+});

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -15,7 +15,7 @@ define([
         TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
-  var PAGE_URL_WITH_MIGRATION = PAGE_URL + '&migration=foo';
+  var PAGE_URL_WITH_MIGRATION = PAGE_URL + '&migration=sync11';
 
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
 

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -16,7 +16,7 @@ define([
         FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_desktop_v1&service=sync';
-  var PAGE_URL_WITH_MIGRATION = PAGE_URL + '&migration=wibble';
+  var PAGE_URL_WITH_MIGRATION = PAGE_URL + '&migration=sync11';
 
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
 

--- a/tests/functional_oauth.js
+++ b/tests/functional_oauth.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
+  './functional/amo_sign_up',
   './functional/oauth_sign_in',
   './functional/oauth_sign_up',
   './functional/oauth_sign_up_verification_redirect',


### PR DESCRIPTION
This PR adds support for the signin/signup views to handle AMO migrations. If `migration=amo` then the AMO migration screens will be displayed. Updates corresponding docs, functional test and unit tests.

Fixes #3399 