### PR TITLE
chore(git): Remove built app based error pages from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,11 +49,6 @@ test/temp
 ### Pre-processed files that become part of the build ###
 app/scripts/processed
 
-### Pre-processed error pages
-app/500.html
-app/502.html
-app/503.html
-
 ### Local configuration ###
 server/config/local.json
 


### PR DESCRIPTION
The build now places the error pages into dist.

issue #3554

@vladikoff or @jrgm