### PR TITLE
feat(styles): Updated password reset flow

### DIFF
--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -41,7 +41,7 @@ define(function (require, exports, module) {
   t('Forgot password');
   t('When you reset your password, you will lose any Sync data that is not on one of your devices.');
   t('Learn how Sync works.');
-  t('Reset Password');
+  t('Reset password');
   t('Click the button within the next hour to set a new password for your Firefox Account.');
   t('You may need to enter your new password on other devices connected to Firefox Sync.');
   t('Your password has been reset.');

--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -25,28 +25,6 @@ define(function (require, exports, module) {
   // for why this could be necessary.
   t('<a href="https://support.mozilla.org/kb/im-having-problems-with-my-firefox-account">Help</a>');
 
-  // Needed for PR #3426, issue #2477
-  t('Email address');
-  t('Display name');
-  t('Account picture');
-  t('%(permissionName)s (required)');
-
-  // Needed for Password flow update PR #3559
-  t('Enter new password');
-  t('Once you submit your new password, you will lose any Sync data that is not on one of your devices.');
-  t('Must be at least 8 characters');
-  t('Submit new password');
-  t('Click on the link we\'ve emailed you at %(email)s within the next hour to create a new password.');
-  t('Remember password? Sign in.');
-  t('Forgot password');
-  t('When you reset your password, you will lose any Sync data that is not on one of your devices.');
-  t('Learn how Sync works.');
-  t('Reset password');
-  t('Click the button within the next hour to set a new password for your Firefox Account.');
-  t('You may need to enter your new password on other devices connected to Firefox Sync.');
-  t('Your password has been reset.');
-  t('Your Firefox Account password has changed. If you did not change it, please <a href="%(resetPasswordUri)s">reset your password</a> now.');
-
   /**
    * Replace instances of %s and %(name)s with their corresponding values in
    * the context

--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -32,13 +32,17 @@
 
   {{#isLinkValid}}
   <header>
-    <h1 id="fxa-complete-reset-password-header">{{#t}}Reset password{{/t}}</h1>
+    <h1 id="fxa-complete-reset-password-header">{{#t}}Enter new password{{/t}}</h1>
   </header>
 
   <section>
     <div class="error"></div>
 
     <form novalidate>
+      <p class="reset-warning reset-warning-complete-password">
+          {{#t}}Once you submit your new password, you will lose any Sync data that is not on one of your devices.{{/t}}<a href="https://support.mozilla.org/en-US/products/firefox/sync" target="_blank">{{#t}}Learn how Sync works.{{/t}}</a>
+      </p>
+
       <div class="input-row password-row">
         <label class="label-helper"></label>
         <input type="password" class="password" id="password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" autofocus required {{#isPasswordAutoCompleteDisabled}}autocomplete="off"{{/isPasswordAutoCompleteDisabled}} />
@@ -47,7 +51,10 @@
         <label for="show-password" class="show-password-label">
           {{#t}}Show{{/t}}
         </label>
+
+        <div class="input-help input-help-complete-password">{{#t}}Must be at least 8 characters{{/t}}</div>
       </div>
+
 
       <div class="input-row password-row">
         <label class="label-helper"></label>
@@ -58,11 +65,10 @@
           {{#t}}Show{{/t}}
         </label>
 
-        <div class="input-help">{{#t}}Must be at least 8 characters{{/t}}</div>
       </div>
 
       <div class="button-row">
-        <button type="submit" class="disabled">{{#t}}Next{{/t}}</button>
+        <button type="submit" class="disabled">{{#t}}Submit new password{{/t}}</button>
       </div>
     </form>
   </section>

--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -40,7 +40,8 @@
 
     <form novalidate>
       <p class="reset-warning reset-warning-complete-password">
-          {{#t}}Once you submit your new password, you will lose any Sync data that is not on one of your devices.{{/t}}<a href="https://support.mozilla.org/en-US/products/firefox/sync" target="_blank">{{#t}}Learn how Sync works.{{/t}}</a>
+        {{#t}}Once you submit your new password, you will lose any Sync data that is not on one of your devices.{{/t}}
+        <a href="https://support.mozilla.org/products/firefox/sync" target="_blank">{{#t}}Learn how Sync works.{{/t}}</a>
       </p>
 
       <div class="input-row password-row">

--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -9,18 +9,18 @@
 
     <div class="graphic graphic-mail">{{#t}}Email Sent{{/t}}</div>
 
-    <p class="verification-email-message">{{#t}}A reset link has been sent to %(email)s{{/t}}</p>
+    <p class="verification-email-message">{{#t}}Click on the link we've emailed you at %(email)s within the next hour to create a new password.{{/t}}</p>
 
     <ul class="links">
       {{#forceAuth}}
       <li>
-        <a href="/force_auth?email={{ encodedEmail }}" class="sign-in">{{#t}}Sign in{{/t}}</a>
+        <a href="/force_auth?email={{ encodedEmail }}" class="sign-in">{{#t}}Remember password? Sign in.{{/t}}</a>
       </li>
       {{/forceAuth}}
 
       {{^forceAuth}}
       <li>
-        <a href="/signin" class="sign-in">{{#t}}Sign in{{/t}}</a>
+        <a href="/signin" class="sign-in">{{#t}}Remember password? Sign in.{{/t}}</a>
       </li>
       {{/forceAuth}}
 

--- a/app/scripts/templates/reset_password.mustache
+++ b/app/scripts/templates/reset_password.mustache
@@ -9,10 +9,10 @@
     <form novalidate>
       <p class="reset-warning">
         {{#t}}When you reset your password, you will lose any Sync data that is not on one of your devices.{{/t}}
-        <a href="https://support.mozilla.org/en-US/products/firefox/sync" target="_blank">{{#t}}Learn how Sync works.{{/t}}</a>
+        <a href="https://support.mozilla.org/products/firefox/sync" target="_blank">{{#t}}Learn how Sync works.{{/t}}</a>
       </p>
       <div class="input-row">
-        <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" autofocus required>
+        <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" spellcheck="false" autofocus required>
       </div>
 
       <div class="button-row">

--- a/app/scripts/templates/reset_password.mustache
+++ b/app/scripts/templates/reset_password.mustache
@@ -1,31 +1,28 @@
 <div id="main-content" class="card">
   <header>
-    <h1 id="fxa-reset-password-header">{{#t}}Reset password{{/t}}</h1>
+    <h1 id="fxa-reset-password-header">{{#t}}Forgot password{{/t}}</h1>
   </header>
 
   <section>
     <div class="error"></div>
 
     <form novalidate>
-      <p>{{#t}}Are you sure you want to reset your account password?{{/t}}</p>
-
       <p class="reset-warning">
-        {{#t}}Resetting your password will erase your browsing data from our servers. Any data on your devices will remain untouched. Begin the reset process by entering your email below.{{/t}}
+        {{#t}}When you reset your password, you will lose any Sync data that is not on one of your devices.{{/t}}
+        <a href="https://support.mozilla.org/en-US/products/firefox/sync" target="_blank">{{#t}}Learn how Sync works.{{/t}}</a>
       </p>
-
       <div class="input-row">
         <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" autofocus required>
       </div>
 
       <div class="button-row">
-        <button id="submit-btn" type="submit" class="disabled">{{#t}}Begin reset{{/t}}</button>
+        <button id="submit-btn" type="submit" class="disabled">{{#t}}Reset password{{/t}}</button>
       </div>
     </form>
 
-    {{#canGoBack}}
-      <div class="links">
-        <a id="back" href="#">{{#t}}Back{{/t}}</a>
-      </div>
-    {{/canGoBack}}
+    <div class="links">
+      <a href="/signin">{{#t}}Remember password? Sign in.{{/t}}</a>
+    </div>
+
   </section>
 </div>

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -6,7 +6,6 @@ define(function (require, exports, module) {
   'use strict';
 
   var AuthErrors = require('lib/auth-errors');
-  var BackMixin = require('views/mixins/back-mixin');
   var BaseView = require('views/base');
   var Cocktail = require('cocktail');
   var FormView = require('views/form');
@@ -25,16 +24,6 @@ define(function (require, exports, module) {
       options = options || {};
 
       this._formPrefill = options.formPrefill;
-    },
-
-    _getPrefillEmail: function () {
-      return this.relier.get('email') || this._formPrefill.get('email') || '';
-    },
-
-    context: function () {
-      return {
-        email: this._getPrefillEmail()
-      };
     },
 
     afterRender: function () {
@@ -78,7 +67,6 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     View,
-    BackMixin,
     PasswordResetMixin,
     ServiceMixin
   );

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -27,11 +27,6 @@ define(function (require, exports, module) {
     },
 
     afterRender: function () {
-      var value = this.$('.email').val();
-      if (value) {
-        this.focus('.email');
-      }
-
       if (this.relier.isOAuth()) {
         this.transformLinks();
       }

--- a/app/styles/_state.scss
+++ b/app/styles/_state.scss
@@ -73,8 +73,20 @@
 }
 
 .reset-warning {
-  font-size: $small-font;
+  background-color: $reset-pw-text-background-color;
+  color: $reset-pw-text-color;
+  font-size: $base-font;
   font-weight: normal;
+  margin-top: 0px;
+  padding: 5px;
+
+  &.reset-warning-complete-password {
+    margin-bottom: 25px;
+  }
+
+  a {
+    color: $reset-pw-text-color;
+  }
 }
 
 // Put a margin on top when the error messages follow a div

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -42,6 +42,10 @@ $settings-header-border-bottom: #b4bdc3;
 $settings-success-background-color: rgb(205, 248, 208);
 $settings-success-border-color: rgb(0, 170, 0);
 
+//Reset Password Colors
+$reset-pw-text-background-color: #f25820;
+$reset-pw-text-color: #fff;
+
 //Font-Size Variables
 $large-font: 24px;
 $medium-font: 18px;

--- a/app/styles/modules/_input-row.scss
+++ b/app/styles/modules/_input-row.scss
@@ -46,7 +46,7 @@
       &:hover {
         border-color: $input-row-hover-border-color;
       }
-      
+
       &:focus {
         border-color: $input-row-focus-border-color;
       }
@@ -78,6 +78,10 @@
     color: $input-placeholder-color;
     margin-top: 6px;
     transition: opacity $medium-transition;
+
+    &.input-help-complete-password {
+      text-align: center;
+    }
 
     @include respond-to('small') {
       font-size: $small-font;

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -73,34 +73,12 @@ define(function (require, exports, module) {
         assert.ok($('#fxa-reset-password-header').length);
       });
 
-      it('pre-fills email addresses from formPrefill.email', function () {
-        formPrefill.set('email', 'prefilled@testuser.com');
-        return view.render()
-          .then(function () {
-            assert.equal(view.$('.email').val(), 'prefilled@testuser.com');
-            assert.equal(view.$('.email').attr('spellcheck'), 'false');
-          });
-      });
-
-      it('shows the back button if back is enabled', function () {
-        view = createView({
-          canGoBack: true
-        });
+      it('shows the signin button', function () {
+        view = createView();
 
         return view.render()
           .then(function () {
-            assert.equal(view.$('#back').length, 1);
-          });
-      });
-
-      it('does not show the back button if back is disabled', function () {
-        view = createView({
-          canGoBack: false
-        });
-
-        return view.render()
-          .then(function () {
-            assert.equal(view.$('#back').length, 0);
+            assert.equal(view.$('a[href="/signin"]').length, 1);
           });
       });
     });
@@ -247,8 +225,8 @@ define(function (require, exports, module) {
       $('#container').empty();
     });
 
-    it('pre-fills email address', function () {
-      assert.equal(view.$('.email').val(), 'testuser@testuser.com');
+    it('does not pre-fills email address', function () {
+      assert.equal(view.$('.email').val(), '');
     });
 
     it('removes the back button - the user probably browsed here directly', function () {


### PR DESCRIPTION
This PR adds updates the password reset flows based on [mockups](https://github.com/mozilla/fxa/tree/master/features/FxA-72-reset-password).

Initial Forgot Password
- [x] Email address not auto filled.
- [x] New warning message with background #f25820
- [x] Replace back button with signin link 

Reset Email Sent
- [x] New body text
- [x] Add signin link

Email Confirmation
- [x] Create PR in Auth-Mailer
- [x] New body text
- [x] Add signin link

Enter New Password
- [x] Change heading copy
- [x] Move password policy help text
- [x] Change submit button copy

Reset Successful
~~- [ ] Sync preferences button (Optional)~~

Password Change Email Confirmation
- [x] Create PR in Auth-Mailer
- [x] New body text
- [x] Link and body text to change password again

Fixes #3467 

~~Don't merge until we get links for `Learn how Sync works`~~