### PR TITLE
fix(styles): fix horizontal align for comm pref

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -179,15 +179,20 @@ body.settings #main-content.card {
 
       html[dir='ltr'] & {
         float: right;
+
+        &.unpaired {
+          float: none;
+        }
       }
 
       html[dir='rtl'] & {
         float: left;
+
+        &.unpaired {
+          float: none;
+        }
       }
 
-      &.unpaired {
-        float: none;
-      }
     }
   }
 


### PR DESCRIPTION
Fixes #3886

Fixed :) Looks like the floats were the issue. I know it results it repeated code (3 lines). Can be avoided if we switched over to flexboxes. Lmk if that is something that sounds good :)

ooooor, can use !important for the `.unpaired` class --> quicker fix ;)

@vladikoff 
@ryanfeeley 