### PR TITLE
fix(client): Reduce the number of `parseMessage` errors.

### DIFF
--- a/app/scripts/lib/channels/receivers/postmessage.js
+++ b/app/scripts/lib/channels/receivers/postmessage.js
@@ -70,14 +70,11 @@ define(function (require, exports, module) {
         err.context = origin;
 
         this.trigger('error', err);
-        return;
+      } else if (! event.data) {
+        this.trigger('error', new Error('malformed event'));
+      } else {
+        this.trigger('message', event.data);
       }
-
-      if (! event.data) {
-        return this.trigger('error', new Error('malformed event'));
-      }
-
-      this.trigger('message', event.data);
     },
 
     teardown: function () {

--- a/app/tests/spec/lib/channels/receivers/postmessage.js
+++ b/app/tests/spec/lib/channels/receivers/postmessage.js
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
         receiver.receiveEvent({
           data: {},
           origin: 'chrome://browser',
-          type: 'click'
+          type: 'message'
         });
 
         assert.isFalse(errorSpy.called);


### PR DESCRIPTION
*Really* ignore messages from ignored origins.

In 7010bbd9 we intended to ignore postMessage messages from the browser. Due to
an error in both the tests and the code, we logged the error to the console
and did *not* ignore the postMessage message.

Now we log the error to the console AND ignore, for real this time.

fixes #3594