### PR TITLE
fix(tests): fix remote tests/server/routes/get-fxa-client-configuration

### DIFF
--- a/tests/intern.js
+++ b/tests/intern.js
@@ -14,6 +14,9 @@ function (intern, topic, firefoxProfile) {
   var args = intern.args;
   var fxaAuthRoot = args.fxaAuthRoot || 'http://127.0.0.1:9000/v1';
   var fxaContentRoot = args.fxaContentRoot || 'http://127.0.0.1:3030/';
+  var fxaOAuthRoot = args.fxaOAuthRoot || 'http://127.0.0.1:9010';
+  var fxaProfileRoot = args.fxaProfileRoot || 'http://127.0.0.1:1111';
+  var fxaTokenRoot = args.fxaTokenRoot || 'http://127.0.0.1:5000/token';
   var fxaEmailRoot = args.fxaEmailRoot || 'http://127.0.0.1:9001';
   var fxaOauthApp = args.fxaOauthApp || 'http://127.0.0.1:8080/';
   var fxaUntrustedOauthApp = args.fxaUntrustedOauthApp || 'http://127.0.0.1:10139/';
@@ -49,9 +52,12 @@ function (intern, topic, firefoxProfile) {
     fxaContentRoot: fxaContentRoot,
     fxaDevBox: fxaDevBox,
     fxaEmailRoot: fxaEmailRoot,
+    fxaOAuthRoot: fxaOAuthRoot,
     fxaOauthApp: fxaOauthApp,
     fxaProduction: fxaProduction,
+    fxaProfileRoot: fxaProfileRoot,
     fxaToken: fxaToken,
+    fxaTokenRoot: fxaTokenRoot,
     fxaUntrustedOauthApp: fxaUntrustedOauthApp,
     maxConcurrency: 3,
     pageLoadTimeout: 28000,

--- a/tests/server/routes/get-fxa-client-configuration.js
+++ b/tests/server/routes/get-fxa-client-configuration.js
@@ -132,12 +132,18 @@ define([
       assert.equal(res.headers['cache-control'], 'public, max-age=' + maxAge);
 
       var result = JSON.parse(res.body);
-
       assert.equal(Object.keys(result).length, 4);
-      assert.equal(result.auth_server_base_url, config.get('fxaccount_url'));
-      assert.equal(result.oauth_server_base_url, config.get('oauth_url'));
-      assert.equal(result.profile_server_base_url, config.get('profile_url'));
-      assert.equal(result.sync_tokenserver_base_url, config.get('sync_tokenserver_url'));
+
+      var conf = intern.config;
+      var expectAuthRoot = conf.fxaAuthRoot;
+      if (conf.fxaDevBox || ! conf.fxaProduction) {
+        expectAuthRoot = expectAuthRoot.replace(/\/v1$/, '');
+      }
+
+      assert.equal(result.auth_server_base_url, expectAuthRoot);
+      assert.equal(result.oauth_server_base_url, conf.fxaOAuthRoot);
+      assert.equal(result.profile_server_base_url, conf.fxaProfileRoot);
+      assert.equal(result.sync_tokenserver_base_url, conf.fxaTokenRoot);
     }, dfd.reject.bind(dfd)));
   };
 

--- a/tests/teamcity/defaults.sh
+++ b/tests/teamcity/defaults.sh
@@ -6,6 +6,10 @@ CHANNELS_DIR="$HOME/firefox-channels"
 
 FXA_CONTENT_ROOT="https://latest.dev.lcip.org/"
 FXA_AUTH_ROOT="https://latest.dev.lcip.org/auth/v1"
+FXA_OAUTH_ROOT="https://oauth-latest.dev.lcip.org"
+FXA_PROFILE_ROOT="https://latest.dev.lcip.org/profile"
+FXA_TOKEN_ROOT="https://latest.dev.lcip.org/syncserver/token"
+
 FXA_OAUTH_APP_ROOT="https://123done-latest.dev.lcip.org/"
 FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done-latest.dev.lcip.org/"
 FXA_FIREFOX_BINARY="$CHANNELS_DIR/latest/en-US/firefox/firefox-bin"

