### PR TITLE
fix(client): propagate flow data to confirm signin view

### DIFF
--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
       // ephemeral properties like unwrapBKey and keyFetchToken
       // that need to be sent to the browser.
       this._account = this.user.initAccount(this.model.get('account'));
+      this.flow = this.model.get('flow');
     },
 
     getAccount: function () {

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -66,11 +66,13 @@ define(function (require, exports, module) {
         if (verificationReason === VerificationReasons.SIGN_IN &&
             verificationMethod === VerificationMethods.EMAIL) {
           return this.navigate('confirm_signin', {
-            account: account
+            account: account,
+            flow: this.flow
           });
         } else {
           return this.navigate('confirm', {
-            account: account
+            account: account,
+            flow: this.flow
           });
         }
       }

--- a/app/scripts/views/mixins/signup-mixin.js
+++ b/app/scripts/views/mixins/signup-mixin.js
@@ -65,8 +65,6 @@ define(function (require, exports, module) {
     },
 
     onSignUpSuccess: function (account) {
-      var self = this;
-
       this.logViewEvent('success');
       this.logViewEvent('signup.success');
 
@@ -74,15 +72,16 @@ define(function (require, exports, module) {
         // user was pre-verified.
         this.logViewEvent('preverified.success');
         return this.invokeBrokerMethod('afterSignIn', account)
-          .then(function () {
-            self.navigate('signup_complete');
+          .then(() => {
+            this.navigate('signup_complete');
           });
       }
 
       return this.invokeBrokerMethod('afterSignUp', account)
-        .then(function () {
-          self.navigate('confirm', {
-            account: account
+        .then(() => {
+          this.navigate('confirm', {
+            account: account,
+            flow: this.flow
           });
         });
     },

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
   describe('views/confirm', function () {
     var account;
     var broker;
+    var flow;
     var fxaClient;
     var metrics;
     var model;
@@ -41,6 +42,9 @@ define(function (require, exports, module) {
     var windowMock;
 
     beforeEach(function () {
+      flow = {
+        pickResumeTokenInfo: function () {}
+      };
       fxaClient = new FxaClient();
       metrics = new Metrics();
       model = new Backbone.Model();
@@ -69,6 +73,7 @@ define(function (require, exports, module) {
 
       model.set({
         account: account,
+        flow: flow,
         type: SIGNUP_REASON
       });
 
@@ -102,6 +107,10 @@ define(function (require, exports, module) {
       view.destroy();
 
       view = metrics = null;
+    });
+
+    it('sets this.flow correctly', function () {
+      assert.equal(view.flow, flow);
     });
 
     describe('render', function () {

--- a/app/tests/spec/views/mixins/signin-mixin.js
+++ b/app/tests/spec/views/mixins/signin-mixin.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
     describe('signIn', function () {
       var account;
       var broker;
+      var flow;
       var model;
       var relier;
       var view;
@@ -39,6 +40,7 @@ define(function (require, exports, module) {
           verified: true
         });
         broker = new AuthBroker();
+        flow = {};
         model = new Backbone.Model();
 
         relier = new Relier();
@@ -47,6 +49,7 @@ define(function (require, exports, module) {
             clear: sinon.spy()
           },
           broker: broker,
+          flow: flow,
           getStringifiedResumeToken: sinon.spy(function () {
             return RESUME_TOKEN;
           }),
@@ -189,6 +192,7 @@ define(function (require, exports, module) {
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'confirm');
           assert.strictEqual(args[1].account, account);
+          assert.strictEqual(args[1].flow, flow);
         });
       });
 
@@ -215,6 +219,7 @@ define(function (require, exports, module) {
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'confirm_signin');
           assert.strictEqual(args[1].account, account);
+          assert.strictEqual(args[1].flow, flow);
         });
       });
 

--- a/app/tests/spec/views/mixins/signup-mixin.js
+++ b/app/tests/spec/views/mixins/signup-mixin.js
@@ -24,6 +24,7 @@ define(function (require, exports, module) {
     describe('signUp', function () {
       var account;
       var broker;
+      var flow;
       var relier;
       var view;
 
@@ -33,6 +34,7 @@ define(function (require, exports, module) {
         });
 
         broker = new Broker();
+        flow = {};
         relier = new Relier();
 
         view = {
@@ -40,6 +42,7 @@ define(function (require, exports, module) {
             clear: sinon.spy()
           },
           broker: broker,
+          flow: flow,
           getStringifiedResumeToken: sinon.spy(),
           invokeBrokerMethod: sinon.spy(function () {
             return p();
@@ -182,8 +185,9 @@ define(function (require, exports, module) {
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'confirm');
           assert.isObject(args[1]);
-          assert.lengthOf(Object.keys(args[1]), 1);
+          assert.lengthOf(Object.keys(args[1]), 2);
           assert.equal(args[1].account, account);
+          assert.equal(args[1].flow, flow);
         });
       });
 


### PR DESCRIPTION
Fixes #3984.

The resume token mixin depends on `this.flow` in order to serialise flow data into the resume token. Prior to this change, only the signin and signup views had a model available as `this.flow`. With this change, it means the confirm views also have that model.

@shane-tomlinson, low-priority r?