### PR TITLE
fix(client): Only show passwords while depressing the "show" button.

### DIFF
--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -37,6 +37,7 @@
     <div class="input-row password-row">
       <input type="password" class="password" id="password" pattern=".{8,}" required />
       <input id="show-password" type="checkbox" class="show-password" aria-controls="password" data-novalue />
+      <label for="show-password" class="show-password-label">Show</label>
       <input type="password" id="old_password" placeholder="Old password" required pattern=".{8,}" />
       <input type="password" id="new_password" placeholder="New password" required pattern=".{8,}" />
       <div class="input-help input-help-focused input-help-signup">Must be at least 8 characters</div>

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -5,7 +5,6 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var $ = require('jquery');
   var Account = require('models/account');
   var AuthErrors = require('lib/auth-errors');
   var Backbone = require('backbone');
@@ -521,27 +520,6 @@ define(function (require, exports, module) {
         assert.isTrue(view.navigate.calledWith('reset_password', {
           forceEmail: email
         }));
-      });
-    });
-
-    describe('password visibility', function () {
-      beforeEach(function () {
-        isEmailRegistered = true;
-
-        return view.render()
-          .then(function () {
-            $('#container').html(view.el);
-          });
-      });
-
-      describe('clicking the show button', function () {
-        it('toggles the password visibility state', function () {
-          view.$('.show-password').click();
-          assert.equal(view.$('#password').attr('type'), 'text');
-
-          view.$('#show-password').click();
-          assert.equal(view.$('#password').attr('type'), 'password');
-        });
       });
     });
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -799,6 +799,27 @@ define([
     startListening();
   }
 
+  function mouseevent(eventType) {
+    return function (selector) {
+      return function () {
+        return this.parent
+          .execute(function (selector, eventType) {
+            var target = selector ? document.querySelector(selector) : window;
+            var event = new MouseEvent(eventType, {
+              bubbles: true,
+              cancelable: true,
+              view: window
+            });
+            target.dispatchEvent(event);
+          }, [ selector, eventType ]);
+      };
+    };
+  }
+
+  var mousedown = mouseevent('mousedown');
+  var mouseout = mouseevent('mouseout');
+  var mouseup = mouseevent('mouseup');
+
   function respondToWebChannelMessage(context, expectedCommand, response) {
     return function () {
       return getRemote(context)
@@ -1326,7 +1347,7 @@ define([
     return function () {
       return this.parent
         .findByCssSelector(selector)
-          .getAtribute(attributeName)
+          .getAttribute(attributeName)
           .then(function (attributeValue) {
             assert[assertion](attributeValue, value);
           })
@@ -1406,6 +1427,10 @@ define([
     getVerificationLink: getVerificationLink,
     imageLoadedByQSA: imageLoadedByQSA,
     listenForWebChannelMessage: listenForWebChannelMessage,
+    mousedown: mousedown,
+    mouseevent: mouseevent,
+    mouseout: mouseout,
+    mouseup: mouseup,
     noEmailExpected: noEmailExpected,
     noPageTransition: noPageTransition,
     noSuchBrowserNotification: noSuchBrowserNotification,

--- a/tests/functional/password_visibility.js
+++ b/tests/functional/password_visibility.js
@@ -5,13 +5,18 @@
 define([
   'intern',
   'intern!object',
-  'intern/chai!assert',
-  'require',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, FunctionalHelpers) {
+], function (intern, registerSuite, FunctionalHelpers) {
   var config = intern.config;
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
-  var SYNC_SIGNIN_URL = config.fxaContentRoot + 'signin?service=sync&context=fx_desktop_v1';
+
+  var thenify = FunctionalHelpers.thenify;
+
+  var mousedown = FunctionalHelpers.mousedown;
+  var mouseup = FunctionalHelpers.mouseup;
+  var openPage = thenify(FunctionalHelpers.openPage);
+  var testAttributeEquals = FunctionalHelpers.testAttributeEquals;
+  var type = FunctionalHelpers.type;
 
   registerSuite({
     name: 'password visibility',
@@ -20,98 +25,22 @@ define([
       return FunctionalHelpers.clearBrowserState(this);
     },
 
-    afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
-    },
-
-    'toggle show password for normal RP': function () {
-      this.remote.get(require.toUrl(SIGNIN_URL))
-        .findByCssSelector('#fxa-signin-header')
-        .end()
-
-        .findByCssSelector('#password')
-          .click()
-          .type('password')
-        .end()
+    'show password ended with mouseup': function () {
+      return this.remote
+        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(type('#password', 'password'))
 
         // turn it into a text field
-        .findByCssSelector('.show-password-label')
-          .click()
-        .end()
+        .then(mousedown('.show-password-label'))
 
-        .findByCssSelector('#password')
-          .getAttribute('type')
-          .then(function (typeValue) {
-            assert.equal(typeValue, 'text');
-          })
-
-          .getAttribute('autocomplete')
-          .then(function (autocompleteValue) {
-            assert.equal(autocompleteValue, 'off');
-          })
-        .end()
+        .then(testAttributeEquals('#password', 'type', 'text'))
+        .then(testAttributeEquals('#password', 'autocomplete', 'off'))
 
         // turn it back into a password field
-        .findByCssSelector('.show-password-label')
-          .click()
-        .end()
+        .then(mouseup('.show-password-label'))
 
-        .findByCssSelector('#password')
-          .getAttribute('type')
-          .then(function (typeValue) {
-            assert.equal(typeValue, 'password');
-          })
-
-          .getAttribute('autocomplete')
-          .then(function (autocompleteValue) {
-            assert.isNull(autocompleteValue);
-          })
-        .end();
-    },
-
-    'toggle show password for Sync': function () {
-      this.remote.get(require.toUrl(SYNC_SIGNIN_URL))
-        .findByCssSelector('#fxa-signin-header')
-        .end()
-
-        .findByCssSelector('#password')
-          .click()
-          .type('password')
-        .end()
-
-        // turn it into a text field
-        .findByCssSelector('.show-password-label')
-          .click()
-        .end()
-
-        .findByCssSelector('#password')
-          .getAttribute('type')
-          .then(function (typeValue) {
-            assert.equal(typeValue, 'text');
-          })
-
-          .getAttribute('autocomplete')
-          .then(function (autocompleteValue) {
-            assert.equal(autocompleteValue, 'off');
-          })
-        .end()
-
-        // turn it back into a password field
-        .findByCssSelector('.show-password-label')
-          .click()
-        .end()
-
-        .findByCssSelector('#password')
-          .getAttribute('type')
-          .then(function (typeValue) {
-            assert.equal(typeValue, 'password');
-          })
-
-          .getAttribute('autocomplete')
-          .then(function (autocompleteValue) {
-            assert.equal(autocompleteValue, 'off');
-          })
-        .end();
+        .then(testAttributeEquals('#password', 'type', 'password'))
+        .then(testAttributeEquals('#password', 'autocomplete', null));
     }
   });
 });


### PR DESCRIPTION
This builds on #3977 by only showing the password field if the show button is depressed.