### PR TITLE
fix(client): Fix sign in from the firstrun flow.

### DIFF
--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -54,6 +54,7 @@ define(function (require, exports, module) {
       afterForceAuth: new NullBehavior(),
       afterResetPasswordConfirmationPoll: new NullBehavior(),
       afterSignIn: new NullBehavior(),
+      afterSignInConfirmationPoll: new NullBehavior(),
       afterSignUp: new NullBehavior(),
       afterSignUpConfirmationPoll: new NullBehavior(),
       beforeSignIn: new NullBehavior(),
@@ -139,6 +140,15 @@ define(function (require, exports, module) {
      */
     afterSignIn: function (/* account */) {
       return p(this.getBehavior('afterSignIn'));
+    },
+
+    /**
+     * Called after sign in confirmation poll. Can be usedc to notify the RP
+     * that the user has signed in and confirmed their email address to verify
+     * they want to allow the signin.
+     */
+    afterSignInConfirmationPoll: function (/* account */) {
+      return p(this.getBehavior('afterSignInConfirmationPoll'));
     },
 
     /**

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -143,7 +143,7 @@ define(function (require, exports, module) {
     },
 
     /**
-     * Called after sign in confirmation poll. Can be usedc to notify the RP
+     * Called after sign in confirmation poll. Can be used to notify the RP
      * that the user has signed in and confirmed their email address to verify
      * they want to allow the signin.
      */

--- a/app/scripts/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/scripts/models/auth_brokers/fx-firstrun-v1.js
@@ -66,6 +66,12 @@ define(function (require, exports, module) {
       return proto.afterSignIn.apply(this, arguments);
     },
 
+    afterSignInConfirmationPoll: function () {
+      this._iframeChannel.send(this._iframeCommands.VERIFICATION_COMPLETE);
+
+      return proto.afterSignInConfirmationPoll.apply(this, arguments);
+    },
+
     afterResetPasswordConfirmationPoll: function () {
       this._iframeChannel.send(this._iframeCommands.VERIFICATION_COMPLETE);
 

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -128,7 +128,7 @@ define(function (require, exports, module) {
           var brokerMethod =
             self.isSignUp() ?
             'afterSignUpConfirmationPoll' :
-            'afterSignIn';
+            'afterSignInConfirmationPoll';
 
           return self.invokeBrokerMethod(brokerMethod, self.getAccount());
         })

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -143,6 +143,13 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('afterSignInConfirmationPoll', function () {
+      it('returns a promise', function () {
+        return broker.afterSignInConfirmationPoll(account)
+          .then(testDoesNotHalt);
+      });
+    });
+
     describe('afterForceAuth', function () {
       it('returns a promise', function () {
         return broker.afterForceAuth(account)

--- a/app/tests/spec/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-firstrun-v1.js
@@ -150,6 +150,17 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('afterSignInConfirmationPoll', function () {
+      it('notifies the iframe channel', function () {
+        sinon.spy(iframeChannel, 'send');
+
+        return broker.afterSignInConfirmationPoll(account)
+          .then(function () {
+            assert.isTrue(iframeChannel.send.calledWith(broker._iframeCommands.VERIFICATION_COMPLETE));
+          });
+      });
+    });
+
     describe('afterSignUpConfirmationPoll', function () {
       it('notifies the iframe channel', function () {
         sinon.spy(iframeChannel, 'send');

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -216,7 +216,7 @@ define(function (require, exports, module) {
             return true;
           });
 
-          testEmailVerificationPoll('afterSignIn');
+          testEmailVerificationPoll('afterSignInConfirmationPoll');
         });
       });
 

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -16,6 +16,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
+  var clearBrowserNotifications = FunctionalHelpers.clearBrowserNotifications;
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -58,6 +59,7 @@ define([
         .then(setupTest(this, true))
 
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(clearBrowserNotifications())
         .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openVerificationLinkInNewTab(this, email, 0))
@@ -66,7 +68,8 @@ define([
           .closeCurrentWindow()
         .switchToWindow('')
 
-        .then(testElementExists('#fxa-sign-in-complete-header'));
+        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(noSuchBrowserNotification(this, 'fxaccounts:login'));
     },
 
     'verified, verify different browser - from original tab\'s P.O.V.': function () {
@@ -74,11 +77,13 @@ define([
         .then(setupTest(this, true))
 
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(clearBrowserNotifications())
         .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openVerificationLinkDifferentBrowser(email))
 
-        .then(testElementExists('#fxa-sign-in-complete-header'));
+        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(noSuchBrowserNotification(this, 'fxaccounts:login'));
     },
 
     'unverified': function () {

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -820,6 +820,15 @@ define([
     };
   }
 
+  function clearBrowserNotifications() {
+    return function () {
+      return this.parent
+        .execute(function (command, done) {
+          sessionStorage.removeItem('webChannelEvents');
+        });
+    };
+  }
+
   function testIsBrowserNotified(context, command, cb) {
     return function () {
       return getRemote(context)
@@ -1325,6 +1334,7 @@ define([
   }
 
   return {
+    clearBrowserNotifications: clearBrowserNotifications,
     clearBrowserState: clearBrowserState,
     clearSessionStorage: clearSessionStorage,
     click: click,


### PR DESCRIPTION
Two `fxaccounts:login` messages were being sent, both with the same
sessionToken and keyFetchToken. When the 2nd message was received by
the browser, it would attempt to re-use the keyFetchToken to fetch
keys. Since keyFetchTokens are single use, this failed.

This occurred because the signin confirmation flow called the
`beforeSignUpConfirmationPoll` broker method before the confirmation poll,
which sent one notice, and then `afterSignIn` when the poll completed, which
sent another notice.

The solution is to only send one `fxaccounts:login` message.

Instead of re-using `afterSignIn`, a new broker method is created,
`afterSignInConfirmationPoll`. The firstrun flow uses
`afterSignInConfirmationPoll` to notify the firstrun page of the signin, but
does NOT notify the browser.

fixes #3880 

@vbudhram, @vladikoff - r?