### PR TITLE
fix(tests): Ensure the complete_sign_in functional tests pass.

### DIFF
--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -81,11 +81,11 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(this, url, '#fxa-verification-link-expired-header'))
+        .then(openPage(this, url, '#fxa-verification-link-reused-header'))
 
         // Ensure that a link expired error message is displayed
         // rather than a damaged link error
-        .then(testElementExists('#fxa-verification-link-expired-header'))
+        .then(testElementExists('#fxa-verification-link-reused-header'))
         .then(noSuchElement(this, '#resend'));
     },
 

--- a/tests/intern_functional_circle.js
+++ b/tests/intern_functional_circle.js
@@ -12,6 +12,7 @@ define([
     'tests/functional/sync_sign_in',
     'tests/functional/sign_up',
     'tests/functional/complete_sign_up',
+    'tests/functional/complete_sign_in',
     'tests/functional/sync_sign_up',
     'tests/functional/sync_v2_sign_up',
     'tests/functional/sync_v2_sign_in',


### PR DESCRIPTION
With #4176, if a verification link is reported as bad, we used to display the
link expired message. Now we show "link has already been re-used". Update the
tests to match reality.

fixes #4182 

@vbudhram - you were the reviewer for #4176, mind reviewing this to ensure I got it right?