### PR TITLE
feat(verify): Pass `service` param when verifying email address.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -293,10 +293,10 @@ define(function (require, exports, module) {
               });
     },
 
-    verifyCode: function (uid, code) {
+    verifyCode: function (uid, code, options) {
       return this._getClient()
               .then(function (client) {
-                return client.verifyCode(uid, code);
+                return client.verifyCode(uid, code, options);
               });
     },
 

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -402,13 +402,16 @@ define(function (require, exports, module) {
      * Verify the account using the verification code
      *
      * @param {string} code - the verification code
+     * @param {object} [options]
+     * @param {object} [options.service] - the service issuing signup request
      * @returns {promise} - resolves when complete
      */
-    verifySignUp: function (code) {
+    verifySignUp: function (code, options) {
       var self = this;
       return self._fxaClient.verifyCode(
         self.get('uid'),
-        code
+        code,
+        options
       )
       .then(function () {
         self.set('verified', true);

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -415,9 +415,11 @@ define(function (require, exports, module) {
      *
      * @param {object} account - account to verify
      * @param {string} code - verification code
+     * @param {object} [options]
+     * @param {object} [options.service] - the service issuing signup request
      * @returns {promise} - resolves with the account when complete
      */
-    completeAccountSignUp: function (account, code) {
+    completeAccountSignUp: function (account, code, options) {
       var self = this;
 
       // The original tab may no longer be open to notify other
@@ -429,7 +431,7 @@ define(function (require, exports, module) {
         }
       }
 
-      return account.verifySignUp(code)
+      return account.verifySignUp(code, options)
         .fail(function (err) {
           if (MarketingEmailErrors.created(err)) {
             // A MarketingEmailError doesn't prevent a user from

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -65,7 +65,10 @@ define(function (require, exports, module) {
       }
 
       var code = verificationInfo.get('code');
-      return self.user.completeAccountSignUp(self.getAccount(), code)
+      var options = {
+        service: self.relier.get('service')
+      };
+      return self.user.completeAccountSignUp(self.getAccount(), code, options)
           .fail(function (err) {
             if (MarketingEmailErrors.created(err)) {
               // A basket error should not prevent the

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
 
     var validCode = TestHelpers.createRandomHexString(Constants.CODE_LENGTH);
     var validUid = TestHelpers.createRandomHexString(Constants.UID_LENGTH);
+    var validService = 'someValidService';
 
     function testShowsExpiredScreen(search) {
       windowMock.location.search = search || '?code=' + validCode + '&uid=' + validUid;
@@ -179,6 +180,25 @@ define(function (require, exports, module) {
 
         it('does not attempt to verify the account', function () {
           assert.isFalse(account.verifySignUp.called);
+        });
+      });
+
+      describe('if service is available in the URL', function () {
+        beforeEach(function () {
+          windowMock.location.search = '?code=' + validCode + '&uid=' + validUid + '&service=' + validService;
+          relier = new Relier({
+            window: windowMock
+          });
+          relier.fetch();
+          initView(account);
+          return view.render();
+        });
+
+        it('attempt to verify the account with service', function () {
+          var args = account.verifySignUp.getCall(0).args;
+          assert.isTrue(account.verifySignUp.called);
+          assert.ok(args[0]);
+          assert.deepEqual(args[1], {service: validService});
         });
       });
 

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
     "fxa-checkbox": "mozilla/fxa-checkbox#9d64a48888e67fe511ee13177b0f3f72fe4a564f",
     "fxa-content-server-l10n": "https://github.com/mozilla/fxa-content-server-l10n.git",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.39",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.40",
     "fxa-password-strength-checker": "https://github.com/mozilla/fxa-password-strength-checker.git#d73b3ade374607e2749ee375301b0a168008b16f",
     "html5shiv": "3.7.2",
     "JavaScript-MD5": "1.1.0",

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -18,6 +18,7 @@ define([
   var PASSWORD = '12345678';
 
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
   registerSuite({
     name: 'Fx Fennec Sync v1 sign_up',
@@ -137,7 +138,10 @@ define([
         .end()
 
         // browser is notified of desire to open Sync preferences
-        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:sync_preferences'));
+        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:sync_preferences'))
+
+        // A post-verification email should be sent, this is Sync.
+        .then(testEmailExpected(email, 1));
 
     }
   });

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -19,6 +19,7 @@ define([
   var PASSWORD = '12345678';
 
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
   registerSuite({
     name: 'Firstrun Sync v1 sign_up',
@@ -90,7 +91,10 @@ define([
         .end()
 
         .findByCssSelector('#fxa-sign-up-complete-header')
-        .end();
+        .end()
+
+        // A post-verification email should be sent, this is Sync.
+        .then(testEmailExpected(email, 1));
     },
 
     'sign up, cancel merge warning': function () {

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -19,6 +19,7 @@ define([
   var PASSWORD = '12345678';
 
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
   registerSuite({
     name: 'Firstrun Sync v2 sign_up',
@@ -135,7 +136,10 @@ define([
 
         .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:sync_preferences', function (data) {
           assert.equal(data.entryPoint, 'fxa:signup-complete');
-        }));
+        }))
+
+        // A post-verification email should be sent, this is Sync.
+        .then(testEmailExpected(email, 1));
     }
   });
 });

--- a/tests/functional/fx_ios_v1_sign_up.js
+++ b/tests/functional/fx_ios_v1_sign_up.js
@@ -19,7 +19,9 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  var testEmailExpected = FunctionalHelpers.testEmailExpected;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
 
   registerSuite({
@@ -83,7 +85,10 @@ define([
         .end()
 
         .findByCssSelector('#fxa-confirm-header')
-        .end();
+        .end()
+
+        // A post-verification email should be sent, this is Sync.
+        .then(testEmailExpected(email, 1));
     },
 
     'user is redirected to /signin and shown an error message when exclude_signup=1': function () {

--- a/tests/functional/fx_ios_v2_sign_up.js
+++ b/tests/functional/fx_ios_v2_sign_up.js
@@ -19,6 +19,7 @@ define([
   var PASSWORD = '12345678';
 
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
   registerSuite({
     name: 'FxiOS v2 sign_up',
@@ -102,7 +103,10 @@ define([
         .end()
 
         .findByCssSelector('#fxa-confirm-header')
-        .end();
+        .end()
+
+        // A post-verification email should be sent, this is Sync.
+        .then(testEmailExpected(email, 1));
     }
   });
 });

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -274,7 +274,8 @@ define([
    * @param {string} user - username or email address
    * @param {number} index - email index.
    * @param {object} [options]
-   *   @param {number} [options.maxAttempts] - number of email fetch attempts to make. Defaults to Infinity
+   *   @param {number} [options.maxAttempts] - number of email fetch attempts
+   *   to make. Defaults to 10.
    * @returns {promise} resolves with the email headers if email is found.
    */
   function getEmailHeaders(user, index, options) {
@@ -301,12 +302,6 @@ define([
    */
   function testEmailExpected(user, index, options) {
     return function () {
-      options = options || {};
-
-      if (! options.maxAttempts) {
-        options.maxAttempts = 10;
-      }
-
       return getEmailHeaders(user, index, options)
         .then(function () {
           return true;
@@ -326,17 +321,11 @@ define([
    * @param {string} user - username or email address
    * @param {number} index - email index.
    * @param {object} [options]
-   *   @param {number} [options.maxAttempts] - number of email fetch attempts to make.
-   *   Defaults to 10.
+   *   @param {number} [options.maxAttempts] - number of email fetch attempts
+   *   to make. Defaults to 10.
    */
   function noEmailExpected(user, index, options) {
     return function () {
-      options = options || {};
-
-      if (! options.maxAttempts) {
-        options.maxAttempts = 10;
-      }
-
       return getEmailHeaders(user, index, options)
         .then(function () {
           throw new Error('NoEmailExpected');

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -262,22 +262,92 @@ define([
       user = TestHelpers.emailToUser(user);
     }
 
-    return getVerificationHeaders(user, index)
+    return getEmailHeaders(user, index)
       .then(function (headers) {
         return require.toUrl(headers['x-link']);
       });
   }
 
-  function getVerificationHeaders(user, index) {
+  /**
+   * Get the email headers
+   *
+   * @param {string} user - username or email address
+   * @param {number} index - email index.
+   * @param {object} [options]
+   *   @param {number} [options.maxAttempts] - number of email fetch attempts to make. Defaults to Infinity
+   * @returns {promise} resolves with the email headers if email is found.
+   */
+  function getEmailHeaders(user, index, options) {
     if (/@/.test(user)) {
       user = TestHelpers.emailToUser(user);
     }
 
     // restmail takes an index that is 1 based instead of 0 based.
-    return restmail(EMAIL_SERVER_ROOT + '/mail/' + user, index + 1)()
+    return restmail(EMAIL_SERVER_ROOT + '/mail/' + user, index + 1, options)()
       .then(function (emails) {
         return emails[index].headers;
       });
+  }
+
+  /**
+   * Test to ensure an expected email arrives
+   *
+   * @param {string} user - username or email address
+   * @param {number} index - email index.
+   * @param {object} [options]
+   *   @param {number} [options.maxAttempts] - number of email fetch attempts to make.
+   *   Defaults to 10.
+   * Defaults to 10.
+   */
+  function testEmailExpected(user, index, options) {
+    return function () {
+      options = options || {};
+
+      if (! options.maxAttempts) {
+        options.maxAttempts = 10;
+      }
+
+      return getEmailHeaders(user, index, options)
+        .then(function () {
+          return true;
+        }, function (err) {
+          if (/EmailTimeout/.test(String(err))) {
+            throw new Error('EmailExpected');
+          }
+
+          throw err;
+        });
+    };
+  }
+
+  /**
+   * Test to ensure an unexpected email does not arrive
+   *
+   * @param {string} user - username or email address
+   * @param {number} index - email index.
+   * @param {object} [options]
+   *   @param {number} [options.maxAttempts] - number of email fetch attempts to make.
+   *   Defaults to 10.
+   */
+  function noEmailExpected(user, index, options) {
+    return function () {
+      options = options || {};
+
+      if (! options.maxAttempts) {
+        options.maxAttempts = 10;
+      }
+
+      return getEmailHeaders(user, index, options)
+        .then(function () {
+          throw new Error('NoEmailExpected');
+        }, function (err) {
+          if (/EmailTimeout/.test(String(err))) {
+            return true;
+          }
+
+          throw err;
+        });
+    };
   }
 
   function openExternalSite(context) {
@@ -367,7 +437,7 @@ define([
 
     var user = TestHelpers.emailToUser(email);
 
-    return getVerificationHeaders(user, emailNumber || 0)
+    return getEmailHeaders(user, emailNumber || 0)
       .then(function (headers) {
         var uid = headers['x-uid'];
         var code = headers['x-verify-code'];
@@ -387,7 +457,7 @@ define([
 
     var user = TestHelpers.emailToUser(email);
 
-    return getVerificationHeaders(user, 0)
+    return getEmailHeaders(user, 0)
       .then(function (headers) {
         var code = headers['x-recovery-code'];
         // there is no x-recovery-token header, so we have to parse it
@@ -423,7 +493,7 @@ define([
   function openUnlockLinkDifferentBrowser(client, email) {
     var user = TestHelpers.emailToUser(email);
 
-    return getVerificationHeaders(user, 0)
+    return getEmailHeaders(user, 0)
       .then(function (headers) {
         var uid = headers['x-uid'];
         var code = headers['x-unlock-code'];
@@ -1258,7 +1328,7 @@ define([
   }
 
   function verifyUser(user, index, client, accountData) {
-    return getVerificationHeaders(user, index)
+    return getEmailHeaders(user, index)
       .then(function (headers) {
         var code = headers['x-verify-code'];
         return client.verifyCode(accountData.uid, code);
@@ -1278,11 +1348,12 @@ define([
     fillOutResetPassword: fillOutResetPassword,
     fillOutSignIn: fillOutSignIn,
     fillOutSignUp: fillOutSignUp,
+    getEmailHeaders: getEmailHeaders,
     getQueryParamValue: getQueryParamValue,
-    getVerificationHeaders: getVerificationHeaders,
     getVerificationLink: getVerificationLink,
     imageLoadedByQSA: imageLoadedByQSA,
     listenForWebChannelMessage: listenForWebChannelMessage,
+    noEmailExpected: noEmailExpected,
     noPageTransition: noPageTransition,
     noSuchBrowserNotification: noSuchBrowserNotification,
     noSuchElement: noSuchElement,
@@ -1312,6 +1383,7 @@ define([
     testElementTextEquals: testElementTextEquals,
     testElementTextInclude: testElementTextInclude,
     testElementValueEquals: testElementValueEquals,
+    testEmailExpected: testEmailExpected,
     testErrorTextInclude: testErrorTextInclude,
     testErrorWasShown: testErrorWasShown,
     testIsBrowserNotified: testIsBrowserNotified,

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -27,6 +27,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
+  var noEmailExpected = FunctionalHelpers.noEmailExpected;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   var openFxaFromRp = FunctionalHelpers.openFxaFromRp;
   var openPage = FunctionalHelpers.openPage;
@@ -104,7 +105,10 @@ define([
         .switchToWindow('')
 
         .findByCssSelector('#loggedin')
-        .end();
+        .end()
+
+        // Do not expect a post-verification email, those are for Sync.
+        .then(noEmailExpected(email, 1));
     },
 
     'signup, verify same browser with original tab closed': function () {

--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -28,7 +28,7 @@ define([
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
 
   function verifyUser(user, index) {
-    return FunctionalHelpers.getVerificationHeaders(user, index)
+    return FunctionalHelpers.getEmailHeaders(user, index)
       .then(function (headers) {
         var code = headers['x-verify-code'];
         return client.verifyCode(accountData.uid, code);

--- a/tests/functional/oauth_webchannel.js
+++ b/tests/functional/oauth_webchannel.js
@@ -29,6 +29,7 @@ define([
    * finish OAuth flows
    */
 
+  var noEmailExpected = FunctionalHelpers.noEmailExpected;
   var testIsBrowserNotifiedOfLogin = WebChannelHelpers.testIsBrowserNotifiedOfLogin;
   var openFxaFromRp = WebChannelHelpers.openFxaFromRp;
 
@@ -130,7 +131,10 @@ define([
         })
 
         .findById('fxa-sign-up-complete-header')
-        .end();
+        .end()
+
+        // Do not expect a post-verification email, those are for Sync.
+        .then(noEmailExpected(email, 1));
     },
 
     'signup, verify same browser with original tab closed': function () {

--- a/tests/functional/oauth_webchannel_keys.js
+++ b/tests/functional/oauth_webchannel_keys.js
@@ -37,6 +37,7 @@ define([
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var listenForSyncCommands = FxDesktopHelpers.listenForFxaCommands;
+  var noEmailExpected = FunctionalHelpers.noEmailExpected;
   var openExternalSite = FunctionalHelpers.openExternalSite;
   var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
@@ -113,7 +114,10 @@ define([
           assert.isTrue(messageReceived, 'expected to receive a WebChannel event in either tab');
         })
 
-        .then(testElementExists('#fxa-sign-up-complete-header'));
+        .then(testElementExists('#fxa-sign-up-complete-header'))
+
+        // Do not expect a post-verification email, those are for Sync.
+        .then(noEmailExpected(email, 1));
     },
 
     'signup, verify same browser, original tab closed navigated to another page': function () {

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -31,6 +31,7 @@ define([
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
+  var testEmailExpected = FunctionalHelpers.testEmailExpected;
   var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
   var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
@@ -88,7 +89,11 @@ define([
         // back to the original window
         .switchToWindow('')
         .then(testElementExists('#fxa-settings-header'))
-        .then(testSuccessWasShown(this));
+        .then(testSuccessWasShown(this))
+
+        // A post-verification email should be sent because no service is sent
+        // in the verificaiton link.
+        .then(testEmailExpected(email, 1));
     },
 
     'signup, verify same browser with original tab closed, sign out': function () {

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -28,6 +28,7 @@ define([
 
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
+  var testEmailExpected = FunctionalHelpers.testEmailExpected;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
 
   registerSuite({
@@ -114,7 +115,10 @@ define([
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.
         // Add an affordance just in case the poll happens unexpectedly.
-        .then(noPageTransition('#fxa-confirm-header', 5000));
+        .then(noPageTransition('#fxa-confirm-header', 5000))
+
+        // A post-verification email should be sent, this is Sync.
+        .then(testEmailExpected(email, 1));
     },
 
     'signup, verify same browser with original tab closed': function () {

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -21,6 +21,7 @@ define([
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testAttributeExists = FunctionalHelpers.testAttributeExists;
+  var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
   registerSuite({
     name: 'Firefox Desktop Sync v2 sign_up',
@@ -129,7 +130,10 @@ define([
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.
         // Add an affordance just in case the poll happens unexpectedly.
-        .then(noPageTransition('#fxa-confirm-header', 5000));
+        .then(noPageTransition('#fxa-confirm-header', 5000))
+
+        // A post-verification email should be sent, this is Sync.
+        .then(testEmailExpected(email, 1));
     }
   });
 });

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -20,6 +20,7 @@ define([
 
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
   registerSuite({
     name: 'Firefox Desktop Sync v3 sign_up',
@@ -123,7 +124,10 @@ define([
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.
         // Add an affordance just in case the poll happens unexpectedly.
-        .then(noPageTransition('#fxa-confirm-header', 5000));
+        .then(noPageTransition('#fxa-confirm-header', 5000))
+
+        // A post-verification email should be sent, this is Sync.
+        .then(testEmailExpected(email, 1));
     }
   });
 });

--- a/tests/lib/restmail.js
+++ b/tests/lib/restmail.js
@@ -16,7 +16,7 @@ define([
    *   @param {number} [options.minAttemptsBeforeLog] - Minimum number of
    *   attempts before attempts are logged. Defaults to 2.
    *   @param {number} [options.maxAttempts] - number of email fetch attempts
-   *   to make. Defaults to Infinity.
+   *   to make. Defaults to 10.
    */
   function waitForEmail(uri, number, options) {
     options = options || {};
@@ -25,7 +25,7 @@ define([
       number = 1;
     }
 
-    var maxAttempts = options.maxAttempts || Infinity;
+    var maxAttempts = options.maxAttempts || 10;
     var minAttemptsBeforeLog = options.minAttemptsBeforeLog ||
                                options.maxAttempts ||
                                2;

--- a/tests/lib/restmail.js
+++ b/tests/lib/restmail.js
@@ -7,15 +7,33 @@ define([
   'intern/node_modules/dojo/Promise'
 ], function (request, Promise) {
 
-  function waitForEmail(uri, number) {
+  /**
+   * Wait for an email.
+   *
+   * @param {string} uri - email uri
+   * @param {number} number
+   * @param {object} [options]
+   *   @param {number} [options.minAttemptsBeforeLog] - Minimum number of
+   *   attempts before attempts are logged. Defaults to 2.
+   *   @param {number} [options.maxAttempts] - number of email fetch attempts
+   *   to make. Defaults to Infinity.
+   */
+  function waitForEmail(uri, number, options) {
+    options = options || {};
     var requestAttempts = 0;
     if (! number) {
       number = 1;
     }
 
+    var maxAttempts = options.maxAttempts || Infinity;
+    var minAttemptsBeforeLog = options.minAttemptsBeforeLog ||
+                               options.maxAttempts ||
+                               2;
+
     return function checkIt () {
-      if (requestAttempts > 2) {
-        // only log if too many attempts, probably means the service is not properly responding
+      if (requestAttempts > minAttemptsBeforeLog) {
+        // only log if too many attempts, probably means the service is
+        // not properly responding
         console.log('Waiting for email at:', uri);
       }
 
@@ -25,6 +43,8 @@ define([
 
           if (result.length >= number) {
             return result;
+          } else if (requestAttempts >= maxAttempts) {
+            return Promise.reject(new Error('EmailTimeout'));
           } else {
             var dfd = new Promise.Deferred();
             setTimeout(function () {


### PR DESCRIPTION
A work-in-progress to pass the `service` param through when verifying an email code.  This would allow us to tailor the content of the post-verification email based on what service is being accessed.  Connects to https://github.com/mozilla/fxa-auth-server/issues/1249

Not ready yet as it obviously needs tests, but @shane-tomlinson does this seem a reasonable approach to you?