### PR TITLE
refactor(tests): Refactor many functional tests to use helper methods.

### DIFF
--- a/tests/functional.js
+++ b/tests/functional.js
@@ -15,6 +15,8 @@ define([
   './functional/sync_v2_reset_password',
   './functional/sync_v2_force_auth',
   './functional/sync_v3_sign_up',
+  './functional/sync_v3_sign_in',
+  './functional/sync_v3_settings',
   './functional/sync_v3_force_auth',
   './functional/fx_firstrun_v1_sign_up',
   './functional/fx_firstrun_v1_sign_in',

--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -5,99 +5,67 @@
 define([
   'intern',
   'intern!object',
-  'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, nodeXMLHttpRequest, FxaClient,
-  TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signin?context=fx_fennec_v1&service=sync';
 
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
-
-  var client;
   var email;
   var PASSWORD = '12345678';
 
-  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var thenify = FunctionalHelpers.thenify;
 
-  function createUser(isPreVerified) {
-    email = TestHelpers.createEmail();
-    return client.signUp(email, PASSWORD,
-      {
-        preVerified: isPreVerified || false
-      }
-    );
-  }
+  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var click = FunctionalHelpers.click;
+  var createUser = FunctionalHelpers.createUser;
+  var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
+  var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
+  var openPage = thenify(FunctionalHelpers.openPage);
+  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+
+  var setupTest = thenify(function (context, preVerified) {
+    return this.parent
+      .then(clearBrowserState(context))
+      .then(createUser(email, PASSWORD, { preVerified: preVerified }))
+      .then(openPage(context, PAGE_URL, '#fxa-signin-header'))
+      .then(noSuchBrowserNotification(context, 'fxaccounts:logout'))
+      .then(respondToWebChannelMessage(context, 'fxaccounts:can_link_account', { ok: true } ))
+      .then(fillOutSignIn(context, email, PASSWORD));
+  });
 
   registerSuite({
     name: 'Fx Fennec Sync v1 sign_in',
 
     beforeEach: function () {
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
-      // clear localStorage to avoid pollution from other tests.
-      return FunctionalHelpers.clearBrowserState(this);
+      email = TestHelpers.createEmail();
     },
 
-    afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+    'verified': function () {
+      return this.remote
+        .then(setupTest(this, true))
+
+        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+
+        .then(noSuchBrowserNotification(this, 'fxaccounts:sync_preferences'))
+        // user wants to open sync preferences.
+        .then(click('#sync-preferences'))
+
+        // browser is notified of desire to open Sync preferences
+        .then(testIsBrowserNotified(this, 'fxaccounts:sync_preferences'));
     },
 
-    'sign in verified': function () {
-      var self = this;
-      return createUser(true)
-        .then(function () {
-          return FunctionalHelpers.openPage(self, PAGE_URL, '#fxa-signin-header')
-            .execute(listenForFxaCommands)
-            .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
+    'unverified': function () {
+      return this.remote
+        .then(setupTest(this, false))
 
-            .then(function () {
-              return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
-            })
-
-            .findByCssSelector('#fxa-sign-in-complete-header')
-            .end()
-
-            // browser should have been notified.
-            .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
-            .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:login'))
-            .then(FunctionalHelpers.noSuchBrowserNotification(self, 'fxaccounts:sync_preferences'))
-
-            // user should be able to click on a sync preferences button.
-            .findByCssSelector('#sync-preferences')
-              // user wants to open sync preferences.
-              .click()
-            .end()
-
-            // browser is notified of desire to open Sync preferences
-            .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:sync_preferences'));
-
-        });
-    },
-
-    'sign in unverified': function () {
-      var self = this;
-
-      return createUser(false)
-        .then(function () {
-          return FunctionalHelpers.openPage(self, PAGE_URL, '#fxa-signin-header')
-            .execute(listenForFxaCommands)
-            .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
-
-            .then(function () {
-              return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
-            })
-
-            .findByCssSelector('#fxa-confirm-header')
-            .end()
-
-            .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
-            .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:login'));
-        });
+        .then(testElementExists('#fxa-confirm-header'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:login'));
     }
   });
 });

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -5,113 +5,99 @@
 define([
   'intern',
   'intern!object',
-  'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, nodeXMLHttpRequest, FxaClient,
-  TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var PAGE_URL = config.fxaContentRoot + 'signin?context=iframe&service=sync';
   var NO_REDIRECT_URL = PAGE_URL + '&haltAfterSignIn=true';
 
   var email;
   var PASSWORD = '12345678';
-  var client;
 
-  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
+  var thenify = FunctionalHelpers.thenify;
+
+  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var createUser = FunctionalHelpers.createUser;
+  var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
+  var noSuchElement = FunctionalHelpers.noSuchElement;
+  var openPage = thenify(FunctionalHelpers.openPage);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  var testIsBrowserNotified = function (context, message) {
+  var testElementExists = FunctionalHelpers.testElementExists;
+
+  var testIsBrowserNotified = function (message) {
     message = message.replace(/:/g, '-');
     return function () {
-      return context.remote
+      return this.parent
        .findByCssSelector('#message-' + message)
        .end();
     };
   };
 
   registerSuite({
-    name: 'Firstrun sign_in',
+    name: 'Firstrun v1 sign_in',
 
     beforeEach: function () {
-      var self = this;
       email = TestHelpers.createEmail();
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
 
-      return client.signUp(email, PASSWORD, { preVerified: true })
-        .then(function () {
-          return FunctionalHelpers.clearBrowserState(self);
-        });
+      return this.remote
+        .then(clearBrowserState(this));
     },
 
-    afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+    'verified': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+
+        .then(fillOutSignIn(this, email, PASSWORD))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
+
+        .then(testElementExists('#fxa-settings-header'))
+        // the user should be unable to sign out.
+        .then(noSuchElement(this, '#signout'));
     },
 
-    'sign in with an already existing account': function () {
-      var self = this;
+    'unverified': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: false }))
+        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
 
-      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signin-header')
-        .execute(listenForFxaCommands)
+        .then(fillOutSignIn(this, email, PASSWORD))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
-        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
-
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
-        })
-
-        .findByCssSelector('#fxa-settings-header')
-        .end()
-
-        .then(testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(self, 'fxaccounts:login'))
-
-        // user should be unable to sign out.
-        .then(FunctionalHelpers.noSuchElement(self, '#signout'))
-        .end();
+        .then(testElementExists('#fxa-confirm-header'));
     },
 
-    'sign in with an existing account with the `haltAfterSignIn=true` query parameter': function () {
-      var self = this;
+    'with an existing account with the `haltAfterSignIn=true` query parameter': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(this, NO_REDIRECT_URL, '#fxa-signin-header'))
+        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
 
-      return FunctionalHelpers.openPage(this, NO_REDIRECT_URL, '#fxa-signin-header')
-        .execute(listenForFxaCommands)
+        .then(fillOutSignIn(this, email, PASSWORD))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
-        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
-
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
-        })
-
-        .then(testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(self, 'fxaccounts:login'))
-
-        .then(FunctionalHelpers.noSuchElement(self, '#fxa-settings-header'))
-        .end();
+        .then(testElementExists('#fxa-signin-header'))
+        .then(noSuchElement(this, '#fxa-settings-header'));
     },
 
-    'sign in, cancel merge warning': function () {
-      var self = this;
-      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signin-header')
-        .execute(listenForFxaCommands)
+    'signin, cancel merge warning': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: false } ))
 
