### PR TITLE
fix(client): Focus the display name field when opening the panel.

### DIFF
--- a/app/scripts/templates/settings/display_name.mustache
+++ b/app/scripts/templates/settings/display_name.mustache
@@ -18,7 +18,7 @@
       </p>
       <div class="input-row">
         <label class="label-helper"></label>
-        <input type="text" class="text display-name" placeholder="{{#t}}Display name{{/t}}" value="{{ displayName }}" autocomplete="off"/>
+        <input type="text" class="text display-name" placeholder="{{#t}}Display name{{/t}}" value="{{ displayName }}" autofocus  autocomplete="off"/>
       </div>
       <div class="button-row">
         <button type="submit" class="settings-button primary disabled">{{#t}}Change{{/t}}</button>


### PR DESCRIPTION
Add an `autofocus` attribute to the input element.

fixes #3517