### PR TITLE
chore(client): Rename `webmailLink` to `unsafeWebmailLink`

### DIFF
--- a/app/scripts/templates/confirm.mustache
+++ b/app/scripts/templates/confirm.mustache
@@ -23,7 +23,7 @@
 
     {{#isOpenWebmailButtonVisible}}
       <div class="button-row">
-        <a href="{{{ webmailLink }}}" data-webmail-type="{{webmailType}}" class="button" target="_blank" id="open-webmail" type="button">{{webmailButtonText}}</a>
+        <a href="{{{ unsafeWebmailLink }}}" data-webmail-type="{{webmailType}}" class="button" target="_blank" id="open-webmail" type="button">{{webmailButtonText}}</a>
       </div>
     {{/isOpenWebmailButtonVisible}}
 

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -67,5 +67,5 @@
 
   <a id="external-link" href="http://external.com">External link</a>
   <a id="internal-link" href="/signin">Internal link</a>
-  <a id="open-webmail" data-webmail-type="{{webmailType}}" href="{{{webmailLink}}}">{{webmailButtonText}}</a>
+  <a id="open-webmail" data-webmail-type="{{webmailType}}" href="{{{ unsafeWebmailLink }}}">{{webmailButtonText}}</a>
 </div>

--- a/app/scripts/views/mixins/open-webmail-mixin.js
+++ b/app/scripts/views/mixins/open-webmail-mixin.js
@@ -75,6 +75,7 @@ define(function (require, exports, module) {
 
       if (email && isOpenWebmailButtonVisible) {
         _.extend(context, {
+          unsafeWebmailLink: this.getWebmailLink(email),
           // function.bind is used to avoid infinite recursion.
           // getWebmailButtonText calls this.translate which calls
           // this.context, which will call this.getContext since context is
@@ -82,7 +83,6 @@ define(function (require, exports, module) {
           // button text, context will be set, and getContext will not be called
           // again. We should fix our l10n.
           webmailButtonText: this.getWebmailButtonText.bind(this, email),
-          webmailLink: this.getWebmailLink(email),
           webmailType: this.getWebmailType(email)
         });
       }


### PR DESCRIPTION
This is to help us keep track of which parameters are written to the DOM using
unsafe techniques.

@vladikoff - mind an r? At some point, I'd like to create a grunt task that looks in the mustache templates for `{{{` and ensures the variable names all have an `unsafe` prefix.