### PR TITLE
fix(mozlog): update to 2.0.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,119 +1,119 @@
 {
   "name": "fxa-content-server",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "dependencies": {
     "bluebird": {
       "version": "3.3.5",
-      "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.5.tgz",
+      "from": "bluebird@3.3.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.5.tgz"
     },
     "body-parser": {
       "version": "1.15.0",
-      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
+      "from": "body-parser@1.15.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+          "from": "bytes@2.2.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
         },
         "content-type": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+          "version": "1.0.2",
+          "from": "content-type@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "from": "depd@1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "http-errors": {
           "version": "1.4.0",
-          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
+          "from": "http-errors@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "statuses": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+              "version": "1.3.0",
+              "from": "statuses@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
             }
           }
         },
         "iconv-lite": {
           "version": "0.4.13",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "from": "iconv-lite@0.4.13",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "from": "on-finished@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+              "from": "ee-first@1.1.1",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "qs": {
           "version": "6.1.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
+          "from": "qs@6.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
         },
         "raw-body": {
           "version": "2.1.6",
-          "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
+          "from": "raw-body@>=2.1.5 <2.2.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
           "dependencies": {
             "bytes": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
+              "from": "bytes@2.3.0",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
             },
             "unpipe": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "from": "unpipe@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "type-is": {
-          "version": "1.6.12",
-          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+          "version": "1.6.13",
+          "from": "type-is@>=1.6.11 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "from": "media-typer@0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.10",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "version": "2.1.11",
+              "from": "mime-types@>=2.1.11 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.22.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                  "version": "1.23.0",
+                  "from": "mime-db@>=1.23.0 <1.24.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
                 }
               }
             }
@@ -123,34 +123,34 @@
     },
     "bower": {
       "version": "1.7.9",
-      "from": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
+      "from": "bower@1.7.9",
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz"
     },
     "connect-cachify": {
       "version": "0.0.17",
-      "from": "https://registry.npmjs.org/connect-cachify/-/connect-cachify-0.0.17.tgz",
+      "from": "connect-cachify@0.0.17",
       "resolved": "https://registry.npmjs.org/connect-cachify/-/connect-cachify-0.0.17.tgz",
       "dependencies": {
         "underscore": {
           "version": "1.8.3",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "from": "underscore@>=1.3.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
     },
     "connect-fonts-firasans": {
       "version": "0.0.4",
-      "from": "https://registry.npmjs.org/connect-fonts-firasans/-/connect-fonts-firasans-0.0.4.tgz",
+      "from": "connect-fonts-firasans@0.0.4",
       "resolved": "https://registry.npmjs.org/connect-fonts-firasans/-/connect-fonts-firasans-0.0.4.tgz"
     },
     "consolidate": {
       "version": "0.14.0",
-      "from": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.0.tgz",
+      "from": "consolidate@0.14.0",
       "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.0.tgz"
     },
     "convict": {
       "version": "1.3.0",
-      "from": "https://registry.npmjs.org/convict/-/convict-1.3.0.tgz",
+      "from": "convict@1.3.0",
       "resolved": "https://registry.npmjs.org/convict/-/convict-1.3.0.tgz",
       "dependencies": {
         "depd": {
@@ -165,7 +165,7 @@
         },
         "moment": {
           "version": "2.12.0",
-          "from": "moment@2.12.0",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
         },
         "optimist": {
@@ -218,1140 +218,248 @@
     },
     "cookie-parser": {
       "version": "1.4.1",
-      "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.1.tgz",
+      "from": "cookie-parser@1.4.1",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.1.tgz",
       "dependencies": {
         "cookie": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/cookie/-/cookie-0.2.3.tgz",
+          "from": "cookie@0.2.3",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.2.3.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "from": "cookie-signature@1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         }
       }
     },
     "cors": {
       "version": "2.7.1",
-      "from": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
+      "from": "cors@2.7.1",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
       "dependencies": {
         "vary": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+          "from": "vary@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
-        }
-      }
-    },
-    "eslint": {
-      "version": "2.9.0",
-      "from": "https://registry.npmjs.org/eslint/-/eslint-2.9.0.tgz",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.9.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "concat-stream": {
-          "version": "1.5.1",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-            },
-            "readable-stream": {
-              "version": "2.0.6",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-            }
-          }
-        },
-        "doctrine": {
-          "version": "1.2.1",
-          "from": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.1.tgz",
-          "dependencies": {
-            "esutils": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            }
-          }
-        },
-        "es6-map": {
-          "version": "0.1.3",
-          "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
-          "dependencies": {
-            "d": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-            },
-            "es5-ext": {
-              "version": "0.10.11",
-              "from": "es5-ext@>=0.10.8 <0.11.0",
-              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
-            },
-            "es6-iterator": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-            },
-            "es6-set": {
-              "version": "0.1.4",
-              "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
-            },
-            "es6-symbol": {
-              "version": "3.0.2",
-              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
-            },
-            "event-emitter": {
-              "version": "0.3.4",
-              "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
-              "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
-            }
-          }
-        },
-        "escope": {
-          "version": "3.6.0",
-          "from": "escope@>=3.2.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-          "dependencies": {
-            "es6-weak-map": {
-              "version": "2.0.1",
-              "from": "es6-weak-map@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                },
-                "es5-ext": {
-                  "version": "0.10.11",
-                  "from": "es5-ext@>=0.10.8 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
-                },
-                "es6-iterator": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                },
-                "es6-symbol": {
-                  "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
-                }
-              }
-            },
-            "esrecurse": {
-              "version": "4.1.0",
-              "from": "esrecurse@>=4.1.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-              "dependencies": {
-                "estraverse": {
-                  "version": "4.1.1",
-                  "from": "estraverse@>=4.1.0 <4.2.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
-                },
-                "object-assign": {
-                  "version": "4.1.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "espree": {
-          "version": "3.1.4",
-          "from": "https://registry.npmjs.org/espree/-/espree-3.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.4.tgz",
-          "dependencies": {
-            "acorn": {
-              "version": "3.1.0",
-              "from": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz"
-            },
-            "acorn-jsx": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
-            }
-          }
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-        },
-        "file-entry-cache": {
-          "version": "1.2.4",
-          "from": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
-          "dependencies": {
-            "flat-cache": {
-              "version": "1.0.10",
-              "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
-              "dependencies": {
-                "del": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
-                  "dependencies": {
-                    "globby": {
-                      "version": "4.0.0",
-                      "from": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
-                      "dependencies": {
-                        "array-union": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-                          "dependencies": {
-                            "array-uniq": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "arrify": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-                        },
-                        "glob": {
-                          "version": "6.0.4",
-                          "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.4",
-                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.4.1",
-                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "is-path-cwd": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
-                    },
-                    "is-path-in-cwd": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                      "dependencies": {
-                        "is-path-inside": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "pify": {
-                      "version": "2.3.0",
-                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.5.2",
-                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "4.1.4",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
-                },
-                "read-json-sync": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz"
-                },
-                "write": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-            }
-          }
-        },
-        "glob": {
-          "version": "7.0.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.4",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.1",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "globals": {
-          "version": "9.6.0",
-          "from": "https://registry.npmjs.org/globals/-/globals-9.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.6.0.tgz"
-        },
-        "ignore": {
-          "version": "3.1.2",
-          "from": "https://registry.npmjs.org/ignore/-/ignore-3.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.2.tgz"
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "from": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-        },
-        "inquirer": {
-          "version": "0.12.0",
-          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.4.0",
-              "from": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
-            },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "dependencies": {
-                "restore-cursor": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "dependencies": {
-                    "exit-hook": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
-                    },
-                    "onetime": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "cli-width": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
-            },
-            "figures": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz"
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                }
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "dependencies": {
-                "once": {
-                  "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2",
-              "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-            },
-            "through": {
-              "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-          }
-        },
-        "is-my-json-valid": {
-          "version": "2.13.1",
-          "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-          "dependencies": {
-            "generate-function": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-            },
-            "generate-object-property": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-              "dependencies": {
-                "is-property": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                }
-              }
-            },
-            "jsonpointer": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "is-resolvable": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-          "dependencies": {
-            "tryit": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
-            }
-          }
-        },
-        "js-yaml": {
-          "version": "3.6.0",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.7",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                }
-              }
-            },
-            "esprima": {
-              "version": "2.7.2",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-            }
-          }
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "dependencies": {
-            "jsonify": {
-              "version": "0.0.0",
-              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-            }
-          }
-        },
-        "optionator": {
-          "version": "0.8.1",
-          "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
-          "dependencies": {
-            "prelude-ls": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-            },
-            "levn": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
-            },
-            "fast-levenshtein": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-        },
-        "path-is-inside": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
-        },
-        "pluralize": {
-          "version": "1.2.1",
-          "from": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
-        },
-        "progress": {
-          "version": "1.1.8",
-          "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
-        },
-        "require-uncached": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
-          "dependencies": {
-            "caller-path": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-              "dependencies": {
-                "callsites": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
-                }
-              }
-            },
-            "resolve-from": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
-            }
-          }
-        },
-        "shelljs": {
-          "version": "0.6.0",
-          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz"
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-        },
-        "table": {
-          "version": "3.7.8",
-          "from": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
-          "resolved": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
-          "dependencies": {
-            "slice-ansi": {
-              "version": "0.0.4",
-              "from": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "tv4": {
-              "version": "1.2.7",
-              "from": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
-              "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz"
-            },
-            "xregexp": {
-              "version": "3.1.0",
-              "from": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.0.tgz"
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-            }
-          }
         }
       }
     },
     "express": {
       "version": "4.13.4",
-      "from": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+      "from": "express@4.13.4",
       "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.2.13",
-          "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+          "from": "accepts@>=1.2.12 <1.3.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.1.10",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "version": "2.1.11",
+              "from": "mime-types@>=2.1.6 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.22.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                  "version": "1.23.0",
+                  "from": "mime-db@>=1.23.0 <1.24.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.5.3",
-              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+              "from": "negotiator@0.5.3",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
             }
           }
         },
         "array-flatten": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "from": "array-flatten@1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
         },
         "content-disposition": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+          "from": "content-disposition@0.5.1",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
         },
         "content-type": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+          "version": "1.0.2",
+          "from": "content-type@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "cookie": {
           "version": "0.1.5",
-          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
+          "from": "cookie@0.1.5",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "from": "cookie-signature@1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "from": "depd@1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+          "from": "escape-html@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "etag": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+          "from": "etag@>=1.7.0 <1.8.0",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
         },
         "finalhandler": {
           "version": "0.4.1",
-          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+          "from": "finalhandler@0.4.1",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
           "dependencies": {
             "unpipe": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "from": "unpipe@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "fresh": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+          "from": "fresh@0.3.0",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+          "from": "merge-descriptors@1.0.1",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
         },
         "methods": {
           "version": "1.1.2",
-          "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "from": "methods@>=1.1.2 <1.2.0",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "from": "on-finished@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+              "from": "ee-first@1.1.1",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.1",
-          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "from": "parseurl@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "from": "path-to-regexp@0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
         },
         "proxy-addr": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+          "from": "proxy-addr@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+              "from": "forwarded@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
+              "from": "ipaddr.js@1.0.5",
               "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
             }
           }
         },
         "qs": {
           "version": "4.0.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "from": "qs@4.0.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
         },
         "range-parser": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+          "from": "range-parser@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
         },
         "send": {
           "version": "0.13.1",
-          "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+          "from": "send@0.13.1",
           "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+              "from": "destroy@>=1.0.4 <1.1.0",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
             },
             "http-errors": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "from": "http-errors@>=1.3.1 <1.4.0",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "from": "mime@1.3.4",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             },
             "statuses": {
               "version": "1.2.1",
-              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+              "from": "statuses@>=1.2.1 <1.3.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
             }
           }
         },
         "type-is": {
-          "version": "1.6.12",
-          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+          "version": "1.6.13",
+          "from": "type-is@>=1.6.11 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "from": "media-typer@0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.10",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "version": "2.1.11",
+              "from": "mime-types@>=2.1.6 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.22.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                  "version": "1.23.0",
+                  "from": "mime-db@>=1.23.0 <1.24.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
                 }
               }
             }
@@ -1359,122 +467,122 @@
         },
         "utils-merge": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "from": "utils-merge@1.0.0",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         },
         "vary": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+          "from": "vary@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
         }
       }
     },
     "express-able": {
       "version": "0.4.4",
-      "from": "https://registry.npmjs.org/express-able/-/express-able-0.4.4.tgz",
+      "from": "express-able@0.4.4",
       "resolved": "https://registry.npmjs.org/express-able/-/express-able-0.4.4.tgz",
       "dependencies": {
         "able": {
           "version": "0.4.3",
-          "from": "https://registry.npmjs.org/able/-/able-0.4.3.tgz",
+          "from": "able@0.4.3",
           "resolved": "https://registry.npmjs.org/able/-/able-0.4.3.tgz",
           "dependencies": {
             "abatar": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/abatar/-/abatar-0.4.1.tgz",
+              "from": "abatar@0.4.1",
               "resolved": "https://registry.npmjs.org/abatar/-/abatar-0.4.1.tgz",
               "dependencies": {
                 "js-sha1": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/js-sha1/-/js-sha1-0.2.0.tgz",
+                  "from": "js-sha1@0.2.0",
                   "resolved": "https://registry.npmjs.org/js-sha1/-/js-sha1-0.2.0.tgz"
                 }
               }
             },
             "async": {
               "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+              "from": "async@0.9.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
             "boom": {
               "version": "2.6.1",
-              "from": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+              "from": "boom@2.6.1",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "from": "hoek@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 }
               }
             },
             "browserify": {
               "version": "9.0.8",
-              "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.8.tgz",
+              "from": "browserify@9.0.8",
               "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.8.tgz",
               "dependencies": {
                 "JSONStream": {
                   "version": "0.10.0",
-                  "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+                  "from": "JSONStream@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
                   "dependencies": {
                     "jsonparse": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                      "from": "jsonparse@0.0.5",
                       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.3.8",
-                      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                      "from": "through@>=2.2.7 <3.0.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
                 },
                 "assert": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+                  "from": "assert@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
                 },
                 "browser-pack": {
                   "version": "4.0.4",
-                  "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
+                  "from": "browser-pack@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
                   "dependencies": {
                     "JSONStream": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
+                      "from": "JSONStream@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
                       "dependencies": {
                         "jsonparse": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+                          "from": "jsonparse@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
                         },
                         "through": {
                           "version": "2.3.8",
-                          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                          "from": "through@>=2.2.7 <3.0.0",
                           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                         }
                       }
                     },
                     "combine-source-map": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                      "from": "combine-source-map@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
                       "dependencies": {
                         "inline-source-map": {
                           "version": "0.3.1",
-                          "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                          "from": "inline-source-map@>=0.3.0 <0.4.0",
                           "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                           "dependencies": {
                             "source-map": {
                               "version": "0.3.0",
-                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                              "from": "source-map@>=0.3.0 <0.4.0",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                               "dependencies": {
                                 "amdefine": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                                  "from": "amdefine@>=0.0.4",
                                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                                 }
                               }
@@ -1483,17 +591,17 @@
                         },
                         "convert-source-map": {
                           "version": "0.3.5",
-                          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+                          "from": "convert-source-map@>=0.3.0 <0.4.0",
                           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                         },
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "from": "source-map@>=0.1.31 <0.2.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
@@ -1502,22 +610,22 @@
                     },
                     "defined": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                      "from": "defined@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                     },
                     "through2": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                      "from": "through2@>=0.5.1 <0.6.0",
                       "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.34",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                          "from": "readable-stream@>=1.0.17 <1.1.0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             }
                           }
@@ -1526,134 +634,134 @@
                     },
                     "umd": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+                      "from": "umd@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
                     }
                   }
                 },
                 "browser-resolve": {
-                  "version": "1.11.1",
-                  "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz",
-                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz"
+                  "version": "1.11.2",
+                  "from": "browser-resolve@>=1.7.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                  "from": "browserify-zlib@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
                       "version": "0.2.8",
-                      "from": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
+                      "from": "pako@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
                     }
                   }
                 },
                 "buffer": {
                   "version": "3.6.0",
-                  "from": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+                  "from": "buffer@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
                   "dependencies": {
                     "base64-js": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+                      "from": "base64-js@0.0.8",
                       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
                     },
                     "ieee754": {
                       "version": "1.1.6",
-                      "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
+                      "from": "ieee754@>=1.1.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "from": "isarray@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     }
                   }
                 },
                 "builtins": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+                  "from": "builtins@>=0.0.3 <0.1.0",
                   "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
                 },
                 "commondir": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+                  "from": "commondir@0.0.1",
                   "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
                 },
                 "concat-stream": {
                   "version": "1.4.10",
-                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                  "from": "concat-stream@>=1.4.1 <1.5.0",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     }
                   }
                 },
                 "console-browserify": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                  "from": "console-browserify@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
                   "dependencies": {
                     "date-now": {
                       "version": "0.1.4",
-                      "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                      "from": "date-now@>=0.1.4 <0.2.0",
                       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                     }
                   }
                 },
                 "constants-browserify": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+                  "from": "constants-browserify@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
                 },
                 "crypto-browserify": {
                   "version": "3.11.0",
-                  "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+                  "from": "crypto-browserify@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
                   "dependencies": {
                     "browserify-cipher": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+                      "from": "browserify-cipher@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
                       "dependencies": {
                         "browserify-aes": {
                           "version": "1.0.6",
-                          "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                          "from": "browserify-aes@>=1.0.4 <2.0.0",
                           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
                           "dependencies": {
                             "buffer-xor": {
                               "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+                              "from": "buffer-xor@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
                             },
                             "cipher-base": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz",
+                              "from": "cipher-base@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
                             }
                           }
                         },
                         "browserify-des": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+                          "from": "browserify-des@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
                           "dependencies": {
                             "cipher-base": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz",
+                              "from": "cipher-base@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
                             },
                             "des.js": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+                              "from": "des.js@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                                 }
                               }
@@ -1662,80 +770,80 @@
                         },
                         "evp_bytestokey": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+                          "from": "evp_bytestokey@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                         }
                       }
                     },
                     "browserify-sign": {
                       "version": "4.0.0",
-                      "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
+                      "from": "browserify-sign@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.11.3",
-                          "from": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz"
+                          "version": "4.11.4",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.4.tgz"
                         },
                         "browserify-rsa": {
                           "version": "4.0.1",
-                          "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+                          "from": "browserify-rsa@>=4.0.0 <5.0.0",
                           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
                         },
                         "elliptic": {
-                          "version": "6.2.3",
-                          "from": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
-                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
+                          "version": "6.2.8",
+                          "from": "elliptic@>=6.0.0 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.8.tgz",
                           "dependencies": {
                             "brorand": {
                               "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                              "from": "brorand@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                             },
                             "hash.js": {
                               "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                              "from": "hash.js@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                             }
                           }
                         },
                         "parse-asn1": {
                           "version": "5.0.0",
-                          "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
+                          "from": "parse-asn1@>=5.0.0 <6.0.0",
                           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "4.5.2",
-                              "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.2.tgz",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.2.tgz",
+                              "version": "4.6.2",
+                              "from": "asn1.js@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.6.2.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                                 }
                               }
                             },
                             "browserify-aes": {
                               "version": "1.0.6",
-                              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                              "from": "browserify-aes@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
                               "dependencies": {
                                 "buffer-xor": {
                                   "version": "1.0.3",
-                                  "from": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+                                  "from": "buffer-xor@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
                                 },
                                 "cipher-base": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz",
+                                  "from": "cipher-base@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
                                 }
                               }
                             },
                             "evp_bytestokey": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+                              "from": "evp_bytestokey@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                             }
                           }
