### PR TITLE
feat(tests): Add more functional tests for sign in unverified flow.

### DIFF
--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -87,7 +87,20 @@ define([
       return this.remote
         .then(setupTest(this, false))
 
-        .then(testElementExists('#fxa-confirm-header'));
+        .then(testElementExists('#fxa-confirm-header'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+
+        // email 0 - initial sign up email
+        // email 1 - sign in w/ unverified address email
+        // email 2 - "You have verified your Firefox Account"
+        .then(openVerificationLinkInNewTab(this, email, 1))
+        .switchToWindow('newwindow')
+          .then(testElementExists('#fxa-sign-up-complete-header'))
+          .closeCurrentWindow()
+        .switchToWindow('')
+
+        .then(testElementExists('#fxa-sign-up-complete-header'));
     }
   });
 });

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -36,7 +36,10 @@ define([
       .then(createUser(email, PASSWORD, { preVerified: preVerified }))
       .then(openPage(context, options.pageUrl || PAGE_URL, '.email'))
       .then(respondToWebChannelMessage(context, 'fxaccounts:can_link_account', { ok: options.canLinkAccountResponse !== false }))
-      .then(fillOutSignIn(context, email, PASSWORD));
+      // delay for the webchannel message
+      .sleep(500)
+      .then(fillOutSignIn(context, email, PASSWORD))
+      .then(testIsBrowserNotified(context, 'fxaccounts:can_link_account'));
   });
 
   registerSuite({
@@ -55,7 +58,6 @@ define([
       return this.remote
         .then(setupTest(this, true))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
         .then(clearBrowserNotifications())
         .then(testElementExists('#fxa-confirm-signin-header'))
@@ -74,7 +76,6 @@ define([
       return this.remote
         .then(setupTest(this, true))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
         .then(clearBrowserNotifications())
         .then(testElementExists('#fxa-confirm-signin-header'))
@@ -88,7 +89,6 @@ define([
     'unverified': function () {
       return this.remote
         .then(setupTest(this, false))
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
         .then(clearBrowserNotifications())
 
@@ -111,7 +111,6 @@ define([
       return this.remote
         .then(setupTest(this, true, { canLinkAccountResponse: false }))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
         .then(noSuchBrowserNotification(this, 'fxaccounts:login'))
 
         // user should not transition to the next screen

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -79,7 +79,19 @@ define([
 
     'unverified': function () {
       return this.remote
-        .then(setupTest(this, false));
+        .then(setupTest(this, false))
+
+        // email 0 - initial sign up email
+        // email 1 - sign in w/ unverified address email
+        // email 2 - "You have verified your Firefox Account"
+        .then(openVerificationLinkInNewTab(this, email, 1))
+        .switchToWindow('newwindow')
+          .then(testElementExists('#fxa-sign-up-complete-header'))
+          .closeCurrentWindow()
+        .switchToWindow('')
+
+        // about:accounts will take over post-verification, no transition
+        .then(noPageTransition('#fxa-confirm-header'));
     },
 
     'signup link is enabled': function () {


### PR DESCRIPTION
We were lacking a lot of tests for the sign in with an unverified user flow
and did not realize that two emails were being sent in this case, the
first email is the "confirm signin" email, the second "confirm signup".

This ensures things work as expected.

fixes #3890

@vladikoff - mind giving a review of this?