### PR TITLE
fix(server): Ensure CSS for the TOS/PP agreements is served from the CDN.

### DIFF
--- a/server/lib/routes/get-terms-privacy.js
+++ b/server/lib/routes/get-terms-privacy.js
@@ -28,6 +28,7 @@ var templates = require('../legal-templates');
 module.exports = function verRoute (i18n) {
   var DEFAULT_LANG = config.get('i18n.defaultLang');
   var DEFAULT_LEGAL_LANG = config.get('i18n.defaultLegalLang');
+  var STATIC_RESOURCE_URL = config.get('static_resource_url');
 
   var getTemplate = templates(i18n, PAGE_TEMPLATE_DIRECTORY);
 
@@ -63,7 +64,11 @@ module.exports = function verRoute (i18n) {
 
         res.format({
           'text/html': function () {
-            var context = {};
+            var context = {
+              // Note that staticResourceUrl is added to templates as a
+              // build step
+              staticResourceUrl: STATIC_RESOURCE_URL
+            };
             context[page] = template;
 
             // the HTML page removes the header to allow embedding.

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -242,11 +242,16 @@ define([
           assert.equal(res.statusCode, 200);
 
           var headers = res.headers;
-          var hasCORSHeaders = headers.hasOwnProperty('Access-Control-Allow-Origin');
+          var hasCORSHeaders =
+            // Node responds with Access-Control-Allow-Origin,
+            // nginx responds with access-control-allow-origin
+            headers.hasOwnProperty('Access-Control-Allow-Origin') ||
+            headers.hasOwnProperty('access-control-allow-origin');
+
           if (doesURLRequireCORS(url)) {
-            assert.ok(hasCORSHeaders, url);
+            assert.ok(hasCORSHeaders, url + ' should have CORS headers');
           } else {
-            assert.notOk(hasCORSHeaders, url);
+            assert.notOk(hasCORSHeaders, url + ' should not have CORS headers');
           }
         });
 


### PR DESCRIPTION
Also ensure CORS headers are found in the server tests. nginx serves
"access-control-allow-origin", node "Access-Control-Allow-Origin".

fixes #3976