### PR TITLE
fix(tokens): Display expired token on sign-in verification error

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -90,15 +90,15 @@ define(function (require, exports, module) {
       message: t('Attempt limit exceeded')
     },
     /*
-    ACCOUNT_LOCKED: {
-      errno: 121,
-      message: t('Your account has been locked for security reasons')
-    },
-    ACCOUNT_NOT_LOCKED: {
-      errno: 122,
-      message: UNEXPECTED_ERROR_MESSAGE
-    },
-    */
+     ACCOUNT_LOCKED: {
+     errno: 121,
+     message: t('Your account has been locked for security reasons')
+     },
+     ACCOUNT_NOT_LOCKED: {
+     errno: 122,
+     message: UNEXPECTED_ERROR_MESSAGE
+     },
+     */
     REQUEST_BLOCKED: {
       errno: 125,
       message: t('The request was blocked for security reasons')
@@ -164,12 +164,12 @@ define(function (require, exports, module) {
       message: t('Valid email required')
     },
     /*
-    Removed in issue #3137
-    YEAR_OF_BIRTH_REQUIRED: {
-      errno: 1012,
-      message: t('Year of birth required')
-    },
-    */
+     Removed in issue #3137
+     YEAR_OF_BIRTH_REQUIRED: {
+     errno: 1012,
+     message: t('Year of birth required')
+     },
+     */
     UNUSABLE_IMAGE: {
       errno: 1013,
       message: t('A usable image was not found')
@@ -183,12 +183,12 @@ define(function (require, exports, module) {
       message: t('Valid URL required')
     },
     /*
-    Removed in issue #3137
-    BIRTHDAY_REQUIRED: {
-      errno: 1016,
-      message: t('Valid birthday required')
-    },
-    */
+     Removed in issue #3137
+     BIRTHDAY_REQUIRED: {
+     errno: 1016,
+     message: t('Valid birthday required')
+     },
+     */
     DESKTOP_CHANNEL_TIMEOUT: {
       errno: 1017,
       message: UNEXPECTED_ERROR_MESSAGE
@@ -218,12 +218,12 @@ define(function (require, exports, module) {
       message: t('Valid email required')
     },
     /*
-    Removed in issue #3040
-    FORCE_AUTH_EMAIL_REQUIRED: {
-      errno: 1024,
-      message: t('/force_auth requires an email')
-    },
-    */
+     Removed in issue #3040
+     FORCE_AUTH_EMAIL_REQUIRED: {
+     errno: 1024,
+     message: t('/force_auth requires an email')
+     },
+     */
     EXPIRED_VERIFICATION_LINK: {
       errno: 1025,
       message: EXPIRED_VERIFICATION_ERROR_MESSAGE
@@ -245,12 +245,12 @@ define(function (require, exports, module) {
       message: t('Signup is coming soon to Firefox for iOS')
     },
     /*
-    Removed in issue #2950
-    SIGNUP_DISABLED_BY_RELIER: {
-      errno: 1030,
-      message: t('Signup has been disabled')
-    },
-    */
+     Removed in issue #2950
+     SIGNUP_DISABLED_BY_RELIER: {
+     errno: 1030,
+     message: t('Signup has been disabled')
+     },
+     */
     AGE_REQUIRED: {
       errno: 1031,
       message: t('You must enter your age to sign up')
@@ -290,6 +290,10 @@ define(function (require, exports, module) {
     },
     UNKNOWN_ACCOUNT_VERIFICATION: {
       errno: 1040,
+      message: EXPIRED_VERIFICATION_ERROR_MESSAGE
+    },
+    REUSED_SIGNIN_VERIFICATION_CODE: {
+      errno: 1041,
       message: EXPIRED_VERIFICATION_ERROR_MESSAGE
     }
   };

--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -90,15 +90,15 @@ define(function (require, exports, module) {
       message: t('Attempt limit exceeded')
     },
     /*
-     ACCOUNT_LOCKED: {
-     errno: 121,
-     message: t('Your account has been locked for security reasons')
-     },
-     ACCOUNT_NOT_LOCKED: {
-     errno: 122,
-     message: UNEXPECTED_ERROR_MESSAGE
-     },
-     */
+    ACCOUNT_LOCKED: {
+      errno: 121,
+      message: t('Your account has been locked for security reasons')
+    },
+    ACCOUNT_NOT_LOCKED: {
+      errno: 122,
+      message: UNEXPECTED_ERROR_MESSAGE
+    },
+    */
     REQUEST_BLOCKED: {
       errno: 125,
       message: t('The request was blocked for security reasons')
@@ -164,12 +164,12 @@ define(function (require, exports, module) {
       message: t('Valid email required')
     },
     /*
-     Removed in issue #3137
-     YEAR_OF_BIRTH_REQUIRED: {
-     errno: 1012,
-     message: t('Year of birth required')
-     },
-     */
+    Removed in issue #3137
+    YEAR_OF_BIRTH_REQUIRED: {
+      errno: 1012,
+      message: t('Year of birth required')
+    },
+    */
     UNUSABLE_IMAGE: {
       errno: 1013,
       message: t('A usable image was not found')
@@ -183,12 +183,12 @@ define(function (require, exports, module) {
       message: t('Valid URL required')
     },
     /*
-     Removed in issue #3137
-     BIRTHDAY_REQUIRED: {
-     errno: 1016,
-     message: t('Valid birthday required')
-     },
-     */
+    Removed in issue #3137
+    BIRTHDAY_REQUIRED: {
+      errno: 1016,
+      message: t('Valid birthday required')
+    },
+    */
     DESKTOP_CHANNEL_TIMEOUT: {
       errno: 1017,
       message: UNEXPECTED_ERROR_MESSAGE
@@ -218,12 +218,12 @@ define(function (require, exports, module) {
       message: t('Valid email required')
     },
     /*
-     Removed in issue #3040
-     FORCE_AUTH_EMAIL_REQUIRED: {
-     errno: 1024,
-     message: t('/force_auth requires an email')
-     },
-     */
+    Removed in issue #3040
+    FORCE_AUTH_EMAIL_REQUIRED: {
+      errno: 1024,
+      message: t('/force_auth requires an email')
+    },
+    */
     EXPIRED_VERIFICATION_LINK: {
       errno: 1025,
       message: EXPIRED_VERIFICATION_ERROR_MESSAGE
@@ -245,12 +245,12 @@ define(function (require, exports, module) {
       message: t('Signup is coming soon to Firefox for iOS')
     },
     /*
-     Removed in issue #2950
-     SIGNUP_DISABLED_BY_RELIER: {
-     errno: 1030,
-     message: t('Signup has been disabled')
-     },
-     */
+    Removed in issue #2950
+    SIGNUP_DISABLED_BY_RELIER: {
+      errno: 1030,
+      message: t('Signup has been disabled')
+    },
+    */
     AGE_REQUIRED: {
       errno: 1031,
       message: t('You must enter your age to sign up')

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -166,9 +166,7 @@ define(function (require, exports, module) {
     context: function () {
       var verificationInfo = this._verificationInfo;
       return {
-        // This is only the case if you've signed up in the
-        // same browser you opened the verification link in.
-        canResend: this._canResend() && this.isSignUp(),
+        canResend: this._canResend(),
         error: this._error,
         // If the link is invalid, print a special error message.
         isLinkDamaged: ! verificationInfo.isValid(),
@@ -177,7 +175,9 @@ define(function (require, exports, module) {
     },
 
     _canResend: function () {
-      return !! this._getResendSessionToken();
+      // _getResendSessionToken is only returned if the user signed up in the
+      // same browser in which they opened the verification link.
+      return !! this._getResendSessionToken() && this.isSignUp();
     },
 
     // This returns the latest sessionToken associated with the user's email

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -61,8 +61,6 @@ define(function (require, exports, module) {
       // cache the email in case we need to attempt to resend the
       // verification link
       this._email = this._account.get('email');
-
-      this._showResend = true;
     },
 
     getAccount: function () {
@@ -145,9 +143,8 @@ define(function (require, exports, module) {
               // When coming from sign-in confirmation verification, show a
               // verification link expired error instead of damaged verification link.
               // This error is generated because the link has already been used.
-              if (self.viewName === 'complete-signin') {
+              if (self.isSignIn()) {
                 // Disable resending verification, can only be triggered from new sign-in
-                self._showResend = false;
                 verificationInfo.markExpired();
                 err = AuthErrors.toError('REUSED_SIGNIN_VERIFICATION_CODE');
               } else {
@@ -171,7 +168,7 @@ define(function (require, exports, module) {
       return {
         // This is only the case if you've signed up in the
         // same browser you opened the verification link in.
-        canResend: this._canResend() && this._showResend,
+        canResend: this._canResend() && this.isSignUp(),
         error: this._error,
         // If the link is invalid, print a special error message.
         isLinkDamaged: ! verificationInfo.isValid(),

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   var AuthErrors = require('lib/auth-errors');
+  var Backbone = require('backbone');
   var Broker = require('models/auth_brokers/base');
   var chai = require('chai');
   var Constants = require('lib/constants');
@@ -326,14 +327,17 @@ define(function (require, exports, module) {
           verificationError = AuthErrors.toError('INVALID_VERIFICATION_CODE', 'this isn\'t a lottery');
 
           windowMock.location.search = '?code=' + validCode + '&uid=' + validUid;
+          var model = new Backbone.Model();
+          model.set('type', VerificationReasons.SIGN_IN);
+
           view = new View({
             account: account,
             broker: broker,
             metrics: metrics,
+            model: model,
             notifier: notifier,
             relier: relier,
             user: user,
-            viewName: 'complete-signin',
             window: windowMock
           });
 

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -321,6 +321,33 @@ define(function (require, exports, module) {
         });
       });
 
+      describe('REUSED_SIGNIN_VERIFICATION_CODE error', function () {
+        beforeEach(function () {
+          verificationError = AuthErrors.toError('INVALID_VERIFICATION_CODE', 'this isn\'t a lottery');
+
+          windowMock.location.search = '?code=' + validCode + '&uid=' + validUid;
+          view = new View({
+            account: account,
+            broker: broker,
+            metrics: metrics,
+            notifier: notifier,
+            relier: relier,
+            user: user,
+            viewName: 'complete-signin',
+            window: windowMock
+          });
+
+          return view.render()
+            .then(function () {
+              assert.ok(view.$('#fxa-verification-link-expired-header').length);
+            });
+        });
+
+        it('displays the verification link expired screen', function () {
+          testErrorLogged(AuthErrors.toError('REUSED_SIGNIN_VERIFICATION_CODE'));
+        });
+      });
+
       describe('all other server errors', function () {
         beforeEach(function () {
           verificationError = AuthErrors.toError('UNEXPECTED_ERROR');

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -124,6 +124,7 @@ The event stream is a log of events and the time they occurred while the user is
 * error.complete_sign_up.auth.1025 - User clicked on an expired verification link.
 * error.complete_sign_up.auth.1026 - User clicked on a damaged verification link.
 * error.complete_sign_up.auth.1040 - User tried to verify an account that does not exist.
+* error.complete_sign_up.auth.1041 - User tried to verify a sign-in that has already been verified.
 
 #### confirm
 

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -8,6 +8,7 @@ define([
   './functional/sync_sign_in',
   './functional/sync_force_auth',
   './functional/sign_up',
+  './functional/complete_sign_in',
   './functional/complete_sign_up',
   './functional/sync_sign_up',
   './functional/sync_v2_sign_up',

--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'require',
+  'app/scripts/lib/constants',
+  'tests/lib/restmail',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers',
+  'tests/functional/lib/fx-desktop'
+], function (intern, registerSuite, require, Constants, restmail, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
+  var config = intern.config;
+  var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
+  var PAGE_COMPLETE_SIGNIN_URL = config.fxaContentRoot + 'complete_signin';
+  var PAGE_SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
+  var PASSWORD = 'password';
+  var user;
+  var email;
+  var code;
+  var uid;
+
+  var thenify = FunctionalHelpers.thenify;
+
+  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var createUser = FunctionalHelpers.createUser;
+  var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
+  var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  var noSuchElement = thenify(FunctionalHelpers.noSuchElement);
+  var openPage = thenify(FunctionalHelpers.openPage);
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testIsBrowserNotified = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfMessage);
+  var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
+
+  var createRandomHexString = TestHelpers.createRandomHexString;
+
+  var setupTest = thenify(function (context) {
+    return this.parent
+      .then(createUser(email, PASSWORD, {preVerified: true}))
+      .then(openPage(context, PAGE_SIGNIN_URL, '#fxa-signin-header'))
+      .execute(listenForFxaCommands)
+      .then(fillOutSignIn(context, email, PASSWORD))
+      .then(testIsBrowserNotified(context, 'can_link_account'))
+      .then(testIsBrowserNotifiedOfLogin(context, email, {checkVerified: false}))
+      .then(testElementExists('#fxa-confirm-signin-header'))
+      .then(restmail(EMAIL_SERVER_ROOT + '/mail/' + user))
+      .then(function (emails) {
+        code = emails[0].headers['x-verify-code'];
+        uid = emails[0].headers['x-uid'];
+      });
+  });
+
+
+  registerSuite({
+    name: 'complete_sign_in',
+
+    beforeEach: function () {
+      email = TestHelpers.createEmail('sync{id}');
+      user = TestHelpers.emailToUser(email);
+      return this.remote
+        .then(clearBrowserState(this))
+        .then(setupTest(this, true));
+    },
+
+    'open verification link with malformed code': function () {
+      code = createRandomHexString(Constants.CODE_LENGTH - 1);
+      var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
+
+      return this.remote
+        .get(require.toUrl(url))
+
+        // a successful user is immediately redirected to the
+        // sign-in-complete page.
+        .findById('fxa-verification-link-damaged-header')
+        .then(noSuchElement(this, '#resend'))
+        .end();
+
+    },
+
+    'open verification link with server reported bad code': function () {
+      var code = createRandomHexString(Constants.CODE_LENGTH);
+      var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
+
+      return this.remote
+        .get(require.toUrl(url))
+
+        // Ensure that a link expired error message is displayed
+        // rather than a damaged link error,
+        .findById('fxa-verification-link-expired-header')
+        .then(noSuchElement(this, '#resend'))
+        .end();
+    },
+
+    'open verification link with malformed uid': function () {
+      var uid = createRandomHexString(Constants.UID_LENGTH - 1);
+      var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
+
+      return this.remote
+        .get(require.toUrl(url))
+
+        // a successful user is immediately redirected to the
+        // sign-un-complete page.
+        .findById('fxa-verification-link-damaged-header')
+        .then(noSuchElement(this, '#resend'))
+        .end();
+    },
+
+    'open verification link with server reported bad uid': function () {
+      var uid = createRandomHexString(Constants.UID_LENGTH);
+      var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
+
+      return this.remote
+        .get(require.toUrl(url))
+
+        // a successful user is immediately redirected to the
+        // sign-in-complete page.
+        .findById('fxa-verification-link-expired-header')
+        .then(noSuchElement(this, '#resend'))
+        .end();
+    },
+
+    'open valid email verification link': function () {
+      var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
+
+      return this.remote
+        .get(require.toUrl(url))
+
+        // a successful user is immediately redirected to the
+        // sign-in-complete page.
+        .findById('fxa-settings-profile-header')
+        .end();
+    }
+  });
+});

--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -5,13 +5,12 @@
 define([
   'intern',
   'intern!object',
-  'require',
   'app/scripts/lib/constants',
   'tests/lib/restmail',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'tests/functional/lib/fx-desktop'
-], function (intern, registerSuite, require, Constants, restmail, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
+], function (intern, registerSuite, Constants, restmail, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
   var EMAIL_SERVER_ROOT = config.fxaEmailRoot;
   var PAGE_COMPLETE_SIGNIN_URL = config.fxaContentRoot + 'complete_signin';

--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -69,14 +69,12 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .get(require.toUrl(url))
+        .then(openPage(this, url, '#fxa-verification-link-damaged-header'))
 
         // a successful user is immediately redirected to the
         // sign-in-complete page.
-        .findById('fxa-verification-link-damaged-header')
-        .then(noSuchElement(this, '#resend'))
-        .end();
-
+        .then(testElementExists('#fxa-verification-link-damaged-header'))
+        .then(noSuchElement(this, '#resend'));
     },
 
     'open verification link with server reported bad code': function () {
@@ -84,13 +82,12 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .get(require.toUrl(url))
+        .then(openPage(this, url, '#fxa-verification-link-expired-header'))
 
         // Ensure that a link expired error message is displayed
-        // rather than a damaged link error,
-        .findById('fxa-verification-link-expired-header')
-        .then(noSuchElement(this, '#resend'))
-        .end();
+        // rather than a damaged link error
+        .then(testElementExists('#fxa-verification-link-expired-header'))
+        .then(noSuchElement(this, '#resend'));
     },
 
     'open verification link with malformed uid': function () {
@@ -98,13 +95,12 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .get(require.toUrl(url))
+        .then(openPage(this, url, '#fxa-verification-link-damaged-header'))
 
         // a successful user is immediately redirected to the
-        // sign-un-complete page.
-        .findById('fxa-verification-link-damaged-header')
-        .then(noSuchElement(this, '#resend'))
-        .end();
+        // sign-in-complete page.
+        .then(testElementExists('#fxa-verification-link-damaged-header'))
+        .then(noSuchElement(this, '#resend'));
     },
 
     'open verification link with server reported bad uid': function () {
@@ -112,25 +108,23 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .get(require.toUrl(url))
+        .then(openPage(this, url, '#fxa-verification-link-expired-header'))
 
-        // a successful user is immediately redirected to the
-        // sign-in-complete page.
-        .findById('fxa-verification-link-expired-header')
-        .then(noSuchElement(this, '#resend'))
-        .end();
+        // Ensure that a link expired error message is displayed
+        // rather than a damaged link error
+        .then(testElementExists('#fxa-verification-link-expired-header'))
+        .then(noSuchElement(this, '#resend'));
     },
 
     'open valid email verification link': function () {
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .get(require.toUrl(url))
+        .then(openPage(this, url, '#fxa-settings-profile-header'))
 
         // a successful user is immediately redirected to the
         // sign-in-complete page.
-        .findById('fxa-settings-profile-header')
-        .end();
+        .then(testElementExists('#fxa-settings-profile-header'));
     }
   });
 });


### PR DESCRIPTION
This PR shows `verification link expired` message if the user has already clicked the sign-in verification email link. It also reports a new metric `error.confirm_signin.auth.1041` to track this error.

Fixes #4009 