### PR TITLE
fix(tests): ignore error from killall firefox-bin

### DIFF
--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -18,7 +18,7 @@ FXA_TEST_NAME=$1
 source $DIRNAME/defaults.sh
 source $DIRNAME/$FXA_TEST_NAME
 
-killall -v firefox-bin
+killall -v firefox-bin || echo 'Ok, no firefox-bin.'
 
 # optionally, GIT_COMMIT can be set in the environment to override
 if [ -z "$GIT_COMMIT" ]; then

--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -18,7 +18,7 @@ FXA_TEST_NAME=$1
 source $DIRNAME/defaults.sh
 source $DIRNAME/$FXA_TEST_NAME
 
-killall -v firefox-bin
+killall -v firefox-bin || echo 'Ok, no firefox-bin.'
 
 # optionally, GIT_COMMIT can be set in the environment to override
 if [ -z "$GIT_COMMIT" ]; then


### PR DESCRIPTION
Bah. Got this wrong. Don't want to error out if there are no leftover processes.