### PR TITLE
fix(client): Check for expired sessions whenever the user focuses the settings page.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -151,8 +151,11 @@ define(function (require, exports, module) {
       NotifierMixin.initialize.call(this, options);
 
       // Prevent errors from being displayed by aborted XHR requests.
-      this._boundDisableErrors = _.bind(this.disableErrors, this);
+      this._boundDisableErrors = this.disableErrors.bind(this);
       $(this.window).on('beforeunload', this._boundDisableErrors);
+
+      this._boundCheckAuthorization = this.checkAuthorization.bind(this);
+      $(this.window).on('focus', this._boundCheckAuthorization);
     },
 
     /**
@@ -174,9 +177,7 @@ define(function (require, exports, module) {
       }
 
       return p()
-        .then(function () {
-          return self.checkAuthorization();
-        })
+        .then(self._boundCheckAuthorization)
         .then(function (isUserAuthorized) {
           return isUserAuthorized && self.beforeRender();
         })
@@ -435,7 +436,8 @@ define(function (require, exports, module) {
         $('body').removeClass(this.layoutClassName);
       }
 
-      this.$(this.window).off('beforeunload', this._boundDisableErrors);
+      $(this.window).off('beforeunload', this._boundDisableErrors);
+      $(this.window).off('focus', this._boundCheckAuthorization);
 
       this.destroyChildViews();
 

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -177,7 +177,9 @@ define(function (require, exports, module) {
       }
 
       return p()
-        .then(self._boundCheckAuthorization)
+        .then(function () {
+          return self.checkAuthorization();
+        })
         .then(function (isUserAuthorized) {
           return isUserAuthorized && self.beforeRender();
         })

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -48,7 +48,6 @@ define(function (require, exports, module) {
       template: Template
     });
 
-
     beforeEach(function () {
       translator = new Translator('en-US', ['en-US']);
       translator.set({
@@ -870,6 +869,25 @@ define(function (require, exports, module) {
         it('returns `viewName` passed in on creation', function () {
           assert.equal(view.getViewName(), 'set on creation');
         });
+      });
+    });
+
+    describe('session check', function () {
+      beforeEach(function () {
+        var SessionView = View.extend({
+          checkAuthorization: sinon.spy()
+        });
+
+        view = new SessionView({
+          window: windowMock
+        });
+
+        assert.equal(view.checkAuthorization.callCount, 0);
+        $(windowMock).trigger('focus');
+      });
+
+      it('checkAuthorization is called on window focus', function () {
+        assert.equal(view.checkAuthorization.callCount, 1);
       });
     });
   });

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -240,6 +240,17 @@ define([
   }
 
   /**
+   * Get an fxa-js-client instance
+   *
+   * @returns {Object}
+   */
+  function getFxaClient () {
+    return new FxaClient(AUTH_SERVER_ROOT, {
+      xhr: nodeXMLHttpRequest.XMLHttpRequest
+    });
+  }
+
+  /**
    * Get the value of a query parameter
    *
    * @param {paramName}
@@ -372,6 +383,22 @@ define([
     };
   }
 
+  /**
+   * Open a new tab with the given URL and window name.
+   *
+   * @param {string} [url] defaults to `about:blank`
+   * @param {string} [name] defaults to `_newtab`
+   * @returns {promise} resolves when complete
+   */
+  function openTab(url, name) {
+    return function () {
+      return this.parent
+        .execute(function (url, name) {
+          window.open(url, name);
+        }, [url || 'about:blank', name || '_newtab']);
+    };
+  }
+
   function openWindow (url, name) {
     var newWindow = window.open(url, name);
 
@@ -419,9 +446,7 @@ define([
     if (typeof client === 'string') {
       emailNumber = email;
       email = client;
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
+      client = getFxaClient();
     }
 
     var user = TestHelpers.emailToUser(email);
@@ -439,9 +464,7 @@ define([
     if (typeof client === 'string') {
       password = email;
       email = client;
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
+      client = getFxaClient();
     }
 
     var user = TestHelpers.emailToUser(email);
@@ -482,9 +505,7 @@ define([
   function openUnlockLinkDifferentBrowser(client, email) {
     if (typeof client === 'string') {
       email = client;
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
+      client = getFxaClient();
     }
 
     var user = TestHelpers.emailToUser(email);
@@ -1072,9 +1093,7 @@ define([
   function lockAccount(email, password) {
     return function () {
       return this.parent.then(function () {
-        var client = new FxaClient(AUTH_SERVER_ROOT, {
-          xhr: nodeXMLHttpRequest.XMLHttpRequest
-        });
+        var client = getFxaClient();
 
         return client.accountLock(email, password);
       });
@@ -1227,9 +1246,7 @@ define([
     options = options || {};
     return function () {
       return this.parent.then(function () {
-        var client = new FxaClient(AUTH_SERVER_ROOT, {
-          xhr: nodeXMLHttpRequest.XMLHttpRequest
-        });
+        var client = getFxaClient();
 
         return client.signUp(
             email, password, { preVerified: options.preVerified });
@@ -1411,6 +1428,7 @@ define([
     fillOutSignIn: fillOutSignIn,
     fillOutSignUp: fillOutSignUp,
     getEmailHeaders: getEmailHeaders,
+    getFxaClient: getFxaClient,
     getQueryParamValue: getQueryParamValue,
     getVerificationLink: getVerificationLink,
     imageLoadedByQSA: imageLoadedByQSA,
@@ -1430,6 +1448,7 @@ define([
     openSettingsInNewTab: openSettingsInNewTab,
     openSignInInNewTab: openSignInInNewTab,
     openSignUpInNewTab: openSignUpInNewTab,
+    openTab: openTab,
     openUnlockLinkDifferentBrowser: openUnlockLinkDifferentBrowser,
     openVerificationLinkDifferentBrowser: openVerificationLinkDifferentBrowser,
     openVerificationLinkInNewTab: openVerificationLinkInNewTab,

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -289,6 +289,12 @@ define([
     return function () {
       return this.parent
         .execute(function (selector) {
+          // The only way to reliably cause a Focus Event is to manually create
+          // one. Just clicking or focusing the window does not work if the
+          // Selenium window is not in focus. This does however. BAM! See the
+          // conversation in
+          // https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/1671
+          // The hint is: "... a hack to work around synthesized events not behaving properly"
           var target = selector ? document.querySelector(selector) : window;
           var event = new FocusEvent('focus');
           target.dispatchEvent(event);

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -280,6 +280,23 @@ define([
   }
 
   /**
+   * Force a focus event to fire on an element.
+   *
+   * @param {string} [selector] - selector of element - defaults to the window.
+   * @returns promise - resolves when complete
+   */
+  function focus (selector) {
+    return function () {
+      return this.parent
+        .execute(function (selector) {
+          var target = selector ? document.querySelector(selector) : window;
+          var event = new FocusEvent('focus');
+          target.dispatchEvent(event);
+        }, [ selector ]);
+    };
+  }
+
+  /**
    * Get the email headers
    *
    * @param {string} user - username or email address
@@ -380,22 +397,6 @@ define([
         .then(function (verificationLink) {
           return this.parent.get(require.toUrl(verificationLink));
         });
-    };
-  }
-
-  /**
-   * Open a new tab with the given URL and window name.
-   *
-   * @param {string} [url] defaults to `about:blank`
-   * @param {string} [name] defaults to `_newtab`
-   * @returns {promise} resolves when complete
-   */
-  function openTab(url, name) {
-    return function () {
-      return this.parent
-        .execute(function (url, name) {
-          window.open(url, name);
-        }, [url || 'about:blank', name || '_newtab']);
     };
   }
 
@@ -730,7 +731,6 @@ define([
         .then(click('button[type=submit]'));
     };
   }
-
 
   function fillOutCompleteResetPassword(context, password, vpassword) {
     return getRemote(context)
@@ -1427,6 +1427,7 @@ define([
     fillOutResetPassword: fillOutResetPassword,
     fillOutSignIn: fillOutSignIn,
     fillOutSignUp: fillOutSignUp,
+    focus: focus,
     getEmailHeaders: getEmailHeaders,
     getFxaClient: getFxaClient,
     getQueryParamValue: getQueryParamValue,
@@ -1448,7 +1449,6 @@ define([
     openSettingsInNewTab: openSettingsInNewTab,
     openSignInInNewTab: openSignInInNewTab,
     openSignUpInNewTab: openSignUpInNewTab,
-    openTab: openTab,
     openUnlockLinkDifferentBrowser: openUnlockLinkDifferentBrowser,
     openVerificationLinkDifferentBrowser: openVerificationLinkDifferentBrowser,
     openVerificationLinkInNewTab: openVerificationLinkInNewTab,


### PR DESCRIPTION
Check for expired session tokens any time the user focuses the settings page. This ensures that users who have the settings page open and click disconnect from within about:preferences#sync are signed out and are unable to make account updates.

fixes bz-1265340
fixes mozilla/fxa-bugzilla-mirror#150

@philbooth - mind doing an r?