### PR TITLE
fix(signin): Add delay for login message on iOS broker

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
     ],
 
     // Login delay for iOS broker
-    LOGIN_MESSAGE_DELAY_MS: 10000
+    IOS_V1_LOGIN_MESSAGE_DELAY_MS: 10000
   };
   /*eslint-enable sorting/sort-object-props*/
 });

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -103,6 +103,9 @@ define(function (require, exports, module) {
       'desktop-addons',
       'desktop-preferences'
     ],
+
+    // Login delay for iOS broker
+    LOGIN_MESSAGE_DELAY_MS: 10000
   };
   /*eslint-enable sorting/sort-object-props*/
 });

--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -30,18 +30,18 @@ define(function (require, exports, module) {
        * This will give the user an indication that they need to verify
        * their email address.
        */
-      const defer = p.defer()
+      const defer = p.defer();
 
       this.window.setTimeout(() => {
         var loginData = this._getLoginData(account);
 
-        if (!this._hasRequiredLoginFields(loginData)) {
-          defer.resolve()
+        if (! this._hasRequiredLoginFields(loginData)) {
+          defer.resolve();
         }
-      this.send(this.getCommand('LOGIN'), loginData);
-      }, 5000)
+        this.send(this.getCommand('LOGIN'), loginData);
+      }, 5000);
 
-      return defer.promise
+      return defer.promise;
     },
   });
 

--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const _ = require('underscore');
+  const Constants = require('lib/constants');
   const p = require('lib/promise');
 
   const FxDesktopV1AuthenticationBroker = require('models/auth_brokers/fx-desktop-v1');
@@ -26,22 +27,13 @@ define(function (require, exports, module) {
     _notifyRelierOfLogin: function (account) {
       /**
        * As a workaround for sign-in/sign-up confirmation view disappearing
-       * on iOS, delay the login message sent via the channel by 5 seconds.
+       * on iOS, delay the login message sent via the channel by LOGIN_MESSAGE_DELAY_MS.
        * This will give the user an indication that they need to verify
        * their email address.
        */
-      const defer = p.defer();
-
-      this.window.setTimeout(() => {
-        var loginData = this._getLoginData(account);
-
-        if (! this._hasRequiredLoginFields(loginData)) {
-          defer.resolve();
-        }
-        this.send(this.getCommand('LOGIN'), loginData);
-      }, 5000);
-
-      return defer.promise;
+      return p().delay(Constants.LOGIN_MESSAGE_DELAY_MS).then(() => {
+        return proto._notifyRelierOfLogin.call(this, account);
+      });
     },
   });
 

--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -31,7 +31,8 @@ define(function (require, exports, module) {
        * This will give the user an indication that they need to verify
        * their email address.
        */
-      return p().delay(Constants.LOGIN_MESSAGE_DELAY_MS).then(() => {
+      const loginMessageDelayMS = this.attributes.loginMessageDelayMS || Constants.IOS_V1_LOGIN_MESSAGE_DELAY_MS;
+      return p().delay(loginMessageDelayMS).then(() => {
         return proto._notifyRelierOfLogin.call(this, account);
       });
     },

--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
        * This will give the user an indication that they need to verify
        * their email address.
        */
-      const loginMessageDelayMS = this.attributes.loginMessageDelayMS || Constants.IOS_V1_LOGIN_MESSAGE_DELAY_MS;
+      const loginMessageDelayMS = this.get('loginMessageDelayMS') || Constants.IOS_V1_LOGIN_MESSAGE_DELAY_MS;
       return p().delay(loginMessageDelayMS).then(() => {
         return proto._notifyRelierOfLogin.call(this, account);
       });

--- a/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -15,12 +15,14 @@ define(function (require, exports, module) {
 
   describe('models/auth_brokers/fx-ios-v1', function () {
     var channel;
+    var loginMessageDelayMS = 250;
     var relier;
     var windowMock;
 
     function createBroker () {
       return new FxiOSAuthenticationBroker({
         channel: channel,
+        loginMessageDelayMS: loginMessageDelayMS,
         relier: relier,
         window: windowMock
       });
@@ -53,6 +55,10 @@ define(function (require, exports, module) {
 
       it('does not have the `syncPreferencesNotification` capability by default', function () {
         assert.isFalse(broker.hasCapability('syncPreferencesNotification'));
+      });
+
+      it('broker loginMessageDelayMS delayed is set', function () {
+        assert.equal(broker.attributes.loginMessageDelayMS, loginMessageDelayMS);
       });
 
       describe('`broker.fetch` is called', function () {


### PR DESCRIPTION
This PR is a temporary work around for not dismissing the `confirm_signin` view when logging in. It adds a 5 second delay for sending the `login` message.

Fixes #4077 