### PR TITLE
fix(tests): Fix the Sync v3 settings WebChannel message checks.

### DIFF
--- a/tests/functional.js
+++ b/tests/functional.js
@@ -27,6 +27,7 @@ define([
   './functional/fx_fennec_v1_sign_in',
   './functional/fx_fennec_v1_force_auth',
   './functional/fx_fennec_v1_sign_up',
+  './functional/fx_fennec_v1_settings',
   './functional/verification_experiments',
   './functional/bounced_email',
   './functional/legal',

--- a/tests/functional/fx_fennec_v1_settings.js
+++ b/tests/functional/fx_fennec_v1_settings.js
@@ -18,15 +18,14 @@ define([
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = thenify(FunctionalHelpers.openPage);
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   var config = intern.config;
-  var SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
-  var SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
+  var SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_fennec_v1&service=sync&forceAboutAccounts=true';
+  var SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_fennec_v1&service=sync&forceAboutAccounts=true';
 
   var FIRST_PASSWORD = 'password';
   var SECOND_PASSWORD = 'new_password';
@@ -34,7 +33,7 @@ define([
 
 
   registerSuite({
-    name: 'Firefox Desktop Sync v3 settings',
+    name: 'Firefox Fennec Sync v1 settings',
 
     beforeEach: function () {
       email = TestHelpers.createEmail('sync{id}');
@@ -47,7 +46,6 @@ define([
         .then(fillOutSignIn(this, email, FIRST_PASSWORD))
         .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
-        .then(openVerificationLinkDifferentBrowser(email))
 
         // wait until account data is in localstorage before redirecting
         .then(FunctionalHelpers.pollUntil(function () {
@@ -74,7 +72,9 @@ define([
         .then(visibleByQSA('#delete-account .settings-unit-details'))
 
         .then(fillOutDeleteAccount(this, FIRST_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:delete'))
+        // Fx desktop requires fxaccounts:delete, Fennec requires
+        // fxaccounts:delete_account
+        .then(testIsBrowserNotified(this, 'fxaccounts:delete_account'))
 
         .then(testElementExists('#fxa-signup-header'));
     },

--- a/tests/functional/sync_v3_settings.js
+++ b/tests/functional/sync_v3_settings.js
@@ -21,7 +21,7 @@ define([
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = thenify(FunctionalHelpers.testIsBrowserNotified);
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   var config = intern.config;
@@ -74,7 +74,7 @@ define([
         .then(visibleByQSA('#delete-account .settings-unit-details'))
 
         .then(fillOutDeleteAccount(this, FIRST_PASSWORD))
-        .then(testIsBrowserNotified(this, 'delete_account'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:delete_account'))
 
         .then(testElementExists('#fxa-signup-header'));
     },


### PR DESCRIPTION
testIsBrowserNotified should not be wrapped in a `thenify`, and
the delete account message is `fxaccounts:delete_account`

fixes #3911

@vbudhram - r?