### PR TITLE
refactor(client): Extract all element type specific code from form.js

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -295,6 +295,10 @@ define(function (require, exports, module) {
     REUSED_SIGNIN_VERIFICATION_CODE: {
       errno: 1041,
       message: EXPIRED_VERIFICATION_ERROR_MESSAGE
+    },
+    INPUT_REQUIRED: {
+      errno: 1042,
+      message: t('This is a required field')
     }
   };
   /*eslint-enable sorting/sort-object-props*/

--- a/app/scripts/templates/partial/coppa-age-input.mustache
+++ b/app/scripts/templates/partial/coppa-age-input.mustache
@@ -1,4 +1,4 @@
 <div class="input-row input-row-age">
   <label class="label-helper"></label>
-  <input type="number" id="age" placeholder="{{#t}}How old are you?{{/t}}" min="0" max="999" value="{{ age }}" {{#shouldFocusAge}}autofocus{{/shouldFocusAge}} required />
+  <input type="number" id="age" placeholder="{{#t}}How old are you?{{/t}}" min="0" max="999" value="{{ age }}" {{#shouldFocusAge}}autofocus{{/shouldFocusAge}} />
 </div>

--- a/app/scripts/views/elements/README.md
+++ b/app/scripts/views/elements/README.md
@@ -4,8 +4,8 @@ Contents of this directory are to define custom element helpers
 for view elements. Each module should define at minimum two functions:
 
 `match` - check whether the current module should be used with the given element.
-`validate` - validate the element. Return a falsy value if valid, and an Error
-if invalid.
+`validate` - validate the element. Set `this.validationError` to the error if
+invalid.
 
 An additional function can also be overridden:
 

--- a/app/scripts/views/elements/README.md
+++ b/app/scripts/views/elements/README.md
@@ -1,0 +1,14 @@
+# Custom Elements
+
+Contents of this directory are to define custom element helpers
+for view elements. Each module should define at minimum two functions:
+
+`match` - check whether the current module should be used with the given element.
+`validate` - validate the element. Return a falsy value if valid, and an Error
+if invalid.
+
+An additional function can also be overridden:
+
+`val` - override $el.val() for the specific use case. When overriding, be sure
+to take care of both get and set. The original element's `val` function is
+available at `__val`.

--- a/app/scripts/views/elements/README.md
+++ b/app/scripts/views/elements/README.md
@@ -4,8 +4,7 @@ Contents of this directory are to define custom element helpers
 for view elements. Each module should define at minimum two functions:
 
 `match` - check whether the current module should be used with the given element.
-`validate` - validate the element. Set `this.validationError` to the error if
-invalid.
+`validate` - validate the element. `throw` the validation error if invalid.
 
 An additional function can also be overridden:
 

--- a/app/scripts/views/elements/checkbox-input.js
+++ b/app/scripts/views/elements/checkbox-input.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  return {
+    match ($el) {
+      return $el.attr('type') === 'checkbox';
+    },
+
+    val (val) {
+      return !! this.is(':checked');
+    },
+
+    validate () {
+      // always valid
+    }
+  };
+});

--- a/app/scripts/views/elements/default.js
+++ b/app/scripts/views/elements/default.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  return {
+    match (/* $el */) {
+      return true;
+    },
+
+    validate () {
+      // default element is always valid
+    }
+  };
+});

--- a/app/scripts/views/elements/email-input.js
+++ b/app/scripts/views/elements/email-input.js
@@ -25,9 +25,9 @@ define(function (require, exports, module) {
       const value = this.val();
 
       if (! value) {
-        this.validationError = AuthErrors.toError('EMAIL_REQUIRED');
+        throw AuthErrors.toError('EMAIL_REQUIRED');
       } else if (! Validate.isEmailValid(value)) {
-        this.validationError = AuthErrors.toError('INVALID_EMAIL');
+        throw AuthErrors.toError('INVALID_EMAIL');
       }
     }
   };

--- a/app/scripts/views/elements/email-input.js
+++ b/app/scripts/views/elements/email-input.js
@@ -25,9 +25,9 @@ define(function (require, exports, module) {
       const value = this.val();
 
       if (! value) {
-        return AuthErrors.toError('EMAIL_REQUIRED');
+        this.validationError = AuthErrors.toError('EMAIL_REQUIRED');
       } else if (! Validate.isEmailValid(value)) {
-        return AuthErrors.toError('INVALID_EMAIL');
+        this.validationError = AuthErrors.toError('INVALID_EMAIL');
       }
     }
   };

--- a/app/scripts/views/elements/email-input.js
+++ b/app/scripts/views/elements/email-input.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const AuthErrors = require('lib/auth-errors');
+  const Validate = require('lib/validate');
+
+  return {
+    match ($el) {
+      return $el.attr('type') === 'email';
+    },
+
+    val (val) {
+      if (arguments.length === 1) {
+        return this.__val(val);
+      }
+
+      return this.__val().trim();
+    },
+
+    validate () {
+      const value = this.val();
+
+      if (! value) {
+        return AuthErrors.toError('EMAIL_REQUIRED');
+      } else if (! Validate.isEmailValid(value)) {
+        return AuthErrors.toError('INVALID_EMAIL');
+      }
+    }
+  };
+});

