### PR TITLE
feat(password): make hints progressively useful

### DIFF
--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -48,7 +48,7 @@
 
       <div class="input-row password-row">
         <label class="label-helper"></label>
-        <input type="password" class="password" id="password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" required autofocus />
+        <input type="password" class="password check-password tooltip-below" id="password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" required autofocus />
 
         <input id="show-password" type="checkbox" class="show-password" aria-controls="password" tabindex="-1" data-novalue data-synchronize-show="true" />
         <label for="show-password" class="show-password-label">

--- a/app/scripts/templates/settings/change_password.mustache
+++ b/app/scripts/templates/settings/change_password.mustache
@@ -28,7 +28,7 @@
 
       <div class="input-row password-row">
         <label class="label-helper"></label>
-        <input type="password" class="password tooltip-below" id="new_password" placeholder="{{#t}}New password{{/t}}" required pattern=".{8,}" />
+        <input type="password" class="password check-password tooltip-below" id="new_password" placeholder="{{#t}}New password{{/t}}" required pattern=".{8,}" />
 
         <input id="show-new-password" type="checkbox" class="show-password" aria-controls="new_password" tabindex="-1" data-novalue />
         <label for="show-new-password" class="show-password-label">

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -44,12 +44,12 @@
       </div>
 
       <div class="input-row password-row">
