### PR TITLE
fix(server): Add `confirm_signin` to the list of front end routes.

### DIFF
--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -106,6 +106,7 @@ module.exports = function (config, i18n) {
       '/confirm',
       '/confirm_account_unlock',
       '/confirm_reset_password',
+      '/confirm_signin',
       '/cookies_disabled',
       '/force_auth',
       '/force_auth_complete',

--- a/tests/functional/pages.js
+++ b/tests/functional/pages.js
@@ -22,6 +22,7 @@ define([
     'confirm',
     'confirm_account_unlock',
     'confirm_reset_password',
+    'confirm_signin',
     'cookies_disabled',
     // valid locale legal pages
     'en/legal/terms',

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -42,6 +42,7 @@ define([
     '/confirm': { statusCode: 200 },
     '/confirm_account_unlock': { statusCode: 200 },
     '/confirm_reset_password': { statusCode: 200 },
+    '/confirm_signin': { statusCode: 200 },
     '/cookies_disabled': { statusCode: 200 },
     '/force_auth': { statusCode: 200 },
     '/force_auth_complete': { statusCode: 200 },


### PR DESCRIPTION
If the user refreshed the /confirm_signin page, the server would 404.

fixes #3904

@philbooth or @vbudhram - r?