### PR TITLE
fix(client): Interpolate error messages before sending to Sentry.

### DIFF
--- a/app/scripts/lib/error-utils.js
+++ b/app/scripts/lib/error-utils.js
@@ -61,7 +61,11 @@ define(function (require, exports, module) {
       var logger = new Logger(win);
       logger.error(error);
 
+      // Ensure the message is interpolated before sending to
+      // sentry and metrics.
+      error.message = this.getErrorMessage(error);
       sentryMetrics.captureException(error);
+
       if (metrics) {
         metrics.logError(error);
       }
@@ -107,6 +111,20 @@ define(function (require, exports, module) {
           var errorPageUrl = self.getErrorPageUrl(error, translator);
           win.location.href = errorPageUrl;
         });
+    },
+
+    /**
+     * Get the error message, performing any interpolation.
+     *
+     * @param {string} err - an error object
+     * @return {string} interpolated error text.
+     */
+    getErrorMessage: function (error) {
+      if (error && error.errorModule) {
+        return error.errorModule.toInterpolatedMessage(error);
+      }
+
+      return error.message;
     }
   };
 });

--- a/app/scripts/models/mixins/resume-token.js
+++ b/app/scripts/models/mixins/resume-token.js
@@ -20,6 +20,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var AuthErrors = require('lib/auth-errors');
+  var ErrorUtils = require('lib/error-utils');
   var ResumeToken = require('models/resume-token');
   var vat = require('lib/vat');
 
@@ -87,11 +88,7 @@ define(function (require, exports, module) {
       error = AuthErrors.toInvalidResumeTokenPropertyError(error.key);
     }
 
-    // HACK: Interpolate the invalid property name into the error
-    //       message. One day this will be handled automagically.
-    error.message = AuthErrors.toInterpolatedMessage(error);
-
-    this.sentryMetrics.captureException(error);
+    ErrorUtils.captureError(error, this.sentryMetrics);
   }
 });
 

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -122,10 +122,11 @@ define(function (require, exports, module) {
             self._bouncedEmailSignup();
           } else if (AuthErrors.is(err, 'UNEXPECTED_ERROR')) {
             // Hide the error from the user if it is an unexpected error.
-            // an error may happen here if the status api is overloaded or if the user is switching networks.
+            // an error may happen here if the status api is overloaded or
+            // if the user is switching networks.
             // Report errors to Sentry, but not the user.
             // Details: github.com/mozilla/fxa-content-server/issues/2638.
-            self.sentryMetrics.captureException(err);
+            self.logError(err);
             var deferred = p.defer();
 
             self.setTimeout(function () {

--- a/app/scripts/views/mixins/flow-begin-mixin.js
+++ b/app/scripts/views/mixins/flow-begin-mixin.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
 
       if (! flowBeginTime) {
         flowBeginTime = undefined;
-        this.sentryMetrics.captureException(AuthErrors.toError('INVALID_DATA_FLOW_BEGIN_ATTR'));
+        this.logError(AuthErrors.toError('INVALID_DATA_FLOW_BEGIN_ATTR'));
       }
 
       this.metrics.setActivityEventMetadata('flowBeginTime', flowBeginTime);

--- a/app/tests/spec/views/mixins/flow-begin-mixin.js
+++ b/app/tests/spec/views/mixins/flow-begin-mixin.js
@@ -30,9 +30,7 @@ define(function (require, exports, module) {
             return 'foo';
           })
         };
-        flowBeginMixin.sentryMetrics = {
-          captureException: sinon.spy()
-        };
+        flowBeginMixin.logError = sinon.spy();
         $('body').attr('data-flow-begin', '42');
         flowBeginMixin.afterRender();
       });
@@ -60,8 +58,8 @@ define(function (require, exports, module) {
         assert.strictEqual(args[1], 42);
       });
 
-      it('did not call sentryMetrics.captureException', function () {
-        assert.strictEqual(flowBeginMixin.sentryMetrics.captureException.callCount, 0);
+      it('did not call view.logError', function () {
+        assert.strictEqual(flowBeginMixin.logError.callCount, 0);
       });
     });
 
@@ -76,9 +74,7 @@ define(function (require, exports, module) {
             return 'wibble';
           })
         };
-        flowBeginMixin.sentryMetrics = {
-          captureException: sinon.spy()
-        };
+        flowBeginMixin.logError = sinon.spy();
         $('body').attr('data-flow-begin', 'bar');
         flowBeginMixin.afterRender();
       });
@@ -106,9 +102,9 @@ define(function (require, exports, module) {
         assert.isUndefined(args[1]);
       });
 
-      it('called sentryMetrics.captureException correctly', function () {
-        assert.strictEqual(flowBeginMixin.sentryMetrics.captureException.callCount, 1);
-        var args = flowBeginMixin.sentryMetrics.captureException.args[0];
+      it('called view.logError correctly', function () {
+        assert.strictEqual(flowBeginMixin.logError.callCount, 1);
+        var args = flowBeginMixin.logError.args[0];
         assert.lengthOf(args, 1);
         assert.instanceOf(args[0], Error);
         assert.equal(args[0].message, 'Invalid data-flow-begin attribute');


### PR DESCRIPTION
## Data sent to sentry endpoint

### Before

<img width="397" alt="screen shot 2016-05-23 at 15 11 08" src="https://cloud.githubusercontent.com/assets/848085/15473604/af824014-20f8-11e6-9942-bbec1a2e7402.png">

### After

<img width="345" alt="screen shot 2016-05-23 at 15 08 52" src="https://cloud.githubusercontent.com/assets/848085/15473606/b5162978-20f8-11e6-8b05-ea46d9ab82c3.png">
