### PR TITLE
fix(client): Password length warning

### DIFF
--- a/app/scripts/templates/settings/change_password.mustache
+++ b/app/scripts/templates/settings/change_password.mustache
@@ -23,7 +23,7 @@
           {{#t}}Show{{/t}}
         </label>
 
-        <div class="input-help links"><a href="/reset_password" class="reset-password">{{#t}}Forgot password?{{/t}}</a></div>
+        <div class="input-help input-help-forgot-pw links"><a href="/reset_password" class="reset-password">{{#t}}Forgot password?{{/t}}</a></div>
       </div>
 
       <div class="input-row password-row">

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -37,10 +37,12 @@
     <div class="input-row password-row">
       <input type="password" class="password" id="password" pattern=".{8,}" required />
       <input id="show-password" type="checkbox" class="show-password" aria-controls="password" data-novalue />
+      <div class="input-help input-help-focused input-help-signup">Must be at least 8 characters</div>
     </div>
     <div class="input-row password-row">
       <input type="password" class="password" id="vpassword" pattern=".{8,}" required />
       <input id="show-password" type="checkbox" class="show-password" aria-controls="vpassword" data-novalue />
+      <div class="input-help input-help-complete-password">Must be at least 8 characters</div>
     </div>
     <div class="input-row password-row">
       <label class="fxa-checkbox"><input type="checkbox" /></label>

--- a/app/scripts/views/mixins/password-mixin.js
+++ b/app/scripts/views/mixins/password-mixin.js
@@ -7,11 +7,12 @@
 define(function (require, exports, module) {
   'use strict';
 
+  var Constants = require('lib/constants');
 
   module.exports = {
     events: {
       'change .show-password': 'onPasswordVisibilityChange',
-      'keyup input.password': 'onPasswordKeyup'
+      'keyup input.password': 'onPasswordKeyUp'
     },
 
     onPasswordVisibilityChange: function (event) {
@@ -56,9 +57,23 @@ define(function (require, exports, module) {
       }
     },
 
-    onPasswordKeyup: function (event) {
-      var val = this.getElementValue('.password').length;
-      if (val < 8) {
+    onPasswordKeyUp: function (event) {
+      var values = [];
+      values.push(this.getElementValue('.password').length);
+
+      // Check to see if change password fields are visible.
+      // If any field does not have 8 chars, display warning.
+      if (this.getElementValue('#new_password') || this.getElementValue('#new_password') === '') {
+        values.push(this.getElementValue('#new_password').length);
+      }
+
+      if (this.getElementValue('#old_password') || this.getElementValue('#old_password') === '') {
+        values.push(this.getElementValue('#old_password').length);
+      }
+
+      var val = Math.min.apply(Math, values);
+
+      if (val < Constants.PASSWORD_MIN_LENGTH) {
         this.showPasswordHelper();
       } else {
         this.hidePasswordHelper();
@@ -70,7 +85,8 @@ define(function (require, exports, module) {
     },
 
     hidePasswordHelper: function () {
-      this.$('.input-help').css('opacity', '0');
+      // Hide all input-help classes except input-help-forgot-pw
+      this.$('.input-help:not(.input-help-forgot-pw)').css('opacity', '0');
     }
   };
 });

--- a/app/scripts/views/mixins/password-mixin.js
+++ b/app/scripts/views/mixins/password-mixin.js
@@ -10,7 +10,8 @@ define(function (require, exports, module) {
 
   module.exports = {
     events: {
-      'change .show-password': 'onPasswordVisibilityChange'
+      'change .show-password': 'onPasswordVisibilityChange',
+      'keyup input.password': 'onPasswordKeyup'
     },
 
     onPasswordVisibilityChange: function (event) {
@@ -53,6 +54,23 @@ define(function (require, exports, module) {
         // IE8 blows up when changing the type of the input field. Other
         // browsers might too. Ignore the error.
       }
+    },
+
+    onPasswordKeyup: function (event) {
+      var val = this.getElementValue('.password').length;
+      if (val < 8) {
+        this.showPasswordHelper();
+      } else {
+        this.hidePasswordHelper();
+      }
+    },
+
+    showPasswordHelper: function () {
+      this.$('.input-help').css('opacity', '1');
+    },
+
+    hidePasswordHelper: function () {
+      this.$('.input-help').css('opacity', '0');
     }
   };
 });

--- a/app/styles/modules/_input-row.scss
+++ b/app/styles/modules/_input-row.scss
@@ -89,6 +89,10 @@
     }
   }
 
+  .input-help-forgot-pw {
+    text-align: left;
+  }
+
   .input-help-focused {
     @include respond-to('reasonableUI') {
       opacity: 0;

--- a/app/tests/spec/views/mixins/password-mixin.js
+++ b/app/tests/spec/views/mixins/password-mixin.js
@@ -6,9 +6,9 @@ define(function (require, exports, module) {
   'use strict';
 
   var $ = require('jquery');
-  var _ = require('underscore');
   var BaseView = require('views/base');
   var chai = require('chai');
+  var Cocktail = require('cocktail');
   var Metrics = require('lib/metrics');
   var PasswordMixin = require('views/mixins/password-mixin');
   var Relier = require('models/reliers/relier');
@@ -18,10 +18,12 @@ define(function (require, exports, module) {
   var assert = chai.assert;
 
   var PasswordView = BaseView.extend({
-    events: { 'change .show-password': 'onPasswordVisibilityChange' },
     template: TestTemplate
   });
-  _.extend(PasswordView.prototype, PasswordMixin);
+  Cocktail.mixin(
+  PasswordView,
+  PasswordMixin
+  );
 
   describe('views/mixins/password-mixin', function () {
     var view;
@@ -114,6 +116,22 @@ define(function (require, exports, module) {
         view.$('.show-password').click();
         assert.isTrue(TestHelpers.isEventLogged(metrics,
                           'password-view.password.hidden'));
+      });
+    });
+
+    describe('show passwordHelper', function () {
+      it('set warning opacity to 1 if password length is less than 8', function () {
+        view.$('.password').val('1234');
+        view.showPasswordHelper();
+        assert.equal(view.$('.input-help').css('opacity'), '1');
+      });
+    });
+
+    describe('hide passwordHelper', function () {
+      it('set warning opacity to 0 if password length is greater than 8', function () {
+        view.$('.password').val('12344456');
+        view.hidePasswordHelper();
+        assert.equal(view.$('.input-help').css('opacity'), '0');
       });
     });
   });

--- a/app/tests/spec/views/mixins/password-mixin.js
+++ b/app/tests/spec/views/mixins/password-mixin.js
@@ -21,8 +21,8 @@ define(function (require, exports, module) {
     template: TestTemplate
   });
   Cocktail.mixin(
-  PasswordView,
-  PasswordMixin
+    PasswordView,
+    PasswordMixin
   );
 
   describe('views/mixins/password-mixin', function () {
@@ -128,7 +128,7 @@ define(function (require, exports, module) {
     });
 
     describe('hide passwordHelper', function () {
-      it('set warning opacity to 0 if password length is greater than 8', function () {
+      it('set warning opacity to 0 if password length is greater than or equal 8', function () {
         view.$('.password').val('12344456');
         view.hidePasswordHelper();
         assert.equal(view.$('.input-help').css('opacity'), '0');

--- a/app/tests/spec/views/settings/change_password.js
+++ b/app/tests/spec/views/settings/change_password.js
@@ -83,6 +83,7 @@ define(function (require, exports, module) {
           assert.ok($('.reset-password').length);
           assert.ok($('#new_password').length);
           assert.isTrue($('.input-help').length === 2);
+          assert.isTrue($('.input-help-forgot-pw').length === 1);
         });
       });
 
@@ -142,6 +143,7 @@ define(function (require, exports, module) {
 
           view.showValidationErrors();
         });
+
       });
 
       describe('submit', function () {


### PR DESCRIPTION
This PR extends work originally done in https://github.com/mozilla/fxa-content-server/pull/3635.

It adds support for the change password view and displays warning if any password field has less than 8 chars.