### PR TITLE
fix(client): Help the password manager save the username on pw reset/change.

### DIFF
--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -46,6 +46,12 @@
       </p>
       {{/showSyncWarning}}
 
+      <!-- hidden email field is to allow Fx password manager
+           to correctly save the updated password. Without it,
+           the password manager tries to save the old password
+           as the username. -->
+      <input type="email" value="{{email}}" class="hidden" />
+
       <div class="input-row password-row">
         <label class="label-helper"></label>
         <input type="password" class="password check-password tooltip-below" id="password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" required autofocus />

--- a/app/scripts/templates/settings/change_password.mustache
+++ b/app/scripts/templates/settings/change_password.mustache
@@ -14,6 +14,11 @@
       <p>
         {{#t}}Once you're finished, use your new password to sign in on all of your devices.{{/t}}
       </p>
+      <!-- hidden email field is to allow Fx password manager
+           to correctly save the updated password. Without it,
+           the password manager saves the old_password
+           as the username. -->
+      <input type="email" value="{{email}}" class="hidden" />
       <div class="input-row password-row">
         <label class="label-helper"></label>
         <input type="password" class="password" id="old_password" placeholder="{{#t}}Old password{{/t}}" required pattern=".{8,}" autofocus />

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -73,6 +73,7 @@ define(function (require, exports, module) {
 
       // damaged and expired links have special messages.
       return {
+        email: verificationInfo.get('email'),
         isLinkDamaged: ! doesLinkValidate,
         isLinkExpired: isLinkExpired,
         isLinkValid: doesLinkValidate && ! isLinkExpired,

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -24,6 +24,13 @@ define(function (require, exports, module) {
     className: 'change-password',
     viewName: 'settings.change-password',
 
+    context () {
+      const account = this.getSignedInAccount();
+      return {
+        email: account.get('email')
+      };
+    },
+
     submit: function () {
       var self = this;
       var account = self.getSignedInAccount();

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -101,6 +101,7 @@ define(function (require, exports, module) {
           .then(function () {
             testEventNotLogged('complete_reset_password.link_expired');
             assert.ok(view.$('#fxa-complete-reset-password-header').length);
+            assert.equal(view.$('input[type=email]').val(), EMAIL);
           });
       });
 

--- a/app/tests/spec/views/settings/change_password.js
+++ b/app/tests/spec/views/settings/change_password.js
@@ -21,6 +21,8 @@ define(function (require, exports, module) {
   var assert = chai.assert;
   var wrapAssertion = TestHelpers.wrapAssertion;
 
+  const EMAIL = 'a@a.com';
+
   describe('views/settings/change_password', function () {
     var account;
     var broker;
@@ -59,7 +61,7 @@ define(function (require, exports, module) {
     describe('with session', function () {
       beforeEach(function () {
         account = user.initAccount({
-          email: 'a@a.com',
+          email: EMAIL,
           sessionToken: 'abc123',
           verified: true
         });
@@ -84,6 +86,7 @@ define(function (require, exports, module) {
           assert.ok($('#new_password').length);
           assert.isTrue($('.input-help').length === 2);
           assert.isTrue($('.input-help-forgot-pw').length === 1);
+          assert.equal(view.$('input[type=email]').val(), EMAIL);
         });
       });
 


### PR DESCRIPTION
Add a hidden input[type=email] that the Firefox password manager uses to
save the username on password reset and change.

Not a full fix for bz1288721. Username is only correctly saved if first password is a password field before submit occurs.

ref bz1288721
issue #3799