### PR TITLE
fix(client): forbid single-part domains in email addresses

### DIFF
--- a/app/tests/spec/lib/validate.js
+++ b/app/tests/spec/lib/validate.js
@@ -16,16 +16,67 @@ define(function (require, exports, module) {
 
   describe('lib/validate', function () {
     describe('isEmailValid', function () {
-      it('returns false for email without a domain', function () {
-        assert.isFalse(Validate.isEmailValid('a'));
-      });
-
-      it('returns true for email with a one part domain', function () {
-        assert.isTrue(Validate.isEmailValid('a@b'));
-      });
-
       it('returns true for valid email', function () {
         assert.isTrue(Validate.isEmailValid('a@b.c'));
+      });
+
+      it('returns false for email without a local part', function () {
+        assert.isFalse(Validate.isEmailValid('@b.c'));
+      });
+
+      it('returns false for email without a domain', function () {
+        assert.isFalse(Validate.isEmailValid('a@'));
+      });
+
+      it('returns false for email with a single-part domain', function () {
+        assert.isFalse(Validate.isEmailValid('a@b'));
+      });
+
+      it('returns true for email with 64-character local part', function () {
+        assert.isTrue(Validate.isEmailValid(createRandomHexString(64) + '@b.c'));
+      });
+
+      it('returns false for email with 65-character local part', function () {
+        assert.isFalse(Validate.isEmailValid(createRandomHexString(65) + '@b.c'));
+      });
+
+      it('returns true for email with 256 characters', function () {
+        assert.isTrue(Validate.isEmailValid('a@' + createRandomHexString(252) + '.b'));
+      });
+
+      it('returns false for email with 257 characters', function () {
+        assert.isFalse(Validate.isEmailValid('a@' + createRandomHexString(253) + '.b'));
+      });
+
+      it('returns true for valid emails from auth server tests', function () {
+        [
+          'tim@tim-example.net',
+          'a+b+c@wibble.example.com',
+          '#!?-@t-e-s-t.c-o-m',
+          // The next two test cases are commented out until we support
+          // unicode email addresses in the content server.
+          //String.fromCharCode(1234) + '@example.com',
+          //'test@' + String.fromCharCode(5678) + '.com'
+        ].forEach(function (email) {
+          assert.isTrue(Validate.isEmailValid(email), email + ' should be valid');
+        });
+      });
+
+      it('returns false for invalid emails from auth server tests', function () {
+        [
+          'notAnEmailAddress',
+          '\n@example.com',
+          'me@hello world.com',
+          'me@hello+world.com',
+          'me@.example',
+          'me@example.com-',
+          'me@example..com',
+          'me@-example-.com',
+          'me@example-.com',
+          'me@example.-com'
+        ].forEach(function (email) {
+          assert.isFalse(Validate.isEmailValid(email), email + ' should not be valid');
+        });
       });
     });
 

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -378,9 +378,9 @@ define(function (require, exports, module) {
           });
       });
 
-      it('returns true if email contains a one part TLD', function () {
+      it('returns false if email contains a one part TLD', function () {
         fillOutSignUp('a@b', 'password');
-        assert.isTrue(view.isValid());
+        assert.isFalse(view.isValid());
       });
 
       it('returns true if email contains a two part TLD', function () {
@@ -510,19 +510,6 @@ define(function (require, exports, module) {
 
       it('shows an error if the user provides a @firefox.com email', function () {
         fillOutSignUp('user@firefox.com', 'password');
-
-        sinon.spy(view, 'showValidationError');
-        view.showValidationErrors();
-
-        assert.isTrue(view.showValidationError.called);
-
-        var err = AuthErrors.toError('DIFFERENT_EMAIL_REQUIRED_FIREFOX_DOMAIN');
-        err.context = 'signup';
-        assert.isTrue(TestHelpers.isErrorLogged(metrics, err));
-      });
-
-      it('shows an error if the user provides an email that ends with @firefox', function () {
-        fillOutSignUp('user@firefox', 'password');
 
         sinon.spy(view, 'showValidationError');
         view.showValidationErrors();

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -270,6 +270,21 @@ define([
         .end();
     },
 
+    'signup with invalid email address': function () {
+      return this.remote
+        .then(fillOutSignUp(this, email + '-', PASSWORD))
+
+        // wait five seconds to allow any errant navigation to occur
+        .sleep(5000)
+
+        // navigation should not occur
+        .findByCssSelector('#fxa-signup-header')
+        .end()
+
+        // the validation tooltip should be visible
+        .then(FunctionalHelpers.visibleByQSA('.tooltip'));
+    },
+
     'signup with existing account, coppa is valid, credentials are correct': function () {
       return signUpWithExistingAccount(this, email, PASSWORD, PASSWORD)
 


### PR DESCRIPTION
Fixes #2199.

This is my second stab at fixing this, after #3542. The difference here is that we now pass all of the auth server tests for email validation. If this PR is successful, I'll update the code there to match so that we have the same implementation in both places.

It uses the latest version of [Gerv's regex](http://blog.gerv.net/2011/05/html5_email_address_regexp/) and passes it a punycoded address if unicode characters are detected, as per [this comment](http://blog.gerv.net/2011/05/html5_email_address_regexp/#comment-9358). As such, the content server now validates unicode email addresses, which it wasn't doing before.

In order to do the punycoding, there is a new bower dependency added. It's 1.5 kb minified+gzipped, hopefully that's tolerable. Without it, we can't get consistency with the auth server / support for unicode addresses.

@shane-tomlinson, @vbudhram, what do you reckon?