### PR TITLE
fix(tests): Add a helper function to close a window.

### DIFF
--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -14,6 +14,7 @@ define([
   var CONFIRM_URL = config.fxaContentRoot + 'confirm';
   var SIGNUP_URL = config.fxaContentRoot + 'signup';
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
 
   registerSuite({
@@ -100,8 +101,7 @@ define([
         .findByCssSelector('.google-header-bar')
         .end()
 
-        .closeCurrentWindow()
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .findByCssSelector('#fxa-confirm-header')
         .end();

--- a/tests/functional/fx_fennec_v1_force_auth.js
+++ b/tests/functional/fx_fennec_v1_force_auth.js
@@ -11,6 +11,7 @@ define([
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
   var click = FunctionalHelpers.click;
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
@@ -61,8 +62,7 @@ define([
 
           // browser is notified of desire to open Sync preferences
           .then(testIsBrowserNotified(this, 'fxaccounts:sync_preferences'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         .then(testElementExists('#fxa-sign-in-complete-header'))
 

--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -18,6 +18,7 @@ define([
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
   var click = FunctionalHelpers.click;
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
@@ -61,8 +62,7 @@ define([
 
           // browser is notified of desire to open Sync preferences
           .then(testIsBrowserNotified(this, 'fxaccounts:sync_preferences'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         .then(testElementExists('#fxa-sign-in-complete-header'))
 
@@ -97,8 +97,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 1))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-up-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         .then(testElementExists('#fxa-sign-up-complete-header'));
     }

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -17,6 +17,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -122,9 +123,7 @@ define([
         .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:sync_preferences'))
 
 
-        .closeCurrentWindow()
-        .switchToWindow('')
-        .end()
+        .then(closeCurrentWindow())
 
         .findByCssSelector('#fxa-sign-up-complete-header')
         .end()

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -18,6 +18,7 @@ define([
 
   var clearBrowserNotifications = FunctionalHelpers.clearBrowserNotifications;
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var noPageTransition = FunctionalHelpers.noPageTransition;
@@ -65,8 +66,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         .then(testElementExists('#fxa-sign-in-complete-header'))
         .then(noSuchBrowserNotification(this, 'fxaccounts:login'));
@@ -100,8 +100,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 1))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-up-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         .then(testElementExists('#fxa-sign-up-complete-header'))
         .then(noSuchBrowserNotification(this, 'fxaccounts:login'));

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -18,6 +18,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -84,11 +85,8 @@ define([
         })
 
         .end()
-        .closeCurrentWindow()
-
         // switch back to the original window, it should transition.
-        .switchToWindow('')
-        .end()
+        .then(closeCurrentWindow())
 
         .findByCssSelector('#fxa-sign-up-complete-header')
         .end()

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -18,6 +18,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -119,11 +120,8 @@ define([
           assert.equal(data.entryPoint, 'fxa:signup-complete');
         }))
 
-        .closeCurrentWindow()
-
         // switch back to the original window, it should transition.
-        .switchToWindow('')
-        .end()
+        .then(closeCurrentWindow())
 
         .findByCssSelector('#fxa-sign-up-complete-header')
         .end()

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -19,6 +19,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
@@ -60,8 +61,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));
@@ -87,8 +87,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 1))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-up-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-header'));

--- a/tests/functional/fx_ios_v1_sign_up.js
+++ b/tests/functional/fx_ios_v1_sign_up.js
@@ -18,6 +18,7 @@ define([
   var PASSWORD = '12345678';
 
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
@@ -78,9 +79,7 @@ define([
           })
         .end()
 
-        .closeCurrentWindow()
-        .switchToWindow('')
-        .end()
+        .then(closeCurrentWindow())
 
         .findByCssSelector('#fxa-confirm-header')
         .end()

--- a/tests/functional/fx_ios_v2_sign_up.js
+++ b/tests/functional/fx_ios_v2_sign_up.js
@@ -18,6 +18,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -98,9 +99,7 @@ define([
           })
         .end()
 
-        .closeCurrentWindow()
-        .switchToWindow('')
-        .end()
+        .then(closeCurrentWindow())
 
         .findByCssSelector('#fxa-confirm-header')
         .end()

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1346,7 +1346,9 @@ define([
       return this.parent
         .getAllWindowHandles()
         .then(function (handles) {
-          if (handles.length > 1) {
+          if (handles.length <= 1) {
+            throw new Error('LastWindowError');
+          } else {
             return this.parent
               .closeCurrentWindow()
               .switchToWindow(tabName || '');

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1335,6 +1335,27 @@ define([
   }
 
   /**
+   * Close the current window and switch to the named tab. If
+   * The window will only be closed if it's not the last open window.
+   *
+   * @param {string} [tabName] - defaults to ''
+   * @returns {promise}
+   */
+  function closeCurrentWindow(tabName) {
+    return function () {
+      return this.parent
+        .getAllWindowHandles()
+        .then(function (handles) {
+          if (handles.length > 1) {
+            return this.parent
+              .closeCurrentWindow()
+              .switchToWindow(tabName || '');
+          }
+        });
+    };
+  }
+
+  /**
    * Assert the value of an attribute
    *
    * @param {string} selector CSS selector for the element
@@ -1411,6 +1432,7 @@ define([
     clearBrowserState: clearBrowserState,
     clearSessionStorage: clearSessionStorage,
     click: click,
+    closeCurrentWindow: closeCurrentWindow,
     createUser: createUser,
     fetchAllMetrics: fetchAllMetrics,
     fillOutChangePassword: fillOutChangePassword,

--- a/tests/functional/oauth_force_auth.js
+++ b/tests/functional/oauth_force_auth.js
@@ -14,6 +14,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
@@ -76,8 +77,7 @@ define([
         .then(testElementTextInclude('.account-ready-service', '123done'))
 
         // switch to the original window
-        .closeCurrentWindow()
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .then(testElementExists('#loggedin'))
         // redirected back to the App

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -21,6 +21,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -142,8 +143,7 @@ define([
         .then(testElementTextInclude('.account-ready-service', '321done Untrusted'))
 
         // switch to the original window
-        .closeCurrentWindow()
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .then(testElementExists('#loggedin'));
     },
@@ -194,8 +194,7 @@ define([
         .then(testElementTextInclude('.account-ready-service', '321done Untrusted'))
 
         // switch to the original window
-        .closeCurrentWindow()
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .then(testElementExists('#loggedin'))
         .then(click('#logout'))
@@ -251,8 +250,7 @@ define([
         .then(click('#display-name button[type=submit]'))
         .then(visibleByQSA('.settings-success'))
 
-        .closeCurrentWindow()
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .then(click('.signin'))
 

--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -22,6 +22,8 @@ define([
   var email;
   var client;
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+
   registerSuite({
     name: 'oauth reset password',
 
@@ -106,9 +108,7 @@ define([
         })
         .end()
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         // the original tab should automatically sign in
         .findByCssSelector('#loggedin')
@@ -150,8 +150,7 @@ define([
         .end()
 
         // switch to the original window
-        .closeCurrentWindow()
-        .switchToWindow('');
+        .then(closeCurrentWindow());
     },
 
     'reset password, verify same browser by replacing the original tab': function () {

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -24,6 +24,7 @@ define([
 
   var click = FunctionalHelpers.click;
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
@@ -101,8 +102,7 @@ define([
         .end()
 
         // switch to the original window
-        .closeCurrentWindow()
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .findByCssSelector('#loggedin')
         .end()
@@ -134,8 +134,7 @@ define([
         .end()
 
         // switch to the original window
-        .closeCurrentWindow()
-        .switchToWindow('');
+        .then(closeCurrentWindow());
     },
 
     'signup, verify same browser by replacing the original tab': function () {
@@ -316,8 +315,7 @@ define([
         .end()
 
         // switch to the original window
-        .closeCurrentWindow()
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .findByCssSelector('#loggedin')
         .end();

--- a/tests/functional/oauth_sign_up_verification_redirect.js
+++ b/tests/functional/oauth_sign_up_verification_redirect.js
@@ -12,6 +12,8 @@ define([
   var PASSWORD = 'password';
   var email;
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+
   registerSuite({
     name: 'oauth sign up verification_redirect',
 
@@ -83,8 +85,7 @@ define([
         .findByCssSelector('#loggedin')
         .end()
 
-        .closeCurrentWindow()
-        .switchToWindow('');
+        .then(closeCurrentWindow());
     },
 
     'signup, same browser different window, verification_redirect=always': function () {
@@ -119,8 +120,7 @@ define([
         .findByCssSelector('#loggedin')
         .end()
 
-        .closeCurrentWindow()
-        .switchToWindow('');
+        .then(closeCurrentWindow());
     },
 
     'signup, verify different browser, verification_redirect=always': function () {

--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -24,6 +24,7 @@ define([
   var PASSWORD = '12345678';
   var accountData;
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
 
@@ -113,8 +114,7 @@ define([
             .end()
 
             // switch to the original window
-            .closeCurrentWindow()
-            .switchToWindow('')
+            .then(closeCurrentWindow())
 
             .findByCssSelector('#loggedin')
             .end()

--- a/tests/functional/oauth_webchannel.js
+++ b/tests/functional/oauth_webchannel.js
@@ -29,9 +29,10 @@ define([
    * finish OAuth flows
    */
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var noEmailExpected = FunctionalHelpers.noEmailExpected;
-  var testIsBrowserNotifiedOfLogin = WebChannelHelpers.testIsBrowserNotifiedOfLogin;
   var openFxaFromRp = WebChannelHelpers.openFxaFromRp;
+  var testIsBrowserNotifiedOfLogin = WebChannelHelpers.testIsBrowserNotifiedOfLogin;
 
   registerSuite({
     name: 'oauth webchannel',
@@ -116,9 +117,7 @@ define([
           // element was not found
         })
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .findById('fxa-sign-up-complete-header')
         .end()
@@ -164,9 +163,7 @@ define([
 
         .then(testIsBrowserNotifiedOfLogin(self, { shouldCloseTab: false }))
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('');
+        .then(closeCurrentWindow());
     },
 
     'signup, verify same browser, replace original tab': function () {
@@ -300,9 +297,7 @@ define([
         })
         .end()
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         // the original tab should automatically sign in
         .findByCssSelector('#fxa-reset-password-complete-header')
@@ -359,9 +354,7 @@ define([
         // the tab should automatically sign in
         .then(testIsBrowserNotifiedOfLogin(self, { shouldCloseTab: false }))
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('');
+        .then(closeCurrentWindow());
     },
 
     'reset password, verify same browser, replace original tab': function () {

--- a/tests/functional/oauth_webchannel_keys.js
+++ b/tests/functional/oauth_webchannel_keys.js
@@ -33,6 +33,7 @@ define([
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
   var click = FunctionalHelpers.click;
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutCompleteResetPassword = thenify(FunctionalHelpers.fillOutCompleteResetPassword);
   var fillOutResetPassword = thenify(FunctionalHelpers.fillOutResetPassword);
@@ -105,10 +106,8 @@ define([
         .then(function (result) {
           messageReceived = result;
         })
-        .closeCurrentWindow()
+        .then(closeCurrentWindow())
 
-        // switch to the original window
-        .switchToWindow('')
         .then(waitForBrowserLoginNotification(this))
         .then(function (result) {
           messageReceived = messageReceived || result;
@@ -141,9 +140,7 @@ define([
 
         .then(testElementExists('#fxa-sign-up-complete-header'))
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('');
+        .then(closeCurrentWindow());
     },
 
     'signup, verify same browser, replace original tab': function () {
@@ -214,9 +211,7 @@ define([
         })
         .end()
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('')
+        .then(closeCurrentWindow())
         .then(waitForBrowserLoginNotification(this))
         .then(function (result) {
           messageReceived = messageReceived || result;
@@ -251,9 +246,7 @@ define([
         .then(testIsBrowserNotifiedOfLogin(this, { shouldCloseTab: false }))
         .then(testElementExists('#fxa-reset-password-complete-header'))
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('');
+        .then(closeCurrentWindow());
     },
 
     'reset password, verify same browser, replace original tab': function () {

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -32,6 +32,7 @@ define([
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
   var click = FunctionalHelpers.click;
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutCompleteResetPassword = thenify(FunctionalHelpers.fillOutCompleteResetPassword);
   var fillOutResetPassword = FunctionalHelpers.fillOutResetPassword;
@@ -286,9 +287,7 @@ define([
           return testAtSettingsWithVerifiedMessage(self);
         })
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .then(function () {
           return testAtSettingsWithVerifiedMessage(self);
@@ -320,8 +319,7 @@ define([
         })
 
         // switch to the original window
-        .closeCurrentWindow()
-        .switchToWindow('');
+        .then(closeCurrentWindow());
     },
 
     'reset password, verify same browser by replacing the original tab': function () {

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -16,6 +16,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var focus = FunctionalHelpers.focus;
@@ -169,8 +170,7 @@ define([
         .findById('fxa-signin-header')
         .end()
 
-        .closeCurrentWindow()
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .findById('fxa-signin-header')
         .end();

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -21,6 +21,7 @@ define([
   var accountData;
   var client;
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var testAttributeMatches = FunctionalHelpers.testAttributeMatches;
   var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
 
@@ -252,8 +253,7 @@ define([
             .findById('fxa-settings-header')
             .end()
 
-            .closeCurrentWindow()
-            .switchToWindow('')
+            .then(closeCurrentWindow())
 
             .findById('fxa-settings-header')
             .end();
@@ -286,8 +286,7 @@ define([
             .findById('fxa-settings-header')
             .end()
 
-            .closeCurrentWindow()
-            .switchToWindow('')
+            .then(closeCurrentWindow())
 
             .findById('fxa-settings-header')
             .end();

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -19,6 +19,7 @@ define([
 
   var click = FunctionalHelpers.click;
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
@@ -84,10 +85,8 @@ define([
         .switchToWindow('newwindow')
         .then(testElementExists('#fxa-settings-header'))
         .then(testSuccessWasShown(this))
-        .closeCurrentWindow()
+        .then(closeCurrentWindow())
 
-        // back to the original window
-        .switchToWindow('')
         .then(testElementExists('#fxa-settings-header'))
         .then(testSuccessWasShown(this));
     },
@@ -117,11 +116,7 @@ define([
         .then(visibleByQSA('#fxa-signin-header'))
         .end()
 
-        .closeCurrentWindow()
-
-        // back to the original window
-        .switchToWindow('')
-        .end();
+        .then(closeCurrentWindow());
     },
 
     'signup, verify and sign out of two accounts, all in the same tab, then sign in to the first account': function () {
@@ -375,13 +370,11 @@ define([
 
         .switchToWindow('newwindow')
         .then(testElementExists('#fxa-settings-header'))
-        .closeCurrentWindow()
+        .then(closeCurrentWindow(windowName))
 
-        .switchToWindow(windowName)
         .then(testElementExists('#fxa-settings-header'))
 
-        .closeCurrentWindow()
-        .switchToWindow('')
+        .then(closeCurrentWindow(''))
 
         .then(testElementExists('#fxa-settings-header'));
     },
@@ -408,9 +401,8 @@ define([
         })
         .switchToWindow(windowName)
         .then(testElementExists('#fxa-settings-header'))
-        .closeCurrentWindow()
+        .then(closeCurrentWindow())
 
-        .switchToWindow('')
         .then(testElementExists('#fxa-settings-header'));
     },
 
@@ -423,10 +415,7 @@ define([
         .switchToWindow('newwindow')
         .then(testElementExists('#fxa-settings-header'))
         .then(testSuccessWasShown(this))
-        .closeCurrentWindow()
-
-        // back to the original window
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         // open verification link again, no error should occur.
         .then(openVerificationLinkInNewTab(this, email, 0))
@@ -434,8 +423,7 @@ define([
         .switchToWindow('newwindow')
         .then(testElementExists('#fxa-settings-header'))
         .then(testSuccessWasShown(this))
-        .closeCurrentWindow()
-        .switchToWindow('')
+        .then(closeCurrentWindow())
 
         .then(testElementExists('#fxa-settings-header'))
         .then(testSuccessWasShown(this));

--- a/tests/functional/sync_force_auth.js
+++ b/tests/functional/sync_force_auth.js
@@ -11,6 +11,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
@@ -56,8 +57,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -23,6 +23,7 @@ define([
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
   var click = FunctionalHelpers.click;
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutCompleteResetPassword = thenify(FunctionalHelpers.fillOutCompleteResetPassword);
   var fillOutResetPassword = thenify(FunctionalHelpers.fillOutResetPassword);
@@ -71,10 +72,7 @@ define([
 
         .then(testElementExists('#fxa-reset-password-complete-header'))
         .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('')
-        .end()
+        .then(closeCurrentWindow())
 
         .then(testSuccessWasShown(this))
         .then(testIsBrowserNotifiedOfLogin(this, email, { checkVerified: true }));
@@ -96,10 +94,7 @@ define([
         .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
         .then(testElementExists('#fxa-reset-password-complete-header'))
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('')
-        .end();
+        .then(closeCurrentWindow());
     },
 
     'reset password, verify same browser by replacing the original tab': function () {

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -22,6 +22,7 @@ define([
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
   var click = FunctionalHelpers.click;
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
@@ -63,8 +64,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));
@@ -91,8 +91,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 1))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -26,6 +26,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
@@ -106,11 +107,7 @@ define([
         })
 
         .end()
-        .closeCurrentWindow()
-
-        // switch to the original window, it should not transition.
-        .switchToWindow('')
-        .end()
+        .then(closeCurrentWindow())
 
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.
@@ -157,9 +154,7 @@ define([
           assert.ok(text.indexOf('Firefox Sync') > -1);
         })
 
-        .closeCurrentWindow()
-        .switchToWindow('')
-        .end();
+        .then(closeCurrentWindow());
     },
 
     'signup, verify same browser by replacing the original tab': function () {

--- a/tests/functional/sync_v2_force_auth.js
+++ b/tests/functional/sync_v2_force_auth.js
@@ -13,6 +13,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var noPageTransition = FunctionalHelpers.noPageTransition;
@@ -66,8 +67,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));

--- a/tests/functional/sync_v2_reset_password.js
+++ b/tests/functional/sync_v2_reset_password.js
@@ -22,6 +22,7 @@ define([
   var client;
   var email;
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var openPage = FunctionalHelpers.openPage;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
@@ -92,10 +93,7 @@ define([
         // because localStorage is not shared.
         .then(testIsBrowserNotified(self, 'fxaccounts:login'))
 
-        .closeCurrentWindow()
-        // switch to the original window
-        .switchToWindow('')
-        .end()
+        .then(closeCurrentWindow())
 
         .then(FunctionalHelpers.testSuccessWasShown(self))
         .then(noSuchBrowserNotification(self, 'fxaccounts:login'));

--- a/tests/functional/sync_v2_sign_in.js
+++ b/tests/functional/sync_v2_sign_in.js
@@ -17,6 +17,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var noPageTransition = FunctionalHelpers.noPageTransition;
@@ -56,8 +57,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -18,6 +18,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testAttributeExists = FunctionalHelpers.testAttributeExists;
@@ -121,11 +122,7 @@ define([
         })
 
         .end()
-        .closeCurrentWindow()
-
-        // switch to the original window, it should not transition.
-        .switchToWindow('')
-        .end()
+        .then(closeCurrentWindow())
 
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.

--- a/tests/functional/sync_v3_force_auth.js
+++ b/tests/functional/sync_v3_force_auth.js
@@ -13,6 +13,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
@@ -59,8 +60,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));
@@ -91,8 +91,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));
@@ -122,8 +121,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));

--- a/tests/functional/sync_v3_sign_in.js
+++ b/tests/functional/sync_v3_sign_in.js
@@ -18,6 +18,7 @@ define([
 
   var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
   var click = FunctionalHelpers.click;
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var noEmailExpected = FunctionalHelpers.noEmailExpected;
@@ -69,8 +70,7 @@ define([
           .then(click('#sync-preferences'))
           // browser is notified of desire to open Sync preferences
           .then(testIsBrowserNotified(this, 'fxaccounts:sync_preferences'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));
@@ -87,8 +87,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 1))
         .switchToWindow('newwindow')
           .then(testElementExists('#fxa-sign-in-complete-header'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));
@@ -134,8 +133,7 @@ define([
           .then(click('#sync-preferences'))
           // browser is notified of desire to open Sync preferences
           .then(testIsBrowserNotified(this, 'fxaccounts:sync_preferences'))
-          .closeCurrentWindow()
-        .switchToWindow('')
+          .then(closeCurrentWindow())
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-header'));

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -18,6 +18,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
@@ -116,11 +117,7 @@ define([
           assert.equal(data.entryPoint, 'fxa:signup-complete');
         }))
 
-        .closeCurrentWindow()
-
-        // switch to the original window, it should not transition.
-        .switchToWindow('')
-        .end()
+        .then(closeCurrentWindow())
 
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.


### PR DESCRIPTION
Use a helper function to close the current window and
go back to the original window. The window will only
be closed if it's not the last window.

fixes #3902

@vladikoff and @jrgm - r?

I am running the functional tests using Marionette with the mock-raven from https://github.com/mozilla/fxa-content-server/pull/4013#issuecomment-237501301. So far, so good. 