### PR TITLE
fix(client): Ensure the "Open Webmail" button is translated.

### DIFF
--- a/app/scripts/templates/confirm.mustache
+++ b/app/scripts/templates/confirm.mustache
@@ -21,11 +21,11 @@
     <p class="verification-email-message">{{#t}}To better protect your Firefox data, we've emailed a confirmation link to %(email)s{{/t}}</p>
     {{/isSignIn}}
 
-    {{#openWebmailButtonVisible}}
+    {{#isOpenWebmailButtonVisible}}
       <div class="button-row">
-        <a href="{{{ webmailLink }}}" data-webmail-type="{{{webmailType}}}" class="button" target="_blank" id="open-webmail" type="button">{{webmailButtonText}}</a>
+        <a href="{{{ webmailLink }}}" data-webmail-type="{{webmailType}}" class="button" target="_blank" id="open-webmail" type="button">{{webmailButtonText}}</a>
       </div>
-    {{/openWebmailButtonVisible}}
+    {{/isOpenWebmailButtonVisible}}
 
     <div class="links">
       {{^canGoBack}}

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -67,5 +67,5 @@
 
   <a id="external-link" href="http://external.com">External link</a>
   <a id="internal-link" href="/signin">Internal link</a>
-  <a id="open-webmail" data-webmail-type="gmail" href="">Open Gmail</a>
+  <a id="open-webmail" data-webmail-type="{{webmailType}}" href="{{{webmailLink}}}">{{webmailButtonText}}</a>
 </div>

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -55,8 +55,7 @@ define(function (require, exports, module) {
         canGoBack: isSignIn && this.canGoBack(),
         email: email,
         isSignIn: isSignIn,
-        isSignUp: isSignUp,
-        openWebmailButtonVisible: this.isOpenWebmailButtonVisible(email)
+        isSignUp: isSignUp
       };
     },
 


### PR DESCRIPTION
The "Open <Webmail_name>" button was not being run through the translator. Now
it is.

In addition, fixed several smaller issues:
* `openWebmailButtonVisible` renamed to `isOpenWebmailButtonVisible`
* Moved `openWebmailButtonVisible` context set from `confirm` to mixin.
* Use a safe write of `webMailType` (convert from {{{ }}} to {{ }})

fixes #4158

@vladikoff - r?