### PR TITLE
fix(client): Fix sign in from the firstrun flow. (#3889)

### DIFF
--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -54,6 +54,7 @@ define(function (require, exports, module) {
       afterForceAuth: new NullBehavior(),
       afterResetPasswordConfirmationPoll: new NullBehavior(),
       afterSignIn: new NullBehavior(),
+      afterSignInConfirmationPoll: new NullBehavior(),
       afterSignUp: new NullBehavior(),
       afterSignUpConfirmationPoll: new NullBehavior(),
       beforeSignIn: new NullBehavior(),
@@ -139,6 +140,15 @@ define(function (require, exports, module) {
      */
     afterSignIn: function (/* account */) {
       return p(this.getBehavior('afterSignIn'));
+    },
+
+    /**
+     * Called after sign in confirmation poll. Can be used to notify the RP
+     * that the user has signed in and confirmed their email address to verify
+     * they want to allow the signin.
+     */
+    afterSignInConfirmationPoll: function (/* account */) {
+      return p(this.getBehavior('afterSignInConfirmationPoll'));
     },
 
     /**

--- a/app/scripts/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/scripts/models/auth_brokers/fx-firstrun-v1.js
@@ -66,6 +66,12 @@ define(function (require, exports, module) {
       return proto.afterSignIn.apply(this, arguments);
     },
 
+    afterSignInConfirmationPoll: function () {
+      this._iframeChannel.send(this._iframeCommands.VERIFICATION_COMPLETE);
+
+      return proto.afterSignInConfirmationPoll.apply(this, arguments);
+    },
+
     afterResetPasswordConfirmationPoll: function () {
       this._iframeChannel.send(this._iframeCommands.VERIFICATION_COMPLETE);
 

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -128,7 +128,7 @@ define(function (require, exports, module) {
           var brokerMethod =
             self.isSignUp() ?
             'afterSignUpConfirmationPoll' :
-            'afterSignIn';
+            'afterSignInConfirmationPoll';
 
           return self.invokeBrokerMethod(brokerMethod, self.getAccount());
         })

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -143,6 +143,13 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('afterSignInConfirmationPoll', function () {
+      it('returns a promise', function () {
+        return broker.afterSignInConfirmationPoll(account)
+          .then(testDoesNotHalt);
+      });
+    });
+
     describe('afterForceAuth', function () {
       it('returns a promise', function () {
         return broker.afterForceAuth(account)

--- a/app/tests/spec/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-firstrun-v1.js
@@ -150,6 +150,17 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('afterSignInConfirmationPoll', function () {
+      it('notifies the iframe channel', function () {
+        sinon.spy(iframeChannel, 'send');
+
+        return broker.afterSignInConfirmationPoll(account)
+          .then(function () {
+            assert.isTrue(iframeChannel.send.calledWith(broker._iframeCommands.VERIFICATION_COMPLETE));
+          });
+      });
+    });
+
     describe('afterSignUpConfirmationPoll', function () {
       it('notifies the iframe channel', function () {
         sinon.spy(iframeChannel, 'send');

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -216,7 +216,7 @@ define(function (require, exports, module) {
             return true;
           });
 
-          testEmailVerificationPoll('afterSignIn');
+          testEmailVerificationPoll('afterSignInConfirmationPoll');
         });
       });
 

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -16,6 +16,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
+  var clearBrowserNotifications = FunctionalHelpers.clearBrowserNotifications;
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -58,6 +59,7 @@ define([
         .then(setupTest(this, true))
 
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(clearBrowserNotifications())
         .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openVerificationLinkInNewTab(this, email, 0))
@@ -66,7 +68,8 @@ define([
           .closeCurrentWindow()
         .switchToWindow('')
 
-        .then(testElementExists('#fxa-sign-in-complete-header'));
+        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(noSuchBrowserNotification(this, 'fxaccounts:login'));
     },
 
     'verified, verify different browser - from original tab\'s P.O.V.': function () {
@@ -74,11 +77,13 @@ define([
         .then(setupTest(this, true))
 
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(clearBrowserNotifications())
         .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openVerificationLinkDifferentBrowser(email))
 
-        .then(testElementExists('#fxa-sign-in-complete-header'));
+        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(noSuchBrowserNotification(this, 'fxaccounts:login'));
     },
 
     'unverified': function () {

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -820,6 +820,15 @@ define([
     };
   }
 
+  function clearBrowserNotifications() {
+    return function () {
+      return this.parent
+        .execute(function (command, done) {
+          sessionStorage.removeItem('webChannelEvents');
+        });
+    };
+  }
+
   function testIsBrowserNotified(context, command, cb) {
     return function () {
       return getRemote(context)
@@ -1325,6 +1334,7 @@ define([
   }
 
   return {
+    clearBrowserNotifications: clearBrowserNotifications,
     clearBrowserState: clearBrowserState,
     clearSessionStorage: clearSessionStorage,
     click: click,

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -31,7 +31,6 @@ define([
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
-  var testEmailExpected = FunctionalHelpers.testEmailExpected;
   var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
   var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
@@ -89,11 +88,7 @@ define([
         // back to the original window
         .switchToWindow('')
         .then(testElementExists('#fxa-settings-header'))
-        .then(testSuccessWasShown(this))
-
-        // A post-verification email should be sent because no service is sent
-        // in the verificaiton link.
-        .then(testEmailExpected(email, 1));
+        .then(testSuccessWasShown(this));
     },
 
     'signup, verify same browser with original tab closed, sign out': function () {


### PR DESCRIPTION
Backfilling fix for https://github.com/mozilla/fxa-content-server/issues/3880 to train-64.

To test first run flow locally
* Update content-server, server/config/local.json, add `http://127.0.0.1:8111` to `allowed_parent_origins`
* Run fxa-local-dev
* Clone and run https://github.com/shane-tomlinson/firstrun-example/
* Open http://127.0.0.1:8111 in browser and go through flow

@vladikoff @rfk, if you want to give it a spin.
