### PR TITLE
feat(amo): Choose signin/signup page based on existing email account

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -112,6 +112,19 @@ define(function (require, exports, module) {
           });
     },
 
+    /**
+     * Check whether an account exists for the given email.
+     */
+    checkAccountExistsByEmail: function (email) {
+      return this._getClient()
+        .then(function (client) {
+          return client.accountStatusByEmail(email)
+            .then(function (status) {
+              return status.exists;
+            });
+        });
+    },
+
     _getUpdatedSessionData: function (email, relier, accountData, options) {
       var sessionTokenContext = options.sessionTokenContext;
       if (! sessionTokenContext && relier.isSync()) {

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -406,6 +406,16 @@ define(function (require, exports, module) {
     },
 
     /**
+     * Check if user exists by stored email.
+     *
+     * @returns {promise} - resolves when complete
+     */
+    checkAccountEmailExists: function () {
+      var email = this.get('email');
+      return this._fxaClient.checkAccountExistsByEmail(email);
+    },
+
+    /**
      * Sign out the user
      *
      * @returns {promise} - resolves when complete

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -88,7 +88,7 @@ define(function (require, exports, module) {
       this._storage.set('accounts', accounts);
     },
 
-    // A conveinience method that initializes an account instance from
+    // A convenience method that initializes an account instance from
     // raw account data.
     initAccount: function (accountData) {
       if (accountData instanceof Account) {

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -50,11 +50,17 @@ define(function (require, exports, module) {
       return this._formPrefill.get('email') || this.relier.get('email');
     },
 
+    getEmail: function () {
+      var suggestedAccount = this.getAccount();
+      var hasSuggestedAccount = suggestedAccount.get('email');
+      return hasSuggestedAccount ?
+        suggestedAccount.get('email') : this.getPrefillEmail();
+    },
+
     context: function () {
       var suggestedAccount = this.getAccount();
       var hasSuggestedAccount = suggestedAccount.get('email');
-      var email = hasSuggestedAccount ?
-                    suggestedAccount.get('email') : this.getPrefillEmail();
+      var email = this.getEmail();
 
       return {
         chooserAskForPassword: this._suggestedAccountAskPassword(suggestedAccount),

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -147,9 +147,9 @@ define(function (require, exports, module) {
         relier.set('email', 'testuser@testuser.com');
 
         return view.render()
-            .then(function () {
-              assert.equal(view.$('[type=email]').val(), 'testuser@testuser.com');
-            });
+          .then(function () {
+            assert.equal(view.$('[type=email]').val(), 'testuser@testuser.com');
+          });
       });
 
       it('shows unchecked `customize sync` checkbox when service is sync even after session is cleared', function () {
@@ -157,10 +157,10 @@ define(function (require, exports, module) {
         Session.clear();
 
         return view.render()
-            .then(function () {
-              assert.equal(view.$('#customize-sync').length, 1);
-              assert.isFalse(view.$('#customize-sync').is(':checked'));
-            });
+          .then(function () {
+            assert.equal(view.$('#customize-sync').length, 1);
+            assert.isFalse(view.$('#customize-sync').is(':checked'));
+          });
       });
 
       it('shows syncCheckbox experiment treatment', function () {
@@ -186,9 +186,9 @@ define(function (require, exports, module) {
         relier.set('customizeSync', true);
 
         return view.render()
-            .then(function () {
-              assert.isTrue(view.$('#customize-sync').is(':checked'));
-            });
+          .then(function () {
+            assert.isTrue(view.$('#customize-sync').is(':checked'));
+          });
       });
 
       it('uses input COPPA', function () {
@@ -1055,9 +1055,9 @@ define(function (require, exports, module) {
           return setupCustomizeSyncTest('hello')
             .then(function () {
               assert.isFalse(TestHelpers.isEventLogged(metrics,
-                                'signup.customizeSync.true'));
+                'signup.customizeSync.true'));
               assert.isFalse(TestHelpers.isEventLogged(metrics,
-                                'signup.customizeSync.false'));
+                'signup.customizeSync.false'));
             });
         });
 
@@ -1065,9 +1065,9 @@ define(function (require, exports, module) {
           return setupCustomizeSyncTest('sync', false)
             .then(function () {
               assert.isFalse(TestHelpers.isEventLogged(metrics,
-                                'signup.customizeSync.true'));
+                'signup.customizeSync.true'));
               assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                'signup.customizeSync.false'));
+                'signup.customizeSync.false'));
             });
         });
 
@@ -1075,7 +1075,7 @@ define(function (require, exports, module) {
           return setupCustomizeSyncTest('sync', true)
             .then(function () {
               assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                'signup.customizeSync.true'));
+                'signup.customizeSync.true'));
             });
         });
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -969,6 +969,14 @@ define([
     };
   }
 
+  function verifyUser(user, index, client, accountData) {
+    return getVerificationHeaders(user, index)
+      .then(function (headers) {
+        var code = headers['x-verify-code'];
+        return client.verifyCode(accountData.uid, code);
+      });
+  }
+
   return {
     clearBrowserState: clearBrowserState,
     clearSessionStorage: clearSessionStorage,
@@ -1013,6 +1021,7 @@ define([
     testUrlPathnameEquals: testUrlPathnameEquals,
     thenify: thenify,
     type: type,
+    verifyUser: verifyUser,
     visibleByQSA: visibleByQSA,
     visibleByQSAErrorHeight: visibleByQSAErrorHeight
   };

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -222,6 +222,24 @@ define([
     };
   }
 
+  /**
+   * Get the value of a query parameter
+   *
+   * @param {paramName}
+   * @returns {promise} that resolves to the query parameter's value
+   */
+  function getQueryParamValue(paramName) {
+    return function () {
+      return this.parent
+        .getCurrentUrl()
+        .then(function (url) {
+          var parsedUrl = Url.parse(url);
+          var parsedQueryString = Querystring.parse(parsedUrl.query);
+          return parsedQueryString[paramName];
+        });
+    };
+  }
+
   function getVerificationLink(user, index) {
     if (/@/.test(user)) {
       user = TestHelpers.emailToUser(user);
@@ -990,6 +1008,7 @@ define([
     fillOutResetPassword: fillOutResetPassword,
     fillOutSignIn: fillOutSignIn,
     fillOutSignUp: fillOutSignUp,
+    getQueryParamValue: getQueryParamValue,
     getVerificationHeaders: getVerificationHeaders,
     getVerificationLink: getVerificationLink,
     imageLoadedByQSA: imageLoadedByQSA,

--- a/tests/functional/oauth_choose_redirect.js
+++ b/tests/functional/oauth_choose_redirect.js
@@ -10,25 +10,37 @@ define([
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var CONTENT_SERVER_ROOT = config.fxaContentRoot;
+  var PASSWORD = 'password';
 
+  var thenify = FunctionalHelpers.thenify;
+  var getQueryParamValue = FunctionalHelpers.getQueryParamValue;
+  var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
   var openPage = FunctionalHelpers.openPage;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
 
-  var oAuthUrl = CONTENT_SERVER_ROOT + 'oauth?client_id=dcdb5ae7add825d2&scope=profile';
-  var PASSWORD = 'password';
   var email;
+  var oAuthUrl = CONTENT_SERVER_ROOT + 'oauth?&scope=profile&client_id=';
 
   registerSuite({
     name: 'oauth choose redirect',
 
+    before: function () {
+      return this.remote
+        .then(openFxaFromRp(this, 'signup'))
+        .then(getQueryParamValue('client_id'))
+        .then(function (clientId) {
+          oAuthUrl += clientId;
+        });
+    },
+
     beforeEach: function () {
+      email = TestHelpers.createEmail();
+
       return FunctionalHelpers.clearBrowserState(this);
     },
 
-    'oauth endpoint redirects to signup with invalid account email': function () {
+    'oauth endpoint redirects to signup with an unregistered email': function () {
       var self = this;
-
-      email = TestHelpers.createEmail();
 
       var invalidAccountUrl = oAuthUrl + '&email=' + email;
 
@@ -36,10 +48,8 @@ define([
         .then(testElementValueEquals('input[type=email]', email));
     },
 
-    'oauth endpoint redirects to signin with valid account email': function () {
+    'oauth endpoint redirects to signin with a registered email': function () {
       var self = this;
-
-      email = TestHelpers.createEmail();
 
       var validAccountUrl = oAuthUrl + '&email=' + email;
 

--- a/tests/functional/oauth_choose_redirect.js
+++ b/tests/functional/oauth_choose_redirect.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
+  var config = intern.config;
+  var CONTENT_SERVER_ROOT = config.fxaContentRoot;
+
+  var openPage = FunctionalHelpers.openPage;
+  var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
+
+  var oAuthUrl = CONTENT_SERVER_ROOT + 'oauth?client_id=dcdb5ae7add825d2&scope=profile';
+  var PASSWORD = 'password';
+  var email;
+
+  registerSuite({
+    name: 'oauth choose redirect',
+
+    beforeEach: function () {
+      return FunctionalHelpers.clearBrowserState(this);
+    },
+
+    'oauth endpoint redirects to signup with invalid account email': function () {
+      var self = this;
+
+      email = TestHelpers.createEmail();
+
+      var invalidAccountUrl = oAuthUrl + '&email=' + email;
+
+      return openPage(self, invalidAccountUrl, '#fxa-signup-header')
+        .then(testElementValueEquals('input[type=email]', email));
+    },
+
+    'oauth endpoint redirects to signin with valid account email': function () {
+      var self = this;
+
+      email = TestHelpers.createEmail();
+
+      var validAccountUrl = oAuthUrl + '&email=' + email;
+
+      return self.remote
+        .then(FunctionalHelpers.createUser(email, PASSWORD, { preVerified: true}))
+        .then(function () {
+          return openPage(self, validAccountUrl, '#fxa-signin-header');
+        })
+        .then(testElementValueEquals('input[type=email]', email));
+    }
+  });
+});

--- a/tests/functional/oauth_query_param_validation.js
+++ b/tests/functional/oauth_query_param_validation.js
@@ -6,9 +6,8 @@ define([
   'intern',
   'intern!object',
   'intern/node_modules/dojo/node!querystring',
-  'intern/node_modules/dojo/node!url',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, Querystring, Url, FunctionalHelpers) {
+], function (intern, registerSuite, Querystring, FunctionalHelpers) {
   var config = intern.config;
 
   var SIGNUP_ROOT = config.fxaContentRoot + 'oauth/signup';
@@ -21,6 +20,7 @@ define([
 
 
   var thenify = FunctionalHelpers.thenify;
+  var getQueryParamValue = FunctionalHelpers.getQueryParamValue;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
   var openFxaFromUntrustedRp = thenify(FunctionalHelpers.openFxaFromUntrustedRp);
   var openPage = FunctionalHelpers.openPage;
@@ -44,18 +44,6 @@ define([
     return testElementTextInclude('.error', expected);
   };
 
-  var getClientId = function () {
-    return function () {
-      return this.parent
-        .getCurrentUrl()
-        .then(function (url) {
-          var parsedUrl = Url.parse(url);
-          var parsedQueryString = Querystring.parse(parsedUrl.query);
-          return parsedQueryString.client_id;
-        });
-    };
-  };
-
   /*eslint-disable camelcase */
   registerSuite({
     name: 'oauth query parameter validation',
@@ -68,12 +56,12 @@ define([
       var self = this;
       return this.remote
         .then(openFxaFromRp(this, 'signup'))
-        .then(getClientId())
+        .then(getQueryParamValue('client_id'))
         .then(function (clientId) {
           TRUSTED_CLIENT_ID = clientId;
         })
         .then(openFxaFromUntrustedRp(self, 'signup'))
-        .then(getClientId())
+        .then(getQueryParamValue('client_id'))
         .then(function (clientId) {
           UNTRUSTED_CLIENT_ID = clientId;
         });

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -22,11 +22,7 @@ define([
   var client;
 
   function verifyUser(user, index) {
-    return FunctionalHelpers.getVerificationHeaders(user, index)
-      .then(function (headers) {
-        var code = headers['x-verify-code'];
-        return client.verifyCode(accountData.uid, code);
-      });
+    return FunctionalHelpers.verifyUser(user,  index, client, accountData);
   }
 
   function fillOutSignIn(context, email, password) {

--- a/tests/functional_oauth.js
+++ b/tests/functional_oauth.js
@@ -4,6 +4,7 @@
 
 define([
   './functional/amo_sign_up',
+  './functional/oauth_choose_redirect',
   './functional/oauth_query_param_validation',
   './functional/oauth_sign_in',
   './functional/oauth_sign_up',


### PR DESCRIPTION
This PR adds the ability for signin/signup page to redirect to the user to the correct location depending on whether `email` query parameter specifies an existing account.

Fixes #3489