### PR TITLE
chore(nsp): Add .nsprc config file to ignore NSP warnings

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,10 @@
+{
+  "exceptions": [
+    "https://nodesecurity.io/advisories/39",
+    "https://nodesecurity.io/advisories/48",
+
+    "https://nodesecurity.io/advisories/45",
+    "https://nodesecurity.io/advisories/63",
+    "https://nodesecurity.io/advisories/65"
+  ]
+}


### PR DESCRIPTION
This drops the **nsp** warnings down to 4:

```
Running "nsp" task
Warning: (+) 4 vulnerabilities found
 Name     Installed   Patched    Path                                                                                                  More Info
 moment   2.8.4       >=2.11.2   fxa-content-server@0.60.0 > express-able@0.4.4 > able@0.4.3 > convict@0.6.1 > moment@2.8.4            https://nodesecurity.io/advisories/55
 moment   2.9.0       >=2.11.2   fxa-content-server@0.60.0 > express-able@0.4.4 > able@0.4.3 > hapi@8.4.0 > joi@6.0.8 > moment@2.9.0   https://nodesecurity.io/advisories/55
 marked   0.3.5       None       fxa-content-server@0.60.0 > grunt-marked@0.1.3 > marked@0.3.5                                         https://nodesecurity.io/advisories/101
 marked   0.3.5       None       fxa-content-server@0.60.0 > marked@0.3.5                                                              https://nodesecurity.io/advisories/101
 Use --force to continue.

Aborted due to warnings.
```

1. I'll file a bug/PR shortly to update **convict** to [**able**](https://www.npmjs.com/package/able).
2. Once we update that, we are stuck with the **moment** issue buried in **hapi**, unless we bump the major version.
3. That just leaves **marked** which never seems to have been updated. We may want to consider replacing it with a different Markdown rendering engine (and hope for 100% compatibility), or, we can just add the https://nodesecurity.io/advisories/101 exception to the .nsprc file.