### PR TITLE
refactor(client): Extract open-gmail logic into a mixin to be shared.

### DIFF
--- a/app/scripts/templates/confirm.mustache
+++ b/app/scripts/templates/confirm.mustache
@@ -15,7 +15,7 @@
 
     {{#isOpenGmailButtonVisible}}
       <div class="button-row">
-        <a href="https://mail.google.com/mail/u/?authuser={{ safeEmail }}" class="button" target="_blank" id="open-gmail" type="button">{{#t}}Open Gmail{{/t}}</a>
+        <a href="{{{ gmailLink }}}" class="button" target="_blank" id="open-gmail" type="button">{{#t}}Open Gmail{{/t}}</a>
       </div>
     {{/isOpenGmailButtonVisible}}
 

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -56,5 +56,6 @@
 
   <a id="external-link" href="http://external.com">External link</a>
   <a id="internal-link" href="/signin">Internal link</a>
+  <a id="open-gmail" href="">Open GMail</a>
 </div>
 

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
   var Constants = require('lib/constants');
   var ExperimentMixin = require('views/mixins/experiment-mixin');
   var FormView = require('views/form');
+  var OpenGmailMixin = require('views/mixins/open-gmail-mixin');
   var p = require('lib/promise');
   var ResendMixin = require('views/mixins/resend-mixin');
   var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
@@ -43,20 +44,12 @@ define(function (require, exports, module) {
 
       return {
         email: email,
-        isOpenGmailButtonVisible: this._isOpenGmailButtonVisible(),
-        safeEmail: encodeURIComponent(email)
+        gmailLink: this.getGmailUrl(email),
+        isOpenGmailButtonVisible: this.isOpenGmailButtonVisible(email)
       };
     },
 
-    _isOpenGmailButtonVisible: function () {
-      var email = this.getAccount().get('email');
-      // The "Open Gmail" is only visible in certain contexts
-      // we do not show it in mobile contexts because it performs worse on mobile
-      return this.broker.hasCapability('openGmailButtonVisible') && email.indexOf('@gmail.com') > 0;
-    },
-
     events: {
-      'click #open-gmail': '_gmailTabOpened',
       // validateAndSubmit is used to prevent multiple concurrent submissions.
       'click #resend': BaseView.preventDefaultThen('validateAndSubmit')
     },
@@ -204,6 +197,7 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     ExperimentMixin,
+    OpenGmailMixin,
     ResendMixin,
     ResumeTokenMixin,
     ServiceMixin

--- a/app/scripts/views/mixins/open-gmail-mixin.js
+++ b/app/scripts/views/mixins/open-gmail-mixin.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+/**
+ * A view mixin that helps confirm* views show the "Open Gmail" button
+ * directly from FxA.
+ */
+define(function (require, exports, module) {
+  'use strict';
+
+  return {
+    events: {
+      'click #open-gmail': '_gmailTabOpened'
+    },
+
+    /**
+     * Check if the `Open Gmail` button should be visible
+     *
+     * @param {string} email
+     * @returns {boolean}
+     */
+    isOpenGmailButtonVisible: function (email) {
+      // The "Open Gmail" is only visible in certain contexts
+      // we do not show it in mobile contexts because it performs worse on mobile
+      return this.broker.hasCapability('openGmailButtonVisible') &&
+             /@gmail\.com$/.test(email);
+    },
+
+    /**
+     * Get the GMail URL for the given email
+     *
+     * @param {string} email
+     * @returns {string}
+     */
+    getGmailUrl: function (email) {
+      return 'https://mail.google.com/mail/u/?authuser=' + encodeURIComponent(email);
+    },
+
+    _gmailTabOpened: function () {
+      this.logViewEvent('openGmail.clicked');
+    }
+  };
+
+});

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -408,14 +408,6 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('_gmailTabOpened', function () {
-      it('triggers gmail tab opening', function () {
-        sinon.spy(view.notifier, 'trigger');
-        view._gmailTabOpened();
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'confirm.openGmail.clicked'));
-      });
-    });
-
     describe('openGmail feature', function () {
       it('it is not visible in basic contexts', function () {
         assert.notOk($('#open-gmail').length);
@@ -452,28 +444,6 @@ define(function (require, exports, module) {
           .then(function () {
             $('#container').html(view.el);
             assert.lengthOf(view.$('#open-gmail'), 1);
-          });
-      });
-
-      it('is not visible with the the openGmailButtonVisible capability and email is not @gmail.com', function () {
-        broker.setCapability('openGmailButtonVisible', true);
-
-        view = new View({
-          broker: broker,
-          fxaClient: fxaClient,
-          metrics: metrics,
-          model: model,
-          notifier: notifier,
-          relier: relier,
-          user: user,
-          viewName: 'confirm',
-          window: windowMock
-        });
-
-        return view.render()
-          .then(function () {
-            $('#container').html(view.el);
-            assert.lengthOf(view.$('#open-gmail'), 0);
           });
       });
     });

--- a/app/tests/spec/views/mixins/open-gmail-mixin.js
+++ b/app/tests/spec/views/mixins/open-gmail-mixin.js
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var BaseView = require('views/base');
+  var Broker = require('models/auth_brokers/base');
+  var Chai = require('chai');
+  var Cocktail = require('cocktail');
+  var OpenGmailMixin = require('views/mixins/open-gmail-mixin');
+  var sinon = require('sinon');
+  var Template = require('stache!templates/test_template');
+
+  var assert = Chai.assert;
+
+  var ConfirmView = BaseView.extend({
+    template: Template
+  });
+
+  Cocktail.mixin(
+    ConfirmView,
+    OpenGmailMixin
+  );
+
+  describe('views/mixins/open-gmail-mixin', function () {
+    var broker;
+    var view;
+
+    beforeEach(function () {
+      broker = new Broker();
+
+      view = new ConfirmView({
+        broker: broker
+      });
+    });
+
+    afterEach(function () {
+      view.remove();
+      view.destroy();
+    });
+
+    describe('isOpenGmailButtonVisible', function () {
+      describe('without broker support', function () {
+        beforeEach(function () {
+          broker.unsetCapability('openGmailButtonVisible');
+        });
+
+        it('returns false even for gmail addresses', function () {
+          assert.isFalse(view.isOpenGmailButtonVisible('testuser@gmail.com'));
+        });
+      });
+
+      describe('with broker support', function () {
+        beforeEach(function () {
+          broker.setCapability('openGmailButtonVisible', true);
+        });
+
+        describe('with a non-gmail address', function () {
+          it('returns false', function () {
+            assert.isFalse(view.isOpenGmailButtonVisible('testuser@yahoo.com'));
+          });
+        });
+
+        describe('with an address that has gmail.com that isn\'t', function () {
+          it('returns false', function () {
+            assert.isFalse(view.isOpenGmailButtonVisible('testuser@mygmail.com'));
+            assert.isFalse(view.isOpenGmailButtonVisible('gmail.com@yahoo.com'));
+          });
+        });
+
+        describe('with a gmail address', function () {
+          it('returns true', function () {
+            assert.isTrue(view.isOpenGmailButtonVisible('testuser@gmail.com'));
+          });
+        });
+      });
+    });
+
+    describe('getGmailUrl', function () {
+      it('returns a URL', function () {
+        var email = 'testuser@gmail.com';
+        var gmailUrl = view.getGmailUrl(email);
+        assert.include(gmailUrl, 'https://mail.google.com/mail/u/?authuser=');
+        assert.include(gmailUrl, encodeURIComponent(email));
+      });
+    });
+
+    describe('click on `open-gmail` button', function () {
+      beforeEach(function () {
+        sinon.spy(view, 'logViewEvent');
+
+        return view.render()
+          .then(function () {
+            $('#container').html(view.el);
+          })
+          .then(function () {
+            $('#open-gmail').click();
+          });
+      });
+
+      it('calls logViewEvent', function () {
+        assert.isTrue(view.logViewEvent.calledWith('openGmail.clicked'));
+      });
+    });
+  });
+});
+

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -131,6 +131,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/loading-mixin',
     '../tests/spec/views/mixins/migration-mixin',
     '../tests/spec/views/mixins/modal-settings-panel-mixin',
+    '../tests/spec/views/mixins/open-gmail-mixin',
     '../tests/spec/views/mixins/settings-panel-mixin',
     '../tests/spec/views/mixins/signed-in-notification-mixin',
     '../tests/spec/views/mixins/signed-out-notification-mixin',


### PR DESCRIPTION
Open Gmail is going to be used on the "confirm sign-in" screen

@vbudhram - mind reviewing this?