### PR TITLE
fix(metrics): Scrub PII from CSP reports

### DIFF
--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -30,7 +30,10 @@ module.exports = function (config, i18n) {
     require('./routes/get-client.json')(i18n),
     require('./routes/post-metrics')(),
     require('./routes/post-csp')({
-      path: config.get('csp.reportUri')
+      path: config.get('csp.reportUri'),
+      write: function (entry) {
+        process.write(JSON.stringify(entry) + '\n');
+      }
     }),
     require('./routes/get-metrics-errors')(),
     require('./routes/get-openid-login')(config),

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -30,10 +30,7 @@ module.exports = function (config, i18n) {
     require('./routes/get-client.json')(i18n),
     require('./routes/post-metrics')(),
     require('./routes/post-csp')({
-      path: config.get('csp.reportUri'),
-      write: function (entry) {
-        process.write(JSON.stringify(entry) + '\n');
-      }
+      path: config.get('csp.reportUri')
     }),
     require('./routes/get-metrics-errors')(),
     require('./routes/get-openid-login')(config),

--- a/server/lib/routes/post-csp.js
+++ b/server/lib/routes/post-csp.js
@@ -6,6 +6,8 @@
  * Route to report CSP Violations to metrics
  */
 
+var url = require('url');
+
 module.exports = function (options) {
   options = options || {};
 
@@ -15,7 +17,7 @@ module.exports = function (options) {
     process: function (req, res) {
       res.json({result: 'ok'});
 
-      if (! req.body || ! req.body['csp-report']) {
+      if (! req.body || ! req.body['csp-report'] || ! Object.keys(req.body['csp-report']).length) {
         return false;
       }
 
@@ -29,15 +31,35 @@ module.exports = function (options) {
         column: report['column-number'],
         line: report['line-number'],
         op: 'server.csp',
-        referrer: report['referrer'],
+        referrer: stripPIIFromUrl(report['referrer']),
         sample: report['script-sample'],
-        source: report['source-file'],
+        source: stripPIIFromUrl(report['source-file']),
         time: today.toISOString(),
         violated: report['violated-directive'],
       };
 
-      process.stderr.write(JSON.stringify(entry) + '\n');
+      options.write(entry);
+
       return true;
     }
   };
 };
+
+function stripPIIFromUrl(urlToScrub) {
+  if (! urlToScrub) {
+    return '';
+  }
+  var parsedUrl = url.parse(urlToScrub, true);
+
+  if (! parsedUrl.query.email && ! parsedUrl.query.uid) {
+    return urlToScrub;
+  }
+
+  delete parsedUrl.query.email;
+  delete parsedUrl.query.uid;
+
+  // delete parsedUrl.search or else format returns the old querystring.
+  delete parsedUrl.search;
+
+  return url.format(parsedUrl);
+}

--- a/server/lib/routes/post-csp.js
+++ b/server/lib/routes/post-csp.js
@@ -66,7 +66,7 @@ function stripPIIFromUrl(urlToScrub) {
   try {
     parsedUrl = url.parse(urlToScrub, true);
   } catch(e) {
-    //
+    // failed to parse the given url
     return '';
   }
 

--- a/tests/server/routes/post-csp.js
+++ b/tests/server/routes/post-csp.js
@@ -113,6 +113,28 @@ define([
     assert.equal(entry.source, 'https://accounts.firefox.com/settings?notaffected=1');
   };
 
+  suite['does not fail with invalid referrer or source-file urls'] = function () {
+    var mockRequest = {
+      body: {
+        'csp-report': {
+          'blocked-uri': 'http://bing.com',
+          'referrer': {},
+          'source-file': 'not-a-url'
+        }
+      },
+      'get': function () {}
+    };
+
+    var writer = sinon.spy();
+    var postCsp = proxyquire(path.join(process.cwd(), 'server', 'lib', 'routes', 'post-csp'), {})({ write: writer });
+
+    postCsp.process(mockRequest, mockResponse);
+
+    var entry = writer.args[0][0];
+    assert.equal(entry.referrer, '');
+    assert.equal(entry.source, 'not-a-url');
+  };
+
   suite['works correctly if no query params'] = function () {
     var mockRequest = {
       body: {

--- a/tests/server/routes/post-csp.js
+++ b/tests/server/routes/post-csp.js
@@ -10,12 +10,14 @@ define([
   'intern/dojo/node!fs',
   'intern/dojo/node!path',
   'intern/dojo/node!../../../server/lib/configuration',
-  'intern/dojo/node!proxyquire'
-], function (intern, registerSuite, assert, initLogging, fs, path, config, proxyquire) {
+  'intern/dojo/node!proxyquire',
+  'intern/dojo/node!sinon'
+], function (intern, registerSuite, assert, initLogging, fs, path, config,
+  proxyquire, sinon) {
   // ensure we don't get any module from the cache, but to load it fresh every time
   proxyquire.noPreserveCache();
   var suite = {
-    name: 'post-metrics'
+    name: 'post-csp'
   };
   var mockRequest = {
     body: {
@@ -31,31 +33,108 @@ define([
   };
 
   suite['it drops if no csp-report set'] = function () {
-    var postCsp = proxyquire(path.join(process.cwd(), 'server', 'lib', 'routes', 'post-csp'), {})();
+    var writer = sinon.spy();
+    var postCsp = proxyquire(path.join(process.cwd(), 'server', 'lib', 'routes', 'post-csp'), {})({ write: writer });
     assert.isFalse(postCsp.process({
       body: {},
       'get': function () {}
     }, mockResponse));
 
-    assert.isTrue(postCsp.process({
+    assert.equal(writer.callCount, 0);
+  };
+
+  suite['it drops if csp-report is empty'] = function () {
+    var writer = sinon.spy();
+    var postCsp = proxyquire(path.join(process.cwd(), 'server', 'lib', 'routes', 'post-csp'), {})({ write: writer });
+    assert.isFalse(postCsp.process({
       body: {
         'csp-report': {}
       },
       'get': function () {}
     }, mockResponse));
 
-    assert.isTrue(postCsp.process(mockRequest, mockResponse));
+    assert.equal(writer.callCount, 0);
   };
 
   suite['it works with csp reports'] = function () {
-    var postCsp = proxyquire(path.join(process.cwd(), 'server', 'lib', 'routes', 'post-csp'), {})();
+    var writer = sinon.spy();
+    var postCsp = proxyquire(path.join(process.cwd(), 'server', 'lib', 'routes', 'post-csp'), {})({ write: writer });
     // check 5 times that all messages drop
     assert.isTrue(postCsp.process(mockRequest, mockResponse));
     assert.isTrue(postCsp.process(mockRequest, mockResponse));
     assert.isTrue(postCsp.process(mockRequest, mockResponse));
     assert.isTrue(postCsp.process(mockRequest, mockResponse));
     assert.isTrue(postCsp.process(mockRequest, mockResponse));
+
+    assert.equal(writer.callCount, 5);
   };
+
+  suite['it strips PII from the referrer and source fields'] = function () {
+    var mockRequest = {
+      body: {
+        'csp-report': {
+          'blocked-uri': 'http://bing.com',
+          'referrer': 'https://addons.mozilla.org/?email=testuser@testuser.com&notaffected=1',
+          'source-file': 'https://accounts.firefox.com/settings?uid=bigscaryuid&email=testuser@testuser.com&notaffected=1'
+        }
+      },
+      'get': function () {}
+    };
+
+    var writer = sinon.spy();
+    var postCsp = proxyquire(path.join(process.cwd(), 'server', 'lib', 'routes', 'post-csp'), {})({ write: writer });
+
+    postCsp.process(mockRequest, mockResponse);
+
+    var entry = writer.args[0][0];
+    assert.equal(entry.referrer, 'https://addons.mozilla.org/?notaffected=1');
+    assert.equal(entry.source, 'https://accounts.firefox.com/settings?notaffected=1');
+  };
+
+  suite['works correctly if query params do not contain PII'] = function () {
+    var mockRequest = {
+      body: {
+        'csp-report': {
+          'blocked-uri': 'http://bing.com',
+          'referrer': 'https://addons.mozilla.org/?notaffected=1',
+          'source-file': 'https://accounts.firefox.com/settings?notaffected=1'
+        }
+      },
+      'get': function () {}
+    };
+
+    var writer = sinon.spy();
+    var postCsp = proxyquire(path.join(process.cwd(), 'server', 'lib', 'routes', 'post-csp'), {})({ write: writer });
+
+    postCsp.process(mockRequest, mockResponse);
+
+    var entry = writer.args[0][0];
+    assert.equal(entry.referrer, 'https://addons.mozilla.org/?notaffected=1');
+    assert.equal(entry.source, 'https://accounts.firefox.com/settings?notaffected=1');
+  };
+
+  suite['works correctly if no query params'] = function () {
+    var mockRequest = {
+      body: {
+        'csp-report': {
+          'blocked-uri': 'http://bing.com',
+          'referrer': 'https://addons.mozilla.org/?',
+          'source-file': 'https://accounts.firefox.com'
+        }
+      },
+      'get': function () {}
+    };
+
+    var writer = sinon.spy();
+    var postCsp = proxyquire(path.join(process.cwd(), 'server', 'lib', 'routes', 'post-csp'), {})({ write: writer });
+
+    postCsp.process(mockRequest, mockResponse);
+
+    var entry = writer.args[0][0];
+    assert.equal(entry.referrer, 'https://addons.mozilla.org/?');
+    assert.equal(entry.source, 'https://accounts.firefox.com');
+  };
+
 
   registerSuite(suite);
 });


### PR DESCRIPTION
CSP reports contain a `source` field. `source` `source-file` in the CSP report.
Clicking on the "manage account" link from about:preferences#sync open the
settings page with the user's email address and uid.

This strips `email` and `uid` from `source` and `referrer` in the report.

fixes #3689

@vladikoff - r?