### PR TITLE
grunt chore(nsp): Exclude moment CVE from nsp checks

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,8 +1,13 @@
 {
   "exceptions": [
+    // moment
+    "https://nodesecurity.io/advisories/55",
+
+    // uglify-js
     "https://nodesecurity.io/advisories/39",
     "https://nodesecurity.io/advisories/48",
 
+    // hapi
     "https://nodesecurity.io/advisories/45",
     "https://nodesecurity.io/advisories/63",
     "https://nodesecurity.io/advisories/65"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
 
 # now run the tests!
 script:
-  - grunt nsp --force # check for vulnerable modules via nodesecurity.io
+  - grunt nsp # check for vulnerable modules via nodesecurity.io
   - grunt selectconfig:dist l10n-generate-pages &> /dev/null
   - grunt htmllint:dist
   - travis_retry npm run test-travis


### PR DESCRIPTION
... Also removed the `--force` flag from the Grunt task in Travis-CI, which means if we fail `nsp` checks in the future, it will start breaking the build again (so we'll actually have to respond to "bad" modules).

**Current status:**

```sh
$ grunt nsp

Running "nsp" task
(+) No known vulnerabilities found
Done.


Execution Time (2016-05-20 00:45:38 UTC)
loading tasks  5.8s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 53%
nsp            5.1s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 47%
Total 10.9s
```

r? @vladikoff @shane-tomlinson 
/cc @jvehent 