### PR TITLE
feat(errors): Add messaging for new "request blocked" errno 125.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -96,6 +96,10 @@ define(function (require, exports, module) {
       errno: 122,
       message: UNEXPECTED_ERROR_MESSAGE
     },
+    REQUEST_BLOCKED: {
+      errno: 125,
+      message: t('The request was blocked for security reasons')
+    },
     ACCOUNT_RESET: {
       errno: 126,
       message: t('Your account has been locked for security reasons')


### PR DESCRIPTION
Adds basic client-side messaging to go along with https://github.com/mozilla/fxa-auth-server/pull/1256; I'm not thrilled about the messaging though, alternative suggestions welcome.  Maybe "unexpected error" would be better?