--- a/tests/teamcity/latest
+++ b/tests/teamcity/latest
@@ -4,6 +4,10 @@
 
 FXA_CONTENT_ROOT="https://latest.dev.lcip.org/"
 FXA_AUTH_ROOT="https://latest.dev.lcip.org/auth/v1"
+FXA_OAUTH_ROOT="https://oauth-latest.dev.lcip.org"
+FXA_PROFILE_ROOT="https://latest.dev.lcip.org/profile"
+FXA_TOKEN_ROOT="https://latest.dev.lcip.org/syncserver/token"
+
 FXA_OAUTH_APP_ROOT="https://123done-latest.dev.lcip.org/"
 FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done-latest.dev.lcip.org/"
 

--- a/tests/teamcity/latest4
+++ b/tests/teamcity/latest4
@@ -4,6 +4,10 @@
 
 FXA_CONTENT_ROOT="https://latest4.dev.lcip.org/"
 FXA_AUTH_ROOT="https://latest4.dev.lcip.org/auth/v1"
+FXA_OAUTH_ROOT="https://oauth-latest4.dev.lcip.org"
+FXA_PROFILE_ROOT="https://latest4.dev.lcip.org/profile"
+FXA_TOKEN_ROOT="https://latest4.dev.lcip.org/syncserver/token"
+
 FXA_OAUTH_APP_ROOT="https://123done-latest4.dev.lcip.org/"
 FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done-latest4.dev.lcip.org/"
 

--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -70,6 +70,9 @@ git show --summary
 npm config set cache ~/.fxacache
 export npm_config_cache=~/.fxacache
 export npm_config_tmp=~/fxatemp
+
+set -o xtrace # echo the following commands
+
 npm install                  \
   bluebird@2.10.1            \
   bower@1.7.1                \
@@ -90,11 +93,13 @@ npm install                  \
   universal-analytics@0.3.9  \
   zaach/node-XMLHttpRequest.git#onerror
 
-set -o xtrace # echo the following commands
-
 ./node_modules/.bin/intern-client \
   config=tests/intern_server \
+  fxaAuthRoot="$FXA_AUTH_ROOT" \
   fxaContentRoot="$FXA_CONTENT_ROOT" \
+  fxaOAuthRoot="$FXA_OAUTH_ROOT" \
+  fxaProfileRoot="$FXA_PROFILE_ROOT" \
+  fxaTokenRoot="$FXA_TOKEN_ROOT" \
   fxaProduction="true" \
   fxaDevBox="$FXA_DEV_BOX" \
   asyncTimeout=10000 \

--- a/tests/teamcity/stable
+++ b/tests/teamcity/stable
@@ -4,6 +4,10 @@
 
 FXA_CONTENT_ROOT="https://stable.dev.lcip.org/"
 FXA_AUTH_ROOT="https://stable.dev.lcip.org/auth/v1"
+FXA_OAUTH_ROOT="https://oauth-stable.dev.lcip.org"
+FXA_PROFILE_ROOT="https://stable.dev.lcip.org/profile"
+FXA_TOKEN_ROOT="https://stable.dev.lcip.org/syncserver/token"
+
 FXA_OAUTH_APP_ROOT="https://123done-stable.dev.lcip.org/"
 FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done-stable.dev.lcip.org/"
 

--- a/tests/teamcity/stage
+++ b/tests/teamcity/stage
@@ -4,6 +4,10 @@
 
 FXA_CONTENT_ROOT="https://accounts.stage.mozaws.net/"
 FXA_AUTH_ROOT="https://api-accounts.stage.mozaws.net/v1"
+FXA_OAUTH_ROOT="https://oauth.stage.mozaws.net"
+FXA_PROFILE_ROOT="https://profile.stage.mozaws.net"
+FXA_TOKEN_ROOT="https://token.stage.mozaws.net"
+
 FXA_OAUTH_APP_ROOT="https://123done-stage.dev.lcip.org/"
 FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done-stage.dev.lcip.org/"
 


### PR DESCRIPTION
To pass when run remotely (latest, stage), this needs to set expectations accordingly (i.e., not from local config). Fugly, but.

r? - @vladikoff 