### PR TITLE
feat(client): add a default name to devices view

### DIFF
--- a/app/scripts/templates/settings/devices.mustache
+++ b/app/scripts/templates/settings/devices.mustache
@@ -19,7 +19,10 @@
       <ul class="device-list button-row">
         {{#devices}}
           <li class="device {{type}}" id="{{id}}">
-            <div class="device-name">{{name}}</div>
+            <div class="device-name">
+              {{#name}}{{name}}{{/name}}
+              {{^name}}{{#t}}Unidentified device{{/t}}{{/name}}
+            </div>
             {{#isCurrentDevice}}
             <div class="device-current">{{#t}}current device{{/t}}</div>
             {{/isCurrentDevice}}

--- a/app/tests/spec/views/settings/devices.js
+++ b/app/tests/spec/views/settings/devices.js
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
         {
           id: 'device-2',
           isCurrentDevice: true,
-          name: 'beta'
+          name: null
         }
       ], {
         notifier: notifier
@@ -110,7 +110,9 @@ define(function (require, exports, module) {
       });
 
       it('renders devices already in the collection', function () {
-        assert.ok(view.$('li.device').length, 2);
+        assert.lengthOf(view.$('li.device'), 2);
+        assert.equal(view.$('#device-1 .device-name').text().trim(), 'alpha');
+        assert.equal(view.$('#device-2 .device-name').text().trim(), 'Unidentified device');
       });
     });
 


### PR DESCRIPTION
As per the [conversation](https://github.com/mozilla/fxa-auth-server/pull/1299#issuecomment-229527028) in https://github.com/mozilla/fxa-auth-server/pull/1299, it will soon be possible (albeit very rare) for device data to be returned without a name. In these cases, we need the UI to display a suitable localised string to the user.

This change aims to do that.

@ryanfeeley, perhaps you want to chime in about what the default device name should be, although in practice it should be something that a user never sees. I went for "unidentified device" because, if they do see it, I thought it should sound kind-of-scary.

@shane-tomlinson, it's been *ages* since I did anything in the content server so apologies if I've done this wrong. Could I get an r?

/cc @rfk and @seanmonstar, who were in conversation over on the auth server PR.