### PR TITLE
fix(client): Ignore postMessages from `chrome://browser`

### DIFF
--- a/app/scripts/lib/channels/receivers/postmessage.js
+++ b/app/scripts/lib/channels/receivers/postmessage.js
@@ -28,6 +28,13 @@ define(function (require, exports, module) {
       this._window.addEventListener('message', this._boundReceiveEvent, false);
     },
 
+    isOriginIgnored: function (origin) {
+      // A lot of messages are sent with the origin `chrome://browser`, whether
+      // these are from Firefox or addons, we are not sure. Completely ignore
+      // these messages. See #3465
+      return origin === 'chrome://browser';
+    },
+
     isOriginTrusted: function (origin) {
       // `message` events that come from the Fx Desktop browser have an
       // origin of the string constant 'null'. See
@@ -50,7 +57,10 @@ define(function (require, exports, module) {
       }
 
       var origin = event.origin;
-      if (! this.isOriginTrusted(origin)) {
+      if (this.isOriginIgnored(origin)) {
+        this._window.console.error(
+          'postMessage received from %s, ignoring', origin);
+      } else if (! this.isOriginTrusted(origin)) {
         this._window.console.error(
           'postMessage received from %s, expected %s', origin, this._origin);
 

--- a/app/tests/spec/lib/channels/receivers/postmessage.js
+++ b/app/tests/spec/lib/channels/receivers/postmessage.js
@@ -30,6 +30,16 @@ define(function (require, exports, module) {
       receiver.teardown();
     });
 
+    describe('isOriginIgnored', function () {
+      it('returns `true` for `chrome://browser`', function () {
+        assert.isTrue(receiver.isOriginIgnored('chrome://browser'));
+      });
+
+      it('returns `false` by default', function () {
+        assert.isFalse(receiver.isOriginIgnored('https://accounts.firefox.com'));
+      });
+    });
+
     describe('isOriginTrusted', function () {
       it('accepts an origin of the string constant `null`', function () {
         // `message` events that come from the Fx Desktop browser have an
@@ -57,6 +67,23 @@ define(function (require, exports, module) {
     });
 
     describe('receiveEvent', function () {
+      it('ignores messages from an ignored origin', function () {
+        var errorSpy = sinon.spy();
+        receiver.on('error', errorSpy);
+
+        var messageSpy = sinon.spy();
+        receiver.on('message', messageSpy);
+
+        receiver.receiveEvent({
+          data: {},
+          origin: 'chrome://browser',
+          type: 'click'
+        });
+
+        assert.isFalse(errorSpy.called);
+        assert.isFalse(messageSpy.called);
+      });
+
       it('ignores messages with an incorrect type', function () {
         var errorSpy = sinon.spy();
         receiver.on('error', errorSpy);


### PR DESCRIPTION
issue #3465

This is a strawman - ignore messages from `chrome://browser`. Don't even log an error. Just ignore.

@jrgm, @vladikoff, @rfk - thoughts?