### PR TITLE
feat(server): emit the new flow.begin activity event

### DIFF
--- a/grunttasks/l10n-generate-pages.js
+++ b/grunttasks/l10n-generate-pages.js
@@ -22,6 +22,12 @@ module.exports = function (grunt) {
   var templateSrc;
   var templateDest;
 
+  var PROPAGATED_TEMPLATE_FIELDS = [
+    'flowBeginTime',
+    'flowId',
+    'message'
+  ];
+
   // Legal templates for each locale, key'ed by languages, e.g.
   // templates['en'] = { terms: ..., privacy: ... }
   var legalTemplates = {
@@ -111,19 +117,21 @@ module.exports = function (grunt) {
         var terms = legalTemplates[context.lang].terms || legalTemplates[defaultLegalLang].terms;
         var privacy = legalTemplates[context.lang].privacy || legalTemplates[defaultLegalLang].privacy;
         var template = Handlebars.compile(contents);
-        var out = template({
+        var data = {
           fontSupportDisabled: context.fontSupportDisabled,
           l10n: context,
           lang: context.lang,
           lang_dir: context.lang_dir, //eslint-disable-line camelcase
           locale: context.locale,
-          // Re-insert the message tag to allow the node server
-          // to render the error message at render time.
-          message: '{{ message }}',
           privacy: privacy,
           terms: terms
+        };
+        // Propagate any tags that are required for data
+        // to be rendered dynamically by the server.
+        PROPAGATED_TEMPLATE_FIELDS.forEach(function (field) {
+          data[field] = '{{' + field + '}}';
         });
-        return out;
+        return template(data);
       }
     });
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "0.57.0",
+  "version": "0.58.1",
   "dependencies": {
     "bluebird": {
       "version": "2.10.1",
@@ -46,7 +46,7 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "statuses": {
@@ -79,14 +79,14 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
         },
         "raw-body": {
-          "version": "2.1.5",
+          "version": "2.1.6",
           "from": "raw-body@>=2.1.4 <2.2.0",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
           "dependencies": {
             "bytes": {
-              "version": "2.2.0",
-              "from": "bytes@2.2.0",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+              "version": "2.3.0",
+              "from": "bytes@2.3.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
             },
             "iconv-lite": {
               "version": "0.4.13",
@@ -101,9 +101,9 @@
           }
         },
         "type-is": {
-          "version": "1.6.11",
-          "from": "type-is@>=1.6.9 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
+          "version": "1.6.12",
+          "from": "type-is@>=1.6.6 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -112,7 +112,7 @@
             },
             "mime-types": {
               "version": "2.1.10",
-              "from": "mime-types@>=2.1.9 <2.2.0",
+              "from": "mime-types@>=2.1.10 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
@@ -1973,7 +1973,7 @@
         },
         "depd": {
           "version": "1.1.0",
-          "from": "depd@1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "moment": {
@@ -2255,9 +2255,9 @@
           }
         },
         "type-is": {
-          "version": "1.6.11",
-          "from": "type-is@>=1.6.9 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
+          "version": "1.6.12",
+          "from": "type-is@>=1.6.6 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -2362,9 +2362,9 @@
                   "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
                   "dependencies": {
                     "JSONStream": {
-                      "version": "1.0.7",
+                      "version": "1.1.1",
                       "from": "JSONStream@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
                       "dependencies": {
                         "jsonparse": {
                           "version": "1.2.0",
@@ -2594,9 +2594,9 @@
                       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.10.3",
-                          "from": "bn.js@>=4.1.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                          "version": "4.11.0",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.0.tgz"
                         },
                         "browserify-rsa": {
                           "version": "4.0.1",
@@ -2626,9 +2626,9 @@
                           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "4.5.0",
+                              "version": "4.5.2",
                               "from": "asn1.js@>=4.0.0 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.2.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
@@ -2669,9 +2669,9 @@
                       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.10.3",
-                          "from": "bn.js@>=4.1.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                          "version": "4.11.0",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.0.tgz"
                         },
                         "elliptic": {
                           "version": "6.2.3",
@@ -2725,9 +2725,9 @@
                       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.10.3",
-                          "from": "bn.js@>=4.1.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                          "version": "4.11.0",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.0.tgz"
                         },
                         "miller-rabin": {
                           "version": "4.0.0",
@@ -2754,9 +2754,9 @@
                       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.10.3",
+                          "version": "4.11.0",
                           "from": "bn.js@>=4.1.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.0.tgz"
                         },
                         "browserify-rsa": {
                           "version": "4.0.1",
@@ -2769,9 +2769,9 @@
                           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "4.5.0",
+                              "version": "4.5.2",
                               "from": "asn1.js@>=4.0.0 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.2.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
@@ -2807,9 +2807,9 @@
                       }
                     },
                     "randombytes": {
-                      "version": "2.0.2",
+                      "version": "2.0.3",
                       "from": "randombytes@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
                     }
                   }
                 },
@@ -2829,9 +2829,9 @@
                   "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
                   "dependencies": {
                     "JSONStream": {
-                      "version": "1.0.7",
+                      "version": "1.1.1",
                       "from": "JSONStream@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
                       "dependencies": {
                         "jsonparse": {
                           "version": "1.2.0",
@@ -2864,7 +2864,7 @@
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@>=4.0.5 <5.0.0",
+                  "from": "glob@>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
@@ -2952,9 +2952,9 @@
                   "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
                   "dependencies": {
                     "JSONStream": {
-                      "version": "1.0.7",
+                      "version": "1.1.1",
                       "from": "JSONStream@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
                       "dependencies": {
                         "jsonparse": {
                           "version": "1.2.0",
@@ -3003,9 +3003,9 @@
                       }
                     },
                     "is-buffer": {
-                      "version": "1.1.2",
+                      "version": "1.1.3",
                       "from": "is-buffer@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                     },
                     "lexical-scope": {
                       "version": "1.2.0",
@@ -3073,9 +3073,9 @@
                   "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
                   "dependencies": {
                     "JSONStream": {
-                      "version": "1.0.7",
+                      "version": "1.1.1",
                       "from": "JSONStream@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
                       "dependencies": {
                         "jsonparse": {
                           "version": "1.2.0",
@@ -3418,7 +3418,7 @@
                 },
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "optimist@0.6.1",
+                  "from": "optimist@>=0.6.1 <0.7.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "wordwrap": {
@@ -3442,7 +3442,7 @@
             },
             "github-url-to-object": {
               "version": "2.0.0",
-              "from": "git://github.com/vladikoff/github-url-to-object.git#clone_url",
+              "from": "../../../../var/folders/rn/3nfj68q57jg_gqyhknskhk480000gp/T/npm-56853-8ea10da8/git-cache-f44e656cc8f5/b8cb2d6747556a9ead1716b3f2212df20545296b",
               "resolved": "git://github.com/vladikoff/github-url-to-object.git#b8cb2d6747556a9ead1716b3f2212df20545296b",
               "dependencies": {
                 "is-url": {
@@ -3563,9 +3563,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.11.2",
+                          "version": "2.12.0",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
                         }
                       }
                     }
@@ -3587,9 +3587,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.11.2",
+                          "version": "2.12.0",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
                         }
                       }
                     }
@@ -3687,9 +3687,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.11.2",
+                          "version": "2.12.0",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
                         }
                       }
                     }
@@ -3752,9 +3752,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.11.2",
+                          "version": "2.12.0",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
                         }
                       }
                     }
@@ -3788,7 +3788,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "mozlog": {
@@ -3820,7 +3820,7 @@
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
@@ -3926,16 +3926,9 @@
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "decamelize": {
-                      "version": "1.1.2",
+                      "version": "1.2.0",
                       "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                      "dependencies": {
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
@@ -4196,7 +4189,7 @@
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "esprima@>=1.0.4 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
@@ -4261,9 +4254,9 @@
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000411",
+              "version": "1.0.30000430",
               "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000411.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000430.tgz"
             }
           }
         },
@@ -4296,7 +4289,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
@@ -4313,7 +4306,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
@@ -4385,7 +4378,7 @@
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.0 <0.2.0",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
@@ -4483,23 +4476,16 @@
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "2.1.0",
+                      "version": "2.1.1",
                       "from": "camelcase@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
-                  "version": "1.1.2",
+                  "version": "1.2.0",
                   "from": "decamelize@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
                   "version": "1.3.0",
@@ -4584,7 +4570,7 @@
                             },
                             "spdx-license-ids": {
                               "version": "1.2.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                             }
                           }
@@ -4604,9 +4590,9 @@
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
-                      "version": "1.1.0",
+                      "version": "1.1.2",
                       "from": "find-up@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
@@ -4768,7 +4754,7 @@
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <2.0.0",
+                          "from": "once@>=1.3.0 <1.4.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
@@ -4781,9 +4767,9 @@
                       }
                     },
                     "readable-stream": {
-                      "version": "2.0.5",
+                      "version": "2.0.6",
                       "from": "readable-stream@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -4791,9 +4777,9 @@
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
@@ -4875,9 +4861,9 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "2.0.5",
+                  "version": "2.0.6",
                   "from": "readable-stream@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -4886,13 +4872,13 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
@@ -5008,9 +4994,9 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
           "dependencies": {
             "glob": {
-              "version": "7.0.0",
+              "version": "7.0.3",
               "from": "glob@>=7.0.0 <8.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
@@ -5026,7 +5012,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -5265,9 +5251,9 @@
           }
         },
         "clean-css": {
-          "version": "3.4.9",
+          "version": "3.4.10",
           "from": "clean-css@>=3.4.2 <3.5.0",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.9.tgz",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.10.tgz",
           "dependencies": {
             "commander": {
               "version": "2.8.1",
@@ -5297,7 +5283,7 @@
         },
         "maxmin": {
           "version": "1.1.0",
-          "from": "maxmin@>=1.0.0 <2.0.0",
+          "from": "maxmin@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
           "dependencies": {
             "figures": {
@@ -5326,9 +5312,9 @@
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
-                      "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "version": "2.0.6",
+                      "from": "readable-stream@>=2.0.5 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -5336,9 +5322,9 @@
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
@@ -5385,7 +5371,7 @@
                 },
                 "meow": {
                   "version": "3.7.0",
-                  "from": "meow@>=3.3.0 <4.0.0",
+                  "from": "meow@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
@@ -5394,23 +5380,16 @@
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "2.1.0",
+                          "version": "2.1.1",
                           "from": "camelcase@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                         }
                       }
                     },
                     "decamelize": {
-                      "version": "1.1.2",
+                      "version": "1.2.0",
                       "from": "decamelize@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                      "dependencies": {
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "loud-rejection": {
                       "version": "1.3.0",
@@ -5515,9 +5494,9 @@
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "dependencies": {
                         "find-up": {
-                          "version": "1.1.0",
+                          "version": "1.1.2",
                           "from": "find-up@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                           "dependencies": {
                             "path-exists": {
                               "version": "2.1.0",
@@ -5838,9 +5817,9 @@
               }
             },
             "clean-css": {
-              "version": "3.4.9",
+              "version": "3.4.10",
               "from": "clean-css@>=3.4.0 <3.5.0",
-              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.9.tgz",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.10.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.8.1",
@@ -5869,9 +5848,9 @@
               }
             },
             "cli": {
-              "version": "0.11.1",
+              "version": "0.11.2",
               "from": "cli@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.11.1.tgz",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.11.2.tgz",
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
@@ -5961,9 +5940,9 @@
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "version": "2.0.6",
+                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -5971,9 +5950,9 @@
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
@@ -6050,9 +6029,9 @@
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "dependencies": {
                                     "is-buffer": {
-                                      "version": "1.1.2",
+                                      "version": "1.1.3",
                                       "from": "is-buffer@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                     }
                                   }
                                 },
@@ -6062,9 +6041,9 @@
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.2",
+                                  "version": "1.5.4",
                                   "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
                             },
@@ -6091,9 +6070,9 @@
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "dependencies": {
                                     "is-buffer": {
-                                      "version": "1.1.2",
+                                      "version": "1.1.3",
                                       "from": "is-buffer@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                     }
                                   }
                                 },
@@ -6103,9 +6082,9 @@
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.2",
+                                  "version": "1.5.4",
                                   "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
                             }
@@ -6119,16 +6098,9 @@
                       }
                     },
                     "decamelize": {
-                      "version": "1.1.2",
+                      "version": "1.2.0",
                       "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                      "dependencies": {
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
@@ -6162,23 +6134,16 @@
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "2.1.0",
+                      "version": "2.1.1",
                       "from": "camelcase@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
-                  "version": "1.1.2",
+                  "version": "1.2.0",
                   "from": "decamelize@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
                   "version": "1.3.0",
@@ -6283,9 +6248,9 @@
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
-                      "version": "1.1.0",
+                      "version": "1.1.2",
                       "from": "find-up@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
@@ -6516,7 +6481,7 @@
         },
         "maxmin": {
           "version": "1.1.0",
-          "from": "maxmin@>=1.0.0 <2.0.0",
+          "from": "maxmin@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
           "dependencies": {
             "figures": {
@@ -6545,9 +6510,9 @@
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
-                      "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "version": "2.0.6",
+                      "from": "readable-stream@>=2.0.5 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -6555,9 +6520,9 @@
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
@@ -6604,7 +6569,7 @@
                 },
                 "meow": {
                   "version": "3.7.0",
-                  "from": "meow@>=3.3.0 <4.0.0",
+                  "from": "meow@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
@@ -6613,23 +6578,16 @@
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "2.1.0",
+                          "version": "2.1.1",
                           "from": "camelcase@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                         }
                       }
                     },
                     "decamelize": {
-                      "version": "1.1.2",
+                      "version": "1.2.0",
                       "from": "decamelize@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                      "dependencies": {
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "loud-rejection": {
                       "version": "1.3.0",
@@ -6734,9 +6692,9 @@
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "dependencies": {
                         "find-up": {
-                          "version": "1.1.0",
+                          "version": "1.1.2",
                           "from": "find-up@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                           "dependencies": {
                             "path-exists": {
                               "version": "2.1.0",
@@ -6946,7 +6904,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.3 <0.2.0",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -6955,9 +6913,9 @@
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "dependencies": {
                                 "is-buffer": {
-                                  "version": "1.1.2",
+                                  "version": "1.1.3",
                                   "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
@@ -6967,9 +6925,9 @@
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
-                              "version": "1.5.2",
+                              "version": "1.5.4",
                               "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
                         },
@@ -6987,7 +6945,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.3 <0.2.0",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -6996,9 +6954,9 @@
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "dependencies": {
                                 "is-buffer": {
-                                  "version": "1.1.2",
+                                  "version": "1.1.3",
                                   "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
@@ -7008,9 +6966,9 @@
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
-                              "version": "1.5.2",
+                              "version": "1.5.4",
                               "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
                         }
@@ -7024,16 +6982,9 @@
                   }
                 },
                 "decamelize": {
-                  "version": "1.1.2",
-                  "from": "decamelize@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    }
-                  }
+                  "version": "1.2.0",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
@@ -7065,7 +7016,7 @@
     },
     "grunt-marked": {
       "version": "0.1.1",
-      "from": "git://github.com/zaach/grunt-marked.git#1a8ed1346c",
+      "from": "../../../../var/folders/rn/3nfj68q57jg_gqyhknskhk480000gp/T/npm-56853-8ea10da8/git-cache-b0d31a6871fa/1a8ed1346c2248a5cc8a234cfe343865bf35b342",
       "resolved": "git://github.com/zaach/grunt-marked.git#1a8ed1346c2248a5cc8a234cfe343865bf35b342",
       "dependencies": {
         "async": {
@@ -7082,7 +7033,7 @@
     },
     "grunt-po2json": {
       "version": "0.2.0",
-      "from": "git://github.com/shane-tomlinson/grunt-po2json.git#aa276503e",
+      "from": "../../../../var/folders/rn/3nfj68q57jg_gqyhknskhk480000gp/T/npm-56853-8ea10da8/git-cache-d800e067034d/aa276503efc70e5cf6739eb0e021df750840919f",
       "resolved": "git://github.com/shane-tomlinson/grunt-po2json.git#aa276503efc70e5cf6739eb0e021df750840919f",
       "dependencies": {
         "po2json": {
@@ -7131,7 +7082,7 @@
               "dependencies": {
                 "encoding": {
                   "version": "0.1.12",
-                  "from": "encoding@>=0.1.0 <0.2.0",
+                  "from": "encoding@>=0.1.11 <0.2.0",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "dependencies": {
                     "iconv-lite": {
@@ -7431,7 +7382,7 @@
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "typedarray": {
@@ -7440,9 +7391,9 @@
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
-                          "version": "2.0.5",
+                          "version": "2.0.6",
                           "from": "readable-stream@>=2.0.0 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
@@ -7450,9 +7401,9 @@
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             },
                             "process-nextick-args": {
                               "version": "1.0.6",
@@ -7559,12 +7510,12 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "from": "minimatch@>=0.2.4",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
                     "brace-expansion": {
@@ -7588,7 +7539,7 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
@@ -7616,23 +7567,16 @@
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "2.1.0",
+                      "version": "2.1.1",
                       "from": "camelcase@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
-                  "version": "1.1.2",
+                  "version": "1.2.0",
                   "from": "decamelize@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
                   "version": "1.3.0",
@@ -7737,9 +7681,9 @@
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
-                      "version": "1.1.0",
+                      "version": "1.1.2",
                       "from": "find-up@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
@@ -7927,7 +7871,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "ini": {
@@ -7949,7 +7893,7 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <1.4.0",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
@@ -7989,9 +7933,9 @@
               }
             },
             "node-gyp": {
-              "version": "3.3.0",
+              "version": "3.3.1",
               "from": "node-gyp@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.3.1.tgz",
               "dependencies": {
                 "fstream": {
                   "version": "1.0.8",
@@ -8120,9 +8064,9 @@
                           "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                         },
                         "readable-stream": {
-                          "version": "2.0.5",
+                          "version": "2.0.6",
                           "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
@@ -8135,9 +8079,9 @@
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             },
                             "process-nextick-args": {
                               "version": "1.0.6",
@@ -8179,9 +8123,9 @@
                               "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
                             },
                             "lodash.tostring": {
-                              "version": "4.1.1",
+                              "version": "4.1.2",
                               "from": "lodash.tostring@>=4.0.0 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.1.tgz"
+                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
                             }
                           }
                         },
@@ -8196,9 +8140,9 @@
                               "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
                             },
                             "lodash.tostring": {
-                              "version": "4.1.1",
+                              "version": "4.1.2",
                               "from": "lodash.tostring@>=4.0.0 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.1.tgz"
+                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
                             }
                           }
                         },
@@ -8213,9 +8157,9 @@
                               "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
                             },
                             "lodash.tostring": {
-                              "version": "4.1.1",
+                              "version": "4.1.2",
                               "from": "lodash.tostring@>=4.0.0 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.1.tgz"
+                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
                             }
                           }
                         }
@@ -8296,9 +8240,9 @@
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                   "dependencies": {
                     "glob": {
-                      "version": "7.0.0",
+                      "version": "7.0.3",
                       "from": "glob@>=7.0.0 <8.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
@@ -8480,20 +8424,15 @@
                     }
                   }
                 },
-                "lodash": {
-                  "version": "4.5.1",
-                  "from": "lodash@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.1.tgz"
-                },
                 "yargs": {
                   "version": "3.32.0",
                   "from": "yargs@>=3.8.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "2.1.0",
+                      "version": "2.1.1",
                       "from": "camelcase@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     },
                     "cliui": {
                       "version": "3.1.0",
@@ -8520,16 +8459,9 @@
                       }
                     },
                     "decamelize": {
-                      "version": "1.1.2",
+                      "version": "1.2.0",
                       "from": "decamelize@>=1.1.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                      "dependencies": {
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "os-locale": {
                       "version": "1.4.0",
@@ -8703,7 +8635,7 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.3 <3.0.0",
+          "from": "debug@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
@@ -8935,9 +8867,9 @@
                   "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
                   "dependencies": {
                     "lodash.isarguments": {
-                      "version": "3.0.7",
+                      "version": "3.0.8",
                       "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                     },
                     "lodash.isarray": {
                       "version": "3.0.4",
@@ -8972,9 +8904,9 @@
                       "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
                       "dependencies": {
                         "lodash.isarguments": {
-                          "version": "3.0.7",
+                          "version": "3.0.8",
                           "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.4",
@@ -9070,7 +9002,7 @@
               "dependencies": {
                 "encoding": {
                   "version": "0.1.12",
-                  "from": "encoding@>=0.1.0 <0.2.0",
+                  "from": "encoding@>=0.1.11 <0.2.0",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "dependencies": {
                     "iconv-lite": {
@@ -9098,9 +9030,9 @@
                   "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
                 },
                 "clean-css": {
-                  "version": "3.4.9",
+                  "version": "3.4.10",
                   "from": "clean-css@>=3.1.9 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.9.tgz",
+                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.10.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.8.1",
@@ -9278,7 +9210,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "from": "align-text@>=0.1.3 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
@@ -9287,9 +9219,9 @@
                                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "dependencies": {
                                         "is-buffer": {
-                                          "version": "1.1.2",
+                                          "version": "1.1.3",
                                           "from": "is-buffer@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                         }
                                       }
                                     },
@@ -9299,9 +9231,9 @@
                                       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                     },
                                     "repeat-string": {
-                                      "version": "1.5.2",
+                                      "version": "1.5.4",
                                       "from": "repeat-string@>=1.5.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
                                 },
@@ -9319,7 +9251,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "from": "align-text@>=0.1.3 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
@@ -9328,9 +9260,9 @@
                                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "dependencies": {
                                         "is-buffer": {
-                                          "version": "1.1.2",
+                                          "version": "1.1.3",
                                           "from": "is-buffer@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                         }
                                       }
                                     },
@@ -9340,9 +9272,9 @@
                                       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                     },
                                     "repeat-string": {
-                                      "version": "1.5.2",
+                                      "version": "1.5.4",
                                       "from": "repeat-string@>=1.5.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
                                 }
@@ -9356,16 +9288,9 @@
                           }
                         },
                         "decamelize": {
-                          "version": "1.1.2",
-                          "from": "decamelize@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                          "dependencies": {
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            }
-                          }
+                          "version": "1.2.0",
+                          "from": "decamelize@>=1.1.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "window-size": {
                           "version": "0.1.0",
@@ -9416,7 +9341,7 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@0.6.1",
+          "from": "optimist@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
@@ -9707,16 +9632,9 @@
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "decamelize": {
-                          "version": "1.1.2",
+                          "version": "1.2.0",
                           "from": "decamelize@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                          "dependencies": {
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "window-size": {
                           "version": "0.1.0",
@@ -9789,7 +9707,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -9886,6 +9804,11 @@
           }
         }
       }
+    },
+    "lodash": {
+      "version": "4.6.1",
+      "from": "lodash@4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz"
     },
     "marked": {
       "version": "0.3.5",
@@ -10054,13 +9977,13 @@
     },
     "node-uap": {
       "version": "0.0.2",
-      "from": "git://github.com/shane-tomlinson/node-uap.git#13fa830e8",
+      "from": "../../../../var/folders/rn/3nfj68q57jg_gqyhknskhk480000gp/T/npm-56853-8ea10da8/git-cache-11af9d866bc2/13fa830e8368c7161aad2f95c1079d2bb9873d18",
       "resolved": "git://github.com/shane-tomlinson/node-uap.git#13fa830e8368c7161aad2f95c1079d2bb9873d18",
       "dependencies": {
         "uap-core": {
           "version": "0.5.0",
-          "from": "git://github.com/ua-parser/uap-core.git",
-          "resolved": "git://github.com/ua-parser/uap-core.git#095b648d9350854e05d442137326d73c3a401882"
+          "from": "../../../../var/folders/rn/3nfj68q57jg_gqyhknskhk480000gp/T/npm-56853-8ea10da8/git-cache-10dd1efc175f/095b648d9350854e05d442137326d73c3a401882",
+          "resolved": "git://github.com/ua-parser/uap-core#095b648d9350854e05d442137326d73c3a401882"
         },
         "uap-ref-impl": {
           "version": "0.2.0",
@@ -10090,9 +10013,9 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "version": "2.0.6",
+              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -10105,9 +10028,9 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
@@ -10157,7 +10080,7 @@
         },
         "mime-types": {
           "version": "2.1.10",
-          "from": "mime-types@>=2.1.7 <2.2.0",
+          "from": "mime-types@>=2.1.10 <2.2.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
           "dependencies": {
             "mime-db": {
@@ -10183,9 +10106,9 @@
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
         },
         "tough-cookie": {
-          "version": "2.2.1",
+          "version": "2.2.2",
           "from": "tough-cookie@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
         },
         "http-signature": {
           "version": "1.1.1",
@@ -10501,7 +10424,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -10632,7 +10555,7 @@
             },
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@>=1.0.0 <2.0.0",
+              "from": "is-finite@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
             },
             "meow": {
@@ -10646,23 +10569,16 @@
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "2.1.0",
+                      "version": "2.1.1",
                       "from": "camelcase@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
-                  "version": "1.1.2",
+                  "version": "1.2.0",
                   "from": "decamelize@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
                   "version": "1.3.0",
@@ -10767,9 +10683,9 @@
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
-                      "version": "1.1.0",
+                      "version": "1.1.2",
                       "from": "find-up@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "i18n-abide": "0.0.23",
     "jsxgettext-recursive": "0.0.5",
     "load-grunt-tasks": "3.2.0",
+    "lodash": "4.6.1",
     "marked": "0.3.5",
     "mkdirp": "0.5.1",
     "morgan": "1.6.1",

--- a/server/lib/activity-event.js
+++ b/server/lib/activity-event.js
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var _ = require('lodash');
+var Promise = require('bluebird');
+
+var DNT_ALLOWED_QUERY_PARAMS = [
+  'context',
+  'entrypoint',
+  'migration',
+  'service',
+];
+var NO_DNT_ALLOWED_QUERY_PARAMS = DNT_ALLOWED_QUERY_PARAMS.concat([
+  'utm_campaign',
+  'utm_content',
+  'utm_medium',
+  'utm_source',
+  'utm_term'
+]);
+var MAX_PARAM_LENGTH = 100;
+
+module.exports = function (event, data, request) {
+  var queryParams = _.pick(request.query, isDNT(request) ?
+    DNT_ALLOWED_QUERY_PARAMS : NO_DNT_ALLOWED_QUERY_PARAMS);
+
+  var eventData = _.assign({
+    event: event,
+    path: removeQueryString(request.originalUrl),
+    userAgent: request.headers['user-agent']
+  }, data, _.mapValues(queryParams, limitLength));
+
+  optionallySetFallbackData(eventData, 'service', request.query.client_id);
+  optionallySetFallbackData(eventData, 'entrypoint', request.query.entryPoint);
+
+  return new Promise(function (resolve) {
+    setImmediate(function () {
+      // The data pipeline listens on stderr.
+      process.stderr.write('activityEvent ' + JSON.stringify(eventData) + '\n');
+      resolve();
+    });
+  });
+};
+
+function isDNT (request) {
+  return request.headers.dnt === '1';
+}
+
+function removeQueryString (url) {
+  var index = url.indexOf('?');
+
+  if (index === -1) {
+    return url;
+  }
+
+  return url.substr(0, index);
+}
+
+function limitLength (param) {
+  if (param && param.length > MAX_PARAM_LENGTH) {
+    return param.substr(0, MAX_PARAM_LENGTH);
+  }
+
+  return param;
+}
+
+function optionallySetFallbackData (eventData, key, fallback) {
+  if (! eventData[key] && fallback) {
+    eventData[key] = limitLength(fallback);
+  }
+}
+

--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+var activityEvent = require('../activity-event');
+var crypto = require('crypto');
 
 module.exports = function (config) {
   var STATIC_RESOURCE_URL = config.get('static_resource_url');
@@ -11,9 +13,21 @@ module.exports = function (config) {
   route.path = '/';
 
   route.process = function (req, res) {
+    var time = Date.now();
+    var flowId = crypto.randomBytes(32).toString('hex');
+
     res.render('index', {
+      flowBeginTime: time,
+      flowId: flowId,
+      // Note that staticResourceUrl is added to templates as a build step
       staticResourceUrl: STATIC_RESOURCE_URL
     });
+
+    activityEvent('flow.begin', {
+      flow_id: flowId, //eslint-disable-line camelcase
+      flow_time: 0, //eslint-disable-line camelcase
+      time: time
+    }, req);
   };
 
   return route;

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -32,7 +32,7 @@
           <!-- endbuild -->
         <![endif]-->
     </head>
-    <body>
+    <body data-flow-id="{{flowId}}" data-flow-begin="{{flowBeginTime}}">
         <div id="fox-logo"></div>
         <div id="stage">
           <div id="main-content" class="card">

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1039,6 +1039,51 @@ define([
     };
   }
 
+  /**
+   * Assert the value of an attribute
+   *
+   * @param {string} elementSelector CSS selector for the element
+   * @param {string} attributeName Name of attribute
+   * @param {string} assertion Name of the chai assertion to invoke
+   * @param {string} value Expected value of the attribute
+   * @returns {promise}
+   */
+  function testAttribute (elementSelector, attributeName, assertion, value) {
+    return function () {
+      return this.parent
+        .findByCssSelector(elementSelector)
+          .getAtribute(attributeName)
+          .then(function (attributeValue) {
+            assert[assertion](attributeValue, value);
+          })
+        .end();
+    };
+  }
+
+  /**
+   * Assert that an attribute value === expected value
+   *
+   * @param {string} elementSelector CSS selector for the element
+   * @param {string} attributeName Name of attribute
+   * @param {string} value Expected value of the attribute
+   * @returns {promise}
+   */
+  function testAttributeEquals (elementSelector, attributeName, value) {
+    return testAttribute(elementSelector, attributeName, 'strictEqual', value);
+  }
+
+  /**
+   * Assert that an attribute value matches a regex
+   *
+   * @param {string} elementSelector CSS selector for the element
+   * @param {string} attributeName Name of attribute
+   * @param {regex} regex Expression for the attribute value to be matched against
+   * @returns {promise}
+   */
+  function testAttributeMatches (elementSelector, attributeName, regex) {
+    return testAttribute(elementSelector, attributeName, 'match', regex);
+  }
+
   function testElementExists(selector) {
     return function () {
       return this.parent
@@ -1090,6 +1135,9 @@ define([
     pollUntil: pollUntil,
     respondToWebChannelMessage: respondToWebChannelMessage,
     testAreEventsLogged: testAreEventsLogged,
+    testAttribute: testAttribute,
+    testAttributeEquals: testAttributeEquals,
+    testAttributeMatches: testAttributeMatches,
     testElementExists: testElementExists,
     testElementTextInclude: testElementTextInclude,
     testElementValueEquals: testElementValueEquals,

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -21,6 +21,8 @@ define([
   var accountData;
   var client;
 
+  var testAttributeMatches = FunctionalHelpers.testAttributeMatches;
+
   function verifyUser(user, index) {
     return FunctionalHelpers.verifyUser(user,  index, client, accountData);
   }
@@ -279,6 +281,12 @@ define([
             .findById('fxa-settings-header')
             .end();
         });
+    },
+
+    'flow data attributes are set': function () {
+      this.remote
+        .then(testAttributeMatches('body', 'data-flow-id', /^[0-9a-f]{64}$/))
+        .then(testAttributeMatches('body', 'data-flow-begin', /^[1-9][0-9]{13,}$/));
     }
   });
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -28,6 +28,7 @@ define([
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
   var openPage = FunctionalHelpers.openPage;
+  var testAttributeMatches = FunctionalHelpers.testAttributeMatches;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   var testErrorWasShown = FunctionalHelpers.testErrorWasShown;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
@@ -501,6 +502,12 @@ define([
 
         .findByCssSelector('#fxa-settings-header')
         .end();
+    },
+
+    'flow data attributes are set': function () {
+      this.remote
+        .then(testAttributeMatches('body', 'data-flow-id', /^[0-9a-f]{64}$/))
+        .then(testAttributeMatches('body', 'data-flow-begin', /^[1-9][0-9]{13,}$/));
     }
   });
 

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -22,6 +22,8 @@ define([
     'tests/server/metrics-unit',
     'tests/server/configuration',
     'tests/server/statsd-collector',
+    'tests/server/activity-event',
+    'tests/server/routes/get-index',
     'tests/server/routes/post-csp'
   ];
 

--- a/tests/server/activity-event.js
+++ b/tests/server/activity-event.js
@@ -1,0 +1,367 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../server/lib/activity-event',
+  'intern/dojo/node!path',
+  'intern/dojo/node!sinon',
+], function (registerSuite, assert, activityEvent, path, sinon) {
+  var write;
+
+  registerSuite({
+    name: 'activity-event',
+
+    'interface is correct': function () {
+      assert.isFunction(activityEvent);
+      assert.lengthOf(activityEvent, 3);
+    },
+
+    'call activityEvent with service and entrypoint': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('mock event', { a: 'b', c: 'd' }, {
+          headers: { 'user-agent': 'foo' },
+          originalUrl: 'bar',
+          query: {
+            context: 'mock context',
+            entrypoint: 'mock entrypoint',
+            migration: 'mock migration',
+            service: 'mock service',
+            /*eslint-disable camelcase*/
+            utm_campaign: 'mock utm_campaign',
+            utm_content: 'mock utm_content',
+            utm_medium: 'mock utm_medium',
+            utm_source: 'mock utm_source',
+            utm_term: 'mock utm_term',
+            /*eslint-enable camelcase*/
+            zignore: 'ignore me'
+          }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var args = process.stderr.write.args[0];
+        assert.lengthOf(args, 1);
+        assert.equal(args[0].substr(0, 14), 'activityEvent ');
+        assert.equal(args[0][args[0].length - 1], '\n');
+
+        var eventData = JSON.parse(args[0].substr(14));
+        assert.isObject(eventData);
+        assert.lengthOf(Object.keys(eventData), 14);
+        assert.equal(eventData.event, 'mock event');
+        assert.equal(eventData.path, 'bar');
+        assert.equal(eventData.userAgent, 'foo');
+        assert.equal(eventData.a, 'b');
+        assert.equal(eventData.c, 'd');
+        assert.equal(eventData.context, 'mock context');
+        assert.equal(eventData.entrypoint, 'mock entrypoint');
+        assert.equal(eventData.migration, 'mock migration');
+        assert.equal(eventData.service, 'mock service');
+        /*eslint-disable camelcase*/
+        assert.equal(eventData.utm_campaign, 'mock utm_campaign');
+        assert.equal(eventData.utm_content, 'mock utm_content');
+        assert.equal(eventData.utm_medium, 'mock utm_medium');
+        assert.equal(eventData.utm_source, 'mock utm_source');
+        assert.equal(eventData.utm_term, 'mock utm_term');
+        /*eslint-enable camelcase*/
+      }
+    },
+
+    'call activityEvent with client_id': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('wibble', {}, {
+          headers: { 'user-agent': 'blee' },
+          originalUrl: '/',
+          query: {
+            client_id: 'mock client id', //eslint-disable-line camelcase
+            ignore: 'ignore me'
+          }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0].substr(14));
+        assert.lengthOf(Object.keys(eventData), 4);
+        assert.equal(eventData.event, 'wibble');
+        assert.equal(eventData.path, '/');
+        assert.equal(eventData.userAgent, 'blee');
+        assert.equal(eventData.service, 'mock client id');
+      }
+    },
+
+    'call activityEvent with service and client_id': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('wibble', {}, {
+          headers: { 'user-agent': 'blee' },
+          originalUrl: '/',
+          query: {
+            client_id: 'mock client id', //eslint-disable-line camelcase
+            service: 'mock service',
+            zignore: 'ignore me'
+          }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0].substr(14));
+        assert.lengthOf(Object.keys(eventData), 4);
+        assert.equal(eventData.service, 'mock service');
+      }
+    },
+
+    'call activityEvent with entryPoint': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('wibble', {}, {
+          headers: { 'user-agent': 'blee' },
+          originalUrl: '/',
+          query: {
+            entryPoint: 'mock entryPoint', //eslint-disable-line camelcase
+            ignore: 'ignore me'
+          }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0].substr(14));
+        assert.lengthOf(Object.keys(eventData), 4);
+        assert.equal(eventData.event, 'wibble');
+        assert.equal(eventData.path, '/');
+        assert.equal(eventData.userAgent, 'blee');
+        assert.equal(eventData.entrypoint, 'mock entryPoint');
+      }
+    },
+
+    'call activityEvent with entrypoint and entryPoint': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('wibble', {}, {
+          headers: { 'user-agent': 'blee' },
+          originalUrl: '/',
+          query: {
+            entryPoint: 'mock entryPoint', //eslint-disable-line camelcase
+            entrypoint: 'mock entrypoint',
+            zignore: 'ignore me'
+          }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0].substr(14));
+        assert.lengthOf(Object.keys(eventData), 4);
+        assert.equal(eventData.entrypoint, 'mock entrypoint');
+      }
+    },
+
+    'call activityEvent with 101-character query parameter': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('wibble', {}, {
+          headers: { 'user-agent': 'blee' },
+          originalUrl: '/',
+          query: {
+            context: (new Array(102)).join('0')
+          }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0].substr(14));
+        assert.lengthOf(eventData.context, 100);
+      }
+    },
+
+    'call activityEvent with 100-character query parameter': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('wibble', {}, {
+          headers: { 'user-agent': 'blee' },
+          originalUrl: '/',
+          query: {
+            entrypoint: (new Array(101)).join('x')
+          }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0].substr(14));
+        assert.lengthOf(eventData.entrypoint, 100);
+      }
+    },
+
+    'call activityEvent with 101-character client_id': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('wibble', {}, {
+          headers: { 'user-agent': 'blee' },
+          originalUrl: '/',
+          query: {
+            client_id: (new Array(102)).join(' ') //eslint-disable-line camelcase
+          }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0].substr(14));
+        assert.lengthOf(eventData.service, 100);
+      }
+    },
+
+    'call activityEvent with 101-character entryPoint': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('wibble', {}, {
+          headers: { 'user-agent': 'blee' },
+          originalUrl: '/',
+          query: {
+            entryPoint: (new Array(102)).join(' ') //eslint-disable-line camelcase
+          }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0].substr(14));
+        assert.lengthOf(eventData.entrypoint, 100);
+      }
+    },
+
+    'call activityEvent with DNT header': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('mock event', {}, {
+          headers: { 'dnt': '1', 'user-agent': 'foo' },
+          originalUrl: 'bar',
+          query: {
+            client_id: 'mock client_id', //eslint-disable-line camelcase
+            context: 'mock context',
+            entryPoint: 'mock entryPoint',
+            entrypoint: 'mock entrypoint',
+            migration: 'mock migration',
+            service: 'mock service',
+            /*eslint-disable camelcase*/
+            utm_campaign: 'mock utm_campaign',
+            utm_content: 'mock utm_content',
+            utm_medium: 'mock utm_medium',
+            utm_source: 'mock utm_source',
+            utm_term: 'mock utm_term',
+            /*eslint-enable camelcase*/
+            zignore: 'ignore me'
+          }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0].substr(14));
+        assert.lengthOf(Object.keys(eventData), 7);
+        assert.equal(eventData.event, 'mock event');
+        assert.equal(eventData.path, 'bar');
+        assert.equal(eventData.userAgent, 'foo');
+        assert.equal(eventData.context, 'mock context');
+        assert.equal(eventData.entrypoint, 'mock entrypoint');
+        assert.equal(eventData.migration, 'mock migration');
+        assert.equal(eventData.service, 'mock service');
+      }
+    },
+
+    'call activityEvent with query params in originalUrl': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return activityEvent('mock event', {}, {
+          headers: { 'user-agent': 'foo' },
+          originalUrl: 'bar?client_id=baz&utm_campaign=qux',
+          query: { zignore: 'ignore me' }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0].substr(14));
+        assert.lengthOf(Object.keys(eventData), 3);
+        assert.equal(eventData.event, 'mock event');
+        assert.equal(eventData.path, 'bar');
+        assert.equal(eventData.userAgent, 'foo');
+      }
+    }
+  });
+});

--- a/tests/server/routes/get-index.js
+++ b/tests/server/routes/get-index.js
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var FLOW_ID_REGEX = /^[0-9a-f]{64}$/;
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!bluebird',
+  'intern/dojo/node!path',
+  'intern/dojo/node!proxyquire',
+  'intern/dojo/node!sinon',
+], function (registerSuite, assert, Promise, path, proxyquire, sinon) {
+  var activityEvent, config, route, request, response;
+
+  registerSuite({
+    name: 'routes/get-index',
+
+    setup: function () {
+      activityEvent = sinon.spy();
+      config = {
+        get: sinon.spy(function () {
+          return 'foo';
+        })
+      };
+      route = proxyquire(path.resolve('server/lib/routes/get-index'), {
+        '../activity-event': activityEvent
+      });
+    },
+
+    'interface is correct': function () {
+      assert.isFunction(route);
+      assert.lengthOf(route, 1);
+
+      var instance = route(config);
+      assert.isObject(instance);
+      assert.lengthOf(Object.keys(instance), 3);
+      assert.equal(instance.method, 'get');
+      assert.equal(instance.path, '/');
+
+      assert.isFunction(instance.process);
+      assert.lengthOf(instance.process, 2);
+    },
+
+    'config.get was called correctly': function () {
+      assert.equal(config.get.callCount, 1);
+      var args = config.get.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], 'static_resource_url');
+    },
+
+    'route.process': {
+      setup: function () {
+        request = {};
+        response = { render: sinon.spy() };
+        route(config).process(request, response);
+      },
+
+      'response.render was called correctly': function () {
+        assert.equal(response.render.callCount, 1);
+
+        var args = response.render.args[0];
+        assert.lengthOf(args, 2);
+
+        assert.equal(args[0], 'index');
+
+        assert.isObject(args[1]);
+        assert.lengthOf(Object.keys(args[1]), 3);
+        assert.match(args[1].flowId, FLOW_ID_REGEX);
+        assert.isAbove(args[1].flowBeginTime, 0);
+        assert.equal(args[1].staticResourceUrl, 'foo');
+      },
+
+      'activityEvent was called correctly': function () {
+        assert.equal(activityEvent.callCount, 1);
+        assert.isTrue(activityEvent.calledAfter(response.render));
+
+        var args = activityEvent.args[0];
+        assert.lengthOf(args, 3);
+
+        assert.equal(args[0], 'flow.begin');
+
+        assert.isObject(args[1]);
+        assert.lengthOf(Object.keys(args[1]), 3);
+        assert.equal(args[1].flow_id, response.render.args[0][1].flowId);
+        assert.strictEqual(args[1].flow_time, 0);
+        assert.isAbove(args[1].time, 0);
+
+        assert.equal(args[2], request);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Fixes #3550.

This continues the discussion from https://github.com/mozilla/fxa-content-server/pull/3562, which I closed while focusing on some other stuff.

There are two main differences to how I left things there:

1. The sample rate has been removed. I asked about it in `#datapipeline` and both @mreid-moz and @kparlante recommended against sampling the events. Our back-of-an-envelope calculations for current peak load of 30 events per second and 300 bytes per event did not cause any alarm.

2. I reverted to calling `process.stderr.write` directly, after realising that `mozlog` is already configured to write to `stdout` in `server/bin/fxa-content-server.js`.

@vladikoff, @vbudhram, r?