-        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: false } ))
-
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
-        })
-
-        .then(testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
+        .then(fillOutSignIn(this, email, PASSWORD))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
         // user should not transition to the next screen
-        .then(FunctionalHelpers.noSuchElement(self, '#fxa-settings-header'))
-        .end();
+        .then(testElementExists('#fxa-signin-header'))
+        .then(noSuchElement(this, '#fxa-confirm-signin-header'));
     }
   });
 });

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -5,117 +5,84 @@
 define([
   'intern',
   'intern!object',
-  'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'tests/functional/lib/fx-desktop'
-], function (intern, registerSuite, nodeXMLHttpRequest, FxaClient,
+], function (intern, registerSuite,
   TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signin?context=fx_ios_v1&service=sync';
   var EXCLUDE_SIGNUP_PAGE_URL = PAGE_URL + '&exclude_signup=1';
 
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
-
-  var client;
   var email;
   var PASSWORD = '12345678';
 
-  var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
-  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+  var thenify = FunctionalHelpers.thenify;
 
-  function createUser(isPreVerified) {
-    email = TestHelpers.createEmail();
-    return client.signUp(email, PASSWORD,
-      {
-        preVerified: isPreVerified || false
-      }
-    );
-  }
+  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var createUser = FunctionalHelpers.createUser;
+  var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
+  var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  var noPageTransition = FunctionalHelpers.noPageTransition;
+  var noSuchElement = FunctionalHelpers.noSuchElement;
+  var openPage = thenify(FunctionalHelpers.openPage);
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
+  var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   registerSuite({
     name: 'FxiOS v1 sign_in',
 
     beforeEach: function () {
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
-      // clear localStorage to avoid pollution from other tests.
-      return FunctionalHelpers.clearBrowserState(this);
-    },
-
-    afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
-    },
-
-    'signup link is disabled': function () {
-      var self = this;
-      return FunctionalHelpers.openPage(self, EXCLUDE_SIGNUP_PAGE_URL, '#fxa-signin-header')
-        .then(FunctionalHelpers.noSuchElement(self, 'a[href="/signup"]'))
-        .end();
-    },
-
-    'signup link is enabled': function () {
-      var self = this;
-      return FunctionalHelpers.openPage(self, PAGE_URL, '#fxa-signin-header')
-
-        .findByCssSelector('a[href="/signup"]')
-        .end();
-    },
-
-    'signin with an unknown account does not allow the user to sign up': function () {
-      var self = this;
       email = TestHelpers.createEmail();
+      return this.remote
+        .then(clearBrowserState(this));
+    },
 
-      return FunctionalHelpers.openPage(self, PAGE_URL, '#fxa-signin-header')
+    'verified': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
         .execute(listenForFxaCommands)
 
-        .then(function () {
-          return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
-        })
-
-        // an error is visible
-        .then(FunctionalHelpers.visibleByQSA('.error'))
-        .end();
-    },
-
-    'sign in verified': function () {
-      var self = this;
-      return createUser(true)
-        .then(function () {
-          return FunctionalHelpers.openPage(self, PAGE_URL, '#fxa-signin-header')
-            .execute(listenForFxaCommands)
-
-            .then(function () {
-              return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
-            })
-
-            .then(function () {
-              return testIsBrowserNotifiedOfLogin(self, email, { checkVerified: true });
-            });
-        });
+        .then(fillOutSignIn(this, email, PASSWORD))
+        .then(noPageTransition('#fxa-signin-header'))
+        .then(testIsBrowserNotifiedOfLogin(this, email, { checkVerified: true }));
     },
 
     'unverified': function () {
-      var self = this;
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: false }))
+        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .execute(listenForFxaCommands)
 
