### PR TITLE
fix(client): Show a sensible error message if basket is unavailable.

### DIFF
--- a/app/scripts/lib/marketing-email-errors.js
+++ b/app/scripts/lib/marketing-email-errors.js
@@ -22,7 +22,7 @@ define(function (require, exports, module) {
   var ERRORS = {
     NETWORK_FAILURE: {
       errno: 1,
-      message: UNEXPECTED_ERROR
+      message: t('System unavailable, try again soon')
     },
     INVALID_EMAIL: {
       errno: 2,


### PR DESCRIPTION
If basket is unavailable, print "Service unavailable, try again soon."

This string is already translated and can be added to prod easily.

fixes #3866