@@ -1744,27 +852,27 @@
                     },
                     "create-ecdh": {
                       "version": "4.0.0",
-                      "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+                      "from": "create-ecdh@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.11.3",
-                          "from": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz"
+                          "version": "4.11.4",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.4.tgz"
                         },
                         "elliptic": {
-                          "version": "6.2.3",
-                          "from": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
-                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
+                          "version": "6.2.8",
+                          "from": "elliptic@>=6.0.0 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.8.tgz",
                           "dependencies": {
                             "brorand": {
                               "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                              "from": "brorand@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                             },
                             "hash.js": {
                               "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                              "from": "hash.js@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                             }
                           }
@@ -1773,49 +881,49 @@
                     },
                     "create-hash": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+                      "from": "create-hash@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
                       "dependencies": {
                         "cipher-base": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz",
+                          "from": "cipher-base@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
                         },
                         "ripemd160": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+                          "from": "ripemd160@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
                         },
                         "sha.js": {
                           "version": "2.4.5",
-                          "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
+                          "from": "sha.js@>=2.3.6 <3.0.0",
                           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz"
                         }
                       }
                     },
                     "create-hmac": {
                       "version": "1.1.4",
-                      "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
+                      "from": "create-hmac@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
                     },
                     "diffie-hellman": {
                       "version": "5.0.2",
-                      "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+                      "from": "diffie-hellman@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.11.3",
-                          "from": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz"
+                          "version": "4.11.4",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.4.tgz"
                         },
                         "miller-rabin": {
                           "version": "4.0.0",
-                          "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+                          "from": "miller-rabin@>=4.0.0 <5.0.0",
                           "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
                           "dependencies": {
                             "brorand": {
                               "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                              "from": "brorand@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                             }
                           }
@@ -1824,61 +932,61 @@
                     },
                     "pbkdf2": {
                       "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz",
+                      "from": "pbkdf2@>=3.0.3 <4.0.0",
                       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
                     },
                     "public-encrypt": {
                       "version": "4.0.0",
-                      "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+                      "from": "public-encrypt@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.11.3",
-                          "from": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz"
+                          "version": "4.11.4",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.4.tgz"
                         },
                         "browserify-rsa": {
                           "version": "4.0.1",
-                          "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+                          "from": "browserify-rsa@>=4.0.0 <5.0.0",
                           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
                         },
                         "parse-asn1": {
                           "version": "5.0.0",
-                          "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
+                          "from": "parse-asn1@>=5.0.0 <6.0.0",
                           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "4.5.2",
-                              "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.2.tgz",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.2.tgz",
+                              "version": "4.6.2",
+                              "from": "asn1.js@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.6.2.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                                 }
                               }
                             },
                             "browserify-aes": {
                               "version": "1.0.6",
-                              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                              "from": "browserify-aes@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
                               "dependencies": {
                                 "buffer-xor": {
                                   "version": "1.0.3",
-                                  "from": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+                                  "from": "buffer-xor@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
                                 },
                                 "cipher-base": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz",
+                                  "from": "cipher-base@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
                                 }
                               }
                             },
                             "evp_bytestokey": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+                              "from": "evp_bytestokey@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                             }
                           }
@@ -1887,39 +995,39 @@
                     },
                     "randombytes": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
+                      "from": "randombytes@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
                     }
                   }
                 },
                 "deep-equal": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+                  "from": "deep-equal@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
                 },
                 "defined": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+                  "from": "defined@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
                 },
                 "deps-sort": {
                   "version": "1.3.9",
-                  "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+                  "from": "deps-sort@>=1.3.5 <2.0.0",
                   "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
                   "dependencies": {
                     "JSONStream": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
+                      "from": "JSONStream@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
                       "dependencies": {
                         "jsonparse": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+                          "from": "jsonparse@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
                         },
                         "through": {
                           "version": "2.3.8",
-                          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                          "from": "through@>=2.2.7 <3.0.0",
                           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                         }
                       }
@@ -1928,54 +1036,54 @@
                 },
                 "domain-browser": {
                   "version": "1.1.7",
-                  "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+                  "from": "domain-browser@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
                 },
                 "duplexer2": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "from": "duplexer2@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
                 },
                 "events": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+                  "from": "events@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "from": "glob@>=4.0.5 <5.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "version": "1.0.5",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "version": "1.1.4",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "version": "0.4.1",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "from": "concat-map@0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -1984,13 +1092,13 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     }
@@ -1998,83 +1106,83 @@
                 },
                 "has": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+                  "from": "has@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
                   "dependencies": {
                     "function-bind": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+                      "from": "function-bind@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
                     }
                   }
                 },
                 "http-browserify": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+                  "from": "http-browserify@>=1.4.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
                   "dependencies": {
                     "Base64": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+                      "from": "Base64@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
                     }
                   }
                 },
                 "https-browserify": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+                  "from": "https-browserify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
                 },
                 "insert-module-globals": {
                   "version": "6.6.3",
-                  "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+                  "from": "insert-module-globals@>=6.2.0 <7.0.0",
                   "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
                   "dependencies": {
                     "JSONStream": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
+                      "from": "JSONStream@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
                       "dependencies": {
                         "jsonparse": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+                          "from": "jsonparse@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
                         },
                         "through": {
                           "version": "2.3.8",
-                          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                          "from": "through@>=2.2.7 <3.0.0",
                           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                         }
                       }
                     },
                     "combine-source-map": {
                       "version": "0.6.1",
-                      "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+                      "from": "combine-source-map@>=0.6.1 <0.7.0",
                       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
                       "dependencies": {
                         "convert-source-map": {
                           "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+                          "from": "convert-source-map@>=1.1.0 <1.2.0",
                           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
                         },
                         "inline-source-map": {
                           "version": "0.5.0",
-                          "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+                          "from": "inline-source-map@>=0.5.0 <0.6.0",
                           "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
                         },
                         "lodash.memoize": {
                           "version": "3.0.4",
-                          "from": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+                          "from": "lodash.memoize@>=3.0.3 <3.1.0",
                           "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
                         },
                         "source-map": {
                           "version": "0.4.4",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                          "from": "source-map@>=0.4.2 <0.5.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
@@ -2083,22 +1191,22 @@
                     },
                     "is-buffer": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                      "from": "is-buffer@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                     },
                     "lexical-scope": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+                      "from": "lexical-scope@>=1.2.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
                       "dependencies": {
                         "astw": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
+                          "from": "astw@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                           "dependencies": {
                             "acorn": {
                               "version": "1.2.2",
-                              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                              "from": "acorn@>=1.0.3 <2.0.0",
                               "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                             }
                           }
@@ -2106,40 +1214,40 @@
                       }
                     },
                     "process": {
-                      "version": "0.11.2",
-                      "from": "https://registry.npmjs.org/process/-/process-0.11.2.tgz",
-                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+                      "version": "0.11.3",
+                      "from": "process@>=0.11.0 <0.12.0",
+                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.3.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "labeled-stream-splicer": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+                  "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
                   "dependencies": {
                     "stream-splicer": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+                      "from": "stream-splicer@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
                       "dependencies": {
                         "readable-wrap": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+                          "from": "readable-wrap@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                         },
                         "indexof": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                          "from": "indexof@0.0.1",
                           "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                         }
                       }
@@ -2148,68 +1256,68 @@
                 },
                 "module-deps": {
                   "version": "3.9.1",
-                  "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+                  "from": "module-deps@>=3.7.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
                   "dependencies": {
                     "JSONStream": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
+                      "from": "JSONStream@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.1.1.tgz",
                       "dependencies": {
                         "jsonparse": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+                          "from": "jsonparse@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
                         },
                         "through": {
                           "version": "2.3.8",
-                          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                          "from": "through@>=2.2.7 <3.0.0",
                           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                         }
                       }
                     },
                     "defined": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                      "from": "defined@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                     },
                     "detective": {
                       "version": "4.3.1",
-                      "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                      "from": "detective@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
-                          "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                          "from": "acorn@>=1.0.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                         }
                       }
                     },
                     "stream-combiner2": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+                      "from": "stream-combiner2@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
                       "dependencies": {
                         "through2": {
                           "version": "0.5.1",
-                          "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                          "from": "through2@>=0.5.1 <0.6.0",
                           "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.34",
-                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                              "from": "readable-stream@>=1.0.17 <1.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 }
                               }
                             },
                             "xtend": {
                               "version": "3.0.0",
-                              "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                              "from": "xtend@>=3.0.0 <3.1.0",
                               "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                             }
                           }
@@ -2218,258 +1326,258 @@
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "os-browserify": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+                  "from": "os-browserify@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
                 },
                 "parents": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+                  "from": "parents@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
                   "dependencies": {
                     "path-platform": {
                       "version": "0.11.15",
-                      "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+                      "from": "path-platform@>=0.11.15 <0.12.0",
                       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
                     }
                   }
                 },
                 "path-browserify": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+                  "from": "path-browserify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
                 },
                 "process": {
                   "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
+                  "from": "process@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
                 },
                 "punycode": {
                   "version": "1.2.4",
-                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+                  "from": "punycode@>=1.2.3 <1.3.0",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
                 },
                 "querystring-es3": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+                  "from": "querystring-es3@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
                 },
                 "read-only-stream": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
+                  "from": "read-only-stream@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
                   "dependencies": {
                     "readable-wrap": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+                      "from": "readable-wrap@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.1.14",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "from": "readable-stream@>=1.1.13 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     }
                   }
                 },
                 "resolve": {
                   "version": "1.1.7",
-                  "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                  "from": "resolve@>=1.1.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
                 },
                 "shallow-copy": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+                  "from": "shallow-copy@0.0.1",
                   "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
                 },
                 "shasum": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+                  "from": "shasum@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
                   "dependencies": {
                     "json-stable-stringify": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                      "from": "json-stable-stringify@>=0.0.0 <0.1.0",
                       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
-                          "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                          "from": "jsonify@>=0.0.0 <0.1.0",
                           "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                         }
                       }
                     },
                     "sha.js": {
                       "version": "2.4.5",
-                      "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
+                      "from": "sha.js@>=2.4.4 <2.5.0",
                       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz"
                     }
                   }
                 },
                 "shell-quote": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+                  "from": "shell-quote@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
                 },
                 "stream-browserify": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+                  "from": "stream-browserify@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "subarg": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+                  "from": "subarg@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "from": "minimist@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     }
                   }
                 },
                 "syntax-error": {
                   "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
+                  "from": "syntax-error@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "2.7.0",
-                      "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+                      "from": "acorn@>=2.7.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
                     }
                   }
                 },
                 "through2": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+                  "from": "through2@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
                   "dependencies": {
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "from": "xtend@>=4.0.0 <4.1.0-0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "timers-browserify": {
                   "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+                  "from": "timers-browserify@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
                   "dependencies": {
                     "process": {
-                      "version": "0.11.2",
-                      "from": "https://registry.npmjs.org/process/-/process-0.11.2.tgz",
-                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+                      "version": "0.11.3",
+                      "from": "process@>=0.11.0 <0.12.0",
+                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.3.tgz"
                     }
                   }
                 },
                 "tty-browserify": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+                  "from": "tty-browserify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
                 },
                 "url": {
                   "version": "0.10.3",
-                  "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+                  "from": "url@>=0.10.1 <0.11.0",
                   "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                      "from": "punycode@1.3.2",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                     },
                     "querystring": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+                      "from": "querystring@0.2.0",
                       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
                     }
                   }
                 },
                 "util": {
                   "version": "0.10.3",
-                  "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                  "from": "util@>=0.10.1 <0.11.0",
                   "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
                 },
                 "vm-browserify": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+                  "from": "vm-browserify@>=0.0.1 <0.1.0",
                   "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
                   "dependencies": {
                     "indexof": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                      "from": "indexof@0.0.1",
                       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                  "from": "xtend@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                 }
               }
             },
             "convict": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/convict/-/convict-0.6.1.tgz",
+              "from": "convict@0.6.1",
               "resolved": "https://registry.npmjs.org/convict/-/convict-0.6.1.tgz",
               "dependencies": {
                 "cjson": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+                  "from": "cjson@0.3.0",
                   "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
                   "dependencies": {
                     "jsonlint": {
                       "version": "1.6.0",
-                      "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+                      "from": "jsonlint@1.6.0",
                       "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
                       "dependencies": {
                         "nomnom": {
                           "version": "1.8.1",
-                          "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+                          "from": "nomnom@>=1.5.0",
                           "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                           "dependencies": {
                             "underscore": {
                               "version": "1.6.0",
-                              "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                              "from": "underscore@>=1.6.0 <1.7.0",
                               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                             },
                             "chalk": {
                               "version": "0.4.0",
-                              "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                              "from": "chalk@>=0.4.0 <0.5.0",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                               "dependencies": {
                                 "has-color": {
                                   "version": "0.1.7",
-                                  "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                                  "from": "has-color@>=0.1.0 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                                 },
                                 "ansi-styles": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                                  "from": "ansi-styles@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                                 },
                                 "strip-ansi": {
                                   "version": "0.1.1",
-                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                                  "from": "strip-ansi@>=0.1.0 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                                 }
                               }
@@ -2478,7 +1586,7 @@
                         },
                         "JSV": {
                           "version": "4.0.2",
-                          "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+                          "from": "JSV@>=4.0.0",
                           "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                         }
                       }
@@ -2487,34 +1595,34 @@
                 },
                 "depd": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
+                  "from": "depd@1.0.0",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
                 },
                 "moment": {
                   "version": "2.8.4",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
+                  "from": "moment@2.8.4",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
                 },
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "from": "optimist@0.6.1",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     },
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "from": "minimist@>=0.0.1 <0.1.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
                 },
                 "validator": {
                   "version": "3.26.0",
-                  "from": "https://registry.npmjs.org/validator/-/validator-3.26.0.tgz",
+                  "from": "validator@3.26.0",
                   "resolved": "https://registry.npmjs.org/validator/-/validator-3.26.0.tgz"
                 }
               }
