### PR TITLE
Removed period

### DIFF
--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -256,7 +256,7 @@ define(function (require, exports, module) {
             assert.equal(view.$('#suggest-sync').html(),
               'Looking for Firefox Sync? <a href="https://mozilla.org/firefox/sync?' +
               'utm_source=fx-website&amp;utm_medium=fx-accounts&amp;utm_campaign=fx-signup&amp;' +
-              'utm_content=fx-sync-get-started">Get started here.</a>');
+              'utm_content=fx-sync-get-started">Get started here</a>');
             assert.isTrue(TestHelpers.isEventLogged(metrics, 'signup.sync-suggest.visible'), 'enrolled');
           });
       });


### PR DESCRIPTION
Removed period from the end of "Get started here". Though it's not documented, we don't use periods in short calls-to-actions that are linked.