### PR TITLE
refactor(cocktail): change _.extend to cocktail.mixin

### DIFF
--- a/app/scripts/views/mixins/account-locked-mixin.js
+++ b/app/scripts/views/mixins/account-locked-mixin.js
@@ -85,4 +85,3 @@ define(function (require, exports, module) {
 
   module.exports = AccountLockedMixin;
 });
-

--- a/app/scripts/views/mixins/password-reset-mixin.js
+++ b/app/scripts/views/mixins/password-reset-mixin.js
@@ -12,10 +12,10 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var _ = require('underscore');
+  var Cocktail = require('cocktail');
   var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
 
-  module.exports = _.extend({
+  module.exports = Cocktail.mixin({
     /**
      * Initiate a password reset. If successful, redirects to
      * `confirm_reset_password`.

--- a/app/scripts/views/mixins/password-reset-mixin.js
+++ b/app/scripts/views/mixins/password-reset-mixin.js
@@ -12,10 +12,10 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var Cocktail = require('cocktail');
+  var _ = require('underscore');
   var ResumeTokenMixin = require('views/mixins/resume-token-mixin');
 
-  module.exports = Cocktail.mixin({
+  module.exports = _.extend({
     /**
      * Initiate a password reset. If successful, redirects to
      * `confirm_reset_password`.

--- a/app/scripts/views/progress_indicator.js
+++ b/app/scripts/views/progress_indicator.js
@@ -20,8 +20,8 @@ define(function (require, exports, module) {
   'use strict';
 
   var $ = require('jquery');
-  var _ = require('underscore');
   var Backbone = require('backbone');
+  var Cocktail = require('cocktail');
   var TimerMixin = require('views/mixins/timer-mixin');
 
   // The show and hide delays are to minimize flash.
@@ -145,7 +145,10 @@ define(function (require, exports, module) {
     }
   });
 
-  _.extend(View.prototype, TimerMixin);
+  Cocktail.mixin(
+    View,
+    TimerMixin
+  );
 
   module.exports = View;
 });

--- a/app/tests/spec/views/mixins/service-mixin.js
+++ b/app/tests/spec/views/mixins/service-mixin.js
@@ -5,9 +5,9 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var _ = require('underscore');
   var BaseView = require('views/base');
   var Chai = require('chai');
+  var Cocktail = require('cocktail');
   var NullBroker = require('models/auth_brokers/base');
   var OAuthRelier = require('models/reliers/oauth');
   var ServiceMixin = require('views/mixins/service-mixin');
@@ -22,7 +22,10 @@ define(function (require, exports, module) {
     className: 'oauth',
     template: TestTemplate
   });
-  _.extend(OAuthView.prototype, ServiceMixin);
+  Cocktail.mixin(
+    OAuthView,
+    ServiceMixin
+  );
 
   describe('views/mixins/service-mixin', function () {
     var view;

--- a/app/tests/spec/views/mixins/timer-mixin.js
+++ b/app/tests/spec/views/mixins/timer-mixin.js
@@ -5,9 +5,9 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var _ = require('underscore');
   var BaseView = require('views/base');
   var Chai = require('chai');
+  var Cocktail = require('cocktail');
   var TestHelpers = require('../../../lib/helpers');
   var TimerMixin = require('views/mixins/timer-mixin');
 
@@ -15,7 +15,10 @@ define(function (require, exports, module) {
 
   var TimerView = BaseView.extend({});
 
-  _.extend(TimerView.prototype, TimerMixin);
+  Cocktail.mixin(
+    TimerView,
+    TimerMixin
+  );
 
   describe('views/mixins/timer-mixin', function () {
     var view;


### PR DESCRIPTION
Fixes #3666
Changes all the `_.extend` statements that were used for mixins to `Cocktail.mixin()` calls.

@pdehaan 
@shane-tomlinson 
