### PR TITLE
chore(cleanup): cleanup gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ app/bower_components
 !.git*
 !.bowerrc
 !.editorconfig
-!.jshintrc
 !.npmignore
 !.travis.yml
 *~


### PR DESCRIPTION
Fixes #3733 
Removes .jshintrc from .gitignore.
@pdehaan 