### PR TITLE
feat(metrics): Generate flowId on the server

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -269,9 +269,13 @@ define(function (require, exports, module) {
       errno: 1036,
       message: t('Missing property in resume token: %(property)s')
     },
-    INVALID_DATA_FLOW_BEGIN_ATTR: {
+    INVALID_DATA_ATTRIBUTE: {
       errno: 1037,
-      message: t('Invalid data-flow-begin attribute')
+      message: t('Invalid data attribute: %(property)s')
+    },
+    MISSING_DATA_ATTRIBUTE: {
+      errno: 1038,
+      message: t('Missing data attribute: %(property)s')
     }
   };
   /*eslint-enable sorting/sort-object-props*/
@@ -300,6 +304,14 @@ define(function (require, exports, module) {
             property: err.property
           };
         } else if (this.is(err, 'MISSING_RESUME_TOKEN_PROPERTY')) {
+          return {
+            property: err.property
+          };
+        } else if (this.is(err, 'INVALID_DATA_ATTRIBUTE')) {
+          return {
+            property: err.property
+          };
+        } else if (this.is(err, 'MISSING_DATA_ATTRIBUTE')) {
           return {
             property: err.property
           };

--- a/app/scripts/lib/errors.js
+++ b/app/scripts/lib/errors.js
@@ -185,6 +185,34 @@ define(function (require, exports, module) {
     },
 
     /**
+     * Create an INVALID_DATA_ATTRIBUTE error.
+     * The returned error will have `property` set to
+     * the property name.
+     *
+     * @property {String} propertyName
+     * @returns {Error}
+     */
+    toInvalidDataAttributeError: function (propertyName) {
+      var err = this.toError('INVALID_DATA_ATTRIBUTE');
+      err.property = propertyName;
+      return err;
+    },
+
+    /**
+     * Create a MISSING_DATA_ATTRIBUTE error.
+     * The returned error will have `property` set to
+     * the property name.
+     *
+     * @property {String} propertyName
+     * @returns {Error}
+     */
+    toMissingDataAttributeError: function (propertyName) {
+      var err = this.toError('MISSING_DATA_ATTRIBUTE');
+      err.property = propertyName;
+      return err;
+    },
+
+    /**
      * Check if an error is of the given type
      */
     is: function (error, type) {

--- a/app/scripts/models/flow.js
+++ b/app/scripts/models/flow.js
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A model to represent a login flow, holding the data that we
+ * need to submit as part of our metrics when we perform actions
+ * during the flow.
+ *
+ * Try to fetch the flowId and flowBegin from the resume token.
+ * If unavailable there, fetch from data attributes in the DOM.
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var $ = require('jquery');
+  var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
+  var Cocktail = require('cocktail');
+  var ErrorUtils = require('lib/error-utils');
+  var p = require('lib/promise');
+  var ResumeTokenMixin = require('models/mixins/resume-token');
+  var SearchParamMixin = require('models/mixins/search-param');
+  var vat = require('lib/vat');
+
+  var Model = Backbone.Model.extend({
+    initialize: function (options) {
+      options = options || {};
+
+      this.sentryMetrics = options.sentryMetrics;
+      this.window = options.window || window;
+    },
+
+    defaults: {
+      flowBegin: null,
+      flowId: null
+    },
+
+    fetch: function () {
+      var self = this;
+      return p()
+        .then(function () {
+          // We should either get both fields from the resume token, or neither.
+          // Getting one without the other is an error.
+          self.populateFromStringifiedResumeToken(self.getSearchParam('resume'));
+          if (self.has('flowId')) {
+            if (! self.has('flowBegin')) {
+              self.logError(AuthErrors.toMissingResumeTokenPropertyError('flowBegin'));
+            }
+          } else if (self.has('flowBegin')) {
+            self.logError(AuthErrors.toMissingResumeTokenPropertyError('flowId'));
+          } else {
+            self.populateFromDataAttribute('flowId');
+            self.populateFromDataAttribute('flowBegin');
+          }
+        });
+    },
+
+    populateFromDataAttribute: function (attribute) {
+      var data = $(this.window.document.body).data(attribute);
+      if (! data) {
+        this.logError(AuthErrors.toMissingDataAttributeError(attribute));
+      } else {
+        try {
+          data = this.resumeTokenSchema[attribute].validate(data);
+          this.set(attribute, data);
+        } catch (err) {
+          this.logError(AuthErrors.toInvalidDataAttributeError(attribute));
+        }
+      }
+    },
+
+    logError: function (error) {
+      return ErrorUtils.captureError(error, this.sentryMetrics);
+    },
+
+    resumeTokenFields: ['flowId', 'flowBegin'],
+
+    resumeTokenSchema: {
+      flowBegin: vat.number().test(function (value) {
+        // Integers only
+        return value === Math.round(value);
+      }),
+      flowId: vat.hex().len(64)
+    }
+  });
+
+  Cocktail.mixin(
+    Model,
+    ResumeTokenMixin,
+    SearchParamMixin
+  );
+
+  module.exports = Model;
+});

--- a/app/scripts/models/resume-token.js
+++ b/app/scripts/models/resume-token.js
@@ -17,6 +17,7 @@ define(function (require, exports, module) {
     defaults: {
       campaign: undefined,
       entrypoint: undefined,
+      flowBegin: undefined,
       flowId: undefined,
       resetPasswordConfirm: undefined,
       state: undefined,

--- a/app/scripts/views/mixins/flow-begin-mixin.js
+++ b/app/scripts/views/mixins/flow-begin-mixin.js
@@ -7,21 +7,27 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var $ = require('jquery');
-  var AuthErrors = require('lib/auth-errors');
+  var Flow = require('models/flow');
 
   module.exports = {
     afterRender: function () {
-      var flowId = this.user.get('flowId');
-      var flowBeginTime = parseInt($('body').attr('data-flow-begin'), 10);
+      var self = this;
 
-      if (! flowBeginTime) {
-        flowBeginTime = undefined;
-        this.logError(AuthErrors.toError('INVALID_DATA_FLOW_BEGIN_ATTR'));
-      }
+      self.flow = new Flow({
+        sentryMetrics: self.sentryMetrics,
+        window: self.window
+      });
 
-      this.metrics.setActivityEventMetadata('flowBeginTime', flowBeginTime);
-      this.metrics.logFlowBegin(flowId, flowBeginTime);
+      return self.flow.fetch().then(function () {
+        var flowId = self.flow.get('flowId');
+        var flowBegin = self.flow.get('flowBegin');
+
+        self.metrics.setActivityEventMetadata({
+          flowBeginTime: flowBegin,
+          flowId: flowId
+        });
+        self.metrics.logFlowBegin(flowId, flowBegin);
+      });
     }
   };
 });

--- a/app/scripts/views/mixins/flow-begin-mixin.js
+++ b/app/scripts/views/mixins/flow-begin-mixin.js
@@ -18,16 +18,14 @@ define(function (require, exports, module) {
         window: self.window
       });
 
-      return self.flow.fetch().then(function () {
-        var flowId = self.flow.get('flowId');
-        var flowBegin = self.flow.get('flowBegin');
+      var flowId = self.flow.get('flowId');
+      var flowBegin = self.flow.get('flowBegin');
 
-        self.metrics.setActivityEventMetadata({
-          flowBeginTime: flowBegin,
-          flowId: flowId
-        });
-        self.metrics.logFlowBegin(flowId, flowBegin);
+      self.metrics.setActivityEventMetadata({
+        flowBeginTime: flowBegin,
+        flowId: flowId
       });
+      self.metrics.logFlowBegin(flowId, flowBegin);
     }
   };
 });

--- a/app/scripts/views/mixins/resume-token-mixin.js
+++ b/app/scripts/views/mixins/resume-token-mixin.js
@@ -20,6 +20,7 @@ define(function (require, exports, module) {
     getResumeToken: function () {
       // there might not be any relier if the resume token is being fetched
       // for an account unlock request caused by changing the password.
+      var flowInfo = this.flow && this.flow.pickResumeTokenInfo();
       var relierInfo = this.relier && this.relier.pickResumeTokenInfo();
       var userInfo = this.user && this.user.pickResumeTokenInfo();
 
@@ -27,6 +28,7 @@ define(function (require, exports, module) {
       // they can be added as part of the resumeTokenInfo
       var resumeTokenInfo = _.extend(
         {},
+        flowInfo,
         relierInfo,
         userInfo
       );

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -103,7 +103,6 @@ define(function (require, exports, module) {
     this.sessionStorage = new NullStorage();
     this.top = this;
 
-
     this.MutationObserver = MutationObserver;
   }
 

--- a/app/tests/spec/models/flow.js
+++ b/app/tests/spec/models/flow.js
@@ -1,0 +1,228 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var $ = require('jquery');
+  var assert = require('chai').assert;
+  var AuthErrors = require('lib/auth-errors');
+  var Flow = require('models/flow');
+  var ResumeToken = require('models/resume-token');
+  var sinon = require('sinon');
+  var Url = require('lib/url');
+  var WindowMock = require('../../mocks/window');
+
+  var BODY_FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
+  var RESUME_FLOW_ID = '71031D71031D71031D71031D71031D71031D71031D71031D71031D71031D7103';
+
+  describe('models/flow', function () {
+    var flow;
+    var sentryMetricsMock;
+    var windowMock;
+
+    beforeEach(function () {
+      sentryMetricsMock = {
+        captureException: sinon.spy()
+      };
+      windowMock = new WindowMock();
+      $(windowMock.document.body).removeData('flowId').removeAttr('data-flow-id');
+      $(windowMock.document.body).removeData('flowBegin').removeAttr('data-flow-begin');
+      flow = new Flow({
+        sentryMetrics: sentryMetricsMock,
+        window: windowMock
+      });
+    });
+
+    afterEach(function () {
+      flow = null;
+    });
+
+    it('fetches from the `resume` search parameter, if available', function () {
+      windowMock.location.search = Url.objToSearchString({
+        resume: ResumeToken.stringify({ flowBegin: 42, flowId: RESUME_FLOW_ID })
+      });
+
+      return flow.fetch().then(function () {
+        assert.equal(flow.get('flowId'), RESUME_FLOW_ID);
+        assert.equal(flow.get('flowBegin'), 42);
+      });
+    });
+
+    it('fetches from body data attributes, if available', function () {
+      $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
+      $(windowMock.document.body).attr('data-flow-begin', '42');
+
+      return flow.fetch().then(function () {
+        assert.equal(flow.get('flowId'), BODY_FLOW_ID);
+        assert.equal(flow.get('flowBegin'), 42);
+      });
+    });
+
+    it('gives preference to values from the `resume` search parameter', function () {
+      windowMock.location.search = Url.objToSearchString({
+        resume: ResumeToken.stringify({ flowBegin: 42, flowId: RESUME_FLOW_ID })
+      });
+      $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
+      $(windowMock.document.body).attr('data-flow-begin', '24');
+
+      return flow.fetch().then(function () {
+        assert.equal(flow.get('flowId'), RESUME_FLOW_ID);
+        assert.equal(flow.get('flowBegin'), 42);
+      });
+    });
+
+    it('logs an error when the resume token contains `flowId` but not `flowBegin`', function () {
+      windowMock.location.search = Url.objToSearchString({
+        resume: ResumeToken.stringify({ flowId: RESUME_FLOW_ID })
+      });
+      $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
+      $(windowMock.document.body).attr('data-flow-begin', '24');
+
+      return flow.fetch().then(function () {
+        assert.equal(flow.get('flowId'), RESUME_FLOW_ID);
+        assert.notOk(flow.has('flowBegin'));
+
+        assert.strictEqual(sentryMetricsMock.captureException.callCount, 1);
+        var args = sentryMetricsMock.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.isTrue(AuthErrors.is(args[0], 'MISSING_RESUME_TOKEN_PROPERTY'));
+        assert.strictEqual(args[0].property, 'flowBegin');
+      });
+    });
+
+    it('logs an error when the resume token contains `flowBegin` but not `flowId`', function () {
+      windowMock.location.search = Url.objToSearchString({
+        resume: ResumeToken.stringify({ flowBegin: 42 })
+      });
+      $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
+      $(windowMock.document.body).attr('data-flow-begin', '24');
+
+      return flow.fetch().then(function () {
+        assert.notOk(flow.has('flowId'));
+        assert.equal(flow.get('flowBegin'), 42);
+
+        assert.strictEqual(sentryMetricsMock.captureException.callCount, 1);
+        var args = sentryMetricsMock.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.isTrue(AuthErrors.is(args[0], 'MISSING_RESUME_TOKEN_PROPERTY'));
+        assert.strictEqual(args[0].property, 'flowId');
+      });
+    });
+
+    it('logs an error when the DOM contains `flowId` but not `flowBegin`', function () {
+      $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
+
+      return flow.fetch().then(function () {
+        assert.equal(flow.get('flowId'), BODY_FLOW_ID);
+        assert.notOk(flow.has('flowBegin'));
+
+        assert.strictEqual(sentryMetricsMock.captureException.callCount, 1);
+        var args = sentryMetricsMock.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.isTrue(AuthErrors.is(args[0], 'MISSING_DATA_ATTRIBUTE'));
+        assert.strictEqual(args[0].property, 'flowBegin');
+      });
+    });
+
+    it('logs an error when the DOM contains `flowBegin` but not `flowId`', function () {
+      $(windowMock.document.body).attr('data-flow-begin', '42');
+
+      return flow.fetch().then(function () {
+        assert.notOk(flow.has('flowId'));
+        assert.equal(flow.get('flowBegin'), 42);
+
+        assert.strictEqual(sentryMetricsMock.captureException.callCount, 1);
+        var args = sentryMetricsMock.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.isTrue(AuthErrors.is(args[0], 'MISSING_DATA_ATTRIBUTE'));
+        assert.strictEqual(args[0].property, 'flowId');
+      });
+    });
+
+    it('logs two errors when there is no flow data available', function () {
+      return flow.fetch().then(function () {
+        assert.notOk(flow.has('flowId'));
+        assert.notOk(flow.has('flowBegin'));
+
+        assert.strictEqual(sentryMetricsMock.captureException.callCount, 2);
+
+        var args = sentryMetricsMock.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.isTrue(AuthErrors.is(args[0], 'MISSING_DATA_ATTRIBUTE'));
+        assert.strictEqual(args[0].property, 'flowId');
+
+        args = sentryMetricsMock.captureException.args[1];
+        assert.lengthOf(args, 1);
+        assert.isTrue(AuthErrors.is(args[0], 'MISSING_DATA_ATTRIBUTE'));
+        assert.strictEqual(args[0].property, 'flowBegin');
+      });
+    });
+
+    it('logs an error when `data-flow-id` is too short', function () {
+      $(windowMock.document.body).attr('data-flow-id', '123456');
+      $(windowMock.document.body).attr('data-flow-begin', '42');
+
+      return flow.fetch().then(function () {
+        assert.notOk(flow.has('flowId'));
+        assert.equal(flow.get('flowBegin'), 42);
+
+        assert.strictEqual(sentryMetricsMock.captureException.callCount, 1);
+        var args = sentryMetricsMock.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.isTrue(AuthErrors.is(args[0], 'INVALID_DATA_ATTRIBUTE'));
+        assert.strictEqual(args[0].property, 'flowId');
+      });
+    });
+
+    it('logs an error when `data-flow-id` is not a hex string', function () {
+      $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID.substr(0, 63) + 'X');
+      $(windowMock.document.body).attr('data-flow-begin', '42');
+
+      return flow.fetch().then(function () {
+        assert.notOk(flow.has('flowId'));
+        assert.equal(flow.get('flowBegin'), 42);
+
+        assert.strictEqual(sentryMetricsMock.captureException.callCount, 1);
+        var args = sentryMetricsMock.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.isTrue(AuthErrors.is(args[0], 'INVALID_DATA_ATTRIBUTE'));
+        assert.strictEqual(args[0].property, 'flowId');
+      });
+    });
+
+    it('logs an error when `data-flow-begin` is not a number', function () {
+      $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
+      $(windowMock.document.body).attr('data-flow-begin', 'forty-two');
+
+      return flow.fetch().then(function () {
+        assert.equal(flow.get('flowId'), BODY_FLOW_ID);
+        assert.notOk(flow.has('flowBegin'));
+
+        assert.strictEqual(sentryMetricsMock.captureException.callCount, 1);
+        var args = sentryMetricsMock.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.isTrue(AuthErrors.is(args[0], 'INVALID_DATA_ATTRIBUTE'));
+        assert.strictEqual(args[0].property, 'flowBegin');
+      });
+    });
+
+    it('logs an error when `data-flow-begin` is not an integer', function () {
+      $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
+      $(windowMock.document.body).attr('data-flow-begin', '3.14159265');
+
+      return flow.fetch().then(function () {
+        assert.equal(flow.get('flowId'), BODY_FLOW_ID);
+        assert.notOk(flow.has('flowBegin'));
+
+        assert.strictEqual(sentryMetricsMock.captureException.callCount, 1);
+        var args = sentryMetricsMock.captureException.args[0];
+        assert.lengthOf(args, 1);
+        assert.isTrue(AuthErrors.is(args[0], 'INVALID_DATA_ATTRIBUTE'));
+        assert.strictEqual(args[0].property, 'flowBegin');
+      });
+    });
+  });
+});
+

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -15,7 +15,6 @@ define(function (require, exports, module) {
   var MarketingEmailErrors = require('lib/marketing-email-errors');
   var Notifier = require('lib/channels/notifier');
   var p = require('lib/promise');
-  var ResumeToken = require('models/resume-token');
   var Session = require('lib/session');
   var SentryMetrics = require('lib/sentry');
   var sinon = require('sinon');
@@ -27,8 +26,6 @@ define(function (require, exports, module) {
   var EMAIL = 'a@a.com';
   var SESSION_TOKEN = 'session token';
   var UUID = '12345678-1234-1234-1234-1234567890ab';
-  var VALID_FLOW_ID = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
-  var INVALID_FLOW_ID = VALID_FLOW_ID + '1';
 
   describe('models/user', function () {
     var fxaClientMock;
@@ -1080,133 +1077,6 @@ define(function (require, exports, module) {
 
       it('returns a promise that resolves to whether the account exists', function () {
         assert.isFalse(exists);
-      });
-    });
-
-    describe('fetch with valid flowId', function () {
-      var resumeToken, result;
-
-      beforeEach(function () {
-        resumeToken = new ResumeToken({
-          flowId: VALID_FLOW_ID,
-          uniqueUserId: UUID
-        });
-        sinon.stub(user, 'getSearchParam', function () {
-          return resumeToken.stringify();
-        });
-        sinon.spy(user, 'populateFromStringifiedResumeToken');
-        result = user.fetch();
-        return result;
-      });
-
-      afterEach(function () {
-        user.populateFromStringifiedResumeToken.reset();
-        user.getSearchParam.restore();
-      });
-
-      it('returned a promise', function () {
-        assert.isObject(result);
-        assert.strictEqual(result.constructor.name, 'Promise');
-      });
-
-      it('called self.getSearchParam correctly', function () {
-        assert.strictEqual(user.getSearchParam.callCount, 2);
-        var args = user.getSearchParam.args[1];
-        assert.lengthOf(args, 1);
-        assert.strictEqual(args[0], 'resume');
-      });
-
-      it('called self.populateFromStringifiedResumeToken correctly', function () {
-        assert.strictEqual(user.populateFromStringifiedResumeToken.callCount, 2);
-        var args = user.populateFromStringifiedResumeToken.args[1];
-        assert.lengthOf(args, 1);
-        assert.strictEqual(args[0], resumeToken.stringify());
-      });
-
-      it('maintained the same flowId', function () {
-        assert.isTrue(user.has('flowId'));
-        assert.strictEqual(user.get('flowId'), VALID_FLOW_ID);
-      });
-
-      it('called metrics.setActivityEventMetadata correctly', function () {
-        assert.strictEqual(metrics.setActivityEventMetadata.callCount, 2);
-        var args = metrics.setActivityEventMetadata.args[1];
-        assert.lengthOf(args, 2);
-        assert.strictEqual(args[0], 'flowId');
-        assert.strictEqual(args[1], VALID_FLOW_ID);
-      });
-    });
-
-    describe('fetch without flowId', function () {
-      beforeEach(function () {
-        sinon.stub(user, 'getSearchParam', function () {
-          return (new ResumeToken({
-            uniqueUserId: UUID
-          })).stringify();
-        });
-        sinon.spy(user, 'populateFromStringifiedResumeToken');
-        return user.fetch();
-      });
-
-      afterEach(function () {
-        user.populateFromStringifiedResumeToken.reset();
-        user.getSearchParam.restore();
-      });
-
-      it('called self.getSearchParam', function () {
-        assert.strictEqual(user.getSearchParam.callCount, 2);
-      });
-
-      it('called self.populateFromStringifiedResumeToken', function () {
-        assert.strictEqual(user.populateFromStringifiedResumeToken.callCount, 2);
-      });
-
-      it('set a new flowId', function () {
-        assert.isTrue(user.has('flowId'));
-        assert.match(user.get('flowId'), /^[0-9a-f]{64}$/i);
-      });
-
-      it('called metrics.setActivityEventMetadata correctly', function () {
-        assert.strictEqual(metrics.setActivityEventMetadata.callCount, 2);
-        var args = metrics.setActivityEventMetadata.args[1];
-        assert.lengthOf(args, 2);
-        assert.strictEqual(args[0], 'flowId');
-        assert.strictEqual(args[1], user.get('flowId'));
-      });
-    });
-
-    describe('fetch with invalid flowId', function () {
-      var resumeToken;
-
-      beforeEach(function () {
-        resumeToken = new ResumeToken({
-          flowId: INVALID_FLOW_ID,
-          uniqueUserId: UUID
-        });
-        sinon.stub(user, 'getSearchParam', function () {
-          return resumeToken.stringify();
-        });
-        sinon.spy(user, 'populateFromStringifiedResumeToken');
-        return user.fetch();
-      });
-
-      afterEach(function () {
-        user.populateFromStringifiedResumeToken.reset();
-        user.getSearchParam.restore();
-      });
-
-      it('called self.getSearchParam', function () {
-        assert.strictEqual(user.getSearchParam.callCount, 2);
-      });
-
-      it('called self.populateFromStringifiedResumeToken', function () {
-        assert.strictEqual(user.populateFromStringifiedResumeToken.callCount, 2);
-      });
-
-      it('set a new flowId', function () {
-        assert.isTrue(user.has('flowId'));
-        assert.notEqual(user.get('flowId'), INVALID_FLOW_ID);
-        assert.match(user.get('flowId'), /^[0-9a-f]{64}$/i);
       });
     });
   });

--- a/app/tests/spec/views/confirm_account_unlock.js
+++ b/app/tests/spec/views/confirm_account_unlock.js
@@ -248,14 +248,11 @@ define(function (require, exports, module) {
     });
 
     describe('afterRender', function () {
+      var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
+
       beforeEach(function () {
-        sinon.stub(user, 'get', function (attribute) {
-          if (attribute === 'flowId') {
-            return 'wibble';
-          }
-          return 'mock ' + attribute;
-        });
-        $('body').attr('data-flow-begin', '3.14159265');
+        $('body').data('flowId', FLOW_ID);
+        $('body').data('flowBegin', 3);
         sinon.spy(metrics, 'setActivityEventMetadata');
         sinon.spy(metrics, 'logFlowBegin');
         return view.afterRender();
@@ -264,16 +261,17 @@ define(function (require, exports, module) {
       it('called metrics.setActivityEventMetadata correctly', function () {
         assert.equal(metrics.setActivityEventMetadata.callCount, 1);
         var args = metrics.setActivityEventMetadata.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], 'flowBeginTime');
-        assert.equal(args[1], 3);
+        assert.lengthOf(args, 1);
+        assert.lengthOf(Object.keys(args[0]), 2);
+        assert.equal(args[0].flowId, FLOW_ID);
+        assert.equal(args[0].flowBeginTime, 3);
       });
 
       it('called metrics.logFlowBegin correctly', function () {
         assert.equal(metrics.logFlowBegin.callCount, 1);
         var args = metrics.logFlowBegin.args[0];
         assert.lengthOf(args, 2);
-        assert.equal(args[0], 'wibble');
+        assert.equal(args[0], FLOW_ID);
         assert.equal(args[1], 3);
       });
     });

--- a/app/tests/spec/views/mixins/flow-begin-mixin.js
+++ b/app/tests/spec/views/mixins/flow-begin-mixin.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         flowBeginMixin.logError = sinon.spy();
         $('body').data('flowId', FLOW_ID);
         $('body').data('flowBegin', 42);
-        return flowBeginMixin.afterRender();
+        flowBeginMixin.afterRender();
       });
 
       it('correctly created a Flow model instance', function () {

--- a/app/tests/spec/views/mixins/flow-begin-mixin.js
+++ b/app/tests/spec/views/mixins/flow-begin-mixin.js
@@ -20,94 +20,44 @@ define(function (require, exports, module) {
     });
 
     describe('afterRender', function () {
+      var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
+
       beforeEach(function () {
         flowBeginMixin.metrics = {
           logFlowBegin: sinon.spy(),
           setActivityEventMetadata: sinon.spy()
         };
-        flowBeginMixin.user = {
-          get: sinon.spy(function () {
-            return 'foo';
-          })
-        };
         flowBeginMixin.logError = sinon.spy();
-        $('body').attr('data-flow-begin', '42');
-        flowBeginMixin.afterRender();
+        $('body').data('flowId', FLOW_ID);
+        $('body').data('flowBegin', 42);
+        return flowBeginMixin.afterRender();
       });
 
-      it('called user.get correctly', function () {
-        assert.strictEqual(flowBeginMixin.user.get.callCount, 1);
-        var args = flowBeginMixin.user.get.args[0];
-        assert.strictEqual(args.length, 1);
-        assert.strictEqual(args[0], 'flowId');
+      it('correctly created a Flow model instance', function () {
+        assert.ok(flowBeginMixin.flow);
+        assert.strictEqual(flowBeginMixin.flow.get('flowId'), FLOW_ID);
+        assert.strictEqual(flowBeginMixin.flow.get('flowBegin'), 42);
       });
 
       it('called metrics.setActivityEventMetadata correctly', function () {
         assert.strictEqual(flowBeginMixin.metrics.setActivityEventMetadata.callCount, 1);
         var args = flowBeginMixin.metrics.setActivityEventMetadata.args[0];
-        assert.lengthOf(args, 2);
-        assert.strictEqual(args[0], 'flowBeginTime');
-        assert.strictEqual(args[1], 42);
+        assert.lengthOf(args, 1);
+        assert.lengthOf(Object.keys(args[0]), 2);
+        assert.strictEqual(args[0].flowId, FLOW_ID);
+        assert.strictEqual(args[0].flowBeginTime, 42);
       });
 
       it('called metrics.logFlowBegin correctly', function () {
         assert.strictEqual(flowBeginMixin.metrics.logFlowBegin.callCount, 1);
         var args = flowBeginMixin.metrics.logFlowBegin.args[0];
         assert.lengthOf(args, 2);
-        assert.strictEqual(args[0], 'foo');
+        assert.strictEqual(args[0], FLOW_ID);
         assert.strictEqual(args[1], 42);
       });
 
       it('did not call view.logError', function () {
         assert.strictEqual(flowBeginMixin.logError.callCount, 0);
-      });
-    });
-
-    describe('afterRender with invalid data-flow-begin attribute', function () {
-      beforeEach(function () {
-        flowBeginMixin.metrics = {
-          logFlowBegin: sinon.spy(),
-          setActivityEventMetadata: sinon.spy()
-        };
-        flowBeginMixin.user = {
-          get: sinon.spy(function () {
-            return 'wibble';
-          })
-        };
-        flowBeginMixin.logError = sinon.spy();
-        $('body').attr('data-flow-begin', 'bar');
-        flowBeginMixin.afterRender();
-      });
-
-      it('called user.get correctly', function () {
-        assert.strictEqual(flowBeginMixin.user.get.callCount, 1);
-        var args = flowBeginMixin.user.get.args[0];
-        assert.strictEqual(args.length, 1);
-        assert.strictEqual(args[0], 'flowId');
-      });
-
-      it('called metrics.set correctly', function () {
-        assert.strictEqual(flowBeginMixin.metrics.setActivityEventMetadata.callCount, 1);
-        var args = flowBeginMixin.metrics.setActivityEventMetadata.args[0];
-        assert.lengthOf(args, 2);
-        assert.strictEqual(args[0], 'flowBeginTime');
-        assert.isUndefined(args[1]);
-      });
-
-      it('called metrics.logFlowBegin correctly', function () {
-        assert.strictEqual(flowBeginMixin.metrics.logFlowBegin.callCount, 1);
-        var args = flowBeginMixin.metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 2);
-        assert.strictEqual(args[0], 'wibble');
-        assert.isUndefined(args[1]);
-      });
-
-      it('called view.logError correctly', function () {
-        assert.strictEqual(flowBeginMixin.logError.callCount, 1);
-        var args = flowBeginMixin.logError.args[0];
-        assert.lengthOf(args, 1);
-        assert.instanceOf(args[0], Error);
-        assert.equal(args[0].message, 'Invalid data-flow-begin attribute');
       });
     });
   });

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -789,14 +789,11 @@ define(function (require, exports, module) {
     });
 
     describe('afterRender', function () {
+      var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
+
       beforeEach(function () {
-        sinon.stub(user, 'get', function (attribute) {
-          if (attribute === 'flowId') {
-            return 'foo';
-          }
-          return 'mock ' + attribute;
-        });
-        $('body').attr('data-flow-begin', '-1.1');
+        $('body').data('flowId', FLOW_ID);
+        $('body').data('flowBegin', -1);
         sinon.spy(metrics, 'setActivityEventMetadata');
         sinon.spy(metrics, 'logFlowBegin');
         return view.afterRender();
@@ -805,16 +802,17 @@ define(function (require, exports, module) {
       it('called metrics.setActivityEventMetadata correctly', function () {
         assert.equal(metrics.setActivityEventMetadata.callCount, 1);
         var args = metrics.setActivityEventMetadata.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], 'flowBeginTime');
-        assert.equal(args[1], -1);
+        assert.lengthOf(args, 1);
+        assert.lengthOf(Object.keys(args[0]), 2);
+        assert.equal(args[0].flowId, FLOW_ID);
+        assert.equal(args[0].flowBeginTime, -1);
       });
 
       it('called metrics.logFlowBegin correctly', function () {
         assert.equal(metrics.logFlowBegin.callCount, 1);
         var args = metrics.logFlowBegin.args[0];
         assert.lengthOf(args, 2);
-        assert.equal(args[0], 'foo');
+        assert.equal(args[0], FLOW_ID);
         assert.equal(args[1], -1);
       });
     });

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -368,14 +368,11 @@ define(function (require, exports, module) {
     });
 
     describe('afterRender', function () {
+      var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
+
       beforeEach(function () {
-        sinon.stub(user, 'get', function (attribute) {
-          if (attribute === 'flowId') {
-            return 'wibble';
-          }
-          return 'mock ' + attribute;
-        });
-        $('body').attr('data-flow-begin', '3.14159265');
+        $('body').data('flowId', FLOW_ID);
+        $('body').data('flowBegin', 3);
         sinon.spy(metrics, 'setActivityEventMetadata');
         sinon.spy(metrics, 'logFlowBegin');
         return view.afterRender();
@@ -384,16 +381,17 @@ define(function (require, exports, module) {
       it('called metrics.setActivityEventMetadata correctly', function () {
         assert.equal(metrics.setActivityEventMetadata.callCount, 1);
         var args = metrics.setActivityEventMetadata.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], 'flowBeginTime');
-        assert.equal(args[1], 3);
+        assert.lengthOf(args, 1);
+        assert.lengthOf(Object.keys(args[0]), 2);
+        assert.equal(args[0].flowId, FLOW_ID);
+        assert.equal(args[0].flowBeginTime, 3);
       });
 
       it('called metrics.logFlowBegin correctly', function () {
         assert.equal(metrics.logFlowBegin.callCount, 1);
         var args = metrics.logFlowBegin.args[0];
         assert.lengthOf(args, 2);
-        assert.equal(args[0], 'wibble');
+        assert.equal(args[0], FLOW_ID);
         assert.equal(args[1], 3);
       });
     });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -85,6 +85,7 @@ function (Translator, Session) {
     '../tests/spec/models/device',
     '../tests/spec/models/devices',
     '../tests/spec/models/email-resend',
+    '../tests/spec/models/flow',
     '../tests/spec/models/form-prefill',
     '../tests/spec/models/marketing-email-prefs',
     '../tests/spec/models/mixins/resume-token',

--- a/grunttasks/l10n-generate-pages.js
+++ b/grunttasks/l10n-generate-pages.js
@@ -23,6 +23,7 @@ module.exports = function (grunt) {
   var templateDest;
 
   var PROPAGATED_TEMPLATE_FIELDS = [
+    'flowId',
     'flowBeginTime',
     'message'
   ];

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -119,6 +119,11 @@ var conf = module.exports = convict({
       doc: 'poll the experiments git repo for changes'
     }
   },
+  flow_id_key: {
+    default: 'YOU MUST CHANGE ME',
+    doc: 'HMAC key used to verify flow event data',
+    format: String
+  },
   fxaccount_url: {
     default: 'http://127.0.0.1:9000',
     doc: 'The url of the Firefox Account auth server',

--- a/server/lib/flow-metrics.js
+++ b/server/lib/flow-metrics.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var crypto = require('crypto');
+
+module.exports = function flowEventData(config, request) {
+
+  var flowId = crypto.randomBytes(16).toString('hex');
+  var flowBeginTime = Date.now();
+
+  // Incorporate a hash of request metadata into the flow id,
+  // so that receiving servers can cross-check the metrics bundle.
+
+  var key = config.get('flow_id_key');
+  var flowSignature = crypto.createHmac('sha256', key)
+    .update([
+      flowId,
+      flowBeginTime.toString(16),
+      request.headers['user-agent']
+    ].join('\n'))
+    .digest('hex')
+    .substr(0, 32);
+
+  return {
+    flowBeginTime: flowBeginTime,
+    flowId: flowId + flowSignature
+  };
+};

--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+var flowMetrics = require('../flow-metrics');
+
 module.exports = function (config) {
   var STATIC_RESOURCE_URL = config.get('static_resource_url');
 
@@ -10,8 +12,12 @@ module.exports = function (config) {
   route.path = '/';
 
   route.process = function (req, res) {
+
+    var flowEventData = flowMetrics(config, req);
+
     res.render('index', {
-      flowBeginTime: Date.now(),
+      flowBeginTime: flowEventData.flowBeginTime,
+      flowId: flowEventData.flowId,
       // Note that staticResourceUrl is added to templates as a build step
       staticResourceUrl: STATIC_RESOURCE_URL
     });

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -34,7 +34,7 @@
           <!-- endbuild -->
         <![endif]-->
     </head>
-    <body data-flow-begin="{{flowBeginTime}}">
+    <body data-flow-id="{{flowId}}" data-flow-begin="{{flowBeginTime}}">
         <div id="fox-logo"></div>
         <div id="loading-spinner" class="spinner"></div>
         <div id="stage">

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -14,6 +14,7 @@ define([
     'tests/server/ver.json.js',
     'tests/server/cookies_disabled',
     'tests/server/csp',
+    'tests/server/flow-metrics',
     'tests/server/l10n',
     'tests/server/lang',
     'tests/server/metrics',

--- a/tests/server/flow-metrics.js
+++ b/tests/server/flow-metrics.js
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!crypto',
+  'intern/dojo/node!../../server/lib/flow-metrics',
+  'intern/dojo/node!sinon'
+], function (registerSuite, assert, crypto, flowMetrics, sinon) {
+
+  var suite = {
+    name: 'flow-metrics'
+  };
+
+  var mockConfig, mockRequest, mockDateNow, mockRandomBytes;
+
+  suite.beforeEach = function () {
+    sinon.stub(Date, 'now', function () {
+      return mockDateNow;
+    });
+    sinon.stub(crypto, 'randomBytes', function (size) {
+      if (mockRandomBytes) {
+        return new Buffer(mockRandomBytes);
+      } else {
+        var b = new Buffer(size);
+        b.fill(0);
+        return b;
+      }
+    });
+    mockConfig = {
+      flow_id_key: 'test hmac key', //eslint-disable-line camelcase
+      get: sinon.spy(function (name) {
+        return this[name];
+      })
+    };
+    mockRequest = {
+      headers: {
+        'user-agent': 'test user agent'
+      }
+    };
+    mockDateNow = 0;
+    mockRandomBytes = null;
+  };
+
+  suite.afterEach = function () {
+    mockConfig = null;
+    mockRequest = null;
+    mockDateNow = 0;
+    mockRandomBytes = null;
+    crypto.randomBytes.restore();
+    Date.now.restore();
+  };
+
+  suite['returns current timestamp for flowBeginTime'] = function () {
+    mockDateNow = 42;
+    var flowEventData = flowMetrics(mockConfig, mockRequest);
+    assert.equal(flowEventData.flowBeginTime, 42);
+  };
+
+  suite['correctly generates a known test vector'] = function () {
+    mockDateNow = 1451566800000;
+    mockRequest.headers['user-agent'] = 'Firefox';
+    mockConfig.flow_id_key = 'S3CR37'; //eslint-disable-line camelcase
+    mockRandomBytes = 'MozillaFirefox!!';
+    // Want to cross-check the test vector here?
+    // The following python code was used to generate it:
+    //
+    //   import hashlib, hmac, binascii
+    //   print binascii.hexlify('MozillaFirefox!!')
+    //   print hmac.new('S3CR37', '\n'.join((
+    //      binascii.hexlify('MozillaFirefox!!'),
+    //      hex(1451566800000)[2:],
+    //      'Firefox'
+    //   )), hashlib.sha256).hexdigest()[:32]
+    //
+    var expectedSalt = '4d6f7a696c6c6146697265666f782121';
+    var expectedHmac = 'c89d56556d22039fbbf54d34e0baf206';
+
+    var flowEventData = flowMetrics(mockConfig, mockRequest);
+
+    assert.equal(flowEventData.flowBeginTime, 1451566800000);
+    assert.equal(flowEventData.flowId, expectedSalt + expectedHmac);
+  };
+
+  suite['generates different flowIds for different keys'] = function () {
+    mockConfig.flow_id_key = 'key1'; //eslint-disable-line camelcase
+    var flowEventData1 = flowMetrics(mockConfig, mockRequest);
+
+    mockConfig.flow_id_key = 'key2'; //eslint-disable-line camelcase
+    var flowEventData2 = flowMetrics(mockConfig, mockRequest);
+
+    assert.notEqual(flowEventData1.flowId, flowEventData2.flowId);
+    assert.equal(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
+  };
+
+  suite['generates different flowIds for different user agents'] = function () {
+    mockRequest.headers['user-agent'] = 'Firefox';
+    var flowEventData1 = flowMetrics(mockConfig, mockRequest);
+
+    mockRequest.headers['user-agent'] = 'Chrome';
+    var flowEventData2 = flowMetrics(mockConfig, mockRequest);
+
+    assert.notEqual(flowEventData1.flowId, flowEventData2.flowId);
+    assert.equal(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
+  };
+
+  suite['generates different flowIds for different random salts'] = function () {
+    mockRandomBytes = 'MozillaFirefox!!';
+    var flowEventData1 = flowMetrics(mockConfig, mockRequest);
+
+    mockRandomBytes = 'AllHailSeaMonkey';
+    var flowEventData2 = flowMetrics(mockConfig, mockRequest);
+
+    assert.notEqual(flowEventData1.flowId, flowEventData2.flowId);
+    assert.equal(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
+  };
+
+  suite['generates different flowIds for different timestamps'] = function () {
+    mockDateNow = +(new Date(2016, 0, 1));
+    var flowEventData1 = flowMetrics(mockConfig, mockRequest);
+
+    mockDateNow = +(new Date(2016, 1, 29));
+    var flowEventData2 = flowMetrics(mockConfig, mockRequest);
+
+    assert.notEqual(flowEventData1.flowId, flowEventData2.flowId);
+    assert.notEqual(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
+  };
+
+  registerSuite(suite);
+});
+

--- a/tests/server/routes/get-index.js
+++ b/tests/server/routes/get-index.js
@@ -48,7 +48,7 @@ define([
 
       'route.process': {
         setup: function () {
-          request = {};
+          request = { headers: {} };
           response = { render: sinon.spy() };
           instance.process(request, response);
         },
@@ -62,7 +62,8 @@ define([
           assert.equal(args[0], 'index');
 
           assert.isObject(args[1]);
-          assert.lengthOf(Object.keys(args[1]), 2);
+          assert.lengthOf(Object.keys(args[1]), 3);
+          assert.ok(/[0-9a-f]{64}/.exec(args[1].flowId));
           assert.isAbove(args[1].flowBeginTime, 0);
           assert.equal(args[1].staticResourceUrl, 'foo');
         }


### PR DESCRIPTION
@philbooth further to our conversation last week, I took a stab at generating the `flow-id` property server-side rather than in the client.  It mostly went OK, but I could use some advice on how to reconcile this with what the `User` model is currently doing, generating it so it can be stored in the resume-token.  Thoughts?