### PR TITLE
feat(settings): escape key hides the current panel

### DIFF
--- a/app/scripts/lib/key-codes.js
+++ b/app/scripts/lib/key-codes.js
@@ -9,6 +9,7 @@ define(function (require, exports, module) {
     BACKSPACE: 8,
     DOWN_ARROW: 40,
     ENTER: 13,
+    ESCAPE: 27,
     LEFT_ARROW: 37,
     NUMPAD_0: 96,
     NUMPAD_9: 105,

--- a/app/scripts/templates/settings/communication_preferences.mustache
+++ b/app/scripts/templates/settings/communication_preferences.mustache
@@ -30,7 +30,7 @@
       </p>
 
       <div class="button-row">
-        <button type="submit" id="marketing-email-optin" class="marketing-email-optin settings-button primary">
+        <button type="submit" id="marketing-email-optin" class="marketing-email-optin settings-button primary" autofocus>
           {{#isOptedIn}}
             {{#t}}Unsubscribe{{/t}}
           {{/isOptedIn}}

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -169,24 +169,6 @@ define([
         .end();
     },
 
-    'sign in, go to settings and opening communication_preferences panel autofocuses the first button element': function () {
-      var self = this;
-      return FunctionalHelpers.fillOutSignIn(self, email, FIRST_PASSWORD, true)
-        .findByCssSelector('[data-href="settings/communication_preferences"]')
-          .click()
-        .end()
-        .findById('marketing-email-optin')
-        .end()
-        .getActiveElement()
-        .then(function (element) {
-          element.getAttribute('class')
-            .then(function (className) {
-              assert.isTrue(className.includes('marketing-email-optin'));
-            });
-        })
-        .end();
-    },
-
     'sign in, open settings in a second tab, sign out': function () {
       var windowName = 'sign-out inter-tab functional test';
       var self = this;

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -5,9 +5,10 @@
 define([
   'intern',
   'intern!object',
+  'intern/chai!assert',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, TestHelpers, FunctionalHelpers) {
 
   var config = intern.config;
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
@@ -147,6 +148,38 @@ define([
           return FunctionalHelpers.fillOutSignIn(self, email, FIRST_PASSWORD);
         })
         .findById('avatar-options')
+        .end();
+    },
+
+    'sign in, go to settings and opening display_name panel autofocuses the first input element': function () {
+      var self = this;
+      return FunctionalHelpers.fillOutSignIn(self, email, FIRST_PASSWORD, true)
+        .findByCssSelector('[data-href="settings/display_name"]')
+          .click()
+        .end()
+        .getActiveElement()
+        .then(function (element) {
+          element.getAttribute('class')
+            .then(function (className) {
+              assert.isTrue(className.includes('display-name'));
+            });
+        })
+        .end();
+    },
+
+    'sign in, go to settings and opening communication_preferences panel autofocuses the first button element': function () {
+      var self = this;
+      return FunctionalHelpers.fillOutSignIn(self, email, FIRST_PASSWORD, true)
+        .findByCssSelector('[data-href="settings/communication_preferences"]')
+          .click()
+        .end()
+        .getActiveElement()
+        .then(function (element) {
+          element.getAttribute('class')
+            .then(function (className) {
+              assert.isTrue(className.includes('marketing-email-optin'));
+            });
+        })
         .end();
     },
 

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -157,6 +157,8 @@ define([
         .findByCssSelector('[data-href="settings/display_name"]')
           .click()
         .end()
+        .findByCssSelector('input.display-name')
+        .end()
         .getActiveElement()
         .then(function (element) {
           element.getAttribute('class')
@@ -172,6 +174,8 @@ define([
       return FunctionalHelpers.fillOutSignIn(self, email, FIRST_PASSWORD, true)
         .findByCssSelector('[data-href="settings/communication_preferences"]')
           .click()
+        .end()
+        .findById('marketing-email-optin')
         .end()
         .getActiveElement()
         .then(function (element) {


### PR DESCRIPTION
Fixes #3648, #3843
Fixes openPanel to focus on first input/button field after closing/cancelling before.
Lets user press `ESC` key to close the current panel.

@shane-tomlinson 
@vladikoff 