### PR TITLE
chore(tests): useTeamCityReporter=true for intern_server tests

### DIFF
--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -90,4 +90,6 @@ set -o xtrace # echo the following commands
   fxaContentRoot="$FXA_CONTENT_ROOT" \
   fxaProduction="true" \
   fxaDevBox="$FXA_DEV_BOX" \
-  asyncTimeout=10000
+  asyncTimeout=10000 \
+  useTeamCityReporter=true
+


### PR DESCRIPTION
r? - @vladikoff 

Use the teamcity report to count and track test results for intern server tests.