### PR TITLE
feat(signin): handle new account must reset error (126)

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -514,6 +514,7 @@ define(function (require, exports, module) {
         notifier: self._notifier,
         relier: self._relier,
         sentryMetrics: self._sentryMetrics,
+        session: Session,
         user: self._user,
         window: self._window
       }, self._router.getViewOptions(options || {}));

--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -96,6 +96,10 @@ define(function (require, exports, module) {
       errno: 122,
       message: UNEXPECTED_ERROR_MESSAGE
     },
+    ACCOUNT_RESET: {
+      errno: 126,
+      message: t('Your account has been locked for security reasons')
+    },
     SERVER_BUSY: {
       errno: 201,
       message: t('Server busy, try again soon')

--- a/app/scripts/views/mixins/account-reset-mixin.js
+++ b/app/scripts/views/mixins/account-reset-mixin.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Handle reset accounts. Mixed into views.
+ *
+ * @class AccountResetMixin
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+
+  var t = BaseView.t;
+
+  var AccountResetMixin = {
+    initialize: function (options) {
+      options = options || {};
+
+      this._session = options.session;
+    },
+
+    events: {
+      'click a[href="/confirm_reset_password"]':
+          BaseView.preventDefaultThen('sendAccountResetEmail')
+    },
+
+    /**
+     * Notify the user their account has been reset
+     *
+     * @param {object} account - account that has been reset
+     */
+    notifyOfResetAccount: function (account) {
+      this._resetAccount = account;
+
+      var err = AuthErrors.toError('ACCOUNT_RESET');
+
+      err.forceMessage =
+        t('Your account has been locked for security reasons') + '<br>' +
+        '<a href="/confirm_reset_password">' + t('Reset password') + '</a>';
+
+      return this.displayErrorUnsafe(err);
+    },
+
+    /**
+     * Send the account reset email
+     *
+     * @returns {promise} - resolves when complete
+     */
+    sendAccountResetEmail: function () {
+      var self = this;
+      var account = self._resetAccount;
+
+      return self.resetPassword(account.get('email'))
+        .fail(function (err) {
+          self._session.clear('oauth');
+          self.displayError(err);
+        });
+    }
+  };
+
+  module.exports = AccountResetMixin;
+});
+

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var AccountLockedMixin = require('views/mixins/account-locked-mixin');
+  var AccountResetMixin = require('views/mixins/account-reset-mixin');
   var allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
   var AuthErrors = require('lib/auth-errors');
   var AvatarMixin = require('views/mixins/avatar-mixin');
