### PR TITLE
feat(referer): Only send origin in referer header, not whole URL.

### DIFF
--- a/server/templates/pages/src/400.html
+++ b/server/templates/pages/src/400.html
@@ -7,6 +7,7 @@
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        <meta name="referrer" content="origin">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/404.html
+++ b/server/templates/pages/src/404.html
@@ -7,6 +7,7 @@
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        <meta name="referrer" content="origin">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/500.html
+++ b/server/templates/pages/src/500.html
@@ -7,6 +7,7 @@
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        <meta name="referrer" content="origin">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/502.html
+++ b/server/templates/pages/src/502.html
@@ -7,6 +7,7 @@
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        <meta name="referrer" content="origin">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/503.html
+++ b/server/templates/pages/src/503.html
@@ -7,6 +7,7 @@
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        <meta name="referrer" content="origin">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -7,6 +7,7 @@
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        <meta name="referrer" content="origin">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/mocha.html
+++ b/server/templates/pages/src/mocha.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="referrer" content="origin">
         <title>Firefox Accounts Unit Tests</title>
         <link rel="stylesheet" href="../bower_components/mocha/mocha.css" />
     </head>

--- a/server/templates/pages/src/privacy.html
+++ b/server/templates/pages/src/privacy.html
@@ -7,6 +7,7 @@
         <title>{{#t}}Firefox Accounts{{/t}}: {{#t}}Privacy Notice{{/t}}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        <meta name="referrer" content="origin">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/terms.html
+++ b/server/templates/pages/src/terms.html
@@ -7,6 +7,7 @@
         <title>{{#t}}Firefox Accounts{{/t}}: {{#t}}Terms of Service{{/t}}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        <meta name="referrer" content="origin">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">


### PR DESCRIPTION
There's a surprisingly-recently-added new feature in Firefox that lets you control how the browser sends referer headers from your site, the "meta referrer" tag:

  https://blog.mozilla.org/security/2015/01/21/meta-referrer/

Yes, sadly, they fixed the typo in "referrer" for the name of the meta tag.

This PR adds `<meta name="referrer" content="origin">` to all our pages, which IIUC instructs the browser to send just the origin in the referer header rather than the full URL.  I'd be open to using "never" instead if that seems like a good idea.  While we don't have many outgoing links, referer headers can still be sent out via e.g. addons or things like that.

One downside of this approach is that we'll lose interesting referer information in our kibana logs, which we sometimes use for debugging things.  But if we want that info then IMO we should be sending it on purpose, e.g. like #3551.