### PR TITLE
fix(style): Autofocus on submit button and added tabindex

### DIFF
--- a/app/scripts/templates/choose_what_to_sync.mustache
+++ b/app/scripts/templates/choose_what_to_sync.mustache
@@ -18,7 +18,7 @@
             {{#hasTabSupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="tabs" autofocus>
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="tabs" tabindex="5">
               <span class="fxa-checkbox__label">
                 {{#t}}Tabs{{/t}}
               </span>
@@ -29,7 +29,7 @@
             {{#hasBookmarkSupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="bookmarks"{{^hasTabSupport}} autofocus{{/hasTabSupport}}>
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="bookmarks" tabindex="10">
               <span class="fxa-checkbox__label">
                 {{#t}}Bookmarks{{/t}}
               </span>
@@ -40,7 +40,7 @@
             {{#hasDesktopAddonSupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="addons"{{^hasTabSupport}}{{^hasBookmarkSupport}} autofocus{{/hasBookmarkSupport}}{{/hasTabSupport}}>
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="addons" tabindex="15">
                 <span class="fxa-checkbox__label">
                   {{#t}}Add-ons{{/t}}
                 </span>
@@ -52,7 +52,7 @@
             {{#hasPasswordSupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="passwords"{{^hasTabSupport}}{{^hasBookmarkSupport}}{{^hasDesktopAddonSupport}} autofocus{{/hasDesktopAddonSupport}}{{/hasBookmarkSupport}}{{/hasTabSupport}}>
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="passwords" tabindex="20">
               <span class="fxa-checkbox__label">
                 {{#t}}Passwords{{/t}}
               </span>
@@ -63,7 +63,7 @@
             {{#hasHistorySupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="history"{{^hasTabSupport}}{{^hasBookmarkSupport}}{{^hasDesktopAddonSupport}}{{^hasPasswordSupport}} autofocus{{/hasPasswordSupport}}{{/hasDesktopAddonSupport}}{{/hasBookmarkSupport}}{{/hasTabSupport}}>
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="history" tabindex="25">
               <span class="fxa-checkbox__label">
                 {{#t}}History{{/t}}
               </span>
@@ -74,7 +74,7 @@
             {{#hasDesktopPreferencesSupport}}
               <div class="input-row choose-what-to-sync-row">
                 <label class="fxa-checkbox">
-                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="prefs"{{^hasTabSupport}}{{^hasBookmarkSupport}}{{^hasDesktopAddonSupport}}{{^hasPasswordSupport}}{{^hasDesktopPreferencesSupport}} autofocus{{/hasDesktopPreferencesSupport}}{{/hasPasswordSupport}}{{/hasDesktopAddonSupport}}{{/hasBookmarkSupport}}{{/hasTabSupport}}>
+                  <input name="sync-content" type="checkbox" class="customize-sync" checked="checked" value="prefs" tabindex="30">
                 <span class="fxa-checkbox__label">
                   {{#t}}Preferences{{/t}}
                 </span>
@@ -85,7 +85,7 @@
         </div>
         <div class="extra-links extra-links-choose-what-to-sync">{{#t}}Add-ons and Preferences do not currently sync on mobile devices.{{/t}}</div>
         <div class="button-row">
-          <button id="submit-btn" type="submit">{{#t}}Save settings{{/t}}</button>
+          <button id="submit-btn" type="submit" tabindex="1" autofocus>{{#t}}Save settings{{/t}}</button>
         </div>
     </form>
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1086,16 +1086,16 @@ define([
   /**
    * Assert the value of an attribute
    *
-   * @param {string} elementSelector CSS selector for the element
+   * @param {string} selector CSS selector for the element
    * @param {string} attributeName Name of attribute
    * @param {string} assertion Name of the chai assertion to invoke
    * @param {string} value Expected value of the attribute
    * @returns {promise}
    */
-  function testAttribute (elementSelector, attributeName, assertion, value) {
+  function testAttribute (selector, attributeName, assertion, value) {
     return function () {
       return this.parent
-        .findByCssSelector(elementSelector)
+        .findByCssSelector(selector)
           .getAtribute(attributeName)
           .then(function (attributeValue) {
             assert[assertion](attributeValue, value);
@@ -1107,25 +1107,44 @@ define([
   /**
    * Assert that an attribute value === expected value
    *
-   * @param {string} elementSelector CSS selector for the element
+   * @param {string} selector CSS selector for the element
    * @param {string} attributeName Name of attribute
    * @param {string} value Expected value of the attribute
    * @returns {promise}
    */
-  function testAttributeEquals (elementSelector, attributeName, value) {
-    return testAttribute(elementSelector, attributeName, 'strictEqual', value);
+  function testAttributeEquals (selector, attributeName, value) {
+    return testAttribute(selector, attributeName, 'strictEqual', value);
   }
 
   /**
    * Assert that an attribute value matches a regex
    *
-   * @param {string} elementSelector CSS selector for the element
+   * @param {string} selector CSS selector for the element
    * @param {string} attributeName Name of attribute
    * @param {regex} regex Expression for the attribute value to be matched against
    * @returns {promise}
    */
-  function testAttributeMatches (elementSelector, attributeName, regex) {
-    return testAttribute(elementSelector, attributeName, 'match', regex);
+  function testAttributeMatches (selector, attributeName, regex) {
+    return testAttribute(selector, attributeName, 'match', regex);
+  }
+
+  /**
+   * Check that an element has an attribute
+   *
+   * @param {string} selector CSS selector for the element
+   * @param {string} attributeName Name of attribute
+   * @returns {promise} resolves to true if attribute exists, false otw.
+   */
+  function testAttributeExists (selector, attributeName) {
+    return function () {
+      return this.parent
+        .findByCssSelector(selector)
+          .getAttribute(attributeName)
+          .then(function (attributeValue) {
+            assert.notStrictEqual(attributeValue, null);
+          })
+        .end();
+    };
   }
 
   function verifyUser(user, index, client, accountData) {
@@ -1173,6 +1192,7 @@ define([
     testAreEventsLogged: testAreEventsLogged,
     testAttribute: testAttribute,
     testAttributeEquals: testAttributeEquals,
+    testAttributeExists: testAttributeExists,
     testAttributeMatches: testAttributeMatches,
     testElementDisabled: testElementDisabled,
     testElementExists: testElementExists,

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -66,20 +66,9 @@ define([
         .findByCssSelector('#fxa-choose-what-to-sync-header')
         .end()
 
-        // test that autofocus attribute has been applied sanely
-        .findByTagName('input')
+        // test that autofocus attribute has been applied to submit button
+        .findById('submit-btn')
           .getAttribute('autofocus')
-          .then(function (value) {
-            assert.strictEqual(value, '');
-          })
-        .end()
-        .findAllByXpath('(//input)[position()>1]')
-          .getAttribute('autofocus')
-          .then(function (values) {
-            values.forEach(function (value) {
-              assert.isNull(value);
-            });
-          })
         .end()
 
         // uncheck the passwords and addons engines.

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -20,6 +20,7 @@ define([
 
   var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testAttributeExists = FunctionalHelpers.testAttributeExists;
 
   registerSuite({
     name: 'Firefox Desktop Sync v2 sign_up',
@@ -36,7 +37,7 @@ define([
         .then(function () {
           // ensure the next test suite (bounced_email) loads a fresh
           // signup page. If a fresh signup page is not forced, the
-          // bounced_email tests try to sign up using the Sync broker,
+          // bounced_email tests try to signup using the Sync broker,
           // resulting in a channel timeout.
           return self.remote
             .get(require.toUrl(SIGNIN_URL))
@@ -46,7 +47,7 @@ define([
         });
     },
 
-    'sign up, verify same browser': function () {
+    'signup, verify same browser': function () {
       var self = this;
 
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
@@ -67,9 +68,7 @@ define([
         .end()
 
         // test that autofocus attribute has been applied to submit button
-        .findById('submit-btn')
-          .getAttribute('autofocus')
-        .end()
+        .then(testAttributeExists('#submit-btn', 'autofocus'))
 
         // uncheck the passwords and addons engines.
         // cannot use input selectors here because labels overlay them.


### PR DESCRIPTION
This PR adds the `autofocus` attribute to the submit button on the CWTS screen and adds `tabindex` to checkbox.

Ref: https://github.com/mozilla/fxa-content-server/issues/3394

@shane-tomlinson @philbooth r?