### PR TITLE
fix(build): copy error pages into dist, not app

### DIFF
--- a/grunttasks/copy.js
+++ b/grunttasks/copy.js
@@ -62,7 +62,7 @@ module.exports = function (grunt) {
     error_pages: { //eslint-disable-line camelcase
       files: [{
         cwd: '<%= yeoman.page_template_dist %>',
-        dest: '<%= yeoman.app %>',
+        dest: '<%= yeoman.dist %>',
         dot: true,
         expand: true,
         flatten: true,


### PR DESCRIPTION
This is just @shane-tomlinson's fix from https://github.com/mozilla/fxa-content-server/issues/3549#issuecomment-190910507

Seems to work for me, and passes tests in CI. (Had a little problem with running it locally against an fxa-dev instance with this change, but I expect the problems were something in my local linux vm).

r? - @shane-tomlinson 