### PR TITLE
fix(client): forbid single-part domains in email addresses

### DIFF
--- a/app/scripts/lib/validate.js
+++ b/app/scripts/lib/validate.js
@@ -32,24 +32,20 @@ define(function (require, exports, module) {
         return false;
       }
 
-      var parts = email.split('@');
-
-      var localLength = parts[0] && parts[0].length;
-      var domainLength = parts[1] && parts[1].length;
-
-      // Original regexp from:
-      //  http://blog.gerv.net/2011/05/html5_email_address_regexp/
-      // Modified to remove the length checks, which are done later.
-      // IETF spec: http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
-      // NOTE: this does *NOT* allow internationalized domain names.
-      return (/^[\w.!#$%&'*+\-\/=?\^`{|}~]+@[a-z\d][a-z\d\-]*(?:\.[a-z\d][a-z\d\-]*)*$/i).test(email) &&
-          // total email allwed to be 256 bytes long
-        email.length <= 256 &&
-          // local side only allowed to be 64 bytes long
-        1 <= localLength && localLength <= 64 &&
-          // domain side allowed to be up to 255 bytes long which
-          // doesn't make much sense unless the local side has 0 length;
-        1 <= domainLength && domainLength <= 255;
+      return email.length <= 256 &&
+        // Original regex:
+        //   * http://blog.gerv.net/2011/05/html5_email_address_regexp/
+        // Modifications:
+        //   * Use case-insensitive regex, delete explicit `A-Z` ranges.
+        //   * Replace `0-9` ranges with `\d` character class.
+        //   * Replace local part `+` with `{1,64}`, to enforce maximum
+        //     64-character limit for the local part.
+        //   * Replace final domain part `*` with `+`, to enforce at least
+        //     one period in the domain part (conent server issue 2199).
+        // IETF spec:
+        //   * http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
+        // NOTE: this does *NOT* allow internationalized domain names.
+        /^[a-z\d.!#$%&’*+/=?^_`{|}~-]{1,64}@[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?(?:\.[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?)+$/i.test(email);
     },
 
     /**

--- a/app/tests/spec/lib/validate.js
+++ b/app/tests/spec/lib/validate.js
@@ -16,16 +16,62 @@ define(function (require, exports, module) {
 
   describe('lib/validate', function () {
     describe('isEmailValid', function () {
-      it('returns false for email without a domain', function () {
-        assert.isFalse(Validate.isEmailValid('a'));
-      });
-
-      it('returns true for email with a one part domain', function () {
-        assert.isTrue(Validate.isEmailValid('a@b'));
-      });
-
       it('returns true for valid email', function () {
         assert.isTrue(Validate.isEmailValid('a@b.c'));
+      });
+
+      it('returns false for email without a local part', function () {
+        assert.isFalse(Validate.isEmailValid('@b.c'));
+      });
+
+      it('returns false for email without a domain', function () {
+        assert.isFalse(Validate.isEmailValid('a@'));
+      });
+
+      it('returns false for email with a single-part domain', function () {
+        assert.isFalse(Validate.isEmailValid('a@b'));
+      });
+
+      it('returns true for email with 64-character local part', function () {
+        assert.isTrue(Validate.isEmailValid(createRandomHexString(64) + '@b.c'));
+      });
+
+      it('returns false for email with 65-character local part', function () {
+        assert.isFalse(Validate.isEmailValid(createRandomHexString(65) + '@b.c'));
+      });
+
+      it('returns true for email with 256 characters', function () {
+        assert.isTrue(Validate.isEmailValid('a@' + createRandomHexString(252) + '.b'));
+      });
+
+      it('returns false for email with 257 characters', function () {
+        assert.isFalse(Validate.isEmailValid('a@' + createRandomHexString(253) + '.b'));
+      });
+
+      it('returns true for valid emails from auth server tests', function () {
+        [
+          'tim@tim-example.net',
+          'a+b+c@example.com',
+          '#!?-@t-e-s-t.c-o-m',
+        ].forEach(function (email) {
+          assert.isTrue(Validate.isEmailValid(email), email + ' should be valid');
+        });
+      });
+
+      it('returns false for invalid emails from auth server tests', function () {
+        [
+          'notAnEmailAddress',
+          '\n@example.com',
+          'me@hello world.com',
+          'me@hello+world.com',
+          'me@.example',
+          'me@example.com-',
+          'me@example..com',
+          'me@example-.com',
+          'me@example.-com'
+        ].forEach(function (email) {
+          assert.isFalse(Validate.isEmailValid(email), email + ' should not be valid');
+        });
       });
     });
 

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -378,9 +378,9 @@ define(function (require, exports, module) {
           });
       });
 
-      it('returns true if email contains a one part TLD', function () {
+      it('returns false if email contains a one part TLD', function () {
         fillOutSignUp('a@b', 'password');
-        assert.isTrue(view.isValid());
+        assert.isFalse(view.isValid());
       });
 
       it('returns true if email contains a two part TLD', function () {
@@ -528,10 +528,6 @@ define(function (require, exports, module) {
         view.showValidationErrors();
 
         assert.isTrue(view.showValidationError.called);
-
-        var err = AuthErrors.toError('DIFFERENT_EMAIL_REQUIRED_FIREFOX_DOMAIN');
-        err.context = 'signup';
-        assert.isTrue(TestHelpers.isErrorLogged(metrics, err));
       });
 
       it('shows an error if the password is invalid', function () {


### PR DESCRIPTION
Fixes #2199.

~~I tried upgrading to the latest version of Gerv's regex but I couldn't make it work. Either regexes are hard or I'm stupid, or possibly both.~~

~~So instead, this change just modifies our existing regex to enforce at least one dot on the domain side of the `@`.~~ I also took the liberty of simplifying the length checks by moving them into the regex because the call to `split` seemed unnecessary to me. And I flipped the order of the tests round so that we perform the cheapest one first.

There's a few new tests added to assert that the length-based stuff didn't break and of course some other tests had to change now that we're rejecting emails we were previously accepting.

@shane-tomlinson, @vladikoff, @vbudhram, can I get a ~~witness~~ r?