### PR TITLE
fix(client): Fix the device view sort order.

### DIFF
--- a/app/scripts/models/devices.js
+++ b/app/scripts/models/devices.js
@@ -22,10 +22,31 @@ define(function (require, exports, module) {
 
     comparator: function (a, b) {
       // 1. the current device is first.
-      // 2. the rest sorted in alphabetical order.
+      // 2. those with lastAccessTime are sorted in descending order
+      // 3. the rest sorted in alphabetical order.
       if (a.get('isCurrentDevice')) {
         return -1;
       }
+
+
+      // check lastAccessTime. If one has an access time and the other does
+      // not, the one with the access time is automatically higher in the
+      // list. If both have access times, sort in descending order, unless
+      // access times are the same, then sort alphabetically.
+      var aLastAccessTime = a.get('lastAccessTime');
+      var bLastAccessTime = b.get('lastAccessTime');
+
+      if (aLastAccessTime && bLastAccessTime &&
+          aLastAccessTime !== bLastAccessTime) {
+        return bLastAccessTime - aLastAccessTime;
+      } else if (aLastAccessTime && ! bLastAccessTime) {
+        return -1;
+      } else if (! aLastAccessTime && bLastAccessTime) {
+        return 1;
+      }
+
+      // neither has an access time, or access time is the same,
+      // sort alphabetically
 
       var aName = (a.get('name') || '').trim().toLowerCase();
       var bName = (b.get('name') || '').trim().toLowerCase();

--- a/app/tests/spec/models/devices.js
+++ b/app/tests/spec/models/devices.js
@@ -22,45 +22,69 @@ define(function (require, exports, module) {
     });
 
     describe('device list ordering', function () {
+      var now = Date.now();
+
       beforeEach(function () {
         devices.set([
           {
             isCurrentDevice: false,
-            name: 'zeta'
-          },
-          {
-            isCurrentDevice: true,
-            name: 'upsilon'
-          },
-          {
-            isCurrentDevice: false,
+            lastAccessTime: null,
             name: 'xi'
           },
           {
             isCurrentDevice: false,
+            lastAccessTime: null,
+            name: 'xi'
+          },
+          {
+            isCurrentDevice: true,
+            lastAccessTime: now - 20,
+            name: 'zeta'
+          },
+          {
+            isCurrentDevice: false,
+            lastAccessTime: now - 10,
+            name: 'mu'
+          },
+          {
+            isCurrentDevice: false,
+            lastAccessTime: now,
             name: 'tau'
           },
           {
             isCurrentDevice: false,
-            name: 'tau'
+            lastAccessTime: now,
+            name: 'sigma'
           },
           {
             isCurrentDevice: false,
+            lastAccessTime: now - 20,
             name: 'theta'
+          },
+          {
+            isCurrentDevice: false,
+            lastAccessTime: null,
+            name: 'upsilon'
           }
         ]);
       });
 
       it('places the `current` device first', function () {
-        assert.equal(devices.at(0).get('name'), 'upsilon');
+        assert.equal(devices.at(0).get('name'), 'zeta');
+      });
+
+      it('sorts those with lastAccessTime next, by access time (descending)', function () {
+        assert.equal(devices.at(1).get('name'), 'sigma');
+        assert.equal(devices.at(2).get('name'), 'tau');
+        assert.equal(devices.at(3).get('name'), 'mu');
+        assert.equal(devices.at(4).get('name'), 'theta');
+
       });
 
       it('sorts the rest alphabetically', function () {
-        assert.equal(devices.at(1).get('name'), 'tau');
-        assert.equal(devices.at(2).get('name'), 'tau');
-        assert.equal(devices.at(3).get('name'), 'theta');
-        assert.equal(devices.at(4).get('name'), 'xi');
-        assert.equal(devices.at(5).get('name'), 'zeta');
+        assert.equal(devices.at(5).get('name'), 'upsilon');
+        assert.equal(devices.at(6).get('name'), 'xi');
+        assert.equal(devices.at(7).get('name'), 'xi');
       });
     });
 


### PR DESCRIPTION
Place the current device first,
Sort items with lastAccessTime in descending order,
Sort the rest alphabetically.

fixes #3899