### PR TITLE
feat(client): implement resume token validation

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -256,6 +256,14 @@ define(function (require, exports, module) {
     DELETED_ACCOUNT: {
       errno: 1034,
       message: t('Account no longer exists.')
+    },
+    INVALID_RESUME_TOKEN_PROPERTY: {
+      errno: 1035,
+      message: t('Invalid property in resume token: %(property)s')
+    },
+    MISSING_RESUME_TOKEN_PROPERTY: {
+      errno: 1036,
+      message: t('Missing property in resume token: %(property)s')
     }
   };
   /*eslint-enable sorting/sort-object-props*/
@@ -278,6 +286,14 @@ define(function (require, exports, module) {
         } else if (this.is(err, 'MISSING_PARAMETER')) {
           return {
             param: err.param
+          };
+        } else if (this.is(err, 'INVALID_RESUME_TOKEN_PROPERTY')) {
+          return {
+            property: err.property
+          };
+        } else if (this.is(err, 'MISSING_RESUME_TOKEN_PROPERTY')) {
+          return {
+            property: err.property
           };
         }
       } catch (e) {

--- a/app/scripts/lib/errors.js
+++ b/app/scripts/lib/errors.js
@@ -157,6 +157,34 @@ define(function (require, exports, module) {
     },
 
     /**
+     * Create an INVALID_RESUME_TOKEN_PROPERTY error.
+     * The returned error will have `property` set to
+     * the property name.
+     *
+     * @property {String} propertyName
+     * @returns {Error}
+     */
+    toInvalidResumeTokenPropertyError: function (propertyName) {
+      var err = this.toError('INVALID_RESUME_TOKEN_PROPERTY');
+      err.property = propertyName;
+      return err;
+    },
+
+    /**
+     * Create a MISSING_RESUME_TOKEN_PROPERTY error.
+     * The returned error will have `property` set to
+     * the property name.
+     *
+     * @property {String} propertyName
+     * @returns {Error}
+     */
+    toMissingResumeTokenPropertyError: function (propertyName) {
+      var err = this.toError('MISSING_RESUME_TOKEN_PROPERTY');
+      err.property = propertyName;
+      return err;
+    },
+
+    /**
      * Check if an error is of the given type
      */
     is: function (error, type) {

--- a/app/scripts/models/mixins/resume-token.js
+++ b/app/scripts/models/mixins/resume-token.js
@@ -5,14 +5,23 @@
 /**
  * A model mixin to work with ResumeTokens.
  *
- * A model should set the array `resumeTokenFields` to add/change
- * fields that are saved to and populated from the ResumeToken.
+ * Expects the following properties on `this`:
+ *
+ *   - resumeTokenFields: array of fields that are serialized to and
+ *                        parsed from the resume token.
+ *
+ *   - resumeTokenSchema: array of vat validators that will be applied
+ *                        when parsing from the resume token.
+ *
+ *   - sentryMetrics: object for reporting validation errors to Sentry.
  */
 
 define(function (require, exports, module) {
   'use strict';
 
+  var authErrors = require('lib/auth-errors');
   var ResumeToken = require('models/resume-token');
+  var vat = require('lib/vat');
 
   module.exports = {
     /**
@@ -28,8 +37,9 @@ define(function (require, exports, module) {
     },
 
     /**
-     * Sets model properties from a stringified ResumeToken. A stringified
-     * ResumeToken is generally one passed in the `resume` query parameter.
+     * Sets model properties from a stringified ResumeToken, unless said token
+     * is invalid according to `this.resumeTokenSchema`. A stringified ResumeToken
+     * is generally one passed in the `resume` query parameter.
      *
      * @method populateFromStringifiedResumeToken
      * @param {String} stringifiedResumeToken
@@ -44,16 +54,47 @@ define(function (require, exports, module) {
     },
 
     /**
-     * Sets model properties from a ResumeToken.
+     * Sets model properties from a ResumeToken, unless said token
+     * is invalid according to `this.resumeTokenSchema`.
      *
      * @method populateFromResumeToken
      * @param {ResumeToken} resumeToken
      */
     populateFromResumeToken: function (resumeToken) {
       if (this.resumeTokenFields) {
-        this.set(resumeToken.pick(this.resumeTokenFields));
+        var pickedResumeToken = resumeToken.pick(this.resumeTokenFields);
+
+        if (isResumeTokenValid.call(this, pickedResumeToken)) {
+          this.set(pickedResumeToken);
+        }
       }
     }
   };
+
+  function isResumeTokenValid (resumeToken) {
+    if (this.resumeTokenSchema) {
+      var error = vat.validate(resumeToken, this.resumeTokenSchema).error;
+
+      if (error) {
+        if (this.sentryMetrics) {
+          if (error instanceof ReferenceError) {
+            error = authErrors.toMissingResumeTokenPropertyError(error.key);
+          } else {
+            error = authErrors.toInvalidResumeTokenPropertyError(error.key);
+          }
+
+          // HACK: Interpolate the invalid property name into the error
+          //       message. One day this will be handled automagically.
+          error.message = authErrors.toInterpolatedMessage(error);
+
+          this.sentryMetrics.captureException(error);
+        }
+
+        return false;
+      }
+    }
+
+    return true;
+  }
 });
 

--- a/app/tests/spec/lib/auth-errors.js
+++ b/app/tests/spec/lib/auth-errors.js
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
         err = AuthErrors.toInvalidParameterError('param name', AuthErrors);
       });
 
-      it('creates an INVALID_PARAMTER Error', function () {
+      it('creates an INVALID_PARAMETER Error', function () {
         assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
         assert.equal(err.param, 'param name');
       });
@@ -52,12 +52,37 @@ define(function (require, exports, module) {
         err = AuthErrors.toMissingParameterError('param name', AuthErrors);
       });
 
-      it('creates an MISSING_PARAMTER Error', function () {
+      it('creates an MISSING_PARAMETER Error', function () {
         assert.isTrue(AuthErrors.is(err, 'MISSING_PARAMETER'));
         assert.equal(err.param, 'param name');
       });
     });
 
+    describe('toInvalidResumeTokenPropertyError', function () {
+      var err;
+
+      before(function () {
+        err = AuthErrors.toInvalidResumeTokenPropertyError('foo', AuthErrors);
+      });
+
+      it('creates an INVALID_RESUME_TOKEN_PROPERTY Error', function () {
+        assert.isTrue(AuthErrors.is(err, 'INVALID_RESUME_TOKEN_PROPERTY'));
+        assert.equal(err.property, 'foo');
+      });
+    });
+
+    describe('toMissingResumeTokenPropertyError', function () {
+      var err;
+
+      before(function () {
+        err = AuthErrors.toMissingResumeTokenPropertyError('bar', AuthErrors);
+      });
+
+      it('creates an MISSING_RESUME_TOKEN_PROPERTY Error', function () {
+        assert.isTrue(AuthErrors.is(err, 'MISSING_RESUME_TOKEN_PROPERTY'));
+        assert.equal(err.property, 'bar');
+      });
+    });
 
     describe('toMessage', function () {
       it('converts a code to a message', function () {

--- a/app/tests/spec/models/mixins/resume-token.js
+++ b/app/tests/spec/models/mixins/resume-token.js
@@ -10,23 +10,35 @@ define(function (require, exports, module) {
   var Cocktail = require('cocktail');
   var ResumeToken = require('models/resume-token');
   var ResumeTokenMixin = require('models/mixins/resume-token');
+  var sinon = require('sinon');
+  var vat = require('lib/vat');
 
   var assert = chai.assert;
 
   describe('models/mixins/resume-token', function () {
-    var model;
-    var CAMPAIGN = 'campaign id';
-    var RESUME_DATA = {
+    var model, sentryMetrics;
+    var CAMPAIGN = 'deadbeef';
+    var RESUME_SCHEMA = {
+      campaign: vat.hex().len(8).required()
+    };
+    var VALID_RESUME_DATA = {
       campaign: CAMPAIGN,
       notResumeable: 'this should not be picked'
     };
+    var INVALID_RESUME_DATA = {
+      campaign: 'foo'
+    };
+    var MISSING_RESUME_DATA = {};
 
     var Model = Backbone.Model.extend({
       initialize: function (options) {
+        this.sentryMetrics = sentryMetrics;
         this.window = options.window;
       },
 
-      resumeTokenFields: ['campaign']
+      resumeTokenFields: ['campaign'],
+
+      resumeTokenSchema: RESUME_SCHEMA
     });
 
     Cocktail.mixin(
@@ -35,12 +47,15 @@ define(function (require, exports, module) {
     );
 
     beforeEach(function () {
+      sentryMetrics = {
+        captureException: sinon.spy()
+      };
       model = new Model({});
     });
 
     describe('pickResumeTokenInfo', function () {
       it('returns an object with info to be passed along with email verification links', function () {
-        model.set(RESUME_DATA);
+        model.set(VALID_RESUME_DATA);
 
         assert.deepEqual(model.pickResumeTokenInfo(), {
           campaign: CAMPAIGN
@@ -48,24 +63,111 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('populateFromResumeToken', function () {
-      it('populates the model with data from the ResumeToken', function () {
-        var resumeToken = new ResumeToken(RESUME_DATA);
+    describe('populateFromResumeToken with valid data', function () {
+      beforeEach(function () {
+        var resumeToken = new ResumeToken(VALID_RESUME_DATA);
         model.populateFromResumeToken(resumeToken);
+      });
 
+      it('populates the model with data from the ResumeToken', function () {
         assert.equal(model.get('campaign'), CAMPAIGN);
         assert.isFalse(model.has('notResumeable'), 'only allow specific resume token values');
       });
+
+      it('does not call sentryMetrics.captureException', function () {
+        assert.strictEqual(sentryMetrics.captureException.callCount, 0);
+      });
     });
 
-    describe('populateFromStringifiedResumeToken', function () {
-      it('parses the resume param into an object', function () {
-        var stringifiedResumeToken = ResumeToken.stringify(RESUME_DATA);
+    describe('populateFromResumeToken with invalid data', function () {
+      beforeEach(function () {
+        var resumeToken = new ResumeToken(INVALID_RESUME_DATA);
+        model.populateFromResumeToken(resumeToken);
+      });
 
+      it('does not populate the model', function () {
+        assert.isFalse(model.has('campaign'));
+      });
+
+      it('called sentryMetrics.captureException correctly', function () {
+        assert.strictEqual(sentryMetrics.captureException.callCount, 1);
+        var args = sentryMetrics.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.instanceOf(args[0], Error);
+        assert.strictEqual(args[0].message, 'Invalid property in resume token: campaign');
+      });
+    });
+
+    describe('populateFromResumeToken with missing data', function () {
+      beforeEach(function () {
+        var resumeToken = new ResumeToken(MISSING_RESUME_DATA);
+        model.populateFromResumeToken(resumeToken);
+      });
+
+      it('does not populate the model', function () {
+        assert.isFalse(model.has('campaign'));
+      });
+
+      it('called sentryMetrics.captureException correctly', function () {
+        assert.strictEqual(sentryMetrics.captureException.callCount, 1);
+        var args = sentryMetrics.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.instanceOf(args[0], Error);
+        assert.strictEqual(args[0].message, 'Missing property in resume token: campaign');
+      });
+    });
+
+    describe('populateFromStringifiedResumeToken with valid data', function () {
+      beforeEach(function () {
+        var stringifiedResumeToken = ResumeToken.stringify(VALID_RESUME_DATA);
         model.populateFromStringifiedResumeToken(stringifiedResumeToken);
+      });
 
+      it('parses the resume param into an object', function () {
         assert.equal(model.get('campaign'), CAMPAIGN);
         assert.isFalse(model.has('notResumeable'), 'only allow specific resume token values');
+      });
+
+      it('does not call sentryMetrics.captureException', function () {
+        assert.strictEqual(sentryMetrics.captureException.callCount, 0);
+      });
+    });
+
+    describe('populateFromStringifiedResumeToken with invalid data', function () {
+      beforeEach(function () {
+        var stringifiedResumeToken = ResumeToken.stringify(INVALID_RESUME_DATA);
+        model.populateFromStringifiedResumeToken(stringifiedResumeToken);
+      });
+
+      it('does not populate the model', function () {
+        assert.isFalse(model.has('campaign'));
+      });
+
+      it('called sentryMetrics.captureException correctly', function () {
+        assert.strictEqual(sentryMetrics.captureException.callCount, 1);
+        var args = sentryMetrics.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.instanceOf(args[0], Error);
+        assert.strictEqual(args[0].message, 'Invalid property in resume token: campaign');
+      });
+    });
+
+    describe('populateFromStringifiedResumeToken with missing data', function () {
+      beforeEach(function () {
+        var stringifiedResumeToken = ResumeToken.stringify(MISSING_RESUME_DATA);
+        model.populateFromStringifiedResumeToken(stringifiedResumeToken);
+      });
+
+      it('does not populate the model', function () {
+        assert.isFalse(model.has('campaign'));
+      });
+
+      it('called sentryMetrics.captureException correctly', function () {
+        assert.strictEqual(sentryMetrics.captureException.callCount, 1);
+        var args = sentryMetrics.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.instanceOf(args[0], Error);
+        assert.strictEqual(args[0].message, 'Missing property in resume token: campaign');
       });
     });
   });


### PR DESCRIPTION
Enables, but is not a complete fix for #3591.

@shane-tomlinson, these are the changes that were originally part of #3619. I'll rebase that presently, so they don't clog up the review over there.