### PR TITLE
fix(client): Fix autofocus being called repeatedly on hidden settings panels.

### DIFF
--- a/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/app/scripts/views/mixins/settings-panel-mixin.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
       // are hidden until opened and focus cannot be set. Instead, set
       // the focus when the panel is opened.
       this.$('[autofocus]')
-        .attr('autofocus-on-panel-open', true)
+        .attr('data-autofocus-on-panel-open', true)
         .removeAttr('autofocus');
     },
 
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
 
     openPanel: function () {
       this.$('.settings-unit').addClass('open');
-      this.focus(this.$('[autofocus-on-panel-open]'));
+      this.focus(this.$('[data-autofocus-on-panel-open]'));
     },
 
     isPanelOpen: function () {

--- a/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/app/scripts/views/mixins/settings-panel-mixin.js
@@ -16,10 +16,20 @@ define(function (require, exports, module) {
     initialize: function (options) {
       this.parentView = options.parentView;
     },
+
     events: {
       'click .cancel': BaseView.preventDefaultThen('_closePanelReturnToSettings'),
       'click .settings-unit-toggle': BaseView.preventDefaultThen('_triggerPanel'),
       'keyup .settings-unit': 'onKeyUp'
+    },
+
+    afterRender () {
+      // Disable autofocus as specified by the templates because the panels
+      // are hidden until opened and focus cannot be set. Instead, set
+      // the focus when the panel is opened.
+      this.$('[autofocus]')
+        .attr('autofocus-on-panel-open', true)
+        .removeAttr('autofocus');
     },
 
     onKeyUp: function (event) {
@@ -54,19 +64,7 @@ define(function (require, exports, module) {
 
     openPanel: function () {
       this.$('.settings-unit').addClass('open');
-      var $input = this.$('.open [autofocus]');
-      if ($input.length > 0) {
-        // if there's an autofocus element, focus that
-        this.focusElement($input[0]);
-      }
-    },
-
-    focusElement: function (autoFocusEl) {
-      // focus element only if not a mobile device
-      // assumption carried over from base.js
-      if ($('html').hasClass('no-touch')) {
-        this.focus(autoFocusEl);
-      }
+      this.focus(this.$('[autofocus-on-panel-open]'));
     },
 
     isPanelOpen: function () {

--- a/app/tests/spec/views/mixins/settings-panel-mixin.js
+++ b/app/tests/spec/views/mixins/settings-panel-mixin.js
@@ -53,9 +53,9 @@ define(function (require, exports, module) {
     });
 
     describe('autofocus elements', () => {
-      it('are converted to [autofocus-on-panel-open] to prevent attempts at autofocusing hidden elements', () => {
+      it('are converted to [data-autofocus-on-panel-open] to prevent attempts at autofocusing hidden elements', () => {
         assert.lengthOf(view.$('[autofocus]'), 0);
-        assert.lengthOf(view.$('[autofocus-on-panel-open]'), 1);
+        assert.lengthOf(view.$('[data-autofocus-on-panel-open]'), 1);
       });
     });
 
@@ -97,14 +97,14 @@ define(function (require, exports, module) {
 
       it('openPanel focuses the first autofocus element if present', function () {
         // create and append an input field
-        var $dummyInput = $('<input type="text" name="dummyholder" autofocus-on-panel-open>');
+        var $dummyInput = $('<input type="text" name="dummyholder" data-autofocus-on-panel-open>');
         view.$('.settings-unit').append($dummyInput);
         // make sure that it is a non-touch device
         $('html').addClass('no-touch');
         view.openPanel();
 
         // input field should be present, we just appended it
-        var $autofocusEl = view.$('.open [autofocus-on-panel-open]');
+        var $autofocusEl = view.$('.open [data-autofocus-on-panel-open]');
         assert.lengthOf($autofocusEl, 1);
         // autofocusEl should have been focused
         assert.equal($autofocusEl[0], document.activeElement, 'autofocus element has focus');

--- a/app/tests/spec/views/mixins/settings-panel-mixin.js
+++ b/app/tests/spec/views/mixins/settings-panel-mixin.js
@@ -52,6 +52,13 @@ define(function (require, exports, module) {
       view = metrics = null;
     });
 
+    describe('autofocus elements', () => {
+      it('are converted to [autofocus-on-panel-open] to prevent attempts at autofocusing hidden elements', () => {
+        assert.lengthOf(view.$('[autofocus]'), 0);
+        assert.lengthOf(view.$('[autofocus-on-panel-open]'), 1);
+      });
+    });
+
     describe('events', function () {
       it('toggles button', function () {
         sinon.stub(view, 'navigate', function () {});
@@ -90,32 +97,17 @@ define(function (require, exports, module) {
 
       it('openPanel focuses the first autofocus element if present', function () {
         // create and append an input field
-        var $dummyInput = $('<input type="text" name="dummyholder" autofocus>');
+        var $dummyInput = $('<input type="text" name="dummyholder" autofocus-on-panel-open>');
         view.$('.settings-unit').append($dummyInput);
         // make sure that it is a non-touch device
         $('html').addClass('no-touch');
         view.openPanel();
 
         // input field should be present, we just appended it
-        var $autofocusEl = view.$('.open [autofocus]');
-        assert.isTrue($autofocusEl.length === 1, 'autofocus field present');
+        var $autofocusEl = view.$('.open [autofocus-on-panel-open]');
+        assert.lengthOf($autofocusEl, 1);
         // autofocusEl should have been focused
         assert.equal($autofocusEl[0], document.activeElement, 'autofocus element has focus');
-      });
-
-      it('openPanel does not focus the first autofocus element if touch device', function () {
-        // create and append an input field
-        var $dummyInput = $('<input type="text" name="dummyholder" autofocus>');
-        view.$('.settings-unit').append($dummyInput);
-        // make sure that it is not a non-touch device
-        $('html').removeClass('no-touch');
-        view.openPanel();
-
-        // input field should be present, we just appended it
-        var $autofocusEl = view.$('.open [autofocus]');
-        assert.isTrue($autofocusEl.length === 1, 'autofocus field present');
-        // autofocusEl should not have been focused
-        assert.notEqual($autofocusEl[0], document.activeElement, 'autofocus element has focus');
       });
 
       it('_hidePanelOnEscape calls hidePanel when escape key is pressed', function () {


### PR DESCRIPTION
The autofocus code assumes an element with `autofocus` should be focused
as soon as the view is rendered, even if the autofocus element is hidden.

For settings panels, this causes the autofocus code to be called repeatedly
for each panel, causing a lot of timers to be created over and over again.

This sidesteps the problem by converting settings panel `autofocus` elements to
`autofocus-on-panel-open`, which are then focused when the panel is opened.

Removed the `focusElement` code which duplicated functionality from the base
view.

fixes #4037

@vladikoff - you were just reviewing some of the autofocus code, weren't you? Want to look at this one too? If not, feel free to pass the buck to someone else. 