### PR TITLE
fix(avatar): prevent buttons from flashing

### DIFF
--- a/app/scripts/templates/settings/avatar_change.mustache
+++ b/app/scripts/templates/settings/avatar_change.mustache
@@ -12,7 +12,9 @@
       <a href="#" id="file">{{#t}}Upload{{/t}}</a>
       <a href="/settings/avatar/camera" id="camera">{{#t}}Camera{{/t}}</a>
       <a href="/settings/avatar/gravatar_permissions" id="gravatar">{{#t}}Gravatar{{/t}}</a>
-      <a href="#" class="remove hidden">{{#t}}Clear{{/t}}</a>
+      {{#hasProfileImage}}
+      <a href="#" class="remove">{{#t}}Clear{{/t}}</a>
+      {{/hasProfileImage}}
     </nav>
 
     <div class="button-row">

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -45,15 +45,17 @@ define(function (require, exports, module) {
       }
     },
 
+    context: function () {
+      var account = this.getSignedInAccount();
+      return {
+        'hasProfileImage': account.has('profileImageUrl')
+      };
+    },
+
     afterVisible: function () {
       var self = this;
       FormView.prototype.afterVisible.call(self);
-      return self.displayAccountProfileImage(self.getAccount())
-        .then(function () {
-          if (self.getAccount().has('profileImageUrl')) {
-            self.$('.remove').removeClass('hidden');
-          }
-        });
+      return self.displayAccountProfileImage(self.getAccount());
     },
 
     afterRender: function () {


### PR DESCRIPTION
Fixes #3543

Changes the display of the button from JavaScript Promise to just mustache rendering, thereby removing the flash.
@shane-tomlinson 
@ryanfeeley 
![noflashavatar](https://cloud.githubusercontent.com/assets/432707/16154686/e49e1d7c-34a3-11e6-8f8e-ce837d68333a.gif)
