### PR TITLE
fix(rtl): rtl weird behavior with special characters

### DIFF
--- a/app/styles/modules/_input-row.scss
+++ b/app/styles/modules/_input-row.scss
@@ -62,7 +62,9 @@
     }
 
     html[dir='rtl'] & {
+      direction: rtl;
       padding: 0  $input-left-right-padding 0 0;
+      unicode-bidi: bidi-override;
     }
 
     &[type='checkbox']:hover,


### PR DESCRIPTION
Fixes #3811 
@vladikoff 
Gives true RTL behavior to text in the input fields:
![rtl thingy](https://cloud.githubusercontent.com/assets/432707/15912509/acdd6526-2d89-11e6-89a8-27c174759311.gif)
