### PR TITLE
refactor(client): Refactor the hide-on-escape key code.

### DIFF
--- a/app/scripts/views/mixins/floating-placeholder-mixin.js
+++ b/app/scripts/views/mixins/floating-placeholder-mixin.js
@@ -31,16 +31,35 @@ define(function (require, exports, module) {
      * @param {object} inputEl - input element whose placeholder
      *        should be shown.
      */
-    showFloatingPlaceholder: function (inputEl) {
-      var placeholder = this.$el.find(inputEl).attr('placeholder');
+    showFloatingPlaceholder (inputEl) {
+      const $inputEl = this.$el.find(inputEl);
+      const $labelHelperEl = $inputEl.prev('.label-helper');
+      const placeholderText = $inputEl.attr('placeholder') || '';
 
       // If the placeholder for the element was already converted, no
       // further conversion will occur.
       // The check for existence is because of the strict equality check,
       // if placeholder is undefined, then it should not go into the block
-      if (placeholder && placeholder !== '') {
-        this.$el.find(inputEl).removeAttr('placeholder');
-        this.$el.find(inputEl).prev('.label-helper').text(placeholder).css({'top': '-17px'});
+      if (placeholderText.length && $labelHelperEl.length) {
+        $inputEl.removeAttr('placeholder');
+        $labelHelperEl.text(placeholderText).css({'top': '-17px'});
+      }
+    },
+
+    /**
+     * Hide the floating placeholder for an element
+     *
+     * @param {object} inputEl - input element whose placeholder
+     *        should be hidden.
+     */
+    hideFloatingPlaceholder (inputEl) {
+      const $inputEl = this.$el.find(inputEl);
+      const $labelHelperEl = $inputEl.prev('.label-helper');
+      const placeholderText = $labelHelperEl.text() || '';
+
+      if (placeholderText) {
+        $inputEl.attr('placeholder', placeholderText);
+        $labelHelperEl.removeClass('focused').text('').css({'top': '0px'});
       }
     },
 

--- a/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/app/scripts/views/mixins/settings-panel-mixin.js
@@ -33,26 +33,9 @@ define(function (require, exports, module) {
     },
 
     onKeyUp: function (event) {
-      this._hidePanelOnEscape(event);
-    },
-
-    _hidePanelOnEscape: function (event) {
       if (event.which === KeyCodes.ESCAPE) {
-        this.hidePanel(event.currentTarget);
+        this.hidePanel();
       }
-    },
-
-    hidePanel: function (el) {
-      // escape key has same behavior as cancel button
-      // so find the cancel button inside the open panel
-      // and simulate a click on that
-      var cancelButton = this.$(el).find('.cancel');
-
-      // synthesize a new event
-      var $event = $.Event('click');
-      $event.currentTarget = $(cancelButton);
-
-      this._closePanelReturnToSettings($event);
     },
 
     _triggerPanel: function (event) {
@@ -67,51 +50,41 @@ define(function (require, exports, module) {
       this.focus(this.$('[data-autofocus-on-panel-open]'));
     },
 
+    hidePanel: function () {
+      this._closePanelReturnToSettings();
+    },
+
     isPanelOpen: function () {
       return this.$('.settings-unit').hasClass('open');
     },
 
-    _closePanelReturnToSettings: function (event) {
+    _closePanelReturnToSettings: function () {
       this.navigate('settings');
-      this.clearInput(event.currentTarget);
+      this.clearInput();
       this.closePanel();
     },
 
-    clearInput: function (el) {
-      // need siblings here, not prev(), there might be 2 password rows
-      var inputFields = this.$(el).parent().siblings('.input-row').find('input');
-      var form = this.$(el).closest('form');
-      var shouldDisableSubmitButtons = false;
-      $(inputFields).each(function (i, anInputField) {
-        // if we have a .label-helper, make that a placeholder
-        // cannot search only inside the .input-row, `input`s
-        // can be from different `.input-row`s
-        var labelHelper = $(anInputField).prev('.label-helper');
-        if (labelHelper.length > 0) {
-          var placeholderText = labelHelper.text();
-          if (placeholderText.length > 0) {
-            $(anInputField).attr('placeholder', placeholderText);
-            // hide the .label-helper again
-            $(labelHelper).text('').css({'top': '0px'});
-          }
-        }
-        // if the input field is text or password, reset it
-        if (anInputField.type === 'text' || anInputField.type === 'password') {
-          // reset the form, do not clear the inputs
-          form[0].reset();
-          // also for input fields that are text or password,
-          // disable the submit buttons if user pressed cancel/esc
-          shouldDisableSubmitButtons = true;
+    clearInput: function () {
+      const $inputEls = this.$('input');
+
+      $inputEls.each((i, inputEl) => {
+        // Make no assumptions that this view has the
+        // floating-placeholder-mixin available. Check first.
+        if (this.hideFloatingPlaceholder) {
+          this.hideFloatingPlaceholder(inputEl);
         }
       });
-      if (shouldDisableSubmitButtons) {
-        this.disableButtons(el);
-      }
-    },
 
-    disableButtons: function (el) {
-      var submitButton = this.$(el).closest('form').find('[type=submit]');
-      submitButton.addClass('disabled');
+      const formEl = this.$('form')[0];
+      if (formEl) {
+        formEl.reset();
+      }
+
+      // Make no assumptions this view is actually based on FormView,
+      // only enable the form if a form view, and if valid.
+      if (this.enableSubmitIfValid) {
+        this.enableSubmitIfValid();
+      }
     },
 
     closePanel: function () {

--- a/app/tests/spec/views/mixins/floating-placeholder-mixin.js
+++ b/app/tests/spec/views/mixins/floating-placeholder-mixin.js
@@ -56,11 +56,28 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('showFloatingPlaceholder', function () {
-      it('forces the display of a floating placeholder', function () {
+    describe('showFloatingPlaceholder', () => {
+      it('forces the display of a floating placeholder', () => {
+        const $floatMeEl = view.$('#float_me');
+        const $labelHelperEl = view.$('.label-helper');
+
         view.showFloatingPlaceholder('#float_me');
-        assert.equal(typeof view.$('#float_me').attr('placeholder'), 'undefined');
-        assert.equal(view.$('.label-helper').text(), 'placeholder text');
+
+        assert.isUndefined($floatMeEl.attr('placeholder'));
+        assert.equal($labelHelperEl.text(), 'placeholder text');
+      });
+    });
+
+    describe('hideFloatingPlaceholder', () => {
+      it('hides the floating placeholder', () => {
+        const $floatMeEl = view.$('#float_me');
+        const $labelHelperEl = view.$('.label-helper');
+
+        view.showFloatingPlaceholder('#float_me');
+        view.hideFloatingPlaceholder('#float_me');
+
+        assert.equal($floatMeEl.attr('placeholder'), 'placeholder text');
+        assert.equal($labelHelperEl.text(), '');
       });
     });
 


### PR DESCRIPTION
Builds on #4043. While doing that PR, I noticed the hide-on-escape code was quite complex, and didn't seem to need to be. This is an attempt to reduce that complexity by moving related code together.

Move the code that hides the floating placehoder from the
settings-panel-mixin to floating-placeholder-mixin.

Remove the duplicate code that deals with enabling/disabling
the form submit.