### PR TITLE
fix(client): Only normalize scopes for trusted reliers when prompting for consent

### DIFF
--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -95,12 +95,15 @@ define(function (require, exports, module) {
     _normalizeScopesAndPermissions: function () {
       var permissions = scopeStrToArray(this.get('scope'));
       if (this.isTrusted()) {
-        // replace `profile` with the expanded permissions for trusted reliers
-        permissions = replaceItemInArray(
-          permissions,
-          Constants.OAUTH_TRUSTED_PROFILE_SCOPE,
-          Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION
-        );
+        // We have to normalize `profile` into is expanded sub-scopes
+        // in order to show the consent screen.
+        if (this.wantsConsent()) {
+          permissions = replaceItemInArray(
+            permissions,
+            Constants.OAUTH_TRUSTED_PROFILE_SCOPE,
+            Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION
+          );
+        }
       } else {
         permissions = sanitizeUntrustedPermissions(permissions);
       }

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -323,9 +323,27 @@ define(function (require, exports, module) {
             testInvalidQueryParams('scope', invalidValues);
           });
 
-          describe('trusted reliers', function () {
+          describe('trusted reliers that dont ask for consent', function () {
             beforeEach(function () {
               sinon.stub(relier, 'isTrusted', function () {
+                return true;
+              });
+              sinon.stub(relier, 'wantsConsent', function () {
+                return false;
+              });
+            });
+
+            var validValues = [SCOPE_WITH_EXTRAS, SCOPE_PROFILE, 'profile:unrecognized'];
+            var expectedValues = [SCOPE_WITH_EXTRAS, SCOPE_PROFILE, 'profile:unrecognized'];
+            testValidQueryParams('scope', validValues, 'scope', expectedValues);
+          });
+
+          describe('trusted reliers that ask for consent', function () {
+            beforeEach(function () {
+              sinon.stub(relier, 'isTrusted', function () {
+                return true;
+              });
+              sinon.stub(relier, 'wantsConsent', function () {
                 return true;
               });
             });


### PR DESCRIPTION
Fixes #3576, hopefully.