### PR TITLE
fix(permissions): remove line break on permissions page

### DIFF
--- a/app/scripts/templates/partial/permission.mustache
+++ b/app/scripts/templates/partial/permission.mustache
@@ -3,12 +3,12 @@
     <input class="permission" name="{{ name }}" type="checkbox" checked="checked" value="{{ name }}" {{#required}}disabled{{/required}}/>
 
     {{#valueVisible}}
-      <div class="fxa-checkbox__value">{{ value }}</div>
+      <span class="fxa-checkbox__value">{{ value }}</span>
       <div class="fxa-checkbox__label">{{ label }}</div>
     {{/valueVisible}}
 
     {{^valueVisible}}
-      <div class="fxa-checkbox__value">{{ label }}</div>
+      <span class="fxa-checkbox__value">{{ label }}</span>
     {{/valueVisible}}
   </label>
 </fieldset>

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -91,9 +91,6 @@ ul.links {
     margin: 20px 0 10px 0;
   }
 
-  .fxa-checkbox__box-outline {
-    top: 1px;
-  }
 }
 
 .choose-what-to-sync-row,
@@ -208,6 +205,7 @@ ul.links {
 #permissions {
   fieldset {
     border: 0;
+    height: fit-content;
   }
 
   .avatar-wrapper {
@@ -223,6 +221,8 @@ ul.links {
       color: $color-grey;
       font-size: 14px;
       margin-top: auto;
+      /*from fxa-checkbox-repo, the padding needs to be 24px*/
+      padding-left: 24px;
     }
 
     .fxa-checkbox__value {

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "chai": "1.8.1",
     "cocktail": "0.5.9",
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
-    "fxa-checkbox": "mozilla/fxa-checkbox#ae5c1765a967a37d05e1f4855e01d42f408e333f",
+    "fxa-checkbox": "mozilla/fxa-checkbox#7f856afffd394a144f718e28e6fb79092d6ccddd",
     "fxa-content-server-l10n": "https://github.com/mozilla/fxa-content-server-l10n.git",
     "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.41",
     "fxa-password-strength-checker": "https://github.com/mozilla/fxa-password-strength-checker.git#d73b3ade374607e2749ee375301b0a168008b16f",


### PR DESCRIPTION
Fixes #3833 
Converts the div into a span
@vladikoff 
@ryanfeeley 

## Screens:
### With value and label
![screenshot 2016-06-10 11 25 28](https://cloud.githubusercontent.com/assets/432707/15974826/5c8bbccc-2eff-11e6-9ac3-9f4488a15664.png)

### With only label
![screenshot 2016-06-10 11 34 25](https://cloud.githubusercontent.com/assets/432707/15974827/5e8dc740-2eff-11e6-8b09-3742f3a339c9.png)