### PR TITLE
fix(css): Remove right margin on settings

### DIFF
--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -42,6 +42,7 @@
   .show-password {
     opacity: 0;
     position: absolute;
+    width: 1px;
   }
 
   /**


### PR DESCRIPTION
This PR makes the `show-password` checkbox style 1px. Without this, it defaults to a 13x13 checkbox, which causes the margin to appear.

Fixes #4048

![simulator screen shot aug 16 2016 1 45 05 pm](https://cloud.githubusercontent.com/assets/1295288/17709548/a07b728c-63b7-11e6-8fdc-2dbd3fcd84bb.png)

