### PR TITLE
fix(tests): Fix the settings/avatar functional tests.

### DIFF
--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -30,16 +30,11 @@ define([
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var openPage = thenify(FunctionalHelpers.openPage);
   var testElementExists = FunctionalHelpers.testElementExists;
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
 
   var testIsBrowserNotifiedOfAvatarChange = thenify(function () {
     return this.parent
-      .findByCssSelector('#message-profile-change')
-        .getProperty('innerText')
-        .then(function (innerText) {
-          var data = JSON.parse(innerText);
-          assert.ok(data.uid);
-        })
-      .end();
+      .then(testIsBrowserNotified(this.parent, 'profile:change'));
   });
 
   function signUp(context, email) {


### PR DESCRIPTION
The tests were looking directly in the DOM for whether the
`profile-change` WebChannel message was sent instead of
using the `testIsBrowserNotified` helper function.
With #4142, writing the messages to the DOM was dropped,
and broke these tests.

fixes #4144