### PR TITLE
feat(client): Show a startup spinner

### DIFF
--- a/app/scripts/views/app.js
+++ b/app/scripts/views/app.js
@@ -12,6 +12,8 @@ define(function (require, exports, module) {
   var $ = require('jquery');
   var Backbone = require('backbone');
   var BaseView = require('views/base');
+  var Cocktail = require('cocktail');
+  var LoadingMixin = require('views/mixins/loading-mixin');
   var p = require('lib/promise');
 
   var AppView = BaseView.extend({
@@ -113,17 +115,9 @@ define(function (require, exports, module) {
 
             self.setTitle(viewToShow.titleFromView());
 
-            // Render the new view while stage is invisible then fade it in
-            // using css animations to catch problems with an explicit
-            // opacity rule after class is added.
-            $('#stage').html(viewToShow.el).addClass('fade-in-forward').css('opacity', 1);
+            self.writeToDOM(viewToShow.el);
+
             viewToShow.afterVisible();
-
-            // The user may be scrolled part way down the page
-            // on view transition. Force them to the top of the page.
-            self.window.scrollTo(0, 0);
-
-            $('#fox-logo').addClass('fade-in-forward').css('opacity', 1);
 
             self.notifier.trigger('view-shown', viewToShow);
 
@@ -185,6 +179,11 @@ define(function (require, exports, module) {
     }
 
   });
+
+  Cocktail.mixin(
+    AppView,
+    LoadingMixin
+  );
 
   module.exports = AppView;
 });

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -200,6 +200,31 @@ define(function (require, exports, module) {
         });
     },
 
+
+    /**
+     * Write content to the DOM
+     *
+     * @param {string || element} content
+     */
+    writeToDOM: function (content) {
+      $('#loading-spinner').hide();
+
+      // Two notes:
+      // 1. Render the new view while stage is invisible then fade it in
+      // using css animations to catch problems with an explicit
+      // opacity rule after class is added.
+      // 2. The html is written directly into #stage instead
+      // of this.$el because overwriting this.$el has a nasty side effect
+      // where the view's DOM event handlers do hook up properly.
+      $('#stage').html(content).addClass('fade-in-forward').css('opacity', 1);
+
+      // The user may be scrolled part way down the page
+      // on view transition. Force them to the top of the page.
+      this.window.scrollTo(0, 0);
+
+      $('#fox-logo').addClass('fade-in-forward').css('opacity', 1);
+    },
+
     // Checks that the user's current account exists and is
     // verified. Returns either true or false.
     _checkUserAuthorization: function () {

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -11,7 +11,6 @@ define(function (require, exports, module) {
   var CompleteSignUpTemplate = require('stache!templates/complete_sign_up');
   var ExperimentMixin = require('views/mixins/experiment-mixin');
   var FormView = require('views/form');
-  var LoadingMixin = require('views/mixins/loading-mixin');
   var MarketingEmailErrors = require('lib/marketing-email-errors');
   var ResendMixin = require('views/mixins/resend-mixin');
   var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
@@ -191,7 +190,6 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     CompleteSignUpView,
     ExperimentMixin,
-    LoadingMixin,
     ResendMixin,
     ResumeTokenMixin
   );

--- a/app/scripts/views/mixins/loading-mixin.js
+++ b/app/scripts/views/mixins/loading-mixin.js
@@ -10,29 +10,12 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var $ = require('jquery');
   var loadingTemplate = require('stache!templates/loading');
 
   module.exports = {
     initialize: function () {
-      var self = this;
       var loadingHTML = loadingTemplate({});
-
-      // TODO - The next three lines are copied from router.js.
-      // It would be nice to consolidate, but that would add even more
-      // code to this PR. Perhaps use a `visible` event or something
-      // like that the router can listen for.
-
-      // note - the loadingHTML is written directly into #stage instead
-      // of this.$el because overwriting this.$el has a nasty side effect
-      // where the view's DOM event handlers do hook up properly.
-      $('#stage').html(loadingHTML).addClass('fade-in-forward').css('opacity', 1);
-
-      // The user may be scrolled part way down the page
-      // on view transition. Force them to the top of the page.
-      self.window.scrollTo(0, 0);
-
-      $('#fox-logo').addClass('fade-in-forward').css('opacity', 1);
+      this.writeToDOM(loadingHTML);
     }
   };
 });

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -349,6 +349,35 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('writeToDOM', function () {
+      var content = '<div id="stage-child">stage child content</div>';
+      beforeEach(function () {
+        $('#container').html('<div id="stage">stage content</div>');
+      });
+
+      describe('with text', function () {
+        beforeEach(function () {
+          view.writeToDOM(content);
+        });
+
+        it('overwrite #stage with the html', function () {
+          assert.notInclude($('#stage').html(), 'stage content');
+          assert.include($('#stage').html(), 'stage child content');
+        });
+      });
+
+      describe('with a jQuery element', function () {
+        beforeEach(function () {
+          view.writeToDOM($(content));
+        });
+
+        it('overwrite #stage with the html', function () {
+          assert.notInclude($('#stage').html(), 'stage content');
+          assert.include($('#stage').html(), 'stage child content');
+        });
+      });
+    });
+
     describe('displayError/isErrorVisible/hideError', function () {
       it('translates and display an error in the .error element', function () {
         var msg = view.displayError('the error message');

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -35,6 +35,7 @@
     </head>
     <body data-flow-begin="{{flowBeginTime}}">
         <div id="fox-logo"></div>
+        <div id="loading-spinner" class="spinner"></div>
         <div id="stage">
           <div id="main-content" class="card">
           </div>


### PR DESCRIPTION
The startup spinner was lost somewhere along the way. Because
real life network conditions are not as awesome as local dev
conditions, leaving a blank screen is less than ideal for many
users. This PR brings back the spinner.

fixes #2980