### PR TITLE
fix(build): Fix l10n extraction of template strings.

### DIFF
--- a/grunttasks/l10n-extract.js
+++ b/grunttasks/l10n-extract.js
@@ -54,9 +54,13 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('l10n-extract', 'Extract strings from templates for localization.', [
+    'clean',
     // jsxgettext does not support ES2015, only ES5. Run babel to convert
     // then run the extractor on the ES5 files.
     'babel',
+    // babel only converts a subset of files, copy all other files
+    // where there may be strings to extract.
+    'copy:requirejs',
     'jsxextract'
   ]);
 };


### PR DESCRIPTION
We forgot to copy the scripts/templates subdir over to the .es5 subdirectory
where l10n-extract uses as the root dir from which to extract strings.

fixes #4027

@vladikoff - r?