### PR TITLE
refactor(client): move fxaClient access out of view

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -15,6 +15,7 @@ define(function (require, exports, module) {
   var FxaClient = require('fxaClient');
   var p = require('lib/promise');
   var Session = require('lib/session');
+  var SIGN_IN_REASONS = require('lib/sign-in-reasons');
 
   function trim(str) {
     return $.trim(str);
@@ -82,11 +83,10 @@ define(function (require, exports, module) {
      * Check the user's current password without affecting session state.
      */
     checkPassword: function (email, password) {
-      var self = this;
       return this._getClient()
         .then(function (client) {
           return client.signIn(email, password, {
-            reason: self.SIGNIN_REASON.PASSWORD_CHECK
+            reason: SIGN_IN_REASONS.PASSWORD_CHECK
           })
           .then(function (sessionInfo) {
             // a session was created on the backend to check the user's
@@ -150,20 +150,6 @@ define(function (require, exports, module) {
       return updatedSessionData;
     },
 
-
-    /**
-     * Signin reasons are indicators to the backend that the signin
-     * is to complete a particular action. The backend can choose
-     * to perform actions, e.g., send emails, based on the reason.
-     */
-    SIGNIN_REASON: { //eslint-disable-line sorting/sort-object-props
-      ACCOUNT_UNLOCK: 'account_unlock',
-      PASSWORD_CHANGE: 'password_change',
-      PASSWORD_CHECK: 'password_check',
-      PASSWORD_RESET: 'password_reset',
-      SIGN_IN: 'signin',
-    },
-
     /**
      * Authenticate a user.
      *
@@ -172,9 +158,8 @@ define(function (require, exports, module) {
      * @param {String} password
      * @param {Releir} relier
      * @param {Object} [options]
-     *   @param {String} [options.reason] - reason for the sign in. Can be
-     *                   one of the values defined in SIGNIN_REASON.
-     *                   Defaults to SIGNIN_REASON.SIGN_IN.
+     *   @param {String} [options.reason] - Reason for the sign in. See definitons
+     *                   in sign-in-reasons.js. Defaults to SIGN_IN_REASONS.SIGN_IN.
      *   @param {Boolean} [options.customizeSync] - If the relier is Sync,
      *                   whether the user wants to customize which items will
      *                   be synced. Defaults to `false`
@@ -191,7 +176,7 @@ define(function (require, exports, module) {
         .then(function (client) {
           var signInOptions = {
             keys: relier.wantsKeys(),
-            reason: options.reason || self.SIGNIN_REASON.SIGN_IN
+            reason: options.reason || SIGN_IN_REASONS.SIGN_IN
           };
 
           // `service` is sent on signIn to notify users when a new service

--- a/app/scripts/lib/sign-in-reasons.js
+++ b/app/scripts/lib/sign-in-reasons.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Indicators to the back-end that the sign-in is to complete some
+// action. The back-end may perform an action based on the reason,
+// e.g. send an email.
+
+define(function (require, exports, module) {
+  'use strict';
+
+  return {
+    ACCOUNT_UNLOCK: 'account_unlock',
+    PASSWORD_CHANGE: 'password_change',
+    PASSWORD_CHECK: 'password_check',
+    PASSWORD_RESET: 'password_reset',
+    SIGN_IN: 'signin'
+  };
+});
+

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -311,7 +311,9 @@ define(function (require, exports, module) {
         var sessionToken = self.get('sessionToken');
 
         if (password) {
-          return self._fxaClient.signIn(email, password, relier);
+          return self._fxaClient.signIn(email, password, relier, {
+            reason: options.reason
+          });
         } else if (sessionToken) {
           // We have a cached Sync session so just check that it hasn't expired.
           // The result includes the latest verified state
@@ -323,6 +325,10 @@ define(function (require, exports, module) {
       .then(function (updatedSessionData) {
         self.set(updatedSessionData);
 
+        if (options.reason === self._fxaClient.SIGNIN_REASON.ACCOUNT_UNLOCK) {
+          return updatedSessionData;
+        }
+
         if (! self.get('verified')) {
           return self._fxaClient.signUpResend(
             relier,
@@ -333,6 +339,10 @@ define(function (require, exports, module) {
           );
         }
       });
+    },
+
+    signInReason: function (key) {
+      return this._fxaClient.SIGNIN_REASON[key];
     },
 
     /**

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -17,6 +17,7 @@ define(function (require, exports, module) {
   var p = require('lib/promise');
   var ProfileClient = require('lib/profile-client');
   var ProfileImage = require('models/profile-image');
+  var SIGN_IN_REASONS = require('lib/sign-in-reasons');
 
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;
 
@@ -325,7 +326,7 @@ define(function (require, exports, module) {
       .then(function (updatedSessionData) {
         self.set(updatedSessionData);
 
-        if (options.reason === self._fxaClient.SIGNIN_REASON.ACCOUNT_UNLOCK) {
+        if (options.reason === SIGN_IN_REASONS.ACCOUNT_UNLOCK) {
           return updatedSessionData;
         }
 
@@ -339,10 +340,6 @@ define(function (require, exports, module) {
           );
         }
       });
-    },
-
-    signInReason: function (key) {
-      return this._fxaClient.SIGNIN_REASON[key];
     },
 
     /**
@@ -618,7 +615,7 @@ define(function (require, exports, module) {
             newPassword,
             relier,
             {
-              reason: fxaClient.SIGNIN_REASON.PASSWORD_CHANGE,
+              reason: SIGN_IN_REASONS.PASSWORD_CHANGE,
               sessionTokenContext: self.get('sessionTokenContext')
             }
           );
@@ -675,7 +672,7 @@ define(function (require, exports, module) {
             password,
             relier,
             {
-              reason: fxaClient.SIGNIN_REASON.PASSWORD_RESET
+              reason: SIGN_IN_REASONS.PASSWORD_RESET
             }
           );
         })

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -325,20 +325,7 @@ define(function (require, exports, module) {
       })
       .then(function (updatedSessionData) {
         self.set(updatedSessionData);
-
-        if (options.reason === SIGN_IN_REASONS.ACCOUNT_UNLOCK) {
-          return updatedSessionData;
-        }
-
-        if (! self.get('verified')) {
-          return self._fxaClient.signUpResend(
-            relier,
-            self.get('sessionToken'),
-            {
-              resume: options.resume
-            }
-          );
-        }
+        return updatedSessionData;
       });
     },
 

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -369,6 +369,11 @@ define(function (require, exports, module) {
       var self = this;
       return account.signIn(password, relier, options)
         .then(function () {
+          if (! account.get('verified')) {
+            return account.retrySignUp(relier, options);
+          }
+        })
+        .then(function () {
           // If there's an account with the same uid in localStorage we merge
           // its attributes with the new account instance to retain state
           // used across sign-ins, such as granted permissions.

--- a/app/scripts/views/confirm_account_unlock.js
+++ b/app/scripts/views/confirm_account_unlock.js
@@ -15,6 +15,7 @@ define(function (require, exports, module) {
   var ResendMixin = require('views/mixins/resend-mixin');
   var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
   var ServiceMixin = require('views/mixins/service-mixin');
+  var SIGN_IN_REASONS = require('lib/sign-in-reasons');
   var Template = require('stache!templates/confirm_account_unlock');
 
   var t = BaseView.t;
@@ -116,7 +117,7 @@ define(function (require, exports, module) {
       // their address, the sign in call will fail with the ACCOUNT_LOCKED
       // error, and we poll again.
       return account.signIn(password, self.relier, {
-        reason: account.signInReason('ACCOUNT_UNLOCK')
+        reason: SIGN_IN_REASONS.ACCOUNT_UNLOCK
       })
         .fail(function (err) {
           if (AuthErrors.is(err, 'ACCOUNT_LOCKED')) {

--- a/app/scripts/views/confirm_account_unlock.js
+++ b/app/scripts/views/confirm_account_unlock.js
@@ -108,7 +108,6 @@ define(function (require, exports, module) {
     _waitForConfirmation: function () {
       var self = this;
       var account = self.getAccount();
-      var email = account.get('email');
       var password = this.model.get('password');
 
       // try to sign the user in using the email/password that caused the
@@ -116,12 +115,9 @@ define(function (require, exports, module) {
       // the sign in will successfully complete. If they have not verified
       // their address, the sign in call will fail with the ACCOUNT_LOCKED
       // error, and we poll again.
-      return self.fxaClient.signIn(
-          email,
-          password,
-          self.relier,
-          { reason: self.fxaClient.SIGNIN_REASON.ACCOUNT_UNLOCK }
-        )
+      return account.signIn(password, self.relier, {
+        reason: account.signInReason('ACCOUNT_UNLOCK')
+      })
         .fail(function (err) {
           if (AuthErrors.is(err, 'ACCOUNT_LOCKED')) {
             // user has not yet verified, poll again.

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -15,6 +15,7 @@ define(function (require, exports, module) {
   var p = require('lib/promise');
   var ResumeToken = require('models/resume-token');
   var sinon = require('sinon');
+  var SIGN_IN_REASONS = require('lib/sign-in-reasons');
   var testHelpers = require('../../lib/helpers');
 
   var STATE = 'state';
@@ -353,7 +354,7 @@ define(function (require, exports, module) {
           .then(function (sessionData) {
             assert.isTrue(realClient.signIn.calledWith(trim(email), password, {
               keys: true,
-              reason: client.SIGNIN_REASON.SIGN_IN,
+              reason: SIGN_IN_REASONS.SIGN_IN,
               service: 'sync'
             }));
 
@@ -376,7 +377,7 @@ define(function (require, exports, module) {
           .then(function (sessionData) {
             assert.isTrue(realClient.signIn.calledWith(trim(email), password, {
               keys: false,
-              reason: client.SIGNIN_REASON.SIGN_IN,
+              reason: SIGN_IN_REASONS.SIGN_IN,
               service: 'chronicle'
             }));
 
@@ -403,7 +404,7 @@ define(function (require, exports, module) {
           .then(function (sessionData) {
             assert.isTrue(realClient.signIn.calledWith(trim(email), password, {
               keys: true,
-              reason: client.SIGNIN_REASON.SIGN_IN,
+              reason: SIGN_IN_REASONS.SIGN_IN,
               service: 'chronicle'
             }));
 
@@ -431,7 +432,7 @@ define(function (require, exports, module) {
           .then(function (result) {
             assert.isTrue(realClient.signIn.calledWith(trim(email), password, {
               keys: true,
-              reason: client.SIGNIN_REASON.SIGN_IN,
+              reason: SIGN_IN_REASONS.SIGN_IN,
               service: 'sync'
             }));
 
@@ -448,11 +449,11 @@ define(function (require, exports, module) {
           return p({});
         });
 
-        return client.signIn(email, password, relier, { reason: client.SIGNIN_REASON.PASSWORD_CHANGE })
+        return client.signIn(email, password, relier, { reason: SIGN_IN_REASONS.PASSWORD_CHANGE })
           .then(function () {
             assert.isTrue(realClient.signIn.calledWith(trim(email), password, {
               keys: true,
-              reason: client.SIGNIN_REASON.PASSWORD_CHANGE,
+              reason: SIGN_IN_REASONS.PASSWORD_CHANGE,
               service: 'sync'
             }));
           });
@@ -606,7 +607,7 @@ define(function (require, exports, module) {
               email,
               password,
               {
-                reason: client.SIGNIN_REASON.PASSWORD_CHECK
+                reason: SIGN_IN_REASONS.PASSWORD_CHECK
               }
             ));
             assert.isFalse(realClient.sessionDestroy.called);
@@ -632,7 +633,7 @@ define(function (require, exports, module) {
               email,
               password,
               {
-                reason: client.SIGNIN_REASON.PASSWORD_CHECK
+                reason: SIGN_IN_REASONS.PASSWORD_CHECK
               }
             ));
             assert.isTrue(realClient.sessionDestroy.calledWith('session token'));

--- a/app/tests/spec/lib/sign-in-reasons.js
+++ b/app/tests/spec/lib/sign-in-reasons.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var assert = require('chai').assert;
+  var SIGN_IN_REASONS = require('lib/sign-in-reasons');
+
+  describe('lib/sign-in-reasons', function () {
+    it('exports correct strings', function () {
+      assert.lengthOf(Object.keys(SIGN_IN_REASONS), 5);
+      assert.equal(SIGN_IN_REASONS.ACCOUNT_UNLOCK, 'account_unlock');
+      assert.equal(SIGN_IN_REASONS.PASSWORD_CHANGE, 'password_change');
+      assert.equal(SIGN_IN_REASONS.PASSWORD_CHECK, 'password_check');
+      assert.equal(SIGN_IN_REASONS.PASSWORD_RESET, 'password_reset');
+      assert.equal(SIGN_IN_REASONS.SIGN_IN, 'signin');
+    });
+  });
+});
+

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -210,14 +210,8 @@ define(function (require, exports, module) {
             assert.isTrue(fxaClient.signIn.calledWith(EMAIL, PASSWORD, relier));
           });
 
-          it('delegates to the fxaClient to resend a signUp email', function () {
-            assert.isTrue(fxaClient.signUpResend.calledWith(
-              relier,
-              SESSION_TOKEN,
-              {
-                resume: 'resume token'
-              }
-            ));
+          it('does not resend a signUp email', function () {
+            assert.isFalse(fxaClient.signUpResend.called);
           });
 
           it('updates the account with the returned data', function () {
@@ -323,9 +317,8 @@ define(function (require, exports, module) {
               fxaClient.recoveryEmailStatus.calledWith(SESSION_TOKEN));
           });
 
-          it('delegates to the fxaClient to resend a signUp email', function () {
-            assert.isTrue(
-              fxaClient.signUpResend.calledWith(relier, SESSION_TOKEN));
+          it('does not resend a signUp email', function () {
+            assert.isFalse(fxaClient.signUpResend.called);
           });
 
           it('updates the account with the returned data', function () {

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -21,6 +21,7 @@ define(function (require, exports, module) {
   var ProfileErrors = require('lib/profile-errors');
   var Relier = require('models/reliers/relier');
   var sinon = require('sinon');
+  var SIGN_IN_REASONS = require('lib/sign-in-reasons');
 
   var assert = chai.assert;
 
@@ -236,7 +237,7 @@ define(function (require, exports, module) {
             });
 
             return account.signIn(PASSWORD, relier, {
-              reason: fxaClient.SIGNIN_REASON.ACCOUNT_UNLOCK,
+              reason: SIGN_IN_REASONS.ACCOUNT_UNLOCK,
               resume: 'resume token'
             });
           });
@@ -398,17 +399,6 @@ define(function (require, exports, module) {
             assert.isTrue(AuthErrors.is(err, 'UNEXPECTED_ERROR'));
           });
         });
-      });
-    });
-
-    describe('signInReason', function () {
-      it('returns expected strings', function () {
-        assert.equal(account.signInReason('ACCOUNT_UNLOCK'), fxaClient.SIGNIN_REASON.ACCOUNT_UNLOCK);
-        assert.equal(account.signInReason('PASSWORD_CHANGE'), fxaClient.SIGNIN_REASON.PASSWORD_CHANGE);
-        assert.equal(account.signInReason('PASSWORD_CHECK'), fxaClient.SIGNIN_REASON.PASSWORD_CHECK);
-        assert.equal(account.signInReason('PASSWORD_RESET'), fxaClient.SIGNIN_REASON.PASSWORD_RESET);
-        assert.equal(account.signInReason('SIGN_IN'), fxaClient.SIGNIN_REASON.SIGN_IN);
-        assert.isUndefined(account.signInReason('foo'));
       });
     });
 
@@ -1245,7 +1235,7 @@ define(function (require, exports, module) {
               newPassword,
               relier,
               {
-                reason: fxaClient.SIGNIN_REASON.PASSWORD_CHANGE,
+                reason: SIGN_IN_REASONS.PASSWORD_CHANGE,
                 sessionTokenContext: 'foo'
               }
             ));
@@ -1277,7 +1267,7 @@ define(function (require, exports, module) {
               PASSWORD,
               relier,
               {
-                reason: fxaClient.SIGNIN_REASON.PASSWORD_RESET
+                reason: SIGN_IN_REASONS.PASSWORD_RESET
               }
             ));
             // ensure data returned from fxaClient.signIn updates the account

--- a/app/tests/spec/views/confirm_account_unlock.js
+++ b/app/tests/spec/views/confirm_account_unlock.js
@@ -64,7 +64,9 @@ define(function (require, exports, module) {
         session: Session,
         window: windowMock
       });
-      user = new User();
+      user = new User({
+        fxaClient: fxaClient
+      });
 
       account = user.initAccount({
         email: EMAIL

--- a/app/tests/spec/views/confirm_account_unlock.js
+++ b/app/tests/spec/views/confirm_account_unlock.js
@@ -17,6 +17,7 @@ define(function (require, exports, module) {
   var Relier = require('models/reliers/relier');
   var Session = require('lib/session');
   var sinon = require('sinon');
+  var SIGN_IN_REASONS = require('lib/sign-in-reasons');
   var TestHelpers = require('../../lib/helpers');
   var User = require('models/user');
   var View = require('views/confirm_account_unlock');
@@ -158,7 +159,7 @@ define(function (require, exports, module) {
           assert.strictEqual(signInRelier, relier);
 
           var signInReason = args[3].reason;
-          assert.equal(signInReason, fxaClient.SIGNIN_REASON.ACCOUNT_UNLOCK);
+          assert.equal(signInReason, SIGN_IN_REASONS.ACCOUNT_UNLOCK);
         });
 
         it('if caused by signin, notifies the broker when complete', function () {

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -56,6 +56,7 @@ function (Translator, Session) {
     '../tests/spec/lib/sentry',
     '../tests/spec/lib/service-name',
     '../tests/spec/lib/session',
+    '../tests/spec/lib/sign-in-reasons',
     '../tests/spec/lib/storage',
     '../tests/spec/lib/storage-metrics',
     '../tests/spec/lib/strings',


### PR DESCRIPTION
This is a change taken from another branch that I'm now completely reworking. Not sure if I've gone about it the right way, it feels kind of clunky. But anyway, I thought I should get it reviewed separately as it is about to get deleted from said other branch.

The problem was that I noticed some direct usage of `fxaClient.signIn` in one of the views. Since the view already used the `account` model, it was straightforward-ish to refactor it to call `account.signIn`. There's a little bit of added complexity because the view isn't interested in the `signUpResend` stuff from `account.signIn`. Hence I added a condition to short-circuit that stuff.

Oh and the view needed to pass in the `reason`, so I added that too. Is it too messy or am I on the right track?

@shane-tomlinson r?