### PR TITLE
feat(server): Enable CSP!

### DIFF
--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -41,6 +41,8 @@ var fourOhFour = require('../lib/404');
 var serverErrorHandler = require('../lib/500');
 var localizedRender = require('../lib/localized-render');
 var csp = require('../lib/csp');
+var cspRulesBlocking = require('../lib/csp/blocking')(config);
+var cspRulesReportOnly = require('../lib/csp/report-only')(config);
 
 
 var STATIC_DIRECTORY =
@@ -75,7 +77,10 @@ function makeApp() {
   app.use(helmet.nosniff());
 
   if (config.get('csp.enabled')) {
-    app.use(csp);
+    app.use(csp({ rules: cspRulesBlocking }));
+  }
+  if (config.get('csp.reportOnlyEnabled')) {
+    app.use(csp({ rules: cspRulesReportOnly }));
   }
 
   app.disable('x-powered-by');

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -70,7 +70,7 @@ var conf = module.exports = convict({
     },
     reportOnly: {
       default: false,
-      doc: 'Only send the "Content-Security-Policy-Report-Only" header'
+      doc: 'DEPRECATED - Only send the "Content-Security-Policy-Report-Only" header'
     },
     reportUri: {
       default: '/_/csp-violation',

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -68,14 +68,24 @@ var conf = module.exports = convict({
       default: false,
       doc: 'Send "Content-Security-Policy" header'
     },
+    /*eslint-disable sorting/sort-object-props*/
+    reportUri: {
+      default: '/_/csp-violation',
+      doc: 'Location of "report-uri" for full, blocking CSP rules'
+    },
     reportOnly: {
       default: false,
       doc: 'DEPRECATED - Only send the "Content-Security-Policy-Report-Only" header'
     },
-    reportUri: {
-      default: '/_/csp-violation',
-      doc: 'Location of "report-uri"'
+    reportOnlyEnabled: {
+      default: false,
+      doc: 'Send "Content-Security-Policy-Report-Only" header'
+    },
+    reportOnlyUri: {
+      default: '/_/csp-violation-report-only',
+      doc: 'Location of "report-uri" for report-only CSP rules'
     }
+    /*eslint-enable sorting/sort-object-props*/
   },
   disable_locale_check: {
     default: false,

--- a/server/lib/csp.js
+++ b/server/lib/csp.js
@@ -7,94 +7,36 @@
 // exception for the /tests/index.html path, which are the frontend unit
 // tests.
 
-var config = require('./configuration');
 var helmet = require('helmet');
-var url = require('url');
 
-var BLOB = 'blob:';
-var CDN_URL = config.get('static_resource_url');
-var DATA = 'data:';
-var GRAVATAR = 'https://secure.gravatar.com';
-var PUBLIC_URL = config.get('public_url');
-var SELF = "'self'";
-
-function addCdnRuleIfRequired(target) {
-  if (CDN_URL !== PUBLIC_URL) {
-    target.push(CDN_URL);
+function isCspRequired(req) {
+  if (req.method !== 'GET') {
+    return false;
   }
-  return target;
-}
 
-function isCspRequired(path) {
+  var path = req.path;
   // is the user running tests? No CSP.
-  return path !== '/tests/index.html' &&
-         ! /\.(js|json|css|woff|ttf|eot|svg|mustache)$/.test(path);
-}
-
-function getOrigin(link) {
-  var parsed = url.parse(link);
-  return parsed.protocol + '//' + parsed.host;
-}
-
-/**
- * blockingCspMiddleware is where to declare rules that will cause a resource
- * to be blocked if it runs afowl of a rule.
- */
-var blockingCspMiddleware = helmet.csp({
-  connectSrc: [
-    SELF,
-    getOrigin(config.get('fxaccount_url')),
-    config.get('oauth_url'),
-    config.get('profile_url'),
-    config.get('marketing_email.api_url')
-  ],
-  defaultSrc: [SELF],
-  fontSrc: addCdnRuleIfRequired([
-    SELF
-  ]),
-  imgSrc: addCdnRuleIfRequired([
-    SELF,
-    DATA,
-    GRAVATAR,
-    config.get('profile_images_url')
-  ]),
-  mediaSrc: [BLOB],
-  reportOnly: false,
-  reportUri: config.get('csp.reportUri'),
-  scriptSrc: addCdnRuleIfRequired([
-    // allow unsafe-eval for functional tests. A report-only middleware
-    // is also added that does not allow 'unsafe-eval' so that we can see
-    // if other scripts are being added.
-    SELF, "'unsafe-eval'"
-  ]),
-  styleSrc: addCdnRuleIfRequired([
-    SELF,
-    // The sha of the embedded <style> tag in default-profile.svg.
-    "'sha256-9n6ek6ecEYlqel7uDyKLy6fdGNo3vw/uScXSq9ooQlk='"
-  ])
-});
-
-/**
- * reportOnlyCspMiddleware is where to declare experimental rules that
- * will not cause a resource to be blocked if it runs afowl of a rule, but will
- * cause the resource to be reported.
- */
-var reportOnlyCspMiddleware = helmet.csp({
-  reportOnly: true,
-  reportUri: config.get('csp.reportUri'),
-  scriptSrc: addCdnRuleIfRequired([
-    SELF
-  ])
-});
-
-module.exports = function (req, res, next) {
-  if (! isCspRequired(req.path)) {
-    return next();
+  if (path === '/tests/index.html') {
+    return false;
   }
 
-  blockingCspMiddleware(req, res, function () {
-    reportOnlyCspMiddleware(req, res, next);
-  });
+  // Only HTML files need CSP headers. Our convention is either .html
+  // extensions or extensionless requests are HTML files. We can't check
+  // the response's Content-Type header yet because the response
+  // hasn't yet been rendered.
+  return /\.html$/.test(path) || ! /\.[a-zA-Z0-9]+$/.test(path);
+}
+
+module.exports = function (config) {
+  var cspMiddleware = helmet.csp(config.rules);
+
+  return function (req, res, next) {
+    if (! isCspRequired(req)) {
+      return next();
+    }
+
+    cspMiddleware(req, res, next);
+  };
 };
 
 module.exports.isCspRequired = isCspRequired;

--- a/server/lib/csp/blocking.js
+++ b/server/lib/csp/blocking.js
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Middleware to take care of CSP. CSP headers are not sent unless config
+// option 'csp.enabled' is set (default true in development), with a special
+// exception for the /tests/index.html path, which are the frontend unit
+// tests.
+
+var url = require('url');
+
+function getOrigin(link) {
+  var parsed = url.parse(link);
+  return parsed.protocol + '//' + parsed.host;
+}
+
+/**
+ * blockingCspMiddleware is where to declare rules that will cause a resource
+ * to be blocked if it runs afowl of a rule.
+ */
+module.exports = function (config) {
+  var BLOB = 'blob:';
+  var CDN_URL = config.get('static_resource_url');
+  var DATA = 'data:';
+  var GRAVATAR = 'https://secure.gravatar.com';
+  var PUBLIC_URL = config.get('public_url');
+  var SELF = "'self'";
+
+
+  function addCdnRuleIfRequired(target) {
+    if (CDN_URL !== PUBLIC_URL) {
+      target.push(CDN_URL);
+    }
+
+    return target;
+  }
+
+  return {
+    connectSrc: [
+      SELF,
+      getOrigin(config.get('fxaccount_url')),
+      config.get('oauth_url'),
+      config.get('profile_url'),
+      config.get('marketing_email.api_url')
+    ],
+    defaultSrc: [SELF],
+    fontSrc: addCdnRuleIfRequired([
+      SELF
+    ]),
+    imgSrc: addCdnRuleIfRequired([
+      SELF,
+      DATA,
+      GRAVATAR,
+      config.get('profile_images_url')
+    ]),
+    mediaSrc: [BLOB],
+    reportOnly: false,
+    reportUri: config.get('csp.reportUri'),
+    scriptSrc: addCdnRuleIfRequired([
+      // allow unsafe-eval for functional tests. A report-only middleware
+      // is also added that does not allow 'unsafe-eval' so that we can see
+      // if other scripts are being added.
+      SELF, "'unsafe-eval'"
+    ]),
+    styleSrc: addCdnRuleIfRequired([
+      SELF,
+      // The sha of the embedded <style> tag in default-profile.svg.
+      "'sha256-9n6ek6ecEYlqel7uDyKLy6fdGNo3vw/uScXSq9ooQlk='"
+    ])
+  };
+};

--- a/server/lib/csp/report-only.js
+++ b/server/lib/csp/report-only.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+/**
+ * reportOnlyCspMiddleware is where to declare experimental rules that
+ * will not cause a resource to be blocked if it runs afowl of a rule, but will
+ * cause the resource to be reported.
+ */
+module.exports = function (config) {
+  var CDN_URL = config.get('static_resource_url');
+  var PUBLIC_URL = config.get('public_url');
+  var SELF = "'self'";
+
+  function addCdnRuleIfRequired(target) {
+    if (CDN_URL !== PUBLIC_URL) {
+      target.push(CDN_URL);
+    }
+
+    return target;
+  }
+
+  return {
+    reportOnly: true,
+    reportUri: config.get('csp.reportOnlyUri'),
+    scriptSrc: addCdnRuleIfRequired([
+      SELF
+    ])
+  };
+};

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -29,14 +29,24 @@ module.exports = function (config, i18n) {
     require('./routes/get-config')(i18n),
     require('./routes/get-client.json')(i18n),
     require('./routes/post-metrics')(),
-    require('./routes/post-csp')({
-      path: config.get('csp.reportUri')
-    }),
     require('./routes/get-metrics-errors')(),
     require('./routes/get-openid-login')(config),
     require('./routes/get-openid-authenticate')(config),
     require('./routes/get-openid-configuration')(config)
   ];
+
+  if (config.get('csp.enabled')) {
+    routes.push(require('./routes/post-csp')({
+      path: config.get('csp.reportUri')
+    }));
+  }
+
+  if (config.get('csp.reportOnlyEnabled')) {
+    routes.push(require('./routes/post-csp')({
+      op: 'server.csp.report-only',
+      path: config.get('csp.reportOnlyUri')
+    }));
+  }
 
   function addVersionPrefix(unversionedUrl) {
     return VERSION_PREFIX + unversionedUrl;

--- a/server/lib/routes/post-csp.js
+++ b/server/lib/routes/post-csp.js
@@ -35,7 +35,7 @@ module.exports = function (options) {
         blocked: report['blocked-uri'],
         column: report['column-number'],
         line: report['line-number'],
-        op: 'server.csp',
+        op: options.op || 'server.csp',
         referrer: stripPIIFromUrl(report['referrer']),
         sample: report['script-sample'],
         source: stripPIIFromUrl(report['source-file']),

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -13,6 +13,7 @@ define([
     'tests/server/routes',
     'tests/server/ver.json.js',
     'tests/server/cookies_disabled',
+    'tests/server/csp',
     'tests/server/l10n',
     'tests/server/lang',
     'tests/server/metrics',

--- a/tests/server/csp.js
+++ b/tests/server/csp.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Ensure the CSP headers are only added to the appropriate requests
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../server/lib/csp',
+], function (registerSuite, assert, csp) {
+
+  var suite = {
+    name: 'csp'
+  };
+
+  suite['isCspRequired'] = function () {
+    assert.isFalse(csp.isCspRequired({ method: 'POST', path: '/csp_report' }));
+    assert.isFalse(csp.isCspRequired({ method: 'GET', path: '/tests/index.html'}));
+    assert.isFalse(csp.isCspRequired({ method: 'GET', path: '/lib/router.js' }));
+    assert.isFalse(csp.isCspRequired({ method: 'GET', path: '/images/firefox.png' }));
+    assert.isFalse(csp.isCspRequired({ method: 'GET', path: '/fonts/clearsans.woff' }));
+
+    assert.isTrue(csp.isCspRequired({ method: 'GET', path: '/404.html' }));
+    assert.isTrue(csp.isCspRequired({ method: 'GET', path: '/' }));
+    assert.isTrue(csp.isCspRequired({ method: 'GET', path: '/confirm' }));
+  };
+
+  registerSuite(suite);
+});
+


### PR DESCRIPTION
Both CSP and CSP-report-only can be used at the same time. This allows us
to enable CSP universally, still have the functional tests run, and still see
if anybody is adding resources we do not expect.

Two CSP middlware configurations are created, one that is "blocking", one
"reportOnly". All the former rules are added to "blocking", scriptSrc was
updated to allow "'unsafe-eval'" to allow the functional tests to run. A second
scriptSrc was added to the reportOnly middlware that does not allow
"'unsafe-eval'", this will allow us to see if anybody has been able to cause
an eval to take place.

fixes #2155

@jrgm, @vladikoff - r?