### PR TITLE
fix(client): Fix show/hide password toggle on force_auth

### DIFF
--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  var _ = require('underscore');
   var allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
   var AuthErrors = require('lib/auth-errors');
   var BaseView = require('views/base');
@@ -47,9 +48,9 @@ define(function (require, exports, module) {
       };
     },
 
-    events: {
+    events: _.extend(SignInView.prototype.events, {
       'click a[href="/confirm_reset_password"]': BaseView.cancelEventThen('resetPasswordNow')
-    },
+    }),
 
     beforeDestroy: function () {
       this._formPrefill.set('password', this.getElementValue('.password'));

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -310,7 +310,6 @@ define(function (require, exports, module) {
             });
         });
       });
-
     });
 
     describe('with unregistered email', function () {
@@ -364,6 +363,30 @@ define(function (require, exports, module) {
           assert.isTrue(AuthErrors.is(err, 'UNKNOWN_ACCOUNT'));
           // no link to sign up.
           assert.equal(view.$('.error').find('a').length, 0);
+        });
+      });
+    });
+
+    describe('password visibility', function () {
+      beforeEach(function () {
+        initDeps();
+
+        email = TestHelpers.createEmail();
+        relier.set('email', email);
+
+        return view.render()
+          .then(function () {
+            $('#container').html(view.el);
+          });
+      });
+
+      describe('clicking the show button', function () {
+        it('toggles the password visibility state', function () {
+          view.$('.show-password').click();
+          assert.equal(view.$('#password').attr('type'), 'text');
+
+          view.$('#show-password').click();
+          assert.equal(view.$('#password').attr('type'), 'password');
         });
       });
     });


### PR DESCRIPTION
The PasswordMixin is on the SignInView, and we clobberred
the SignInView's events.

Add the ForceAuthView's events to the SignInView's event.

fixes #3532