### PR TITLE
refactor(text):New messages for sign-in already verified tokens

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -299,7 +299,7 @@ define(function (require, exports, module) {
     },
     REUSED_SIGNIN_VERIFICATION_CODE: {
       errno: 1041,
-      message: EXPIRED_VERIFICATION_ERROR_MESSAGE
+      message: t('That confirmation link was already used, and can only be used once.')
     },
     INPUT_REQUIRED: {
       errno: 1042,

--- a/app/scripts/models/verification/base.js
+++ b/app/scripts/models/verification/base.js
@@ -99,6 +99,14 @@ define(function (require, exports, module) {
       return !! this._isExpired;
     },
 
+    markUsed: function () {
+      this._isUsed = true;
+    },
+
+    isUsed: function () {
+      return !! this._isUsed;
+    },
+
     /**
      * Mark the verification info as damaged. This will cause `isValid` to
      * return `false`.

--- a/app/scripts/templates/complete_sign_up.mustache
+++ b/app/scripts/templates/complete_sign_up.mustache
@@ -20,6 +20,22 @@
   </section>
   {{/isLinkExpired}}
 
+  {{#isLinkUsed}}
+  <header>
+    <h1 id="fxa-verification-link-reused-header">{{#t}}Sign-in already confirmed{{/t}}</h1>
+  </header>
+
+  <section>
+    <div class="error"></div>
+    <div class="success"></div>
+
+    <p>
+      {{#t}}That confirmation link was already used, and can only be used once.{{/t}}
+    </p>
+
+  </section>
+  {{/isLinkUsed}}
+
   {{#isLinkDamaged}}
   <header>
     <h1 id="fxa-verification-link-damaged-header">{{#t}}Verification link damaged{{/t}}</h1>

--- a/app/scripts/templates/complete_sign_up.mustache
+++ b/app/scripts/templates/complete_sign_up.mustache
@@ -1,4 +1,20 @@
 <div id="main-content" class="card">
+  {{#isLinkUsed}}
+  <header>
+    <h1 id="fxa-verification-link-reused-header">{{#t}}Sign-in already confirmed{{/t}}</h1>
+  </header>
+
+  <section>
+    <div class="error"></div>
+    <div class="success"></div>
+
+    <p>
+      {{#t}}That confirmation link was already used, and can only be used once.{{/t}}
+    </p>
+
+  </section>
+  {{/isLinkUsed}}
+  
   {{#isLinkExpired}}
   <header>
     <h1 id="fxa-verification-link-expired-header">{{#t}}Verification link expired{{/t}}</h1>
@@ -19,22 +35,6 @@
     {{/canResend}}
   </section>
   {{/isLinkExpired}}
-
-  {{#isLinkUsed}}
-  <header>
-    <h1 id="fxa-verification-link-reused-header">{{#t}}Sign-in already confirmed{{/t}}</h1>
-  </header>
-
-  <section>
-    <div class="error"></div>
-    <div class="success"></div>
-
-    <p>
-      {{#t}}That confirmation link was already used, and can only be used once.{{/t}}
-    </p>
-
-  </section>
-  {{/isLinkUsed}}
 
   {{#isLinkDamaged}}
   <header>

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -165,7 +165,7 @@ define(function (require, exports, module) {
         // If the link is invalid, print a special error message.
         isLinkDamaged: ! verificationInfo.isValid(),
         isLinkExpired: verificationInfo.isExpired(),
-	isLinkUsed: verificationInfo.isUsed()
+        isLinkUsed: verificationInfo.isUsed()
       };
     },
 

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
               // This error is generated because the link has already been used.
               if (self.isSignIn()) {
                 // Disable resending verification, can only be triggered from new sign-in
-                verificationInfo.markExpired();
+                verificationInfo.markUsed();
                 err = AuthErrors.toError('REUSED_SIGNIN_VERIFICATION_CODE');
               } else {
                 // These server says the verification code or any parameter is
@@ -164,7 +164,8 @@ define(function (require, exports, module) {
         error: this.model.get('error'),
         // If the link is invalid, print a special error message.
         isLinkDamaged: ! verificationInfo.isValid(),
-        isLinkExpired: verificationInfo.isExpired()
+        isLinkExpired: verificationInfo.isExpired(),
+	isLinkUsed: verificationInfo.isUsed()
       };
     },
 

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -339,7 +339,7 @@ define(function (require, exports, module) {
 
           return view.render()
             .then(function () {
-              assert.ok(view.$('#fxa-verification-link-expired-header').length);
+              assert.ok(view.$('#fxa-verification-link-reused-header').length);
             });
         });
 


### PR DESCRIPTION
Fix For #4148.
New Title: "Sign-in already confirmed."
New Message : "That confirmation link was already used, and can only be used once.".