@@ -2526,46 +1634,46 @@
               "dependencies": {
                 "is-url": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz",
+                  "from": "is-url@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz"
                 }
               }
             },
             "glob": {
               "version": "5.0.5",
-              "from": "https://registry.npmjs.org/glob/-/glob-5.0.5.tgz",
+              "from": "glob@5.0.5",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.5.tgz",
               "dependencies": {
                 "inflight": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "version": "1.0.5",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "version": "1.1.4",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "version": "0.4.1",
+                          "from": "balanced-match@>=0.4.1 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -2574,77 +1682,77 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "hapi": {
               "version": "8.4.0",
-              "from": "https://registry.npmjs.org/hapi/-/hapi-8.4.0.tgz",
+              "from": "hapi@8.4.0",
               "resolved": "https://registry.npmjs.org/hapi/-/hapi-8.4.0.tgz",
               "dependencies": {
                 "accept": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz",
+                  "from": "accept@1.0.0",
                   "resolved": "https://registry.npmjs.org/accept/-/accept-1.0.0.tgz"
                 },
                 "ammo": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz",
+                  "from": "ammo@1.0.0",
                   "resolved": "https://registry.npmjs.org/ammo/-/ammo-1.0.0.tgz"
                 },
                 "call": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/call/-/call-2.0.1.tgz",
+                  "from": "call@2.0.1",
                   "resolved": "https://registry.npmjs.org/call/-/call-2.0.1.tgz"
                 },
                 "catbox": {
                   "version": "4.2.2",
-                  "from": "https://registry.npmjs.org/catbox/-/catbox-4.2.2.tgz",
+                  "from": "catbox@4.2.2",
                   "resolved": "https://registry.npmjs.org/catbox/-/catbox-4.2.2.tgz"
                 },
                 "catbox-memory": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz",
+                  "from": "catbox-memory@1.1.1",
                   "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+                  "from": "cryptiles@2.0.4",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "h2o2": {
                   "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.0.tgz",
+                  "from": "h2o2@4.0.0",
                   "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.0.tgz",
                   "dependencies": {
                     "joi": {
                       "version": "5.1.0",
-                      "from": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                      "from": "joi@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
                       "dependencies": {
                         "isemail": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+                          "from": "isemail@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.12.0",
-                          "from": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
+                          "version": "2.13.0",
+                          "from": "moment@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
                         }
                       }
                     }
@@ -2652,23 +1760,23 @@
                 },
                 "heavy": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
+                  "from": "heavy@3.0.0",
                   "resolved": "https://registry.npmjs.org/heavy/-/heavy-3.0.0.tgz",
                   "dependencies": {
                     "joi": {
                       "version": "5.1.0",
-                      "from": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                      "from": "joi@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
                       "dependencies": {
                         "isemail": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+                          "from": "isemail@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.12.0",
-                          "from": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
+                          "version": "2.13.0",
+                          "from": "moment@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
                         }
                       }
                     }
@@ -2676,99 +1784,99 @@
                 },
                 "hoek": {
                   "version": "2.11.1",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz",
+                  "from": "hoek@2.11.1",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
                 },
                 "inert": {
                   "version": "2.1.4",
-                  "from": "https://registry.npmjs.org/inert/-/inert-2.1.4.tgz",
+                  "from": "inert@2.1.4",
                   "resolved": "https://registry.npmjs.org/inert/-/inert-2.1.4.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                      "from": "lru-cache@2.5.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     }
                   }
                 },
                 "iron": {
                   "version": "2.1.2",
-                  "from": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz",
+                  "from": "iron@2.1.2",
                   "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.2.tgz"
                 },
                 "items": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/items/-/items-1.1.0.tgz",
+                  "from": "items@1.1.0",
                   "resolved": "https://registry.npmjs.org/items/-/items-1.1.0.tgz"
                 },
                 "joi": {
                   "version": "6.0.8",
-                  "from": "https://registry.npmjs.org/joi/-/joi-6.0.8.tgz",
+                  "from": "joi@6.0.8",
                   "resolved": "https://registry.npmjs.org/joi/-/joi-6.0.8.tgz",
                   "dependencies": {
                     "isemail": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
+                      "from": "isemail@1.1.1",
                       "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
                     },
                     "moment": {
                       "version": "2.9.0",
-                      "from": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz",
+                      "from": "moment@2.9.0",
                       "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
                     }
                   }
                 },
                 "kilt": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
+                  "from": "kilt@1.1.1",
                   "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
                 },
                 "mimos": {
                   "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
+                  "from": "mimos@2.0.2",
                   "resolved": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.7.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
+                      "from": "mime-db@1.7.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
                     }
                   }
                 },
                 "peekaboo": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz",
+                  "from": "peekaboo@1.0.0",
                   "resolved": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz"
                 },
                 "qs": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-2.4.0.tgz",
+                  "from": "qs@2.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.0.tgz"
                 },
                 "shot": {
                   "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/shot/-/shot-1.4.2.tgz",
+                  "from": "shot@1.4.2",
                   "resolved": "https://registry.npmjs.org/shot/-/shot-1.4.2.tgz"
                 },
                 "statehood": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/statehood/-/statehood-2.0.0.tgz",
+                  "from": "statehood@2.0.0",
                   "resolved": "https://registry.npmjs.org/statehood/-/statehood-2.0.0.tgz",
                   "dependencies": {
                     "joi": {
                       "version": "5.1.0",
-                      "from": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                      "from": "joi@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
                       "dependencies": {
                         "isemail": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+                          "from": "isemail@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.12.0",
-                          "from": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
+                          "version": "2.13.0",
+                          "from": "moment@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
                         }
                       }
                     }
@@ -2776,32 +1884,32 @@
                 },
                 "subtext": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
+                  "from": "subtext@1.0.2",
                   "resolved": "https://registry.npmjs.org/subtext/-/subtext-1.0.2.tgz",
                   "dependencies": {
                     "content": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/content/-/content-1.0.1.tgz",
+                      "from": "content@1.0.1",
                       "resolved": "https://registry.npmjs.org/content/-/content-1.0.1.tgz"
                     },
                     "pez": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
+                      "from": "pez@1.0.0",
                       "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
                       "dependencies": {
                         "b64": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz",
+                          "from": "b64@2.0.0",
                           "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.0.tgz"
                         },
                         "nigel": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
+                          "from": "nigel@1.0.1",
                           "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
                           "dependencies": {
                             "vise": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
+                              "from": "vise@1.0.0",
                               "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz"
                             }
                           }
@@ -2812,28 +1920,28 @@
                 },
                 "topo": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz",
+                  "from": "topo@1.0.2",
                   "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
                 },
                 "vision": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/vision/-/vision-2.0.0.tgz",
+                  "from": "vision@2.0.0",
                   "resolved": "https://registry.npmjs.org/vision/-/vision-2.0.0.tgz",
                   "dependencies": {
                     "joi": {
                       "version": "5.1.0",
-                      "from": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+                      "from": "joi@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
                       "dependencies": {
                         "isemail": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+                          "from": "isemail@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.12.0",
-                          "from": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
+                          "version": "2.13.0",
+                          "from": "moment@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
                         }
                       }
                     }
@@ -2841,24 +1949,24 @@
                 },
                 "wreck": {
                   "version": "5.2.0",
-                  "from": "https://registry.npmjs.org/wreck/-/wreck-5.2.0.tgz",
+                  "from": "wreck@5.2.0",
                   "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.2.0.tgz"
                 }
               }
             },
             "hapi-fxa-oauth": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/hapi-fxa-oauth/-/hapi-fxa-oauth-2.0.1.tgz",
+              "from": "hapi-fxa-oauth@2.0.1",
               "resolved": "https://registry.npmjs.org/hapi-fxa-oauth/-/hapi-fxa-oauth-2.0.1.tgz",
               "dependencies": {
                 "poolee": {
                   "version": "0.4.15",
-                  "from": "https://registry.npmjs.org/poolee/-/poolee-0.4.15.tgz",
+                  "from": "poolee@0.4.15",
                   "resolved": "https://registry.npmjs.org/poolee/-/poolee-0.4.15.tgz",
                   "dependencies": {
                     "keep-alive-agent": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
+                      "from": "keep-alive-agent@0.0.1",
                       "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
                     }
                   }
@@ -2867,149 +1975,149 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "mozlog": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.0.tgz",
+              "from": "mozlog@2.0.0",
               "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.0.tgz",
               "dependencies": {
                 "intel": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/intel/-/intel-1.1.0.tgz",
+                  "from": "intel@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/intel/-/intel-1.1.0.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "from": "chalk@>=1.1.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                          "from": "ansi-styles@>=2.2.1 <3.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "dbug": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
+                      "from": "dbug@>=0.4.2 <0.5.0",
                       "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
                     },
                     "stack-trace": {
                       "version": "0.0.9",
-                      "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+                      "from": "stack-trace@>=0.0.9 <0.1.0",
                       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                     },
                     "strftime": {
                       "version": "0.9.2",
-                      "from": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz",
+                      "from": "strftime@>=0.9.2 <0.10.0",
                       "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz"
                     },
                     "symbol": {
-                      "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
+                      "version": "0.2.3",
+                      "from": "symbol@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz"
                     },
                     "utcstring": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
+                      "from": "utcstring@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
                     }
                   }
                 },
                 "merge": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+                  "from": "merge@>=1.2.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
                 }
               }
             },
             "uglify-js": {
               "version": "2.4.24",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+              "from": "uglify-js@2.4.24",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "from": "async@>=0.2.6 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.34",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "from": "source-map@0.1.34",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.5.4",
-                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "from": "yargs@>=3.5.4 <3.6.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "from": "window-size@0.1.0",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "from": "wordwrap@0.0.2",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
@@ -3018,58 +2126,58 @@
             },
             "xhr": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/xhr/-/xhr-2.0.1.tgz",
+              "from": "xhr@2.0.1",
               "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.0.1.tgz",
               "dependencies": {
                 "global": {
                   "version": "4.3.0",
-                  "from": "https://registry.npmjs.org/global/-/global-4.3.0.tgz",
+                  "from": "global@>=4.3.0 <4.4.0",
                   "resolved": "https://registry.npmjs.org/global/-/global-4.3.0.tgz",
                   "dependencies": {
                     "min-document": {
                       "version": "2.18.0",
-                      "from": "https://registry.npmjs.org/min-document/-/min-document-2.18.0.tgz",
+                      "from": "min-document@>=2.6.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.18.0.tgz",
                       "dependencies": {
                         "dom-walk": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+                          "from": "dom-walk@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz"
                         }
                       }
                     },
                     "process": {
                       "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+                      "from": "process@>=0.5.1 <0.6.0",
                       "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
                     }
                   }
                 },
                 "once": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/once/-/once-1.1.1.tgz",
+                  "from": "once@>=1.1.1 <1.2.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
                 },
                 "parse-headers": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+                  "from": "parse-headers@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
                   "dependencies": {
                     "for-each": {
                       "version": "0.3.2",
-                      "from": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+                      "from": "for-each@>=0.3.2 <0.4.0",
                       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
                       "dependencies": {
                         "is-function": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+                          "from": "is-function@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz"
                         }
                       }
                     },
                     "trim": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+                      "from": "trim@0.0.1",
                       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz"
                     }
                   }
@@ -3080,849 +2188,74 @@
         },
         "parseurl": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
+          "from": "parseurl@1.3.0",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
         }
       }
     },
     "extend": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+      "from": "extend@3.0.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "grunt": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/grunt/-/grunt-1.0.1.tgz",
