### PR TITLE
fix(client): Fix /force_auth and /complete_sign_up error handling.

### DIFF
--- a/app/scripts/templates/complete_sign_up.mustache
+++ b/app/scripts/templates/complete_sign_up.mustache
@@ -38,7 +38,7 @@
   </header>
 
   <section>
-    <div class="error">{{error}}</div>
+    <div class="error"></div>
   </section>
   {{/error}}
 </div>

--- a/app/scripts/templates/force_auth.mustache
+++ b/app/scripts/templates/force_auth.mustache
@@ -5,7 +5,7 @@
 
   <section>
     {{#fatalError}}
-      <div class="error visible">{{fatalError}}</div>
+      <div class="error visible"></div>
     {{/fatalError}}
     {{^fatalError}}
 

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -155,7 +155,7 @@ define(function (require, exports, module) {
               }
             } else {
               // all other errors show the standard error box.
-              self._error = self.translateError(err);
+              self.model.set('error', err);
             }
 
             self.logError(err);
@@ -167,7 +167,7 @@ define(function (require, exports, module) {
       var verificationInfo = this._verificationInfo;
       return {
         canResend: this._canResend(),
-        error: this._error,
+        error: this.model.get('error'),
         // If the link is invalid, print a special error message.
         isLinkDamaged: ! verificationInfo.isValid(),
         isLinkExpired: verificationInfo.isExpired()

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -18,14 +18,6 @@ define(function (require, exports, module) {
   var Transform = require('lib/transform');
   var Vat = require('lib/vat');
 
-  function getFatalErrorMessage(self, fatalError) {
-    if (fatalError) {
-      return self.translateError(fatalError);
-    }
-
-    return '';
-  }
-
   var RELIER_DATA_SCHEMA = {
     email: Vat.email().required(),
     uid: Vat.uid().allow(null)
@@ -41,8 +33,6 @@ define(function (require, exports, module) {
     // call with which data when signin is successful.
     afterSignInBrokerMethod: 'afterForceAuth',
     afterSignInNavigateData: { clearQueryParams: true },
-
-    _fatalError: null,
 
     _getAndValidateAccountData: function () {
       var fieldsToPick = ['email', 'uid'];
@@ -123,7 +113,7 @@ define(function (require, exports, module) {
       if (this.broker.hasCapability('allowUidChange')) {
         return this._navigateToForceSignUp(account);
       } else {
-        this._fatalError = AuthErrors.toError('DELETED_ACCOUNT');
+        this.model.set('error', AuthErrors.toError('DELETED_ACCOUNT'));
       }
     },
 
@@ -131,7 +121,7 @@ define(function (require, exports, module) {
       // if the broker supports a UID change, use force_auth to sign in,
       // otherwise print a big error message.
       if (! this.broker.hasCapability('allowUidChange')) {
-        this._fatalError = AuthErrors.toError('DELETED_ACCOUNT');
+        this.model.set('error', AuthErrors.toError('DELETED_ACCOUNT'));
       }
     },
 
@@ -160,7 +150,7 @@ define(function (require, exports, module) {
     context: function () {
       return {
         email: this.relier.get('email'),
-        fatalError: getFatalErrorMessage(this, this._fatalError),
+        fatalError: this.model.get('error'),
         password: this._formPrefill.get('password')
       };
     },

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -355,7 +355,7 @@ define(function (require, exports, module) {
       describe('all other server errors', function () {
         beforeEach(function () {
           verificationError = AuthErrors.toError('UNEXPECTED_ERROR');
-          return view.render();
+          return view.render().then(() => view.afterVisible());
         });
 
         it('attempts to verify the account', function () {

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -192,15 +192,16 @@ define(function (require, exports, module) {
         describe('broker does not support UID change', function () {
           beforeEach(function () {
             broker.unsetCapability('allowUidChange');
-            return view.render();
+            sinon.spy(view, 'displayError');
+            return view.render().then(() => view.afterVisible());
           });
 
           it('does not navigate', function () {
             assert.isFalse(view.navigate.called);
           });
 
-          it('errors', function () {
-            assert.lengthOf(view.$('.error.visible'), 1);
+          it('displays the error', function () {
+            assert.isTrue(view.displayError.called);
           });
         });
       });
@@ -241,15 +242,16 @@ define(function (require, exports, module) {
         describe('broker does not support UID change', function () {
           beforeEach(function () {
             broker.unsetCapability('allowUidChange');
-            return view.render();
+            sinon.spy(view, 'displayError');
+            return view.render().then(() => view.afterVisible());
           });
 
           it('does not navigate', function () {
             assert.isFalse(view.navigate.called);
           });
 
-          it('errors', function () {
-            assert.lengthOf(view.$('.error.visible'), 1);
+          it('displays the error', function () {
+            assert.isTrue(view.displayError.called);
           });
         });
       });
@@ -277,15 +279,16 @@ define(function (require, exports, module) {
         describe('broker does not support UID change', function () {
           beforeEach(function () {
             broker.unsetCapability('allowUidChange');
-            return view.render();
+            sinon.spy(view, 'displayError');
+            return view.render().then(() => view.afterVisible());
           });
 
           it('does not navigate', function () {
             assert.isFalse(view.navigate.called);
           });
 
-          it('errors', function () {
-            assert.lengthOf(view.$('.error.visible'), 1);
+          it('displays the error', function () {
+            assert.isTrue(view.displayError.called);
           });
         });
       });


### PR DESCRIPTION
Commit 1:
No `error` was set on the view's model, which caused `enableSubmitIfValid`
to hide the visible error message when called in `afterRender`.

The force_auth view saved it's errors into a local `this._fatalError`
attribute. Instead of saving the error to `this._fatalError`, save it to
`this.model.error` so the displayed error remains visible.

Commit 2:
complete_sign_up suffered from the same problem as /force_auth, it stored
a local reference to generic errors instead of storing the error on this.model.

`afterRender` calls `enableSubmitIfValid` if no `this.model.error` exists,
which hides the error printed into the template.

Instead of storing a local reference, store the error into this.model.

fixes #4127

@vladikoff - r?


