### PR TITLE
fix(tests): Fix the sync v2 force_auth unverified test.

### DIFF
--- a/tests/functional/sync_v2_force_auth.js
+++ b/tests/functional/sync_v2_force_auth.js
@@ -116,7 +116,9 @@ define([
         .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
 
-        .then(openVerificationLinkDifferentBrowser(email, 1))
+        // There are 1 signup and 2 verification reminder emails before this
+        // email is sent.
+        .then(openVerificationLinkDifferentBrowser(email, 3))
         .then(testElementExists('#fxa-sign-up-complete-header'));
     }
   });


### PR DESCRIPTION
With verification reminder emails, we have to look at the 4th email, not
the 2nd.

Add a Sync v3 version of the test, just to make sure.

fixes #3929