### PR TITLE
refactor(client): Move error reporting from app-start a shared module.

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -80,6 +80,9 @@ define(function (require, exports, module) {
 
     INTERNAL_ERROR_PAGE: '/500.html',
     BAD_REQUEST_PAGE: '/400.html',
+    // delay before redirecting to the error page to
+    // ensure metrics are reported to the backend.
+    ERROR_REDIRECT_TIMEOUT_MS: 1000,
 
     // A relier can indicate they do not want to allow
     // cached credentials if they set email === 'blank'

--- a/app/scripts/lib/error-utils.js
+++ b/app/scripts/lib/error-utils.js
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Error handling utilities
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var Constants = require('lib/constants');
+  var Logger = require('lib/logger');
+  var OAuthErrors = require('lib/oauth-errors');
+  var p = require('lib/promise');
+  var Url = require('lib/url');
+
+  var ERROR_REDIRECT_TIMEOUT_MS = Constants.ERROR_REDIRECT_TIMEOUT_MS;
+
+  module.exports = {
+    ERROR_REDIRECT_TIMEOUT_MS: ERROR_REDIRECT_TIMEOUT_MS,
+
+    /**
+     * Get the URL of the error page to which an error should redirect.
+     *
+     * @param {Error} error - error for which to get error page URL
+     * @param {Object} translator - translator to translate error
+     * @returns {String}
+     */
+    getErrorPageUrl: function (error, translator) {
+      if (AuthErrors.is(error, 'INVALID_PARAMETER') ||
+          AuthErrors.is(error, 'MISSING_PARAMETER') ||
+          OAuthErrors.is(error, 'INVALID_PARAMETER') ||
+          OAuthErrors.is(error, 'MISSING_PARAMETER') ||
+          OAuthErrors.is(error, 'UNKNOWN_CLIENT')) {
+        var queryString = Url.objToSearchString({
+          client_id: error.client_id, //eslint-disable-line camelcase
+          context: error.context,
+          errno: error.errno,
+          message: error.errorModule.toInterpolatedMessage(error, translator),
+          namespace: error.namespace,
+          param: error.param
+        });
+
+        return Constants.BAD_REQUEST_PAGE + queryString;
+      }
+
+      return Constants.INTERNAL_ERROR_PAGE;
+    },
+
+    /**
+     * Report an error to metrics. No metrics report is sent.
+     *
+     * @param {Error} error
+     * @param {Object} sentryMetrics
+     * @param {Object} metrics
+     * @param {Object} window
+     */
+    captureError: function (error, sentryMetrics, metrics, win) {
+      var logger = new Logger(win);
+      logger.error(error);
+
+      sentryMetrics.captureException(error);
+      if (metrics) {
+        metrics.logError(error);
+      }
+    },
+
+    /**
+     * Report an error to metrics. Send metrics report.
+     *
+     * @param {Error} error
+     * @param {Object} sentryMetrics
+     * @param {Object} metrics
+     * @param {Object} window
+     * @returns {promise};
+     */
+    captureAndFlushError: function (error, sentryMetrics, metrics, win) {
+      this.captureError(error, sentryMetrics, metrics, win);
+      return p().then(function () {
+        if (metrics) {
+          return metrics.flush();
+        }
+      });
+    },
+
+    /**
+     * Handle a fatal error. Logs and reports the error, then redirects
+     * to the appropriate error page.
+     *
+     * @param {Error} error
+     * @param {Object} sentryMetrics
+     * @param {Object} metrics
+     * @param {Object} window
+     * @param {Object} translator
+     * @returns {promise}
+     */
+    fatalError: function (error, sentryMetrics, metrics, win, translator) {
+      var self = this;
+
+      return self.captureAndFlushError(error, sentryMetrics, metrics, win)
+        // give a bit of time to flush the Sentry error logs,
+        // otherwise Safari Mobile redirects too quickly.
+        .delay(self.ERROR_REDIRECT_TIMEOUT_MS)
+        .then(function () {
+          var errorPageUrl = self.getErrorPageUrl(error, translator);
+          win.location.href = errorPageUrl;
+        });
+    }
+  };
+});

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -10,6 +10,7 @@ define(function (require, exports, module) {
   var AuthErrors = require('lib/auth-errors');
   var Backbone = require('backbone');
   var Cocktail = require('cocktail');
+  var ErrorUtils = require('lib/error-utils');
   var NotifierMixin = require('views/mixins/notifier-mixin');
   var NullMetrics = require('lib/null-metrics');
   var Logger = require('lib/logger');
@@ -578,10 +579,20 @@ define(function (require, exports, module) {
       }
       err.logged = true;
 
-      this.logger.error(err);
+      ErrorUtils.captureError(err, this.sentryMetrics, this.metrics);
+    },
 
-      this.sentryMetrics.captureException(err);
-      this.metrics.logError(err);
+
+    /**
+     * Handle a fatal error. Logs and reports the error, then redirects
+     * to the appropriate error page.
+     *
+     * @param {Error} error
+     * @returns {promise}
+     */
+    fatalError: function (err) {
+      return ErrorUtils.fatalError(
+        err, this.sentryMetrics, this.metrics, this.window, this.translator);
     },
 
     /**

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -22,7 +22,6 @@ define(function (require, exports, module) {
   var Metrics = require('lib/metrics');
   var Notifier = require('lib/channels/notifier');
   var NullChannel = require('lib/channels/null');
-  var OAuthErrors = require('lib/oauth-errors');
   var OAuthRelier = require('models/reliers/oauth');
   var p = require('lib/promise');
   var Raven = require('raven');
@@ -103,8 +102,6 @@ define(function (require, exports, module) {
 
           return p.reject(new Error('boom!'));
         });
-
-        appStart.ERROR_REDIRECT_TIMEOUT_MS = 10;
 
         return appStart.startApp()
           .then(function () {
@@ -530,28 +527,6 @@ define(function (require, exports, module) {
       it('creates a router', function () {
         appStart.initializeRouter();
         assert.isDefined(appStart._router);
-      });
-    });
-
-    describe('_getErrorPage', function () {
-      var badRequestPageErrors = [
-        AuthErrors.toError('INVALID_PARAMETER'),
-        AuthErrors.toError('MISSING_PARAMETER'),
-        OAuthErrors.toError('INVALID_PARAMETER'),
-        OAuthErrors.toError('MISSING_PARAMETER'),
-        OAuthErrors.toError('UNKNOWN_CLIENT')
-      ];
-
-      badRequestPageErrors.forEach(function (err) {
-        it('redirects to BAD_REQUEST_PAGE for ' + err.message, function () {
-          var errorUrl = appStart._getErrorPage(OAuthErrors.toError('MISSING_PARAMETER'));
-          assert.include(errorUrl, Constants.BAD_REQUEST_PAGE);
-        });
-      });
-
-      it('returns INTERNAL_ERROR_PAGE by default', function () {
-        var errorUrl = appStart._getErrorPage(OAuthErrors.toError('INVALID_ASSERTION'));
-        assert.include(errorUrl, Constants.INTERNAL_ERROR_PAGE);
       });
     });
 

--- a/app/tests/spec/lib/error-utils.js
+++ b/app/tests/spec/lib/error-utils.js
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var chai = require('chai');
+  var Constants = require('lib/constants');
+  var ErrorUtils = require('lib/error-utils');
+  var OAuthErrors = require('lib/oauth-errors');
+  var sinon = require('sinon');
+  var WindowMock = require('../../mocks/window');
+
+  var assert = chai.assert;
+
+  describe('lib/error-utils', function () {
+    var err;
+    var metrics;
+    var sentry;
+    var sandbox;
+    var windowMock;
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+
+      metrics = {
+        flush: sinon.spy(),
+        logError: sinon.spy()
+      };
+
+      sentry = {
+        captureException: sinon.spy()
+      };
+
+      windowMock = new WindowMock();
+      sandbox.spy(windowMock.console, 'error');
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('getErrorPageUrl', function () {
+      var badRequestPageErrors = [
+        AuthErrors.toInvalidParameterError('paramName'),
+        AuthErrors.toMissingParameterError('paramName'),
+        OAuthErrors.toInvalidParameterError('paramName'),
+        OAuthErrors.toMissingParameterError('paramName'),
+        OAuthErrors.toError('UNKNOWN_CLIENT')
+      ];
+
+      badRequestPageErrors.forEach(function (err) {
+        it('redirects to BAD_REQUEST_PAGE for ' + err.message, function () {
+          var errorPageUrl = ErrorUtils.getErrorPageUrl(err);
+          assert.include(errorPageUrl, Constants.BAD_REQUEST_PAGE);
+        });
+      });
+
+      it('returns INTERNAL_ERROR_PAGE by default', function () {
+        var errorPageUrl =
+          ErrorUtils.getErrorPageUrl(OAuthErrors.toError('INVALID_ASSERTION'));
+        assert.include(errorPageUrl, Constants.INTERNAL_ERROR_PAGE);
+      });
+    });
+
+    describe('captureError', function () {
+      beforeEach(function () {
+        err = AuthErrors.toError('UNEXPECTED_ERROR');
+        return ErrorUtils.captureError(err, sentry, metrics, windowMock);
+      });
+
+      it('logs the error to both metrics', function () {
+        assert.isTrue(sentry.captureException.calledWith(err));
+        assert.isTrue(metrics.logError.calledWith(err));
+      });
+
+      it('writes an error message to the console', function () {
+        assert.isTrue(windowMock.console.error.called);
+      });
+    });
+
+    describe('captureAndFlushError', function () {
+      beforeEach(function () {
+        err = AuthErrors.toError('UNEXPECTED_ERROR');
+        return ErrorUtils.captureAndFlushError(
+          err, sentry, metrics, windowMock);
+      });
+
+      it('logs the error to both metrics', function () {
+        assert.isTrue(sentry.captureException.calledWith(err));
+        assert.isTrue(metrics.logError.calledWith(err));
+      });
+
+      it('writes an error message to the console', function () {
+        assert.isTrue(windowMock.console.error.called);
+      });
+
+      it('flushes metrics', function () {
+        assert.isTrue(metrics.flush.called);
+      });
+    });
+
+    describe('fatalError', function () {
+      var translator;
+
+      beforeEach(function () {
+        err = AuthErrors.toError('UNEXPECTED_ERROR');
+
+        // set the timeout to 0 to speed up the tests.
+        ErrorUtils.ERROR_REDIRECT_TIMEOUT_MS = 0;
+        return ErrorUtils.fatalError(
+          err, sentry, metrics, windowMock, translator);
+      });
+
+      it('logs the error to both metrics', function () {
+        assert.isTrue(sentry.captureException.calledWith(err));
+        assert.isTrue(metrics.logError.calledWith(err));
+      });
+
+      it('writes an error message to the console', function () {
+        assert.isTrue(windowMock.console.error.called);
+      });
+
+      it('flushes metrics', function () {
+        assert.isTrue(metrics.flush.called);
+      });
+
+      it('redirects the user to the error page', function () {
+        assert.include(windowMock.location.href, '500.html');
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -12,6 +12,7 @@ define(function (require, exports, module) {
   var BaseView = require('views/base');
   var chai = require('chai');
   var DOMEventMock = require('../../mocks/dom-event');
+  var ErrorUtils = require('lib/error-utils');
   var Metrics = require('lib/metrics');
   var Notifier = require('lib/channels/notifier');
   var p = require('lib/promise');
@@ -661,6 +662,29 @@ define(function (require, exports, module) {
 
         assert.isTrue(view.window.console.trace.calledOnce);
         view.window.console.trace.restore();
+      });
+    });
+
+    describe('fatalError', function () {
+      var err;
+      var sandbox;
+
+      beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+        sandbox.spy(ErrorUtils, 'fatalError');
+
+        err = AuthErrors.toError('UNEXPECTED_ERROR');
+
+        return view.fatalError(err);
+      });
+
+      afterEach(function () {
+        sandbox.restore();
+      });
+
+      it('delegates to the ErrorUtils.fatalError', function () {
+        assert.isTrue(ErrorUtils.fatalError.calledWith(
+          err, view.sentryMetrics, metrics, windowMock, translator));
       });
     });
 

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -37,6 +37,7 @@ function (Translator, Session) {
     '../tests/spec/lib/strings',
     '../tests/spec/lib/auth-errors',
     '../tests/spec/lib/oauth-errors',
+    '../tests/spec/lib/error-utils',
     '../tests/spec/lib/profile-client',
     '../tests/spec/lib/app-start',
     '../tests/spec/lib/validate',


### PR DESCRIPTION
Create lib/error-utils.js to use as shared code.

issue #3040

@vladikoff - I split #3606 in two. This PR contains the refactoring to extract shared error handling code. This PR is also the first commit in #3606. The second commit of #3606 is only adds more validation to force_auth. Hopefully this is a bit easier to review now.