### PR TITLE
refactor(client): Add the external-links-mixin to the BaseView

### DIFF
--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -67,5 +67,6 @@
 
   <a id="external-link" href="http://external.com">External link</a>
   <a id="internal-link" href="/signin">Internal link</a>
+  <a id="data-visible-url-not-added" href="https://mozilla.org">https://mozilla.org</a>
   <a id="open-webmail" data-webmail-type="{{webmailType}}" href="{{{ unsafeWebmailLink }}}">{{webmailButtonText}}</a>
 </div>

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -12,6 +12,7 @@ define(function (require, exports, module) {
   var Cocktail = require('cocktail');
   var domWriter = require('lib/dom-writer');
   var ErrorUtils = require('lib/error-utils');
+  var ExternalLinksMixin = require('views/mixins/external-links-mixin');
   var NotifierMixin = require('views/mixins/notifier-mixin');
   var NullMetrics = require('lib/null-metrics');
   var Logger = require('lib/logger');
@@ -362,18 +363,32 @@ define(function (require, exports, module) {
       }
     },
 
-    beforeRender: function () {
-      // Implement in subclasses. If returns false, or if returns a promise
-      // that resolves to false, then the view is not rendered.
-      // Useful if the view must immediately redirect to another view.
+    /**
+     * Called before rendering begins. If returns false, or if returns
+     * a promise that resolves to false, then the view is not
+     * rendered. Useful to immediately redirect to another view before
+     * rendering begins.
+     */
+    beforeRender () {
     },
 
-    afterRender: function () {
-      // Implement in subclasses
+    /**
+     * Called after the rendering occurs. Can be used to print an
+     * error message after the view is already rendered.
+     *
+     * @returns {Promise}
+     */
+    afterRender () {
+      // Override in subclasses
+      return p();
     },
 
-    // called after the view is visible.
-    afterVisible: function () {
+    /**
+     * Called after the view is visible.
+     *
+     * @returns {Promise}
+     */
+    afterVisible () {
       // jQuery 3.x requires the view to be visible
       // before animating the status messages.
       this.displayStatusMessages();
@@ -401,6 +416,7 @@ define(function (require, exports, module) {
       }
 
       this.focusAutofocusElement();
+      return p();
     },
 
     destroy: function (remove) {
@@ -893,6 +909,10 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     BaseView,
+    // Attach the external links mixin in case the
+    // view has any external links that need to have
+    // their behaviors modified.
+    ExternalLinksMixin,
     TimerMixin
   );
 

--- a/app/scripts/views/cannot_create_account.js
+++ b/app/scripts/views/cannot_create_account.js
@@ -5,12 +5,10 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var BaseView = require('views/base');
-  var CannotCreateAccountTemplate = require('stache!templates/cannot_create_account');
-  var Cocktail = require('cocktail');
-  var ExternalLinksMixin = require('views/mixins/external-links-mixin');
+  const BaseView = require('views/base');
+  const CannotCreateAccountTemplate = require('stache!templates/cannot_create_account');
 
-  var CannotCreateAccountView = BaseView.extend({
+  const CannotCreateAccountView = BaseView.extend({
     template: CannotCreateAccountTemplate,
     className: 'cannot-create-account',
 
@@ -21,11 +19,6 @@ define(function (require, exports, module) {
     }
 
   });
-
-  Cocktail.mixin(
-    CannotCreateAccountView,
-    ExternalLinksMixin
-  );
 
   module.exports = CannotCreateAccountView;
 });

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -6,7 +6,6 @@ define(function (require, exports, module) {
   'use strict';
 
   var AuthErrors = require('lib/auth-errors');
-  var BaseView = require('views/base');
   var Cocktail = require('cocktail');
   var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
   var FormView = require('views/form');
@@ -17,11 +16,12 @@ define(function (require, exports, module) {
   var ResendMixin = require('views/mixins/resend-mixin');
   var ServiceMixin = require('views/mixins/service-mixin');
   var Template = require('stache!templates/complete_reset_password');
+  var { t } = require('views/base');
   var Url = require('lib/url');
   var VerificationInfo = require('models/verification/reset-password');
 
-  var t = BaseView.t;
-  var View = FormView.extend({
+  const proto = FormView.prototype;
+  const View = FormView.extend({
     template: Template,
     className: 'complete-reset-password',
 
@@ -56,10 +56,11 @@ define(function (require, exports, module) {
         });
     },
 
-    afterRender: function () {
+    afterVisible () {
       // The originating tab will start listening for `login` events once
       // it knows the complete reset password tab is open in the same browser.
       this.notifier.triggerRemote(Notifier.COMPLETE_RESET_PASSWORD_TAB_OPEN);
+      return proto.afterVisible.call(this);
     },
 
     context: function () {

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -21,7 +21,8 @@ define(function (require, exports, module) {
 
   var t = BaseView.t;
 
-  var View = BaseView.extend({
+  const proto = BaseView.prototype;
+  const View = BaseView.extend({
     template: Template,
     className: 'confirm',
 
@@ -86,28 +87,25 @@ define(function (require, exports, module) {
       }
     },
 
-    afterRender: function () {
+    afterRender () {
       var graphic = this.$el.find('.graphic');
       graphic.addClass('pulse');
 
       this.transformLinks();
+      return proto.afterRender.call(this);
     },
 
-    afterVisible: function () {
-      var self = this;
-
+    afterVisible () {
       // the view is always rendered, but the confirmation poll may be
       // prevented by the broker. An example is Firefox Desktop where the
       // browser is already performing a poll, so a second poll is not needed.
-
-      return self.broker.persistVerificationData(self.getAccount())
-        .then(function () {
-          return self.invokeBrokerMethod(
-                    'beforeSignUpConfirmationPoll', self.getAccount());
-        })
-        .then(function () {
-          return self._startPolling();
-        });
+      const account = this.getAccount();
+      return proto.afterVisible.call(this)
+        .then(() => this.broker.persistVerificationData(account))
+        .then(() =>
+          this.invokeBrokerMethod('beforeSignUpConfirmationPoll', account)
+        )
+        .then(() => this._startPolling());
     },
 
     _startPolling: function () {

--- a/app/scripts/views/coppa/coppa-age-input.js
+++ b/app/scripts/views/coppa/coppa-age-input.js
@@ -5,27 +5,23 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var AuthErrors = require('lib/auth-errors');
-  var Cocktail = require('cocktail');
-  var FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
-  var FormView = require('views/form');
-  var KeyCodes = require('lib/key-codes');
-  var Template = require('stache!templates/partial/coppa-age-input');
+  const AuthErrors = require('lib/auth-errors');
+  const Cocktail = require('cocktail');
+  const FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  const FormView = require('views/form');
+  const KeyCodes = require('lib/key-codes');
+  const Template = require('stache!templates/partial/coppa-age-input');
 
-  var CUTOFF_AGE = 13;
-  var AGE_ELEMENT = '#age';
-  var AGE_SIZE_LIMIT = 3;
+  const AGE_ELEMENT = '#age';
+  const AGE_SIZE_LIMIT = 3;
+  const CUTOFF_AGE = 13;
 
   const proto = FormView.prototype;
-
-  var View = FormView.extend({
-
+  const View = FormView.extend({
     template: Template,
     className: 'coppa-age-input',
 
-    initialize: function (options) {
-      options = options || {};
-
+    initialize (options = {}) {
       this._formPrefill = options.formPrefill;
     },
 
@@ -40,7 +36,7 @@ define(function (require, exports, module) {
      * @method isUserOldEnough
      * @return {Boolean} true if user is old enough, false otw.
      */
-    isUserOldEnough: function () {
+    isUserOldEnough () {
       return this._getAge() >= CUTOFF_AGE;
     },
 
@@ -49,11 +45,11 @@ define(function (require, exports, module) {
      * @method hasValue
      * @return {Boolean} true if the element has text, false otherwise.
      * */
-    hasValue: function () {
+    hasValue () {
       return !! this.getElementValue(AGE_ELEMENT);
     },
 
-    onInput: function () {
+    onInput () {
       // limit age to only 3 characters
       var age = this.$(AGE_ELEMENT);
       if (age.val().length > AGE_SIZE_LIMIT) {
@@ -61,7 +57,7 @@ define(function (require, exports, module) {
       }
     },
 
-    onKeyDown: function (event) {
+    onKeyDown (event) {
       // helper function to check for digit
       function isKeyADigitOrSpecialCharacter (keyCode) {
         return (
@@ -92,7 +88,7 @@ define(function (require, exports, module) {
      *
      * @method showValidationErrorsEnd
      */
-    showValidationErrorsEnd: function () {
+    showValidationErrorsEnd () {
       if (! this._validateAge()) {
         this.showValidationError(AGE_ELEMENT, AuthErrors.toError('AGE_REQUIRED'));
       }
@@ -105,19 +101,19 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isValid: function () {
+    isValid () {
       return this._validateAge();
     },
 
-    _validateAge: function () {
+    _validateAge () {
       return ! isNaN(this._getAge());
     },
 
-    _getAge: function () {
+    _getAge () {
       return parseInt(this.$(AGE_ELEMENT).val(), 10);
     },
 
-    _selectPrefillAge: function (context) {
+    _selectPrefillAge (context) {
       var prefillYear = this._formPrefill.get(context);
       if (prefillYear) {
         var ageEl = this.$(AGE_ELEMENT);
@@ -126,7 +122,7 @@ define(function (require, exports, module) {
       }
     },
 
-    beforeDestroy: function () {
+    beforeDestroy () {
       this._formPrefill.set('age', this.$(AGE_ELEMENT).val());
     }
   });

--- a/app/scripts/views/coppa/coppa-age-input.js
+++ b/app/scripts/views/coppa/coppa-age-input.js
@@ -16,6 +16,8 @@ define(function (require, exports, module) {
   var AGE_ELEMENT = '#age';
   var AGE_SIZE_LIMIT = 3;
 
+  const proto = FormView.prototype;
+
   var View = FormView.extend({
 
     template: Template,
@@ -80,8 +82,9 @@ define(function (require, exports, module) {
       }
     },
 
-    afterRender: function () {
+    afterRender () {
       this._selectPrefillAge('age');
+      return proto.afterRender.call(this);
     },
 
     /**

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
       'submit form': BaseView.preventDefaultThen('validateAndSubmit')
     },
 
-    afterRender: function () {
+    afterRender () {
       // Firefox has a strange issue where if the previous
       // screen was submit using the keyboard, the `enter` key's
       // `keyup` event fires here on the element that receives
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
         this.enableSubmitIfValid();
       }
 
-      proto.afterRender.call(this);
+      return proto.afterRender.call(this);
     },
 
     /**

--- a/app/scripts/views/legal_copy.js
+++ b/app/scripts/views/legal_copy.js
@@ -2,63 +2,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/**
+ * A view to fetch and render legal copy. Sub-classes must provide
+ * a `copyUrl` where the copy template can be fetched, as well a
+ * `fetchError`, which is an error to display if there is a
+ * problem fetching the copy template.
+ */
+
 define(function (require, exports, module) {
   'use strict';
 
-  var BackMixin = require('views/mixins/back-mixin');
-  var BaseView = require('views/base');
-  var Cocktail = require('cocktail');
-  var xhr = require('lib/xhr');
+  const BackMixin = require('views/mixins/back-mixin');
+  const BaseView = require('views/base');
+  const Cocktail = require('cocktail');
+  const xhr = require('lib/xhr');
 
-  // A view to fetch and render legal copy. Sub-classes must provide
-  // a `copyUrl` where the copy template can be fetched, as well a
-  // `fetchError`, which is an error to display if there is a
-  // problem fetching the copy template.
-
-  var View = BaseView.extend({
-    initialize: function (options) {
+  const proto = BaseView.prototype;
+  const View = BaseView.extend({
+    initialize (options = {}) {
       this._xhr = options.xhr || xhr;
     },
 
-    afterRender: function () {
-      var self = this;
-      return self._xhr.ajax({
+    afterRender () {
+      return this._xhr.ajax({
         accepts: { text: 'text/partial' },
         dataType: 'text',
-        url: self.copyUrl
+        url: this.copyUrl
       })
-      .then(function (template) {
-        var $legalCopy = self.$('#legal-copy');
-
-        $legalCopy.html(template);
-
-        // data-visible-url is used to display the href in
-        // brackets next to the original text.
-        // Only show the href if the href is different from
-        // the text. See #2225.
-        //
-        // Links are only made visible from the main app. If
-        // the user browses directly to a TOS/PP page, the links
-        // are normal.
-        self.$el.addClass('show-visible-url');
-        self.$('a').each(function (index, element) {
-          element = $(element);
-
-          var href = element.attr('href');
-          var text = element.text();
-          // if the href is the same as the link text, don't convert.
-          if (href && href !== text) {
-            element.attr('data-visible-url', href);
-          }
-        });
-
-        self.$('.hidden').removeClass('hidden');
-
-        // The `data-shown` attribute is searched for by the functional
-        // tests. The legal copy HTML has unstable markup, so the functional
-        // tests need some stable identifier to look for to know the copy is
-        // ready.
-        $legalCopy.attr('data-shown', 'true');
+      .then((template) => {
+        this.$('#legal-copy').html(template);
+        this.$('.hidden').removeClass('hidden');
 
         // Set a session cookie that informs the server
         // the user can go back if they refresh the page.
@@ -72,12 +45,25 @@ define(function (require, exports, module) {
         // it on other requests, and to ensure the server
         // only sends the user back to the app if the user in fact
         // came from this page.
-        self.window.document.cookie = 'canGoBack=1; path=' + self.window.location.pathname;
+        this.window.document.cookie = 'canGoBack=1; path=' + this.window.location.pathname;
+        return proto.afterRender.call(this);
       })
-      .fail(function () {
-        self.displayError(self.fetchError);
-        self.$('.hidden').removeClass('hidden');
+      .fail(() => {
+        this.displayError(this.fetchError);
+        this.$('.hidden').removeClass('hidden');
       });
+    },
+
+    afterVisible () {
+      this.$('.hidden').removeClass('hidden');
+
+      // The `data-shown` attribute is searched for by the functional
+      // tests. The legal copy HTML has unstable markup, so the functional
+      // tests need some stable identifier to look for to know the copy is
+      // ready.
+      this.$('#legal-copy').attr('data-shown', 'true');
+
+      return proto.afterVisible.call(this);
     }
   });
 

--- a/app/scripts/views/mixins/external-links-mixin.js
+++ b/app/scripts/views/mixins/external-links-mixin.js
@@ -10,21 +10,35 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var $ = require('jquery');
+  const $ = require('jquery');
 
-  return {
-    afterRender: function () {
+  function shouldConvertExternalLinksToText(broker) {
+    // not all views have a broker, e.g., the CoppaAgeInput
+    // has no need for a broker.
+    return broker && broker.hasCapability('convertExternalLinksToText');
+  }
+
+  function convertToVisibleLink (el) {
+    const $el = $(el);
+    const href = $el.attr('href');
+    const text = $el.text();
+
+    if (href && href !== text) {
+      $el
+        .addClass('visible-url')
+        .attr('data-visible-url', $el.attr('href'));
+    }
+  }
+
+  module.exports = {
+    afterRender () {
       this.$('a[href^=http]').each(function (index, el) {
         var $el = $(el);
         $el.attr('rel','noopener noreferrer');
       });
-      if (this.broker.hasCapability('convertExternalLinksToText')) {
-        this.$('a[href^=http]').each(function (index, el) {
-          var $el = $(el);
-          $el
-            .addClass('visible-url')
-            .attr('data-visible-url', $el.attr('href'));
-        });
+
+      if (shouldConvertExternalLinksToText(this.broker)) {
+        this.$('a[href^=http]').each((index, el) => convertToVisibleLink(el));
       }
     }
   };

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -10,30 +10,29 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var Cocktail = require('cocktail');
-  var Constants = require('lib/constants');
-  var FormView = require('views/form');
-  var MarketingSnippet = require('views/marketing_snippet');
-  var MarketingSnippetiOS = require('views/marketing_snippet_ios');
-  var ServiceMixin = require('views/mixins/service-mixin');
-  var Template = require('stache!templates/ready');
-  var Url = require('lib/url');
-  var VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
+  const Cocktail = require('cocktail');
+  const Constants = require('lib/constants');
+  const FormView = require('views/form');
+  const MarketingSnippet = require('views/marketing_snippet');
+  const MarketingSnippetiOS = require('views/marketing_snippet_ios');
+  const p = require('lib/promise');
+  const ServiceMixin = require('views/mixins/service-mixin');
+  const Template = require('stache!templates/ready');
+  const Url = require('lib/url');
+  const VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
 
-  function t(msg) {
-    return msg;
-  }
+  const t = msg => msg;
 
   /*eslint-disable camelcase*/
 
-  var FX_SYNC_WILL_BEGIN_MOMENTARILY =
+  const FX_SYNC_WILL_BEGIN_MOMENTARILY =
           t('Firefox Sync will begin momentarily');
 
   /**
    * Some template strings are fetched from JS to keep
    * the template marginally cleaner and easier to read.
    */
-  var TEMPLATE_INFO = {
+  const TEMPLATE_INFO = {
     FORCE_AUTH: {
       headerId: 'fxa-force-auth-complete-header',
       headerTitle: t('Welcome back'),
@@ -59,7 +58,8 @@ define(function (require, exports, module) {
 
   /*eslint-enable camelcase*/
 
-  var View = FormView.extend({
+  const proto = FormView.prototype;
+  const View = FormView.extend({
     template: Template,
     className: 'ready',
 
@@ -152,16 +152,17 @@ define(function (require, exports, module) {
                  this.broker.hasCapability('syncPreferencesNotification'));
     },
 
-    afterRender: function () {
+    afterRender () {
       var graphic = this.$el.find('.graphic');
       graphic.addClass('pulse');
 
-      return this._createMarketingSnippet();
+      return this._createMarketingSnippet()
+        .then(proto.afterRender.bind(this));
     },
 
-    _createMarketingSnippet: function () {
+    _createMarketingSnippet () {
       if (! this.broker.hasCapability('emailVerificationMarketingSnippet')) {
-        return;
+        return p();
       }
 
       var marketingSnippetOpts = {

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -8,7 +8,6 @@ define(function (require, exports, module) {
   var AuthErrors = require('lib/auth-errors');
   var BaseView = require('views/base');
   var Cocktail = require('cocktail');
-  var ExternalLinksMixin = require('views/mixins/external-links-mixin');
   var FormView = require('views/form');
   var PasswordResetMixin = require('views/mixins/password-reset-mixin');
   var ServiceMixin = require('views/mixins/service-mixin');
@@ -88,7 +87,6 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     View,
-    ExternalLinksMixin,
     PasswordResetMixin,
     ServiceMixin
   );

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -45,7 +45,8 @@ define(function (require, exports, module) {
     GravatarPermissionsView
   ];
 
-  var View = BaseView.extend({
+  const proto = BaseView.prototype;
+  const View = BaseView.extend({
     template: Template,
     className: 'settings',
     layoutClassName: 'settings',
@@ -155,23 +156,22 @@ define(function (require, exports, module) {
         });
     },
 
-    afterRender: function () {
+    afterRender () {
       this._subPanels.setElement(this.$('#sub-panels')[0]);
-      return this._subPanels.render();
+      return this._subPanels.render()
+        .then(proto.afterRender.bind(this));
     },
 
-    afterVisible: function () {
-      var self = this;
-      BaseView.prototype.afterVisible.call(self);
-
+    afterVisible () {
       // Clients may link to the settings page with a `setting` query param
       // so that that field can be displayed/focused.
-      if (self.relier.get('setting') === 'avatar') {
-        self.relier.set('setting', null);
-        self.navigate('settings/avatar/change');
+      if (this.relier.get('setting') === 'avatar') {
+        this.relier.set('setting', null);
+        this.navigate('settings/avatar/change');
       }
 
-      return self._showAvatar();
+      return proto.afterVisible.call(this)
+        .then(this._showAvatar.bind(this));
     },
 
     // When the user adds, removes or changes a display name

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -29,7 +29,8 @@ define(function (require, exports, module) {
   var JPEG_QUALITY = Constants.PROFILE_IMAGE_JPEG_QUALITY;
   var MIME_TYPE = Constants.DEFAULT_PROFILE_IMAGE_MIME_TYPE;
 
-  var View = FormView.extend({
+  const proto = FormView.prototype;
+  const View = FormView.extend({
     template: Template,
     className: 'avatar-camera',
     viewName: 'settings.avatar.camera',
@@ -120,7 +121,7 @@ define(function (require, exports, module) {
       }
     },
 
-    afterRender: function () {
+    afterRender () {
       this.startStream();
 
       this._avatarProgressIndicator = new ProgressIndicator();
@@ -132,6 +133,8 @@ define(function (require, exports, module) {
       this.canvas = this.$('#canvas')[0];
 
       this.video.addEventListener('loadedmetadata', _.bind(this.onLoadedMetaData, this), false);
+
+      return proto.afterRender.call(this);
     },
 
     onLoadedMetaData: function () {

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -16,7 +16,8 @@ define(function (require, exports, module) {
   var p = require('lib/promise');
   var Template = require('stache!templates/settings/avatar_change');
 
-  var View = FormView.extend({
+  const proto = FormView.prototype;
+  const View = FormView.extend({
     template: Template,
     className: 'avatar-change',
     viewName: 'settings.avatar.change',
@@ -52,13 +53,12 @@ define(function (require, exports, module) {
       };
     },
 
-    afterVisible: function () {
-      var self = this;
-      FormView.prototype.afterVisible.call(self);
-      return self.displayAccountProfileImage(self.getAccount());
+    afterVisible () {
+      return proto.afterVisible.call(this)
+        .then(() => this.displayAccountProfileImage(this.getAccount()));
     },
 
-    afterRender: function () {
+    afterRender () {
       // Wrapper hides the browser's file picker widget so we can use
       // our own. Set the height/width to 1px by 1px so that Selenium
       // can interact with the element. The element is not visible
@@ -70,6 +70,7 @@ define(function (require, exports, module) {
         width: 1
       });
       this.$(':file').wrap(wrapper);
+      return proto.afterRender.call(this);
     },
 
     removeAvatar: function () {

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -20,7 +20,8 @@ define(function (require, exports, module) {
   var HORIZONTAL_GUTTER = 90;
   var VERTICAL_GUTTER = 0;
 
-  var View = FormView.extend({
+  const proto = FormView.prototype;
+  const View = FormView.extend({
     template: Template,
     className: 'avatar-crop',
     viewName: 'settings.avatar.crop',
@@ -45,8 +46,8 @@ define(function (require, exports, module) {
     },
 
     afterRender: function () {
-      FormView.prototype.afterRender.call(this);
       this.canvas = this.$('canvas')[0];
+      return proto.afterRender.call(this);
     },
 
     afterVisible: function () {
@@ -82,6 +83,8 @@ define(function (require, exports, module) {
           error: AuthErrors.toMessage('UNUSABLE_IMAGE')
         });
       }
+
+      return proto.afterVisible.call(this);
     },
 
     toBlob: function () {

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -27,7 +27,8 @@ define(function (require, exports, module) {
   var DISPLAY_LENGTH = Constants.PROFILE_IMAGE_DISPLAY_SIZE;
   var GRAVATAR_URL = 'https://secure.gravatar.com/avatar/';
 
-  var View = FormView.extend({
+  const proto = FormView.prototype;
+  const View = FormView.extend({
     template: Template,
     className: 'avatar-gravatar',
     viewName: 'settings.avatar.gravatar',
@@ -38,10 +39,12 @@ define(function (require, exports, module) {
       };
     },
 
-    afterRender: function () {
+    afterRender () {
       if (! this.gravatar) {
         this._showGravatar();
       }
+
+      return proto.afterRender.call(this);
     },
 
     _showGravatar: showProgressIndicator(function () {

--- a/app/scripts/views/sub_panels.js
+++ b/app/scripts/views/sub_panels.js
@@ -12,7 +12,8 @@ define(function (require, exports, module) {
   var p = require('lib/promise');
   var Template = require('stache!templates/sub_panels');
 
-  var View = BaseView.extend({
+  const proto = BaseView.prototype;
+  const View = BaseView.extend({
     template: Template,
     className: 'sub-panels',
 
@@ -118,17 +119,16 @@ define(function (require, exports, module) {
         });
     },
 
-    afterRender: function () {
-      var self = this;
-
+    afterRender () {
       // Initial childViews to render; excludes modal views
-      var initialChildViews = self._panelViews.filter(function (ChildView) {
-        return ! self._isModalView(ChildView);
+      var initialChildViews = this._panelViews.filter((ChildView) => {
+        return ! this._isModalView(ChildView);
       });
 
-      return p.all(initialChildViews.map(function (ChildView) {
-        return self._createChildViewIfNeeded(ChildView);
-      }));
+      return p.all(initialChildViews.map((ChildView) => {
+        return this._createChildViewIfNeeded(ChildView);
+      }))
+      .then(proto.afterRender.bind(this));
     }
   });
 

--- a/app/scripts/views/tooltip.js
+++ b/app/scripts/views/tooltip.js
@@ -16,7 +16,8 @@ define(function (require, exports, module) {
   var PADDING_BELOW_TOOLTIP_PX = 2;
   var PADDING_ABOVE_TOOLTIP_PX = 4;
 
-  var Tooltip = BaseView.extend({
+  const proto = BaseView.prototype;
+  const Tooltip = BaseView.extend({
     tagName: 'aside',
     className: 'tooltip',
     // tracks the type of a tooltip, used for metrics purposes
@@ -39,7 +40,7 @@ define(function (require, exports, module) {
       return this.translator.get(this.message);
     },
 
-    afterRender: function () {
+    afterRender () {
       // only one tooltip at a time!
       if (displayedTooltip) {
         displayedTooltip.destroy(true);
@@ -58,6 +59,8 @@ define(function (require, exports, module) {
       }
 
       this.bindDOMEvents();
+
+      return proto.afterRender.call(this);
     },
 
     beforeDestroy: function () {

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -83,7 +83,8 @@ define(function (require, exports, module) {
         return p(isPasswordResetComplete);
       });
 
-      return view.render();
+      return view.render()
+        .then(() => $('#container').html(view.$el));
     });
 
     afterEach(function () {
@@ -286,6 +287,7 @@ define(function (require, exports, module) {
       describe('non-direct-access', function () {
         beforeEach(function () {
           view.$('[type=password]').val(PASSWORD);
+          view.enableForm();
 
           sinon.stub(user, 'completeAccountPasswordReset', function (account) {
             account.set('verified', true);
@@ -344,6 +346,7 @@ define(function (require, exports, module) {
 
         beforeEach(function () {
           view.$('[type=password]').val(PASSWORD);
+          view.enableForm();
 
           sinon.stub(user, 'completeAccountPasswordReset', function (_account) {
             account = _account;
@@ -375,6 +378,7 @@ define(function (require, exports, module) {
           relier.set('resetPasswordConfirm', false);
 
           view.$('[type=password]').val(PASSWORD);
+          view.enableForm();
 
           sinon.stub(user, 'completeAccountPasswordReset', function (account) {
             return p(account);
@@ -398,6 +402,7 @@ define(function (require, exports, module) {
 
       it('reload view to allow user to resend an email on INVALID_TOKEN error', function () {
         view.$('[type=password]').val('password');
+        view.enableForm();
 
         sinon.stub(view.fxaClient, 'completePasswordReset', function () {
           return p.reject(AuthErrors.toError('INVALID_TOKEN'));
@@ -417,6 +422,7 @@ define(function (require, exports, module) {
 
       it('shows error message if server returns an error', function () {
         view.$('[type=password]').val('password');
+        view.enableForm();
 
         sinon.stub(view.fxaClient, 'completePasswordReset', function () {
           return p.reject(new Error('uh oh'));

--- a/app/tests/spec/views/mixins/external-links-mixin.js
+++ b/app/tests/spec/views/mixins/external-links-mixin.js
@@ -82,6 +82,13 @@ define(function (require, exports, module) {
         assert.notEqual(
          $internalLink.attr('rel'),'noopener noreferrer');
       });
+
+      it('does not convert if text and the href are the same', () => {
+        assert.equal(
+          typeof view.$('#data-visible-url-not-added').attr('data-visible-url'),
+          'undefined'
+        );
+      });
     });
   });
 });

--- a/app/tests/spec/views/pp.js
+++ b/app/tests/spec/views/pp.js
@@ -34,6 +34,9 @@ define(function (require, exports, module) {
       windowMock.location.pathname = '/legal/privacy';
 
       view = new View({
+        broker: {
+          hasCapability: () => true
+        },
         window: windowMock,
         xhr: xhrMock
       });
@@ -96,7 +99,7 @@ define(function (require, exports, module) {
       return view.render()
         .then(function () {
           assert.equal(
-            view.$('#data-visible-url-added').attr('data-visible-url'),
+            view.$('#data-visible-url-added').data('visible-url'),
             'https://accounts.firefox.com'
           );
         });
@@ -106,7 +109,7 @@ define(function (require, exports, module) {
       return view.render()
         .then(function () {
           assert.equal(
-            typeof view.$('#data-visible-url-not-added').attr('data-visible-url'),
+            typeof view.$('#data-visible-url-not-added').data('visible-url'),
             'undefined'
           );
         });

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -253,10 +253,18 @@ define(function (require, exports, module) {
         return view.render()
           .then(function () {
             assert.lengthOf(view.$('#suggest-sync'), 1);
-            assert.equal(view.$('#suggest-sync').html(),
-              'Looking for Firefox Sync? <a href="https://mozilla.org/firefox/sync?' +
-              'utm_source=fx-website&amp;utm_medium=fx-accounts&amp;utm_campaign=fx-signup&amp;' +
-              'utm_content=fx-sync-get-started">Get started here</a>');
+
+            const $suggestSyncEl = view.$('#suggest-sync');
+            assert.include($suggestSyncEl.text(), 'Looking for Firefox Sync?');
+            assert.include($suggestSyncEl.text(), 'Get started here');
+
+            const $getStartedEl = $suggestSyncEl.find('a');
+            assert.equal($getStartedEl.attr('rel'), 'noopener noreferrer');
+            assert.equal($getStartedEl.attr('href'),
+              'https://mozilla.org/firefox/sync?' +
+              'utm_source=fx-website&utm_medium=fx-accounts&' +
+              'utm_campaign=fx-signup&utm_content=fx-sync-get-started');
+
             assert.isTrue(TestHelpers.isEventLogged(metrics, 'signup.sync-suggest.visible'), 'enrolled');
           });
       });

--- a/app/tests/spec/views/tos.js
+++ b/app/tests/spec/views/tos.js
@@ -34,6 +34,9 @@ define(function (require, exports, module) {
       windowMock.location.pathname = '/legal/terms';
 
       view = new View({
+        broker: {
+          hasCapability: () => true
+        },
         window: windowMock,
         xhr: xhrMock
       });


### PR DESCRIPTION
It's easy to forget to add the external-links-mixin to all views that need
them. Duplicate code also existed to convert external links in both the
external-links-mixin and legal_copy.

This PR attaches the external-links-mixin to the BaseView and ensures
all View's call the BaseView's `afterRender`, and tangentially, `afterVisible`

Noticed this was a problem when reviewing issue #4179 that adds
`rel=noopener noreferrer` to all external links.

This continues with the work that @divyabiyani did in #4179 so that the solution is generalized to all views w/o additional developer work.

fixes #4181 

@vbudhram - mind reviewing this one too?

