### PR TITLE
refactor(tests): Overhaul the force_auth tests.

### DIFF
--- a/tests/functional/amo_sign_up.js
+++ b/tests/functional/amo_sign_up.js
@@ -4,11 +4,23 @@
 
 define([
   'intern!object',
-  'intern/chai!assert',
   'tests/functional/lib/helpers'
-], function (registerSuite, assert, FunctionalHelpers) {
+], function (registerSuite, FunctionalHelpers) {
 
-  var MIGRATE_PARAMS = 'state=state&migration=amo&scope=profile&email=fakeemail@restmail.com';
+  var QUERY_PARAMS = {
+    email: 'fakeemail@restmail.com',
+    migration: 'amo',
+    scope: 'profile',
+    state: 'state'
+  };
+
+  var thenify = FunctionalHelpers.thenify;
+
+  var click = FunctionalHelpers.click;
+  var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
+  var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   registerSuite({
     name: 'oauth amo sign up',
@@ -18,22 +30,13 @@ define([
     },
 
     'as a migrating user': function () {
-      return FunctionalHelpers.openFxaFromRp(this, 'signup', MIGRATE_PARAMS)
-        .then(FunctionalHelpers.visibleByQSA('.info.nudge'))
-        .findByCssSelector('.info.nudge a')
-          .click()
-        .end()
+      return this.remote
+        .then(openFxaFromRp(this, 'signup', { query: QUERY_PARAMS }))
+        .then(visibleByQSA('.info.nudge'))
+        .then(click('.info.nudge a'))
 
-        .findByCssSelector('#fxa-signin-header')
-        .end()
-
-        .findByCssSelector('input[type="email"]')
-        .getAttribute('value')
-        .then(function (resultText) {
-          // check the email address is empty
-          assert.equal(resultText, '');
-        })
-        .end();
+        .then(testElementExists('#fxa-signin-header'))
+        .then(testElementValueEquals('input[type="email"]', ''));
     }
   });
 });

--- a/tests/functional/lib/webchannel-helpers.js
+++ b/tests/functional/lib/webchannel-helpers.js
@@ -8,16 +8,15 @@
 
 define([
   'intern/chai!assert',
-  'intern/node_modules/dojo/node!querystring',
   'tests/functional/lib/helpers',
-], function (assert, queryString, FunctionalHelpers) {
+], function (assert, FunctionalHelpers) {
 
-  function openFxaFromRp(context, page, queryParams) {
-    queryParams = queryParams || {};
-    queryParams.webChannelId = 'test';
-    var searchString = '?' + queryString.stringify(queryParams);
+  function openFxaFromRp(context, page, options) {
+    options = options || {};
+    options.query = options.query || {};
+    options.query.webChannelId = 'test';
 
-    return FunctionalHelpers.openFxaFromRp(context, page, searchString);
+    return FunctionalHelpers.openFxaFromRp(context, page, options);
   }
 
   function testIsBrowserNotifiedOfLogin(context, options) {

--- a/tests/functional/oauth_force_auth.js
+++ b/tests/functional/oauth_force_auth.js
@@ -5,40 +5,25 @@
 define([
   'intern',
   'intern!object',
-  'intern/chai!assert',
-  'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var OAUTH_APP = config.fxaOauthApp;
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+
+  var thenify = FunctionalHelpers.thenify;
+
+  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var click = FunctionalHelpers.click;
+  var createUser = FunctionalHelpers.createUser;
+  var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
+  var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testUrlEquals = FunctionalHelpers.testUrlEquals;
+  var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   var PASSWORD = 'password';
   var email;
-  var client;
-
-  function openFxaFromRp(context, email) {
-    var emailParam = '?email=' + encodeURIComponent(email);
-    return FunctionalHelpers.openFxaFromRp(context, 'force_auth', emailParam);
-  }
-
-  function attemptSignIn(context) {
-    return context.remote
-      // user should be at the force-auth screen
-      .findByCssSelector('#fxa-force-auth-header')
-      .end()
-
-      .findByCssSelector('input[type=password]')
-        .click()
-        .type(PASSWORD)
-      .end()
-
-      .findByCssSelector('button[type="submit"]')
-        .click()
-      .end();
-  }
 
 
   registerSuite({
@@ -46,36 +31,21 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
-      var self = this;
-      return client.signUp(email, PASSWORD, { preVerified: true })
-        .then(function () {
-          // clear localStorage to avoid polluting other tests.
-          return FunctionalHelpers.clearBrowserState(self, {
-            '123done': true,
-            contentServer: true
-          });
-        });
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(clearBrowserState(this, {
+          '123done': true,
+          contentServer: true
+        }));
     },
 
     'allows the user to sign in': function () {
-      var self = this;
-      return openFxaFromRp(this, email)
-        .then(function () {
-          return attemptSignIn(self);
-        })
+      return this.remote
+        .then(openFxaFromRp(this, 'force_auth', { query: { email: email }}))
+        .then(fillOutForceAuth(PASSWORD))
 
-        .findByCssSelector('#loggedin')
-        .end()
-
-        .getCurrentUrl()
-        .then(function (url) {
-          // redirected back to the App
-          assert.ok(url.indexOf(OAUTH_APP) > -1);
-        })
-        .end();
+        .then(testElementExists('#loggedin'))
+        .then(testUrlEquals(OAUTH_APP));
     }
   });
 
@@ -85,32 +55,25 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail();
       // clear localStorage to avoid polluting other tests.
-      return FunctionalHelpers.clearBrowserState(this, {
-        '123done': true,
-        contentServer: true
-      });
+      return this.remote
+        .then(clearBrowserState(this, {
+          '123done': true,
+          contentServer: true
+        }));
     },
 
     'sign in shows an error message': function () {
-      var self = this;
-      return openFxaFromRp(self, email)
-        .then(function () {
-          return attemptSignIn(self);
-        })
-
-        .then(FunctionalHelpers.visibleByQSA('.error'))
-        .end();
+      return this.remote
+        .then(openFxaFromRp(this, 'force_auth', { query: { email: email }}))
+        .then(fillOutForceAuth(PASSWORD))
+        .then(visibleByQSA('.error'));
     },
 
     'reset password shows an error message': function () {
-      var self = this;
-      return openFxaFromRp(self, email)
-        .findByCssSelector('a[href="/confirm_reset_password"]')
-          .click()
-        .end()
-
-        .then(FunctionalHelpers.visibleByQSA('.error'))
-        .end();
+      return this.remote
+        .then(openFxaFromRp(this, 'force_auth', { query: { email: email }}))
+        .then(click('a[href="/confirm_reset_password"]'))
+        .then(visibleByQSA('.error'));
     }
   });
 });

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -22,17 +22,18 @@ define([
 
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
-  var fillOutForceAuth = thenify(FunctionalHelpers.fillOutForceAuth);
+  var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openFxaFromTrustedRp = FunctionalHelpers.openFxaFromRp;
-  var openFxaFromUntrustedRp = FunctionalHelpers.openFxaFromUntrustedRp;
+  var openFxaFromTrustedRp = thenify(FunctionalHelpers.openFxaFromRp);
+  var openFxaFromUntrustedRp = thenify(FunctionalHelpers.openFxaFromUntrustedRp);
   var openPage = FunctionalHelpers.openPage;
   var openSettingsInNewTab = thenify(FunctionalHelpers.openSettingsInNewTab);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testUrlEquals = FunctionalHelpers.testUrlEquals;
   var type = FunctionalHelpers.type;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
@@ -51,35 +52,28 @@ define([
     },
 
     'signin verified': function () {
-      var self = this;
-
-      return openFxaFromUntrustedRp(self, 'signin')
+      return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-
-        .then(fillOutSignIn(self, email, PASSWORD))
+        .then(openFxaFromUntrustedRp(this, 'signin'))
+        .then(fillOutSignIn(this, email, PASSWORD))
 
         .then(testElementExists('#fxa-permissions-header'))
-
         .then(click('#accept'))
 
         .then(testElementExists('#loggedin'))
-
         .then(testUrlEquals(UNTRUSTED_OAUTH_APP));
     },
 
     're-signin verified, no additional permissions': function () {
-      var self = this;
-
-      return openFxaFromUntrustedRp(self, 'signin')
+      return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-
-        .then(fillOutSignIn(self, email, PASSWORD))
+        .then(openFxaFromUntrustedRp(this, 'signin'))
+        .then(fillOutSignIn(this, email, PASSWORD))
 
         .then(testElementExists('#fxa-permissions-header'))
         .then(click('#accept'))
 
         .then(testElementExists('#loggedin'))
-
         .then(testUrlEquals(UNTRUSTED_OAUTH_APP))
 
         .then(click('#logout'))
@@ -87,23 +81,21 @@ define([
 
         // user signed in previously and should not need to enter
         // their email address.
+        .then(testElementExists('#fxa-signin-header'))
         .then(type('input[type=password]', PASSWORD))
         .then(click('button[type=submit]'))
 
         // no permissions additional asked for
         .then(testElementExists('#loggedin'))
-
         // redirected back to the App without seeing the permissions screen.
         .then(testUrlEquals(UNTRUSTED_OAUTH_APP));
     },
 
     'signin unverified, acts like signup': function () {
-      var self = this;
-
-      return openFxaFromUntrustedRp(self, 'signin')
+      return this.remote
         .then(createUser(email, PASSWORD, { preVerified: false }))
-
-        .then(fillOutSignIn(self, email, PASSWORD))
+        .then(openFxaFromUntrustedRp(this, 'signin'))
+        .then(fillOutSignIn(this, email, PASSWORD))
 
         .then(testElementExists('#fxa-permissions-header'))
         .then(click('#accept'))
@@ -114,51 +106,40 @@ define([
         // preVerified: false above. The second email has the `service` and
         // `resume` parameters.
         .then(getVerificationLink(user, 1))
-
         .then(function (verifyUrl) {
           // user verifies in the same tab, so they are logged in to the RP.
-          return openPage(self, verifyUrl, '#loggedin');
+          return openPage(this.parent, verifyUrl, '#loggedin');
         });
     },
 
     'signup, verify same browser': function () {
-      var self = this;
-      return openFxaFromUntrustedRp(self, 'signup')
-        .findByCssSelector('#fxa-signup-header .service')
-        .end()
-
+      return this.remote
+        .then(openFxaFromUntrustedRp(this, 'signup'))
+        .then(testElementExists('#fxa-signup-header .service'))
         .getCurrentUrl()
-        .then(function (url) {
-          assert.ok(url.indexOf('client_id=') > -1);
-          assert.ok(url.indexOf('redirect_uri=') > -1);
-          assert.ok(url.indexOf('state=') > -1);
-        })
+          .then(function (url) {
+            assert.ok(url.indexOf('client_id=') > -1);
+            assert.ok(url.indexOf('redirect_uri=') > -1);
+            assert.ok(url.indexOf('state=') > -1);
+          })
         .end()
 
-        .then(fillOutSignUp(self, email, PASSWORD))
+        .then(fillOutSignUp(this, email, PASSWORD))
 
         .then(testElementExists('#fxa-permissions-header'))
-
         .then(click('#accept'))
 
         .then(testElementExists('#fxa-confirm-header'))
 
-        .then(openVerificationLinkInNewTab(self, email, 0))
-
+        .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
         // wait for the verified window in the new tab
-        .findById('fxa-sign-up-complete-header')
-        .end()
-
+        .then(testElementExists('#fxa-sign-up-complete-header'))
         .sleep(5000)
-        .findByCssSelector('.account-ready-service')
-        .getVisibleText()
-        .then(function (text) {
-          // user sees the name of the RP,
-          // but cannot redirect
-          assert.ok(/321done Untrusted/i.test(text));
-        })
-        .end()
+
+        // user sees the name of the RP,
+        // but cannot redirect
+        .then(testElementTextInclude('.account-ready-service', '321done Untrusted'))
 
         // switch to the original window
         .closeCurrentWindow()
@@ -168,18 +149,16 @@ define([
     },
 
     'preverified signup': function () {
-      var self = this;
       var SIGNUP_URL = UNTRUSTED_OAUTH_APP + 'api/preverified-signup?' +
                         'email=' + encodeURIComponent(email);
 
-      return openPage(self, SIGNUP_URL, '#fxa-signup-header')
+      return openPage(this, SIGNUP_URL, '#fxa-signup-header')
 
         .then(type('input[type=password]', PASSWORD))
         .then(type('#age', 24))
         .then(click('button[type="submit"]'))
 
         .then(testElementExists('#fxa-permissions-header'))
-
         .then(click('#accept'))
 
         // user is redirected to 123done, wait for the footer first,
@@ -191,66 +170,50 @@ define([
 
         // user is pre-verified and sent directly to the RP.
         .then(visibleByQSA('#loggedin'))
-
-        .findByCssSelector('#loggedin')
-        .getVisibleText()
-        .then(function (text) {
-          // user is signed in as pre-verified email
-          assert.equal(text, email);
-        })
-        .end();
+        .then(testElementTextInclude('#loggedin', email));
     },
 
     'signup, then signin with no additional permissions': function () {
-      var self = this;
-      return openFxaFromUntrustedRp(self, 'signup')
-        .then(fillOutSignUp(self, email, PASSWORD))
+      return this.remote
+        .then(openFxaFromUntrustedRp(this, 'signup'))
+        .then(fillOutSignUp(this, email, PASSWORD))
 
         .then(testElementExists('#fxa-permissions-header'))
         .then(click('#accept'))
 
         .then(testElementExists('#fxa-confirm-header'))
 
-        .then(openVerificationLinkInNewTab(self, email, 0))
-
+        .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
         // wait for the verified window in the new tab
         .then(testElementExists('#fxa-sign-up-complete-header'))
 
         .sleep(5000)
-        .findByCssSelector('.account-ready-service')
-        .getVisibleText()
-        .then(function (text) {
-          // user sees the name of the RP,
-          // but cannot redirect
-          assert.ok(/321done Untrusted/i.test(text));
-        })
-        .end()
+        // user sees the name of the RP,
+        // but cannot redirect
+        .then(testElementTextInclude('.account-ready-service', '321done Untrusted'))
 
         // switch to the original window
         .closeCurrentWindow()
         .switchToWindow('')
 
         .then(testElementExists('#loggedin'))
-
         .then(click('#logout'))
-
         .then(click('.signin'))
 
         // user signed in previously and should not need to enter
         // their email address.
+        .then(testElementExists('#fxa-signin-header'))
         .then(type('input[type=password]', PASSWORD))
         .then(click('button[type=submit]'))
 
         .then(testElementExists('#loggedin'))
-
         .then(testUrlEquals(UNTRUSTED_OAUTH_APP));
     },
 
     'signin from signup page': function () {
-      var self = this;
-
-      return openFxaFromUntrustedRp(self, 'signup')
+      return this.remote
+        .then(openFxaFromUntrustedRp(this, 'signup'))
         .then(createUser(email, PASSWORD, { preVerified: true }))
 
         .then(type('input[type=email]', email))
@@ -259,27 +222,21 @@ define([
         .then(click('button[type=submit]'))
 
         .then(testElementExists('#fxa-permissions-header'))
-
         .then(click('#accept'))
 
         .then(testElementExists('#loggedin'))
-
         .then(testUrlEquals(UNTRUSTED_OAUTH_APP));
     },
 
     'signin with new permission available b/c of new account information': function () {
-      var self = this;
-
-      return openFxaFromUntrustedRp(self, 'signin')
+      return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-
-        .then(fillOutSignIn(self, email, PASSWORD))
+        .then(openFxaFromUntrustedRp(this, 'signin'))
+        .then(fillOutSignIn(this, email, PASSWORD))
 
         .then(testElementExists('#fxa-permissions-header'))
-
         // display name is not available because user has not set their name
-        .then(noSuchElement(self, 'input[name="profile:display_name"]'))
-
+        .then(noSuchElement(this, 'input[name="profile:display_name"]'))
         .then(click('#accept'))
 
         .then(testElementExists('#loggedin'))
@@ -287,12 +244,11 @@ define([
 
         .then(click('#logout'))
 
-        .then(openSettingsInNewTab(self, 'settings', 'display_name'))
+        .then(openSettingsInNewTab(this, 'settings', 'display_name'))
         .switchToWindow('settings')
 
         .then(type('#display-name input[type=text]', 'test user'))
         .then(click('#display-name button[type=submit]'))
-
         .then(visibleByQSA('.settings-success'))
 
         .closeCurrentWindow()
@@ -305,40 +261,33 @@ define([
 
         // display name is now available
         .then(testElementExists('input[name="profile:display_name"]'))
-
         .then(click('#accept'))
+
         .then(testElementExists('#loggedin'));
     },
 
     'signin with additional requested permission': function () {
-      var self = this;
-
-      return self.remote
+      return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-
-        .then(fillOutSignIn(self, email, PASSWORD))
+        .then(fillOutSignIn(this, email, PASSWORD))
 
         // make display_name available from the start
         .then(click('#display-name button.settings-unit-toggle'))
-
         .then(type('#display-name input[type=text]', 'test user'))
         .then(click('#display-name button[type=submit]'))
-
         .then(visibleByQSA('.settings-success'))
 
-        .then(function () {
-          // the first time through, only request email and uid
-          return openFxaFromUntrustedRp(self, 'signin', '?scope=profile%3Aemail profile%3Auid');
-        })
+        // the first time through, only request email and uid
+        .then(openFxaFromUntrustedRp(this, 'signin', { query: {
+          scope: 'profile:email profile:uid'
+        }}))
 
         .then(type('input[type=password', PASSWORD))
         .then(click('button[type=submit]'))
 
         .then(testElementExists('#fxa-permissions-header'))
-
         // display name is not available because it's not requested
-        .then(noSuchElement(self, 'input[name="profile:display_name"]'))
-
+        .then(noSuchElement(this, 'input[name="profile:display_name"]'))
         .then(click('#accept'))
 
         .then(testElementExists('#loggedin'))
@@ -360,39 +309,29 @@ define([
     },
 
     'signin after de-selecting a requested permission': function () {
-      var self = this;
-
-      return self.remote
+      return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-
-        .then(fillOutSignIn(self, email, PASSWORD))
+        .then(fillOutSignIn(this, email, PASSWORD))
 
         // make display_name available from the start
         .then(click('#display-name button.settings-unit-toggle'))
-
         .then(type('#display-name input[type=text]', 'test user'))
         .then(click('#display-name button[type=submit]'))
-
         .then(visibleByQSA('.settings-success'))
 
-        .then(function () {
-          return openFxaFromUntrustedRp(self, 'signin');
-        })
+        .then(openFxaFromUntrustedRp(this, 'signin'))
 
         .then(type('input[type=password', PASSWORD))
         .then(click('button[type=submit]'))
 
         .then(testElementExists('input[name="profile:display_name"]'))
-
         // deselect display name to ensure permission state is
         // saved correctly.
         .then(click('input[name="profile:display_name"]'))
-
         .then(click('#accept'))
+
         .then(testElementExists('#loggedin'))
-
         .then(click('#logout'))
-
         // signin again, no permissions should be asked for even though
         // display_name was de-selected last time.
         .then(click('.signin'))
@@ -418,8 +357,8 @@ define([
     },
 
     'signup without `prompt=consent`': function () {
-      return openFxaFromTrustedRp(this, 'signup')
-
+      return this.remote
+        .then(openFxaFromTrustedRp(this, 'signup'))
         .then(fillOutSignUp(this, email, PASSWORD))
 
         // no permissions asked for, straight to confirm
@@ -427,8 +366,8 @@ define([
     },
 
     'signup with `prompt=consent`': function () {
-      return openFxaFromTrustedRp(this, 'signup', 'prompt=consent')
-
+      return this.remote
+        .then(openFxaFromTrustedRp(this, 'signup', { query: { prompt: 'consent' }}))
         .then(fillOutSignUp(this, email, PASSWORD))
 
         // permissions are asked for with `prompt=consent`
@@ -439,9 +378,9 @@ define([
     },
 
     'signin without `prompt=consent`': function () {
-      return openFxaFromTrustedRp(this, 'signin')
+      return this.remote
+        .then(openFxaFromTrustedRp(this, 'signin'))
         .then(createUser(email, PASSWORD, { preVerified: true }))
-
         .then(fillOutSignIn(this, email, PASSWORD))
 
         // no permissions asked for, straight to relier
@@ -449,9 +388,9 @@ define([
     },
 
     'signin with `prompt=consent`': function () {
-      return openFxaFromTrustedRp(this, 'signin', 'prompt=consent')
+      return this.remote
+        .then(openFxaFromTrustedRp(this, 'signin', { query: { prompt: 'consent' }}))
         .then(createUser(email, PASSWORD, { preVerified: true }))
-
         .then(fillOutSignIn(this, email, PASSWORD))
 
         // permissions are asked for with `prompt=consent`
@@ -462,23 +401,18 @@ define([
     },
 
     'signin without `prompt=consent`, then re-signin with `prompt=consent`': function () {
-      var self = this;
-      return openFxaFromTrustedRp(this, 'signin')
+      return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-
+        .then(openFxaFromTrustedRp(this, 'signin'))
         .then(fillOutSignIn(this, email, PASSWORD))
 
         // no permissions asked for, straight to relier
         .then(testElementExists('#loggedin'))
-
         .then(testUrlEquals(TRUSTED_OAUTH_APP))
-
         .then(click('#logout'))
 
-        .then(function () {
-          // relier changes to request consent
-          return openFxaFromTrustedRp(self, 'signin', '?prompt=consent');
-        })
+        // relier changes to request consent
+        .then(openFxaFromTrustedRp(this, 'signin', { query: { prompt: 'consent' }}))
 
         .then(type('input[type=password', PASSWORD))
         .then(click('button[type=submit]'))
@@ -492,20 +426,23 @@ define([
 
 
     'force_auth without `prompt=consent`': function () {
-      return openFxaFromTrustedRp(this, 'force_auth', 'email=' + encodeURIComponent(email))
+      return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-
-        .then(fillOutForceAuth(this, PASSWORD))
+        .then(openFxaFromTrustedRp(this, 'force_auth', { query: { email: email }}))
+        .then(fillOutForceAuth(PASSWORD))
 
         // no permissions asked for, straight to relier
         .then(testElementExists('#loggedin'));
     },
 
     'force_auth with `prompt=consent`': function () {
-      return openFxaFromTrustedRp(this, 'force_auth', 'prompt=consent&email=' + encodeURIComponent(email))
+      return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-
-        .then(fillOutForceAuth(this, PASSWORD))
+        .then(openFxaFromTrustedRp(this, 'force_auth', { query: {
+          email: email,
+          prompt: 'consent'
+        }}))
+        .then(fillOutForceAuth(PASSWORD))
 
         // permissions are asked for with `prompt=consent`
         .then(testElementExists('#fxa-permissions-header'))

--- a/tests/functional/oauth_query_param_validation.js
+++ b/tests/functional/oauth_query_param_validation.js
@@ -53,14 +53,13 @@ define([
       // FxA from the reliers. This is done instead of hard coding
       // the values because the client_ids change depending on
       // the environment.
-      var self = this;
       return this.remote
         .then(openFxaFromRp(this, 'signup'))
         .then(getQueryParamValue('client_id'))
         .then(function (clientId) {
           TRUSTED_CLIENT_ID = clientId;
         })
-        .then(openFxaFromUntrustedRp(self, 'signup'))
+        .then(openFxaFromUntrustedRp(this, 'signup'))
         .then(getQueryParamValue('client_id'))
         .then(function (clientId) {
           UNTRUSTED_CLIENT_ID = clientId;

--- a/tests/functional/oauth_webchannel_force_auth.js
+++ b/tests/functional/oauth_webchannel_force_auth.js
@@ -3,69 +3,48 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
-  'intern',
   'intern!object',
-  'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'tests/functional/lib/webchannel-helpers'
-], function (intern, registerSuite, nodeXMLHttpRequest, FxaClient, TestHelpers,
-  FunctionalHelpers, WebChannelHelpers) {
-  var config = intern.config;
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+], function (registerSuite, TestHelpers, FunctionalHelpers, WebChannelHelpers) {
+  var thenify = FunctionalHelpers.thenify;
+
+  var createUser = FunctionalHelpers.createUser;
+  var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
+  var openFxaFromRp = thenify(WebChannelHelpers.openFxaFromRp);
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testIsBrowserNotifiedOfLogin = WebChannelHelpers.testIsBrowserNotifiedOfLogin;
 
   var PASSWORD = 'password';
   var email;
-  var client;
-
-  var testIsBrowserNotifiedOfLogin = WebChannelHelpers.testIsBrowserNotifiedOfLogin;
-  var openFxaFromRp = WebChannelHelpers.openFxaFromRp;
 
   registerSuite({
     name: 'oauth webchannel force_auth',
     beforeEach: function () {
       email = TestHelpers.createEmail();
 
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
-
       return FunctionalHelpers.clearBrowserState(this);
     },
 
     'verified': function () {
-      var self = this;
-      return client.signUp(email, PASSWORD, { preVerified: true })
-        .then(function () {
-          return openFxaFromRp(self, 'force_auth', { email: email })
-            .execute(FunctionalHelpers.listenForWebChannelMessage)
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openFxaFromRp(this, 'force_auth', { query: { email: email }}))
+        .then(fillOutForceAuth(PASSWORD))
 
-            .then(function () {
-              return FunctionalHelpers.fillOutForceAuth(self, PASSWORD);
-            })
-
-            // the page does not transition, loop will close the screen
-            .findByCssSelector('#fxa-force-auth-header')
-            .end()
-
-            .then(testIsBrowserNotifiedOfLogin(self, { shouldCloseTab: true }));
-        });
+        // the page does not transition, loop will close the screen
+        .then(testElementExists('#fxa-force-auth-header'))
+        .then(testIsBrowserNotifiedOfLogin(this, { shouldCloseTab: true }));
     },
 
     'unverified': function () {
-      var self = this;
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: false }))
+        .then(openFxaFromRp(this, 'force_auth', { query: { email: email }}))
+        .then(fillOutForceAuth(PASSWORD))
 
-      return client.signUp(email, PASSWORD, { preVerified: false})
-        .then(function () {
-          return openFxaFromRp(self, 'force_auth', { email: email })
-            .then(function () {
-              return FunctionalHelpers.fillOutForceAuth(self, PASSWORD);
-            })
-
-            .findByCssSelector('#fxa-confirm-header')
-            .end();
-        });
+        .then(testElementExists('#fxa-confirm-header'));
     }
   });
 });

--- a/tests/functional/sync_force_auth.js
+++ b/tests/functional/sync_force_auth.js
@@ -3,91 +3,65 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
-  'intern',
   'intern!object',
-  'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'tests/functional/lib/fx-desktop'
-], function (intern, registerSuite, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
-  var config = intern.config;
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
-  var FORCE_AUTH_URL = config.fxaContentRoot + 'force_auth?context=fx_desktop_v1&service=sync';
+], function (registerSuite, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
+  var thenify = FunctionalHelpers.thenify;
+
+  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var createUser = FunctionalHelpers.createUser;
+  var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
+  var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  var openForceAuth = FunctionalHelpers.openForceAuth;
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testIsBrowserNotified = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfMessage);
 
   var PASSWORD = 'password';
   var email;
-  var client;
-  var url;
 
-  var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+
+  var setupTest = thenify(function (context, isUserVerified) {
+    return this.parent
+      .then(clearBrowserState(context))
+      .then(createUser(email, PASSWORD, { preVerified: isUserVerified }))
+      .then(openForceAuth({ query: {
+        context: 'fx_desktop_v1',
+        email: email,
+        service: 'sync'
+      }}))
+      .execute(listenForFxaCommands)
+      .then(fillOutForceAuth(PASSWORD));
+  });
+
   registerSuite({
     name: 'Firefox Desktop Sync force_auth',
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      url = FORCE_AUTH_URL + '&email=' + encodeURIComponent(email);
-
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
-
-      return FunctionalHelpers.clearBrowserState(this);
     },
 
     'verified': function () {
-      var self = this;
-      return client.signUp(email, PASSWORD, { preVerified: true })
-        .then(function () {
-          return FunctionalHelpers.openPage(self, url, '#fxa-force-auth-header')
-            .execute(listenForFxaCommands)
+      return this.remote
+        .then(setupTest(this, true))
 
-            .then(function () {
-              return FunctionalHelpers.fillOutForceAuth(self, PASSWORD);
-            })
+        // add a slight delay to ensure the page does not transition
+        .sleep(1000)
 
-            // add a slight delay to ensure the page does not transition
-            .sleep(1000)
-
-            // the page does not transition.
-            .findByCssSelector('#fxa-force-auth-header')
-            .end()
-
-            .then(function () {
-              return FxDesktopHelpers.testIsBrowserNotifiedOfMessage(
-                          self, 'can_link_account');
-            })
-            .then(function () {
-              return FxDesktopHelpers.testIsBrowserNotifiedOfMessage(
-                          self, 'login');
-            });
-        });
+        // the page does not transition.
+        .then(testElementExists('#fxa-force-auth-header'))
+        .then(testIsBrowserNotified(this, 'can_link_account'))
+        .then(testIsBrowserNotified(this, 'login'));
     },
 
     'unverified': function () {
-      var self = this;
+      return this.remote
+        .then(setupTest(this, false))
 
-      return client.signUp(email, PASSWORD, { preVerified: false})
-        .then(function () {
-          return FunctionalHelpers.openPage(self, url, '#fxa-force-auth-header')
-            .execute(listenForFxaCommands)
-
-            .then(function () {
-              return FunctionalHelpers.fillOutForceAuth(self, PASSWORD);
-            })
-
-            .findByCssSelector('#fxa-confirm-header')
-            .end()
-
-            .then(function () {
-              return FxDesktopHelpers.testIsBrowserNotifiedOfMessage(
-                          self, 'can_link_account');
-            })
-            .then(function () {
-              return FxDesktopHelpers.testIsBrowserNotifiedOfMessage(
-                          self, 'login');
-            });
-        });
+        .then(testElementExists('#fxa-confirm-header'))
+        .then(testIsBrowserNotified(this, 'can_link_account'))
+        .then(testIsBrowserNotified(this, 'login'));
     }
   });
 });

--- a/tests/functional/sync_v2_force_auth.js
+++ b/tests/functional/sync_v2_force_auth.js
@@ -3,26 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
-  'app/bower_components/fxa-js-client/fxa-client',
-  'intern',
   'intern!object',
-  'intern/node_modules/dojo/node!xmlhttprequest',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (FxaClient, intern, registerSuite, nodeXMLHttpRequest,
-  TestHelpers, FunctionalHelpers) {
-  var config = intern.config;
-
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
-  var FORCE_AUTH_URL = config.fxaContentRoot + 'force_auth?context=fx_desktop_v2&service=sync';
-
-  var client;
+], function (registerSuite, TestHelpers, FunctionalHelpers) {
   var email;
   var PASSWORD = '12345678';
-  var url;
 
+  var createUser = FunctionalHelpers.createUser;
+  var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
+  var openForceAuth = FunctionalHelpers.openForceAuth;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
 
   registerSuite({
@@ -30,39 +23,29 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      url = FORCE_AUTH_URL + '&email=' + encodeURIComponent(email);
-
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
 
       return FunctionalHelpers.clearBrowserState(this);
     },
 
     'verified': function () {
-      var self = this;
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openForceAuth({ query: {
+          context: 'fx_desktop_v2',
+          email: email,
+          service: 'sync'
+        }}))
+        .then(noSuchBrowserNotification(this, 'fxaccounts:logout'))
+        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(fillOutForceAuth(PASSWORD))
 
-      return client.signUp(email, PASSWORD, { preVerified: true })
-        .then(function () {
-          return FunctionalHelpers.openPage(self, url, '#fxa-force-auth-header')
-            .then(noSuchBrowserNotification(self, 'fxaccounts:logout'))
+        // add a slight delay to ensure the page does not transition
+        .sleep(2000)
 
-            .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
-
-            .then(function () {
-              return FunctionalHelpers.fillOutForceAuth(self, PASSWORD);
-            })
-
-            // add a slight delay to ensure the page does not transition
-            .sleep(2000)
-
-            // the page does not transition.
-            .findByCssSelector('#fxa-force-auth-header')
-            .end()
-
-            .then(testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
-            .then(testIsBrowserNotified(self, 'fxaccounts:login'));
-        });
+        // the page does not transition.
+        .then(testElementExists('#fxa-force-auth-header'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:login'));
     }
   });
 });


### PR DESCRIPTION
PR #3419 was out of control, largely due to functional test refactoring.
I took the refactoring out of that PR into this PR.

* Use new helper functions to reduce boilerplate
* Add helpers.openForceAuth
* Update helpers.openFxaFromUntrustedRp and helpers.openFxaFromTrustedRp to
  take an options block instead of urlSuffix and trusted/untrusted flags.
* update helpers.fillOutForceAuth to skip entering the email if `options.enterEmail` === false

@vladikoff, @vbudhram or @philbooth - mind an r? This is a functional test only update meant to reduce the size of #3419.