### PR TITLE
fix(client): Fix password reset in e10s (for train 56)

### DIFF
--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -64,7 +64,25 @@ define(function (require, exports, module) {
       openGmailButtonVisible: true
     }),
 
-    type: 'fx-desktop-v2'
+    type: 'fx-desktop-v2',
+
+    afterResetPasswordConfirmationPoll: function (/*account*/) {
+      // this is only called if the user verifies in the same browser.
+      // With Fx's E10s enabled, the account data only contains an
+      // unwrapBKey and keyFetchToken, not enough to sign in the user.
+      // Luckily, with WebChannels, the verification page can send
+      // the data to the browser and everybody is happy
+      return p(new HaltBehavior());
+    },
+
+    afterCompleteResetPassword: function (account) {
+      var self = this;
+      // See the note in afterResetPasswordConfirmationPoll
+      return self._notifyRelierOfLogin(account)
+        .then(function () {
+          return proto.afterCompleteResetPassword.call(self, account);
+        });
+    }
   });
 
   module.exports = FxDesktopV2AuthenticationBroker;

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -22,10 +22,10 @@ define(function (require, exports, module) {
     var user;
     var windowMock;
 
-    before(function () {
+    beforeEach(function () {
       windowMock = new WindowMock();
       channelMock = new NullChannel();
-      channelMock.send = sinon.spy(function () {
+      sinon.stub(channelMock, 'send', function () {
         return p();
       });
 
@@ -104,12 +104,38 @@ define(function (require, exports, module) {
     });
 
     describe('afterResetPasswordConfirmationPoll', function () {
-      it('notifies the channel with `fxaccounts:login`, halts', function () {
+      var result;
+      beforeEach(function () {
         return broker.afterResetPasswordConfirmationPoll(account)
-          .then(function (result) {
-            assert.isTrue(channelMock.send.calledWith('fxaccounts:login'));
-            assert.isTrue(result.halt);
+          .then(function (_result) {
+            result = _result;
           });
+      });
+
+      it('does not notify the channel', function () {
+        assert.isFalse(channelMock.send.called);
+      });
+
+      it('halts', function () {
+        assert.isTrue(result.halt);
+      });
+    });
+
+    describe('afterCompleteResetPassword', function () {
+      var result;
+      beforeEach(function () {
+        return broker.afterCompleteResetPassword(account)
+          .then(function (_result) {
+            result = _result;
+          });
+      });
+
+      it('notifies the channel with `fxaccounts:login`', function () {
+        assert.isTrue(channelMock.send.calledWith('fxaccounts:login'));
+      });
+
+      it('does not halt', function () {
+        assert.isFalse(!! result.halt);
       });
     });
 

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -12,6 +12,7 @@ define([
   './functional/sync_sign_up',
   './functional/sync_v2_sign_up',
   './functional/sync_v2_sign_in',
+  './functional/sync_v2_reset_password',
   './functional/sync_v2_force_auth',
   './functional/sync_v3_sign_up',
   './functional/fx_firstrun_v1_sign_up',

--- a/tests/functional/sync_v2_reset_password.js
+++ b/tests/functional/sync_v2_reset_password.js
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'intern/node_modules/dojo/promise',
+  'intern/node_modules/dojo/node!xmlhttprequest',
+  'app/bower_components/fxa-js-client/fxa-client',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, assert, Promise, nodeXMLHttpRequest,
+        FxaClient, TestHelpers, FunctionalHelpers) {
+  var config = intern.config;
+
+  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+  var PASSWORD = 'password';
+  var RESET_PASSWORD_URL = config.fxaContentRoot + 'reset_password?context=fx_desktop_v2&service=sync';
+
+  var client;
+  var email;
+
+  var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
+  var openPage = FunctionalHelpers.openPage;
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+
+  registerSuite({
+    name: 'Firefox Desktop Sync v2 reset password',
+
+    beforeEach: function () {
+      // timeout after 90 seconds
+      this.timeout = 90000;
+
+      client = new FxaClient(AUTH_SERVER_ROOT, {
+        xhr: nodeXMLHttpRequest.XMLHttpRequest
+      });
+      email = TestHelpers.createEmail();
+
+      return Promise.all([
+        client.signUp(email, PASSWORD, { preVerified: true }),
+        FunctionalHelpers.clearBrowserState(this)
+      ]);
+    },
+
+    teardown: function () {
+      // clear localStorage to avoid polluting other tests.
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'reset password, verify same browser': function () {
+      var self = this;
+
+      return openPage(self, RESET_PASSWORD_URL, '#fxa-reset-password-header')
+
+        .then(function () {
+          return FunctionalHelpers.fillOutResetPassword(self, email);
+        })
+
+        .findByCssSelector('#fxa-confirm-reset-password-header')
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.openVerificationLinkInNewTab(
+                self, email, 0);
+        })
+        .switchToWindow('newwindow')
+
+        .findByCssSelector('#fxa-complete-reset-password-header')
+        .end()
+
+        .then(function () {
+          return FunctionalHelpers.fillOutCompleteResetPassword(
+                    self, PASSWORD, PASSWORD);
+        })
+
+        .findByCssSelector('#fxa-reset-password-complete-header')
+        .end()
+
+        .findByCssSelector('.account-ready-service')
+        .getVisibleText()
+        .then(function (text) {
+          assert.ok(text.indexOf('Firefox Sync') > -1);
+        })
+
+        .end()
+
+        // the verification tab sends the WebChannel message. This fixes
+        // two problems: 1) initiating tab is closed, 2) The initiating
+        // tab when running in E10s does not have all the necessary data
+        // because localStorage is not shared.
+        .then(testIsBrowserNotified(self, 'fxaccounts:login'))
+
+        .closeCurrentWindow()
+        // switch to the original window
+        .switchToWindow('')
+        .end()
+
+        .then(FunctionalHelpers.testSuccessWasShown(self))
+        .then(noSuchBrowserNotification(self, 'fxaccounts:login'));
+    }
+  });
+
+});


### PR DESCRIPTION
Have the verification tab send the login web channel message to the browser,
prevent the originating tab that does not have all of the necessary data.

@jrgm, @vladikoff - this is #3525 against the current train 56