### PR TITLE
fix(client): No screen transition post confirm signin for OAuth Webchannel keys

### DIFF
--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -55,7 +55,8 @@ define(function (require, exports, module) {
     defaultBehaviors: _.extend({}, proto.defaultBehaviors, {
       // the relier will take over after sign in, no need to transition.
       afterForceAuth: new HaltBehavior(),
-      afterSignIn: new HaltBehavior()
+      afterSignIn: new HaltBehavior(),
+      afterSignInConfirmationPoll: new HaltBehavior()
     }),
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
         });
 
         return broker.afterSignInConfirmationPoll(account)
-          .then(() => {
+          .then((behavior) => {
             assert.isTrue(broker.finishOAuthFlow.calledWith(account, {
               action: Constants.OAUTH_ACTION_SIGNIN
             }));
@@ -123,6 +123,8 @@ define(function (require, exports, module) {
               redirect: VALID_OAUTH_CODE_REDIRECT_URL,
               state: 'state'
             }));
+            // The Hello window will close the screen, no need to transition
+            assert.isTrue(behavior.halt);
           });
       });
 


### PR DESCRIPTION
We forgot to add a `HaltBehavior` to `afterSignInConfirmationPoll` and the
functional tests were not failing locally but were remotely due to
the way the tests were structured and the effects of latency.

This is https://github.com/mozilla/fxa-content-server/pull/3997 for train-66.