### PR TITLE
chore(deps): Bump fxa-js-client to 0.1.46

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
     "fxa-checkbox": "mozilla/fxa-checkbox#7f856afffd394a144f718e28e6fb79092d6ccddd",
     "fxa-content-server-l10n": "https://github.com/mozilla/fxa-content-server-l10n.git",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.45",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.46",
     "fxa-password-strength-checker": "https://github.com/mozilla/fxa-password-strength-checker.git#d73b3ade374607e2749ee375301b0a168008b16f",
     "html5shiv": "3.7.2",
     "JavaScript-MD5": "1.1.0",


### PR DESCRIPTION
Sends the sessionTokenId instead of the sessionToken for password/change/finish

@vbudhram - r?