### PR TITLE
fix(settings): cancel button resets values

### DIFF
--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -54,7 +54,11 @@
     <input type="checkbox" name="named-checkbox" data-novalue />
     <div class="input-row">
       <span class="label-helper"></span>
-      <input type="text" id="float_me" placeholder="placeholder text" />
+      <input type="text" id="float_me" class="display-name" placeholder="placeholder text" />
+    </div>
+    <div class="button-row">
+      <button type="submit" class="settings-button primary">Change</button>
+      <button class="settings-button secondary cancel">Cancel</button>
     </div>
     <input type="text" id="novalue" value="heyho" data-novalue />
     <button type="submit" class="disabled">Submit</button>

--- a/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/app/scripts/views/mixins/settings-panel-mixin.js
@@ -35,9 +35,36 @@ define(function (require, exports, module) {
       return this.$('.settings-unit').hasClass('open');
     },
 
-    _closePanelReturnToSettings: function () {
+    _closePanelReturnToSettings: function (event) {
       this.navigate('settings');
+      this.clearInput(event.currentTarget);
       this.closePanel();
+    },
+
+    clearInput: function (el) {
+      // need siblings here, not prev(), there might be 2 password rows
+      var inputFields = this.$(el).parent().siblings('.input-row').find('input');
+      $(inputFields).each(function (i, anInputField) {
+        // if we have a .label-helper, make that a placeholder
+        // cannot search only inside the .input-row, `input`s
+        // can be from different `.input-row`s
+        var labelHelper = $(anInputField).prev('.label-helper');
+        if (labelHelper.length > 0) {
+          var placeholderText = labelHelper.text();
+          if (placeholderText.length > 0) {
+            $(anInputField).attr('placeholder', placeholderText);
+            // hide the .label-helper again
+            $(labelHelper).text('').css({'top': '0px'});
+          }
+        }
+        // if the input field is text or password, reset it
+        if (anInputField.type === 'text' || anInputField.type === 'password') {
+          // only reset if the field has a value
+          if (anInputField.value.length > 0) {
+            anInputField.value = '';
+          }
+        }
+      });
     },
 
     closePanel: function () {

--- a/app/tests/spec/views/mixins/settings-panel-mixin.js
+++ b/app/tests/spec/views/mixins/settings-panel-mixin.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  var $ = require('jquery');
   var BaseView = require('views/base');
   var chai = require('chai');
   var Cocktail = require('cocktail');
@@ -52,16 +53,18 @@ define(function (require, exports, module) {
 
     describe('events', function () {
       it('toggles button', function () {
-        sinon.stub(view, 'navigate', function () { });
+        sinon.stub(view, 'navigate', function () {});
         $('.settings-unit-toggle').click();
         assert.isTrue(view.navigate.calledWith('settings/display_name'));
       });
 
       it('toggles open and closed', function () {
         sinon.stub(view, 'closePanel', function () {});
-        sinon.stub(view, 'navigate', function () { });
+        sinon.stub(view, 'clearInput', function () {});
+        sinon.stub(view, 'navigate', function () {});
         $('button.cancel').click();
         assert.isTrue(view.closePanel.called);
+        assert.isTrue(view.clearInput.called);
         assert.isTrue(view.navigate.calledWith('settings'));
       });
     });
@@ -81,6 +84,16 @@ define(function (require, exports, module) {
         view.displaySuccess('hi');
         assert.isTrue(view.parentView.displaySuccess.calledWith('hi'));
         assert.isTrue(view.closePanel.called);
+      });
+
+      it('clears panels', function () {
+        view.$('.display-name').val('spc');
+        view.$('.display-name').prev('.label-helper').text('placeholder text');
+        view.clearInput('.settings-button.cancel');
+        assert.isTrue(view.$('.display-name').val() === '');
+        assert.isTrue(view.$('.display-name').attr('placeholder') === 'placeholder text');
+        assert.isTrue(view.$('.display-name').prev('.label-helper').text() === '');
+        assert.isTrue(view.$('.display-name').prev('.label-helper').css('top') === '0px');
       });
     });
 


### PR DESCRIPTION
Fixes #3544
On pressing cancel button, reverses the changes that were done by entering text into the input field:
1. Unfloats `floating_placeholder`
2. Adds back the placeholder text to the `input` field
3. Clears the `input` field

@vladikoff 
@ryanfeeley 