### PR TITLE
feat(client): Handle the upcoming /complete_signin route.

### DIFF
--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -67,6 +67,7 @@ define(function (require, exports, module) {
       'choose_what_to_sync(/)': createViewHandler(ChooseWhatToSyncView),
       'clear(/)': createViewHandler(ClearStorageView),
       'complete_reset_password(/)': createViewHandler(CompleteResetPasswordView),
+      'complete_signin(/)': createViewHandler(CompleteSignUpView),
       'complete_unlock_account(/)': createViewHandler(CompleteAccountUnlockView),
       'confirm(/)': createViewHandler(ConfirmView),
       'confirm_account_unlock(/)': createViewHandler(ConfirmAccountUnlockView),

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -101,6 +101,7 @@ module.exports = function (config, i18n) {
       '/choose_what_to_sync',
       '/clear',
       '/complete_reset_password',
+      '/complete_signin',
       '/complete_unlock_account',
       '/confirm',
       '/confirm_account_unlock',

--- a/tests/functional/pages.js
+++ b/tests/functional/pages.js
@@ -17,6 +17,7 @@ define([
     'choose_what_to_sync',
     'clear',
     'complete_reset_password',
+    'complete_signin',
     'complete_unlock_account',
     'confirm',
     'confirm_account_unlock',

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -33,6 +33,7 @@ define([
     '/cannot_create_account': { statusCode: 200 },
     '/choose_what_to_sync': { statusCode: 200 },
     '/complete_reset_password': { statusCode: 200 },
+    '/complete_signin': { statusCode: 200 },
     '/complete_unlock_account': { statusCode: 200 },
     '/config': {
       headerAccept: 'application/json',


### PR DESCRIPTION
Other than messaging, /complete_signin acts identically to
/verify_email, even calling the same auth-server endpoints. 
Create a placeholder route so that content server rollback 
from train-63 to train-62 is possible.

@philbooth, @jrgm, @jbuck - r?

fxa-83