### PR TITLE
fix(client): always send a service param to /certificate/sign

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
     FX_IOS_V2_CONTEXT: 'fx_ios_v2',
     IFRAME_CONTEXT: 'iframe',
 
+    CONTENT_SERVER_SERVICE: 'content-server',
     SYNC_SERVICE: 'sync',
 
     SYNC11_MIGRATION: 'sync11',

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -541,7 +541,8 @@ define(function (require, exports, module) {
                 return client.certificateSign(
                   sessionToken,
                   pubkey,
-                  duration);
+                  duration,
+                  { service: Constants.CONTENT_SERVER_SERVICE });
               });
     },
 

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -1293,6 +1293,13 @@ define(function (require, exports, module) {
         return client.certificateSign(publicKey, duration)
           .then(function (cert) {
             assert.ok(cert);
+
+            assert.equal(realClient.certificateSign.callCount, 1);
+            var args = realClient.certificateSign.args[0];
+            assert.lengthOf(args, 4);
+            assert.equal(args[1], publicKey);
+            assert.equal(args[2], duration);
+            assert.deepEqual(args[3], { service: 'content-server' });
           });
       });
     });

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
     "fxa-checkbox": "mozilla/fxa-checkbox#7f856afffd394a144f718e28e6fb79092d6ccddd",
     "fxa-content-server-l10n": "https://github.com/mozilla/fxa-content-server-l10n.git",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.43",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.44",
     "fxa-password-strength-checker": "https://github.com/mozilla/fxa-password-strength-checker.git#d73b3ade374607e2749ee375301b0a168008b16f",
     "html5shiv": "3.7.2",
     "JavaScript-MD5": "1.1.0",


### PR DESCRIPTION
This fixes #3933, setting a `service` query param on requests to `/certificate/sign` so that the auth server can accurately identify requests that come from Sync, in order to create placeholder device records for them.

It relies on https://github.com/mozilla/fxa-js-client/pull/205/commits/d68dd76dc0e666e0f84ba1d0013259cae9d1a95e, hence the dependency bump.

@vbudhram, r?