### PR TITLE
Adjust robots metadata to avoid any indexing at all

### DIFF
--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,2 +1,7 @@
+# Per the guidelines at [1] we allow robots to crawl the site,
+# then use the "noindex" directive to instruct them not to store
+# any site contents in their index.
+#
+# [1] https://support.google.com/webmasters/answer/93710
 User-agent: *
-Disallow: /
+Allow:

--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -37,6 +37,7 @@ var routes = require('../lib/routes')(config, i18n);
 // Side effect - Adds default_fxa and dev_fxa to express.logger formats
 var routeLogging = require('../lib/logging/route_logging');
 
+var noindex = require('../lib/noindex');
 var fourOhFour = require('../lib/404');
 var serverErrorHandler = require('../lib/500');
 var localizedRender = require('../lib/localized-render');
@@ -118,6 +119,8 @@ function makeApp() {
     app.route(/\.(js|css|woff|ttf)$/)
       .get(cors(corsOptions));
   }
+
+  app.use(noindex);
 
   routes(app);
 

--- a/server/lib/csp.js
+++ b/server/lib/csp.js
@@ -9,6 +9,8 @@
 
 var helmet = require('helmet');
 
+var utils = require('./utils');
+
 function isCspRequired(req) {
   if (req.method !== 'GET') {
     return false;
@@ -20,11 +22,8 @@ function isCspRequired(req) {
     return false;
   }
 
-  // Only HTML files need CSP headers. Our convention is either .html
-  // extensions or extensionless requests are HTML files. We can't check
-  // the response's Content-Type header yet because the response
-  // hasn't yet been rendered.
-  return /\.html$/.test(path) || ! /\.[a-zA-Z0-9]+$/.test(path);
+  // Only HTML files need CSP headers.
+  return utils.isHTMLPage(path);
 }
 
 module.exports = function (config) {

--- a/server/lib/noindex.js
+++ b/server/lib/noindex.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Our page URLs might contain sensitive info like verification tokens.
+// We want to avoid them showing up in search engine indexes, even if a user
+// accidentally posts e.g. their account verification link into a public
+// support website and it gets found by the googlebot.
+//
+// Disallowing robots entirely from the site does *not* achieve this, per [1].
+// Instead we have to:
+//
+//  * send a 'noindex' meta-tag on every page, so that any links the
+//    bot does find will be discarded from its index.
+//
+//  * allow the bot to access the site, so that it can attempt to crawl
+//    any links it finds and discover the 'noindex' directive.
+//
+//  * send a 'nofollow' meta-tag on every page, so that the bot doesn't
+//    get carried away and try to crawl the entire site.
+//
+// [1] https://support.google.com/webmasters/answer/93710
+
+var utils = require('./utils');
+
+function isRobotsTagRequired(req) {
+  // Only HTML pages need the robots control header.
+  return utils.isHTMLPage(req.path);
+}
+
+module.exports = function (req, res, next) {
+  if (isRobotsTagRequired(req)) {
+    res.setHeader('X-Robots-Tag', 'noindex,nofollow');
+  }
+  next();
+};
+
+module.exports.isRobotsTagRequired = isRobotsTagRequired;

--- a/server/lib/utils.js
+++ b/server/lib/utils.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Shared utils for server-side routes to use.
+
+module.exports = {
+
+  // Our convention is either .html extensions or extensionless requests
+  // are HTML files.  Use this function when you need to know the type of
+  // the document before the response has been rendered (and hence you can't
+  // just look at the Content-Type header).
+  isHTMLPage: function isHTMLPage(path) {
+    if (/\.html$/.test(path)) {
+      return true;
+    }
+    if (! /\.[a-zA-Z0-9]+$/.test(path)) {
+      // Some special-case routes are *not* HTML.
+      if (path === '/config') {
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
+
+};

--- a/server/templates/pages/src/404.html
+++ b/server/templates/pages/src/404.html
@@ -8,6 +8,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <meta name="referrer" content="origin">
+        <meta name="robots" content="noindex,nofollow">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/500.html
+++ b/server/templates/pages/src/500.html
@@ -8,6 +8,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <meta name="referrer" content="origin">
+        <meta name="robots" content="noindex,nofollow">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/502.html
+++ b/server/templates/pages/src/502.html
@@ -8,6 +8,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <meta name="referrer" content="origin">
+        <meta name="robots" content="noindex,nofollow">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/503.html
+++ b/server/templates/pages/src/503.html
@@ -8,6 +8,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <meta name="referrer" content="origin">
+        <meta name="robots" content="noindex,nofollow">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -8,6 +8,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <meta name="referrer" content="origin">
+        <meta name="robots" content="noindex,nofollow">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/mocha.html
+++ b/server/templates/pages/src/mocha.html
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="referrer" content="origin">
+        <meta name="robots" content="noindex,nofollow">
         <title>Firefox Accounts Unit Tests</title>
         <link rel="stylesheet" href="/bower_components/mocha/mocha.css" />
     </head>

--- a/server/templates/pages/src/privacy.html
+++ b/server/templates/pages/src/privacy.html
@@ -8,6 +8,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <meta name="referrer" content="origin">
+        <meta name="robots" content="noindex,nofollow">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/server/templates/pages/src/terms.html
+++ b/server/templates/pages/src/terms.html
@@ -8,6 +8,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <meta name="referrer" content="origin">
+        <meta name="robots" content="noindex,nofollow">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">

--- a/tests/functional/robots_txt.js
+++ b/tests/functional/robots_txt.js
@@ -13,7 +13,7 @@ define([
   registerSuite({
     name: 'robots.txt',
 
-    'should disallow root': function () {
+    'should allow bots to access all pages': function () {
 
       return this.remote
         .get(require.toUrl(url))
@@ -21,7 +21,7 @@ define([
         .findByTagName('body')
         .getVisibleText()
         .then(function (source) {
-          assert.isTrue(/Disallow: \//g.test(source));
+          assert.isTrue(/^Allow:/mg.test(source));
         })
         .end();
     }

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -21,6 +21,7 @@ define([
     'tests/server/metrics-errors',
     'tests/server/metrics-ga',
     'tests/server/metrics-unit',
+    'tests/server/noindex',
     'tests/server/configuration',
     'tests/server/statsd-collector',
     'tests/server/activity-event',

--- a/tests/server/noindex.js
+++ b/tests/server/noindex.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Ensure the headers to prevent indexing are only added to the appropriate requests
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../server/lib/noindex',
+], function (registerSuite, assert, noindex) {
+
+  var suite = {
+    name: 'noindex'
+  };
+
+  suite['isRobotsTagRequried'] = function () {
+    assert.isFalse(noindex.isRobotsTagRequired({ path: '/lib/router.js' }));
+    assert.isFalse(noindex.isRobotsTagRequired({ path: '/images/firefox.png' }));
+    assert.isFalse(noindex.isRobotsTagRequired({ path: '/fonts/clearsans.woff' }));
+
+    assert.isTrue(noindex.isRobotsTagRequired({ path: '/tests/index.html' }));
+    assert.isTrue(noindex.isRobotsTagRequired({ path: '/404.html' }));
+    assert.isTrue(noindex.isRobotsTagRequired({ path: '/' }));
+    assert.isTrue(noindex.isRobotsTagRequired({ path: '/confirm' }));
+  };
+
+  registerSuite(suite);
+});
+

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -185,6 +185,11 @@ define([
       assert.ok(headers.hasOwnProperty('content-security-policy'));
     }
 
+    // All non-json routes in this test should have an x-robots-tag header.
+    if (routes[routePathname].headerAccept !== 'application/json') {
+      assert.equal(headers['x-robots-tag'], 'noindex,nofollow');
+    }
+
     assert.equal(headers['x-content-type-options'], 'nosniff');
     assert.include(headers['strict-transport-security'], 'max-age=');
   }


### PR DESCRIPTION
Fixes #3565 (but needs tests).

This adds "noindex" and "nofollow" comands to all our resources, and uses robots.txt to allow robots to find them.  I couldn't think of a good way to have this only enabled in production, and since it's part of a security enhancement, I think it should be done in the app rather than in e.g. nginx.

But I agree with https://github.com/mozilla/fxa-content-server/issues/3565#issuecomment-193599844 that we should keep disallowing robots on our dev boxes.  @vladikoff, how would you feel about use achieving this the other way around, and explicitly *adding* a robots.txt in nginx on those boxes that restores the "disallow all" behaviour?