### PR TITLE
chore(deps): Update fxa-js-client to 0.1.39

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -376,7 +376,8 @@ define(function (require, exports, module) {
                   newPassword,
                   result.accountResetToken,
                   {
-                    keys: relier.wantsKeys()
+                    keys: relier.wantsKeys(),
+                    sessionToken: true
                   }
                 );
               })

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -730,7 +730,7 @@ define(function (require, exports, module) {
             assert.isTrue(realClient.passwordForgotVerifyCode.calledWith(
                 code, token));
             assert.isTrue(realClient.accountReset.calledWith(
-                trim(email), password, 'reset_token', { keys: true }));
+                trim(email), password, 'reset_token', { keys: true, sessionToken: true }));
 
             assert.equal(sessionData.email, trim(email));
             assert.equal(sessionData.keyFetchToken, 'new keyFetchToken');
@@ -783,7 +783,7 @@ define(function (require, exports, module) {
             assert.isTrue(realClient.passwordForgotVerifyCode.calledWith(
                 code, token));
             assert.isTrue(realClient.accountReset.calledWith(
-                trim(email), password, 'reset_token', { keys: true }));
+                trim(email), password, 'reset_token', { keys: true, sessionToken: true }));
             assert.isTrue(realClient.signIn.calledWith(
                 trim(email), password, {
                   keys: true,

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
     "fxa-checkbox": "mozilla/fxa-checkbox#76be01b4919dc09f591f46b015d43fc0576fc212",
     "fxa-content-server-l10n": "https://github.com/mozilla/fxa-content-server-l10n.git",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.37",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.39",
     "fxa-password-strength-checker": "https://github.com/mozilla/fxa-password-strength-checker.git#d73b3ade374607e2749ee375301b0a168008b16f",
     "html5shiv": "3.7.2",
     "JavaScript-MD5": "1.1.0",


### PR DESCRIPTION
Includes the password change/reset updates that avoid an extra call
to /account/login to complete the flow.

fxa-client.js needed to be updated to pass `sessionToken: true` to
actually receive the new session token.

@vbudhram - r?