### PR TITLE
feat(sass): add hover and active states for avatar upload dialog buttons

### DIFF
--- a/app/styles/modules/_avatar.scss
+++ b/app/styles/modules/_avatar.scss
@@ -178,6 +178,12 @@
       &#camera, &#file, &#gravatar, &.remove {
         background-position: 50% 22%;
         background-size: 41%;
+        &:hover {
+          filter: hue-rotate(3deg) saturate(1.1) brightness(.85);
+        }
+        &:active {
+          filter: hue-rotate(3deg) saturate(1.1) brightness(.75);
+        }
       }
 
       &#camera {


### PR DESCRIPTION
Add the CSS filters for hover/active states for the buttons for the avatar change dialog, as provided by the venerable @ryanfeeley.

![hover-states](https://cloud.githubusercontent.com/assets/47222/13229394/9cb7ff4a-d955-11e5-96c3-4e355ea88c65.gif)

As best I can see, there is no strictly-css way to make this work in IE10+11; it should work on our other target browsers, however.

Fixes #3451 