### PR TITLE
feat(config): Add a /.well-known/fxa-client-configuration endpoint

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -124,6 +124,13 @@ var conf = module.exports = convict({
     doc: 'HMAC key used to verify flow event data',
     format: String
   },
+  fxa_client_configuration: {
+    max_age: {
+      default: '1 day',
+      doc: 'Cache max age for /.well-known/fxa-client-configuration, in ms',
+      format: 'duration'
+    }
+  },
   fxaccount_url: {
     default: 'http://127.0.0.1:9000',
     doc: 'The url of the Firefox Account auth server',
@@ -493,6 +500,12 @@ var conf = module.exports = convict({
       format: 'port'
     },
     sample_rate: 1
+  },
+  sync_tokenserver_url: {
+    default: 'http://127.0.0.1:5000/token',
+    doc: 'The url of the Firefox Sync tokenserver',
+    env: 'SYNC_TOKENSERVER_URL',
+    format: 'url'
   },
   template_path: {
     default: path.resolve(__dirname, '..', 'templates'),

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -27,6 +27,7 @@ module.exports = function (config, i18n) {
     require('./routes/get-ver.json'),
     require('./routes/get-client.json')(i18n),
     require('./routes/get-config')(i18n),
+    require('./routes/get-fxa-client-configuration')(config),
     require('./routes/get-openid-configuration')(config),
     require('./routes/get-metrics-errors')(),
     require('./routes/get-version.json'),

--- a/server/lib/routes/get-fxa-client-configuration.js
+++ b/server/lib/routes/get-fxa-client-configuration.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+function normalizeUrl(url) {
+  // Strip any trailing slashes.
+  url = url.replace(/\/+$/, '');
+  return url;
+}
+
+module.exports = function (config) {
+  var route = {};
+  route.method = 'get';
+  route.path = '/.well-known/fxa-client-configuration';
+
+  var fxaClientConfig = {
+    /*eslint-disable camelcase */
+    auth_server_base_url: normalizeUrl(config.get('fxaccount_url')),
+    oauth_server_base_url: normalizeUrl(config.get('oauth_url')),
+    profile_server_base_url: normalizeUrl(config.get('profile_url')),
+    sync_tokenserver_base_url: normalizeUrl(config.get('sync_tokenserver_url'))
+  };
+
+  // This response will very rarely change, so enable caching by default.
+  // It defaults to one day, and can be disabled by setting max_age to zero.
+  var maxAge = config.get('fxa_client_configuration.max_age');
+  if (maxAge) {
+    maxAge = Math.floor(maxAge / 1000);  // the config value is in milliseconds
+  }  else if (maxAge !== 0) {
+    maxAge = 60 * 60 * 24;
+  }
+
+  var cacheControlHeader = '';
+  if (maxAge) {
+    cacheControlHeader = 'public, max-age=' + maxAge;
+  }
+
+  route.process = function (req, res) {
+
+    if (cacheControlHeader) {
+      res.header('Cache-Control', cacheControlHeader);
+    }
+
+    // charset must be set on json responses.
+    res.charset = 'utf-8';
+
+    res.json(fxaClientConfig);
+  };
+
+  return route;
+};

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -26,6 +26,7 @@ define([
     'tests/server/configuration',
     'tests/server/statsd-collector',
     'tests/server/activity-event',
+    'tests/server/routes/get-fxa-client-configuration',
     'tests/server/routes/get-index',
     'tests/server/routes/post-csp',
     'tests/server/routes/post-metrics'

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -28,6 +28,7 @@ define([
   };
 
   var routes = {
+    '/.well-known/fxa-client-configuration': { statusCode: 200 },
     '/.well-known/openid-configuration': { statusCode: 200 },
     '/account_unlock_complete': { statusCode: 200 },
     '/cannot_create_account': { statusCode: 200 },

--- a/tests/server/routes/get-fxa-client-configuration.js
+++ b/tests/server/routes/get-fxa-client-configuration.js
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../../server/lib/configuration',
+  'intern/dojo/node!../../../server/lib/routes/get-fxa-client-configuration',
+  'intern/dojo/node!request',
+  'intern/dojo/node!sinon'
+], function (intern, registerSuite, assert, config, getFxAClientConfig, request, sinon) {
+  var serverUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
+
+  var suite = {
+    name: 'fxa-client-configuration'
+  };
+
+  var mocks, route;
+
+  suite['get-fxa-client-configuration route function'] = {
+
+    beforeEach: function () {
+      mocks = {
+        config: {
+          get: sinon.spy(function (name) {
+            return mocks.config[name];
+          })
+        },
+        request: null,
+        response: {
+          header: sinon.spy(),
+          json: sinon.spy()
+        }
+      };
+      /*eslint-disable camelcase*/
+      mocks.config.fxaccount_url = 'https://accounts.firefox.com';
+      mocks.config.oauth_url = 'https://oauth.accounts.firefox.com';
+      mocks.config.profile_url = 'https://profile.accounts.firefox.com';
+      mocks.config.sync_tokenserver_url = 'https://token.services.mozilla.org';
+      /*eslint-enable camelcase*/
+    },
+
+    'module interface is correct': function () {
+      assert.isFunction(getFxAClientConfig);
+      assert.lengthOf(getFxAClientConfig, 1);
+    },
+
+    'route interface is correct': function () {
+      route = getFxAClientConfig(mocks.config);
+      assert.equal(mocks.config.get.callCount, 5);
+      assert.isObject(route);
+      assert.lengthOf(Object.keys(route), 3);
+      assert.equal(route.method, 'get');
+      assert.equal(route.path, '/.well-known/fxa-client-configuration');
+      assert.isFunction(route.process);
+      assert.lengthOf(route.process, 2);
+    },
+
+    'route.process strips trailing slashes from URLs in config': function () {
+      /*eslint-disable camelcase*/
+      mocks.config.fxaccount_url += '//';
+      mocks.config.oauth_url += '/path/component/';
+      mocks.config.profile_url += '/path/component';
+      /*eslint-enable camelcase*/
+
+      route = getFxAClientConfig(mocks.config);
+      route.process(mocks.request, mocks.response);
+
+      assert.equal(mocks.config.get.callCount, 5);
+      assert.equal(mocks.response.json.callCount, 1);
+      var args = mocks.response.json.args[0];
+      assert.lengthOf(args, 1);
+      var resp = args[0];
+      assert.equal(resp.auth_server_base_url, 'https://accounts.firefox.com');
+      assert.equal(resp.oauth_server_base_url, 'https://oauth.accounts.firefox.com/path/component');
+      assert.equal(resp.profile_server_base_url, 'https://profile.accounts.firefox.com/path/component');
+    },
+
+    'route.process sets cache-control header from config': function () {
+      mocks.config['fxa_client_configuration.max_age'] = 12345;
+
+      route = getFxAClientConfig(mocks.config);
+      route.process(mocks.request, mocks.response);
+
+      assert.equal(mocks.config.get.callCount, 5);
+      assert.equal(mocks.response.json.callCount, 1);
+      assert.equal(mocks.response.header.callCount, 1);
+      var args = mocks.response.header.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'Cache-Control');
+      assert.equal(args[1], 'public, max-age=12');
+    },
+
+    'route.process defaults cache-control header to one day': function () {
+      mocks.config['fxa_client_configuration.max_age'] = null;
+
+      route = getFxAClientConfig(mocks.config);
+      route.process(mocks.request, mocks.response);
+
+      assert.equal(mocks.config.get.callCount, 5);
+      assert.equal(mocks.response.json.callCount, 1);
+      assert.equal(mocks.response.header.callCount, 1);
+      var args = mocks.response.header.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'Cache-Control');
+      assert.equal(args[1], 'public, max-age=86400');
+    },
+
+    'route.process omits cache-control header when max_age is zero': function () {
+      mocks.config['fxa_client_configuration.max_age'] = 0;
+
+      route = getFxAClientConfig(mocks.config);
+      route.process(mocks.request, mocks.response);
+
+      assert.equal(mocks.config.get.callCount, 5);
+      assert.equal(mocks.response.json.callCount, 1);
+      assert.equal(mocks.response.header.callCount, 0);
+    }
+  };
+
+  suite['#get /.well-known/fxa-client-configuration - returns a JSON doc with expected values'] = function () {
+    var dfd = this.async(intern.config.asyncTimeout);
+
+    request(serverUrl + '/.well-known/fxa-client-configuration', {},
+    dfd.callback(function (err, res) {
+      assert.equal(res.statusCode, 200);
+      assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
+
+      var maxAge = config.get('fxa_client_configuration.max_age') / 1000;
+      assert.equal(res.headers['cache-control'], 'public, max-age=' + maxAge);
+
+      var result = JSON.parse(res.body);
+
+      assert.equal(Object.keys(result).length, 4);
+      assert.equal(result.auth_server_base_url, config.get('fxaccount_url'));
+      assert.equal(result.oauth_server_base_url, config.get('oauth_url'));
+      assert.equal(result.profile_server_base_url, config.get('profile_url'));
+      assert.equal(result.sync_tokenserver_base_url, config.get('sync_tokenserver_url'));
+    }, dfd.reject.bind(dfd)));
+  };
+
+  registerSuite(suite);
+});


### PR DESCRIPTION
I get periodic requests from client teams to revisit this feature, so here we go - let's add a simple endpoint from which clients can automagically discover all the URLs they need in order to connect to Firefox Accounts and Sync.

The idea is that, given a single URL like "https://accounts.firefox.com", a client can perform discovery to find and/or construct all the other URLs that it needs.  All of the many `about:config` entries that you currently need to tweak to use a custom sync setup, could be replaced by this single URL.

Some previous discussion in https://github.com/mozilla/fxa-content-server/pull/3364.  This version adds an explicit pointer to the sync tokenserver, because let's face it, that's almost certainly where you're trying to get to, and if you're using a custom FxA server, the default Mozilla-hosted sync servers are not going to work for you.

@shane-tomlinson f?; /cc @mhammond @rtilder