+      "from": "grunt@1.0.1",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.1.tgz",
       "dependencies": {
         "coffee-script": {
           "version": "1.10.0",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
+          "from": "coffee-script@>=1.10.0 <1.11.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz"
         },
         "dateformat": {
           "version": "1.0.12",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+          "from": "dateformat@>=1.0.12 <1.1.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.7.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+              "from": "meow@>=3.3.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                  "from": "camelcase-keys@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "2.1.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                      "from": "camelcase@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "from": "decamelize@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
+                  "version": "1.4.1",
+                  "from": "loud-rejection@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.4.1.tgz",
                   "dependencies": {
-                    "array-find-index": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
-                    },
-                    "signal-exit": {
-                      "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
-                    }
-                  }
-                },
-                "map-obj": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                },
-                "normalize-package-data": {
-                  "version": "2.3.5",
-                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                  "dependencies": {
-                    "hosted-git-info": {
-                      "version": "2.1.4",
-                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-                    },
-                    "is-builtin-module": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                    "currently-unhandled": {
+                      "version": "0.4.1",
+                      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
                       "dependencies": {
-                        "builtin-modules": {
-                          "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                        "array-find-index": {
+                          "version": "1.0.1",
+                          "from": "array-find-index@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                         }
                       }
-                    },
-                    "semver": {
-                      "version": "5.1.0",
-                      "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    },
-                    "validate-npm-package-license": {
-                      "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                      "dependencies": {
-                        "spdx-correct": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-license-ids": {
-                              "version": "1.2.1",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
-                            }
-                          }
-                        },
-                        "spdx-expression-parse": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.2.1",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                      "dependencies": {
-                        "path-exists": {
-                          "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.3",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-                            },
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.0",
-                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                }
-                              }
-                            },
-                            "strip-bom": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "dependencies": {
-                                "is-utf8": {
-                                  "version": "0.2.1",
-                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.3",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "redent": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                  "dependencies": {
-                    "indent-string": {
-                      "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-indent": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-                    }
-                  }
-                },
-                "trim-newlines": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "eventemitter2": {
-          "version": "0.4.14",
-          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
-        },
-        "exit": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-        },
-        "findup-sync": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "5.0.15",
-              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "7.0.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "once": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "grunt-cli": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
-          "dependencies": {
-            "resolve": {
-              "version": "1.1.7",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-            }
-          }
-        },
-        "grunt-known-options": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz"
-        },
-        "grunt-legacy-log": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
-          "dependencies": {
-            "colors": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-            },
-            "grunt-legacy-log-utils": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "4.3.0",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz"
-                }
-              }
-            },
-            "hooker": {
-              "version": "0.2.3",
-              "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
-            "underscore.string": {
-              "version": "3.2.3",
-              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz"
-            }
-          }
-        },
-        "grunt-legacy-util": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-            },
-            "getobject": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
-            },
-            "hooker": {
-              "version": "0.2.3",
-              "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-            },
-            "lodash": {
-              "version": "4.3.0",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz"
-            },
-            "underscore.string": {
-              "version": "3.2.3",
-              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz"
-            },
-            "which": {
-              "version": "1.2.4",
-              "from": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
-              "dependencies": {
-                "is-absolute": {
-                  "version": "0.1.7",
-                  "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-                  "dependencies": {
-                    "is-relative": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-                    }
-                  }
-                },
-                "isexe": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.13",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-        },
-        "js-yaml": {
-          "version": "3.5.5",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.7",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                }
-              }
-            },
-            "esprima": {
-              "version": "2.7.2",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-            }
-          }
-        },
-        "minimatch": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.7",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-        }
-      }
-    },
-    "grunt-autoprefixer": {
-      "version": "3.0.4",
-      "from": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.4.tgz",
-      "dependencies": {
-        "autoprefixer-core": {
-          "version": "5.2.1",
-          "from": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
-          "dependencies": {
-            "browserslist": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
-            },
-            "num2fraction": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-            },
-            "caniuse-db": {
-              "version": "1.0.30000454",
-              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000454.tgz",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000454.tgz"
-            }
-          }
-        },
-        "chalk": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                },
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
-            }
-          }
-        },
-        "diff": {
-          "version": "1.3.2",
-          "from": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz"
-        },
-        "postcss": {
-          "version": "4.1.16",
-          "from": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-          "dependencies": {
-            "es6-promise": {
-              "version": "2.3.0",
-              "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-cdn": {
-      "version": "0.6.5",
-      "from": "https://registry.npmjs.org/grunt-cdn/-/grunt-cdn-0.6.5.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-cdn/-/grunt-cdn-0.6.5.tgz"
-    },
-    "grunt-concurrent": {
-      "version": "2.3.0",
-      "from": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-2.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-2.3.0.tgz",
-      "dependencies": {
-        "arrify": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-        },
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.5.2 <1.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "dependencies": {
-            "repeating": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "pad-stream": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/pad-stream/-/pad-stream-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/pad-stream/-/pad-stream-1.2.0.tgz",
-          "dependencies": {
-            "meow": {
-              "version": "3.7.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "2.1.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                },
-                "loud-rejection": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
-                  "dependencies": {
-                    "array-find-index": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                     },
                     "signal-exit": {
                       "version": "2.1.2",
@@ -3933,27 +2266,27 @@
                 },
                 "map-obj": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                  "from": "map-obj@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "from": "minimist@>=1.1.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
-                      "version": "2.1.4",
-                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                      "version": "2.1.5",
+                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
@@ -3965,12 +2298,12 @@
                     },
                     "semver": {
                       "version": "5.1.0",
-                      "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
@@ -3980,7 +2313,7 @@
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.1",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
@@ -3997,7 +2330,7 @@
                             },
                             "spdx-license-ids": {
                               "version": "1.2.1",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
@@ -4007,33 +2340,33 @@
                   }
                 },
                 "object-assign": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                  "version": "4.1.0",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                      "from": "find-up@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                          "from": "path-exists@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                              "from": "pinkie@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
@@ -4042,7 +2375,7 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "from": "read-pkg@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "dependencies": {
                         "load-json-file": {
@@ -4051,9 +2384,9 @@
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
-                              "version": "4.1.3",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                              "version": "4.1.4",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
@@ -4081,12 +2414,12 @@
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
@@ -4111,9 +2444,9 @@
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
-                              "version": "4.1.3",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                              "version": "4.1.4",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
@@ -4122,12 +2455,12 @@
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
@@ -4140,17 +2473,794 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                  "from": "redent@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                  "dependencies": {
+                    "indent-string": {
+                      "version": "2.1.0",
+                      "from": "indent-string@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "2.0.1",
+                          "from": "repeating@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-indent": {
+                      "version": "1.0.1",
+                      "from": "strip-indent@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                    }
+                  }
+                },
+                "trim-newlines": {
+                  "version": "1.0.0",
+                  "from": "trim-newlines@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "eventemitter2": {
+          "version": "0.4.14",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "findup-sync": {
+          "version": "0.3.0",
+          "from": "findup-sync@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@>=5.0.0 <5.1.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.5",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "7.0.3",
+          "from": "glob@>=7.0.0 <7.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.5",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "once": {
+              "version": "1.3.3",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "grunt-cli": {
+          "version": "1.2.0",
+          "from": "grunt-cli@>=1.2.0 <1.3.0",
+          "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+          "dependencies": {
+            "resolve": {
+              "version": "1.1.7",
+              "from": "resolve@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+            }
+          }
+        },
+        "grunt-known-options": {
+          "version": "1.1.0",
+          "from": "grunt-known-options@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz"
+        },
+        "grunt-legacy-log": {
+          "version": "1.0.0",
+          "from": "grunt-legacy-log@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
+          "dependencies": {
+            "colors": {
+              "version": "1.1.2",
+              "from": "colors@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+            },
+            "grunt-legacy-log-utils": {
+              "version": "1.0.0",
+              "from": "grunt-legacy-log-utils@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "chalk@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "4.3.0",
+                  "from": "lodash@>=4.3.0 <4.4.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz"
+                }
+              }
+            },
+            "hooker": {
+              "version": "0.2.3",
+              "from": "hooker@>=0.2.3 <0.3.0",
+              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@>=3.10.1 <3.11.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "underscore.string": {
+              "version": "3.2.3",
+              "from": "underscore.string@>=3.2.3 <3.3.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz"
+            }
+          }
+        },
+        "grunt-legacy-util": {
+          "version": "1.0.0",
+          "from": "grunt-legacy-util@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "from": "async@>=1.5.2 <1.6.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+            },
+            "getobject": {
+              "version": "0.1.0",
+              "from": "getobject@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+            },
+            "hooker": {
+              "version": "0.2.3",
+              "from": "hooker@>=0.2.3 <0.3.0",
+              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+            },
+            "lodash": {
+              "version": "4.3.0",
+              "from": "lodash@>=4.3.0 <4.4.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz"
+            },
+            "underscore.string": {
+              "version": "3.2.3",
+              "from": "underscore.string@>=3.2.3 <3.3.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz"
+            },
+            "which": {
+              "version": "1.2.10",
+              "from": "which@>=1.2.1 <1.3.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
+              "dependencies": {
+                "isexe": {
+                  "version": "1.1.2",
+                  "from": "isexe@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "from": "iconv-lite@>=0.4.13 <0.5.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+        },
+        "js-yaml": {
+          "version": "3.5.5",
+          "from": "js-yaml@>=3.5.2 <3.6.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.7",
+              "from": "argparse@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.2",
+              "from": "esprima@>=2.6.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.0",
+          "from": "minimatch@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.4",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.4.1",
+                  "from": "balanced-match@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "from": "nopt@>=3.0.6 <3.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "from": "path-is-absolute@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.8 <2.3.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        }
+      }
+    },
+    "grunt-autoprefixer": {
+      "version": "3.0.4",
+      "from": "grunt-autoprefixer@3.0.4",
+      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.4.tgz",
+      "dependencies": {
+        "autoprefixer-core": {
+          "version": "5.2.1",
+          "from": "autoprefixer-core@>=5.1.7 <6.0.0",
+          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
+          "dependencies": {
+            "browserslist": {
+              "version": "0.4.0",
+              "from": "browserslist@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
+            },
+            "num2fraction": {
+              "version": "1.2.2",
+              "from": "num2fraction@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
+            },
+            "caniuse-db": {
+              "version": "1.0.30000476",
+              "from": "caniuse-db@>=1.0.30000214 <2.0.0",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000476.tgz"
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.3.2",
+          "from": "diff@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz"
+        },
+        "postcss": {
+          "version": "4.1.16",
+          "from": "postcss@>=4.1.11 <5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+          "dependencies": {
+            "es6-promise": {
+              "version": "2.3.0",
+              "from": "es6-promise@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.2 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "js-base64@>=2.1.8 <2.2.0",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-cdn": {
+      "version": "0.6.5",
+      "from": "grunt-cdn@0.6.5",
+      "resolved": "https://registry.npmjs.org/grunt-cdn/-/grunt-cdn-0.6.5.tgz"
+    },
+    "grunt-concurrent": {
+      "version": "2.3.0",
+      "from": "grunt-concurrent@2.3.0",
+      "resolved": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-2.3.0.tgz",
+      "dependencies": {
+        "arrify": {
+          "version": "1.0.1",
+          "from": "arrify@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+        },
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.2.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "from": "indent-string@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "dependencies": {
+            "repeating": {
+              "version": "2.0.1",
+              "from": "repeating@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pad-stream": {
+          "version": "1.2.0",
+          "from": "pad-stream@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pad-stream/-/pad-stream-1.2.0.tgz",
+          "dependencies": {
+            "meow": {
+              "version": "3.7.0",
+              "from": "meow@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "2.1.0",
+                  "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "2.1.1",
+                      "from": "camelcase@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "from": "decamelize@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                },
+                "loud-rejection": {
+                  "version": "1.4.1",
+                  "from": "loud-rejection@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.4.1.tgz",
+                  "dependencies": {
+                    "currently-unhandled": {
+                      "version": "0.4.1",
+                      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                      "dependencies": {
+                        "array-find-index": {
+                          "version": "1.0.1",
+                          "from": "array-find-index@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "signal-exit": {
+                      "version": "2.1.2",
+                      "from": "signal-exit@>=2.1.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                    }
+                  }
+                },
+                "map-obj": {
+                  "version": "1.0.1",
+                  "from": "map-obj@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "normalize-package-data": {
+                  "version": "2.3.5",
+                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "dependencies": {
+                    "hosted-git-info": {
+                      "version": "2.1.5",
+                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
+                    },
+                    "is-builtin-module": {
+                      "version": "1.0.0",
+                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "dependencies": {
+                        "builtin-modules": {
+                          "version": "1.1.1",
+                          "from": "builtin-modules@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "5.1.0",
+                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                    },
+                    "validate-npm-package-license": {
+                      "version": "3.0.1",
+                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "dependencies": {
+                        "spdx-correct": {
+                          "version": "1.0.2",
+                          "from": "spdx-correct@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "dependencies": {
+                            "spdx-license-ids": {
+                              "version": "1.2.1",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
+                            }
+                          }
+                        },
+                        "spdx-expression-parse": {
+                          "version": "1.0.2",
+                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                          "dependencies": {
+                            "spdx-exceptions": {
+                              "version": "1.0.4",
+                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                            },
+                            "spdx-license-ids": {
+                              "version": "1.2.1",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "4.1.0",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+                },
+                "read-pkg-up": {
+                  "version": "1.0.1",
+                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.1.2",
+                      "from": "find-up@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                      "dependencies": {
+                        "path-exists": {
+                          "version": "2.1.0",
+                          "from": "path-exists@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "read-pkg": {
+                      "version": "1.1.0",
+                      "from": "read-pkg@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "dependencies": {
+                        "load-json-file": {
+                          "version": "1.1.0",
+                          "from": "load-json-file@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.4",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+                            },
+                            "parse-json": {
+                              "version": "2.2.0",
+                              "from": "parse-json@>=2.2.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "dependencies": {
+                                "error-ex": {
+                                  "version": "1.3.0",
+                                  "from": "error-ex@>=1.2.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                  "dependencies": {
+                                    "is-arrayish": {
+                                      "version": "0.2.1",
+                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                }
+                              }
+                            },
+                            "strip-bom": {
+                              "version": "2.0.0",
+                              "from": "strip-bom@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "dependencies": {
+                                "is-utf8": {
+                                  "version": "0.2.1",
+                                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-type": {
+                          "version": "1.1.0",
+                          "from": "path-type@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.4",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "redent": {
+                  "version": "1.0.0",
+                  "from": "redent@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                      "from": "strip-indent@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                       "dependencies": {
                         "get-stdin": {
                           "version": "4.0.1",
-                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
                           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                         }
                       }
@@ -4159,165 +3269,73 @@
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                  "from": "trim-newlines@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
             },
             "pumpify": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.4.tgz",
+              "from": "pumpify@>=1.3.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.4.tgz",
               "dependencies": {
                 "duplexify": {
                   "version": "3.4.3",
-                  "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
+                  "from": "duplexify@>=3.1.2 <4.0.0",
                   "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "from": "end-of-stream@1.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "from": "once@>=1.3.0 <1.4.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.2",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         }
                       }
                     },
                     "readable-stream": {
-                      "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
+                      "version": "2.1.4",
+                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
                       "dependencies": {
+                        "buffer-shims": {
+                          "version": "1.0.0",
+                          "from": "buffer-shims@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                        },
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "inline-process-browser": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
-                          "dependencies": {
-                            "falafel": {
-                              "version": "1.2.0",
-                              "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-                              "dependencies": {
-                                "acorn": {
-                                  "version": "1.2.2",
-                                  "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-                                },
-                                "foreach": {
-                                  "version": "2.0.5",
-                                  "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-                                  "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                },
-                                "object-keys": {
-                                  "version": "1.0.9",
-                                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
-                                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
-                                }
-                              }
-                            },
-                            "through2": {
-                              "version": "0.6.5",
-                              "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                              "dependencies": {
-                                "readable-stream": {
-                                  "version": "1.0.34",
-                                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                                  "dependencies": {
-                                    "isarray": {
-                                      "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                    }
-                                  }
-                                },
-                                "xtend": {
-                                  "version": "4.0.1",
-                                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "from": "isarray@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "version": "1.0.7",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "unreachable-branch-transform": {
-                          "version": "0.5.1",
-                          "from": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
-                          "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
-                          "dependencies": {
-                            "esmangle-evaluator": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
-                            },
-                            "recast": {
-                              "version": "0.11.5",
-                              "from": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
-                              "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
-                              "dependencies": {
-                                "ast-types": {
-                                  "version": "0.8.16",
-                                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
-                                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
-                                },
-                                "esprima": {
-                                  "version": "2.7.2",
-                                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-                                },
-                                "private": {
-                                  "version": "0.1.6",
-                                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-                                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-                                },
-                                "source-map": {
-                                  "version": "0.5.3",
-                                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                                }
-                              }
-                            }
-                          }
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -4326,28 +3344,28 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "pump": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
+                  "from": "pump@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                      "from": "end-of-stream@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "from": "once@>=1.3.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     }
@@ -4357,17 +3375,17 @@
             },
             "repeating": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+              "from": "repeating@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -4376,54 +3394,54 @@
             },
             "split2": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/split2/-/split2-1.1.1.tgz",
+              "from": "split2@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/split2/-/split2-1.1.1.tgz"
             },
             "through2": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+              "from": "through2@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "from": "isarray@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "from": "xtend@>=4.0.0 <4.1.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -4434,17 +3452,17 @@
     },
     "grunt-connect-fonts": {
       "version": "0.0.5",
-      "from": "https://registry.npmjs.org/grunt-connect-fonts/-/grunt-connect-fonts-0.0.5.tgz",
+      "from": "grunt-connect-fonts@0.0.5",
       "resolved": "https://registry.npmjs.org/grunt-connect-fonts/-/grunt-connect-fonts-0.0.5.tgz",
       "dependencies": {
         "connect-fonts": {
           "version": "2.0.2",
-          "from": "https://registry.npmjs.org/connect-fonts/-/connect-fonts-2.0.2.tgz",
+          "from": "connect-fonts@2.0.2",
           "resolved": "https://registry.npmjs.org/connect-fonts/-/connect-fonts-2.0.2.tgz",
           "dependencies": {
             "filed": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/filed/-/filed-0.1.0.tgz",
+              "from": "filed@0.1.0",
               "resolved": "https://registry.npmjs.org/filed/-/filed-0.1.0.tgz"
             },
             "node-font-face-generator": {
@@ -4464,7 +3482,7 @@
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.2.4",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+                      "from": "lru-cache@2.2.4",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
                     }
                   }
@@ -4478,22 +3496,22 @@
             },
             "oppressor": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/oppressor/-/oppressor-0.0.1.tgz",
+              "from": "oppressor@0.0.1",
               "resolved": "https://registry.npmjs.org/oppressor/-/oppressor-0.0.1.tgz",
               "dependencies": {
                 "through": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/through/-/through-0.1.4.tgz",
+                  "from": "through@0.1.4",
                   "resolved": "https://registry.npmjs.org/through/-/through-0.1.4.tgz"
                 },
                 "response-stream": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/response-stream/-/response-stream-0.0.0.tgz",
+                  "from": "response-stream@0.0.0",
                   "resolved": "https://registry.npmjs.org/response-stream/-/response-stream-0.0.0.tgz"
                 },
                 "negotiator": {
                   "version": "0.2.6",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.6.tgz",
+                  "from": "negotiator@0.2.6",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.6.tgz"
                 }
               }
@@ -4509,59 +3527,59 @@
     },
     "grunt-contrib-clean": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.0.0.tgz",
+      "from": "grunt-contrib-clean@1.0.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.0.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.2 <1.6.0",
+          "from": "async@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "rimraf": {
           "version": "2.5.2",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+          "from": "rimraf@>=2.5.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
           "dependencies": {
             "glob": {
               "version": "7.0.3",
-              "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+              "from": "glob@>=7.0.0 <8.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
               "dependencies": {
                 "inflight": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "version": "1.0.5",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "version": "1.1.4",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "version": "0.4.1",
+                          "from": "balanced-match@>=0.4.1 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -4570,19 +3588,19 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
@@ -4593,70 +3611,70 @@
     },
     "grunt-contrib-concat": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.0.tgz",
+      "from": "grunt-contrib-concat@1.0.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "source-map": {
-          "version": "0.5.3",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.3 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "grunt-contrib-copy": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+      "from": "grunt-contrib-copy@1.0.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -4702,87 +3720,87 @@
         },
         "file-sync-cmp": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+          "from": "file-sync-cmp@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz"
         }
       }
     },
     "grunt-contrib-cssmin": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-1.0.1.tgz",
+      "from": "grunt-contrib-cssmin@1.0.1",
       "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-1.0.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "clean-css": {
-          "version": "3.4.12",
-          "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
+          "version": "3.4.17",
+          "from": "clean-css@>=3.4.2 <3.5.0",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.17.tgz",
           "dependencies": {
             "commander": {
               "version": "2.8.1",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+              "from": "commander@>=2.8.0 <2.9.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "from": "graceful-readlink@>=1.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "from": "source-map@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "from": "amdefine@>=0.0.4",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
@@ -4791,62 +3809,74 @@
         },
         "maxmin": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
+          "from": "maxmin@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
           "dependencies": {
             "figures": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz"
+              "version": "1.7.0",
+              "from": "figures@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "dependencies": {
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.0",
+                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+                }
+              }
             },
             "gzip-size": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+              "from": "gzip-size@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.1",
-                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                  "from": "concat-stream@>=1.4.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.6",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "from": "isarray@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "version": "1.0.7",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -4855,12 +3885,12 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
                       "version": "0.2.8",
-                      "from": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
+                      "from": "pako@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
                     }
                   }
@@ -4869,120 +3899,127 @@
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+              "from": "pretty-bytes@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.7.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+                  "from": "meow@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                      "from": "camelcase-keys@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "2.1.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                          "from": "camelcase@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "from": "decamelize@>=1.1.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "loud-rejection": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
+                      "version": "1.4.1",
+                      "from": "loud-rejection@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.4.1.tgz",
                       "dependencies": {
-                        "array-find-index": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                        "currently-unhandled": {
+                          "version": "0.4.1",
+                          "from": "currently-unhandled@>=0.4.1 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                          "dependencies": {
+                            "array-find-index": {
+                              "version": "1.0.1",
+                              "from": "array-find-index@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                            }
+                          }
                         },
                         "signal-exit": {
                           "version": "2.1.2",
-                          "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
+                          "from": "signal-exit@>=2.1.2 <3.0.0",
                           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                         }
                       }
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "from": "map-obj@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "from": "minimist@>=1.1.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
                       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                       "dependencies": {
                         "hosted-git-info": {
-                          "version": "2.1.4",
-                          "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                          "version": "2.1.5",
+                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
-                              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                              "from": "builtin-modules@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                             }
                           }
                         },
                         "semver": {
                           "version": "5.1.0",
-                          "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                           "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "from": "spdx-correct@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                                  "from": "spdx-exceptions@>=1.0.4 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                 }
                               }
@@ -4992,33 +4029,33 @@
                       }
                     },
                     "object-assign": {
-                      "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                      "version": "4.1.0",
+                      "from": "object-assign@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                     },
                     "read-pkg-up": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "dependencies": {
                         "find-up": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                          "from": "find-up@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                           "dependencies": {
                             "path-exists": {
                               "version": "2.1.0",
-                              "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                              "from": "path-exists@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
@@ -5027,32 +4064,32 @@
                         },
                         "read-pkg": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "from": "read-pkg@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "dependencies": {
                             "load-json-file": {
                               "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                              "from": "load-json-file@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.3",
-                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                                  "version": "4.1.4",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
-                                  "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                  "from": "parse-json@>=2.2.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "dependencies": {
                                     "error-ex": {
                                       "version": "1.3.0",
-                                      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                      "from": "error-ex@>=1.2.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                       "dependencies": {
                                         "is-arrayish": {
                                           "version": "0.2.1",
-                                          "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                          "from": "is-arrayish@>=0.2.1 <0.3.0",
                                           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                         }
                                       }
@@ -5061,29 +4098,29 @@
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                                  "from": "pify@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
-                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                     }
                                   }
                                 },
                                 "strip-bom": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "from": "strip-bom@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "dependencies": {
                                     "is-utf8": {
                                       "version": "0.2.1",
-                                      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                                      "from": "is-utf8@>=0.2.0 <0.3.0",
                                       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                     }
                                   }
@@ -5092,27 +4129,27 @@
                             },
                             "path-type": {
                               "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                              "from": "path-type@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.3",
-                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                                  "version": "4.1.4",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                                  "from": "pify@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
-                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                     }
                                   }
@@ -5125,27 +4162,27 @@
                     },
                     "redent": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                      "from": "redent@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "dependencies": {
                         "indent-string": {
                           "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                          "from": "indent-string@>=2.1.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "dependencies": {
                             "repeating": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                              "from": "repeating@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                     }
                                   }
@@ -5156,14 +4193,14 @@
                         },
                         "strip-indent": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                          "from": "strip-indent@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                         }
                       }
                     },
                     "trim-newlines": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                      "from": "trim-newlines@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                     }
                   }
@@ -5176,12 +4213,12 @@
     },
     "grunt-contrib-htmlmin": {
       "version": "1.3.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-htmlmin/-/grunt-contrib-htmlmin-1.3.0.tgz",
+      "from": "grunt-contrib-htmlmin@1.3.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-htmlmin/-/grunt-contrib-htmlmin-1.3.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -5227,121 +4264,121 @@
         },
         "html-minifier": {
           "version": "1.5.0",
-          "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.5.0.tgz",
+          "from": "html-minifier@>=1.5.0 <1.6.0",
           "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.5.0.tgz",
           "dependencies": {
             "change-case": {
               "version": "2.3.1",
-              "from": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
+              "from": "change-case@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
               "dependencies": {
                 "camel-case": {
                   "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
+                  "from": "camel-case@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
                 },
                 "constant-case": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
+                  "from": "constant-case@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
                 },
                 "dot-case": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz",
+                  "from": "dot-case@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
                 },
                 "is-lower-case": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+                  "from": "is-lower-case@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
                 },
                 "is-upper-case": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+                  "from": "is-upper-case@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
                 },
                 "lower-case": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz",
+                  "from": "lower-case@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
                 },
                 "lower-case-first": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+                  "from": "lower-case-first@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
                 },
                 "param-case": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
+                  "from": "param-case@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
                 },
                 "pascal-case": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz",
+                  "from": "pascal-case@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
                 },
                 "path-case": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
+                  "from": "path-case@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
                 },
                 "sentence-case": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
+                  "from": "sentence-case@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
                 },
                 "snake-case": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
+                  "from": "snake-case@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
                 },
                 "swap-case": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+                  "from": "swap-case@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
                 },
                 "title-case": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz",
+                  "from": "title-case@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
                 },
                 "upper-case": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+                  "from": "upper-case@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
                 },
                 "upper-case-first": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+                  "from": "upper-case-first@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
                 }
               }
             },
             "clean-css": {
-              "version": "3.4.12",
-              "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
-              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
+              "version": "3.4.17",
+              "from": "clean-css@>=3.4.2 <3.5.0",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.17.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.8.1",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "from": "commander@>=2.8.0 <2.9.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "from": "graceful-readlink@>=1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "from": "source-map@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -5350,59 +4387,59 @@
             },
             "commander": {
               "version": "2.9.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "from": "commander@>=2.9.0 <2.10.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "from": "graceful-readlink@>=1.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "concat-stream": {
               "version": "1.5.1",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+              "from": "concat-stream@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.6",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "from": "isarray@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -5411,132 +4448,132 @@
             },
             "he": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/he/-/he-1.0.0.tgz",
+              "from": "he@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/he/-/he-1.0.0.tgz"
             },
             "ncname": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+              "from": "ncname@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
               "dependencies": {
                 "xml-char-classes": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
+                  "from": "xml-char-classes@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
                 }
               }
             },
             "relateurl": {
               "version": "0.2.6",
-              "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz",
+              "from": "relateurl@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
             },
             "uglify-js": {
               "version": "2.6.2",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
+              "from": "uglify-js@>=2.6.0 <2.7.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "from": "async@>=0.2.6 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                  "version": "0.5.6",
+                  "from": "source-map@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.10.0",
-                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "from": "yargs@>=3.10.0 <3.11.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "from": "cliui@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "from": "center-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "from": "align-text@>=0.1.3 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
-                                  "version": "3.0.2",
-                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                  "version": "3.0.3",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.3",
-                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "from": "longest@>=1.0.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
                             },
                             "lazy-cache": {
-                              "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                              "version": "1.0.4",
+                              "from": "lazy-cache@>=1.0.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "from": "right-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
-                                  "version": "3.0.2",
-                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                  "version": "3.0.3",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.3",
-                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "from": "longest@>=1.0.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
@@ -5545,19 +4582,19 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "from": "wordwrap@0.0.2",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "from": "window-size@0.1.0",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                     }
                   }
@@ -5568,12 +4605,12 @@
         },
         "pretty-bytes": {
           "version": "3.0.1",
-          "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+          "from": "pretty-bytes@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
           "dependencies": {
             "number-is-nan": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+              "from": "number-is-nan@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
             }
           }
@@ -5582,113 +4619,125 @@
     },
     "grunt-contrib-uglify": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-1.0.1.tgz",
+      "from": "grunt-contrib-uglify@1.0.1",
       "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-1.0.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "maxmin": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
+          "from": "maxmin@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
           "dependencies": {
             "figures": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz"
+              "version": "1.7.0",
+              "from": "figures@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "dependencies": {
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.0",
+                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+                }
+              }
             },
             "gzip-size": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+              "from": "gzip-size@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.1",
