### PR TITLE
fix: Close the settings screen panes when back button is pressed

### DIFF
--- a/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/app/scripts/views/mixins/settings-panel-mixin.js
@@ -53,4 +53,24 @@ define(function (require, exports, module) {
       self.closePanel();
     }
   };
+  if (window.history && window.history.pushState) {
+    $(window).on('popstate', function() {
+      var hashLocation = location.hash;
+      var hashSplit = hashLocation.split('#!/');
+      var hashName = hashSplit[1];
+
+      if (hashName !== '') {
+        var hash = window.location.hash;
+        if (hash === '') {
+          var openElements = $('.settings-child-view').find('.open');
+          if(openElements !== '' || openElements !== undefined){
+            for(var i = 0 ; i < openElements.length; i++){
+              $(openElements[i]).removeClass('open');
+            }
+          }
+        }
+      }
+    });
+  }
+
 });


### PR DESCRIPTION
The screen panes now close when back button is pressed. The details of the issue can be found here: https://github.com/mozilla/fxa-content-server/issues/3386#issuecomment-199949785