### PR TITLE
fix(build): Fix `grunt build` exception if server template open in vim

### DIFF
--- a/grunttasks/l10n-generate-pages.js
+++ b/grunttasks/l10n-generate-pages.js
@@ -91,11 +91,16 @@ module.exports = function (grunt) {
     var destRoot = path.join(templateDest, locale);
     var context = i18n.localizationContext(language);
 
-    grunt.file.recurse(templateSrc,
-                    function (srcPath, rootDir, subDir, fileName) {
-                      var destPath = path.join(destRoot, (subDir || ''), fileName);
-                      generatePage(srcPath, destPath, context);
-                    });
+    // only worry about html files. Things like .swp files
+    // for editors should be ignored.
+    var templates = grunt.file.expand({
+      cwd: templateSrc
+    }, '**/*.html');
+    templates.forEach(function (fileName) {
+      var srcPath = path.join(templateSrc, fileName);
+      var destPath = path.join(destRoot, fileName);
+      generatePage(srcPath, destPath, context);
+    });
   }
 
   function generatePage(srcPath, destPath, context) {


### PR DESCRIPTION
Only attempt to compile html pages

fixes #3581