### PR TITLE
Use a more specific marketing opt-in string

### DIFF
--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -46,6 +46,10 @@ define(function (require, exports, module) {
   t('Sign-in confirmed');
   t('You are now ready to use %(serviceName)s');
 
+  // We're temporarily changing the string for marketing optin, see #3792.
+  // This keeps the old string around for if/when we need to change it back.
+  t('Get the latest news about Mozilla and Firefox.');
+
   /**
    * Replace instances of %s and %(name)s with their corresponding values in
    * the context

--- a/app/scripts/templates/settings/communication_preferences.mustache
+++ b/app/scripts/templates/settings/communication_preferences.mustache
@@ -23,7 +23,7 @@
 
     <form novalidate>
       <p>
-        {{#t}}Get the latest news about Mozilla and Firefox.{{/t}}
+        {{#t}}Send me the monthly Firefox newsletter.{{/t}}
         {{#preferencesUrl}}
           <a href="{{preferencesUrl}}" id="preferences-url" class="right">{{#t}}Email preferences{{/t}}</a>
         {{/preferencesUrl}}

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -56,7 +56,7 @@
 
       {{#isEmailOptInVisible}}
       <div class="input-row marketing-email-optin-row">
-          <label class="fxa-checkbox"><input id="marketing-email-optin" type="checkbox" class="marketing-email-optin"><span>{{#t}}Get the latest news about Mozilla and Firefox.{{/t}}</span></label>
+          <label class="fxa-checkbox"><input id="marketing-email-optin" type="checkbox" class="marketing-email-optin"><span>{{#t}}Send me the monthly Firefox newsletter.{{/t}}</span></label>
       </div>
       {{/isEmailOptInVisible}}
 


### PR DESCRIPTION
Before launching any email-driven onboarding flows, we will need to change the text on the marketing opt-in checkbox, to be more specific about what it does (and hence does *not*) opt you in to or out of.

The ask is to change it for the duration of the first email onboarding experiment; but I actually think it's a good honest change overall and we might want to consider making it permanent.  @shane-tomlinson @javaun thoughts?

Connects to https://github.com/mozilla/fxa/issues/148