### PR TITLE
fix(teamcity): fail fast if all servers are not up

### DIFF
--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -6,6 +6,18 @@
 
 set -o errexit # exit on first command with non-zero status
 
+# Dump out the `/__version__` data, and if not valid JSON, then
+# exit and abort this test run, to make it clear early on that
+# one or more test servers are not in a testable state.
+function check_version {
+  echo "Checking server $1"
+  local version_info=$(curl -s $1)
+  if ! echo $version_info | python -mjson.tool; then
+    echo "Invalid Server Response. Exiting: ${version_info}"
+    exit 1
+  fi
+}
+
 BASENAME=$(basename $0)
 DIRNAME=$(dirname $0)
 
@@ -20,33 +32,32 @@ source $DIRNAME/$FXA_TEST_NAME
 
 killall -v firefox-bin || echo 'Ok, no firefox-bin.'
 
-# optionally, GIT_COMMIT can be set in the environment to override
-if [ -z "$GIT_COMMIT" ]; then
-  GIT_COMMIT=$(curl -s "$FXA_CONTENT_VERSION" | jsawk  "return this.commit" | perl -pe 's/^OUT: //')
-else
-  echo "Using GIT_COMMIT from the environment $GIT_COMMIT"
-fi
-
 echo "FXA_TEST_NAME       $FXA_TEST_NAME"
 echo "FXA_CONTENT_ROOT    $FXA_CONTENT_ROOT"
 echo "FXA_AUTH_ROOT       $FXA_AUTH_ROOT"
 echo "FXA_OAUTH_APP_ROOT  $FXA_OAUTH_APP_ROOT"
 echo "FXA_FIREFOX_BINARY  $FXA_FIREFOX_BINARY"
-echo "GIT_COMMIT          $GIT_COMMIT"
 
 echo "FXA_CONTENT_VERSION $FXA_CONTENT_VERSION"
 echo "FXA_OAUTH_VERSION   $FXA_OAUTH_VERSION"
 echo "FXA_PROFILE_VERSION $FXA_PROFILE_VERSION"
 echo "FXA_AUTH_VERSION    $FXA_AUTH_VERSION"
 
-
 echo ""
 echo "Server versions:"
-curl -s $FXA_CONTENT_VERSION
-curl -s $FXA_OAUTH_VERSION
-curl -s $FXA_PROFILE_VERSION
-curl -s $FXA_AUTH_VERSION
+check_version $FXA_CONTENT_VERSION
+check_version $FXA_OAUTH_VERSION
+check_version $FXA_PROFILE_VERSION
+check_version $FXA_AUTH_VERSION
 echo ""
+
+# optionally, GIT_COMMIT can be set in the environment to override
+if [ -z "$GIT_COMMIT" ]; then
+  GIT_COMMIT=$(curl -s "$FXA_CONTENT_VERSION" | jsawk  "return this.commit" | perl -pe 's/^OUT: //')
+else
+  echo "Using GIT_COMMIT from the environment."
+fi
+echo "GIT_COMMIT          $GIT_COMMIT"
 
 echo ""
 echo "Selenium version:"


### PR DESCRIPTION
There was a case recently where the auth-server was not running correctly at the start of a test run, leading to hard-to-understand timeouts and 177 other failures, making it look like something was wrong with an unrelated commit to content-server.

These changes are intended to abort the test early with a clearer message on why the test run failed. (It cannot defend against a subsequent failure of one of the test servers, but at least defends against the "table stakes" case that all servers should be up at the beginning of the test run).

r? - @vladikoff 