### PR TITLE
fix(styles): Fix the click area of side by side links.

### DIFF
--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -15,16 +15,16 @@
 
   .left {
     float: left;
+    max-width: 50%;
     padding: 0 4% 0 0;
     text-align: left;
-    width: 50%;
   }
 
   .right {
     float: right;
+    max-width: 50%;
     padding: 0 0 0 4%;
     text-align: right;
-    width: 50%;
   }
 
   a {
@@ -131,9 +131,9 @@ ul.links {
     display: block;
     float: none;
     margin: 5px 0;
+    max-width: 100%;
     padding: 0;
     text-align: center;
-    width: 100%;
   }
 }
 


### PR DESCRIPTION
Side by side links had a click area that extended far beyond
the link. The problem is the width on the link was set to 50%.
This sets the max-width instead, so links fill their natural width
up to the limit, then they break.

fixes #3776

Here's what it looks like now if there is a really long link:

<img width="427" alt="screen shot 2016-05-26 at 16 00 40" src="https://cloud.githubusercontent.com/assets/848085/15579565/0e419670-235d-11e6-9474-e4a5e77a0b66.png">
