### PR TITLE
New messages for sign-in already verified tokens

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -299,7 +299,7 @@ define(function (require, exports, module) {
     },
     REUSED_SIGNIN_VERIFICATION_CODE: {
       errno: 1041,
-      message: EXPIRED_VERIFICATION_ERROR_MESSAGE
+      message: t('That confirmation link was already used, and can only be used once.')
     },
     INPUT_REQUIRED: {
       errno: 1042,


### PR DESCRIPTION
Fix For #4148.

New Message :  "That confirmation link was already used, and can only be used once.".