-                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                  "from": "concat-stream@>=1.4.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.6",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "from": "isarray@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "version": "1.0.7",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -5697,12 +4746,12 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
                       "version": "0.2.8",
-                      "from": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
+                      "from": "pako@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
                     }
                   }
@@ -5711,45 +4760,52 @@
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+              "from": "pretty-bytes@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.7.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+                  "from": "meow@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                      "from": "camelcase-keys@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "2.1.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                          "from": "camelcase@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "from": "decamelize@>=1.1.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "loud-rejection": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
+                      "version": "1.4.1",
+                      "from": "loud-rejection@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.4.1.tgz",
                       "dependencies": {
-                        "array-find-index": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                        "currently-unhandled": {
+                          "version": "0.4.1",
+                          "from": "currently-unhandled@>=0.4.1 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                          "dependencies": {
+                            "array-find-index": {
+                              "version": "1.0.1",
+                              "from": "array-find-index@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                            }
+                          }
                         },
                         "signal-exit": {
                           "version": "2.1.2",
@@ -5760,71 +4816,71 @@
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "from": "map-obj@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "from": "minimist@>=1.1.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
                       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                       "dependencies": {
                         "hosted-git-info": {
-                          "version": "2.1.4",
-                          "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                          "version": "2.1.5",
+                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
-                              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                              "from": "builtin-modules@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                             }
                           }
                         },
                         "semver": {
                           "version": "5.1.0",
-                          "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                           "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "from": "spdx-correct@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                                  "from": "spdx-exceptions@>=1.0.4 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.2.1",
-                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                 }
                               }
@@ -5834,33 +4890,33 @@
                       }
                     },
                     "object-assign": {
-                      "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                      "version": "4.1.0",
+                      "from": "object-assign@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                     },
                     "read-pkg-up": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "dependencies": {
                         "find-up": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                          "from": "find-up@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                           "dependencies": {
                             "path-exists": {
                               "version": "2.1.0",
-                              "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                              "from": "path-exists@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
@@ -5869,32 +4925,32 @@
                         },
                         "read-pkg": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "from": "read-pkg@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "dependencies": {
                             "load-json-file": {
                               "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                              "from": "load-json-file@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.3",
-                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                                  "version": "4.1.4",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
-                                  "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                  "from": "parse-json@>=2.2.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "dependencies": {
                                     "error-ex": {
                                       "version": "1.3.0",
-                                      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                      "from": "error-ex@>=1.2.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                       "dependencies": {
                                         "is-arrayish": {
                                           "version": "0.2.1",
-                                          "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                          "from": "is-arrayish@>=0.2.1 <0.3.0",
                                           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                         }
                                       }
@@ -5903,29 +4959,29 @@
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                                  "from": "pify@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
-                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                     }
                                   }
                                 },
                                 "strip-bom": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "from": "strip-bom@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "dependencies": {
                                     "is-utf8": {
                                       "version": "0.2.1",
-                                      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                                      "from": "is-utf8@>=0.2.0 <0.3.0",
                                       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                     }
                                   }
@@ -5934,27 +4990,27 @@
                             },
                             "path-type": {
                               "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                              "from": "path-type@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.3",
-                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                                  "version": "4.1.4",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                                  "from": "pify@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
-                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                     }
                                   }
@@ -5967,27 +5023,27 @@
                     },
                     "redent": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                      "from": "redent@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "dependencies": {
                         "indent-string": {
                           "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                          "from": "indent-string@>=2.1.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "dependencies": {
                             "repeating": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                              "from": "repeating@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                     }
                                   }
@@ -5998,14 +5054,14 @@
                         },
                         "strip-indent": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                          "from": "strip-indent@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                         }
                       }
                     },
                     "trim-newlines": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                      "from": "trim-newlines@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                     }
                   }
@@ -6016,110 +5072,110 @@
         },
         "uglify-js": {
           "version": "2.6.2",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
+          "from": "uglify-js@>=2.6.2 <2.7.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "version": "0.5.6",
+              "from": "source-map@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.10.0",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "from": "yargs@>=3.10.0 <3.11.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "from": "cliui@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "from": "center-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "3.0.2",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                              "version": "3.0.3",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.3",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "from": "longest@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.4",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
                         },
                         "lazy-cache": {
-                          "version": "1.0.3",
-                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                          "version": "1.0.4",
+                          "from": "lazy-cache@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "from": "right-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "3.0.2",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                              "version": "3.0.3",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.3",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "from": "longest@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.4",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
@@ -6128,19 +5184,19 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "from": "wordwrap@0.0.2",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "from": "window-size@0.1.0",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 }
               }
@@ -6149,19 +5205,19 @@
         },
         "uri-path": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz",
+          "from": "uri-path@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz"
         }
       }
     },
     "grunt-githash": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/grunt-githash/-/grunt-githash-0.1.3.tgz",
+      "from": "grunt-githash@0.1.3",
       "resolved": "https://registry.npmjs.org/grunt-githash/-/grunt-githash-0.1.3.tgz",
       "dependencies": {
         "git-rev-2": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/git-rev-2/-/git-rev-2-0.1.0.tgz",
+          "from": "git-rev-2@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/git-rev-2/-/git-rev-2-0.1.0.tgz"
         }
       }
@@ -6173,37 +5229,37 @@
       "dependencies": {
         "po2json": {
           "version": "0.4.2",
-          "from": "https://registry.npmjs.org/po2json/-/po2json-0.4.2.tgz",
+          "from": "po2json@*",
           "resolved": "https://registry.npmjs.org/po2json/-/po2json-0.4.2.tgz",
           "dependencies": {
             "nomnom": {
               "version": "1.8.1",
-              "from": "nomnom@>=1.5.0",
+              "from": "nomnom@1.8.1",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                  "from": "underscore@>=1.6.0 <1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 },
                 "chalk": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                  "from": "chalk@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                   "dependencies": {
                     "has-color": {
                       "version": "0.1.7",
-                      "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                      "from": "has-color@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                     },
                     "ansi-styles": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                      "from": "ansi-styles@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                     },
                     "strip-ansi": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                      "from": "strip-ansi@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                     }
                   }
@@ -6212,17 +5268,17 @@
             },
             "gettext-parser": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.0.tgz",
+              "from": "gettext-parser@1.1.0",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.12",
-                  "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                  "from": "encoding@>=0.1.11 <0.2.0",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.13",
-                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                      "from": "iconv-lite@>=0.4.13 <0.5.0",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     }
                   }
@@ -6235,34 +5291,34 @@
     },
     "grunt-remarkable": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/grunt-remarkable/-/grunt-remarkable-1.0.2.tgz",
+      "from": "grunt-remarkable@1.0.2",
       "resolved": "https://registry.npmjs.org/grunt-remarkable/-/grunt-remarkable-1.0.2.tgz",
       "dependencies": {
         "remarkable": {
           "version": "1.6.2",
-          "from": "https://registry.npmjs.org/remarkable/-/remarkable-1.6.2.tgz",
+          "from": "remarkable@>=1.6.0 <1.7.0",
           "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.6.2.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@>=0.1.15 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "autolinker": {
               "version": "0.15.3",
-              "from": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
+              "from": "autolinker@>=0.15.0 <0.16.0",
               "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz"
             }
           }