@@ -77,8 +78,7 @@ define(function (require, exports, module) {
 
     events: {
       'click .use-different': 'useDifferentAccount',
-      'click .use-logged-in': 'useLoggedInAccount',
-      'click a[href="/confirm_reset_password"]': 'resetPasswordNow'
+      'click .use-logged-in': 'useLoggedInAccount'
     },
 
     afterRender: function () {
@@ -133,7 +133,7 @@ define(function (require, exports, module) {
       } else if (AuthErrors.is(err, 'ACCOUNT_LOCKED')) {
         return self.notifyOfLockedAccount(account, password);
       } else if (AuthErrors.is(err, 'ACCOUNT_RESET')) {
-        return self._suggestReset(err);
+        return self.notifyOfResetAccount(account);
       }
       // re-throw error, it will be handled at a lower level.
       throw err;
@@ -142,23 +142,6 @@ define(function (require, exports, module) {
     _suggestSignUp: function (err) {
       err.forceMessage = t('Unknown account. <a href="/signup">Sign up</a>');
       return this.displayErrorUnsafe(err);
-    },
-
-    _suggestReset: function (err) {
-      this.email = err.email;
-      var msg = t('Your account has been locked for security reasons') + '<br>' +
-        '<a href="/confirm_reset_password">' + t('Reset password') + '</a>';
-      err.forceMessage = msg;
-      return this.displayErrorUnsafe(err);
-    },
-
-    resetPasswordNow: function () {
-      var self = this;
-      return self.resetPassword(self.email)
-        .fail(function (err) {
-          Session.clear('oauth');
-          throw err;
-        });
     },
 
     /**
@@ -270,6 +253,7 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     AccountLockedMixin,
+    AccountResetMixin,
     AvatarMixin,
     MigrationMixin,
     PasswordMixin,

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -4,6 +4,8 @@
 define(function (require, exports, module) {
   'use strict';
 
+  var AccountLockedMixin = require('views/mixins/account-locked-mixin');
+  var AccountResetMixin = require('views/mixins/account-reset-mixin');
   var AuthErrors = require('lib/auth-errors');
   var BaseView = require('views/base');
   var CheckboxMixin = require('views/mixins/checkbox-mixin');
@@ -307,6 +309,10 @@ define(function (require, exports, module) {
         } else {
           throw AuthErrors.toError('AGE_REQUIRED');
         }
+      } else if (AuthErrors.is(err, 'ACCOUNT_LOCKED')) {
+        return this.notifyOfLockedAccount(account, password);
+      } else if (AuthErrors.is(err, 'ACCOUNT_RESET')) {
+        return this.notifyOfResetAccount(account);
       }
 
       // re-throw error, it will be handled at a lower level.
@@ -401,6 +407,8 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     View,
+    AccountLockedMixin,
+    AccountResetMixin,
     CheckboxMixin,
     ExperimentMixin,
     MigrationMixin,

--- a/app/tests/spec/views/mixins/account-reset-mixin.js
+++ b/app/tests/spec/views/mixins/account-reset-mixin.js
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var AccountResetMixin = require('views/mixins/account-reset-mixin');
+  var AuthErrors = require('lib/auth-errors');
+  var BaseView = require('views/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var FxaClient = require('lib/fxa-client');
+  var Metrics = require('lib/metrics');
+  var Notifier = require('lib/channels/notifier');
+  var p = require('lib/promise');
+  var Relier = require('models/reliers/base');
+  var sinon = require('sinon');
+  var Template = require('stache!templates/test_template');
+  var User = require('models/user');
+
+  var assert = Chai.assert;
+
+  var EMAIL = 'testuser@testuser.com';
+
+  var AccountResetView = BaseView.extend({
+    template: Template,
+    resetPassword: function () {
+      return p();
+    }
+  });
+  Cocktail.mixin(AccountResetView, AccountResetMixin);
+
+  describe('views/mixins/account-reset-mixin', function () {
+    var account;
+    var fxaClient;
+    var metrics;
+    var notifier;
+    var relier;
+    var session;
+    var view;
+
+    beforeEach(function () {
+      account = new User().initAccount({
+        email: EMAIL
+      });
+
+      fxaClient = new FxaClient();
+      metrics = new Metrics();
+      notifier = new Notifier();
+      relier = new Relier();
+      session = {
+        clear: sinon.spy()
+      };
+
+      view = new AccountResetView({
+        fxaClient: fxaClient,
+        metrics: metrics,
+        notifier: notifier,
+        relier: relier,
+        session: session,
+        viewName: 'delete-account'  // just an example name
+      });
+
+      return view.render();
+    });
+
+    describe('notifyOfResetAccount', function () {
+      beforeEach(function () {
+        sinon.spy(view, 'displayErrorUnsafe');
+
+        view.notifyOfResetAccount(account);
+      });
+
+      it('displays an error with a `send reset email` link', function () {
+        assert.isTrue(view.displayErrorUnsafe.called);
+        var err = view.displayErrorUnsafe.args[0][0];
+        assert.isTrue(AuthErrors.is(err, 'ACCOUNT_RESET'));
+
+        assert.include(view.$('.error').html(), '/confirm_reset_password');
+      });
+    });
+
+    describe('sendAccountResetEmail', function () {
+      describe('with a registered account', function () {
+        beforeEach(function () {
+          sinon.stub(view, 'resetPassword', function () {
+            return p();
+          });
+
+          view.notifyOfResetAccount(account);
+          return view.sendAccountResetEmail();
+        });
+
+        it('sends a reset email', function () {
+          assert.isTrue(view.resetPassword.calledWith(EMAIL));
+        });
+      });
+
+      describe('with an error', function () {
+        beforeEach(function () {
+          sinon.stub(view, 'resetPassword', function () {
+            return p.reject(AuthErrors.toError('UNKNOWN_ACCOUNT'));
+          });
+
+          view.notifyOfResetAccount(account, 'password');
+          return view.sendAccountResetEmail();
+        });
+
+        it('displays the error', function () {
+          assert.isTrue(view.isErrorVisible());
+        });
+
+        it('clears session.oauth', function () {
+          assert.isTrue(session.clear.calledWith('oauth'));
+        });
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -231,7 +231,7 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('with a locked out user', function () {
+      describe('with a locked out account', function () {
         beforeEach(function () {
           sinon.stub(view, 'signIn', function () {
             return p.reject(AuthErrors.toError('ACCOUNT_LOCKED'));
@@ -249,6 +249,25 @@ define(function (require, exports, module) {
           assert.instanceOf(account, Account);
           var lockedAccountPassword = args[1];
           assert.equal(lockedAccountPassword, 'password');
+        });
+      });
+
+      describe('with a reset account', function () {
+        beforeEach(function () {
+          sinon.stub(view, 'signIn', function () {
+            return p.reject(AuthErrors.toError('ACCOUNT_RESET'));
+          });
+
+          sinon.spy(view, 'notifyOfResetAccount');
+
+          return view.submit();
+        });
+
+        it('notifies the user of the reset account', function () {
+          assert.isTrue(view.notifyOfResetAccount.called);
+          var args = view.notifyOfResetAccount.args[0];
+          var account = args[0];
+          assert.instanceOf(account, Account);
         });
       });
 

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -827,6 +827,70 @@ define(function (require, exports, module) {
           });
         });
 
+        describe('signin fails with a locked out account', function () {
+          beforeEach(function () {
+            sinon.stub(view, 'signIn', function () {
+              return p.reject(AuthErrors.toError('ACCOUNT_LOCKED'));
+            });
+
+            sinon.spy(view, 'notifyOfLockedAccount');
+
+            return view.submit();
+          });
+
+          it('does not call view.signUp', function () {
+            assert.isFalse(view.signUp.called);
+          });
+
+          it('calls view.signIn correctly', function () {
+            assert.equal(view.signIn.callCount, 1);
+
+            var args = view.signIn.args[0];
+            assert.instanceOf(args[0], Account);
+            assert.equal(args[1], 'password');
+          });
+
+          it('notifies the user of the locked account', function () {
+            assert.isTrue(view.notifyOfLockedAccount.called);
+            var args = view.notifyOfLockedAccount.args[0];
+            var account = args[0];
+            assert.instanceOf(account, Account);
+            var lockedAccountPassword = args[1];
+            assert.equal(lockedAccountPassword, 'password');
+          });
+        });
+
+        describe('signin failse with a reset accont', function () {
+          beforeEach(function () {
+            sinon.stub(view, 'signIn', function () {
+              return p.reject(AuthErrors.toError('ACCOUNT_RESET'));
+            });
+
+            sinon.spy(view, 'notifyOfResetAccount');
+
+            return view.submit();
+          });
+
+          it('does not call view.signUp', function () {
+            assert.isFalse(view.signUp.called);
+          });
+
+          it('calls view.signIn correctly', function () {
+            assert.equal(view.signIn.callCount, 1);
+
+            var args = view.signIn.args[0];
+            assert.instanceOf(args[0], Account);
+            assert.equal(args[1], 'password');
+          });
+
+          it('notifies the user of the reset account', function () {
+            assert.isTrue(view.notifyOfResetAccount.called);
+            var args = view.notifyOfResetAccount.args[0];
+            var account = args[0];
+            assert.instanceOf(account, Account);
+          });
+        });
+
         describe('signin fails with some other error', function () {
           beforeEach(function () {
             sandbox.stub(view, 'signIn', function () {

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -125,6 +125,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/avatar-mixin',
     '../tests/spec/views/mixins/back-mixin',
     '../tests/spec/views/mixins/account-locked-mixin',
+    '../tests/spec/views/mixins/account-reset-mixin',
     '../tests/spec/views/mixins/checkbox-mixin',
     '../tests/spec/views/mixins/notifier-mixin',
     '../tests/spec/views/mixins/loading-mixin',


### PR DESCRIPTION
display an error message on signin when the user must reset with a link to /confirm_password_reset