### PR TITLE
fix(cwts): show all sync engine options to all clients

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -86,7 +86,15 @@ define(function (require, exports, module) {
     ACCESS_TYPE_ONLINE: 'online',
     ACCESS_TYPE_OFFLINE: 'offline',
 
-    DEFAULT_XHR_TIMEOUT_MS: 2500
+    DEFAULT_XHR_TIMEOUT_MS: 2500,
+    DEFAULT_DECLINED_ENGINES: [
+      'bookmarks',
+      'history',
+      'passwords',
+      'tabs',
+      'desktop-addons',
+      'desktop-preferences'
+    ],
   };
   /*eslint-enable sorting/sort-object-props*/
 });

--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -14,6 +14,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var _ = require('underscore');
+  var Constants = require('lib/constants');
   var FxSyncWebChannelAuthenticationBroker = require('./fx-sync-web-channel');
   var HaltBehavior = require('views/behaviors/halt');
 
@@ -39,14 +40,7 @@ define(function (require, exports, module) {
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       chooseWhatToSyncCheckbox: false,
       chooseWhatToSyncWebV1: {
-        engines: [
-          'bookmarks',
-          'history',
-          'passwords',
-          'tabs',
-          'desktop-addons',
-          'desktop-preferences'
-        ]
+        engines: Constants.DEFAULT_DECLINED_ENGINES
       },
       openGmailButtonVisible: true
     }),

--- a/app/scripts/models/auth_brokers/fx-fennec-v1.js
+++ b/app/scripts/models/auth_brokers/fx-fennec-v1.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var _ = require('underscore');
+  var Constants = require('lib/constants');
   var FxSyncWebChannelAuthenticationBroker = require('models/auth_brokers/fx-sync-web-channel');
   var NavigateBehavior = require('views/behaviors/navigate');
 
@@ -26,12 +27,7 @@ define(function (require, exports, module) {
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       chooseWhatToSyncCheckbox: false,
       chooseWhatToSyncWebV1: {
-        engines: [
-          'bookmarks',
-          'history',
-          'passwords',
-          'tabs'
-        ]
+        engines: Constants.DEFAULT_DECLINED_ENGINES
       },
       emailVerificationMarketingSnippet: false,
       syncPreferencesNotification: true

--- a/app/scripts/models/auth_brokers/fx-firstrun-v2.js
+++ b/app/scripts/models/auth_brokers/fx-firstrun-v2.js
@@ -12,6 +12,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var _ = require('underscore');
+  var Constants = require('lib/constants');
   var FxFirstrunV1AuthenticationBroker = require('./fx-firstrun-v1');
 
   var proto = FxFirstrunV1AuthenticationBroker.prototype;
@@ -20,14 +21,7 @@ define(function (require, exports, module) {
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       chooseWhatToSyncCheckbox: false,
       chooseWhatToSyncWebV1: {
-        engines: [
-          'bookmarks',
-          'history',
-          'passwords',
-          'tabs',
-          'desktop-addons',
-          'desktop-preferences'
-        ]
+        engines: Constants.DEFAULT_DECLINED_ENGINES
       },
       syncPreferencesNotification: true
     }),

--- a/app/scripts/models/auth_brokers/fx-ios-v2.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v2.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var _ = require('underscore');
+  var Constants = require('lib/constants');
   var FxDesktopV1AuthenticationBroker = require('models/auth_brokers/fx-desktop-v1');
 
   var proto = FxDesktopV1AuthenticationBroker.prototype;
@@ -19,12 +20,7 @@ define(function (require, exports, module) {
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       chooseWhatToSyncCheckbox: false,
       chooseWhatToSyncWebV1: {
-        engines: [
-          'bookmarks',
-          'history',
-          'passwords',
-          'tabs'
-        ]
+        engines: Constants.DEFAULT_DECLINED_ENGINES
       },
       convertExternalLinksToText: true,
       emailVerificationMarketingSnippet: false,

--- a/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var chai = require('chai');
+  var Constants = require('lib/constants');
   var FxFennecV1AuthenticationBroker = require('models/auth_brokers/fx-fennec-v1');
   var NullChannel = require('lib/channels/null');
   var Relier = require('models/reliers/relier');
@@ -58,6 +59,10 @@ define(function (require, exports, module) {
 
     it('has the `syncPreferencesNotification` capability by default', function () {
       assert.isTrue(broker.hasCapability('syncPreferencesNotification'));
+    });
+
+    it('has all sync content types', function () {
+      assert.equal(broker.defaultCapabilities.chooseWhatToSyncWebV1.engines, Constants.DEFAULT_DECLINED_ENGINES);
     });
 
     it('disables the `chooseWhatToSyncCheckbox` capability', function () {

--- a/app/tests/spec/models/auth_brokers/fx-firstrun-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-firstrun-v2.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var chai = require('chai');
+  var Constants = require('lib/constants');
   var FxFirstrunV2AuthenticationBroker = require('models/auth_brokers/fx-firstrun-v2');
   var WindowMock = require('../../../mocks/window');
 
@@ -21,6 +22,10 @@ define(function (require, exports, module) {
       broker = new FxFirstrunV2AuthenticationBroker({
         window: windowMock
       });
+    });
+
+    it('has all sync content types', function () {
+      assert.equal(broker.defaultCapabilities.chooseWhatToSyncWebV1.engines, Constants.DEFAULT_DECLINED_ENGINES);
     });
 
     describe('capabilities', function () {

--- a/app/tests/spec/models/auth_brokers/fx-ios-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v2.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var chai = require('chai');
+  var Constants = require('lib/constants');
   var FxiOSV2AuthenticationBroker = require('models/auth_brokers/fx-ios-v2');
   var NullChannel = require('lib/channels/null');
   var Relier = require('models/reliers/relier');
@@ -49,6 +50,10 @@ define(function (require, exports, module) {
         .then(function () {
           assert.isFalse(broker.hasCapability('chooseWhatToSyncCheckbox'));
         });
+    });
+
+    it('has all sync content types', function () {
+      assert.equal(broker.defaultCapabilities.chooseWhatToSyncWebV1.engines, Constants.DEFAULT_DECLINED_ENGINES);
     });
 
     describe('afterSignUp', function () {


### PR DESCRIPTION
Fixes #3494

## depends on https://github.com/mozilla/fxa-content-server/pull/3493