@@ -6276,57 +5332,57 @@
       "dependencies": {
         "requirejs": {
           "version": "2.1.22",
-          "from": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.22.tgz",
+          "from": "requirejs@>=2.1.0 <2.2.0",
           "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.22.tgz"
         },
         "cheerio": {
           "version": "0.13.1",
-          "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
+          "from": "cheerio@>=0.13.0 <0.14.0",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.13.1.tgz",
           "dependencies": {
             "htmlparser2": {
               "version": "3.4.0",
-              "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
+              "from": "htmlparser2@>=3.4.0 <3.5.0",
               "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.4.0.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
+                  "from": "domhandler@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
                 },
                 "domutils": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz",
+                  "from": "domutils@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz"
                 },
                 "domelementtype": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.14",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -6335,32 +5391,32 @@
             },
             "underscore": {
               "version": "1.5.2",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
+              "from": "underscore@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz",
+              "from": "entities@>=0.0.0 <1.0.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
             },
             "CSSselect": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+              "from": "CSSselect@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
               "dependencies": {
                 "CSSwhat": {
                   "version": "0.4.7",
-                  "from": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+                  "from": "CSSwhat@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
                 },
                 "domutils": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                  "from": "domutils@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                     }
                   }
@@ -6371,277 +5427,209 @@
         },
         "almond": {
           "version": "0.2.9",
-          "from": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz",
+          "from": "almond@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/almond/-/almond-0.2.9.tgz"
         },
         "gzip-js": {
           "version": "0.3.2",
-          "from": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
+          "from": "gzip-js@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
           "dependencies": {
             "crc32": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
+              "from": "crc32@>=0.2.2",
               "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
             },
             "deflate-js": {
               "version": "0.2.3",
-              "from": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz",
+              "from": "deflate-js@>=0.2.2",
               "resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz"
             }
           }
         },
         "q": {
           "version": "0.8.12",
-          "from": "https://registry.npmjs.org/q/-/q-0.8.12.tgz",
+          "from": "q@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/q/-/q-0.8.12.tgz"
         }
       }
     },
     "grunt-rev": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/grunt-rev/-/grunt-rev-0.1.0.tgz",
+      "from": "grunt-rev@0.1.0",
       "resolved": "https://registry.npmjs.org/grunt-rev/-/grunt-rev-0.1.0.tgz"
     },
     "grunt-sass": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-1.1.0.tgz",
+      "from": "grunt-sass@1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-1.1.0.tgz",
       "dependencies": {
         "each-async": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+          "from": "each-async@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+              "from": "onetime@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
             },
             "set-immediate-shim": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
             }
           }
         },
         "node-sass": {
-          "version": "3.4.2",
-          "from": "https://registry.npmjs.org/node-sass/-/node-sass-3.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.4.2.tgz",
+          "version": "3.7.0",
+          "from": "node-sass@>=3.4.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.7.0.tgz",
           "dependencies": {
             "async-foreach": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+              "from": "async-foreach@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
             },
             "chalk": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
-            "cross-spawn": {
-              "version": "2.2.3",
-              "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.2.3.tgz",
+            "cross-spawn-async": {
+              "version": "2.2.4",
+              "from": "cross-spawn-async@>=2.1.9 <3.0.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
               "dependencies": {
-                "cross-spawn-async": {
-                  "version": "2.2.2",
-                  "from": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.2.tgz",
+                "lru-cache": {
+                  "version": "4.0.1",
+                  "from": "lru-cache@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
                   "dependencies": {
-                    "lru-cache": {
-                      "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-                      "dependencies": {
-                        "pseudomap": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
-                        },
-                        "yallist": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
-                        }
-                      }
+                    "pseudomap": {
+                      "version": "1.0.2",
+                      "from": "pseudomap@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
                     },
-                    "which": {
-                      "version": "1.2.4",
-                      "from": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
-                      "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
-                      "dependencies": {
-                        "is-absolute": {
-                          "version": "0.1.7",
-                          "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-                          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-                          "dependencies": {
-                            "is-relative": {
-                              "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-                            }
-                          }
-                        },
-                        "isexe": {
-                          "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-                        }
-                      }
+                    "yallist": {
+                      "version": "2.0.0",
+                      "from": "yallist@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
                     }
                   }
                 },
-                "spawn-sync": {
-                  "version": "1.0.15",
-                  "from": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-                  "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+                "which": {
+                  "version": "1.2.10",
+                  "from": "which@>=1.2.8 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
                   "dependencies": {
-                    "concat-stream": {
-                      "version": "1.5.1",
-                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "typedarray": {
-                          "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                        },
-                        "readable-stream": {
-                          "version": "2.0.6",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                            },
-                            "isarray": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.6",
-                              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "os-shim": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
+                    "isexe": {
+                      "version": "1.1.2",
+                      "from": "isexe@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                     }
                   }
                 }
               }
             },
             "gaze": {
-              "version": "0.5.2",
-              "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+              "version": "1.0.0",
+              "from": "gaze@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.0.0.tgz",
               "dependencies": {
                 "globule": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                  "version": "0.2.0",
+                  "from": "globule@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
                   "dependencies": {
                     "lodash": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                      "version": "2.4.2",
+                      "from": "lodash@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                     },
                     "glob": {
-                      "version": "3.1.21",
-                      "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "version": "3.2.11",
+                      "from": "glob@>=3.2.7 <3.3.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                       "dependencies": {
-                        "graceful-fs": {
-                          "version": "1.2.3",
-                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                        },
                         "inherits": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "from": "minimatch@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.3",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
                         }
                       }
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.7.3",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
@@ -6652,49 +5640,49 @@
             },
             "get-stdin": {
               "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "glob": {
-              "version": "5.0.15",
-              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "version": "7.0.3",
+              "from": "glob@>=7.0.3 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
               "dependencies": {
                 "inflight": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "version": "1.0.5",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "version": "1.1.4",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "version": "0.4.1",
+                          "from": "balanced-match@>=0.4.1 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -6703,129 +5691,136 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "meow": {
               "version": "3.7.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+              "from": "meow@>=3.7.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                  "from": "camelcase-keys@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "2.1.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                      "from": "camelcase@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "from": "decamelize@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "loud-rejection": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
+                  "version": "1.4.1",
+                  "from": "loud-rejection@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.4.1.tgz",
                   "dependencies": {
-                    "array-find-index": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                    "currently-unhandled": {
+                      "version": "0.4.1",
+                      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                      "dependencies": {
+                        "array-find-index": {
+                          "version": "1.0.1",
+                          "from": "array-find-index@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                        }
+                      }
                     },
                     "signal-exit": {
                       "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
+                      "from": "signal-exit@>=2.1.2 <3.0.0",
                       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                     }
                   }
                 },
                 "map-obj": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                  "from": "map-obj@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "from": "minimist@>=1.1.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
-                      "version": "2.1.4",
-                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                      "version": "2.1.5",
+                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                          "from": "builtin-modules@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.1.0",
-                      "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "from": "spdx-correct@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.1",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                             },
                             "spdx-license-ids": {
                               "version": "1.2.1",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
@@ -6836,27 +5831,27 @@
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                      "from": "find-up@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                          "from": "path-exists@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                              "from": "pinkie@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
@@ -6865,32 +5860,32 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "from": "read-pkg@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                          "from": "load-json-file@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
-                              "version": "4.1.3",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                              "version": "4.1.4",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
-                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "from": "parse-json@>=2.2.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.0",
-                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                  "from": "error-ex@>=1.2.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
-                                      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
                                       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                     }
                                   }
@@ -6899,29 +5894,29 @@
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "from": "pify@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "from": "strip-bom@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.1",
-                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                                  "from": "is-utf8@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                 }
                               }
@@ -6930,27 +5925,27 @@
                         },
                         "path-type": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                          "from": "path-type@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
-                              "version": "4.1.3",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                              "version": "4.1.4",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "from": "pify@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
@@ -6963,27 +5958,27 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                  "from": "redent@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                      "from": "indent-string@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                          "from": "repeating@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -6994,160 +5989,85 @@
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                      "from": "strip-indent@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                  "from": "trim-newlines@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
             },
-            "nan": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz"
+            "in-publish": {
+              "version": "2.0.0",
+              "from": "in-publish@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz"
             },
-            "npmconf": {
-              "version": "2.1.2",
-              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
-              "dependencies": {
-                "config-chain": {
-                  "version": "1.1.10",
-                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
-                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
-                  "dependencies": {
-                    "proto-list": {
-                      "version": "1.2.4",
-                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                },
-                "nopt": {
-                  "version": "3.0.6",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    },
-                    "os-tmpdir": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "4.3.6",
-                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-                },
-                "uid-number": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
-                }
-              }
+            "nan": {
+              "version": "2.3.5",
+              "from": "nan@>=2.3.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
             },
             "node-gyp": {
               "version": "3.3.1",
-              "from": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.3.1.tgz",
+              "from": "node-gyp@>=3.3.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.3.1.tgz",
               "dependencies": {
                 "fstream": {
-                  "version": "1.0.8",
-                  "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+                  "version": "1.0.9",
+                  "from": "fstream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.9.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "from": "glob@>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "version": "1.0.5",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "version": "1.1.4",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "version": "0.4.1",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "from": "concat-map@0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -7156,202 +6076,110 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     }
                   }
                 },
                 "graceful-fs": {
-                  "version": "4.1.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                  "version": "4.1.4",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
                 },
                 "minimatch": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "from": "minimatch@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "nopt": {
                   "version": "3.0.6",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                  "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "npmlog": {
-                  "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz",
+                  "version": "2.0.4",
+                  "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
                   "dependencies": {
                     "ansi": {
                       "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+                      "from": "ansi@>=0.3.1 <0.4.0",
                       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
                     },
                     "are-we-there-yet": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
                       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
                       "dependencies": {
                         "delegates": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                          "from": "delegates@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                         },
                         "readable-stream": {
-                          "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
+                          "version": "2.1.4",
+                          "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
                           "dependencies": {
+                            "buffer-shims": {
+                              "version": "1.0.0",
+                              "from": "buffer-shims@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                            },
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "inherits@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "inline-process-browser": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
-                              "dependencies": {
-                                "falafel": {
-                                  "version": "1.2.0",
-                                  "from": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-                                  "dependencies": {
-                                    "acorn": {
-                                      "version": "1.2.2",
-                                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-                                    },
-                                    "foreach": {
-                                      "version": "2.0.5",
-                                      "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-                                      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                                    },
-                                    "isarray": {
-                                      "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                    },
-                                    "object-keys": {
-                                      "version": "1.0.9",
-                                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
-                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
-                                    }
-                                  }
-                                },
-                                "through2": {
-                                  "version": "0.6.5",
-                                  "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                                  "dependencies": {
-                                    "readable-stream": {
-                                      "version": "1.0.34",
-                                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                                      "dependencies": {
-                                        "isarray": {
-                                          "version": "0.0.1",
-                                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                        }
-                                      }
-                                    },
-                                    "xtend": {
-                                      "version": "4.0.1",
-                                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
                             },
                             "isarray": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                              "from": "isarray@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             },
                             "process-nextick-args": {
-                              "version": "1.0.6",
-                              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                              "version": "1.0.7",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "unreachable-branch-transform": {
-                              "version": "0.5.1",
-                              "from": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
-                              "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
-                              "dependencies": {
-                                "esmangle-evaluator": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
-                                },
-                                "recast": {
-                                  "version": "0.11.5",
-                                  "from": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
-                                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
-                                  "dependencies": {
-                                    "ast-types": {
-                                      "version": "0.8.16",
-                                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz",
-                                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
-                                    },
-                                    "esprima": {
-                                      "version": "2.7.2",
-                                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-                                    },
-                                    "private": {
-                                      "version": "0.1.6",
-                                      "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-                                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-                                    },
-                                    "source-map": {
-                                      "version": "0.5.3",
-                                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-                                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                                    }
-                                  }
-                                }
-                              }
                             },
                             "util-deprecate": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
                               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                             }
                           }
@@ -7360,62 +6188,77 @@
                     },
                     "gauge": {
                       "version": "1.2.7",
-                      "from": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+                      "from": "gauge@>=1.2.5 <1.3.0",
                       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
                       "dependencies": {
                         "has-unicode": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
+                          "from": "has-unicode@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
                         },
                         "lodash.pad": {
-                          "version": "4.3.0",
-                          "from": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.3.0.tgz",
+                          "version": "4.4.0",
+                          "from": "lodash.pad@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz",
                           "dependencies": {
                             "lodash._baseslice": {
                               "version": "4.0.0",
-                              "from": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
+                              "from": "lodash._baseslice@>=4.0.0 <4.1.0",
                               "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz"
                             },
+                            "lodash._basetostring": {
+                              "version": "4.12.0",
+                              "from": "lodash._basetostring@>=4.12.0 <4.13.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz"
+                            },
                             "lodash.tostring": {
-                              "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
+                              "version": "4.1.3",
+                              "from": "lodash.tostring@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.3.tgz"
                             }
                           }
                         },
                         "lodash.padend": {
-                          "version": "4.4.0",
-                          "from": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.4.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.4.0.tgz",
+                          "version": "4.5.0",
+                          "from": "lodash.padend@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz",
                           "dependencies": {
                             "lodash._baseslice": {
                               "version": "4.0.0",
-                              "from": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
+                              "from": "lodash._baseslice@>=4.0.0 <4.1.0",
                               "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz"
                             },
+                            "lodash._basetostring": {
+                              "version": "4.12.0",
+                              "from": "lodash._basetostring@>=4.12.0 <4.13.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz"
+                            },
                             "lodash.tostring": {
-                              "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
+                              "version": "4.1.3",
+                              "from": "lodash.tostring@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.3.tgz"
                             }
                           }
                         },
                         "lodash.padstart": {
-                          "version": "4.4.0",
-                          "from": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.4.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.4.0.tgz",
+                          "version": "4.5.0",
+                          "from": "lodash.padstart@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz",
                           "dependencies": {
                             "lodash._baseslice": {
                               "version": "4.0.0",
-                              "from": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
+                              "from": "lodash._baseslice@>=4.0.0 <4.1.0",
                               "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz"
                             },
+                            "lodash._basetostring": {
+                              "version": "4.12.0",
+                              "from": "lodash._basetostring@>=4.12.0 <4.13.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz"
+                            },
                             "lodash.tostring": {
-                              "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
+                              "version": "4.1.3",
+                              "from": "lodash.tostring@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.3.tgz"
                             }
                           }
                         }
@@ -7425,62 +6268,67 @@
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "from": "osenv@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "path-array": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
+                  "from": "path-array@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
                   "dependencies": {
                     "array-index": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
+                      "from": "array-index@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
                       "dependencies": {
                         "debug": {
                           "version": "2.2.0",
-                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "from": "debug@>=2.2.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "from": "ms@0.7.1",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
                         },
                         "es6-symbol": {
-                          "version": "3.0.2",
-                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
+                          "version": "3.1.0",
+                          "from": "es6-symbol@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
                           "dependencies": {
                             "d": {
                               "version": "0.1.1",
-                              "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                              "from": "d@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                             },
                             "es5-ext": {
                               "version": "0.10.11",
-                              "from": "es5-ext@>=0.10.8 <0.11.0",
+                              "from": "es5-ext@>=0.10.11 <0.11.0",
                               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
                               "dependencies": {
                                 "es6-iterator": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                                  "from": "es6-iterator@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                                },
+                                "es6-symbol": {
+                                  "version": "3.0.2",
+                                  "from": "es6-symbol@>=3.0.2 <3.1.0",
+                                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                                 }
                               }
                             }
@@ -7492,49 +6340,49 @@
                 },
                 "rimraf": {
                   "version": "2.5.2",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "from": "rimraf@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "7.0.3",
-                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "from": "glob@>=7.0.0 <8.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                       "dependencies": {
                         "inflight": {
-                          "version": "1.0.4",
-                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "version": "1.0.5",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.2",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "minimatch": {
                           "version": "3.0.0",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.3",
-                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "version": "1.1.4",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                               "dependencies": {
                                 "balanced-match": {
-                                  "version": "0.3.0",
-                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                  "version": "0.4.1",
+                                  "from": "balanced-match@>=0.4.1 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "from": "concat-map@0.0.1",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
@@ -7543,19 +6391,19 @@
                         },
                         "once": {
                           "version": "1.3.3",
-                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "from": "once@>=1.3.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.2",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                         }
                       }
@@ -7564,46 +6412,34 @@
                 },
                 "semver": {
                   "version": "5.1.0",
-                  "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                 },
                 "tar": {
                   "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                  "from": "tar@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
                   "dependencies": {
                     "block-stream": {
-                      "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                      "version": "0.0.9",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "which": {
-                  "version": "1.2.4",
-                  "from": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
-                  "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+                  "version": "1.2.10",
+                  "from": "which@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
                   "dependencies": {
-                    "is-absolute": {
-                      "version": "0.1.7",
-                      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-                      "dependencies": {
-                        "is-relative": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-                        }
-                      }
-                    },
                     "isexe": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+                      "from": "isexe@>=1.1.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                     }
                   }
@@ -7612,49 +6448,49 @@
             },
             "sass-graph": {
               "version": "2.1.1",
-              "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.1.tgz",
+              "from": "sass-graph@>=2.1.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.1.tgz",
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
-                  "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "from": "glob@>=6.0.4 <7.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                   "dependencies": {
                     "inflight": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "version": "1.0.5",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "version": "1.1.4",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "version": "0.4.1",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "from": "concat-map@0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -7663,75 +6499,75 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
                 },
                 "yargs": {
                   "version": "3.32.0",
-                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+                  "from": "yargs@>=3.8.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "2.1.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                      "from": "camelcase@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                     },
                     "cliui": {
                       "version": "3.2.0",
-                      "from": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                      "from": "cliui@>=3.0.3 <4.0.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
                       "dependencies": {
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "from": "strip-ansi@>=3.0.1 <4.0.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
                         },
                         "wrap-ansi": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
+                          "from": "wrap-ansi@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "from": "decamelize@>=1.1.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "os-locale": {
                       "version": "1.4.0",
-                      "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                      "from": "os-locale@>=1.4.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                       "dependencies": {
                         "lcid": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                          "from": "lcid@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                           "dependencies": {
                             "invert-kv": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                              "from": "invert-kv@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                             }
                           }
@@ -7740,41 +6576,41 @@
                     },
                     "string-width": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+                      "from": "string-width@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                          "from": "code-point-at@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                             }
                           }
@@ -7783,12 +6619,12 @@
                     },
                     "window-size": {
                       "version": "0.1.4",
-                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+                      "from": "window-size@>=0.1.4 <0.2.0",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
                     },
                     "y18n": {
                       "version": "3.2.1",
-                      "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                      "from": "y18n@>=3.2.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
                     }
                   }
@@ -7798,281 +6634,281 @@
           }
         },
         "object-assign": {
-          "version": "4.0.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "version": "4.1.0",
+          "from": "object-assign@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "grunt-sri": {
       "version": "0.0.5",
-      "from": "https://registry.npmjs.org/grunt-sri/-/grunt-sri-0.0.5.tgz",
+      "from": "grunt-sri@0.0.5",
       "resolved": "https://registry.npmjs.org/grunt-sri/-/grunt-sri-0.0.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "ramda": {
           "version": "0.11.0",
-          "from": "https://registry.npmjs.org/ramda/-/ramda-0.11.0.tgz",
+          "from": "ramda@>=0.11.0 <0.12.0",
           "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.11.0.tgz"
         },
         "sri-toolbox": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/sri-toolbox/-/sri-toolbox-0.1.3.tgz",
+          "from": "sri-toolbox@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/sri-toolbox/-/sri-toolbox-0.1.3.tgz"
         }
       }
     },
     "grunt-text-replace": {
       "version": "0.4.0",
-      "from": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz",
+      "from": "grunt-text-replace@0.4.0",
       "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz"
     },
     "grunt-usemin": {
       "version": "3.1.1",
-      "from": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-3.1.1.tgz",
+      "from": "grunt-usemin@3.1.1",
       "resolved": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-3.1.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "debug": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
+          "from": "lodash@>=3.6.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "path-exists": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "from": "path-exists@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
         }
       }
     },
     "grunt-z-schema": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/grunt-z-schema/-/grunt-z-schema-0.1.0.tgz",
+      "from": "grunt-z-schema@0.1.0",
       "resolved": "https://registry.npmjs.org/grunt-z-schema/-/grunt-z-schema-0.1.0.tgz",
       "dependencies": {
         "z-schema": {
           "version": "2.4.10",
-          "from": "https://registry.npmjs.org/z-schema/-/z-schema-2.4.10.tgz",
+          "from": "z-schema@>=2.4.3 <2.5.0",
           "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-2.4.10.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "from": "async@>=0.2.10 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "handlebars": {
       "version": "4.0.5",
-      "from": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+      "from": "handlebars@4.0.5",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "from": "async@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "from": "source-map@>=0.4.4 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+              "from": "amdefine@>=0.0.4",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.6.2",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
+          "from": "uglify-js@>=2.6.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "version": "0.5.6",
+              "from": "source-map@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.10.0",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "from": "yargs@>=3.10.0 <3.11.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "from": "cliui@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "from": "center-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "from": "align-text@>=0.1.3 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "3.0.2",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                              "version": "3.0.3",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.3",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "from": "longest@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.4",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
                         },
                         "lazy-cache": {
-                          "version": "1.0.3",
-                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                          "version": "1.0.4",
+                          "from": "lazy-cache@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "from": "right-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "3.0.2",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                              "version": "3.0.3",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.3",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "from": "longest@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.4",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                             }
                           }
@@ -8081,19 +6917,19 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "from": "wordwrap@0.0.2",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "from": "window-size@0.1.0",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 }
               }
@@ -8104,17 +6940,17 @@
     },
     "helmet": {
       "version": "0.12.0",
-      "from": "https://registry.npmjs.org/helmet/-/helmet-0.12.0.tgz",
+      "from": "helmet@0.12.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-0.12.0.tgz",
       "dependencies": {
         "connect": {
           "version": "3.4.0",
-          "from": "https://registry.npmjs.org/connect/-/connect-3.4.0.tgz",
+          "from": "connect@3.4.0",
           "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.0.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
@@ -8126,17 +6962,17 @@
             },
             "finalhandler": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
+              "from": "finalhandler@0.4.0",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
+                  "from": "escape-html@1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
@@ -8148,132 +6984,132 @@
                 },
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                  "from": "unpipe@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "parseurl": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+              "from": "parseurl@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+              "from": "utils-merge@1.0.0",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "from": "depd@1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "dont-sniff-mimetype": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-0.1.0.tgz",
+          "from": "dont-sniff-mimetype@0.1.0",
           "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-0.1.0.tgz"
         },
         "frameguard": {
           "version": "0.2.2",
-          "from": "https://registry.npmjs.org/frameguard/-/frameguard-0.2.2.tgz",
+          "from": "frameguard@0.2.2",
           "resolved": "https://registry.npmjs.org/frameguard/-/frameguard-0.2.2.tgz",
           "dependencies": {
             "lodash.isstring": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-3.0.1.tgz",
+              "from": "lodash.isstring@3.0.1",
               "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-3.0.1.tgz"
             }
           }
         },
         "helmet-crossdomain": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/helmet-crossdomain/-/helmet-crossdomain-0.1.0.tgz",
+          "from": "helmet-crossdomain@0.1.0",
           "resolved": "https://registry.npmjs.org/helmet-crossdomain/-/helmet-crossdomain-0.1.0.tgz"
         },
         "helmet-csp": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-0.3.0.tgz",
+          "from": "helmet-csp@0.3.0",
           "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-0.3.0.tgz",
           "dependencies": {
             "camelize": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+              "from": "camelize@1.0.0",
               "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz"
             },
             "content-security-policy-builder": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-0.2.0.tgz",
+              "from": "content-security-policy-builder@0.2.0",
               "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-0.2.0.tgz",
               "dependencies": {
                 "dashify": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/dashify/-/dashify-0.1.0.tgz",
+                  "from": "dashify@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/dashify/-/dashify-0.1.0.tgz"
                 }
               }
             },
             "lodash.isstring": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-3.0.1.tgz",
+              "from": "lodash.isstring@3.0.1",
               "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-3.0.1.tgz"
             },
             "lodash.pick": {
               "version": "3.1.0",
-              "from": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz",
+              "from": "lodash.pick@3.1.0",
               "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz",
               "dependencies": {
                 "lodash._baseflatten": {
                   "version": "3.1.4",
-                  "from": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+                  "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
                   "dependencies": {
                     "lodash.isarguments": {
                       "version": "3.0.8",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                     },
                     "lodash.isarray": {
                       "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
                 },
                 "lodash._bindcallback": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                 },
                 "lodash._pickbyarray": {
                   "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+                  "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
                 },
                 "lodash._pickbycallback": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+                  "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
                   "dependencies": {
                     "lodash._basefor": {
                       "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                      "from": "lodash._basefor@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
                     },
                     "lodash.keysin": {
                       "version": "3.0.8",
-                      "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                      "from": "lodash.keysin@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
                       "dependencies": {
                         "lodash.isarguments": {
                           "version": "3.0.8",
-                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.4",
-                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                         }
                       }
@@ -8282,65 +7118,65 @@
                 },
                 "lodash.restparam": {
                   "version": "3.6.1",
-                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                 }
               }
             },
             "platform": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/platform/-/platform-1.3.0.tgz",
+              "from": "platform@1.3.0",
               "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.0.tgz"
             }
           }
         },
         "hide-powered-by": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-0.1.0.tgz",
+          "from": "hide-powered-by@0.1.0",
           "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-0.1.0.tgz"
         },
         "hpkp": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/hpkp/-/hpkp-0.2.0.tgz",
+          "from": "hpkp@0.2.0",
           "resolved": "https://registry.npmjs.org/hpkp/-/hpkp-0.2.0.tgz"
         },
         "hsts": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/hsts/-/hsts-0.2.0.tgz",
+          "from": "hsts@0.2.0",
           "resolved": "https://registry.npmjs.org/hsts/-/hsts-0.2.0.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+              "from": "core-util-is@1.0.1",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "ienoopen": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/ienoopen/-/ienoopen-0.1.0.tgz",
+          "from": "ienoopen@0.1.0",
           "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-0.1.0.tgz"
         },
         "nocache": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/nocache/-/nocache-0.3.0.tgz",
+          "from": "nocache@0.3.0",
           "resolved": "https://registry.npmjs.org/nocache/-/nocache-0.3.0.tgz"
         },
         "x-xss-protection": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-0.1.2.tgz",
+          "from": "x-xss-protection@0.1.2",
           "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-0.1.2.tgz"
         }
       }
     },
     "i18n-abide": {
       "version": "0.0.25",
-      "from": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.25.tgz",
+      "from": "i18n-abide@0.0.25",
       "resolved": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.25.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+          "from": "async@0.9.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "gobbledygook": {
@@ -8350,27 +7186,27 @@
         },
         "jsxgettext": {
           "version": "0.7.0",
-          "from": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.7.0.tgz",
+          "from": "jsxgettext@0.7.0",
           "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.7.0.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.11.0",
-              "from": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
+              "from": "acorn@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
             },
             "gettext-parser": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.2.tgz",
