### PR TITLE
fix(tests): speed up the relier unit tests

### DIFF
--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -15,7 +15,6 @@ define(function (require, exports, module) {
   var WindowMock = require('../../../mocks/window');
 
   var assert = chai.assert;
-  var getValueLabel = TestHelpers.getValueLabel;
 
   describe('models/reliers/relier', function () {
     var relier;
@@ -42,387 +41,288 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('fetch', function () {
-      it('a missing `resume` token is not a problem', function () {
-        windowMock.location.search = TestHelpers.toSearchString({
-          campaign: CAMPAIGN
-        });
-
-        return relier.fetch()
-          .then(function () {
-            assert.equal(relier.get('campaign'), CAMPAIGN);
-          });
+    it('fetch with missing `resume` token is not a problem', function () {
+      windowMock.location.search = TestHelpers.toSearchString({
+        campaign: CAMPAIGN
       });
 
-      it('populates expected fields from the search parameters, unexpected search parameters are ignored', function () {
-        windowMock.location.search = TestHelpers.toSearchString({
-          allowCachedCredentials: false,
-          campaign: CAMPAIGN,
-          email: EMAIL,
-          entrypoint: ENTRYPOINT,
-          ignored: 'ignored',
-          preVerifyToken: PREVERIFY_TOKEN,
-          service: SERVICE,
-          setting: SETTING,
-          uid: UID,
-          utm_campaign: UTM_CAMPAIGN, //eslint-disable-line camelcase
-          utm_content: UTM_CONTENT, //eslint-disable-line camelcase
-          utm_medium: UTM_MEDIUM, //eslint-disable-line camelcase
-          utm_source: UTM_SOURCE, //eslint-disable-line camelcase
-          utm_term: UTM_TERM //eslint-disable-line camelcase
+      return relier.fetch()
+        .then(function () {
+          assert.equal(relier.get('campaign'), CAMPAIGN);
         });
+    });
 
-        return relier.fetch()
-            .then(function () {
-              // not imported from the search parameters, but is set manually.
-              assert.isTrue(relier.get('allowCachedCredentials'));
+    it('fetch populates expected fields from the search parameters, unexpected search parameters are ignored', function () {
+      windowMock.location.search = TestHelpers.toSearchString({
+        allowCachedCredentials: false,
+        campaign: CAMPAIGN,
+        email: EMAIL,
+        entrypoint: ENTRYPOINT,
+        ignored: 'ignored',
+        preVerifyToken: PREVERIFY_TOKEN,
+        service: SERVICE,
+        setting: SETTING,
+        uid: UID,
+        utm_campaign: UTM_CAMPAIGN, //eslint-disable-line camelcase
+        utm_content: UTM_CONTENT, //eslint-disable-line camelcase
+        utm_medium: UTM_MEDIUM, //eslint-disable-line camelcase
+        utm_source: UTM_SOURCE, //eslint-disable-line camelcase
+        utm_term: UTM_TERM //eslint-disable-line camelcase
+      });
 
-              assert.equal(relier.get('preVerifyToken'), PREVERIFY_TOKEN);
-              assert.equal(relier.get('service'), SERVICE);
-              assert.equal(relier.get('email'), EMAIL);
+      return relier.fetch()
+        .then(function () {
+          // not imported from the search parameters, but is set manually.
+          assert.isTrue(relier.get('allowCachedCredentials'));
 
-              assert.equal(relier.get('setting'), SETTING);
-              assert.equal(relier.get('uid'), UID);
-              assert.equal(relier.get('entrypoint'), ENTRYPOINT);
-              assert.equal(relier.get('campaign'), CAMPAIGN);
+          assert.equal(relier.get('preVerifyToken'), PREVERIFY_TOKEN);
+          assert.equal(relier.get('service'), SERVICE);
+          assert.equal(relier.get('email'), EMAIL);
 
-              assert.equal(relier.get('utmCampaign'), UTM_CAMPAIGN);
-              assert.equal(relier.get('utmContent'), UTM_CONTENT);
-              assert.equal(relier.get('utmMedium'), UTM_MEDIUM);
-              assert.equal(relier.get('utmSource'), UTM_SOURCE);
-              assert.equal(relier.get('utmTerm'), UTM_TERM);
+          assert.equal(relier.get('setting'), SETTING);
+          assert.equal(relier.get('uid'), UID);
+          assert.equal(relier.get('entrypoint'), ENTRYPOINT);
+          assert.equal(relier.get('campaign'), CAMPAIGN);
 
-              assert.isFalse(relier.has('ignored'));
-            });
+          assert.equal(relier.get('utmCampaign'), UTM_CAMPAIGN);
+          assert.equal(relier.get('utmContent'), UTM_CONTENT);
+          assert.equal(relier.get('utmMedium'), UTM_MEDIUM);
+          assert.equal(relier.get('utmSource'), UTM_SOURCE);
+          assert.equal(relier.get('utmTerm'), UTM_TERM);
+
+          assert.isFalse(relier.has('ignored'));
+        });
+    });
+
+    it('entryPoint is correctly translated to `entrypoint` if `entrypoint` is not specified', function () {
+      windowMock.location.search = TestHelpers.toSearchString({
+        entryPoint: ENTRYPOINT
+      });
+
+      return relier.fetch()
+        .then(function () {
+          assert.equal(relier.get('entrypoint'), ENTRYPOINT);
+        });
+    });
+
+    it('entryPoint is ignored if `entrypoint` is already specified', function () {
+      windowMock.location.search = TestHelpers.toSearchString({
+        entryPoint: 'ignored entrypoint',
+        entrypoint: ENTRYPOINT
+      });
+
+      return relier.fetch()
+        .then(function () {
+          assert.equal(relier.get('entrypoint'), ENTRYPOINT);
+        });
+    });
+
+    ['', ' ', 'invalid token'].forEach(function (value) {
+      testInvalidQueryParam('preVerifyToken', value);
+    });
+
+    [undefined, PREVERIFY_TOKEN].forEach(function (value) {
+      testValidQueryParam('preVerifyToken', value, 'preVerifyToken', value);
+    });
+
+    ['', ' ', 'invalid migration'].forEach(function (token) {
+      testInvalidQueryParam('migration', token);
+    });
+
+    [undefined, Constants.AMO_MIGRATION, Constants.SYNC11_MIGRATION].forEach(function (value) {
+      testValidQueryParam('migration', value, 'migration', value);
+    });
+
+    describe('email non-verification flow', function () {
+      beforeEach(function () {
+        relier.set('isVerification', false);
+      });
+
+      ['', ' ', 'invalid email'].forEach(function (email) {
+        testInvalidQueryParam('email', email);
+      });
+
+      ['testuser@testuser.com', 'testuser@testuser.co.uk'].forEach(function (value) {
+        testValidQueryParam('email', value, 'email', value);
       });
     });
 
-    describe('entryPoint', function () {
-      it('is correctly translated to `entrypoint` if `entrypoint` is not specified', function () {
-        windowMock.location.search = TestHelpers.toSearchString({
-          entryPoint: ENTRYPOINT
+    describe('email verification flow', function () {
+      beforeEach(function () {
+        relier = new Relier({
+          isVerification: true,
+          window: windowMock
         });
-
-        return relier.fetch()
-          .then(function () {
-            assert.equal(relier.get('entrypoint'), ENTRYPOINT);
-          });
       });
 
-      it('is ignored if `entrypoint` is already specified', function () {
-        windowMock.location.search = TestHelpers.toSearchString({
-          entryPoint: 'ignored entrypoint',
-          entrypoint: ENTRYPOINT
-        });
-
-        return relier.fetch()
-          .then(function () {
-            assert.equal(relier.get('entrypoint'), ENTRYPOINT);
-          });
+      [
+        // the non-email strings will cause a validation error in
+        // the consuming views.
+        '',
+        ' ',
+        'invalid email',
+        'testuser@testuser.com',
+        'testuser@testuser.co.uk'
+      ].forEach(function (value) {
+        testValidQueryParam('email', value, 'email', value.trim());
       });
     });
 
-    describe('preVerifyToken', function () {
-      describe('invalid', function () {
-        var invalidTokens = ['', ' ', 'invalid token'];
-        invalidTokens.forEach(function (value) {
-          describe(getValueLabel(value), function () {
-            testInvalidQueryParam('preVerifyToken', value);
-          });
-        });
+    testValidQueryParam('email', Constants.DISALLOW_CACHED_CREDENTIALS, 'allowCachedCredentials', false);
+
+    describe('uid non-verification flow', function () {
+      beforeEach(function () {
+        relier.set('isVerification', false);
       });
 
-      describe('valid', function () {
-        var validTokens = [undefined, PREVERIFY_TOKEN];
-        validTokens.forEach(function (value) {
-          describe(getValueLabel(value), function () {
-            testValidQueryParam('preVerifyToken', value, 'preVerifyToken', value);
-          });
-        });
+      ['', ' ', 'invalid uid'].forEach(function (uid) {
+        testInvalidQueryParam('uid', uid);
+      });
+
+      [ UID ].forEach(function (value) {
+        testValidQueryParam('uid', value, 'uid', value);
       });
     });
 
-    describe('migration', function () {
-      describe('invalid', function () {
-        var invalidMigrations = ['', ' ', 'invalid migration'];
-        invalidMigrations.forEach(function (token) {
-          describe(getValueLabel(token), function () {
-            testInvalidQueryParam('migration', token);
-          });
+    describe('uid verification flow', function () {
+      beforeEach(function () {
+        relier = new Relier({
+          isVerification: true,
+          window: windowMock
         });
       });
 
-      describe('valid', function () {
-        var validMigrations = [undefined, Constants.AMO_MIGRATION, Constants.SYNC11_MIGRATION];
-        validMigrations.forEach(function (value) {
-          describe(getValueLabel(value), function () {
-            testValidQueryParam('migration', value, 'migration', value);
-          });
-        });
-      });
-    });
-
-    describe('email', function () {
-      describe('non-verification flow', function () {
-        beforeEach(function () {
-          relier.set('isVerification', false);
-        });
-
-        describe('invalid', function () {
-          var invalidEmails = ['', ' ', 'invalid email'];
-          invalidEmails.forEach(function (email) {
-            describe(getValueLabel(email), function () {
-              testInvalidQueryParam('email', email);
-            });
-          });
-        });
-
-        describe('valid', function () {
-          var validEmails = [
-            'testuser@testuser.com',
-            'testuser@testuser.co.uk'
-          ];
-
-          validEmails.forEach(function (value) {
-            describe(getValueLabel(value), function () {
-              testValidQueryParam('email', value, 'email', value);
-            });
-          });
-        });
-      });
-
-      describe('verification flow', function () {
-        beforeEach(function () {
-          relier = new Relier({
-            isVerification: true,
-            window: windowMock
-          });
-        });
-
-        describe('valid', function () {
-          var validEmails = [
-            // the non-email strings will cause a validation error in
-            // the consuming views.
-            '',
-            ' ',
-            'invalid email',
-            'testuser@testuser.com',
-            'testuser@testuser.co.uk'
-          ];
-
-          validEmails.forEach(function (value) {
-            describe(getValueLabel(value), function () {
-              testValidQueryParam('email', value, 'email', value.trim());
-            });
-          });
-        });
-      });
-
-      describe('email=blank', function () {
-        it('sets allowCachedCredentials to false', function () {
-          testValidQueryParam('email', Constants.DISALLOW_CACHED_CREDENTIALS, 'allowCachedCredentials', false);
-        });
+      [
+        // the non-uid strings will cause a validation error in
+        // the consuming views.
+        '',
+        ' ',
+        'invalid uid',
+        UID
+      ].forEach(function (value) {
+        testValidQueryParam('uid', value, 'uid', value.trim());
       });
     });
 
-    describe('uid', function () {
-      describe('non-verification flow', function () {
-        beforeEach(function () {
-          relier.set('isVerification', false);
-        });
+    testValidQueryParam('email', Constants.DISALLOW_CACHED_CREDENTIALS, 'allowCachedCredentials', false);
 
-        describe('invalid', function () {
-          var invalidUid = ['', ' ', 'invalid uid'];
-          invalidUid.forEach(function (uid) {
-            describe(getValueLabel(uid), function () {
-              testInvalidQueryParam('uid', uid);
-            });
-          });
-        });
+    it('isOAuth returns `false`', function () {
+      assert.isFalse(relier.isOAuth());
+    });
 
-        describe('valid', function () {
-          var validUid = [ UID ];
-
-          validUid.forEach(function (value) {
-            describe(getValueLabel(value), function () {
-              testValidQueryParam('uid', value, 'uid', value);
-            });
-          });
-        });
+    it('isSync returns `false` by default', function () {
+      windowMock.location.search = TestHelpers.toSearchString({
+        service: SERVICE
       });
 
-      describe('verification flow', function () {
-        beforeEach(function () {
-          relier = new Relier({
-            isVerification: true,
-            window: windowMock
-          });
+      return relier.fetch()
+        .then(function () {
+          assert.isFalse(relier.isSync());
         });
+    });
 
-        describe('valid', function () {
-          var validUid = [
-            // the non-uid strings will cause a validation error in
-            // the consuming views.
-            '',
-            ' ',
-            'invalid uid',
-            UID
-          ];
-
-          validUid.forEach(function (value) {
-            describe(getValueLabel(value), function () {
-              testValidQueryParam('uid', value, 'uid', value.trim());
-            });
-          });
+    it('allowCachedCredentials returns `true` if `email` not set', function () {
+      return relier.fetch()
+        .then(function () {
+          assert.isTrue(relier.allowCachedCredentials());
         });
+    });
+
+    it('allowCachedCredentials returns `true` if `email` is set to an email address', function () {
+      windowMock.location.search = TestHelpers.toSearchString({
+        email: 'testuser@testuser.com'
       });
 
-      describe('email=blank', function () {
-        it('sets allowCachedCredentials to false', function () {
-          testValidQueryParam('email', Constants.DISALLOW_CACHED_CREDENTIALS, 'allowCachedCredentials', false);
+      return relier.fetch()
+        .then(function () {
+          assert.isTrue(relier.allowCachedCredentials());
         });
+    });
+
+    it('allowCachedCredentials returns `false` if `email` is set to `blank`', function () {
+      windowMock.location.search = TestHelpers.toSearchString({
+        email: Constants.DISALLOW_CACHED_CREDENTIALS
+      });
+
+      return relier.fetch()
+        .then(function () {
+          assert.isFalse(relier.allowCachedCredentials());
+
+          // the email should not be set on the relier model
+          // if the specified email === blank
+          assert.isFalse(relier.has('email'));
+        });
+    });
+
+    it('pickResumeTokenInfo returns an object with info to be passed along with email verification links', function () {
+      var CAMPAIGN = 'campaign id';
+      var ITEM = 'item';
+      var ENTRYPOINT = 'entry point';
+
+      relier.set({
+        campaign: CAMPAIGN,
+        entrypoint: ENTRYPOINT,
+        notPassed: 'this should not be picked',
+        resetPasswordConfirm: true,
+        utmCampaign: CAMPAIGN,
+        utmContent: ITEM,
+        utmMedium: ITEM,
+        utmSource: ITEM,
+        utmTerm: ITEM
+      });
+
+      assert.deepEqual(relier.pickResumeTokenInfo(), {
+        campaign: CAMPAIGN,
+        entrypoint: ENTRYPOINT,
+        resetPasswordConfirm: true,
+        utmCampaign: CAMPAIGN,
+        utmContent: ITEM,
+        utmMedium: ITEM,
+        utmSource: ITEM,
+        utmTerm: ITEM
       });
     });
 
-    describe('isOAuth', function () {
-      it('returns `false`', function () {
-        assert.isFalse(relier.isOAuth());
-      });
-    });
+    it('re-population from resume token parses the resume param into an object', function () {
+      var CAMPAIGN = 'campaign id';
+      var ENTRYPOINT = 'entry point';
+      var resumeData = {
+        campaign: CAMPAIGN,
+        entrypoint: ENTRYPOINT,
+        notImported: 'this should not be picked',
+        resetPasswordConfirm: false
+      };
+      var resumeToken = ResumeToken.stringify(resumeData);
 
-    describe('isSync', function () {
-      it('returns `false` by default', function () {
-        windowMock.location.search = TestHelpers.toSearchString({
-          service: SERVICE
+      windowMock.location.search = TestHelpers.toSearchString({
+        resume: resumeToken
+      });
+
+      return relier.fetch()
+        .then(function () {
+          assert.equal(relier.get('campaign'), CAMPAIGN);
+          assert.equal(relier.get('entrypoint'), ENTRYPOINT);
+          assert.isUndefined(relier.get('notImported'), 'only allow specific resume token values');
+          assert.isFalse(relier.get('resetPasswordConfirm'));
         });
-
-        return relier.fetch()
-          .then(function () {
-            assert.isFalse(relier.isSync());
-          });
-      });
-    });
-
-    describe('allowCachedCredentials', function () {
-      it('returns `true` if `email` not set', function () {
-        return relier.fetch()
-          .then(function () {
-            assert.isTrue(relier.allowCachedCredentials());
-          });
-      });
-
-      it('returns `true` if `email` is set to an email address', function () {
-        windowMock.location.search = TestHelpers.toSearchString({
-          email: 'testuser@testuser.com'
-        });
-
-        return relier.fetch()
-          .then(function () {
-            assert.isTrue(relier.allowCachedCredentials());
-          });
-      });
-
-      it('returns `false` if `email` is set to `blank`', function () {
-        windowMock.location.search = TestHelpers.toSearchString({
-          email: Constants.DISALLOW_CACHED_CREDENTIALS
-        });
-
-        return relier.fetch()
-          .then(function () {
-            assert.isFalse(relier.allowCachedCredentials());
-
-            // the email should not be set on the relier model
-            // if the specified email === blank
-            assert.isFalse(relier.has('email'));
-          });
-      });
-    });
-
-    describe('pickResumeTokenInfo', function () {
-      it('returns an object with info to be passed along with email verification links', function () {
-        var CAMPAIGN = 'campaign id';
-        var ITEM = 'item';
-        var ENTRYPOINT = 'entry point';
-
-        relier.set({
-          campaign: CAMPAIGN,
-          entrypoint: ENTRYPOINT,
-          notPassed: 'this should not be picked',
-          resetPasswordConfirm: true,
-          utmCampaign: CAMPAIGN,
-          utmContent: ITEM,
-          utmMedium: ITEM,
-          utmSource: ITEM,
-          utmTerm: ITEM
-        });
-
-        assert.deepEqual(relier.pickResumeTokenInfo(), {
-          campaign: CAMPAIGN,
-          entrypoint: ENTRYPOINT,
-          resetPasswordConfirm: true,
-          utmCampaign: CAMPAIGN,
-          utmContent: ITEM,
-          utmMedium: ITEM,
-          utmSource: ITEM,
-          utmTerm: ITEM
-        });
-      });
-    });
-
-    describe('re-population from resume token', function () {
-      it('parses the resume param into an object', function () {
-        var CAMPAIGN = 'campaign id';
-        var ENTRYPOINT = 'entry point';
-        var resumeData = {
-          campaign: CAMPAIGN,
-          entrypoint: ENTRYPOINT,
-          notImported: 'this should not be picked',
-          resetPasswordConfirm: false
-        };
-        var resumeToken = ResumeToken.stringify(resumeData);
-
-        windowMock.location.search = TestHelpers.toSearchString({
-          resume: resumeToken
-        });
-
-        return relier.fetch()
-          .then(function () {
-            assert.equal(relier.get('campaign'), CAMPAIGN);
-            assert.equal(relier.get('entrypoint'), ENTRYPOINT);
-            assert.isUndefined(relier.get('notImported'), 'only allow specific resume token values');
-            assert.isFalse(relier.get('resetPasswordConfirm'));
-          });
-      });
     });
 
     function testInvalidQueryParam(paramName, value) {
-      var err;
-
-      beforeEach(function () {
+      it('invalid query param fails (' + paramName + ':\'' + value + '\')', function () {
         var params = {};
-
-        if (! _.isUndefined(value)) {
-          params[paramName] = value;
-        } else {
-          delete params[paramName];
-        }
-
+        params[paramName] = value;
         windowMock.location.search = TestHelpers.toSearchString(params);
 
         return relier.fetch()
-          .then(assert.fail, function (_err) {
-            err = _err;
+          .then(assert.fail, function (err) {
+            assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
+            assert.equal(err.param, paramName);
           });
-      });
-
-      it('errors correctly', function () {
-        assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
-        assert.equal(err.param, paramName);
       });
     }
 
     function testValidQueryParam(paramName, paramValue, modelName, expectedValue) {
-      beforeEach(function () {
+      it('valid query param succeeds (' + paramName + ':' + paramValue + ')', function () {
         var params = {};
 
         if (! _.isUndefined(paramValue)) {
@@ -433,15 +333,14 @@ define(function (require, exports, module) {
 
         windowMock.location.search = TestHelpers.toSearchString(params);
 
-        return relier.fetch();
-      });
-
-      it('is successful', function () {
-        if (_.isUndefined(expectedValue)) {
-          assert.isFalse(relier.has(modelName));
-        } else {
-          assert.equal(relier.get(modelName), expectedValue);
-        }
+        return relier.fetch()
+          .then(function () {
+            if (_.isUndefined(expectedValue)) {
+              assert.isFalse(relier.has(modelName));
+            } else {
+              assert.equal(relier.get(modelName), expectedValue);
+            }
+          });
       });
     }
   });


### PR DESCRIPTION
Earlier, I noticed that the unit tests had jumped from taking 57 seconds to 71 seconds. A bit of poking around pointed at [these relier tests](https://github.com/mozilla/fxa-content-server/commit/298be44a5a3cf142200ed9a31caa720ba7607f1e#diff-271e3329d7651c7cb1cef5747adcd1dfR165), specifically the repeated nested calls to `describe` inside loops.

By removing every call to `describe` unless it was required to contain a `beforeEach`, the time taken to run the tests was reduced to 59 seconds.

@shane-tomlinson, what do you think, is it worth making these changes to win back ~12 seconds? (probably worth adding `?w=1` to the URL for this one to hide the indentation changes)

