### PR TITLE
fix(client): Only normalize scopes for trusted reliers when prompting for consent

### DIFF
--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -85,12 +85,15 @@ define(function (require, exports, module) {
     _normalizeScopesAndPermissions: function () {
       var permissions = scopeStrToArray(this.get('scope'));
       if (this.isTrusted()) {
-        // replace `profile` with the expanded permissions for trusted reliers
-        permissions = replaceItemInArray(
-          permissions,
-          Constants.OAUTH_TRUSTED_PROFILE_SCOPE,
-          Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION
-        );
+        // We have to normalize `profile` into is expanded sub-scopes
+        // in order to show the consent screen.
+        if (this.wantsConsent()) {
+          permissions = replaceItemInArray(
+            permissions,
+            Constants.OAUTH_TRUSTED_PROFILE_SCOPE,
+            Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION
+          );
+        }
       } else {
         permissions = sanitizeUntrustedPermissions(permissions);
       }

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -34,6 +34,7 @@ define(function (require, exports, module) {
     var ACTION = 'signup';
     var CLIENT_ID = 'dcdb5ae7add825d2';
     var PERMISSIONS_EXPANDED_PROFILE = Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION;
+    var PERMISSIONS_PROFILE = [Constants.OAUTH_TRUSTED_PROFILE_SCOPE];
     var PERMISSIONS_WITH_UNRECOGNIZED = ['profile:email', 'profile:uid', 'profile:unrecognized'];
     var PREVERIFY_TOKEN = 'abigtoken';
     var PROMPT = Constants.OAUTH_PROMPT_CONSENT;
@@ -251,10 +252,11 @@ define(function (require, exports, module) {
           });
         });
 
-        describe('`profile` scope', function () {
+        describe('`profile` scope with consent prompt', function () {
           beforeEach(function () {
             windowMock.location.search = TestHelpers.toSearchString({
               client_id: CLIENT_ID,
+              prompt: PROMPT,
               scope: SCOPE_PROFILE
             });
 
@@ -268,6 +270,22 @@ define(function (require, exports, module) {
           });
         });
 
+        describe('`profile` scope without consent prompt', function () {
+          beforeEach(function () {
+            windowMock.location.search = TestHelpers.toSearchString({
+              client_id: CLIENT_ID,
+              scope: SCOPE_PROFILE,
+            });
+
+            return relier.fetch();
+          });
+
+          it('is not expanded to individual components', function () {
+            assert.equal(relier.get('scope'), SCOPE_PROFILE);
+            testPermissionsEqual(
+              relier.get('permissions'), PERMISSIONS_PROFILE);
+          });
+        });
       });
 
       it('errors if `client_id` is missing', function () {


### PR DESCRIPTION
This cherry-picks #3577 onto the train-57 branch.  Unfortunately required some changes to the tests but they don't look too bad.  @shane-tomlinson r?  /cc @jrgm 