### PR TITLE
feat(client): Add a mixin to handle updating external URLs on Fx for iOS

### DIFF
--- a/app/scripts/templates/cannot_create_account.mustache
+++ b/app/scripts/templates/cannot_create_account.mustache
@@ -3,12 +3,12 @@
     <h1 id="fxa-cannot-create-account-header">{{#t}}Cannot create account{{/t}}</h1>
   </header>
 
-  <section class="cannot-create-account-content {{#convertExternalLinksToText}}show-visible-url{{/convertExternalLinksToText}}">
+  <section class="cannot-create-account-content">
     <p>
       <strong>{{#t}}You must meet certain age requirements to create a Firefox&nbsp;Account.{{/t}}</strong>
     </p>
     <p class="links">
-      <a class="ftc" data-visible-url="http://www.ftc.gov/news-events/media-resources/protecting-consumer-privacy/kids-privacy-coppa" href="http://www.ftc.gov/news-events/media-resources/protecting-consumer-privacy/kids-privacy-coppa" {{#isSync}} target="_blank"{{/isSync}}>{{#t}}Learn more.{{/t}}</a>
+      <a class="ftc" href="http://www.ftc.gov/news-events/media-resources/protecting-consumer-privacy/kids-privacy-coppa" {{#isSync}} target="_blank"{{/isSync}}>{{#t}}Learn more.{{/t}}</a>
     </p>
 
   </section>

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -53,5 +53,8 @@
     <input type="text" id="novalue" value="heyho" data-novalue />
     <button type="submit" class="disabled">Submit</button>
   </form>
+
+  <a id="external-link" href="http://external.com">External link</a>
+  <a id="internal-link" href="/signin">Internal link</a>
 </div>
 

--- a/app/scripts/views/cannot_create_account.js
+++ b/app/scripts/views/cannot_create_account.js
@@ -7,6 +7,8 @@ define(function (require, exports, module) {
 
   var BaseView = require('views/base');
   var CannotCreateAccountTemplate = require('stache!templates/cannot_create_account');
+  var Cocktail = require('cocktail');
+  var ExternalLinksMixin = require('views/mixins/external-links-mixin');
 
   var CannotCreateAccountView = BaseView.extend({
     template: CannotCreateAccountTemplate,
@@ -14,12 +16,16 @@ define(function (require, exports, module) {
 
     context: function () {
       return {
-        convertExternalLinksToText: this.broker.hasCapability('convertExternalLinksToText'),
         isSync: this.relier.isSync()
       };
     }
 
   });
+
+  Cocktail.mixin(
+    CannotCreateAccountView,
+    ExternalLinksMixin
+  );
 
   module.exports = CannotCreateAccountView;
 });

--- a/app/scripts/views/mixins/external-links-mixin.js
+++ b/app/scripts/views/mixins/external-links-mixin.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A View Mixin to convert external links to visible text for
+ * environments that cannot open external links.
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var $ = require('jquery');
+
+  return {
+    afterRender: function () {
+      if (this.broker.hasCapability('convertExternalLinksToText')) {
+        this.$('a[href^=http]').each(function (index, el) {
+          var $el = $(el);
+          $el
+            .addClass('visible-url')
+            .attr('data-visible-url', $el.attr('href'));
+        });
+      }
+    }
+  };
+});

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -8,6 +8,7 @@ define(function (require, exports, module) {
   var AuthErrors = require('lib/auth-errors');
   var BaseView = require('views/base');
   var Cocktail = require('cocktail');
+  var ExternalLinksMixin = require('views/mixins/external-links-mixin');
   var FormView = require('views/form');
   var PasswordResetMixin = require('views/mixins/password-reset-mixin');
   var ServiceMixin = require('views/mixins/service-mixin');
@@ -62,6 +63,7 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     View,
+    ExternalLinksMixin,
     PasswordResetMixin,
     ServiceMixin
   );

--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -181,31 +181,30 @@ section p {
   display: block;
 }
 
-.show-visible-url & {
-  // Links cannot be opened from the TOS/PP text when signing
-  // in to Sync on Fx for iOS. When signing in elsewhere, links
-  // replace the app. Yuck. Show the links href next to the link text.
-  // The href is fetched from the data-visible-url attribute instead of
-  // the href attribute because some links are the same as their
-  // text. In those cases, there is no point showing both.
-  //
-  // hrefs are only visible from the app, when the TOS/PP agreements
-  // are opened directly, the links display/act normally.
-  a[href^=http] {
-    // using text-decoration: underline underlines the ::after
-    // section as well, with no way to remove it.
-    // So, add a border to the entire element, then hide
-    // the border in the ::after using a border that is the same
-    // color as the background.
-    color: $text-color;
-    cursor: default;
-    pointer-events: none;
-    text-decoration: none;
-  }
+// Links cannot be opened from the TOS/PP text when signing
+// in to Sync on Fx for iOS. When signing in elsewhere, links
+// replace the app. Yuck. Show the links href next to the link text.
+// The href is fetched from the data-visible-url attribute instead of
+// the href attribute because some links are the same as their
+// text. In those cases, there is no point showing both.
+//
+// hrefs are only visible from the app, when the TOS/PP agreements
+// are opened directly, the links display/act normally.
+a[href^=http].visible-url {
+  // using text-decoration: underline underlines the ::after
+  // section as well, with no way to remove it.
+  // So, add a border to the entire element, then hide
+  // the border in the ::after using a border that is the same
+  // color as the background.
+  color: $text-color;
+  cursor: default;
+  pointer-events: none;
+  text-decoration: none;
+}
 
-  a[data-visible-url^=http]:after,
-  a[data-visible-url^=http]::after {
-    border-bottom: 1px solid $content-background-color;
-    content: " (" attr(href) ") ";
-  }
+a[data-visible-url^=http]:after,
+a[data-visible-url^=http]::after {
+  border-bottom: 1px solid $content-background-color;
+  content: " (" attr(href) ") ";
+  word-break: break-all;
 }

--- a/app/styles/_state.scss
+++ b/app/styles/_state.scss
@@ -87,6 +87,15 @@
   a {
     color: $reset-pw-text-color;
   }
+
+  a[href^=http].visible-url {
+    color: $reset-pw-text-color;
+  }
+
+  a[data-visible-url^=http]:after,
+  a[data-visible-url^=http]::after {
+    border-bottom: 1px solid $reset-pw-text-background-color;
+  }
 }
 
 // Put a margin on top when the error messages follow a div

--- a/app/tests/spec/views/cannot_create_account.js
+++ b/app/tests/spec/views/cannot_create_account.js
@@ -65,17 +65,11 @@ define(function (require, exports, module) {
     });
 
     it('has a `Learn More` link converted to text with `convertExternalLinksToText` capability', function () {
-      sinon.stub(broker, 'hasCapability', function (capability) {
-        if (capability === 'convertExternalLinksToText') {
-          return true;
-        }
-
-        return false;
-      });
+      broker.setCapability('convertExternalLinksToText', true);
 
       return view.render()
         .then(function () {
-          assert.lengthOf(view.$('.show-visible-url'), 1);
+          assert.lengthOf(view.$('.visible-url'), 1);
         });
     });
   });

--- a/app/tests/spec/views/mixins/external-links-mixin.js
+++ b/app/tests/spec/views/mixins/external-links-mixin.js
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var BaseView = require('views/base');
+  var Broker = require('models/auth_brokers/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var ExternalLinksMixin = require('views/mixins/external-links-mixin');
+  var TestTemplate = require('stache!templates/test_template');
+  var WindowMock = require('../../../mocks/window');
+
+  var assert = Chai.assert;
+
+  var View = BaseView.extend({
+    template: TestTemplate
+  });
+  Cocktail.mixin(View, ExternalLinksMixin);
+
+  describe('views/mixins/external-links-mixin', function () {
+    var broker;
+    var view;
+    var windowMock;
+
+    beforeEach(function () {
+      broker = new Broker();
+      windowMock = new WindowMock();
+      windowMock.navigator.userAgent = 'mocha';
+
+      view = new View({
+        broker: broker,
+        window: windowMock
+      });
+    });
+
+    afterEach(function () {
+      return view.destroy();
+    });
+
+    describe('broker does not support convertExternalLinksToText', function () {
+      beforeEach(function () {
+        return view.render();
+      });
+
+      it('does not convert external links', function () {
+        assert.isFalse(view.$('#external-link').hasClass('visible-url'));
+      });
+
+      it('does not convert internal links', function () {
+        assert.isFalse(view.$('#internal-link').hasClass('visible-url'));
+      });
+    });
+
+    describe('broker supports convertExternalLinksToText', function () {
+      beforeEach(function () {
+        broker.setCapability('convertExternalLinksToText', true);
+        return view.render();
+      });
+
+      it('converts external links', function () {
+        var $externalLink = view.$('#external-link');
+        assert.isTrue($externalLink.hasClass('visible-url'));
+        assert.equal(
+          $externalLink.attr('data-visible-url'), $externalLink.attr('href'));
+      });
+
+      it('does not convert internal links', function () {
+        assert.isFalse(view.$('#internal-link').hasClass('visible-url'));
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -81,6 +81,18 @@ define(function (require, exports, module) {
             assert.equal(view.$('a[href="/signin"]').length, 1);
           });
       });
+
+      describe('with broker that supports `convertExternalLinksToText`', function () {
+        beforeEach(function () {
+          broker.setCapability('convertExternalLinksToText', true);
+
+          return view.render();
+        });
+
+        it('converts the `learn more` link', function () {
+          assert.lengthOf(view.$('.visible-url'), 1);
+        });
+      });
     });
 
     describe('isValid', function () {

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -111,6 +111,7 @@ function (Translator, Session) {
     '../tests/spec/views/behaviors/null',
     '../tests/spec/views/mixins/floating-placeholder-mixin',
     '../tests/spec/views/mixins/experiment-mixin',
+    '../tests/spec/views/mixins/external-links-mixin',
     '../tests/spec/views/mixins/timer-mixin',
     '../tests/spec/views/mixins/resume-token-mixin',
     '../tests/spec/views/mixins/service-mixin',


### PR DESCRIPTION
Follow on for #3559, issue #3467

@vbudhram - r?

Open these pages to test:

* /reset_password?context=fx_ios_v1&service=sync
  * Initiate password reset, open verification link in same browser and ensure link *can* be clicked. User cannot open verification link from within Fx for iOS's WebView, but will open the verification link in a normal browser where the link can be clicked.
* /reset_password?context=fx_ios_v2&service=sync
  * User cannot open verification link from within Fx for iOS's WebView, but will open the verification link in a normal browser where the link can be clicked.
* /cannot_create_account?context=fx_ios_v1&service=sync
* /cannot_create_account?context=fx_ios_v2&service=sync