+              "from": "gettext-parser@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.2.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.12",
-                  "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                  "from": "encoding@>=0.1.11 <0.2.0",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.13",
-                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                      "from": "iconv-lite@>=0.4.13 <0.5.0",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     }
                   }
@@ -8379,44 +7215,44 @@
             },
             "commander": {
               "version": "2.5.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.5.0.tgz",
+              "from": "commander@2.5.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.0.tgz"
             },
             "jade": {
               "version": "1.11.0",
-              "from": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
+              "from": "jade@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
               "dependencies": {
                 "character-parser": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz",
+                  "from": "character-parser@1.2.1",
                   "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
                 },
                 "clean-css": {
-                  "version": "3.4.12",
-                  "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
-                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
+                  "version": "3.4.17",
+                  "from": "clean-css@>=3.1.9 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.17.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.8.1",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                      "from": "commander@>=2.8.0 <2.9.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "from": "graceful-readlink@>=1.0.0",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "source-map": {
                       "version": "0.4.4",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                      "from": "source-map@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                         }
                       }
@@ -8425,39 +7261,39 @@
                 },
                 "commander": {
                   "version": "2.6.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+                  "from": "commander@>=2.6.0 <2.7.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
                 },
                 "constantinople": {
                   "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
+                  "from": "constantinople@>=3.0.1 <3.1.0",
                   "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "2.7.0",
-                      "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+                      "from": "acorn@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
                     }
                   }
                 },
                 "jstransformer": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
+                  "from": "jstransformer@0.0.2",
                   "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
                   "dependencies": {
                     "is-promise": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+                      "from": "is-promise@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
                     },
                     "promise": {
                       "version": "6.1.0",
-                      "from": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+                      "from": "promise@>=6.0.1 <7.0.0",
                       "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
                       "dependencies": {
                         "asap": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+                          "from": "asap@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
                         }
                       }
@@ -8466,63 +7302,63 @@
                 },
                 "transformers": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
+                  "from": "transformers@2.1.0",
                   "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
                   "dependencies": {
                     "promise": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+                      "from": "promise@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                       "dependencies": {
                         "is-promise": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+                          "from": "is-promise@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                         }
                       }
                     },
                     "css": {
                       "version": "1.0.8",
-                      "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+                      "from": "css@>=1.0.8 <1.1.0",
                       "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                       "dependencies": {
                         "css-parse": {
                           "version": "1.0.4",
-                          "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
+                          "from": "css-parse@1.0.4",
                           "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                         },
                         "css-stringify": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+                          "from": "css-stringify@1.0.5",
                           "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                         }
                       }
                     },
                     "uglify-js": {
                       "version": "2.2.5",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                      "from": "uglify-js@>=2.2.5 <2.3.0",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "from": "source-map@>=0.1.7 <0.2.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
                         },
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                          "from": "optimist@>=0.3.5 <0.4.0",
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.3",
-                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                              "from": "wordwrap@>=0.0.2 <0.1.0",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                             }
                           }
@@ -8533,110 +7369,110 @@
                 },
                 "uglify-js": {
                   "version": "2.6.2",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
+                  "from": "uglify-js@>=2.4.19 <3.0.0",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "from": "async@>=0.2.6 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "source-map": {
-                      "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                      "version": "0.5.6",
+                      "from": "source-map@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                     },
                     "yargs": {
                       "version": "3.10.0",
-                      "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                      "from": "yargs@>=3.10.0 <3.11.0",
                       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                          "from": "camelcase@>=1.0.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "cliui": {
                           "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                          "from": "cliui@>=2.1.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                           "dependencies": {
                             "center-align": {
                               "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                              "from": "center-align@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
-                                      "version": "3.0.2",
-                                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                      "version": "3.0.3",
+                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
-                                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                         }
                                       }
                                     },
                                     "longest": {
                                       "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                      "from": "longest@>=1.0.1 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
                                 },
                                 "lazy-cache": {
-                                  "version": "1.0.3",
-                                  "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                  "version": "1.0.4",
+                                  "from": "lazy-cache@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                                 }
                               }
                             },
                             "right-align": {
                               "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                              "from": "right-align@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
-                                      "version": "3.0.2",
-                                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                      "version": "3.0.3",
+                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
                                       "dependencies": {
                                         "is-buffer": {
                                           "version": "1.1.3",
-                                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                         }
                                       }
                                     },
                                     "longest": {
                                       "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                      "from": "longest@>=1.0.1 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.4",
-                                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                     }
                                   }
@@ -8645,19 +7481,19 @@
                             },
                             "wordwrap": {
                               "version": "0.0.2",
-                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                              "from": "wordwrap@0.0.2",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                             }
                           }
                         },
                         "decamelize": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                          "from": "decamelize@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "window-size": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                          "from": "window-size@0.1.0",
                           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                         }
                       }
@@ -8666,27 +7502,27 @@
                 },
                 "void-elements": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+                  "from": "void-elements@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
                 },
                 "with": {
                   "version": "4.0.3",
-                  "from": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
+                  "from": "with@>=4.0.0 <4.1.0",
                   "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "1.2.2",
-                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                      "from": "acorn@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                     },
                     "acorn-globals": {
                       "version": "1.0.9",
-                      "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+                      "from": "acorn-globals@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "2.7.0",
-                          "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+                          "from": "acorn@>=2.1.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
                         }
                       }
@@ -8697,58 +7533,58 @@
             },
             "escape-string-regexp": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz",
+              "from": "escape-string-regexp@1.0.1",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz"
             }
           }
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "plist": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/plist/-/plist-1.1.0.tgz",
+          "from": "plist@1.1.0",
           "resolved": "https://registry.npmjs.org/plist/-/plist-1.1.0.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.6.tgz",
+              "from": "base64-js@0.0.6",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.6.tgz"
             },
             "xmlbuilder": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.2.1.tgz",
+              "from": "xmlbuilder@2.2.1",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.2.1.tgz",
               "dependencies": {
                 "lodash-node": {
                   "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+                  "from": "lodash-node@>=2.4.1 <2.5.0",
                   "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
                 }
               }
             },
             "xmldom": {
               "version": "0.1.22",
-              "from": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz",
+              "from": "xmldom@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz"
             },
             "util-deprecate": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.0.tgz",
+              "from": "util-deprecate@1.0.0",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.0.tgz"
             }
           }
