### PR TITLE
Run intern server with optional fxaDevBox setting

### DIFF
--- a/tests/teamcity/latest
+++ b/tests/teamcity/latest
@@ -11,3 +11,6 @@ FXA_CONTENT_VERSION="https://latest.dev.lcip.org/__version__"
 FXA_OAUTH_VERSION="https://oauth-latest.dev.lcip.org/__version__"
 FXA_PROFILE_VERSION="https://latest.dev.lcip.org/profile/__version__"
 FXA_AUTH_VERSION="https://latest.dev.lcip.org/auth/__version__"
+
+# production-like, but not quite
+FXA_DEV_BOX="true"

--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -20,7 +20,7 @@ source $DIRNAME/$FXA_TEST_NAME
 
 # optionally, GIT_COMMIT can be set in the environment to override
 if [ -z "$GIT_COMMIT" ]; then
-  GIT_COMMIT=$(curl -s "$FXA_CONTENT_ROOT/ver.json" | jsawk  "return this.commit")
+  GIT_COMMIT=$(curl -s "$FXA_CONTENT_VERSION" | jsawk  "return this.commit" | perl -pe 's/^OUT: //')
 else
   echo "Using GIT_COMMIT from the environment $GIT_COMMIT"
 fi

--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -29,6 +29,7 @@ echo "FXA_TEST_NAME       $FXA_TEST_NAME"
 echo "FXA_CONTENT_ROOT    $FXA_CONTENT_ROOT"
 echo "FXA_AUTH_ROOT       $FXA_AUTH_ROOT"
 echo "FXA_OAUTH_APP_ROOT  $FXA_OAUTH_APP_ROOT"
+echo "FXA_DEV_BOX         $FXA_DEV_BOX"
 echo "FXA_FIREFOX_BINARY  $FXA_FIREFOX_BINARY"
 echo "GIT_COMMIT          $GIT_COMMIT"
 
@@ -77,4 +78,5 @@ set -o xtrace # echo the following commands
   config=tests/intern_server \
   fxaContentRoot="$FXA_CONTENT_ROOT" \
   fxaProduction="true" \
+  fxaDevBox="$FXA_DEV_BOX" \
   asyncTimeout=10000

--- a/tests/teamcity/stable
+++ b/tests/teamcity/stable
@@ -11,3 +11,6 @@ FXA_CONTENT_VERSION="https://stable.dev.lcip.org/__version__"
 FXA_OAUTH_VERSION="https://oauth-stable.dev.lcip.org/__version__"
 FXA_PROFILE_VERSION="https://stable.dev.lcip.org/profile/__version__"
 FXA_AUTH_VERSION="https://stable.dev.lcip.org/auth/__version__"
+
+# production-like, but not quite
+FXA_DEV_BOX="true"


### PR DESCRIPTION
`fxaDevBox` is a flag I think I introduced to distinguish between `stage` and `latest` for small differences in what tests should expect. I had teamcity using a handrolled script against latest and with run-server.sh for stage, so this missing flag wasn't noticed until I switched latest on tests to use the same script. 

Also fixes an oddity: a new version of `jwawk` prefixes the result with 'OUT: ' (and an error with 'ERR: '). Which is pretty dumb, but anyways, this just adjusts the script to strip it out if it is in the result.

r? @vladikoff 
