### PR TITLE
fix(client): Do not skip "reset password" screen in force_auth.

### DIFF
--- a/app/scripts/templates/force_auth.mustache
+++ b/app/scripts/templates/force_auth.mustache
@@ -14,7 +14,7 @@
     </div>
     <form novalidate>
       <p class="prefillEmail">{{ email }}</p>
-      <input type="email" class="email hidden" value="{{ email }}" />
+      <input type="email" class="email hidden" value="{{ email }}" disabled />
       <div class="input-row password-row">
         <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" required pattern=".{8,}" value="{{ password }}" required {{#email}}autofocus{{/email}} />
 
@@ -30,7 +30,7 @@
     </form>
 
     <div class="links">
-      <a href="/confirm_reset_password" class="reset-password">{{#t}}Forgot password?{{/t}}</a>
+      <a href="/reset_password" class="reset-password">{{#t}}Forgot password?{{/t}}</a>
     </div>
 
     <div class="extra-links">

--- a/app/scripts/templates/reset_password.mustache
+++ b/app/scripts/templates/reset_password.mustache
@@ -12,7 +12,13 @@
         <a href="https://support.mozilla.org/products/firefox/sync" target="_blank">{{#t}}Learn how Sync works.{{/t}}</a>
       </p>
       <div class="input-row">
-        <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" spellcheck="false" autofocus required>
+        {{#forceEmail}}
+          <p class="prefillEmail">{{ forceEmail }}</p>
+          <input type="email" class="email hidden" value="{{ forceEmail }}" disabled />
+        {{/forceEmail}}
+        {{^forceEmail}}
+          <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" spellcheck="false" autofocus required>
+        {{/forceEmail}}
       </div>
 
       <div class="button-row">
@@ -21,7 +27,12 @@
     </form>
 
     <div class="links">
-      <a href="/signin">{{#t}}Remember password? Sign in.{{/t}}</a>
+      {{#forceEmail}}
+        <a href="/force_auth" class="sign-in">{{#t}}Remember password? Sign in.{{/t}}</a>
+      {{/forceEmail}}
+      {{^forceEmail}}
+        <a href="/signin" class="sign-in">{{#t}}Remember password? Sign in.{{/t}}</a>
+      {{/forceEmail}}
     </div>
 
   </section>

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -6,7 +6,6 @@ define(function (require, exports, module) {
   'use strict';
 
   var _ = require('underscore');
-  var allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
   var AuthErrors = require('lib/auth-errors');
   var BaseView = require('views/base');
   var Cocktail = require('cocktail');
@@ -152,6 +151,12 @@ define(function (require, exports, module) {
       });
     },
 
+    _navigateToForceResetPassword: function () {
+      return this.navigate(this.broker.transformLink('reset_password'), {
+        forceEmail: this.relier.get('email')
+      });
+    },
+
     context: function () {
       return {
         email: this.relier.get('email'),
@@ -160,8 +165,8 @@ define(function (require, exports, module) {
       };
     },
 
-    events: _.extend(SignInView.prototype.events, {
-      'click a[href="/confirm_reset_password"]': BaseView.cancelEventThen('resetPasswordNow')
+    events: _.extend({}, SignInView.prototype.events, {
+      'click a[href="/reset_password"]': BaseView.cancelEventThen('_navigateToForceResetPassword')
     }),
 
     beforeDestroy: function () {
@@ -183,20 +188,6 @@ define(function (require, exports, module) {
 
       return proto.onSignInError.call(this, account, password, error);
     },
-
-    resetPasswordNow: allowOnlyOneSubmit(function () {
-      var self = this;
-      var email = self.relier.get('email');
-
-      return self.resetPassword(email)
-        .fail(function (error) {
-          if (AuthErrors.is(error, 'UNKNOWN_ACCOUNT')) {
-            error = AuthErrors.toError('DELETED_ACCOUNT');
-          }
-
-          self.displayError(error);
-        });
-    }),
 
     /**
      * Displays the account's avatar

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -27,6 +27,12 @@ define(function (require, exports, module) {
       this._formPrefill = options.formPrefill;
     },
 
+    context: function () {
+      return {
+        forceEmail: this.model.get('forceEmail')
+      };
+    },
+
     afterRender: function () {
       if (this.relier.isOAuth()) {
         this.transformLinks();

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -508,51 +508,15 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('resetPasswordNow', function () {
-      var err;
-      var passwordForgotToken = 'foo';
-
+    describe('_navigateToForceResetPassword', function () {
       beforeEach(function () {
-        sinon.stub(view, 'resetPassword', function () {
-          if (err) {
-            return p.reject(err);
-          } else {
-            return p({ passwordForgotToken: passwordForgotToken });
-          }
-        });
-
-        view.$('input[type=password]').val('password');
-        sinon.spy(view, 'displayError');
-
-        return view.resetPasswordNow();
+        return view._navigateToForceResetPassword();
       });
 
-      it('delegates to `resetPassword` with the correct email address', function () {
-        assert.isTrue(view.resetPassword.calledWith(email));
-      });
-
-      it('allows only one forget password request at a time', function () {
-        view.resetPasswordNow();
-        return view.resetPasswordNow()
-          .then(assert.fail, function (err) {
-            assert.equal(err.message, 'submit already in progress');
-          });
-      });
-
-      describe('with email that is deleted while page is open', function () {
-        beforeEach(function () {
-          err = AuthErrors.toError('UNKNOWN_ACCOUNT');
-
-          return view.resetPasswordNow();
-        });
-
-        it('prints an error message and does not allow the user to sign up', function () {
-          assert.isTrue(view.displayError.called);
-          var err = view.displayError.args[0][0];
-          assert.isTrue(AuthErrors.is(err, 'DELETED_ACCOUNT'));
-          // no link to sign up.
-          assert.equal(view.$('.error').find('a').length, 0);
-        });
+      it('navigates to `/reset_password` with the expected email', function () {
+        assert.isTrue(view.navigate.calledWith('reset_password', {
+          forceEmail: email
+        }));
       });
     });
 

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -7,6 +7,7 @@ define(function (require, exports, module) {
 
   var _ = require('underscore');
   var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
   var Broker = require('models/auth_brokers/base');
   var chai = require('chai');
   var FormPrefill = require('models/form-prefill');
@@ -210,10 +211,10 @@ define(function (require, exports, module) {
   });
 
   describe('views/reset_password with email specified in relier', function () {
-    var view;
-    var relier;
     var broker;
     var formPrefill;
+    var relier;
+    var view;
 
     beforeEach(function () {
       relier = new Relier();
@@ -228,6 +229,7 @@ define(function (require, exports, module) {
         formPrefill: formPrefill,
         relier: relier
       });
+
       return view.render();
     });
 
@@ -240,9 +242,48 @@ define(function (require, exports, module) {
     it('does not pre-fills email address', function () {
       assert.equal(view.$('.email').val(), '');
     });
+  });
 
-    it('removes the back button - the user probably browsed here directly', function () {
-      assert.equal(view.$('#back').length, 0);
+  describe('views/reset_password with model.forceEmail', function () {
+    var broker;
+    var email = 'testuser@testuser.com';
+    var formPrefill;
+    var model;
+    var relier;
+    var view;
+
+    beforeEach(function () {
+      broker = new Broker({ relier: relier });
+      formPrefill = new FormPrefill();
+      model = new Backbone.Model({ forceEmail: email });
+      relier = new Relier({ email: email });
+
+      view = new View({
+        broker: broker,
+        formPrefill: formPrefill,
+        model: model,
+        relier: relier
+      });
+
+      return view.render();
+    });
+
+    afterEach(function () {
+      view.destroy();
+      view = null;
+      $('#container').empty();
+    });
+
+    it('shows a readonly email', function () {
+      var $emailInputEl = view.$('[type=email]');
+      assert.equal($emailInputEl.val(), email);
+      assert.isTrue($emailInputEl.hasClass('hidden'));
+
+      assert.equal(view.$('.prefillEmail').text(), email);
+    });
+
+    it('has a link back to /force_auth', function () {
+      assert.ok(view.$('a[href="/force_auth"]').length);
     });
   });
 });

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -164,18 +164,37 @@ define([
         .then(testAccountNoLongerExistsErrorShown);
     },
 
-    'forgot password flow via force-auth goes directly to confirm email screen': function () {
+    'forgot password flow via force_auth': function () {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(openForceAuth({ query: { email: email }}))
         .then(click('.reset-password'))
 
-        .then(testElementExists('#fxa-confirm-reset-password-header'))
-        // user remembers her password, clicks the "sign in" link. They
-        // should go back to the /force_auth screen.
+        .then(testElementExists('#fxa-reset-password-header'))
+        .then(testElementValueEquals('input[type=email]', email))
+        .then(testElementDisabled('input[type=email]'))
+        .then(testElementTextInclude('.prefillEmail', email))
+
+        // User thinks they have remembered their password, clicks the
+        // "sign in" link. Go back to /force_auth.
         .then(click('.sign-in'))
 
-        .then(testElementExists('#fxa-force-auth-header'));
+        .then(testElementExists('#fxa-force-auth-header'))
+        // User goes back to reset password to submit.
+        .then(click('.reset-password'))
+
+        .then(testElementExists('#fxa-reset-password-header'))
+        .then(click('button[type=submit]'))
+
+        .then(testElementExists('#fxa-confirm-reset-password-header'))
+        // User has remembered their password, for real this time.
+        // Go back to /force_auth.
+        .then(click('.sign-in'))
+
+        .then(testElementExists('#fxa-force-auth-header'))
+        .then(testElementValueEquals('input[type=email]', email))
+        .then(testElementDisabled('input[type=email]'))
+        .then(testElementTextInclude('.prefillEmail', email));
     },
 
     'visiting the tos/pp links saves information for return': function () {


### PR DESCRIPTION
The "Forgot password" from force_auth should go to the "reset password" screen
where the email should not be editable.

fixes #3477