### PR TITLE
fix(client): Hide all visible passwords on form submit.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -670,22 +670,37 @@ define(function (require, exports, module) {
     /**
      * Safely focus an element
      */
-    focus: function (which) {
+    focus (which) {
       try {
-        var focusEl = this.$(which);
+        const focusEl = this.$(which);
         // place the cursor at the end of the input when the
         // element is focused.
+        var self = this;
         focusEl.one('focus', function () {
-          try {
-            this.selectionStart = this.selectionEnd = this.value.length;
-          } catch (e) {
-            // This can blow up on password fields in Chrome. Drop the error on
-            // the ground, for whatever reason, it still behaves as we expect.
-          }
+          self.placeCursorAt(this, this.value.length);
         });
         focusEl.get(0).focus();
       } catch (e) {
         // IE can blow up if the element is not visible.
+      }
+    },
+
+    /**
+     * Place the cursor at the given position within the input element
+     *
+     * @param {selector | element} which
+     * @param {number} selectionStart - defaults to 0.
+     * @param {number} selectionEnd - defaults to selectionStart.
+     */
+    placeCursorAt (which, selectionStart = 0, selectionEnd = selectionStart) {
+      const el = $(which).get(0);
+
+      try {
+        el.selectionStart = selectionStart;
+        el.selectionEnd = selectionEnd;
+      } catch (e) {
+        // This can blow up on password fields in Chrome. Drop the error on
+        // the ground, for whatever reason, it still behaves as we expect.
       }
     },
 

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -199,6 +199,10 @@ define(function (require, exports, module) {
 
     _submitForm: notifyDelayedRequest(showButtonProgressIndicator(function () {
       var self = this;
+      // sets all password fields to type=password
+      self.$el.find('.password').each(function (i, el) {
+        el.type = 'password';
+      });
       return p()
           .then(_.bind(self.beforeSubmit, self))
           .then(function (shouldSubmit) {

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -172,6 +172,8 @@ define(function (require, exports, module) {
         event.stopImmediatePropagation();
       }
 
+      this.trigger('submitStart');
+
       return p()
         .then(function () {
           if (self.isHalted()) {
@@ -199,10 +201,6 @@ define(function (require, exports, module) {
 
     _submitForm: notifyDelayedRequest(showButtonProgressIndicator(function () {
       var self = this;
-      // sets all password fields to type=password
-      self.$el.find('.password').each(function (i, el) {
-        el.type = 'password';
-      });
       return p()
           .then(_.bind(self.beforeSubmit, self))
           .then(function (shouldSubmit) {

--- a/app/tests/lib/helpers.js
+++ b/app/tests/lib/helpers.js
@@ -11,6 +11,23 @@ define(function (require, exports, module) {
   var ProfileMock = require('../mocks/profile.js');
   var sinon = require('sinon');
 
+  function noOp () {}
+
+  function ifDocumentFocused(callback, done = noOp) {
+    if (document.hasFocus && document.hasFocus()) {
+      callback();
+    } else {
+      const message =
+          'Cannot check for focus - document does not have focus.\n' +
+          'If this is in Travis-CI, Sauce Labs, or Opera, this is expected.\n' +
+          'Otherwise, try focusing the test document instead of \n' +
+          'another window or dev tools.';
+
+      console.warn(message);
+      done();
+    }
+  }
+
   function requiresFocus(callback, done) {
     // Give the document focus
     window.focus();
@@ -20,20 +37,7 @@ define(function (require, exports, module) {
       document.activeElement.blur();
     }
 
-    if (document.hasFocus && document.hasFocus()) {
-      callback();
-    } else {
-      var message =
-          'Cannot check for focus - document does not have focus.\n' +
-          'If this is in Travis-CI, Sauce Labs, or Opera, this is expected.\n' +
-          'Otherwise, try focusing the test document instead of \n' +
-          'another window or dev tools.';
-
-      console.warn(message);
-      if (done) {
-        done();
-      }
-    }
+    ifDocumentFocused(callback, done);
   }
 
   function addFxaClientSpy(fxaClient) {
@@ -164,6 +168,7 @@ define(function (require, exports, module) {
     createUid: createUid,
     emailToUser: emailToUser,
     getValueLabel: getValueLabel,
+    ifDocumentFocused: ifDocumentFocused,
     indexOfEvent: indexOfEvent,
     isErrorLogged: isErrorLogged,
     isEventLogged: isEventLogged,

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -361,7 +361,7 @@ define(function (require, exports, module) {
       it('focuses descendent element containing `autofocus` if html has `no-touch` class', function (done) {
         requiresFocus(function () {
           $('html').addClass('no-touch');
-          // wekbit fails unless focusing another element first.
+          // webkit fails unless focusing another element first.
           $('#otherElement').focus();
 
           var handlerCalled = false;
@@ -592,7 +592,7 @@ define(function (require, exports, module) {
     describe('focus', () => {
       it('focuses an element, sets the cursor position', (done) => {
         requiresFocus(() => {
-          // wekbit fails unless focusing another element first.
+          // webkit fails unless focusing another element first.
           $('#otherElement').focus();
 
           const elText = 'some text';

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -589,17 +589,51 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('focus', function () {
-      it('focuses an element', function (done) {
-        requiresFocus(function () {
+    describe('focus', () => {
+      it('focuses an element, sets the cursor position', (done) => {
+        requiresFocus(() => {
           // wekbit fails unless focusing another element first.
           $('#otherElement').focus();
 
-          view.$('#focusMe').one('focus', function () {
+          const elText = 'some text';
+          const $focusEl = view.$('#focusMe').val(elText);
+
+          // Use setTimeout because the selection is set in a `focus` handler
+          // and this `focus` handler is run first.
+          view.$('#focusMe').one('focus', () => setTimeout(() => {
+            const focusEl = $focusEl.get(0);
+            assert.equal(focusEl.selectionStart, elText.length);
+            assert.equal(focusEl.selectionEnd, elText.length);
             done();
-          });
+          }, 0));
+
           view.focus('#focusMe');
         }, done);
+      });
+    });
+
+    describe('placeCursorAt', () => {
+      const elText = 'some text';
+      let $focusEl;
+      let focusEl;
+
+      beforeEach(() => {
+        $focusEl = view.$('#focusMe').val(elText);
+        focusEl = $focusEl.get(0);
+      });
+
+      it('places the cursor at the specified position if only start given', () => {
+        view.placeCursorAt('#focusMe', elText.length);
+
+        assert.equal(focusEl.selectionStart, elText.length);
+        assert.equal(focusEl.selectionEnd, elText.length);
+      });
+
+      it('places the cursor at the specified selection if both given', () => {
+        view.placeCursorAt('#focusMe', elText.length - 2, elText.length);
+
+        assert.equal(focusEl.selectionStart, elText.length - 2);
+        assert.equal(focusEl.selectionEnd, elText.length);
       });
     });
 

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -170,6 +170,20 @@ define(function (require, exports, module) {
         return testFormSubmitted();
       });
 
+      it('sets all password fields to type `password`', function () {
+        view.$('.password').each(function (i, el) {
+          el.type = 'text';
+        });
+        view.formIsValid = true;
+        view.enableSubmitIfValid();
+        return view.validateAndSubmit()
+                  .then(function () {
+                    self.$('.password').each(function (i, el) {
+                      assert.equal(el.type, 'password', 'password fields were not set properly');
+                    });
+                  });
+      });
+
       it('shows validation errors if isValid returns false', function () {
         view.formIsValid = false;
         view.enableSubmitIfValid();

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -164,24 +164,16 @@ define(function (require, exports, module) {
     });
 
     describe('validateAndSubmit', function () {
+      it('triggers a `submitStart` event', (done) => {
+        view.on('submitStart', () => done());
+
+        view.validateAndSubmit();
+      });
+
       it('submits form if isValid returns true', function () {
         view.formIsValid = true;
         view.enableSubmitIfValid();
         return testFormSubmitted();
-      });
-
-      it('sets all password fields to type `password`', function () {
-        view.$('.password').each(function (i, el) {
-          el.type = 'text';
-        });
-        view.formIsValid = true;
-        view.enableSubmitIfValid();
-        return view.validateAndSubmit()
-                  .then(function () {
-                    self.$('.password').each(function (i, el) {
-                      assert.equal(el.type, 'password', 'password fields were not set properly');
-                    });
-                  });
       });
 
       it('shows validation errors if isValid returns false', function () {


### PR DESCRIPTION
This builds on @TDA's work.

Before the form is submit, convert all visible passwords from
[type=text] to [type=password] so that they are not saved as
form data.

In the process, I noticed two problems that are fixed:

* The cursor was not being correctly replaced to its original position
   once a password field was converted.
* If `setPasswordVisibility` was called programatically to toggle the
   state of the password field, the corresponding "Show" checkbox was
   not kept in sync.

fixes #3799