### PR TITLE
Improved calls to action

### DIFF
--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -15,19 +15,19 @@
       {{#isSignInEnabled}}
         {{#forceAuth}}
         <li>
-          <a href="/force_auth?email={{ encodedEmail }}" class="sign-in">{{#t}}Remember password? Sign in.{{/t}}</a>
+          <a href="/force_auth?email={{ encodedEmail }}" class="sign-in">{{#t}}Remember password? Sign in{{/t}}</a>
         </li>
         {{/forceAuth}}
 
         {{^forceAuth}}
         <li>
-          <a href="/signin" class="sign-in">{{#t}}Remember password? Sign in.{{/t}}</a>
+          <a href="/signin" class="sign-in">{{#t}}Remember password? Sign in{{/t}}</a>
         </li>
         {{/forceAuth}}
       {{/isSignInEnabled}}
 
       <li>
-        <a id="resend" class="resend-email" href="#">{{#t}}Resend email{{/t}}</a>
+        <a id="resend" class="resend-email" href="#">{{#t}}Didn’t arrive? Resend{{/t}}</a>
       </li>
     </ul>
 


### PR DESCRIPTION
Removed periods from short link, and changed "Resend email" to "Didn’t arrive? Resend".

Take note of curly apostrophe in didn’t so that it doesn't break anything.