### PR TITLE
style(devices): make devices and buttons responsive

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -459,8 +459,20 @@ body.settings #main-content.card {
   padding-left: 40px;
   position: relative;
 
+  .device-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    /*allows 5% gutter between device-name and .device-disconnected button*/
+    /*reduce by 95px to accomodate the width of the .device-disconnected button*/
+    white-space: nowrap;
+    width: calc(95% - 95px);
+  }
+
   .settings-button {
     height: 35px;
+    /*minimum width required for the button to look good without occupying too much space*/
+    /*is also the default computed width on desktop screen*/
+    min-width: 95px;
     position: absolute;
     right: 0;
     top: 0;


### PR DESCRIPTION
Fixes #3806 
Allows a 5% gutter between device name and device-disconnected button
Sets min-width on the button so that it does not shrink too much
@vladikoff 
@ryanfeeley 