### PR TITLE
perf(external-link): rel==noopener added to all external links

### DIFF
--- a/app/scripts/views/mixins/external-links-mixin.js
+++ b/app/scripts/views/mixins/external-links-mixin.js
@@ -14,13 +14,16 @@ define(function (require, exports, module) {
 
   return {
     afterRender: function () {
+      this.$('a[href^=http]').each(function (index, el) {
+          var $el = $(el);
+          $el.attr('rel','noopener noreferrer');
+      });
       if (this.broker.hasCapability('convertExternalLinksToText')) {
         this.$('a[href^=http]').each(function (index, el) {
           var $el = $(el);
           $el
             .addClass('visible-url')
             .attr('data-visible-url', $el.attr('href'))
-            .attr('rel','noopener noreferrer');
         });
       }
     }

--- a/app/scripts/views/mixins/external-links-mixin.js
+++ b/app/scripts/views/mixins/external-links-mixin.js
@@ -19,7 +19,8 @@ define(function (require, exports, module) {
           var $el = $(el);
           $el
             .addClass('visible-url')
-            .attr('data-visible-url', $el.attr('href'));
+            .attr('data-visible-url', $el.attr('href'))
+            .attr('rel','noopener');
         });
       }
     }

--- a/app/scripts/views/mixins/external-links-mixin.js
+++ b/app/scripts/views/mixins/external-links-mixin.js
@@ -15,15 +15,15 @@ define(function (require, exports, module) {
   return {
     afterRender: function () {
       this.$('a[href^=http]').each(function (index, el) {
-          var $el = $(el);
-          $el.attr('rel','noopener noreferrer');
+        var $el = $(el);
+        $el.attr('rel','noopener noreferrer');
       });
       if (this.broker.hasCapability('convertExternalLinksToText')) {
         this.$('a[href^=http]').each(function (index, el) {
           var $el = $(el);
           $el
             .addClass('visible-url')
-            .attr('data-visible-url', $el.attr('href'))
+            .attr('data-visible-url', $el.attr('href'));
         });
       }
     }

--- a/app/scripts/views/mixins/external-links-mixin.js
+++ b/app/scripts/views/mixins/external-links-mixin.js
@@ -20,7 +20,7 @@ define(function (require, exports, module) {
           $el
             .addClass('visible-url')
             .attr('data-visible-url', $el.attr('href'))
-            .attr('rel','noopener');
+            .attr('rel','noopener noreferrer');
         });
       }
     }

--- a/app/tests/spec/views/mixins/external-links-mixin.js
+++ b/app/tests/spec/views/mixins/external-links-mixin.js
@@ -73,8 +73,8 @@ define(function (require, exports, module) {
 
       it('adds rel in external links', function () {
         var $externalLink = view.$('#external-link');
-         assert.equal(
-          $externalLink.attr('rel'),'noopener noreferrer');
+        assert.equal(
+         $externalLink.attr('rel'),'noopener noreferrer');
       });
 
       it('does not add rel in internal links', function () {

--- a/app/tests/spec/views/mixins/external-links-mixin.js
+++ b/app/tests/spec/views/mixins/external-links-mixin.js
@@ -65,12 +65,22 @@ define(function (require, exports, module) {
         assert.isTrue($externalLink.hasClass('visible-url'));
         assert.equal(
           $externalLink.attr('data-visible-url'), $externalLink.attr('href'));
-        assert.equal(
-          $externalLink.attr('rel'),'noopener noreferrer');
       });
 
       it('does not convert internal links', function () {
         assert.isFalse(view.$('#internal-link').hasClass('visible-url'));
+      });
+
+      it('adds rel in external links', function () {
+        var $externalLink = view.$('#external-link');
+         assert.equal(
+          $externalLink.attr('rel'),'noopener noreferrer');
+      });
+
+      it('does not add rel in internal links', function () {
+        var $internalLink = view.$('#internal-link');
+         assert.notEqual(
+          $internalLink.attr('rel'),'noopener noreferrer');
       });
     });
   });

--- a/app/tests/spec/views/mixins/external-links-mixin.js
+++ b/app/tests/spec/views/mixins/external-links-mixin.js
@@ -79,8 +79,8 @@ define(function (require, exports, module) {
 
       it('does not add rel in internal links', function () {
         var $internalLink = view.$('#internal-link');
-         assert.notEqual(
-          $internalLink.attr('rel'),'noopener noreferrer');
+        assert.notEqual(
+         $internalLink.attr('rel'),'noopener noreferrer');
       });
     });
   });

--- a/app/tests/spec/views/mixins/external-links-mixin.js
+++ b/app/tests/spec/views/mixins/external-links-mixin.js
@@ -65,6 +65,8 @@ define(function (require, exports, module) {
         assert.isTrue($externalLink.hasClass('visible-url'));
         assert.equal(
           $externalLink.attr('data-visible-url'), $externalLink.attr('href'));
+        assert.equal(
+          $externalLink.attr('rel'),'noopener noreferrer');
       });
 
       it('does not convert internal links', function () {


### PR DESCRIPTION
Fix for #4091.
 Line ".attr('rel', "noopener");" is added.