### PR TITLE
chore(ci): add circleci scripts into tests

### DIFF
--- a/tests/ci/config_circleci.json
+++ b/tests/ci/config_circleci.json
@@ -1,0 +1,13 @@
+{
+  "csp": {
+    "enabled": false
+  },
+  "public_url": "http://127.0.0.1:3030",
+  "fxaccount_url": "http://fxadeploybox.dev.lcip.org:9000",
+  "oauth_client_id": "98e6508e88680e1a",
+  "oauth_url": "http://fxadeploybox.dev.lcip.org:9010",
+  "profile_url": "http://fxadeploybox.dev.lcip.org:1111",
+  "profile_images_url": "http://fxadeploybox.dev.lcip.org:1112",
+  "allowed_parent_origins": ["http://fxadeploybox.dev.lcip.org:8080"],
+  "use_https": false
+}

--- a/tests/ci/setvncpass.sh
+++ b/tests/ci/setvncpass.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# This script sets up a default password for VNC
+# If you do not run this then the first time VNC
+# starts it will ask you to set a password.
+
+prog=/usr/bin/vnc4passwd
+mypass="newpass"
+
+/usr/bin/expect <<EOF
+spawn "$prog"
+expect "Password:"
+send "$mypass\r"
+expect "Verify:"
+send "$mypass\r"
+expect eof
+exit
+EOF


### PR DESCRIPTION
Domain that pulls this config for circleci is expiring in the next few days so I'm adding the configs into `tests/ci`