### PR TITLE
feat(metrics): Add a `<view_name>.back` event when the user clicks a back link

### DIFF
--- a/app/scripts/views/mixins/back-mixin.js
+++ b/app/scripts/views/mixins/back-mixin.js
@@ -52,6 +52,8 @@ define(function (require, exports, module) {
      * @param {object} [nextViewData] - data to send to the next(last) view.
      */
     back: function (nextViewData) {
+      this.logViewEvent('back');
+
       this.notifier.trigger('navigate-back', {
         nextViewData: nextViewData
       });

--- a/app/tests/spec/views/mixins/back-mixin.js
+++ b/app/tests/spec/views/mixins/back-mixin.js
@@ -29,7 +29,8 @@ define(function (require, exports, module) {
       notifier = new Notifier();
 
       view = new View({
-        notifier: notifier
+        notifier: notifier,
+        screenName: 'back-screen'
       });
 
       return view.render();
@@ -47,6 +48,17 @@ define(function (require, exports, module) {
               nextViewField: 'value'
             }
           }));
+      });
+
+      it('logs a `back` event on the view', () => {
+        sinon.spy(view, 'logViewEvent');
+
+        assert.isFalse(view.logViewEvent.called);
+
+        view.back();
+
+        assert.isTrue(view.logViewEvent.calledOnce);
+        assert.isTrue(view.logViewEvent.calledWith('back'));
       });
     });
 


### PR DESCRIPTION
fixes #3979

@philbooth - mind an r?

Here's what the event stream looks like if the user clicks "back" from the confirm-signin screen:

![screen shot 2016-07-26 at 13 37 20](https://cloud.githubusercontent.com/assets/848085/17138022/340bf3f6-5336-11e6-80a9-4ac997178bac.png)