-        <input id="password" type="password" class="password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required {{#shouldFocusPassword}}autofocus{{/shouldFocusPassword}} />
+        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required {{#shouldFocusPassword}}autofocus{{/shouldFocusPassword}} />
         <input id="show-password" type="checkbox" class="show-password" aria-controls="password" tabindex="-1" data-novalue />
         <label for="show-password" class="show-password-label">
           {{#t}}Show{{/t}}
         </label>
-        <div class="input-help input-help-focused input-help-signup">{{#t}}Must be at least 8 characters{{/t}}</div>
+        <div class="input-help input-help-focused input-help-signup">{{#t}}A strong, unique password will keep your Firefox data safe from intruders.{{/t}}</div>
       </div>
 
       <div id="coppa">

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -43,10 +43,10 @@
       <div class="input-help input-help-forgot-pw links"><a href="/" class="reset-password">Forgot password?</a></div>
     </div>
     <div class="input-row password-row">
-      <input type="password" class="password" id="vpassword" pattern=".{8,}" required />
+      <input type="password" class="password check-password tooltip-below" id="vpassword" pattern=".{8,}" required />
       <input id="show-password" type="checkbox" class="show-password" aria-controls="vpassword" data-novalue />
       <label for="show-password" class="show-password-label">Show</label>
-      <div class="input-help input-help-complete-password">Must be at least 8 characters</div>
+      <div class="input-help input-help-focused input-help-complete-password">Must be at least 8 characters</div>
     </div>
     <div class="input-row password-row">
       <label class="fxa-checkbox"><input type="checkbox" /></label>

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -13,6 +13,7 @@ define(function (require, exports, module) {
   var Notifier = require('lib/channels/notifier');
   var PasswordMixin = require('views/mixins/password-mixin');
   var PasswordResetMixin = require('views/mixins/password-reset-mixin');
+  var PasswordStrengthMixin = require('views/mixins/password-strength-mixin');
   var ServiceMixin = require('views/mixins/service-mixin');
   var Template = require('stache!templates/complete_reset_password');
   var Url = require('lib/url');
@@ -170,6 +171,7 @@ define(function (require, exports, module) {
     FloatingPlaceholderMixin,
     PasswordMixin,
     PasswordResetMixin,
+    PasswordStrengthMixin,
     ServiceMixin
   );
 

--- a/app/scripts/views/mixins/password-prompt-mixin.js
+++ b/app/scripts/views/mixins/password-prompt-mixin.js
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Plugin to display hints for passwords,
+ * hints change as the user types
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var BaseView = require('views/base');
+  var t = BaseView.t;
+
+  var Tooltip = require('views/tooltip');
+
+  var CHECK_PASSWORD_FIELD_SELECTOR = '.check-password';
+  var INPUT_HELP_FOCUSED = '.input-help-focused';
+  var TOOLTIP_MESSAGES = {
+    FOCUS_PROMPT_MESSAGE: t('8 characters minimum, but longer if you plan to sync passwords.'),
+    INITIAL_PROMPT_MESSAGE: t('A strong, unique password will keep your Firefox data safe from intruders.'),
+    WARNING_PROMPT_MESSAGE: t('This is a common password; please consider another one.')
+  };
+
+  var PasswordPromptMixin = {
+    // only the .check-password fields will be checked
+    events: {
+      'blur .check-password': 'onPasswordBlur',
+      'focus .check-password': 'onInputFocus',
+      'keyup .check-password': 'onInputKeyUp'
+    },
+
+    afterRender: function () {
+      this.updateFormValueChanges();
+    },
+
+    displayPasswordInitialPrompt: function (inputEl) {
+      this.$el.find(inputEl).siblings(INPUT_HELP_FOCUSED).html(TOOLTIP_MESSAGES.INITIAL_PROMPT_MESSAGE);
+      this._logPromptExperimentEvent('INITIAL_PROMPT_MESSAGE');
+    },
+
+    displayPasswordFocusPrompt: function (inputEl) {
+      this.$el.find(inputEl).siblings(INPUT_HELP_FOCUSED).html(TOOLTIP_MESSAGES.FOCUS_PROMPT_MESSAGE);
+      this._logPromptExperimentEvent('FOCUS_PROMPT_MESSAGE');
+    },
+
+    displayPasswordWarningPrompt: function () {
+      var tooltip = new Tooltip({
+        dismissible: false,
+        extraClassNames: 'tooltip-suggest tooltip-warning',
+        invalidEl: this.$el.find(CHECK_PASSWORD_FIELD_SELECTOR),
+        message: TOOLTIP_MESSAGES.WARNING_PROMPT_MESSAGE
+      });
+      tooltip.render();
+      this._logPromptExperimentEvent('WARNING_PROMPT_MESSAGE');
+    },
+
+    showPasswordPrompt: function (inputEl) {
+      var length = this.$el.find(inputEl).val().length;
+      if (length === 0) {
+        this.displayPasswordInitialPrompt(inputEl);
+      } else {
+        this.displayPasswordFocusPrompt(inputEl);
+      }
+    },
+
+    onInputFocus: function (event) {
+      this.showPasswordPrompt(this.$el.find(event.currentTarget));
+    },
+
+    onInputKeyUp: function (event) {
+      this.showPasswordPrompt(this.$el.find(event.currentTarget));
+    },
+
+    onPasswordBlur: function () {
+      var password = this.getElementValue(CHECK_PASSWORD_FIELD_SELECTOR);
+      this.checkPasswordStrength(password);
+    },
+
+    _logPromptExperimentEvent: function (eventNameSuffix) {
+      var eventName = 'experiment.pw_prompt.' + eventNameSuffix.toLowerCase();
+      this.logViewEvent(eventName);
+    },
+
+    // Constants, exposed for testing
+    CHECK_PASSWORD_FIELD_SELECTOR: CHECK_PASSWORD_FIELD_SELECTOR,
+    INPUT_HELP_FOCUSED: INPUT_HELP_FOCUSED,
+    TOOLTIP_MESSAGES: TOOLTIP_MESSAGES
+  };
+  module.exports = PasswordPromptMixin;
+});

--- a/app/scripts/views/mixins/password-strength-mixin.js
+++ b/app/scripts/views/mixins/password-strength-mixin.js
@@ -9,8 +9,10 @@ define(function (require, exports, module) {
   var p = require('lib/promise');
   var requireOnDemand = require('lib/require-on-demand');
   var Url = require('lib/url');
+  var PasswordPromptMixin = require('views/mixins/password-prompt-mixin');
 
   var PasswordStrengthMixin = {
+
     initialize: function (options) {
       this._able = options.able;
     },
@@ -76,12 +78,17 @@ define(function (require, exports, module) {
         .then(function (passwordStrengthChecker) {
           var deferred = p.defer();
           passwordStrengthChecker(password, function (passwordCheckStatus) {
-            // in the future, do some fancy tooltip here.
             passwordCheckStatus = passwordCheckStatus || 'UNKNOWN';
 
             if (passwordCheckStatus === 'BLOOMFILTER_HIT' ||
                 passwordCheckStatus === 'BLOOMFILTER_MISS') {
               self._logStrengthExperimentEvent('bloomfilter_used');
+            }
+            if (passwordCheckStatus === 'BLOOMFILTER_HIT' ||
+                passwordCheckStatus === 'ALL_LETTERS_OR_NUMBERS') {
+              // display the warning prompt only if the password is ALL_LETTERS_OR_NUMBERS
+              // or password is found in list of common passwords
+              self.displayPasswordWarningPrompt();
             }
             self._logStrengthExperimentEvent(passwordCheckStatus);
 
@@ -96,5 +103,5 @@ define(function (require, exports, module) {
       this.logViewEvent(eventName);
     }
   };
-  module.exports = PasswordStrengthMixin;
+  module.exports = _.extend(PasswordStrengthMixin, PasswordPromptMixin);
 });

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -14,6 +14,7 @@ define(function (require, exports, module) {
   var FormView = require('views/form');
   var ExperimentMixin = require('views/mixins/experiment-mixin');
   var PasswordMixin = require('views/mixins/password-mixin');
+  var PasswordStrengthMixin = require('views/mixins/password-strength-mixin');
   var ServiceMixin = require('views/mixins/service-mixin');
   var SettingsPanelMixin = require('views/mixins/settings-panel-mixin');
   var Template = require('stache!templates/settings/change_password');
@@ -56,12 +57,14 @@ define(function (require, exports, module) {
           throw err;
         });
     }
+
   });
 
   Cocktail.mixin(
     View,
     ExperimentMixin,
     PasswordMixin,
+    PasswordStrengthMixin,
     FloatingPlaceholderMixin,
     SettingsPanelMixin,
     ServiceMixin,

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -131,7 +131,6 @@ define(function (require, exports, module) {
 
     events: {
       'blur input.email': 'onEmailBlur',
-      'blur input.password': 'onPasswordBlur',
       'click #amo-migration a': 'onAmoSignIn'
     },
 
@@ -304,11 +303,6 @@ define(function (require, exports, module) {
 
       // re-throw error, it will be handled at a lower level.
       throw err;
-    },
-
-    onPasswordBlur: function () {
-      var password = this.getElementValue('.password');
-      this.checkPasswordStrength(password);
     },
 
     onEmailBlur: function () {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -53,6 +53,7 @@ $chromeless-html-background-color: $color-white;
 $content-background-color: $color-white;
 $cropper-background-color: $color-black;
 $error-background-color: $color-red;
+$warning-background-color: $color-orange;
 $error-text-color: $color-red;
 $faint-text-color: $color-grey-faint-text;
 $horizontal-rule-color: darken($color-grey-light, 5);

--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -20,10 +20,18 @@
 
     html[dir='ltr'] & {
       text-align: left;
+
+      &.input-help-focused {
+        text-align: center;
+      }
     }
 
     html[dir='rtl'] & {
       text-align: right;
+
+      &.input-help-focused {
+        text-align: center;
+      }
     }
   }
 

--- a/app/styles/modules/_tooltip.scss
+++ b/app/styles/modules/_tooltip.scss
@@ -15,6 +15,9 @@
     right: 3px;
   }
 
+  a {
+    color: $message-text-color;
+  }
 
   /* tooltip caret */
   &::before {
@@ -64,6 +67,17 @@
     }
   }
 
+  &.tooltip-warning {
+    background: $warning-background-color;
+
+    &::before {
+      background-color: $warning-background-color;
+    }
+
+    a {
+      text-decoration: underline;
+    }
+  }
 
   @include respond-to('trustedUI') {
     font-size: $small-font;

--- a/app/tests/spec/views/mixins/password-prompt-mixin.js
+++ b/app/tests/spec/views/mixins/password-prompt-mixin.js
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  var $ = require('jquery');
+  var chai = require('chai');
+  var Cocktail = require('cocktail');
+  var PasswordPromptMixin = require('views/mixins/password-prompt-mixin');
+  var PasswordStrengthMixin = require('views/mixins/password-strength-mixin');
+  var sinon = require('sinon');
+
+  var FormView = require('views/form');
+  var Template = require('stache!templates/test_template');
+
+  var TestView = FormView.extend({
+    template: Template
+  });
+
+  Cocktail.mixin(
+    TestView,
+    PasswordPromptMixin,
+    PasswordStrengthMixin
+  );
+
+  var TOOLTIP_SELECTOR = '.tooltip-warning';
+
+  var assert = chai.assert;
+
+  describe('views/mixins/password-prompt-mixin', function () {
+    var view;
+
+    describe('showPasswordPrompt displays different prompts', function () {
+      beforeEach(function () {
+        view = new TestView();
+        return view.render();
+      });
+
+      it('displays the initial password prompt when password field is empty', function () {
+        var password = '';
+        view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR).val(password);
+        view.showPasswordPrompt(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR);
+        assert.equal(
+          view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR).siblings(PasswordPromptMixin.INPUT_HELP_FOCUSED).html(),
+          PasswordPromptMixin.TOOLTIP_MESSAGES.INITIAL_PROMPT_MESSAGE
+        );
+      });
+
+      it('displays the focused password prompt when password field is not empty', function () {
+        var password = 's';
+        view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR).val(password);
+        view.showPasswordPrompt(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR);
+        assert.equal(
+          view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR).siblings(PasswordPromptMixin.INPUT_HELP_FOCUSED).html(),
+          PasswordPromptMixin.TOOLTIP_MESSAGES.FOCUS_PROMPT_MESSAGE
+        );
+      });
+    });
+
+    describe('event triggers call the correct methods', function () {
+      beforeEach(function () {
+        view = new TestView();
+        sinon.spy(view, 'showPasswordPrompt');
+        return view.render();
+      });
+
+      it('onInputFocus calls showPasswordPrompt with the right password field', function () {
+        var event = new $.Event('focus');
+        event.currentTarget = PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR;
+        view.onInputFocus(event);
+        assert.isTrue(view.showPasswordPrompt.calledWith(view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR)));
+      });
+
+      it('onInputKeyUp calls showPasswordPrompt with the right password field', function () {
+        var event = new $.Event('keyup');
+        event.currentTarget = PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR;
+        view.onInputKeyUp(event);
+        assert.isTrue(view.showPasswordPrompt.calledWith(view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR)));
+      });
+    });
+
+    describe('checks password strength and displays tooltip if required', function () {
+      beforeEach(function () {
+        view = new TestView();
+        return view.render();
+      });
+
+      it('calls checkPasswordStrength with the right password', function () {
+        var password = 'charlie2';
+        view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR).val(password);
+        sinon.stub(view, 'checkPasswordStrength', function (password) {
+          // do nothing
+        });
+        view.onPasswordBlur();
+        assert.isTrue(view.checkPasswordStrength.calledWith('charlie2'));
+      });
+
+      it('displays tooltip when password is weak', function (done) {
+        var password = 'charlie2';
+        view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR).val(password);
+        sinon.stub(view, 'checkPasswordStrength', function (password) {
+          view.displayPasswordWarningPrompt();
+        });
+        view.onPasswordBlur();
+        // wait for tooltip
+        setTimeout(function () {
+          assert.equal(view.$(TOOLTIP_SELECTOR).length, 1);
+          done();
+        }, 50);
+      });
+
+      it('does not display tooltip when password is strong', function (done) {
+        var password = 'imstronglol';
+        view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR).val(password);
+        sinon.stub(view, 'checkPasswordStrength', function (password) {
+          // do nothing
+        });
+        view.onPasswordBlur();
+        // wait for tooltip
+        setTimeout(function () {
+          assert.equal(view.$(TOOLTIP_SELECTOR).length, 0);
+          done();
+        }, 50);
+      });
+    });
+
+  });
+});

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -1309,7 +1309,7 @@ define(function (require, exports, module) {
         // wait for tooltip
         setTimeout(function () {
           assert.equal($('.tooltip-suggest').text(), 'Did you mean gmail.com?✕');
-          // there is exactly 3 elements with tabindex in the page
+          // there are exactly 3 elements with tabindex in the page
           assert.equal($('[tabindex]').length, 3);
           // the first element with tabindex is the span containing the website name
           assert.equal($('.tooltip-suggest span:first').get(0), $('[tabindex="1"]').get(0));

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -142,6 +142,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/open-webmail-mixin',
     '../tests/spec/views/mixins/password-mixin',
     '../tests/spec/views/mixins/password-reset-mixin',
+    '../tests/spec/views/mixins/password-prompt-mixin',
     '../tests/spec/views/mixins/password-strength-mixin',
     '../tests/spec/views/mixins/resume-token-mixin',
     '../tests/spec/views/mixins/service-mixin',


### PR DESCRIPTION
Fixes #3731 
signup page and change_password page now shows useful hints to users
uses password_strength_checker to decide if password is common or not
only new_password field is checked
Thanks to @ryanfeeley for the continuous help on this one!

@shane-tomlinson 
@vladikoff 
