### PR TITLE
chore(tests): More tests for expired tokens.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -444,11 +444,11 @@ define(function (require, exports, module) {
         .then(function (client) {
           return client.recoveryEmailStatus(sessionToken);
         })
-        .then(null, function (err) {
+        .fail(function (err) {
           // The user's email may have bounced because it's invalid. Check
           // if the account still exists, if it doesn't, it means the email
           // bounced. Show a message allowing the user to sign up again.
-          if (AuthErrors.is(err, 'INVALID_TOKEN')) {
+          if (uid && AuthErrors.is(err, 'INVALID_TOKEN')) {
             return self.checkAccountExists(uid)
               .then(function (accountExists) {
                 if (! accountExists) {

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -15,7 +15,6 @@ define(function (require, exports, module) {
   var MarketingEmailPrefs = require('models/marketing-email-prefs');
   var OAuthToken = require('models/oauth-token');
   var p = require('lib/promise');
-  var ProfileClient = require('lib/profile-client');
   var ProfileErrors = require('lib/profile-errors');
   var ProfileImage = require('models/profile-image');
   var SIGN_IN_REASONS = require('lib/sign-in-reasons');

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -272,6 +272,137 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('recoveryEmailStatus', function () {
+      var accountInfo;
+      var clientMock;
+      var err;
+
+      beforeEach(function () {
+        clientMock = {
+          accountStatus: function () {},
+          recoveryEmailStatus: function () {}
+        };
+
+        accountInfo = err = null;
+
+        sinon.stub(client, '_getClient', function () {
+          return p(clientMock);
+        });
+      });
+
+      describe('with a sessionToken only', function () {
+        describe('valid session', function () {
+          beforeEach(function () {
+            sinon.stub(clientMock, 'recoveryEmailStatus', function () {
+              return p({ verified: true });
+            });
+
+            return client.recoveryEmailStatus('session token')
+              .then(function (_accountInfo) {
+                accountInfo = _accountInfo;
+              });
+          });
+
+          it('resolves with the status information', function () {
+            assert.isTrue(clientMock.recoveryEmailStatus.calledWith('session token'));
+            assert.isTrue(accountInfo.verified);
+          });
+        });
+
+        describe('invalid session', function () {
+          beforeEach(function () {
+            sinon.stub(clientMock, 'recoveryEmailStatus', function () {
+              return p.reject(AuthErrors.toError('INVALID_TOKEN'));
+            });
+
+            sinon.spy(clientMock, 'accountStatus');
+
+            return client.recoveryEmailStatus('session token')
+              .then(assert.fail, function (_err) {
+                err = _err;
+              });
+          });
+
+          it('rejects with an INVALID_TOKEN error', function () {
+            assert.isTrue(AuthErrors.is(err, 'INVALID_TOKEN'));
+          });
+
+          it('does not call accountStatus', function () {
+            assert.isFalse(clientMock.accountStatus.called);
+          });
+        });
+      });
+
+      describe('both a sessionToken and uid', function () {
+        describe('valid session', function () {
+          beforeEach(function () {
+            sinon.stub(clientMock, 'recoveryEmailStatus', function () {
+              return p({ verified: true });
+            });
+
+            return client.recoveryEmailStatus('session token', 'uid')
+              .then(function (_accountInfo) {
+                accountInfo = _accountInfo;
+              });
+          });
+
+          it('resolves with the status information', function () {
+            assert.isTrue(accountInfo.verified);
+          });
+        });
+
+        describe('invalid session', function () {
+          beforeEach(function () {
+            sinon.stub(clientMock, 'recoveryEmailStatus', function () {
+              return p.reject(AuthErrors.toError('INVALID_TOKEN'));
+            });
+          });
+
+          describe('account exists', function () {
+            beforeEach(function () {
+              sinon.stub(clientMock, 'accountStatus', function() {
+                return p({ exists: true });
+              });
+
+              return client.recoveryEmailStatus('session token', 'uid')
+                .then(assert.fail, function (_err) {
+                  err = _err;
+                });
+            });
+
+            it('rejects with an INVALID_TOKEN error', function () {
+              assert.isTrue(AuthErrors.is(err, 'INVALID_TOKEN'));
+            });
+
+            it('calls accountStatus', function () {
+              assert.isTrue(clientMock.accountStatus.called);
+            });
+          });
+
+          describe('account does not exist', function () {
+            beforeEach(function () {
+              sinon.stub(clientMock, 'accountStatus', function() {
+                return p({ exists: false });
+              });
+
+              return client.recoveryEmailStatus('session token', 'uid')
+                .then(assert.fail, function (_err) {
+                  err = _err;
+                });
+            });
+
+            it('rejects with an SIGNUP_EMAIL_BOUNCE error', function () {
+              assert.isTrue(AuthErrors.is(err, 'SIGNUP_EMAIL_BOUNCE'));
+            });
+
+            it('calls accountStatus', function () {
+              assert.isTrue(clientMock.accountStatus.called);
+            });
+          });
+        });
+      });
+    });
+
     describe('signUpResend', function () {
       it('resends the validation email', function () {
         var sessionToken = 'session token';

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -360,7 +360,7 @@ define(function (require, exports, module) {
 
           describe('account exists', function () {
             beforeEach(function () {
-              sinon.stub(clientMock, 'accountStatus', function() {
+              sinon.stub(clientMock, 'accountStatus', function () {
                 return p({ exists: true });
               });
 
@@ -381,7 +381,7 @@ define(function (require, exports, module) {
 
           describe('account does not exist', function () {
             beforeEach(function () {
-              sinon.stub(clientMock, 'accountStatus', function() {
+              sinon.stub(clientMock, 'accountStatus', function () {
                 return p({ exists: false });
               });
 

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -148,6 +148,27 @@ define(function (require, exports, module) {
           });
       });
 
+      describe('with an invalid sessionToken', function () {
+        beforeEach(function () {
+          account.set({
+            accessToken: 'access token',
+            sessionToken: SESSION_TOKEN,
+            sessionTokenContext: Constants.SYNC_SERVICE
+          });
+
+          sinon.stub(fxaClient, 'recoveryEmailStatus', function () {
+            return p.reject(AuthErrors.toError('INVALID_TOKEN'));
+          });
+
+          return account.fetch();
+        });
+
+        it('invalidates the session and access tokens', function () {
+          assert.isFalse(account.has('accessToken'));
+          assert.isFalse(account.has('sessionToken'));
+          assert.isFalse(account.has('sessionTokenContext'));
+        });
+      });
     });
 
     describe('isVerified', function () {
@@ -768,7 +789,7 @@ define(function (require, exports, module) {
       PROFILE_CLIENT_METHODS.forEach(function (method) {
         it('retries on ' + method, function () {
           sinon.stub(profileClient, method, function () {
-            return p.reject(ProfileClient.Errors.toError('UNAUTHORIZED'));
+            return p.reject(ProfileErrors.toError('UNAUTHORIZED'));
           });
           return account[method]()
             .then(
@@ -776,7 +797,7 @@ define(function (require, exports, module) {
               function (err) {
                 assert.isTrue(account.createOAuthToken.calledTwice);
                 assert.isTrue(profileClient[method].calledTwice);
-                assert.isTrue(ProfileClient.Errors.is(err, 'UNAUTHORIZED'));
+                assert.isTrue(ProfileErrors.is(err, 'UNAUTHORIZED'));
                 assert.isUndefined(account.get('accessToken'));
               }
             );
@@ -785,7 +806,7 @@ define(function (require, exports, module) {
         it('retries and succeeds on ' + method, function () {
           sinon.stub(profileClient, method, function (token) {
             if (token === 'token1') {
-              return p.reject(ProfileClient.Errors.toError('UNAUTHORIZED'));
+              return p.reject(ProfileErrors.toError('UNAUTHORIZED'));
             } else {
               return p();
             }
@@ -802,18 +823,73 @@ define(function (require, exports, module) {
 
         it('throws other errors on ' + method, function () {
           sinon.stub(profileClient, method, function () {
-            return p.reject(ProfileClient.Errors.toError('UNKNOWN_ACCOUNT'));
+            return p.reject(ProfileErrors.toError('UNKNOWN_ACCOUNT'));
           });
           return account[method]()
             .then(
               assert.fail,
               function (err) {
-                assert.isTrue(ProfileClient.Errors.is(err, 'UNKNOWN_ACCOUNT'));
+                assert.isTrue(ProfileErrors.is(err, 'UNKNOWN_ACCOUNT'));
                 assert.isTrue(account.createOAuthToken.calledOnce);
                 assert.isTrue(profileClient[method].calledOnce);
                 assert.equal(account.get('accessToken'), 'token1');
               }
             );
+        });
+      });
+    });
+
+    describe('with an invalid sessionToken', function () {
+      PROFILE_CLIENT_METHODS.forEach(function (method) {
+        describe(method, function () {
+          var err;
+          var accessTokenChangeSpy;
+          var sessionTokenChangeSpy;
+          var sessionTokenContextChangeSpy;
+
+          beforeEach(function () {
+            var tokens = 0;
+            sinon.stub(account, 'fetch', function () {
+              return p();
+            });
+
+            account.set({
+              accessToken: 'access token',
+              sessionToken: 'session token',
+              sessionTokenContext: 'session token context',
+              verified: true
+            });
+
+            sinon.stub(profileClient, method, function () {
+              return p.reject(ProfileErrors.toError('INVALID_TOKEN'));
+            });
+
+            accessTokenChangeSpy = sinon.spy();
+            account.on('change:accessToken', accessTokenChangeSpy);
+
+            sessionTokenChangeSpy = sinon.spy();
+            account.on('change:sessionToken', sessionTokenChangeSpy);
+
+            sessionTokenContextChangeSpy = sinon.spy();
+            account.on('change:sessionTokenContext', sessionTokenContextChangeSpy);
+
+            return account[method]()
+              .then(assert.fail, function (_err) {
+                err = _err;
+              });
+          });
+
+          it('unsets the expected fields ' + method, function () {
+            assert.isFalse(account.has('accessToken'));
+            assert.isFalse(account.has('sessionToken'));
+            assert.isFalse(account.has('sessionTokenContext'));
+          });
+
+          it('triggers the `change` event on the expected fields', function () {
+            assert.isTrue(accessTokenChangeSpy.called);
+            assert.isTrue(sessionTokenChangeSpy.called);
+            assert.isTrue(sessionTokenContextChangeSpy.called);
+          });
         });
       });
     });
@@ -826,7 +902,7 @@ define(function (require, exports, module) {
         account.set('verified', true);
 
         sinon.stub(account, 'createOAuthToken', function () {
-          return p.reject(ProfileClient.Errors.toError('UNAUTHORIZED'));
+          return p.reject(ProfileErrors.toError('UNAUTHORIZED'));
         });
       });
 
@@ -839,7 +915,7 @@ define(function (require, exports, module) {
               function (err) {
                 assert.isTrue(account.createOAuthToken.calledTwice);
                 assert.isFalse(spy.called);
-                assert.isTrue(ProfileClient.Errors.is(err, 'UNAUTHORIZED'));
+                assert.isTrue(ProfileErrors.is(err, 'UNAUTHORIZED'));
                 assert.isUndefined(account.get('accessToken'));
               }
             );

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -848,7 +848,6 @@ define(function (require, exports, module) {
           var sessionTokenContextChangeSpy;
 
           beforeEach(function () {
-            var tokens = 0;
             sinon.stub(account, 'fetch', function () {
               return p();
             });
@@ -889,6 +888,10 @@ define(function (require, exports, module) {
             assert.isTrue(accessTokenChangeSpy.called);
             assert.isTrue(sessionTokenChangeSpy.called);
             assert.isTrue(sessionTokenContextChangeSpy.called);
+          });
+
+          it('rejects with the correct error', function () {
+            assert.isTrue(ProfileErrors.is(err, 'INVALID_TOKEN'));
           });
         });
       });

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -150,11 +150,11 @@ define(function (require, exports, module) {
           initView();
 
           var account = user.initAccount({
-              accessToken: 'access token',
-              email: 'a@a.com',
-              sessionToken: 'session token',
-              sessionTokenContext: Constants.SYNC_SERVICE
-            });
+            accessToken: 'access token',
+            email: 'a@a.com',
+            sessionToken: 'session token',
+            sessionTokenContext: Constants.SYNC_SERVICE
+          });
 
           sinon.stub(view, '_suggestedAccount', function () {
             return account;

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -144,6 +144,47 @@ define(function (require, exports, module) {
               assert.equal(view.$('[type=email]').val(), 'testuser@testuser.com');
             });
       });
+
+      describe('with a cached account whose accessToken is invalidated after render', function () {
+        beforeEach(function () {
+          initView();
+
+          var account = user.initAccount({
+              accessToken: 'access token',
+              email: 'a@a.com',
+              sessionToken: 'session token',
+              sessionTokenContext: Constants.SYNC_SERVICE
+            });
+
+          sinon.stub(view, '_suggestedAccount', function () {
+            return account;
+          });
+
+          sinon.spy(view, 'render');
+
+          return view.render()
+            .then(function () {
+              account.set({
+                accessToken: null,
+                sessionToken: null,
+                sessionTokenContext: null
+              });
+            });
+        });
+
+        it('re-renders', function () {
+          assert.equal(view.render.callCount, 2);
+        });
+
+        it('keeps the original email', function () {
+          assert.equal(view.$('.prefillEmail').text(), 'a@a.com');
+          assert.equal(view.$('input[type=email]').val(), 'a@a.com');
+        });
+
+        it('forces the user to enter their password', function () {
+          assert.lengthOf(view.$('input[type=password]'), 1);
+        });
+      });
     });
 
     describe('migration', function () {

--- a/tests/functional/upgrade_storage_formats.js
+++ b/tests/functional/upgrade_storage_formats.js
@@ -74,19 +74,22 @@ define([
 
     'Upgrade from Session w/ cached Sync credentials': function () {
       return this.remote
-        .execute(function (email) {
-          var userData = {
-            cachedCredentials: {
-              email: email,
-              sessionToken: 'another fake session token',
-              sessionTokenContext: 'sync',
-              uid: 'users id'
-            },
-            email: 'oauth@testuser.com',
-            sessionToken: 'a fake session token'
-          };
-          localStorage.setItem('__fxa_session', JSON.stringify(userData));
-        }, [ email ])
+        .then(createUser(email, 'password', { preVerified: true }))
+        .then(function (accountInfo) {
+          return this.parent.execute(function (email, sessionToken) {
+            var userData = {
+              cachedCredentials: {
+                email: email,
+                sessionToken: sessionToken,
+                sessionTokenContext: 'sync',
+                uid: 'users id'
+              },
+              email: 'oauth@testuser.com',
+              sessionToken: 'a fake session token'
+            };
+            localStorage.setItem('__fxa_session', JSON.stringify(userData));
+          }, [ email, accountInfo.sessionToken ]);
+        })
         .then(openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header'))
 
         // Sync creds take precedence


### PR DESCRIPTION
* In `fxa-client.js->recoveryEmailStatus, only check if the account exists if
a uid was passed in.
* In `account.js->fetch`, invalidate the session if
  fxaClient.recoveryEmailStatus returns `INVALID_TOKEN`
* Since sessionToken's are checked on startup and cleared if invalid, update
  the `Upgrade from Session w/ cached Sync credentials` to use real creds