### PR TITLE
Fix #3760 show password label on RTL locales_1

### DIFF
--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -68,11 +68,21 @@
   }
 
   .password:focus ~ .show-password-label {
-    border-left-color: $input-row-focus-border-color;
+	html[dir=ltr] & {
+	    border-left-color: $input-row-focus-border-color;
+	}
+    html[dir=rtl] & {
+        border-right-color: $input-row-focus-border-color;
+    }
   }
 
   .password.invalid ~ .show-password-label {
-    border-left: 1px solid $error-background-color !important;
+    html[dir=ltr] & {
+        border-left: 1px solid $error-background-color !important;
+    }
+    html[dir=rtl] & {
+        border-right: 1px solid $error-background-color !important;
+    }
   }
 
 }


### PR DESCRIPTION
In previous commit, I miss change the the border color in focus and invalid password and notice them after test.

![2016-05-24 23-18-26](https://cloud.githubusercontent.com/assets/9789109/15520893/32158b1c-2211-11e6-95b6-b4309ab25402.png)
![2016-05-24 23-20-52](https://cloud.githubusercontent.com/assets/9789109/15520892/31fb4202-2211-11e6-92e2-e8bbe558a132.png)

