### PR TITLE
fix(tests): Remove listenForWebChannelMessages from functional tests.

### DIFF
--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -14,7 +14,6 @@ define([
   var CONFIRM_URL = config.fxaContentRoot + 'confirm';
   var SIGNUP_URL = config.fxaContentRoot + 'signup';
 
-  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
 
   registerSuite({
@@ -76,7 +75,6 @@ define([
       var SIGNUP_URL = intern.config.fxaContentRoot + 'signup?context=fx_desktop_v2&service=sync';
 
       return FunctionalHelpers.openPage(this, SIGNUP_URL, '#fxa-signup-header')
-        .execute(listenForFxaCommands)
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
 
         .then(function () {

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -17,7 +17,6 @@ define([
   var email;
   var PASSWORD = '12345678';
 
-  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
 
   registerSuite({
@@ -45,8 +44,6 @@ define([
       var self = this;
 
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
-        .execute(listenForFxaCommands)
-
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
 
         .then(FunctionalHelpers.noSuchElement(self, '#customize-sync'))

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -42,7 +42,7 @@ define([
   });
 
   registerSuite({
-    name: 'Firstrun v1 sign_in',
+    name: 'Firstrun Sync v1 sign_in',
 
     beforeEach: function () {
       email = TestHelpers.createEmail();

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -18,11 +18,10 @@ define([
   var email;
   var PASSWORD = '12345678';
 
-  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
 
   registerSuite({
-    name: 'Firstrun sign_up',
+    name: 'Firstrun Sync v1 sign_up',
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
@@ -49,8 +48,6 @@ define([
       var self = this;
 
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
-        .execute(listenForFxaCommands)
-
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
 
 
@@ -99,8 +96,6 @@ define([
     'sign up, cancel merge warning': function () {
       var self = this;
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
-        .execute(listenForFxaCommands)
-
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: false } ))
 
 

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -18,11 +18,10 @@ define([
   var email;
   var PASSWORD = '12345678';
 
-  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
 
   registerSuite({
-    name: 'Firefox Firstrun Sync v2 sign_up',
+    name: 'Firstrun Sync v2 sign_up',
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
@@ -50,8 +49,6 @@ define([
       var self = this;
 
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
-        .execute(listenForFxaCommands)
-
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
 
         .then(function () {

--- a/tests/functional/oauth_webchannel.js
+++ b/tests/functional/oauth_webchannel.js
@@ -74,8 +74,6 @@ define([
           return client.signUp(email, PASSWORD, { preVerified: true });
         })
 
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
         .then(function () {
           return FunctionalHelpers.fillOutSignIn(self, email, PASSWORD);
         })
@@ -94,8 +92,6 @@ define([
       var messageReceived = false;
 
       return openFxaFromRp(self, 'signup')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
         .then(function () {
           return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
         })
@@ -108,8 +104,6 @@ define([
                       self, email, 0);
         })
         .switchToWindow('newwindow')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
         // wait for the verified window in the new tab
         .findById('fxa-sign-up-complete-header')
         .end()
@@ -159,8 +153,6 @@ define([
         })
 
         .switchToWindow('newwindow')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
         .then(testIsBrowserNotifiedOfLogin(self, { shouldCloseTab: false }))
 
         .findById('fxa-sign-up-complete-header')
@@ -188,8 +180,7 @@ define([
           return FunctionalHelpers.getVerificationLink(email, 0);
         })
         .then(function (verificationLink) {
-          return self.remote.get(require.toUrl(verificationLink))
-            .execute(FunctionalHelpers.listenForWebChannelMessage);
+          return self.remote.get(require.toUrl(verificationLink));
         })
 
         .then(testIsBrowserNotifiedOfLogin(self, { shouldCloseTab: false }))
@@ -203,8 +194,6 @@ define([
       self.timeout = TIMEOUT;
 
       return openFxaFromRp(self, 'signup')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
         .then(function () {
           return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
         })
@@ -227,8 +216,6 @@ define([
       self.timeout = TIMEOUT;
 
       return openFxaFromRp(self, 'signup')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
         .then(function () {
           return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
         })
@@ -261,8 +248,6 @@ define([
       var messageReceived = false;
 
       return openFxaFromRp(self, 'signin')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
         .then(function () {
           return client.signUp(email, PASSWORD, { preVerified: true });
         })
@@ -285,8 +270,6 @@ define([
 
         // Complete the reset password in the new tab
         .switchToWindow('newwindow')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
         .then(function () {
           return FunctionalHelpers.fillOutCompleteResetPassword(
             self, PASSWORD, PASSWORD);
@@ -356,7 +339,6 @@ define([
         })
 
         .switchToWindow('newwindow')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
 
         .then(function () {
           return FunctionalHelpers.fillOutCompleteResetPassword(
@@ -399,8 +381,7 @@ define([
           return FunctionalHelpers.getVerificationLink(email, 0);
         })
         .then(function (verificationLink) {
-          return self.remote.get(require.toUrl(verificationLink))
-            .execute(FunctionalHelpers.listenForWebChannelMessage);
+          return self.remote.get(require.toUrl(verificationLink));
         })
 
         .then(function () {
@@ -420,8 +401,6 @@ define([
       self.timeout = TIMEOUT;
 
       return openFxaFromRp(self, 'signin')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
         .then(function () {
           return client.signUp(email, PASSWORD, { preVerified: true });
         })

--- a/tests/functional/oauth_webchannel_keys.js
+++ b/tests/functional/oauth_webchannel_keys.js
@@ -36,7 +36,6 @@ define([
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
-  var listenForWebChannelMessage = FunctionalHelpers.listenForWebChannelMessage;
   var listenForSyncCommands = FxDesktopHelpers.listenForFxaCommands;
   var openExternalSite = FunctionalHelpers.openExternalSite;
   var openPage = FunctionalHelpers.openPage;
@@ -95,7 +94,6 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
 
         .switchToWindow('newwindow')
-        .execute(listenForWebChannelMessage)
         .then(testElementExists('#fxa-sign-up-complete-header'))
 
         .then(waitForBrowserLoginNotification(this))
@@ -131,7 +129,6 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
 
         .switchToWindow('newwindow')
-        .execute(listenForWebChannelMessage)
         .then(testIsBrowserNotifiedOfLogin(this, { shouldCloseTab: false }))
 
         .then(testElementExists('#fxa-sign-up-complete-header'))
@@ -192,8 +189,6 @@ define([
 
         // Complete the reset password in the new tab
         .switchToWindow('newwindow')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
-
         .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
 
         // this tab should get the reset password complete header.
@@ -243,7 +238,6 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
 
         .switchToWindow('newwindow')
-        .execute(FunctionalHelpers.listenForWebChannelMessage)
         .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
 
         // the tab should automatically sign in

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -18,7 +18,6 @@ define([
   var email;
   var PASSWORD = '12345678';
 
-  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testAttributeExists = FunctionalHelpers.testAttributeExists;
@@ -52,8 +51,6 @@ define([
       var self = this;
 
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
-        .execute(listenForFxaCommands)
-
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
 
         .then(function () {

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -18,7 +18,6 @@ define([
   var email;
   var PASSWORD = '12345678';
 
-  var listenForFxaCommands = FunctionalHelpers.listenForWebChannelMessage;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
 
@@ -51,8 +50,6 @@ define([
       var self = this;
 
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
-        .execute(listenForFxaCommands)
-
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
 
         .then(function () {


### PR DESCRIPTION
WebChannel messages are now listened to automatically, in code, to avoid
timing problems with messages being sent before the DOM event listeners
for the WebChannel messages are attached.

fixes #3748


@vladikoff - r?