-      return createUser(false)
-        .then(function () {
-          return FunctionalHelpers.openPage(self, PAGE_URL, '#fxa-signin-header')
-            .execute(listenForFxaCommands)
+        .then(fillOutSignIn(this, email, PASSWORD))
 
-            .then(function () {
-              return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
-            })
+        .then(testElementExists('#fxa-confirm-header'))
 
-            .findByCssSelector('#fxa-confirm-header')
-            .end()
+        .then(testIsBrowserNotifiedOfLogin(this, email));
+    },
 
-            .then(function () {
-              return testIsBrowserNotifiedOfLogin(self, email);
-            });
-        });
+    'signup link is disabled': function () {
+      return this.remote
+        .then(openPage(this, EXCLUDE_SIGNUP_PAGE_URL, '#fxa-signin-header'))
+        .then(noSuchElement(this, 'a[href="/signup"]'));
+    },
+
+    'signup link is enabled': function () {
+      return this.remote
+        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(testElementExists('a[href="/signup"]'));
+    },
+
+    'signin with an unknown account does not allow the user to sign up': function () {
+      return this.remote
+        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .execute(listenForFxaCommands)
+
+        .then(fillOutSignIn(this, email, PASSWORD))
+
+        .then(visibleByQSA('.error'));
     }
   });
 });

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -8,14 +8,10 @@ define([
   'require',
   'intern/node_modules/dojo/node!xmlhttprequest',
   'app/bower_components/fxa-js-client/fxa-client',
-  'app/scripts/lib/constants',
   'tests/lib/helpers',
-  'tests/functional/lib/helpers',
-  'tests/functional/lib/fx-desktop'
+  'tests/functional/lib/helpers'
 ], function (intern, registerSuite, require, nodeXMLHttpRequest,
-      FxaClient, Constants, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
-  var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
-  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+      FxaClient, TestHelpers, FunctionalHelpers) {
 
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
@@ -94,29 +90,6 @@ define([
         // success is going to the signin page
         .findById('fxa-signin-header')
         .end();
-    },
-
-    'sign in to desktop context, go to settings, no way to sign out': function () {
-      var self = this;
-      var url = SIGNIN_URL + '?context=' + Constants.FX_DESKTOP_V1_CONTEXT + '&service=sync';
-
-      return FunctionalHelpers.openPage(self, url, '#fxa-signin-header')
-        .execute(listenForFxaCommands)
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignIn(self, email, FIRST_PASSWORD);
-        })
-
-        .then(function () {
-          return testIsBrowserNotifiedOfLogin(self, email, { checkVerified: true });
-        })
-
-        .then(function () {
-          return FunctionalHelpers.openPage(self, SETTINGS_URL, '#fxa-settings-header');
-        })
-
-        // make sure the sign out element doesn't exist
-        .then(FunctionalHelpers.noSuchElement(self, '#signout'));
     },
 
     'sign in, go to settings with setting param set to avatar redirects to avatar change page ': function () {

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -27,6 +27,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var noPageTransition = FunctionalHelpers.noPageTransition;
   var openPage = FunctionalHelpers.openPage;
   var testAttributeMatches = FunctionalHelpers.testAttributeMatches;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
@@ -288,11 +289,7 @@ define([
         .then(fillOutSignUp(this, email + '-', PASSWORD))
 
         // wait five seconds to allow any errant navigation to occur
-        .sleep(5000)
-
-        // navigation should not occur
-        .findByCssSelector('#fxa-signup-header')
-        .end()
+        .then(noPageTransition('#fxa-signup-header', 5000))
 
         // the validation tooltip should be visible
         .then(visibleByQSA('.tooltip'));

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -5,145 +5,96 @@
 define([
   'intern',
   'intern!object',
-  'intern/chai!assert',
   'require',
-  'intern/node_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'tests/functional/lib/fx-desktop'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
-        FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
+], function (intern, registerSuite, require,
+        TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
+
   var PAGE_URL = config.fxaContentRoot + 'reset_password?context=fx_desktop_v1&service=sync';
-
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
-
   var PASSWORD = 'password';
-  var user;
-  var email;
-  var client;
 
+  var email;
+  var user;
+
+  var thenify = FunctionalHelpers.thenify;
+
+  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var click = FunctionalHelpers.click;
+  var createUser = FunctionalHelpers.createUser;
+  var fillOutCompleteResetPassword = thenify(FunctionalHelpers.fillOutCompleteResetPassword);
+  var fillOutResetPassword = thenify(FunctionalHelpers.fillOutResetPassword);
+  var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
-  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+  var openExternalSite = FunctionalHelpers.openExternalSite;
+  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPasswordResetLinkDifferentBrowser = thenify(FunctionalHelpers.openPasswordResetLinkDifferentBrowser);
+  var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
+  var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
+  var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
+  var type = FunctionalHelpers.type;
+
 
   registerSuite({
-    name: 'Firefox Desktop Sync reset password',
+    name: 'Firefox Desktop Sync v1 reset_password',
 
     beforeEach: function () {
       // timeout after 90 seconds
       this.timeout = 90000;
 
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
       email = TestHelpers.createEmail();
       user = TestHelpers.emailToUser(email);
-      var self = this;
 
-      return client.signUp(email, PASSWORD, { preVerified: true })
-        .then(function (result) {
-          // do nothing
-        })
-        .then(function () {
-          // clear localStorage to avoid polluting other tests.
-          return FunctionalHelpers.clearBrowserState(self);
-        });
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(clearBrowserState(this));
     },
 
-    afterEach: function () {
-      // clear localStorage to avoid polluting other tests.
-      return FunctionalHelpers.clearBrowserState(this);
-    },
-
-    'sync reset password, verify same browser': function () {
-      var self = this;
-
+    'reset password, verify same browser': function () {
       // verify account
-      return self.remote
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+      return this.remote
+        .then(openPage(this, PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
+        .then(fillOutResetPassword(this, email))
 
-        .findByCssSelector('#fxa-reset-password-header')
-        .end()
+        .then(testElementExists('#fxa-confirm-reset-password-header'))
 
-        .then(function () {
-          return FunctionalHelpers.fillOutResetPassword(self, email);
-        })
-
-        .findByCssSelector('#fxa-confirm-reset-password-header')
-        .end()
-
-        .then(function () {
-          return FunctionalHelpers.openVerificationLinkInNewTab(
-                self, email, 0);
-        })
+        .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
 
-        .findByCssSelector('#fxa-complete-reset-password-header')
-        .end()
+        .then(testElementExists('#fxa-complete-reset-password-header'))
+        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
 
-        .then(function () {
-          return FunctionalHelpers.fillOutCompleteResetPassword(
-                    self, PASSWORD, PASSWORD);
-        })
-
-        .findByCssSelector('#fxa-reset-password-complete-header')
-        .end()
-
-        .findByCssSelector('.account-ready-service')
-        .getVisibleText()
-        .then(function (text) {
-          assert.ok(text.indexOf('Firefox Sync') > -1);
-        })
-
-        .end()
-
+        .then(testElementExists('#fxa-reset-password-complete-header'))
+        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
         .closeCurrentWindow()
         // switch to the original window
         .switchToWindow('')
         .end()
 
-        .then(FunctionalHelpers.testSuccessWasShown(this))
-
-        .then(function () {
-          return testIsBrowserNotifiedOfLogin(self, email, { checkVerified: true });
-        });
+        .then(testSuccessWasShown(this))
+        .then(testIsBrowserNotifiedOfLogin(this, email, { checkVerified: true }));
     },
 
     'reset password, verify same browser with original tab closed': function () {
-      var self = this;
-
-      return self.remote
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+      return this.remote
+        .then(openPage(this, PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
+        .then(fillOutResetPassword(this, email))
 
-        .then(function () {
-          return FunctionalHelpers.fillOutResetPassword(self, email);
-        })
-
-        .findByCssSelector('#fxa-confirm-reset-password-header')
-        .end()
+        .then(testElementExists('#fxa-confirm-reset-password-header'))
 
         // user browses to another site.
-        .then(FunctionalHelpers.openExternalSite(self))
-
-        .then(function () {
-          return FunctionalHelpers.openVerificationLinkInNewTab(
-                      self, email, 0);
-        })
-
+        .then(openExternalSite(this))
+        .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
 
-        .then(function () {
-          return FunctionalHelpers.fillOutCompleteResetPassword(
-              self, PASSWORD, PASSWORD);
-        })
-
-        .findByCssSelector('#fxa-reset-password-complete-header')
-        .end()
+        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(testElementExists('#fxa-reset-password-complete-header'))
 
         .closeCurrentWindow()
         // switch to the original window
@@ -153,79 +104,44 @@ define([
 
     'reset password, verify same browser by replacing the original tab': function () {
       var self = this;
-
-      return self.remote
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+      return this.remote
+        .then(openPage(this, PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
+        .then(fillOutResetPassword(this, email))
 
-        .then(function () {
-          return FunctionalHelpers.fillOutResetPassword(self, email);
-        })
+        .then(testElementExists('#fxa-confirm-reset-password-header'))
 
-        .findByCssSelector('#fxa-confirm-reset-password-header')
-        .end()
-
-        .then(function () {
-          return FunctionalHelpers.getVerificationLink(email, 0);
-        })
+        .then(getVerificationLink(email, 0))
         .then(function (verificationLink) {
           return self.remote.get(require.toUrl(verificationLink));
         })
 
-        .then(function () {
-          return FunctionalHelpers.fillOutCompleteResetPassword(
-              self, PASSWORD, PASSWORD);
-        })
-
-        .findByCssSelector('#fxa-reset-password-complete-header')
-        .end();
+        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(testElementExists('#fxa-reset-password-complete-header'));
     },
 
     'reset password, verify different browser - from original tab\'s P.O.V.': function () {
-      var self = this;
-
       // verify account
-      return self.remote
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+      return this.remote
+        .then(openPage(this, PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
+        .then(fillOutResetPassword(this, email))
+        .then(testElementExists('#fxa-confirm-reset-password-header'))
 
+        .then(openPasswordResetLinkDifferentBrowser(email, PASSWORD))
 
-        .findByCssSelector('#fxa-reset-password-header')
-        .end()
+        .then(testElementExists('#fxa-signin-header'))
+        .then(testSuccessWasShown(this))
 
-        .then(function () {
-          return FunctionalHelpers.fillOutResetPassword(self, email);
-        })
+        .then(type('#password', PASSWORD))
+        .then(click('button[type=submit]'))
 
-        .findByCssSelector('#fxa-confirm-reset-password-header')
-        .end()
+        .then(testIsBrowserNotifiedOfLogin(this, email, { checkVerified: true }))
 
-        .then(function () {
-          return FunctionalHelpers.openPasswordResetLinkDifferentBrowser(
-                      client, email, PASSWORD);
-        })
-
-        // for an unknown reason, it sometimes takes an exceptionally
-        // long time to transition to the new screen.
-
-        .findByCssSelector('#fxa-signin-header')
-        .end()
-
-        .then(FunctionalHelpers.testSuccessWasShown(this))
-
-        .findByCssSelector('#password')
-          .type(PASSWORD)
-        .end()
-
-        .findByCssSelector('button[type=submit]')
-          .click()
-        .end()
-
-        .then(function () {
-          return testIsBrowserNotifiedOfLogin(self, email, { checkVerified: true });
-        });
+        // user verified the reset password in another browser, they must
+        // re-verify they want to sign in on this device to avoid
+        // opening up an attack vector.
+        .then(testElementExists('#fxa-signin-header'));
     },
 
     'reset password, verify different browser - from new browser\'s P.O.V.': function () {
@@ -233,51 +149,24 @@ define([
       var self = this;
 
       // verify account
-      return self.remote
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+      return this.remote
+        .then(openPage(this, PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
+        .then(fillOutResetPassword(this, email))
+        .then(testElementExists('#fxa-confirm-reset-password-header'))
 
-
-        .findByCssSelector('#fxa-reset-password-header')
-        .end()
-
-        .then(function () {
-          return FunctionalHelpers.fillOutResetPassword(self, email);
-        })
-
-        .findByCssSelector('#fxa-confirm-reset-password-header')
-        .then(function () {
-          // clear all browser state, simulate opening in a new
-          // browser
-          return FunctionalHelpers.clearBrowserState(self);
-        })
-        .then(function () {
-          return FunctionalHelpers.getVerificationLink(user, 0);
-        })
+        // clear all browser state, simulate opening in a new
+        // browser
+        .then(clearBrowserState(this))
+        .then(getVerificationLink(user, 0))
         .then(function (url) {
           return self.remote.get(require.toUrl(url));
         })
-        .end()
+        .then(testElementExists('#fxa-complete-reset-password-header'))
+        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
 
-        .findByCssSelector('#fxa-complete-reset-password-header')
-        .end()
-
-        .then(function () {
-          return FunctionalHelpers.fillOutCompleteResetPassword(
-                    self, PASSWORD, PASSWORD);
-        })
-
-        .findByCssSelector('#fxa-reset-password-complete-header')
-        .end()
-
-        .findByCssSelector('.account-ready-service')
-        .getVisibleText()
-        .then(function (text) {
-          assert.ok(text.indexOf('Firefox Sync') > -1);
-        })
-
-        .end();
+        .then(testElementExists('#fxa-reset-password-complete-header'))
+        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'));
     }
   });
 

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -27,6 +27,7 @@ define([
   var PASSWORD = '12345678';
 
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  var noPageTransition = FunctionalHelpers.noPageTransition;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
 
   registerSuite({
@@ -113,10 +114,7 @@ define([
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.
         // Add an affordance just in case the poll happens unexpectedly.
-        .sleep(5000)
-
-        .then(FunctionalHelpers.visibleByQSA('#fxa-confirm-header'))
-        .end();
+        .then(noPageTransition('#fxa-confirm-header', 5000));
     },
 
     'signup, verify same browser with original tab closed': function () {

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -19,6 +19,7 @@ define([
   var PASSWORD = '12345678';
 
   var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
+  var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testAttributeExists = FunctionalHelpers.testAttributeExists;
 
@@ -131,10 +132,7 @@ define([
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.
         // Add an affordance just in case the poll happens unexpectedly.
-        .sleep(5000)
-
-        .then(FunctionalHelpers.visibleByQSA('#fxa-confirm-header'))
-        .end();
+        .then(noPageTransition('#fxa-confirm-header', 5000));
     }
   });
 });

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -19,6 +19,7 @@ define([
   var PASSWORD = '12345678';
 
   var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
+  var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
 
   registerSuite({
@@ -125,10 +126,7 @@ define([
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.
         // Add an affordance just in case the poll happens unexpectedly.
-        .sleep(5000)
-
-        .then(FunctionalHelpers.visibleByQSA('#fxa-confirm-header'))
-        .end();
+        .then(noPageTransition('#fxa-confirm-header', 5000));
     }
   });
 });


### PR DESCRIPTION
This is to prepare for confirm signin feature so the test changes should be smaller and easier to understand.

* Add two new suites, sync_v3_force_auth and sync_v3_sign_in.
* Expose new FunctionalHelpers methods:
  * `noPageTransition`
  * `takeScreenshot`
  * `testElementTextEquals`
* Add a `force` option to FunctionalHelpers.clearBrowserState to force the
  `/clear` page to be loaded.

fxa-83