--- a/app/scripts/views/elements/password-input.js
+++ b/app/scripts/views/elements/password-input.js
@@ -19,9 +19,9 @@ define(function (require, exports, module) {
       const value = this.val();
 
       if (! value) {
-        return AuthErrors.toError('PASSWORD_REQUIRED');
+        this.validationError = AuthErrors.toError('PASSWORD_REQUIRED');
       } else if (! Validate.isPasswordValid(value)) {
-        return AuthErrors.toError('PASSWORD_TOO_SHORT');
+        this.validationError = AuthErrors.toError('PASSWORD_TOO_SHORT');
       }
     }
   };

--- a/app/scripts/views/elements/password-input.js
+++ b/app/scripts/views/elements/password-input.js
@@ -19,9 +19,9 @@ define(function (require, exports, module) {
       const value = this.val();
 
       if (! value) {
-        this.validationError = AuthErrors.toError('PASSWORD_REQUIRED');
+        throw AuthErrors.toError('PASSWORD_REQUIRED');
       } else if (! Validate.isPasswordValid(value)) {
-        this.validationError = AuthErrors.toError('PASSWORD_TOO_SHORT');
+        throw AuthErrors.toError('PASSWORD_TOO_SHORT');
       }
     }
   };

--- a/app/scripts/views/elements/password-input.js
+++ b/app/scripts/views/elements/password-input.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const AuthErrors = require('lib/auth-errors');
+  const Validate = require('lib/validate');
+
+  return {
+    match ($el) {
+      const type = $el.attr('type');
+      return type === 'password' ||
+             (type === 'text' && $el.hasClass('password'));
+    },
+
+    validate () {
+      const value = this.val();
+
+      if (! value) {
+        return AuthErrors.toError('PASSWORD_REQUIRED');
+      } else if (! Validate.isPasswordValid(value)) {
+        return AuthErrors.toError('PASSWORD_TOO_SHORT');
+      }
+    }
+  };
+});

--- a/app/scripts/views/elements/text-input.js
+++ b/app/scripts/views/elements/text-input.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const AuthErrors = require('lib/auth-errors');
+
+  return {
+    match ($el) {
+      return $el.attr('type') === 'text';
+    },
+
+    validate () {
+      const isRequired = typeof this.attr('required') !== 'undefined';
+      const value = this.val();
+
+      if (isRequired && ! value.length) {
+        return AuthErrors.toError('INPUT_REQUIRED');
+      }
+    }
+  };
+});

--- a/app/scripts/views/elements/text-input.js
+++ b/app/scripts/views/elements/text-input.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
       const value = this.val();
 
       if (isRequired && ! value.length) {
-        this.validationError = AuthErrors.toError('INPUT_REQUIRED');
+        throw AuthErrors.toError('INPUT_REQUIRED');
       }
     }
   };

--- a/app/scripts/views/elements/text-input.js
+++ b/app/scripts/views/elements/text-input.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
       const value = this.val();
 
       if (isRequired && ! value.length) {
-        return AuthErrors.toError('INPUT_REQUIRED');
+        this.validationError = AuthErrors.toError('INPUT_REQUIRED');
       }
     }
   };

