### PR TITLE
Fix #1360 inputs tooltip on RTL locales

### DIFF
--- a/app/styles/modules/_tooltip.scss
+++ b/app/styles/modules/_tooltip.scss
@@ -2,12 +2,14 @@
   background: $error-background-color;
   border-radius: $small-border-radius;
   color: $message-text-color;
+  
   html[dir=ltr] & {
   	left: 3px;
-  	}
+  }
+  
   html[dir=rtl] & {
   	right: 3px;
-  	}
+  }
   padding: 5px 12px;
   position: absolute;
   top: -32px;
@@ -20,12 +22,14 @@
     bottom: -8px;
     content: '.';
     height: 16px;
+    
     html[dir=ltr] & {
-    	left: 12px;
-    	}
+      left: 12px;
+    }
+    
     html[dir=rtl] & {
-  		right: 12px;
-  		}
+  	  right: 12px;
+  	}
     position: absolute;
     text-indent: -999px;
     transform: rotate(45deg);

--- a/app/styles/modules/_tooltip.scss
+++ b/app/styles/modules/_tooltip.scss
@@ -2,7 +2,12 @@
   background: $error-background-color;
   border-radius: $small-border-radius;
   color: $message-text-color;
-  left: 3px;
+  html[dir=ltr] & {
+  	left: 3px;
+  	}
+  html[dir=rtl] & {
+  	right: 3px;
+  	}
   padding: 5px 12px;
   position: absolute;
   top: -32px;
@@ -15,7 +20,12 @@
     bottom: -8px;
     content: '.';
     height: 16px;
-    left: 12px;
+    html[dir=ltr] & {
+    	left: 12px;
+    	}
+    html[dir=rtl] & {
+  		right: 12px;
+  		}
     position: absolute;
     text-indent: -999px;
     transform: rotate(45deg);


### PR DESCRIPTION
The tooltip should be float right to beginning of the write in Email and password input.