### PR TITLE
fix(styles): change focused fields color scheme

### DIFF
--- a/app/scripts/views/mixins/floating-placeholder-mixin.js
+++ b/app/scripts/views/mixins/floating-placeholder-mixin.js
@@ -15,6 +15,8 @@ define(function (require, exports, module) {
 
   module.exports = {
     events: {
+      'blur input': 'onInputBlur',
+      'focus input': 'onInputFocus',
       'input input[placeholder]': 'floatingPlaceholderMixinOnInput'
     },
 
@@ -30,15 +32,24 @@ define(function (require, exports, module) {
      *        should be shown.
      */
     showFloatingPlaceholder: function (inputEl) {
-      var $inputEl = $(inputEl);
-      var placeholder = $inputEl.attr('placeholder');
+      var placeholder = this.$el.find(inputEl).attr('placeholder');
 
       // If the placeholder for the element was already converted, no
       // further conversion will occur.
-      if (placeholder !== '') {
-        $inputEl.removeAttr('placeholder');
-        $inputEl.prev('.label-helper').text(placeholder).animate( {'top': '-17px'}, 400);
+      // The check for existence is because of the strict equality check,
+      // if placeholder is undefined, then it should not go into the block
+      if (placeholder && placeholder !== '') {
+        this.$el.find(inputEl).removeAttr('placeholder');
+        this.$el.find(inputEl).prev('.label-helper').text(placeholder).css({'top': '-17px'});
       }
+    },
+
+    focusFloatingPlaceholder: function (inputEl) {
+      this.$el.find(inputEl).prev('.label-helper').addClass('focused');
+    },
+
+    unfocusFloatingPlaceholder: function (inputEl) {
+      this.$el.find(inputEl).prev('.label-helper').removeClass('focused');
     },
 
     /**
@@ -55,6 +66,15 @@ define(function (require, exports, module) {
       }
 
       this.showFloatingPlaceholder($inputEl);
+      this.focusFloatingPlaceholder($inputEl);
+    },
+
+    onInputFocus: function (event) {
+      this.focusFloatingPlaceholder($(event.currentTarget));
+    },
+
+    onInputBlur: function (event) {
+      this.unfocusFloatingPlaceholder($(event.currentTarget));
     }
   };
 });

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -25,6 +25,7 @@ $message-text-color: #fff;
 $mobile-html-background-color: #fff;
 $show-password-background-color: #9aabb8;
 $show-password-label-color: #8a9ba8;
+$show-password-focus-label-color: #fff;
 $content-background-color: #fff;
 $success-background-color: #5fad47;
 $text-color: #424f59;

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -163,6 +163,22 @@ ul.links {
   margin: 0 10px;
 }
 
+.show-password-label {
+  background-color: $show-password-background-color;
+  color: $show-password-label-color;
+  transition: background-color 450ms,
+              color 450ms;
+}
+
+.password:focus ~ .show-password-label {
+  color: $input-row-focus-border-color;
+}
+
+.password[type=text]:focus ~ .show-password-label {
+  background-color: $input-row-focus-border-color;
+  color: $show-password-focus-label-color;
+}
+
 .modal {
   .small-label,
   .label-helper {
@@ -173,6 +189,8 @@ ul.links {
 .label-helper {
   position: absolute;
   top: 0;
+  transition: top 400ms,
+              color 450ms;
   z-index: 1;
 }
 

--- a/app/styles/modules/_input-row.scss
+++ b/app/styles/modules/_input-row.scss
@@ -102,6 +102,15 @@
   input:focus ~ .input-help-focused,
   label:active ~ .input-help-focused,
   label:focus ~ .input-help-focused {
+    color: $input-row-focus-border-color;
     opacity: 1;
+  }
+
+  .label-helper {
+    color: $input-row-border-color;
+  }
+
+  .label-helper.focused {
+    color: $input-row-focus-border-color;
   }
 }

--- a/app/tests/spec/views/mixins/floating-placeholder-mixin.js
+++ b/app/tests/spec/views/mixins/floating-placeholder-mixin.js
@@ -59,9 +59,24 @@ define(function (require, exports, module) {
     describe('showFloatingPlaceholder', function () {
       it('forces the display of a floating placeholder', function () {
         view.showFloatingPlaceholder('#float_me');
-        assert.equal(view.$('#float_me').attr('placeholder'), 'placeholder text');
-        assert.equal(view.$('.label-helper').text(), '');
+        assert.equal(typeof view.$('#float_me').attr('placeholder'), 'undefined');
+        assert.equal(view.$('.label-helper').text(), 'placeholder text');
       });
     });
+
+    describe('focusFloatingPlaceholder', function () {
+      it('focuses the floating placeholder by adding the "focused" class', function () {
+        view.focusFloatingPlaceholder('#float_me');
+        assert.isTrue(view.$('#float_me').prev('.label-helper').hasClass('focused'));
+      });
+    });
+
+    describe('unfocusFloatingPlaceholder', function () {
+      it('unfocuses the floating placeholder by removing the "focused" class', function () {
+        view.unfocusFloatingPlaceholder('#float_me');
+        assert.isFalse(view.$('#float_me').prev('.label-helper').hasClass('focused'));
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Fixes #3384 
### Before
<img width="406" alt="screenshot 2016-05-11 14 34 47" src="https://cloud.githubusercontent.com/assets/432707/15197355/e021d54e-1785-11e6-9b9b-d45a3e219fbc.png">

### After
* Has Focus (sign-up page)
<img width="407" alt="screenshot 2016-05-11 14 19 18" src="https://cloud.githubusercontent.com/assets/432707/15197040/29961dd6-1784-11e6-8506-330ce0a69a58.png">

* Has Focus, unmasked (sign-up page)
<img width="395" alt="screenshot 2016-05-11 14 19 27" src="https://cloud.githubusercontent.com/assets/432707/15197079/5a86fc44-1784-11e6-8fb3-5d47b55dbc08.png">

* Has Focus (change password page)
<img width="625" alt="screenshot 2016-05-11 14 18 39" src="https://cloud.githubusercontent.com/assets/432707/15197062/4aac20ec-1784-11e6-87cd-f6a8483a7ce6.png">

* Has Focus, unmasked  (change password page)
<img width="506" alt="screenshot 2016-05-11 14 18 01" src="https://cloud.githubusercontent.com/assets/432707/15197239/2a80ecde-1785-11e6-9dad-a10bf36f69e8.png">


* No Focus, masked
<img width="401" alt="screenshot 2016-05-11 14 36 32" src="https://cloud.githubusercontent.com/assets/432707/15197334/c6ab0dc4-1785-11e6-8ff1-3d467d253bc2.png">

* No Focus, unmasked
<img width="395" alt="screenshot 2016-05-11 14 35 25" src="https://cloud.githubusercontent.com/assets/432707/15197319/b023c1c2-1785-11e6-963d-d89ff75d3e63.png">


@ryanfeeley 
@shane-tomlinson 
@johngruen 