### PR TITLE
style(links): stack side-by-side links

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -389,6 +389,27 @@ define(function (require, exports, module) {
 
     // called after the view is visible.
     afterVisible: function () {
+      // restyle side-by-side links to stack if they are too long
+      // to fit on one line
+      var linkContainer = this.$el.find('.links');
+      if (linkContainer.length > 0) {
+        // takes care of odd number widths
+        var halfContainerWidth = Math.floor(linkContainer.width() / 2);
+        var shouldResetLinkSize = false;
+
+        linkContainer.children('a').each(function (i, item) {
+          var linkWidth = linkContainer.find(item).width();
+          // if any link is equal to or more than half its parent's width,
+          // make *all* links in the same parent to be stacked
+          if (linkWidth >= halfContainerWidth) {
+            shouldResetLinkSize = true;
+          }
+        });
+
+        if (shouldResetLinkSize === true) {
+          linkContainer.addClass('centered');
+        }
+      }
       // make a huge assumption and say if the device does not have touch,
       // it's a desktop device and autofocus can be applied without
       // hiding part of the view. The no-touch class is added by

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -16,15 +16,22 @@
   .left {
     float: left;
     max-width: 50%;
-    padding: 0 4% 0 0;
     text-align: left;
   }
 
   .right {
     float: right;
     max-width: 50%;
-    padding: 0 0 0 4%;
     text-align: right;
+  }
+
+  &.centered a:not(:only-child) {
+    display: block;
+    float: none;
+    margin: 5px auto;
+    max-width: 100%;
+    text-align: center;
+    width: fit-content;
   }
 
   a {
@@ -130,10 +137,10 @@ ul.links {
   .links .right {
     display: block;
     float: none;
-    margin: 5px 0;
+    margin: 5px auto;
     max-width: 100%;
-    padding: 0;
     text-align: center;
+    width: fit-content;
   }
 }
 

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -271,6 +271,26 @@ define(function (require, exports, module) {
         $('html').removeClass('no-touch');
       });
 
+      it('adds `centered` class to `.links` if any child has width >= half of `.links` width', function () {
+        var link1 = '<a href="/reset_password" class="left reset-password">Forgot password?</a>';
+        var link2 = '<a href="/signup" class="right sign-up">Create an account with really really looooooooooooooong text</a>';
+        $('.links').html(link1 + link2);
+        // force the width to be 50%
+        $('.links > .right').css({'display':'inline-block', 'width':'50%'});
+        view.afterVisible();
+        assert.isTrue($('.links').hasClass('centered'));
+      });
+
+      it('does not add `centered` class to `.links` if all children have width < half of `.links` width', function () {
+        var link1 = '<a href="/reset_password" class="left reset-password">Forgot password?</a>';
+        var link2 = '<a href="/signup" class="right sign-up">Create an account</a>';
+        $('.links').html(link1 + link2);
+        // force the widths of all children to be less than 50%
+        $('.links').children().css({'display':'inline-block', 'width':'49%'});
+        view.afterVisible();
+        assert.isFalse($('.links').hasClass('centered'));
+      });
+
       it('focuses descendent element containing `autofocus` if html has `no-touch` class', function (done) {
         requiresFocus(function () {
           $('html').addClass('no-touch');


### PR DESCRIPTION
Fixes #3798

Thanks to @vladikoff 
@shane-tomlinson 
@ryanfeeley 

### Preview:
* When the links are normal sized:
<img width="564" alt="screenshot 2016-06-03 14 07 48" src="https://cloud.githubusercontent.com/assets/432707/15794097/2ae6973a-299d-11e6-9e99-64d8fa5a0a4e.png">

* When links are longer:
<img width="565" alt="screenshot 2016-06-03 14 06 51" src="https://cloud.githubusercontent.com/assets/432707/15794106/3c69502e-299d-11e6-9a63-1fca9e7074ac.png">
