### PR TITLE
refactor(client): In siginin, rename `.prefill` to `.prefillEmail`.

### DIFF
--- a/app/scripts/templates/force_auth.mustache
+++ b/app/scripts/templates/force_auth.mustache
@@ -13,7 +13,7 @@
     <div class="avatar-wrapper avatar-view">
     </div>
     <form novalidate>
-      <p class="prefill">{{ email }}</p>
+      <p class="prefillEmail">{{ email }}</p>
       <input type="email" class="email hidden" value="{{ email }}" />
       <div class="input-row password-row">
         <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" required pattern=".{8,}" value="{{ password }}" required {{#email}}autofocus{{/email}} />

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -26,7 +26,7 @@
       {{#suggestedAccount}}
           <div class="avatar-wrapper avatar-view">
           </div>
-          <p class="prefill">{{ email }}</p>
+          <p class="prefillEmail">{{ email }}</p>
 
         {{#chooserAskForPassword}}
           <form novalidate>

--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -151,7 +151,7 @@ section p {
   }
 
 
-  &.prefill {
+  &.prefillEmail {
     word-wrap: break-word;
 
     @include respond-to('reasonableUI') {

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -130,7 +130,7 @@ define(function (require, exports, module) {
         return view.render()
             .then(function () {
               assert.ok($('#fxa-signin-header').length);
-              assert.equal(view.$('.prefill').html(), 'a@a.com');
+              assert.equal(view.$('.prefillEmail').html(), 'a@a.com');
               assert.equal(view.$('[type=password]').val(), '');
             });
       });

--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -149,7 +149,7 @@ define([
               return FunctionalHelpers.openFxaFromRp(self, 'signin');
             })
 
-            .findByCssSelector('.prefill')
+            .findByCssSelector('.prefillEmail')
               .getVisibleText()
               .then(function (text) {
                 // We should see the email we signed up for Sync with

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -402,7 +402,7 @@ define([
         // testing to make sure cached signin comes back after a refresh
         .get(require.toUrl(PAGE_SIGNIN))
 
-        .findByCssSelector('.prefill')
+        .findByCssSelector('.prefillEmail')
         .getVisibleText()
         .then(function (text) {
           // confirm prefilled email
@@ -484,7 +484,7 @@ define([
         // testing to make sure cached signin comes back after a refresh
         .get(require.toUrl(PAGE_SIGNIN))
 
-        .findByCssSelector('.prefill')
+        .findByCssSelector('.prefillEmail')
         .getVisibleText()
         .then(function (text) {
           // confirm prefilled email


### PR DESCRIPTION
Other views use the `prefillEmail` class name for prefilled, non-editible
emails. This PR brings the signin and force_auth views into consistency and applies the same
styles everywhere as a result.

Found while working on #3631

@philbooth - mind an r?