### PR TITLE
fix(client): Handle old accounts that contain `accountData`

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -519,7 +519,14 @@ define(function (require, exports, module) {
     },
 
     upgradeStorageFormats: function () {
-      return this._user.upgradeFromSession(Session, this._fxaClient);
+      var user = this._user;
+
+      // upgradeFromUnfilteredAccountData comes first
+      // otherwise upgradeFromSession fails because it tries
+      // to read and create Accounts for unfiltered data.
+      // upgradeFromSession writes the new format, so this is safe.
+      return user.upgradeFromUnfilteredAccountData()
+        .then(user.upgradeFromSession.bind(user, Session, this._fxaClient));
     },
 
     createView: function (Constructor, options) {

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -773,6 +773,7 @@ define(function (require, exports, module) {
         });
     }
   }, {
+    ALLOWED_KEYS: ALLOWED_KEYS,
     PERMISSIONS_TO_KEYS: PERMISSIONS_TO_KEYS
   });
 

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -115,14 +115,15 @@ define(function (require, exports, module) {
           });
       });
 
-      it('updates old sessions', function () {
-        sinon.stub(userMock, 'upgradeFromSession', function () {
+      it('updates old storage formats', function () {
+        sinon.stub(appStart, 'upgradeStorageFormats', function () {
+          return p();
         });
 
         return appStart.startApp()
-                    .then(function () {
-                      assert.isTrue(userMock.upgradeFromSession.calledOnce);
-                    });
+          .then(function () {
+            assert.isTrue(appStart.upgradeStorageFormats.calledOnce);
+          });
       });
 
       it('uses storage metrics when an automated browser is detected', function () {
@@ -978,6 +979,28 @@ define(function (require, exports, module) {
           appStart._getSameBrowserVerificationModel('context'),
           SameBrowserVerificationModel
         );
+      });
+    });
+
+    describe('upgradeStorageFormats', function () {
+      beforeEach(function () {
+        appStart = new AppStart({
+          user: userMock,
+          window: windowMock
+        });
+
+        sinon.spy(userMock, 'upgradeFromUnfilteredAccountData');
+        sinon.spy(userMock, 'upgradeFromSession');
+
+        return appStart.upgradeStorageFormats();
+      });
+
+      it('upgrades unfiltered account data', function () {
+        assert.isTrue(userMock.upgradeFromUnfilteredAccountData.called);
+      });
+
+      it('upgrades from Session data', function () {
+        assert.isTrue(userMock.upgradeFromSession.called);
       });
     });
   });

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -50,5 +50,6 @@ define([
   './functional/avatar',
   './functional/alternative_styles',
   './functional/email_opt_in',
-  './functional/refreshes_metrics'
+  './functional/refreshes_metrics',
+  './functional/upgrade_storage_formats'
 ], function () {});

--- a/tests/functional/upgrade_storage_formats.js
+++ b/tests/functional/upgrade_storage_formats.js
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers'
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
+  var config = intern.config;
+  var SIGNIN_PAGE_URL = config.fxaContentRoot + 'signin';
+
+  var thenify = FunctionalHelpers.thenify;
+
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
+  var createUser = FunctionalHelpers.createUser;
+  var openPage = thenify(FunctionalHelpers.openPage);
+  var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
+
+  var email;
+
+  registerSuite({
+    name: 'upgrade storage formats',
+
+    beforeEach: function () {
+      email = TestHelpers.createEmail();
+      return clearBrowserState(this);
+    },
+
+    after: function () {
+      return clearBrowserState(this);
+    },
+
+    'Upgrade from Session w/o cached credentials, session invalid': function () {
+      return this.remote
+        .execute(function (email) {
+          var namespace = '__fxa_session';
+          localStorage.removeItem(namespace);
+          var userData = {
+            email: email,
+            sessionToken: 'an invalid session token'
+          };
+          localStorage.setItem(namespace, JSON.stringify(userData));
+
+        }, [ email ])
+        .then(openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header'))
+
+        // sessionToken was invalid, email should be cleared
+        .then(testElementValueEquals('input[type=email]', ''));
+    },
+
+    'Upgrade from Session w/o cached Sync credentials, session valid': function () {
+      return this.remote
+        .then(createUser(email, 'password', { preVerified: true }))
+
+        .then(function (accountInfo) {
+          return this.parent.execute(function (email, sessionToken) {
+            var namespace = '__fxa_session';
+            var userData = {
+              email: email,
+              sessionToken: sessionToken
+            };
+            localStorage.setItem(namespace, JSON.stringify(userData));
+          }, [email, accountInfo.sessionToken]);
+        })
+
+        .then(openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header'))
+
+        // sessionToken was valid, email should be pre-filled
+        .then(testElementValueEquals('input[type=email]', email));
+
+    },
+
+    'Upgrade from Session w/ cached Sync credentials': function () {
+      return this.remote
+        .execute(function (email) {
+          var userData = {
+            cachedCredentials: {
+              email: email,
+              sessionToken: 'another fake session token',
+              sessionTokenContext: 'sync',
+              uid: 'users id'
+            },
+            email: 'oauth@testuser.com',
+            sessionToken: 'a fake session token'
+          };
+          localStorage.setItem('__fxa_session', JSON.stringify(userData));
+        }, [ email ])
+        .then(openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header'))
+
+        // Sync creds take precedence
+        .then(testElementValueEquals('input[type=email]', email));
+
+    },
+
+    'Upgrade from account that has `accountData`': function () {
+      return this.remote
+        .execute(function (email) {
+          // data is taken from localStorage of a browser profile
+          // which suffered from #3466.
+          localStorage.setItem('__fxa_storage.uniqueUserId', JSON.stringify('fc561101-cab6-4c2d-983e-7eedb59e5ef6'));
+          localStorage.setItem('__fxa_session', JSON.stringify({}));
+          localStorage.setItem('__fxa_storage.currentAccountUid', JSON.stringify('fb02d1dda57f4d19a7bc7c29a9ffa772'));
+          /*eslint-disable sorting/sort-object-props */
+          localStorage.setItem('__fxa_storage.accounts', JSON.stringify({
+            'fb02d1dda57f4d19a7bc7c29a9ffa772': {
+              'accountData': {
+                'email': email,
+                'uid': 'fb02d1dda57f4d19a7bc7c29a9ffa772',
+                'sessionToken': '75468c96fa1f5ad69861afcf396eb127c2b30e7af9e5d5c6e295e03d8b7e8558',
+                'verified': true
+              },
+              'assertion': {
+                '_fxaClient': {
+                  '_client': {
+                    'request': {
+                      'baseUri': 'http://127.0.0.1:9000/v1',
+                      'timeout': 30000
+                    }
+                  },
+                  '_signUpResendCount': 0,
+                  '_passwordResetResendCount': 0,
+                  '_interTabChannel': {}
+                },
+                '_audience': 'http://127.0.0.1:9010'
+              },
+              'oAuthClient': {},
+              'profileClient': {
+                'profileUrl': 'http://127.0.0.1:1111'
+              },
+              'fxaClient': {
+                '_client': {
+                  'request': {
+                    'baseUri': 'http://127.0.0.1:9000/v1',
+                    'timeout': 30000
+                  }
+                },
+                '_signUpResendCount': 0,
+                '_passwordResetResendCount': 0,
+                '_interTabChannel': {}
+              },
+              'oAuthClientId': '98e6508e88680e1a',
+              'uid': 'fb02d1dda57f4d19a7bc7c29a9ffa772',
+              'email': email,
+              'sessionToken': '75468c96fa1f5ad69861afcf396eb127c2b30e7af9e5d5c6e295e03d8b7e8558',
+              'accessToken': '01abda6160a0d5864fe577d2bead1480222ae6228d014d628315d59e5efc5b3d',
+              'verified': true,
+              'lastLogin': 1456833973259
+            }
+          }));
+          /*eslint-enable sorting/sort-object-props */
+
+        }, [ email ])
+        // success is not going to the 500 page.
+        .then(openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header'));
+    }
+  });
+});


### PR DESCRIPTION
Upgrade storage formats before trying to do any more data access.

fixes #3466 