### PR TITLE
fix(server): Allow FxOS 1.x and Fennec < 25 to sign in/up

### DIFF
--- a/app/scripts/head/startup-styles.js
+++ b/app/scripts/head/startup-styles.js
@@ -76,12 +76,17 @@
     },
 
     initialize: function () {
+      this.addJSStyle();
       this.addTouchEventStyles();
       this.addPasswordRevealerStyles();
       this.addIframeStyles();
       this.addSearchParamStyles();
       this.addFxiOSSyncStyles();
       this.addGetUserMediaStyles();
+    },
+
+    addJSStyle: function () {
+      this._addClass('js');
     },
 
     addTouchEventStyles: function () {

--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -613,11 +613,26 @@ define(function (require, exports, module) {
       // immediately redirected
       const startPage = this._selectStartPage();
       const isSilent = !! startPage;
+
       // pushState must be specified or else no screen transitions occur.
-      this._history.start({ pushState: true, silent: isSilent });
+      this._history.start({ pushState: this._canUseHistoryAPI(), silent: isSilent });
       if (startPage) {
         this._router.navigate(startPage);
       }
+    },
+
+    _canUseHistoryAPI () {
+      // Check whether the history API can be used by calling replaceState
+      // with the current window information. This fixes problems in some
+      // environments like the Firefox OS 1.x trusted UI where the history
+      // API is available, but can't be used.
+      const win = this._window;
+      try {
+        win.history.replaceState({}, win.document.title, win.location.href);
+      } catch (e) {
+        return false;
+      }
+      return true;
     },
 
     _getStorageInstance () {

--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -39,6 +39,10 @@ body {
 
 noscript {
   top: 10%;
+
+  .js & {
+    display: none;
+  }
 }
 
 .browsehappy {

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -105,10 +105,6 @@
     opacity: 1;
   }
 
-  .js & {
-    display: none;
-  }
-
   .lt-ie10 & {
     display: block;
   }

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -49,7 +49,8 @@ define(function (require, exports, module) {
     this.history = {
       back: function () {
         self.history.back.called = true;
-      }
+      },
+      replaceState: function () {}
     };
 
     this.navigator = {

--- a/app/tests/spec/head/startup-styles.js
+++ b/app/tests/spec/head/startup-styles.js
@@ -28,6 +28,13 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('addJSStyle', function () {
+      it('adds `js`', function () {
+        startupStyles.addJSStyle();
+        assert.isTrue(/js/.test(startupStyles.getClassName()));
+      });
+    });
+
     describe('addTouchEventStyles', function () {
       it('adds `touch` if the UA supports touch events', function () {
         sinon.stub(environment, 'hasTouchEvents', function () {

--- a/server/lib/csp/blocking.js
+++ b/server/lib/csp/blocking.js
@@ -7,11 +7,42 @@
 // exception for the /tests/index.html path, which are the frontend unit
 // tests.
 
+var uaParser = require('node-uap');
 var url = require('url');
 
 function getOrigin(link) {
   var parsed = url.parse(link);
   return parsed.protocol + '//' + parsed.host;
+}
+
+
+function isFxOS1x(agent) {
+  // If no os.major, assume FxOS1, it could be the simulator, but we don't
+  // really know at this point.
+  return agent.os.family === 'Firefox OS' &&
+         (! agent.os.major || parseInt(agent.os.major, 10) === 1);
+}
+
+function isFennecLessThan24(agent) {
+  return agent.os.family === 'Android' &&
+         agent.ua.family === 'Firefox Mobile' &&
+         (parseInt(agent.ua.major, 10) < 24);
+}
+
+function agentRequiresConnectSrcCopiedToDefaultSrc (uaHeader) {
+  if (! uaHeader) {
+    return false;
+  }
+
+  var agent = uaParser.parse(uaHeader);
+
+  // FxOS < 2.0 and Fennec < 24 do not recognize connectSrc, only xhrSrc.
+  // Helmet will convert connectSrc to xhrSrc for Firefox
+  // desktop, but not FxOS and Fennec. Add the auth,
+  // OAuth, and profile server URLs to defaultSrc so that users
+  // can still signin/signup for Marketplace on FxOS and in general on Fennec.
+  return isFxOS1x(agent) ||
+         isFennecLessThan24(agent);
 }
 
 /**
@@ -35,7 +66,7 @@ module.exports = function (config) {
     return target;
   }
 
-  return {
+  var rules = {
     directives: {
       connectSrc: [
         SELF,
@@ -44,7 +75,14 @@ module.exports = function (config) {
         config.get('profile_url'),
         config.get('marketing_email.api_url')
       ],
-      defaultSrc: [SELF],
+      defaultSrc: function (req, res) {
+        var userAgent = req.headers['user-agent'];
+        if (agentRequiresConnectSrcCopiedToDefaultSrc(userAgent)) {
+          return [].concat(rules.directives.connectSrc);
+        }
+
+        return [SELF];
+      },
       fontSrc: addCdnRuleIfRequired([
         SELF
       ]),
@@ -70,4 +108,9 @@ module.exports = function (config) {
     },
     reportOnly: false
   };
+
+  return rules;
 };
+
+module.exports.agentRequiresConnectSrcCopiedToDefaultSrc =
+  agentRequiresConnectSrcCopiedToDefaultSrc;

--- a/server/lib/csp/blocking.js
+++ b/server/lib/csp/blocking.js
@@ -26,7 +26,9 @@ function isFxOS1x(agent) {
 function isFennecLessThan24(agent) {
   return agent.os.family === 'Android' &&
          agent.ua.family === 'Firefox Mobile' &&
-         (parseInt(agent.ua.major, 10) < 24);
+         // Fennec 25 is the first version w/ the CSP 1.0 parser, see
+         // https://bugzilla.mozilla.org/show_bug.cgi?id=858780
+         (parseInt(agent.ua.major, 10) < 25);
 }
 
 function agentRequiresConnectSrcCopiedToDefaultSrc (uaHeader) {

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -48,7 +48,6 @@
             <p class="browsehappy">{{#t}}You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.{{/t}}</p>
         <![endif]-->
 
-        <!-- this will be overwritten if JS is enabled -->
         <!--[if !(IE) | (gte IE 10)]><!-->
         <noscript>
           {{#t}}Firefox Accounts requires JavaScript.{{/t}}

--- a/tests/server/csp.js
+++ b/tests/server/csp.js
@@ -8,7 +8,8 @@ define([
   'intern!object',
   'intern/chai!assert',
   'intern/dojo/node!../../server/lib/csp',
-], function (registerSuite, assert, csp) {
+  'intern/dojo/node!../../server/lib/csp/blocking',
+], function (registerSuite, assert, csp, blockingRules) {
 
   var suite = {
     name: 'csp'
@@ -24,6 +25,43 @@ define([
     assert.isTrue(csp.isCspRequired({ method: 'GET', path: '/404.html' }));
     assert.isTrue(csp.isCspRequired({ method: 'GET', path: '/' }));
     assert.isTrue(csp.isCspRequired({ method: 'GET', path: '/confirm' }));
+  };
+
+  suite['agentRequiresConnectSrcCopiedToDefaultSrc'] = function () {
+    var agentRequiresConnectSrcCopiedToDefaultSrc =
+      blockingRules.agentRequiresConnectSrcCopiedToDefaultSrc;
+
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc());
+
+    // FxOS 1.3
+    assert.isTrue(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Mobile; rv:28.0) Gecko/28.0 Firefox/28.0'));
+    // FxOS 1.4
+    assert.isTrue(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Mobile; rv:30.0) Gecko/30.0 Firefox/30.0'));
+    // FxOS 2.0
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Mobile; rv:32.0) Gecko/32.0 Firefox/32.0'));
+
+    // Fennec 23
+    assert.isTrue(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Android; Mobile; rv:23.0) Gecko/23.0 Firefox/23.0'));
+    // Fennec 24
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Android; Mobile; rv:24.0) Gecko/24.0 Firefox/24.0'));
+
+    // FxDesktop on a Mac
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:10.0) Gecko/20100101 Firefox/10.0'));
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:47.0) Gecko/20100101 Firefox/47.0'));
+
+    // FxDesktop on Linux
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0'));
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (X11; Linux x86_64; rv:47.0) Gecko/20100101 Firefox/47.0'));
+
+    // FxDesktop on Windows
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Windows NT 7.0; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0'));
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Windows NT 7.0; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0'));
+
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Windows NT 7.0; rv:10.0) Gecko/20100101 Firefox/10.0'));
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Windows NT 7.0; rv:47.0) Gecko/20100101 Firefox/47.0'));
+
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Windows NT 7.0; WOW64; rv:10.0) Gecko/20100101 Firefox/10.0'));
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Windows NT 7.0; WOW64; rv:47.0) Gecko/20100101 Firefox/47.0'));
   };
 
   registerSuite(suite);

--- a/tests/server/csp.js
+++ b/tests/server/csp.js
@@ -40,12 +40,14 @@ define([
     // FxOS 2.0
     assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Mobile; rv:32.0) Gecko/32.0 Firefox/32.0'));
 
-    // Fennec 23
-    assert.isTrue(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Android; Mobile; rv:23.0) Gecko/23.0 Firefox/23.0'));
     // Fennec 24
-    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Android; Mobile; rv:24.0) Gecko/24.0 Firefox/24.0'));
+    assert.isTrue(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Android; Mobile; rv:24.0) Gecko/24.0 Firefox/24.0'));
+    // Fennec 25 (first version w/ CSP 1.0 - see
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=858780)
+    assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Android; Mobile; rv:25.0) Gecko/25.0 Firefox/25.0'));
 
-    // FxDesktop on a Mac
+    // FxDesktop on a Mac - Helmet takes care of all
+    // Fx Desktop versions for us.
     assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:10.0) Gecko/20100101 Firefox/10.0'));
     assert.isFalse(agentRequiresConnectSrcCopiedToDefaultSrc('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:47.0) Gecko/20100101 Firefox/47.0'));
 


### PR DESCRIPTION
FxOS 1.x and Fennec < 25 does not recognize the connectSrc CSP declaration,
only xhrSrc. Helmet will convert connectSrc to xhrSrc for Firefox desktop,
but not Firefox Mobile and FxOS. Add the auth, OAuth, and profile server
URLs to defaultSrc so that users can still signin/signup for Marketplace.

FxOS trusted UI does not support actually calling history.pushState even though
it's reported as available. Check to ensure history.pushState/replaceState can
be used before initializing Backbone's history manager.

The <noscript> tag was not being properly hidden in FxOS. Add a `js` class
to the HTML tag, and hide the noscript element with CSS if `js` is declared.



----------------------------

cc @vladikoff and @rfk.
I'm not happy with this because it adds the auth server, oauth server, and profile server URLs to the `defaultSrc`. That's a lot of servers to fall back to for all of the other directives. The newest helmet allows [dynamic directives](https://github.com/helmetjs/csp/blob/50d8dd44bbea9195ad1bf0396a0517cfd6c5e170/index.js#L48) based off of the request, so maybe we can only set these extra values IFF FxOS 1.3. Or, I could file a PR with helmet to convert connectSrc to xhrSrc for [Firefox Mobile as well as Firefox Desktop](https://github.com/helmetjs/csp/blob/50d8dd44bbea9195ad1bf0396a0517cfd6c5e170/lib/transform-directives-for-browser.js#L5).