--- a/app/scripts/views/elements/upgrade-element.js
+++ b/app/scripts/views/elements/upgrade-element.js
@@ -23,7 +23,7 @@ define(function (require, exports, module) {
     emailInput,
     passwordInput,
     textInput,
-    defaultElement // defaultElemehnt is last since it is the fallback.
+    defaultElement // defaultElement is last since it is the fallback.
   ];
 
   return function ($el) {
@@ -36,7 +36,11 @@ define(function (require, exports, module) {
     }
 
     if (! $el.validate) {
-      $el.validate = elementOverride.validate.bind($el);
+      $el.validate = function () {
+        delete this.validationError;
+        elementOverride.validate.call(this);
+        return ! this.validationError;
+      };
     }
 
     return $el;

--- a/app/scripts/views/elements/upgrade-element.js
+++ b/app/scripts/views/elements/upgrade-element.js
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Upgrade jQuery elements with two functions:
+ * 1. `val` - overridden in some cases to do cleanup
+ * 2. `validate` - validate the element value. If valid, returns falsy value,
+ *    if invalid, returns an Error
+ */
+define(function (require, exports, module) {
+  'use strict';
+
+  const _ = require('underscore');
+  const checkboxInput = require('views/elements/checkbox-input');
+  const defaultElement = require('views/elements/default');
+  const emailInput = require('views/elements/email-input');
+  const passwordInput = require('views/elements/password-input');
+  const textInput = require('views/elements/text-input');
+
+  const elementOverrides = [
+    checkboxInput,
+    emailInput,
+    passwordInput,
+    textInput,
+    defaultElement // defaultElemehnt is last since it is the fallback.
+  ];
+
+  return function ($el) {
+    const elementOverride =
+      _.find(elementOverrides, (elementOverride) => elementOverride.match($el));
+
+    if (elementOverride.val && ! $el.__val) {
+      $el.__val = $el.val;
+      $el.val = elementOverride.val.bind($el);
+    }
+
+    if (! $el.validate) {
+      $el.validate = elementOverride.validate.bind($el);
+    }
+
+    return $el;
+  };
+});

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -299,14 +299,9 @@ define(function (require, exports, module) {
         const el = inputEls[i];
         const $el = this.$(el);
 
-        let validationError;
         try {
           $el.validate();
-        } catch (e) {
-          validationError = e;
-        }
-
-        if (validationError) {
+        } catch (validationError) {
           this.showValidationError(el, validationError);
           // only one message at a time.
           return;

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -20,17 +20,18 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var $ = require('jquery');
-  var _ = require('underscore');
-  var allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
-  var AuthErrors = require('lib/auth-errors');
-  var BaseView = require('views/base');
-  var Duration = require('duration');
-  var notifyDelayedRequest = require('views/decorators/notify_delayed_request');
-  var p = require('lib/promise');
-  var showButtonProgressIndicator = require('views/decorators/progress_indicator');
-  var Tooltip = require('views/tooltip');
-  var Validate = require('lib/validate');
+  const $ = require('jquery');
+  const _ = require('underscore');
+  const allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
+  const AuthErrors = require('lib/auth-errors');
+  const BaseView = require('views/base');
+  const Duration = require('duration');
+  const upgradeElement = require('views/elements/upgrade-element');
+  const notifyDelayedRequest = require('views/decorators/notify_delayed_request');
+  const p = require('lib/promise');
+  const showButtonProgressIndicator = require('views/decorators/progress_indicator');
+  const Tooltip = require('views/tooltip');
+
 
   /**
    * Decorator that checks whether the form has changed, and if so, call
@@ -48,6 +49,8 @@ define(function (require, exports, module) {
     };
   }
 
+  const proto = BaseView.prototype;
+
   var FormView = BaseView.extend({
 
     // Time to wait for a request to finish before showing a notice
@@ -57,7 +60,7 @@ define(function (require, exports, module) {
       BaseView.call(this, options);
 
       // attach events of the descendent view and this view.
-      this.delegateEvents(_.extend({}, FormView.prototype.events, this.events));
+      this.delegateEvents(_.extend({}, proto.events, this.events));
     },
 
     events: {
@@ -82,8 +85,22 @@ define(function (require, exports, module) {
         this.enableSubmitIfValid();
       }
 
-      BaseView.prototype.afterRender.call(this);
+      proto.afterRender.call(this);
     },
+
+    /**
+     * Get a view element. View element will contain
+     * an additional `validate` function.
+     *
+     * @param {String} el - selector or element
+     * @returns {Object} jQuery Element
+     */
+    $ (el) {
+      const $el = proto.$.call(this, el);
+
+      return upgradeElement($el);
+    },
+
 
     /**
      * Get the current form values. Does not fetch the value of elements with
@@ -237,10 +254,10 @@ define(function (require, exports, module) {
         return false;
       }
 
-      var inputEls = this.$('input').not('#coppa input');
+      const inputEls = this.$('input');
       for (var i = 0, length = inputEls.length; i < length; ++i) {
         var el = inputEls[i];
-        if (! this.isElementValid(el)) {
+        if (this.$(el).validate()) {
           return false;
         }
       }
@@ -273,26 +290,6 @@ define(function (require, exports, module) {
     },
 
     /**
-     * Check to see if an element passes HTML5 form validation.
-     *
-     * @param {String} el
-     * @returns {Boolean}
-     */
-    isElementValid: function (el) {
-      el = this.$(el);
-      var type = this.getElementType(el);
-
-      // email and password follow our own rules.
-      if (type === 'email') {
-        return this.validateEmail(el);
-      } else if (type === 'password') {
-        return this.validatePassword(el);
-      }
-
-      return this.validateInput(el);
-    },
-
-    /**
      * Display form validation errors.
      *
      * Descendent views can override showValidationErrorsStart
@@ -308,19 +305,12 @@ define(function (require, exports, module) {
         return;
       }
 
-      // exclude coppa inputs from validation, coppa has its own validation
-      var inputEls = this.$('input').not('#coppa input');
+      const inputEls = this.$('input');
       for (var i = 0, length = inputEls.length; i < length; ++i) {
-        var el = inputEls[i];
-        if (! this.isElementValid(el)) {
-          var fieldType = this.getElementType(el);
-
-          if (fieldType === 'email') {
-            return this.showEmailValidationError(el);
-          } else if (fieldType === 'password') {
-            return this.showPasswordValidationError(el);
-          }
-
+        const el = inputEls[i];
+        const err = this.$(el).validate();
+        if (err) {
+          this.showValidationError(el, err);
           // only one message at a time.
           return;
         }
@@ -336,26 +326,7 @@ define(function (require, exports, module) {
      * @returns {String}
      */
     getElementValue: function (el) {
-      var value = this.$(el).val();
-
-      if (value && this.getElementType(el) === 'email') {
-        value = $.trim(value);
-      }
-
-      return value;
-    },
-
-    getElementType: function (el) {
-      var fieldType = $(el).attr('type');
-
-      // text fields with the password class are treated as passwords.
-      // These are password fields that have been converted to text
-      // fields when the user clicked on 'show'
-      if (fieldType === 'text' && $(el).hasClass('password')) {
-        fieldType = 'password';
-      }
-
-      return fieldType;
+      return this.$(el).val();
     },
 
     /**
@@ -378,77 +349,6 @@ define(function (require, exports, module) {
      * @return {undefined} true if a validation error is displayed.
      */
     showValidationErrorsEnd: function () {
-    },
-
-    /**
-     * Validate an email field
-     *
-     * @param {String} el
-     * @return {Boolean} true if email is valid, false otw.
-     */
-    validateEmail: function (el) {
-      var email = this.getElementValue(el);
-      return Validate.isEmailValid(email);
-    },
-
-    showEmailValidationError: function (el) {
-      var value = this.getElementValue(el);
-      var err = value && value.length ?
-                  // if the email element has any length, but is marked
-                  // as invalid, it's invalid.
-                  AuthErrors.toError('INVALID_EMAIL') :
-                  // email has no length, it's missing.
-                  AuthErrors.toError('EMAIL_REQUIRED');
-
-      return this.showValidationError(el, err);
-    },
-
-    /**
-     * Validate a password field
-     *
-     * @param {String} el
-     * @return {Boolean} true if password is valid, false otw.
-     */
-    validatePassword: function (el) {
-      var password = this.getElementValue(el);
-      return Validate.isPasswordValid(password);
-    },
-
-    /**
-     * Basic text input validation. By default, only performs `required`
-     * attribute validation. If the browser supports HTML5 form validation,
-     * browser validation will kick in. If validating an email or password
-     * field, call validateEmail or validatePassword instead.
-     *
-     * @param {String} el
-     * @return {Boolean}
-     */
-    validateInput: function (el) {
-      el = this.$(el);
-      var isRequired = typeof el.attr('required') !== 'undefined';
-
-      var value = this.getElementValue(el);
-
-      if (isRequired && value.length === 0) {
-        return false;
-      }
-
-      // If the browser supports HTML5 form validation, hooray,
-      // use its validation too.
-      var hasHtml5Validation = !! el[0].validity;
-      if (hasHtml5Validation) {
-        return el[0].validity.valid;
-      }
-
-      return true;
-    },
-
-    showPasswordValidationError: function (el) {
-      var passwordVal = this.getElementValue(el);
-
-      var errType = passwordVal ? 'PASSWORD_TOO_SHORT' : 'PASSWORD_REQUIRED';
-
-      return this.showValidationError(el, AuthErrors.toError(errType));
     },
 
     /**

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -20,13 +20,14 @@
 define(function (require, exports, module) {
   'use strict';
 
+  require('views/elements/jquery-plugin');
+
   const $ = require('jquery');
   const _ = require('underscore');
   const allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
   const AuthErrors = require('lib/auth-errors');
   const BaseView = require('views/base');
   const Duration = require('duration');
-  const upgradeElement = require('views/elements/upgrade-element');
   const notifyDelayedRequest = require('views/decorators/notify_delayed_request');
   const p = require('lib/promise');
   const showButtonProgressIndicator = require('views/decorators/progress_indicator');
@@ -87,20 +88,6 @@ define(function (require, exports, module) {
 
       proto.afterRender.call(this);
     },
-
-    /**
-     * Get a view element. View element will contain
-     * an additional `validate` function.
-     *
-     * @param {String} el - selector or element
-     * @returns {Object} jQuery Element
-     */
-    $ (el) {
-      const $el = proto.$.call(this, el);
-
-      return upgradeElement($el);
-    },
-
 
     /**
      * Get the current form values. Does not fetch the value of elements with
@@ -257,7 +244,9 @@ define(function (require, exports, module) {
       const inputEls = this.$('input');
       for (var i = 0, length = inputEls.length; i < length; ++i) {
         var $el = this.$(inputEls[i]);
-        if (! $el.validate()) {
+        try {
+          $el.validate();
+        } catch (e) {
           return false;
         }
       }
@@ -309,8 +298,16 @@ define(function (require, exports, module) {
       for (var i = 0, length = inputEls.length; i < length; ++i) {
         const el = inputEls[i];
         const $el = this.$(el);
-        if (! $el.validate()) {
-          this.showValidationError(el, $el.validationError);
+
+        let validationError;
+        try {
+          $el.validate();
+        } catch (e) {
+          validationError = e;
+        }
+
+        if (validationError) {
+          this.showValidationError(el, validationError);
           // only one message at a time.
           return;
         }

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -60,7 +60,7 @@ define(function (require, exports, module) {
       BaseView.call(this, options);
 
       // attach events of the descendent view and this view.
-      this.delegateEvents(_.extend({}, proto.events, this.events));
+      this.delegateEvents(_.extend({}, FormView.prototype.events, this.events));
     },
 
     events: {
@@ -256,8 +256,8 @@ define(function (require, exports, module) {
 
       const inputEls = this.$('input');
       for (var i = 0, length = inputEls.length; i < length; ++i) {
-        var el = inputEls[i];
-        if (this.$(el).validate()) {
+        var $el = this.$(inputEls[i]);
+        if (! $el.validate()) {
           return false;
         }
       }
@@ -308,9 +308,9 @@ define(function (require, exports, module) {
       const inputEls = this.$('input');
       for (var i = 0, length = inputEls.length; i < length; ++i) {
         const el = inputEls[i];
-        const err = this.$(el).validate();
-        if (err) {
-          this.showValidationError(el, err);
+        const $el = this.$(el);
+        if (! $el.validate()) {
+          this.showValidationError(el, $el.validationError);
           // only one message at a time.
           return;
         }

--- a/app/scripts/views/mixins/password-prompt-mixin.js
+++ b/app/scripts/views/mixins/password-prompt-mixin.js
@@ -10,10 +10,8 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const BaseView = require('views/base');
-  const t = BaseView.t;
   const Strings = require('lib/strings');
-
+  const t = require('views/base').t;
   const Tooltip = require('views/tooltip');
 
   // this link is not suitable for L10N and should be available in only `en` locales.
@@ -41,12 +39,12 @@ define(function (require, exports, module) {
     },
 
     displayPasswordInitialPrompt: function (inputEl) {
-      this.$el.find(inputEl).siblings(INPUT_HELP_FOCUSED).html(this.translate(TOOLTIP_MESSAGES.INITIAL_PROMPT_MESSAGE));
+      this.$(inputEl).siblings(INPUT_HELP_FOCUSED).html(this.translate(TOOLTIP_MESSAGES.INITIAL_PROMPT_MESSAGE));
       this._logPromptExperimentEvent('INITIAL_PROMPT_MESSAGE');
     },
 
     displayPasswordFocusPrompt: function (inputEl) {
-      this.$el.find(inputEl).siblings(INPUT_HELP_FOCUSED).html(this.translate(TOOLTIP_MESSAGES.FOCUS_PROMPT_MESSAGE));
+      this.$(inputEl).siblings(INPUT_HELP_FOCUSED).html(this.translate(TOOLTIP_MESSAGES.FOCUS_PROMPT_MESSAGE));
       this._logPromptExperimentEvent('FOCUS_PROMPT_MESSAGE');
     },
 
@@ -61,7 +59,7 @@ define(function (require, exports, module) {
       const tooltip = new Tooltip({
         dismissible: false,
         extraClassNames: 'tooltip-suggest tooltip-warning',
-        invalidEl: this.$el.find(CHECK_PASSWORD_FIELD_SELECTOR),
+        invalidEl: this.$(CHECK_PASSWORD_FIELD_SELECTOR),
         message: promptContent
       });
       tooltip.render();
@@ -69,7 +67,7 @@ define(function (require, exports, module) {
     },
 
     showPasswordPrompt: function (inputEl) {
-      const length = this.$el.find(inputEl).val().length;
+      const length = this.$(inputEl).val().length;
       if (length === 0) {
         this.displayPasswordInitialPrompt(inputEl);
       } else {
@@ -78,11 +76,11 @@ define(function (require, exports, module) {
     },
 
     onInputFocus: function (event) {
-      this.showPasswordPrompt(this.$el.find(event.currentTarget));
+      this.showPasswordPrompt(event.currentTarget);
     },
 
     onInputKeyUp: function (event) {
-      this.showPasswordPrompt(this.$el.find(event.currentTarget));
+      this.showPasswordPrompt(event.currentTarget);
     },
 
     onPasswordBlur: function () {

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -410,87 +410,64 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('validateEmail', function () {
-      it('returns false if an empty email', function () {
+    describe('validate - mail', function () {
+      it('not valid if an empty email', function () {
         view.$('#email').val('');
-        assert.isFalse(view.validateEmail('#email'));
-        assert.isFalse(view.isElementValid('#email'));
+        assert.isTrue(AuthErrors.is(
+          view.$('#email').validate(), 'EMAIL_REQUIRED'));
       });
 
-      it('returns false if an invalid email', function () {
+      it('not valid if an invalid email', function () {
         view.$('#email').val('invalid');
-        assert.isFalse(view.validateEmail('#email'));
-        assert.isFalse(view.isElementValid('#email'));
+        assert.isTrue(AuthErrors.is(
+          view.$('#email').validate(), 'INVALID_EMAIL'));
       });
 
-      it('returns true if a valid email', function () {
+      it('valid if a valid email', function () {
         view.$('#email').val('testuser@testuser.com');
-        assert.isTrue(view.validateEmail('#email'));
-        assert.isTrue(view.isElementValid('#email'));
+        assert.notOk(view.$('#email').validate());
       });
     });
 
-    describe('validatePassword', function () {
-      it('returns false if an empty password', function () {
+    describe('validate - password', function () {
+      it('invalid if an empty password', function () {
         view.$('#password').val('');
-        assert.isFalse(view.validatePassword('#password'));
-        assert.isFalse(view.isElementValid('#password'));
+        assert.isTrue(AuthErrors.is(
+          view.$('#password').validate(), 'PASSWORD_REQUIRED'));
       });
 
-      it('returns false if too short a password', function () {
+      it('invalid if too short a password', function () {
         view.$('#password').val('1');
-        assert.isFalse(view.validatePassword('#password'));
-        assert.isFalse(view.isElementValid('#password'));
+        assert.isTrue(AuthErrors.is(
+          view.$('#password').validate(), 'PASSWORD_TOO_SHORT'));
       });
 
-      it('returns true if a valid password', function () {
+      it('valid if a valid password', function () {
         view.$('#password').val(TestHelpers.createRandomHexString(Constants.PASSWORD_MIN_LENGTH));
-        assert.isTrue(view.validatePassword('#password'));
-        assert.isTrue(view.isElementValid('#password'));
+        assert.notOk(view.$('#password').validate());
       });
     });
 
-    describe('validateInput', function () {
-      it('returns true for an empty non-required input', function () {
+    describe('validate - text', function () {
+      it('valid for an empty non-required input', function () {
         view.$('#notRequired').val('');
-        assert.isTrue(view.validateInput('#notRequired'));
-        assert.isTrue(view.isElementValid('#notRequired'));
+        assert.notOk(view.$('#notRequired').validate());
       });
 
-      it('returns true for a filled out non-required input', function () {
+      it('valid for a filled out non-required input', function () {
         view.$('#notRequired').val('value');
-        assert.isTrue(view.validateInput('#notRequired'));
-        assert.isTrue(view.isElementValid('#notRequired'));
+        assert.notOk(view.$('#notRequired').validate());
       });
 
-      it('returns false for an empty required input', function () {
+      it('invalid for an empty required input', function () {
         view.$('#required').val('');
-        assert.isFalse(view.validateInput('#required'));
-        assert.isFalse(view.isElementValid('#required'));
+        assert.isTrue(AuthErrors.is(
+          view.$('#required').validate(), 'INPUT_REQUIRED'));
       });
 
       it('returns true for a filled out required input', function () {
         view.$('#required').val('value');
-        assert.isTrue(view.validateInput('#required'));
-        assert.isTrue(view.isElementValid('#required'));
-      });
-
-      it('returns true if no internal validation fails, and HTML5 validation is not available', function () {
-        sinon.stub(view, '$', function () {
-          // completely synthesize a mock element that
-          // has no HTML5 form validity.
-          return {
-            attr: function () {
-            },
-            val: function () {
-              return 'hiya!';
-            },
-            '0': {
-            }
-          };
-        });
-        assert.isTrue(view.validateInput({}));
-        view.$.restore();
+        assert.notOk(view.$('#required').validate());
       });
     });
 
@@ -650,19 +627,6 @@ define(function (require, exports, module) {
             assert.equal(view.$('.error').text(), 'BOOM');
             assert.isTrue(view._isErrorVisible);
           });
-      });
-    });
-
-    describe('getElementType', function () {
-      it('returns the type of the element', function () {
-        assert.equal(view.getElementType('#focusMe'), 'text');
-        assert.equal(view.getElementType('#password'), 'password');
-      });
-
-      it('returns `password` for text inputs with the `password` class', function () {
-        assert.equal(view.getElementType('#focusMe'), 'text');
-        view.$('#focusMe').addClass('password');
-        assert.equal(view.getElementType('#focusMe'), 'password');
       });
     });
 

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -68,6 +68,31 @@ define(function (require, exports, module) {
         });
     }
 
+    function testValidationError($el, expectedError) {
+      let validationError;
+
+      try {
+        $el.validate();
+      } catch (e) {
+        validationError = e;
+      }
+
+      assert.isTrue(AuthErrors.is(validationError, expectedError));
+    }
+
+    function testNoValidationError($el) {
+      let validationError;
+
+      try {
+        $el.validate();
+      } catch (e) {
+        validationError = e;
+      }
+
+      assert.isUndefined(validationError);
+    }
+
+
     beforeEach(function () {
       metrics = new Metrics();
       model = new Backbone.Model({});
@@ -415,23 +440,21 @@ define(function (require, exports, module) {
         const $el = view.$('#email');
         $el.val('');
 
-        assert.isFalse($el.validate());
-        assert.isTrue(AuthErrors.is($el.validationError, 'EMAIL_REQUIRED'));
+        testValidationError($el, 'EMAIL_REQUIRED');
       });
 
       it('not valid if an invalid email', function () {
         const $el = view.$('#email');
         $el.val('invalid');
 
-        assert.isFalse($el.validate());
-        assert.isTrue(AuthErrors.is($el.validationError, 'INVALID_EMAIL'));
+        testValidationError($el, 'INVALID_EMAIL');
       });
 
       it('valid if a valid email', function () {
         const $el = view.$('#email');
         $el.val('testuser@testuser.com');
 
-        assert.isTrue($el.validate());
+        testNoValidationError($el);
       });
     });
 
@@ -440,47 +463,44 @@ define(function (require, exports, module) {
         const $el = view.$('#password');
         $el.val('');
 
-        assert.isFalse($el.validate());
-        assert.isTrue(AuthErrors.is($el.validationError, 'PASSWORD_REQUIRED'));
+        testValidationError($el, 'PASSWORD_REQUIRED');
       });
 
       it('invalid if too short a password', function () {
         const $el = view.$('#password');
         $el.val('1');
 
-        assert.isFalse($el.validate());
-        assert.isTrue(AuthErrors.is($el.validationError, 'PASSWORD_TOO_SHORT'));
+        testValidationError($el, 'PASSWORD_TOO_SHORT');
       });
 
       it('valid if a valid password', function () {
         const $el = view.$('#password');
         $el.val(TestHelpers.createRandomHexString(Constants.PASSWORD_MIN_LENGTH));
-        assert.isTrue($el.validate());
+        testNoValidationError($el);
       });
     });
 
     describe('validate - text', function () {
       it('valid for an empty non-required input', function () {
         view.$('#notRequired').val('');
-        assert.isTrue(view.$('#notRequired').validate());
+        testNoValidationError(view.$('#notRequired'));
       });
 
       it('valid for a filled out non-required input', function () {
         view.$('#notRequired').val('value');
-        assert.isTrue(view.$('#notRequired').validate());
+        testNoValidationError(view.$('#notRequired'));
       });
 
       it('invalid for an empty required input', function () {
         const $el = view.$('#required');
         $el.val('');
 
-        assert.isFalse($el.validate());
-        assert.isTrue(AuthErrors.is($el.validationError, 'INPUT_REQUIRED'));
+        testValidationError($el, 'INPUT_REQUIRED');
       });
 
       it('valid for a filled out required input', function () {
         view.$('#required').val('value');
-        assert.isTrue(view.$('#required').validate());
+        testNoValidationError(view.$('#required'));
       });
     });
 

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -412,62 +412,75 @@ define(function (require, exports, module) {
 
     describe('validate - mail', function () {
       it('not valid if an empty email', function () {
-        view.$('#email').val('');
-        assert.isTrue(AuthErrors.is(
-          view.$('#email').validate(), 'EMAIL_REQUIRED'));
+        const $el = view.$('#email');
+        $el.val('');
+
+        assert.isFalse($el.validate());
+        assert.isTrue(AuthErrors.is($el.validationError, 'EMAIL_REQUIRED'));
       });
 
       it('not valid if an invalid email', function () {
-        view.$('#email').val('invalid');
-        assert.isTrue(AuthErrors.is(
-          view.$('#email').validate(), 'INVALID_EMAIL'));
+        const $el = view.$('#email');
+        $el.val('invalid');
+
+        assert.isFalse($el.validate());
+        assert.isTrue(AuthErrors.is($el.validationError, 'INVALID_EMAIL'));
       });
 
       it('valid if a valid email', function () {
-        view.$('#email').val('testuser@testuser.com');
-        assert.notOk(view.$('#email').validate());
+        const $el = view.$('#email');
+        $el.val('testuser@testuser.com');
+
+        assert.isTrue($el.validate());
       });
     });
 
     describe('validate - password', function () {
       it('invalid if an empty password', function () {
-        view.$('#password').val('');
-        assert.isTrue(AuthErrors.is(
-          view.$('#password').validate(), 'PASSWORD_REQUIRED'));
+        const $el = view.$('#password');
+        $el.val('');
+
+        assert.isFalse($el.validate());
+        assert.isTrue(AuthErrors.is($el.validationError, 'PASSWORD_REQUIRED'));
       });
 
       it('invalid if too short a password', function () {
-        view.$('#password').val('1');
-        assert.isTrue(AuthErrors.is(
-          view.$('#password').validate(), 'PASSWORD_TOO_SHORT'));
+        const $el = view.$('#password');
+        $el.val('1');
+
+        assert.isFalse($el.validate());
+        assert.isTrue(AuthErrors.is($el.validationError, 'PASSWORD_TOO_SHORT'));
       });
 
       it('valid if a valid password', function () {
-        view.$('#password').val(TestHelpers.createRandomHexString(Constants.PASSWORD_MIN_LENGTH));
-        assert.notOk(view.$('#password').validate());
+        const $el = view.$('#password');
+        $el.val(TestHelpers.createRandomHexString(Constants.PASSWORD_MIN_LENGTH));
+        assert.isTrue($el.validate());
       });
     });
 
     describe('validate - text', function () {
       it('valid for an empty non-required input', function () {
         view.$('#notRequired').val('');
-        assert.notOk(view.$('#notRequired').validate());
+        assert.isTrue(view.$('#notRequired').validate());
       });
 
       it('valid for a filled out non-required input', function () {
         view.$('#notRequired').val('value');
-        assert.notOk(view.$('#notRequired').validate());
+        assert.isTrue(view.$('#notRequired').validate());
       });
 
       it('invalid for an empty required input', function () {
-        view.$('#required').val('');
-        assert.isTrue(AuthErrors.is(
-          view.$('#required').validate(), 'INPUT_REQUIRED'));
+        const $el = view.$('#required');
+        $el.val('');
+
+        assert.isFalse($el.validate());
+        assert.isTrue(AuthErrors.is($el.validationError, 'INPUT_REQUIRED'));
       });
 
-      it('returns true for a filled out required input', function () {
+      it('valid for a filled out required input', function () {
         view.$('#required').val('value');
-        assert.notOk(view.$('#required').validate());
+        assert.isTrue(view.$('#required').validate());
       });
     });
 

--- a/app/tests/spec/views/mixins/password-prompt-mixin.js
+++ b/app/tests/spec/views/mixins/password-prompt-mixin.js
@@ -70,14 +70,16 @@ define(function (require, exports, module) {
         var event = new $.Event('focus');
         event.currentTarget = PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR;
         view.onInputFocus(event);
-        assert.isTrue(view.showPasswordPrompt.calledWith(view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR)));
+        assert.isTrue(view.showPasswordPrompt.calledWith(
+          PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR));
       });
 
       it('onInputKeyUp calls showPasswordPrompt with the right password field', function () {
         var event = new $.Event('keyup');
         event.currentTarget = PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR;
         view.onInputKeyUp(event);
-        assert.isTrue(view.showPasswordPrompt.calledWith(view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR)));
+        assert.isTrue(view.showPasswordPrompt.calledWith(
+          PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR));
       });
     });
 


### PR DESCRIPTION
Move these into helpers/custom elements.

@philbooth - this is the PR I was just talking about. Mind giving some feedback?

This started because I found it a bit ridiculous that I was adding code to form.js to validate an "unblock code" when I was putting together the demos yesterday.