### PR TITLE
refactor(client): Unify all the resend email code into resend-mixin.

### DIFF
--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -6,7 +6,7 @@
 
   <section>
     <div class="error"></div>
-    <div class="success">{{#t}}Email resent{{/t}}</div>
+    <div class="success"></div>
 
     <p>
       {{#t}}The link you clicked to reset your password is expired.{{/t}}

--- a/app/scripts/templates/complete_sign_up.mustache
+++ b/app/scripts/templates/complete_sign_up.mustache
@@ -6,7 +6,7 @@
 
   <section>
     <div class="error"></div>
-    <div class="success">{{#t}}Email resent{{/t}}</div>
+    <div class="success"></div>
 
     <p>
       {{#t}}The link you clicked to verify your email is expired.{{/t}}

--- a/app/scripts/templates/confirm.mustache
+++ b/app/scripts/templates/confirm.mustache
@@ -10,9 +10,7 @@
 
   <section>
     <div class="error"></div>
-    <div class="success">
-      {{#t}}Email resent{{/t}}
-    </div>
+    <div class="success"></div>
 
     <div class="graphic graphic-mail">{{#t}}Email Sent{{/t}}</div>
 

--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -5,7 +5,7 @@
 
   <section>
     <div class="error"></div>
-    <div class="success">{{#t}}Email resent{{/t}}</div>
+    <div class="success"></div>
 
     <div class="graphic graphic-mail">{{#t}}Email Sent{{/t}}</div>
 

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -14,6 +14,7 @@ define(function (require, exports, module) {
   var PasswordMixin = require('views/mixins/password-mixin');
   var PasswordResetMixin = require('views/mixins/password-reset-mixin');
   var PasswordStrengthMixin = require('views/mixins/password-strength-mixin');
+  var ResendMixin = require('views/mixins/resend-mixin');
   var ServiceMixin = require('views/mixins/service-mixin');
   var Template = require('stache!templates/complete_reset_password');
   var Url = require('lib/url');
@@ -29,10 +30,6 @@ define(function (require, exports, module) {
 
       var searchParams = Url.searchParams(this.window.location.search);
       this._verificationInfo = new VerificationInfo(searchParams);
-    },
-
-    events: {
-      'click #resend': BaseView.preventDefaultThen('resendResetEmail')
     },
 
     // beforeRender is asynchronous and returns a promise. Only render
@@ -158,12 +155,8 @@ define(function (require, exports, module) {
       return this.$('#vpassword').val();
     },
 
-    resendResetEmail: function () {
-      var self = this;
-      self.logViewEvent('resend');
-      var email = self._verificationInfo.get('email');
-      return self.resetPassword(email)
-        .fail(self.displayError.bind(self));
+    resend () {
+      return this.resetPassword(this._verificationInfo.get('email'));
     }
   });
 
@@ -173,6 +166,7 @@ define(function (require, exports, module) {
     PasswordMixin,
     PasswordResetMixin,
     PasswordStrengthMixin,
+    ResendMixin,
     ServiceMixin
   );
 

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -11,7 +11,6 @@ define(function (require, exports, module) {
   var Cocktail = require('cocktail');
   var Constants = require('lib/constants');
   var ExperimentMixin = require('views/mixins/experiment-mixin');
-  var FormView = require('views/form');
   var OpenConfirmationEmailMixin = require('views/mixins/open-webmail-mixin');
   var p = require('lib/promise');
   var ResendMixin = require('views/mixins/resend-mixin');
@@ -22,7 +21,7 @@ define(function (require, exports, module) {
 
   var t = BaseView.t;
 
-  var View = FormView.extend({
+  var View = BaseView.extend({
     template: Template,
     className: 'confirm',
 
@@ -59,11 +58,6 @@ define(function (require, exports, module) {
         isSignUp: isSignUp,
         openWebmailButtonVisible: this.isOpenWebmailButtonVisible(email)
       };
-    },
-
-    events: {
-      // validateAndSubmit is used to prevent multiple concurrent submissions.
-      'click #resend': BaseView.preventDefaultThen('validateAndSubmit')
     },
 
     _bouncedEmailSignup: function () {
@@ -191,23 +185,16 @@ define(function (require, exports, module) {
         });
     },
 
-    submit: function () {
-      var self = this;
-
-      self.logViewEvent('resend');
-
-      return self.getAccount().retrySignUp(
-        self.relier,
+    resend () {
+      return this.getAccount().retrySignUp(
+        this.relier,
         {
-          resume: self.getStringifiedResumeToken()
+          resume: this.getStringifiedResumeToken()
         }
       )
-      .then(function () {
-        self.displaySuccess();
-      })
-      .fail(function (err) {
+      .fail((err) => {
         if (AuthErrors.is(err, 'INVALID_TOKEN')) {
-          return self.navigate('signup', {
+          return this.navigate('signup', {
             error: err
           });
         }
@@ -215,11 +202,7 @@ define(function (require, exports, module) {
         // unexpected error, rethrow for display.
         throw err;
       });
-    },
-
-    // The ResendMixin overrides beforeSubmit. Unless set to undefined,
-    // Cocktail runs both the original version and the overridden version.
-    beforeSubmit: undefined
+    }
   });
 
   Cocktail.mixin(

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -29,10 +29,6 @@ define(function (require, exports, module) {
               this.VERIFICATION_POLL_IN_MS;
     },
 
-    events: {
-      'click #resend': BaseView.preventDefaultThen('validateAndSubmit')
-    },
-
     context: function () {
       var email = this.model.get('email');
       var isSignInEnabled = this.relier.get('resetPasswordConfirm');
@@ -261,20 +257,14 @@ define(function (require, exports, module) {
       this._stopListeningForInterTabMessages();
     },
 
-    submit: function () {
-      var self = this;
-      self.logViewEvent('resend');
-
-      return self.retryResetPassword(
-        self.model.get('email'),
-        self.model.get('passwordForgotToken')
+    resend () {
+      return this.retryResetPassword(
+        this.model.get('email'),
+        this.model.get('passwordForgotToken')
       )
-      .then(function () {
-        self.displaySuccess();
-      })
-      .fail(function (err) {
+      .fail((err) => {
         if (AuthErrors.is(err, 'INVALID_TOKEN')) {
-          return self.navigate('reset_password', {
+          return this.navigate('reset_password', {
             error: err
           });
         }
@@ -282,11 +272,7 @@ define(function (require, exports, module) {
         // unexpected error, rethrow for display.
         throw err;
       });
-    },
-
-    // The ResendMixin overrides beforeSubmit. Unless set to undefined,
-    // Cocktail runs both the original version and the overridden version.
-    beforeSubmit: undefined
+    }
   });
 
   Cocktail.mixin(

--- a/app/scripts/views/mixins/resend-mixin.js
+++ b/app/scripts/views/mixins/resend-mixin.js
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
         this.logViewEvent('resend');
         this._updateSuccessMessage();
 
-        // The button is hidden after the forth click for 5 minutes, then
+        // The button is hidden after the fourth click for 5 minutes, then
         // start the process again.
         this._emailResend.incrementRequestCount();
         if (this._emailResend.shouldResend()) {

--- a/app/scripts/views/mixins/resend-mixin.js
+++ b/app/scripts/views/mixins/resend-mixin.js
@@ -2,56 +2,69 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// helper functions for views with passwords. Meant to be mixed into views.
-// Note, this mixin overrides beforeSubmit and is incompatible with Cocktail.
+// Helper functions to allow a view to resend an email.
+//
+// Binds a click event to the #resend DOM element which causes
+// an email to be resent.
+//
+// Consumers must expose a `resend` function which returns a promise
+// and actually sends the email.
+//
+// When #resend is clicked, a <viewname>.resend event is logged.
 
 define(function (require, exports, module) {
   'use strict';
 
-  var Duration = require('duration');
-  var EmailResend = require('models/email-resend');
+  const Duration = require('duration');
+  const EmailResend = require('models/email-resend');
+  const p = require('lib/promise');
+  const { preventDefaultThen, t } = require('views/base');
 
-  var SHOW_RESEND_IN_MS = new Duration('5m').milliseconds();
+  const SHOW_RESEND_IN_MS = new Duration('5m').milliseconds();
 
   module.exports = {
-
-    initialize: function () {
+    initialize () {
       this._emailResend = new EmailResend();
-      this._emailResend.on('maxTriesReached', this._onMaxTriesReached.bind(this));
+      this.listenTo(this._emailResend, 'maxTriesReached', this._onMaxTriesReached);
     },
 
-    beforeSubmit: function () {
-      // See https://github.com/mozilla/fxa-content-server/issues/885.
-      // The first click of the resend button sends an email.
-      // The forth click of the resend button sends an email.
-      // All other clicks are ignored.
-      // The button is hidden after the forth click for 5 minutes, then
-      // start the process again.
-
-      this._emailResend.incrementRequestCount();
-      this._updateSuccessMessage();
-
-      return this._emailResend.shouldResend();
+    events: {
+      'click #resend': preventDefaultThen('_resend')
     },
 
-    _updateSuccessMessage: function () {
+    _resend () {
+      return p().then(() => {
+        this.logViewEvent('resend');
+        this._updateSuccessMessage();
+
+        // The button is hidden after the forth click for 5 minutes, then
+        // start the process again.
+        this._emailResend.incrementRequestCount();
+        if (this._emailResend.shouldResend()) {
+          return this.resend()
+            .then(() => this.displaySuccess(t('Email resent')))
+            .fail((err) => this.displayError(err));
+        }
+      });
+    },
+
+    _updateSuccessMessage () {
       // if a success message is already being displayed, shake it.
       var successEl = this.$('.success:visible');
       if (successEl) {
-        successEl.one('animationend', function () {
+        successEl.one('animationend', () => {
           successEl.removeClass('shake');
         }).addClass('shake');
       }
     },
 
-    _onMaxTriesReached: function () {
-      var self = this;
+    _onMaxTriesReached () {
       // Hide the button after too many attempts. Redisplay button after a delay.
-      self.logViewEvent('too_many_attempts');
-      self.$('#resend').hide();
-      self.setTimeout(function () {
-        self._emailResend.reset();
-        self.$('#resend').show();
+      this.logViewEvent('too_many_attempts');
+      this.$('#resend').hide();
+      this.setTimeout(() => {
+        this._emailResend.reset();
+        this.$('#resend').show();
       }, SHOW_RESEND_IN_MS);
     }
   };

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -429,27 +429,27 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('resendResetEmail', function () {
+    describe('resend', function () {
       it('delegates to the `resetPassword` method', function () {
         sinon.stub(view, 'resetPassword', function () {
           return p();
         });
 
-        return view.resendResetEmail()
+        return view.resend()
           .then(function () {
             assert.isTrue(view.resetPassword.calledOnce);
             assert.isTrue(view.resetPassword.calledWith(EMAIL));
           });
       });
 
-      it('shows server response as an error otherwise', function () {
+      it('re-throws all errors', function () {
         sinon.stub(view, 'resetPassword', function () {
           return p.reject(new Error('server error'));
         });
 
-        return view.resendResetEmail()
-          .then(function () {
-            assert.equal(view.$('.error').text(), 'server error');
+        return view.resend()
+          .then(assert.fail, (err) => {
+            assert.equal(err.message, 'server error');
           });
       });
     });

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -58,10 +58,6 @@ define(function (require, exports, module) {
         });
     }
 
-    function testEventLogged(eventName) {
-      assert.isTrue(TestHelpers.isEventLogged(metrics, eventName));
-    }
-
     function testErrorLogged(error) {
       var normalizedError = view._normalizeError(error);
       assert.isTrue(TestHelpers.isErrorLogged(metrics, normalizedError));
@@ -226,8 +222,8 @@ define(function (require, exports, module) {
 
       describe('if reminder and service is available in the URL', function () {
         beforeEach(function () {
-          windowMock.location.search = '?code=' + validCode + '&uid=' + validUid
-            + '&service=' + validService + '&reminder=' + validReminder;
+          windowMock.location.search = '?code=' + validCode + '&uid=' + validUid +
+            '&service=' + validService + '&reminder=' + validReminder;
           relier = new Relier({
             window: windowMock
           });
@@ -523,7 +519,7 @@ define(function (require, exports, module) {
 
     });
 
-    describe('submit - attempt to resend the verification email', function () {
+    describe('resend', function () {
       var retrySignUpAccount;
 
       beforeEach(function () {
@@ -567,12 +563,8 @@ define(function (require, exports, module) {
 
           return view.render()
             .then(function () {
-              return view.submit();
+              return view.resend();
             });
-        });
-
-        it('logs the event', function () {
-          testEventLogged('complete_sign_up.resend');
         });
 
         it('tells the account to retry signUp', function () {
@@ -582,10 +574,6 @@ define(function (require, exports, module) {
               resume: 'resume token'
             }
           ));
-        });
-
-        it('shows the success message', function () {
-          assert.isTrue(view.isSuccessVisible());
         });
       });
 
@@ -601,7 +589,7 @@ define(function (require, exports, module) {
 
           sinon.spy(view, 'navigate');
 
-          return view.submit();
+          return view.resend();
         });
 
         it('sends the user to the /signup page', function () {
@@ -620,8 +608,8 @@ define(function (require, exports, module) {
           });
         });
 
-        it('are re-thrown for display', function () {
-          return view.submit()
+        it('re-throws other errors', function () {
+          return view.resend()
             .then(assert.fail, function (err) {
               assert.isTrue(AuthErrors.is(err, 'UNEXPECTED_ERROR'));
             });

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -504,7 +504,7 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('submit', function () {
+    describe('resend', function () {
       beforeEach(function () {
         createDeps();
 
@@ -523,10 +523,8 @@ define(function (require, exports, module) {
           return p(true);
         });
 
-        return view.submit()
+        return view.resend()
           .then(function () {
-            assert.isTrue(view.$('.success').is(':visible'));
-
             assert.isTrue(view.retryResetPassword.calledOnce);
             assert.isTrue(view.retryResetPassword.calledWith(
               EMAIL,
@@ -542,78 +540,21 @@ define(function (require, exports, module) {
 
         sinon.spy(view, 'navigate');
 
-        return view.submit()
+        return view.resend()
           .then(function () {
             assert.isTrue(view.navigate.calledWith('reset_password'));
-
-            assert.isTrue(TestHelpers.isEventLogged(metrics,
-                              'confirm_reset_password.resend'));
           });
       });
 
-      it('displays other error messages if there is a problem', function () {
+      it('re-throws other errors', function () {
         sinon.stub(view, 'retryResetPassword', function () {
           return p.reject(new Error('synthesized error from auth server'));
         });
 
-        return view.submit()
+        return view.resend()
           .then(assert.fail, function (err) {
             assert.equal(err.message, 'synthesized error from auth server');
           });
-      });
-    });
-
-    describe('validateAndSubmit', function () {
-      beforeEach(function () {
-        createDeps();
-
-        return view.render()
-          .then(function () {
-            $('#container').html(view.el);
-          });
-      });
-
-      afterEach(function () {
-        destroyView();
-      });
-
-      it('only called after click on #resend', function () {
-        var count = 0;
-        view.validateAndSubmit = function () {
-          count++;
-        };
-
-        view.$('section').click();
-        assert.equal(count, 0);
-
-        view.$('#resend').click();
-        assert.equal(count, 1);
-      });
-
-      it('debounces resend calls - submit on first four attempts', function () {
-        sinon.stub(view, 'retryResetPassword', function () {
-          return p(true);
-        });
-
-        return view.validateAndSubmit()
-              .then(function () {
-                assert.equal(view.retryResetPassword.callCount, 1);
-                return view.validateAndSubmit();
-              }).then(function () {
-                assert.equal(view.retryResetPassword.callCount, 2);
-                return view.validateAndSubmit();
-              }).then(function () {
-                assert.equal(view.retryResetPassword.callCount, 3);
-                return view.validateAndSubmit();
-              }).then(function () {
-                assert.equal(view.retryResetPassword.callCount, 4);
-                assert.equal(view.$('#resend:visible').length, 0);
-
-                assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                  'confirm_reset_password.resend'));
-                assert.isTrue(TestHelpers.isEventLogged(metrics,
-                                  'confirm_reset_password.too_many_attempts'));
-              });
       });
     });
   });

--- a/app/tests/spec/views/mixins/resend-mixin.js
+++ b/app/tests/spec/views/mixins/resend-mixin.js
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const $ = require('jquery');
+  const assert = require('chai').assert;
+  const BaseView = require('views/base');
+  const Cocktail = require('cocktail');
+  const p = require('lib/promise');
+  const ResendMixin = require('views/mixins/resend-mixin');
+  const sinon = require('sinon');
+  const TestTemplate = require('stache!templates/confirm');
+
+  const View = BaseView.extend({
+    template: TestTemplate,
+
+    resendError: null,
+    resend () {
+      if (this.resendError) {
+        return p.reject(this.resendError);
+      }
+
+      return p();
+    }
+  });
+
+  Cocktail.mixin(
+    View,
+    ResendMixin
+  );
+
+  describe('views/mixins/resend-mixin', () => {
+    let view;
+
+    beforeEach(() => {
+      view = new View();
+
+      return view.render()
+        .then(() => {
+          $('#container').html(view.el);
+        });
+    });
+
+    it('hooks up to `click` on #resend', () => {
+      sinon.spy(view, '_resend');
+
+      view.$('section').click();
+      assert.equal(view._resend.callCount, 0);
+
+      view.$('#resend').click();
+      assert.equal(view._resend.callCount, 1);
+    });
+
+    it('debounces resend calls - submit on first four attempts', () => {
+      sinon.spy(view, 'logViewEvent');
+      sinon.spy(view, 'displaySuccess');
+      sinon.spy(view, 'resend');
+
+      return view._resend()
+        .then(() => {
+          assert.equal(view.logViewEvent.callCount, 1);
+          assert.isTrue(view.logViewEvent.calledWith('resend'));
+          assert.isFalse(view.logViewEvent.calledWith('too_many_attempts'));
+          assert.equal(view.resend.callCount, 1);
+          assert.equal(view.displaySuccess.callCount, 1);
+          assert.isTrue(view.displaySuccess.calledWith('Email resent'));
+          assert.lengthOf(view.$('#resend:visible'), 1);
+
+          return view._resend();
+        }).then(() => {
+          assert.equal(view.logViewEvent.callCount, 2);
+          assert.isFalse(view.logViewEvent.calledWith('too_many_attempts'));
+          assert.equal(view.resend.callCount, 2);
+          assert.equal(view.displaySuccess.callCount, 2);
+          assert.lengthOf(view.$('#resend:visible'), 1);
+
+          return view._resend();
+        }).then(() => {
+          assert.equal(view.logViewEvent.callCount, 3);
+          assert.isFalse(view.logViewEvent.calledWith('too_many_attempts'));
+          assert.equal(view.resend.callCount, 3);
+          assert.equal(view.displaySuccess.callCount, 3);
+          assert.lengthOf(view.$('#resend:visible'), 1);
+
+          return view._resend();
+        }).then(() => {
+          assert.equal(view.logViewEvent.callCount, 5);
+          assert.isTrue(view.logViewEvent.calledWith('too_many_attempts'));
+          assert.equal(view.resend.callCount, 4);
+          assert.equal(view.displaySuccess.callCount, 4);
+          assert.lengthOf(view.$('#resend:visible'), 0);
+        });
+    });
+  });
+});

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -140,6 +140,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/password-reset-mixin',
     '../tests/spec/views/mixins/password-prompt-mixin',
     '../tests/spec/views/mixins/password-strength-mixin',
+    '../tests/spec/views/mixins/resend-mixin',
     '../tests/spec/views/mixins/resume-token-mixin',
     '../tests/spec/views/mixins/service-mixin',
     '../tests/spec/views/mixins/settings-panel-mixin',


### PR DESCRIPTION
The resend-mixin now contains all of the generic logic to resend an email.
A consumer of the mixin must declare a `resend` method that provices the
strategy to perform the email resending.

As a side effect:
fixes #3994

@philbooth or @vladikoff - mind an r?

This PR came to be because I need it for signin unblock. The `signin_unblock` screen is an actual form that also has a resend button. The resend-mixin overrode `beforeSubmit` because I previously used the `submit` handler to resend the email. I made this terrible decision nearly 3 years ago and I've regretted it ever since. I'm undoing the horribleness, and enabling resend for signin unblock.