### PR TITLE
fix(checkbox): make only text clickable

### DIFF
--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -87,10 +87,10 @@ ul.links {
 
 .choose-what-to-sync-row,
 .checkbox-row {
+  text-align: left;
 
   label {
-    display: block;
-    text-align: left;
+    display: inline;
 
     .fxa-checkbox__label {
       // The default is 0px, but -3px sets the label


### PR DESCRIPTION
Fixes #3744
Referencing https://github.com/mozilla/fxa-checkbox/issues/7 as this fixes that as well.

### Before:
![baby-blue](https://cloud.githubusercontent.com/assets/68213/15335192/499d3186-1c3f-11e6-87f5-8c906163d4f8.gif)

### After:
![checkboxes](https://cloud.githubusercontent.com/assets/432707/15444655/e4d500ce-1ea7-11e6-81cd-fe348f7b8db4.gif)


@ryanfeeley 
@rfk 
@vladikoff 