### PR TITLE
refactor(logging): Add logging module

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -43,6 +43,7 @@ define(function (require, exports, module) {
   var IframeAuthenticationBroker = require('models/auth_brokers/iframe');
   var IframeChannel = require('lib/channels/iframe');
   var InterTabChannel = require('lib/channels/inter-tab');
+  var Logger = require('lib/logger');
   var MarketingEmailClient = require('lib/marketing-email-client');
   var Metrics = require('lib/metrics');
   var Notifier = require('lib/channels/notifier');
@@ -86,6 +87,7 @@ define(function (require, exports, module) {
     this._storage = options.storage || Storage;
     this._user = options.user;
     this._window = options.window || window;
+    this._logger = new Logger(this._window);
   }
 
   Start.prototype = {
@@ -604,9 +606,7 @@ define(function (require, exports, module) {
     captureError: function (error) {
       var self = this;
 
-      if (window.console && console.error) {
-        console.error(String(error));
-      }
+      self._logger.error(error);
 
       if (! self._sentryMetrics) {
         self.enableSentryMetrics();

--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -9,6 +9,8 @@ define(function (require, exports, module) {
 
   var _ = require('underscore');
   var Errors = require('lib/errors');
+  var Logger = require('lib/logger');
+  var logger = new Logger();
 
   var t = function (msg) {
     return msg;
@@ -273,9 +275,7 @@ define(function (require, exports, module) {
         }
       } catch (e) {
         // handle invalid/unexpected data from the backend.
-        if (window.console && console.error) {
-          console.error('Error in errors.js->toInterpolationContext: %s', String(e));
-        }
+        logger.error('Error in errors.js->toInterpolationContext: %s', String(e));
       }
 
       return {};

--- a/app/scripts/lib/channels/duplex.js
+++ b/app/scripts/lib/channels/duplex.js
@@ -16,6 +16,7 @@ define(function (require, exports, module) {
   var _ = require('underscore');
   var BaseChannel = require('lib/channels/base');
   var Duration = require('duration');
+  var Logger = require('lib/logger');
   var p = require('lib/promise');
 
   var DEFAULT_SEND_TIMEOUT_LENGTH_MS = new Duration('90s').milliseconds();
@@ -24,6 +25,7 @@ define(function (require, exports, module) {
     this._window = options.window;
     this._sendTimeoutLength = options.sendTimeoutLength || DEFAULT_SEND_TIMEOUT_LENGTH_MS;
     this._requests = {};
+    this._logger = new Logger(this._window);
   }
 
   OutstandingRequests.prototype = {
@@ -32,7 +34,7 @@ define(function (require, exports, module) {
       this.remove(messageId);
 
       request.timeout = this._window.setTimeout(function (command) {
-        this._window.console.error('Response not received for: ' + command);
+        this._logger.error('Response not received for: ' + command);
       }.bind(this, request.command), this._sendTimeoutLength);
 
       this._requests[messageId] = request;

--- a/app/scripts/lib/channels/receivers/postmessage.js
+++ b/app/scripts/lib/channels/receivers/postmessage.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
   var _ = require('underscore');
   var AuthErrors = require('lib/auth-errors');
   var Backbone = require('backbone');
-
+  var Logger = require('lib/logger');
 
   function PostMessageReceiver() {
     // nothing to do
@@ -26,6 +26,7 @@ define(function (require, exports, module) {
 
       this._boundReceiveEvent = this.receiveEvent.bind(this);
       this._window.addEventListener('message', this._boundReceiveEvent, false);
+      this._logger = new Logger(this._window);
     },
 
     isOriginIgnored: function (origin) {
@@ -58,11 +59,9 @@ define(function (require, exports, module) {
 
       var origin = event.origin;
       if (this.isOriginIgnored(origin)) {
-        this._window.console.error(
-          'postMessage received from %s, ignoring', origin);
+        this._logger.error('postMessage received from %s, ignoring', origin);
       } else if (! this.isOriginTrusted(origin)) {
-        this._window.console.error(
-          'postMessage received from %s, expected %s', origin, this._origin);
+        this._logger.error('postMessage received from %s, expected %s', origin, this._origin);
 
         // from an unexpected origin, drop it on the ground.
         var err = AuthErrors.toError('UNEXPECTED_POSTMESSAGE_ORIGIN');

--- a/app/scripts/lib/channels/receivers/web-channel.js
+++ b/app/scripts/lib/channels/receivers/web-channel.js
@@ -13,6 +13,7 @@ define(function (require, exports, module) {
 
   var _ = require('underscore');
   var Backbone = require('backbone');
+  var Logger = require('lib/logger');
 
   function WebChannelReceiver() {
     // nothing to do
@@ -25,6 +26,7 @@ define(function (require, exports, module) {
       this._boundReceiveMessage = this.receiveMessage.bind(this);
       this._window.addEventListener('WebChannelMessageToContent', this._boundReceiveMessage, true);
       this._webChannelId = options.webChannelId;
+      this._logger = new Logger(this._window);
     },
 
     receiveMessage: function (event) {
@@ -32,7 +34,7 @@ define(function (require, exports, module) {
 
       if (! (detail && detail.id)) {
         // malformed message
-        this._window.console.error('malformed WebChannelMessageToContent event', JSON.stringify(detail));
+        this._logger.error('malformed WebChannelMessageToContent event', JSON.stringify(detail));
         return;
       }
 

--- a/app/scripts/lib/logger.js
+++ b/app/scripts/lib/logger.js
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Logging module that performs proper checks and string
+ * interpolation before logging message.
+ *
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  /**
+   * Constructor of log module.
+   *
+   * @param logWindow Window object that contains console used for logging.
+   *
+   * @constructor
+   */
+  function Logger(logWindow) {
+    this._window = logWindow || window;
+  }
+
+  Logger.prototype = {
+
+    /**
+     * Wrapper for `console.info` function that checks for availability and
+     * then prints info.
+     *
+     */
+    info: function () {
+      if (this._window.console && this._window.console.info) {
+        this._window.console.info.apply(this._window.console, arguments);
+      }
+    },
+
+    /**
+     * Wrapper for `console.trace` function that checks for availability and then prints
+     * trace.
+     *
+     */
+    trace: function () {
+      if (this._window.console && this._window.console.trace) {
+        this._window.console.trace();
+      }
+    },
+
+    /**
+     * Wrapper for `console.warn` function that checks for availability and
+     * then prints warn.
+     *
+     */
+    warn: function () {
+      if (this._window.console && this._window.console.warn) {
+        this._window.console.warn.apply(this._window.console, arguments);
+      }
+    },
+
+    /**
+     * Wrapper for `console.error` function that checks for availability and interpolates
+     * error messages if a translation exists.
+     *
+     * @param {error} Error object with optional errorModule.
+     */
+    error: function (error) {
+      if (this._window.console && this._window.console.error) {
+        var errorMessage = '';
+
+        // If error module is present, attempt to interpolate string, else use error object message
+        if (error.errorModule) {
+          errorMessage = error.errorModule.toInterpolatedMessage(error);
+          this._window.console.error(errorMessage);
+        } else {
+          // Use regular console.error
+          this._window.console.error.apply(this._window.console, arguments);
+        }
+      }
+    }
+  };
+
+  module.exports = Logger;
+});

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -9,6 +9,8 @@ define(function (require, exports, module) {
 
   var _ = require('underscore');
   var Errors = require('lib/errors');
+  var Logger = require('lib/logger');
+  var logger = new Logger();
   var Strings = require('lib/strings');
 
   var t = function (msg) {
@@ -130,9 +132,7 @@ define(function (require, exports, module) {
         }
       } catch (e) {
         // handle invalid/unexpected data from the backend.
-        if (window.console && console.error) {
-          console.error('Error in oauth-errors.js->toInterpolationContext: %s', String(e));
-        }
+        logger.error('Error in oauth-errors.js->toInterpolationContext: %s', String(e));
       }
 
       return {};

--- a/app/scripts/lib/sentry.js
+++ b/app/scripts/lib/sentry.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var _ = require('underscore');
+  var Logger = require('lib/logger');
   var Raven = require('raven');
   var Url = require('lib/url');
 
@@ -106,6 +107,8 @@ define(function (require, exports, module) {
    * @constructor
    */
   function SentryMetrics (host) {
+    this._logger = new Logger();
+
     if (host) {
       // use __API_KEY__ instead of the real API key because raven.js requires it
       // we can configure the real API key on the server using our local endpoint instead.
@@ -113,7 +116,7 @@ define(function (require, exports, module) {
 
       this._endpoint = '//__API_KEY__@' + host + '/metrics-errors';
     } else {
-      console.error('No Sentry host provided');
+      this._logger.error('No Sentry host provided');
       return;
     }
 
@@ -122,7 +125,7 @@ define(function (require, exports, module) {
       Raven.debug = false;
     } catch (e) {
       Raven.uninstall();
-      console.error(e);
+      this._logger.error(e);
     }
   }
 

--- a/app/scripts/models/auth_brokers/fx-sync.js
+++ b/app/scripts/models/auth_brokers/fx-sync.js
@@ -17,6 +17,7 @@ define(function (require, exports, module) {
   var ChannelMixin = require('models/auth_brokers/mixins/channel');
   var Cocktail = require('cocktail');
   var p = require('lib/promise');
+  var Logger = require('lib/logger');
 
   var proto = BaseAuthenticationBroker.prototype;
 
@@ -62,6 +63,8 @@ define(function (require, exports, module) {
       options = options || {};
       var self = this;
 
+      self._logger = new Logger();
+
       // channel can be passed in for testing.
       self._channel = options.channel;
 
@@ -95,7 +98,7 @@ define(function (require, exports, module) {
           self._verifiedCanLinkAccount = true;
           return proto.beforeSignIn.call(self, email);
         }, function (err) {
-          console.error('beforeSignIn failed with', err);
+          self._logger.error('beforeSignIn failed with', err);
           // If the browser doesn't implement this command, then it will
           // handle prompting the relink warning after sign in completes.
           // This can likely be changed to 'reject' after Fx31 hits nightly,

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -12,6 +12,7 @@ define(function (require, exports, module) {
   var Cocktail = require('cocktail');
   var NotifierMixin = require('views/mixins/notifier-mixin');
   var NullMetrics = require('lib/null-metrics');
+  var Logger = require('lib/logger');
   var p = require('lib/promise');
   var Raven = require('raven');
   var TimerMixin = require('views/mixins/timer-mixin');
@@ -49,7 +50,7 @@ define(function (require, exports, module) {
     // Errors are disabled on page unload to supress errors
     // caused by aborted XHR requests.
     if (! this._areErrorsEnabled) {
-      console.error('Error ignored: %s', JSON.stringify(err));
+      this.logger.error('Error ignored: %s', JSON.stringify(err));
       return;
     }
 
@@ -123,6 +124,7 @@ define(function (require, exports, module) {
       this.childViews = [];
       this.user = options.user;
       this.window = options.window || window;
+      this.logger = new Logger(this.window);
 
       this.navigator = options.navigator || this.window.navigator || navigator;
       this.translator = options.translator || this.window.translator;
@@ -551,9 +553,8 @@ define(function (require, exports, module) {
       }
       err.logged = true;
 
-      if (typeof console !== 'undefined' && console) {
-        console.error(err.message || err);
-      }
+      this.logger.error(err);
+
       this.sentryMetrics.captureException(err);
       this.metrics.logError(err);
     },
@@ -574,9 +575,7 @@ define(function (require, exports, module) {
         // user and show a console trace to help us debug.
         err = errors.toError('UNEXPECTED_ERROR');
 
-        if (this.window.console && this.window.console.trace) {
-          this.window.console.trace();
-        }
+        this.logger.trace();
       }
 
       if (_.isString(err)) {

--- a/app/scripts/views/sub_panels.js
+++ b/app/scripts/views/sub_panels.js
@@ -8,6 +8,7 @@ define(function (require, exports, module) {
 
   var Backbone = require('backbone');
   var BaseView = require('views/base');
+  var Logger = require('lib/logger');
   var p = require('lib/promise');
   var Template = require('stache!templates/sub_panels');
 
@@ -21,12 +22,13 @@ define(function (require, exports, module) {
       this._panelViews = options.panelViews || [];
       this._parent = options.parent;
       this._createView = options.createView;
+      this._logger = new Logger();
     },
 
     showChildView: function (ChildView, options) {
       var self = this;
       if (self._panelViews.indexOf(ChildView) === -1) {
-        console.warn('Tried to show a view that is not a subpanel');
+        self._logger.warn('Tried to show a view that is not a subpanel');
         return p(null);
       }
 

--- a/app/tests/spec/lib/logger.js
+++ b/app/tests/spec/lib/logger.js
@@ -1,0 +1,192 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Logger = require('lib/logger');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
+
+  var assert = chai.assert;
+
+  describe('lib/logger', function () {
+    var logger;
+
+    describe('constructor', function () {
+      it('should create logger', function () {
+        sinon.spy(window.console, 'info');
+
+        var information = 'Hello Firefox!';
+
+        logger = new Logger();
+        logger.info(information);
+
+        assert.equal(window.console.info.args[0][0], information);
+        assert.isNotNull(window.console.info.thisValues[0]);
+        window.console.info.restore();
+      });
+
+      it('should create logger with window', function () {
+        var mockWindow = new WindowMock();
+        var information = 'Hello Firefox!';
+        sinon.spy(mockWindow.console, 'info');
+
+        logger = new Logger(mockWindow);
+        logger.info(information);
+
+        assert.equal(mockWindow.console.info.args[0][0], information);
+        assert.isNotNull(mockWindow.console.info.thisValues[0]);
+        mockWindow.console.info.restore();
+      });
+    });
+
+    describe('info', function () {
+      beforeEach(function () {
+        logger = new Logger(window);
+        sinon.spy(window.console, 'info');
+      });
+
+      afterEach(function () {
+        window.console.info.restore();
+      });
+
+      it('should log from string', function () {
+        var information = 'Information about stuff!';
+        logger.info(information);
+
+        assert.equal(window.console.info.args[0][0], information);
+        assert.isNotNull(window.console.info.thisValues[0]);
+      });
+
+      it('should not throw when logging with undefined console', function () {
+        var tempConsole = window.console;
+        window.console = undefined;
+
+        logger = new Logger(window);
+
+        assert.doesNotThrow(function () {
+          logger.info('Hello Firefox!');
+        });
+
+        window.console = tempConsole;
+      });
+    });
+
+    describe('trace', function () {
+      beforeEach(function () {
+        logger = new Logger(window);
+        sinon.spy(window.console, 'trace');
+      });
+
+      afterEach(function () {
+        window.console.trace.restore();
+      });
+
+      it('should print trace', function () {
+        logger.trace();
+
+        assert.equal(window.console.trace.calledOnce, true);
+        assert.isNotNull(window.console.trace.thisValues[0]);
+      });
+
+      it('should not throw when logging with undefined console', function () {
+        var tempConsole = window.console;
+        window.console = undefined;
+
+        logger = new Logger(window);
+
+        assert.doesNotThrow(function () {
+          logger.trace();
+        });
+
+        window.console = tempConsole;
+      });
+    });
+
+    describe('warn', function () {
+      beforeEach(function () {
+        logger = new Logger(window);
+        sinon.spy(window.console, 'warn');
+      });
+
+      afterEach(function () {
+        window.console.warn.restore();
+      });
+
+      it('should log from string', function () {
+        var warning = 'Warning about something!';
+        logger.warn(warning);
+
+        assert.equal(window.console.warn.args[0][0], warning);
+        assert.isNotNull(window.console.warn.thisValues[0]);
+      });
+
+      it('should not throw when logging with undefined console', function () {
+        var tempConsole = window.console;
+        window.console = undefined;
+
+        logger = new Logger(window);
+
+        assert.doesNotThrow(function () {
+          logger.warn('Warning Firefox!');
+        });
+
+        window.console = tempConsole;
+      });
+    });
+
+    describe('error', function () {
+      beforeEach(function () {
+        logger = new Logger(window);
+        sinon.spy(window.console, 'error');
+      });
+
+      afterEach(function () {
+        window.console.error.restore();
+      });
+
+      it('should log from string', function () {
+        var error = 'Something went really wrong!';
+        logger.error(error);
+
+        assert.equal(window.console.error.args[0][0], error);
+        assert.isNotNull(window.console.error.thisValues[0]);
+      });
+
+      it('should log from object', function () {
+        var error = new Error('Something went super wrong!');
+        logger.error('Error %s', String(error));
+
+        assert.equal(window.console.error.args[0][0], 'Error %s');
+        assert.equal(window.console.error.args[0][1], String(error));
+        assert.isNotNull(window.console.error.thisValues[0]);
+      });
+
+      it('should interpolate message from object', function () {
+        var error = AuthErrors.toMissingParameterError('param name', AuthErrors);
+        logger.error(error);
+
+        assert.equal(window.console.error.args[0][0], 'Missing parameter in request body: param name');
+        assert.isNotNull(window.console.error.thisValues[0]);
+      });
+
+      it('should not throw when logging with undefined console', function () {
+        var tempConsole = window.console;
+        window.console = undefined;
+
+        logger = new Logger(window);
+
+        assert.doesNotThrow(function () {
+          logger.error('Error Firefox!');
+        });
+
+        window.console = tempConsole;
+      });
+    });
+  });
+});
+

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -54,6 +54,7 @@ function (Translator, Session) {
     '../tests/spec/lib/sentry',
     '../tests/spec/lib/relier-keys',
     '../tests/spec/lib/able',
+    '../tests/spec/lib/logger',
     '../tests/spec/lib/environment',
     '../tests/spec/lib/base64url',
     '../tests/spec/lib/origin-check',


### PR DESCRIPTION
This PR adds a logging module that standardizes our logging. It performs the required checks and interpolation as needed on the `info, trace, warn, error` console functions. 

Below is a list of the different ways logging is used in the content server. 

```javascript
console.error('Error in errors.js->toInterpolationContext: %s', String(e));
console.error('No Sentry host provided');
console.error(e);
this._window.console.error('Response not received for: ' + command);
this._window.console.error('postMessage received from %s, ignoring', origin);
this._window.console.error('postMessage received from %s, expected %s', origin, this._origin);
this._window.console.error('malformed WebChannelMessageToContent event', JSON.stringify(detail));
console.error('beforeSignIn failed with', err);
console.error('Error ignored: %s', JSON.stringify(err));

if (typeof console !== 'undefined' && console) {
  var errorMessage = err.errorModule ? err.errorModule.toInterpolatedMessage(err) : (err.message || err);
  console.error(errorMessage);
}

if (this.window.console && this.window.console.trace) {
  this.window.console.trace();
}

console.warn('Tried to show a view that is not a subpanel');

```
Check [test cases](https://github.com/mozilla/fxa-content-server/blob/issue-3561-error-message-interpolate/app/tests/spec/lib/logger.js) for usage.

Fixes #3561 
Fixes #3025 