@@ -8757,44 +7593,44 @@
     },
     "jsxgettext-recursive": {
       "version": "0.0.5",
-      "from": "https://registry.npmjs.org/jsxgettext-recursive/-/jsxgettext-recursive-0.0.5.tgz",
+      "from": "jsxgettext-recursive@0.0.5",
       "resolved": "https://registry.npmjs.org/jsxgettext-recursive/-/jsxgettext-recursive-0.0.5.tgz",
       "dependencies": {
         "walk": {
           "version": "2.3.9",
-          "from": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
+          "from": "walk@>=2.3.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
           "dependencies": {
             "foreachasync": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+              "from": "foreachasync@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
             }
           }
         },
         "jsxgettext": {
           "version": "0.4.10",
-          "from": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.4.10.tgz",
+          "from": "jsxgettext@>=0.4.8 <0.5.0",
           "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.4.10.tgz",
           "dependencies": {
             "acorn": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/acorn/-/acorn-0.5.0.tgz",
+              "from": "acorn@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.5.0.tgz"
             },
             "gettext-parser": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
+              "from": "gettext-parser@0.2.0",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.12",
-                  "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                  "from": "encoding@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "dependencies": {
                     "iconv-lite": {
                       "version": "0.4.13",
-                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                      "from": "iconv-lite@>=0.4.13 <0.5.0",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     }
                   }
@@ -8803,102 +7639,102 @@
             },
             "nomnom": {
               "version": "1.5.2",
-              "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+              "from": "nomnom@1.5.2",
               "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.1.7",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+                  "from": "underscore@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
                 },
                 "colors": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+                  "from": "colors@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
                 }
               }
             },
             "jade": {
               "version": "0.30.0",
-              "from": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
+              "from": "jade@0.30.0",
               "resolved": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
               "dependencies": {
                 "commander": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+                  "from": "commander@>=1.1.1 <1.2.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
                   "dependencies": {
                     "keypress": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+                      "from": "keypress@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                  "from": "mkdirp@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 },
                 "transformers": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
+                  "from": "transformers@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
                   "dependencies": {
                     "promise": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+                      "from": "promise@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                       "dependencies": {
                         "is-promise": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+                          "from": "is-promise@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                         }
                       }
                     },
                     "css": {
                       "version": "1.0.8",
-                      "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+                      "from": "css@>=1.0.8 <1.1.0",
                       "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                       "dependencies": {
                         "css-parse": {
                           "version": "1.0.4",
-                          "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
+                          "from": "css-parse@1.0.4",
                           "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                         },
                         "css-stringify": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+                          "from": "css-stringify@1.0.5",
                           "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                         }
                       }
                     },
                     "uglify-js": {
                       "version": "2.2.5",
-                      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                      "from": "uglify-js@>=2.2.5 <2.3.0",
                       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                       "dependencies": {
                         "source-map": {
                           "version": "0.1.43",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                          "from": "source-map@>=0.1.7 <0.2.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
                         },
                         "optimist": {
                           "version": "0.3.7",
-                          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                          "from": "optimist@>=0.3.5 <0.4.0",
                           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                           "dependencies": {
                             "wordwrap": {
                               "version": "0.0.3",
-                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                              "from": "wordwrap@>=0.0.2 <0.1.0",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                             }
                           }
@@ -8909,37 +7745,37 @@
                 },
                 "character-parser": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz",
+                  "from": "character-parser@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
                 },
                 "monocle": {
                   "version": "0.1.50",
-                  "from": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
+                  "from": "monocle@>=0.1.46 <0.2.0",
                   "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
                   "dependencies": {
                     "readdirp": {
                       "version": "0.2.5",
-                      "from": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
+                      "from": "readdirp@>=0.2.3 <0.3.0",
                       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
                       "dependencies": {
                         "minimatch": {
                           "version": "3.0.0",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "from": "minimatch@>=0.2.4",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.3",
-                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "version": "1.1.4",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                               "dependencies": {
                                 "balanced-match": {
-                                  "version": "0.3.0",
-                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                  "version": "0.4.1",
+                                  "from": "balanced-match@>=0.4.1 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "from": "concat-map@0.0.1",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
@@ -8954,59 +7790,59 @@
             },
             "swig": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/swig/-/swig-1.3.2.tgz",
+              "from": "swig@1.3.2",
               "resolved": "https://registry.npmjs.org/swig/-/swig-1.3.2.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "2.4.24",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+                  "from": "uglify-js@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "from": "async@>=0.2.6 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "source-map": {
                       "version": "0.1.34",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                      "from": "source-map@0.1.34",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                         }
                       }
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                     },
                     "yargs": {
                       "version": "3.5.4",
-                      "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                      "from": "yargs@>=3.5.4 <3.6.0",
                       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                          "from": "camelcase@>=1.0.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "decamelize": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                          "from": "decamelize@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "window-size": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                          "from": "window-size@0.1.0",
                           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "from": "wordwrap@0.0.2",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
@@ -9015,17 +7851,17 @@
                 },
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "from": "optimist@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     },
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "from": "minimist@>=0.0.1 <0.1.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
@@ -9034,7 +7870,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz",
+              "from": "escape-string-regexp@1.0.1",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz"
             }
           }
@@ -9043,54 +7879,54 @@
     },
     "load-grunt-tasks": {
       "version": "3.5.0",
-      "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.5.0.tgz",
+      "from": "load-grunt-tasks@3.5.0",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.5.0.tgz",
       "dependencies": {
         "arrify": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "from": "arrify@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
         },
         "multimatch": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+          "from": "multimatch@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "from": "array-differ@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "from": "array-union@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "from": "minimatch@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "version": "1.1.4",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                      "version": "0.4.1",
+                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -9101,27 +7937,27 @@
         },
         "pkg-up": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
+          "from": "pkg-up@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "from": "find-up@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
               "dependencies": {
                 "path-exists": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                  "from": "path-exists@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
@@ -9132,12 +7968,12 @@
         },
         "resolve-pkg": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-0.1.0.tgz",
+          "from": "resolve-pkg@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-0.1.0.tgz",
           "dependencies": {
             "resolve-from": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+              "from": "resolve-from@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
             }
           }
@@ -9146,160 +7982,160 @@
     },
     "lodash": {
       "version": "4.11.1",
-      "from": "https://registry.npmjs.org/lodash/-/lodash-4.11.1.tgz",
+      "from": "lodash@4.11.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.1.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "from": "mkdirp@0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "morgan": {
       "version": "1.7.0",
-      "from": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz",
+      "from": "morgan@1.7.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz",
       "dependencies": {
         "basic-auth": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
+          "version": "1.0.4",
+          "from": "basic-auth@>=1.0.3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "from": "depd@1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "from": "on-finished@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+              "from": "ee-first@1.1.1",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "on-headers": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+          "from": "on-headers@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
         }
       }
     },
     "mozlog": {
-      "version": "2.0.3",
-      "from": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.3.tgz",
+      "version": "2.0.4",
+      "from": "mozlog@2.0.4",
+      "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.4.tgz",
       "dependencies": {
         "intel": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/intel/-/intel-1.1.0.tgz",
+          "from": "intel@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/intel/-/intel-1.1.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "from": "chalk@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "dbug": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz",
+              "from": "dbug@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "from": "stack-trace@>=0.0.9 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             },
             "strftime": {
               "version": "0.9.2",
-              "from": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz",
+              "from": "strftime@>=0.9.2 <0.10.0",
               "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz"
             },
             "symbol": {
-              "version": "0.2.1",
-              "from": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
+              "version": "0.2.3",
+              "from": "symbol@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz"
             },
             "utcstring": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
+              "from": "utcstring@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
             }
           }
         },
         "merge": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+          "from": "merge@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
         }
       }
     },
     "node-statsd": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.1.1.tgz",
+      "from": "node-statsd@0.1.1",
       "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.1.1.tgz"
     },
     "node-uap": {
@@ -9309,61 +8145,61 @@
       "dependencies": {
         "array.prototype.find": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.0.tgz",
+          "from": "array.prototype.find@2.0.0",
           "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.0.tgz",
           "dependencies": {
             "define-properties": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+              "from": "define-properties@>=1.1.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
               "dependencies": {
                 "foreach": {
                   "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+                  "from": "foreach@>=2.0.5 <3.0.0",
                   "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                 },
                 "object-keys": {
                   "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz",
+                  "from": "object-keys@>=1.0.8 <2.0.0",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
                 }
               }
             },
             "es-abstract": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.0.tgz",
+              "version": "1.5.1",
+              "from": "es-abstract@>=1.5.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.1.tgz",
               "dependencies": {
                 "function-bind": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+                  "from": "function-bind@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
                 },
                 "is-callable": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+                  "from": "is-callable@>=1.1.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
                 },
                 "es-to-primitive": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+                  "from": "es-to-primitive@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
                   "dependencies": {
                     "is-date-object": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+                      "from": "is-date-object@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
                     },
                     "is-symbol": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+                      "from": "is-symbol@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
                     }
                   }
                 },
                 "is-regex": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
+                  "from": "is-regex@>=1.0.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
                 }
               }
@@ -9372,98 +8208,79 @@
         },
         "uap-core": {
           "version": "0.5.0",
-          "from": "git://github.com/ua-parser/uap-core.git#c7c5284a1fc25e3345b0c5d8fc323cb01373dd13",
-          "resolved": "git://github.com/ua-parser/uap-core.git#c7c5284a1fc25e3345b0c5d8fc323cb01373dd13"
+          "from": "git://github.com/ua-parser/uap-core.git#49b141ffe86d5138c332f733d6b2007675bbeb43",
+          "resolved": "git://github.com/ua-parser/uap-core.git#49b141ffe86d5138c332f733d6b2007675bbeb43"
         },
         "uap-ref-impl": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/uap-ref-impl/-/uap-ref-impl-0.2.0.tgz",
+          "from": "uap-ref-impl@0.2.0",
           "resolved": "https://registry.npmjs.org/uap-ref-impl/-/uap-ref-impl-0.2.0.tgz"
         },
         "yamlparser": {
           "version": "0.0.2",
-          "from": "https://registry.npmjs.org/yamlparser/-/yamlparser-0.0.2.tgz",
+          "from": "yamlparser@0.0.2",
           "resolved": "https://registry.npmjs.org/yamlparser/-/yamlparser-0.0.2.tgz"
         }
       }
     },
     "openid": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/openid/-/openid-1.0.0.tgz",
+      "from": "openid@1.0.0",
       "resolved": "https://registry.npmjs.org/openid/-/openid-1.0.0.tgz"
     },
     "request": {
       "version": "2.71.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.71.0.tgz",
+      "from": "request@2.71.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.71.0.tgz",
       "dependencies": {
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "from": "aws-sign2@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
-          "version": "1.3.2",
-          "from": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
-          "dependencies": {
-            "lru-cache": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
-                },
-                "yallist": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
-                }
-              }
-            }
-          }
+          "version": "1.4.1",
+          "from": "aws4@>=1.2.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
         },
         "bl": {
           "version": "1.1.2",
-          "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+          "from": "bl@>=1.1.2 <1.2.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "from": "readable-stream@>=2.0.5 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "from": "isarray@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -9472,97 +8289,97 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "from": "caseless@>=0.11.0 <0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "from": "combined-stream@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "from": "delayed-stream@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "from": "forever-agent@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "1.0.0-rc4",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+          "from": "form-data@>=1.0.0-rc3 <1.1.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "from": "async@>=1.5.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             }
           }
         },
         "har-validator": {
           "version": "2.0.6",
-          "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "from": "har-validator@>=2.0.6 <2.1.0",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.9.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "from": "commander@>=2.9.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "from": "graceful-readlink@>=1.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
@@ -9596,19 +8413,19 @@
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+              "from": "pinkie-promise@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                  "from": "pinkie@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 }
               }
@@ -9617,7 +8434,7 @@
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "from": "hawk@>=3.1.3 <3.2.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "hoek": {
@@ -9627,93 +8444,96 @@
             },
             "boom": {
               "version": "2.10.1",
-              "from": "boom@2.10.1",
+              "from": "boom@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "from": "cryptiles@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "from": "sntp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "http-signature": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "from": "http-signature@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+              "from": "assert-plus@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+              "from": "jsprim@>=1.2.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                  "from": "extsprintf@1.0.2",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                  "from": "json-schema@0.2.2",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
-                  "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                  "from": "verror@1.3.6",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 }
               }
             },
             "sshpk": {
-              "version": "1.7.4",
-              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
+              "version": "1.8.3",
+              "from": "sshpk@>=1.7.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                  "from": "asn1@>=0.2.3 <0.3.0",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                },
                 "dashdash": {
-                  "version": "1.13.0",
-                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
-                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    }
-                  }
+                  "version": "1.14.0",
+                  "from": "dashdash@>=1.12.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                },
+                "getpass": {
+                  "version": "0.1.6",
+                  "from": "getpass@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                 },
                 "jsbn": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                  "from": "jsbn@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "tweetnacl": {
-                  "version": "0.14.3",
-                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                  "version": "0.13.3",
+                  "from": "tweetnacl@>=0.13.0 <0.14.0",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                  "from": "jodid25519@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 }
               }
@@ -9722,150 +8542,150 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "from": "is-typedarray@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "from": "isstream@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
-          "version": "2.1.10",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+          "version": "2.1.11",
+          "from": "mime-types@>=2.1.7 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.22.0",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+              "version": "1.23.0",
+              "from": "mime-db@>=1.23.0 <1.24.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+          "from": "node-uuid@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "oauth-sign": {
-          "version": "0.8.1",
-          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+          "version": "0.8.2",
+          "from": "oauth-sign@>=0.8.1 <0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
           "version": "6.1.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
+          "from": "qs@6.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "from": "stringstream@>=0.0.4 <0.1.0",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
           "version": "2.2.2",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+          "from": "tough-cookie@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
         },
         "tunnel-agent": {
-          "version": "0.4.2",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+          "version": "0.4.3",
+          "from": "tunnel-agent@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         }
       }
     },
     "serve-static": {
       "version": "1.10.2",
-      "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
+      "from": "serve-static@1.10.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
       "dependencies": {
         "escape-html": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+          "from": "escape-html@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "parseurl": {
           "version": "1.3.1",
-          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "from": "parseurl@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         },
         "send": {
           "version": "0.13.1",
-          "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+          "from": "send@0.13.1",
           "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
             },
             "depd": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+              "from": "depd@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
             },
             "destroy": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+              "from": "destroy@>=1.0.4 <1.1.0",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
             },
             "etag": {
               "version": "1.7.0",
-              "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+              "from": "etag@>=1.7.0 <1.8.0",
               "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
             },
             "fresh": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+              "from": "fresh@0.3.0",
               "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
             },
             "http-errors": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "from": "http-errors@>=1.3.1 <1.4.0",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "from": "mime@1.3.4",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "from": "on-finished@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                  "from": "ee-first@1.1.1",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "range-parser": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+              "from": "range-parser@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
             },
             "statuses": {
               "version": "1.2.1",
-              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+              "from": "statuses@>=1.2.1 <1.3.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
             }
           }
@@ -9874,12 +8694,12 @@
     },
     "time-grunt": {
       "version": "1.3.0",
-      "from": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.3.0.tgz",
+      "from": "time-grunt@1.3.0",
       "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.3.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -9925,13 +8745,25 @@
         },
         "date-time": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz",
+          "from": "date-time@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
         },
         "figures": {
-          "version": "1.5.0",
-          "from": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz"
+          "version": "1.7.0",
+          "from": "figures@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "dependencies": {
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "from": "object-assign@>=4.1.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+            }
+          }
         },
         "hooker": {
           "version": "0.2.3",
@@ -9940,27 +8772,27 @@
         },
         "number-is-nan": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+          "from": "number-is-nan@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
         },
         "pretty-ms": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
+          "from": "pretty-ms@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
           "dependencies": {
             "is-finite": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+              "from": "is-finite@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
             },
             "parse-ms": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+              "from": "parse-ms@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz"
             },
             "plur": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+              "from": "plur@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
             }
           }
@@ -9974,22 +8806,22 @@
     },
     "universal-analytics": {
       "version": "0.3.11",
-      "from": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.11.tgz",
+      "from": "universal-analytics@0.3.11",
       "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.11.tgz",
       "dependencies": {
         "underscore": {
           "version": "1.8.3",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "from": "underscore@>=1.3.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+          "from": "node-uuid@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "from": "async@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lodash": "4.11.1",
     "mkdirp": "0.5.1",
     "morgan": "1.7.0",
-    "mozlog": "2.0.3",
+    "mozlog": "2.0.4",
     "node-statsd": "0.1.1",
     "node-uap": "git://github.com/vladikoff/node-uap.git#9cdd16247",
     "openid": "1.0.0",


### PR DESCRIPTION
update to mozlog@2.0.4 for the fix there.

This pulls in an update of `npm shrinkwrap` (no --dev). I can just update shrinkwrap for mozlog if that is preferred.