### PR TITLE
fix(metrics): Remove the caching sha from urls in the sentry stacktrace

### DIFF
--- a/app/scripts/lib/sentry.js
+++ b/app/scripts/lib/sentry.js
@@ -41,6 +41,7 @@ define(function (require, exports, module) {
       if (data.request.url) {
         data.request.url = cleanUpQueryParam(data.request.url);
       }
+
       if (data.request.headers && data.request.headers.Referer) {
         data.request.headers.Referer = cleanUpQueryParam(data.request.headers.Referer);
       }
@@ -50,9 +51,14 @@ define(function (require, exports, module) {
       // this helps errors stay consistent across deploys
       var removeRegex = /\/[0-9a-f]{8}\./gi;
       var addPart = '/';
-      if (data.stacktrace && data.stacktrace.frames) {
-        _.each(data.stacktrace.frames, function (frame) {
-          frame.filename = frame.filename.replace(removeRegex, addPart);
+
+      if (data.exception && data.exception.values) {
+        _.each(data.exception.values, function (value) {
+          if (value.stacktrace && value.stacktrace.frames) {
+            _.each(value.stacktrace.frames, function (frame) {
+              frame.filename = frame.filename.replace(removeRegex, addPart);
+            });
+          }
         });
       }
 

--- a/app/tests/spec/lib/sentry.js
+++ b/app/tests/spec/lib/sentry.js
@@ -164,18 +164,24 @@ define(function (require, exports, module) {
         var goodCulprit = 'https://accounts.firefox.com/scripts/main.js';
         var data = {
           culprit: badCulprit,
-          request: {
-            url: url
-          },
-          stacktrace: {
-            frames: [
+          exception: {
+            values: [
               {
-                filename: badFile
-              },
-              {
-                filename: otherFile
+                stacktrace: {
+                  frames: [
+                    {
+                      filename: badFile
+                    },
+                    {
+                      filename: otherFile
+                    }
+                  ]
+                }
               }
             ]
+          },
+          request: {
+            url: url
           }
         };
 
@@ -190,8 +196,8 @@ define(function (require, exports, module) {
 
         assert.equal(resultData.url, goodData.url);
         assert.equal(resultData.culprit, goodCulprit);
-        assert.equal(resultData.stacktrace.frames[0].filename, goodFile, 'removes cache part');
-        assert.equal(resultData.stacktrace.frames[1].filename, otherFile, 'does not remove cache part');
+        assert.equal(resultData.exception.values[0].stacktrace.frames[0].filename, goodFile, 'removes cache part');
+        assert.equal(resultData.exception.values[0].stacktrace.frames[1].filename, otherFile, 'does not remove cache part');
       });
 
     });
@@ -227,7 +233,9 @@ define(function (require, exports, module) {
     describe('captureException', function () {
       it('reports the error to Raven, passing along tags', function () {
         var sandbox = sinon.sandbox.create();
-        sandbox.spy(Raven, 'captureException');
+        // do not call the real captureException,
+        // no need to make network requests.
+        sandbox.stub(Raven, 'captureException', function () {});
 
         var sentry = new SentryMetrics(host);
 


### PR DESCRIPTION
When we updated Sentry, the payload format changed. This handles the new
payload format and cleans the stacktrace appropriately.

fixes #3829

@vladikoff - r?

Here's a sample from the stack trace:

<img width="380" alt="screen shot 2016-06-21 at 12 30 33" src="https://cloud.githubusercontent.com/assets/848085/16228091/d76daf4e-37ac-11e6-8d62-5ea030e98bbc.png">
