### PR TITLE
fix(password): save passwords as passwords, not text

### DIFF
--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -199,6 +199,10 @@ define(function (require, exports, module) {
 
     _submitForm: notifyDelayedRequest(showButtonProgressIndicator(function () {
       var self = this;
+      // sets all password fields to type=password
+      self.$el.find('.password').each(function (i, el) {
+        el.type = 'password';
+      });
       return p()
           .then(_.bind(self.beforeSubmit, self))
           .then(function (shouldSubmit) {

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -170,6 +170,20 @@ define(function (require, exports, module) {
         return testFormSubmitted();
       });
 
+      it('sets all password fields to type `password`', function () {
+        view.$('.password').each(function (i, el) {
+          el.type = 'text';
+        });
+        view.formIsValid = true;
+        view.enableSubmitIfValid();
+        return view.validateAndSubmit()
+                  .then(function () {
+                    self.$('.password').each(function (i, el) {
+                      assert.equal(el.type, 'password', 'password fields were not set properly');
+                    });
+                  });
+      });
+
       it('shows validation errors if isValid returns false', function () {
         view.formIsValid = false;
         view.enableSubmitIfValid();


### PR DESCRIPTION
Fixes #3799 
Converts the text fields back to `type=password` before submission
@vladikoff 
@ryanfeeley 