### PR TITLE
revert(server): remove server-generated flowId and flow.begin event

### DIFF
--- a/grunttasks/l10n-generate-pages.js
+++ b/grunttasks/l10n-generate-pages.js
@@ -24,7 +24,6 @@ module.exports = function (grunt) {
 
   var PROPAGATED_TEMPLATE_FIELDS = [
     'flowBeginTime',
-    'flowId',
     'message'
   ];
 

--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var activityEvent = require('../activity-event');
-var crypto = require('crypto');
-
 module.exports = function (config) {
   var STATIC_RESOURCE_URL = config.get('static_resource_url');
 
@@ -13,21 +10,11 @@ module.exports = function (config) {
   route.path = '/';
 
   route.process = function (req, res) {
-    var time = Date.now();
-    var flowId = crypto.randomBytes(32).toString('hex');
-
     res.render('index', {
-      flowBeginTime: time,
-      flowId: flowId,
+      flowBeginTime: Date.now(),
       // Note that staticResourceUrl is added to templates as a build step
       staticResourceUrl: STATIC_RESOURCE_URL
     });
-
-    activityEvent('flow.begin', {
-      flow_id: flowId, //eslint-disable-line camelcase
-      flow_time: 0, //eslint-disable-line camelcase
-      time: time
-    }, req);
   };
 
   return route;

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -32,7 +32,7 @@
           <!-- endbuild -->
         <![endif]-->
     </head>
-    <body data-flow-id="{{flowId}}" data-flow-begin="{{flowBeginTime}}">
+    <body data-flow-begin="{{flowBeginTime}}">
         <div id="fox-logo"></div>
         <div id="stage">
           <div id="main-content" class="card">

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -283,9 +283,8 @@ define([
         });
     },
 
-    'flow data attributes are set': function () {
+    'data-flow-begin attribute is set': function () {
       this.remote
-        .then(testAttributeMatches('body', 'data-flow-id', /^[0-9a-f]{64}$/))
         .then(testAttributeMatches('body', 'data-flow-begin', /^[1-9][0-9]{13,}$/));
     }
   });

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -504,9 +504,8 @@ define([
         .end();
     },
 
-    'flow data attributes are set': function () {
+    'data-flow-begin attribute is set': function () {
       this.remote
-        .then(testAttributeMatches('body', 'data-flow-id', /^[0-9a-f]{64}$/))
         .then(testAttributeMatches('body', 'data-flow-begin', /^[1-9][0-9]{13,}$/));
     }
   });

--- a/tests/server/routes/get-index.js
+++ b/tests/server/routes/get-index.js
@@ -2,92 +2,70 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var FLOW_ID_REGEX = /^[0-9a-f]{64}$/;
-
 define([
   'intern!object',
   'intern/chai!assert',
   'intern/dojo/node!bluebird',
   'intern/dojo/node!path',
-  'intern/dojo/node!proxyquire',
   'intern/dojo/node!sinon',
-], function (registerSuite, assert, Promise, path, proxyquire, sinon) {
-  var activityEvent, config, route, request, response;
+  'intern/dojo/node!../../../server/lib/routes/get-index',
+], function (registerSuite, assert, Promise, path, sinon, route) {
+  var config, instance, request, response;
 
   registerSuite({
     name: 'routes/get-index',
 
-    setup: function () {
-      activityEvent = sinon.spy();
-      config = {
-        get: sinon.spy(function () {
-          return 'foo';
-        })
-      };
-      route = proxyquire(path.resolve('server/lib/routes/get-index'), {
-        '../activity-event': activityEvent
-      });
-    },
-
-    'interface is correct': function () {
+    'route interface is correct': function () {
       assert.isFunction(route);
       assert.lengthOf(route, 1);
-
-      var instance = route(config);
-      assert.isObject(instance);
-      assert.lengthOf(Object.keys(instance), 3);
-      assert.equal(instance.method, 'get');
-      assert.equal(instance.path, '/');
-
-      assert.isFunction(instance.process);
-      assert.lengthOf(instance.process, 2);
     },
 
-    'config.get was called correctly': function () {
-      assert.equal(config.get.callCount, 1);
-      var args = config.get.args[0];
-      assert.lengthOf(args, 1);
-      assert.equal(args[0], 'static_resource_url');
-    },
-
-    'route.process': {
+    'initialise route': {
       setup: function () {
-        request = {};
-        response = { render: sinon.spy() };
-        route(config).process(request, response);
+        config = {
+          get: sinon.spy(function () {
+            return 'foo';
+          })
+        };
+        instance = route(config);
       },
 
-      'response.render was called correctly': function () {
-        assert.equal(response.render.callCount, 1);
-
-        var args = response.render.args[0];
-        assert.lengthOf(args, 2);
-
-        assert.equal(args[0], 'index');
-
-        assert.isObject(args[1]);
-        assert.lengthOf(Object.keys(args[1]), 3);
-        assert.match(args[1].flowId, FLOW_ID_REGEX);
-        assert.isAbove(args[1].flowBeginTime, 0);
-        assert.equal(args[1].staticResourceUrl, 'foo');
+      'instance interface is correct': function () {
+        assert.isObject(instance);
+        assert.lengthOf(Object.keys(instance), 3);
+        assert.equal(instance.method, 'get');
+        assert.equal(instance.path, '/');
+        assert.isFunction(instance.process);
+        assert.lengthOf(instance.process, 2);
       },
 
-      'activityEvent was called correctly': function () {
-        assert.equal(activityEvent.callCount, 1);
-        assert.isTrue(activityEvent.calledAfter(response.render));
+      'config.get was called correctly': function () {
+        assert.equal(config.get.callCount, 1);
+        var args = config.get.args[0];
+        assert.lengthOf(args, 1);
+        assert.equal(args[0], 'static_resource_url');
+      },
 
-        var args = activityEvent.args[0];
-        assert.lengthOf(args, 3);
+      'route.process': {
+        setup: function () {
+          request = {};
+          response = { render: sinon.spy() };
+          instance.process(request, response);
+        },
 
-        assert.equal(args[0], 'flow.begin');
+        'response.render was called correctly': function () {
+          assert.equal(response.render.callCount, 1);
 
-        assert.isObject(args[1]);
-        assert.lengthOf(Object.keys(args[1]), 3);
-        assert.equal(args[1].flow_id, response.render.args[0][1].flowId);
-        assert.strictEqual(args[1].flow_time, 0);
-        assert.isAbove(args[1].time, 0);
+          var args = response.render.args[0];
+          assert.lengthOf(args, 2);
 
-        assert.equal(args[2], request);
+          assert.equal(args[0], 'index');
+
+          assert.isObject(args[1]);
+          assert.lengthOf(Object.keys(args[1]), 2);
+          assert.isAbove(args[1].flowBeginTime, 0);
+          assert.equal(args[1].staticResourceUrl, 'foo');
+        }
       }
     }
   });


### PR DESCRIPTION
@shane-tomlinson, as per RL discussion, this change removes the `flow.begin` activity event and the server-generated `flowId`. I'll open a proper issue to handle the resume token and new endpoint shenanigans.