### PR TITLE
fix(server): Ensure the 400 page prints error messages in production.

### DIFF
--- a/grunttasks/l10n-generate-pages.js
+++ b/grunttasks/l10n-generate-pages.js
@@ -112,6 +112,9 @@ module.exports = function (grunt) {
           lang: context.lang,
           lang_dir: context.lang_dir, //eslint-disable-line camelcase
           locale: context.locale,
+          // Re-insert the message tag to allow the node server
+          // to render the error message at render time.
+          message: '{{ message }}',
           privacy: privacy,
           terms: terms
         });

--- a/server/templates/pages/src/400.html
+++ b/server/templates/pages/src/400.html
@@ -28,9 +28,7 @@
               </header>
 
               <section>
-                {{#if message}}
-                  <div class="error visible">{{message}}</div>
-                {{/if}}
+                <div class="error visible">{{message}}</div>
               </section>
             </div>
         </div>


### PR DESCRIPTION
Users should always arrive at 400.html with a `message` query parameter.
`message` is used to display an error message to the user.

Because our templates are compiled for production, all Handlebars tags
are removed. This PR replaces `{{message}}` in the dev templates
with `{{message}}` in the production templates. The node server
can then insert the correct error message.

fixes #2070
fixes #3572 

@vbudhram, @vladikoff - r?

The way to test - build production resources, restart the content server using the production resources, run all the functional tests.

I'm running the functional tests using:
```bash
npm run test-functional-oauth fxaProduction=true && npm run test-functional fxaProduction=true
```

@vladikoff, @jrgm - does this need to be backported to train-57 too?