### PR TITLE
fix(build): Only copy resources to dist if they are used.

### DIFF
--- a/grunttasks/copy.js
+++ b/grunttasks/copy.js
@@ -40,24 +40,9 @@ module.exports = function (grunt) {
             '*.{ico,png,txt}',
             '.htaccess',
             'images/{,*/}*.{webp,gif,svg,jpg,jpeg,png}',
-            'styles/fonts/{,*/}*.*',
             'fonts/**/*.{woff,woff2,eot,ttf,svg,ofl}',
             'i18n/{,*/}{,*/}*.*'
           ]
-        },
-        {
-          cwd: '<%= yeoman.app %>/bower_components/jquery-ui',
-          dest: '<%= yeoman.dist %>/bower_components/jquery-ui',
-          // jquery ui
-          expand: true,
-          src: ['**/*.js']
-        },
-        {
-          cwd: '<%= yeoman.app %>/bower_components/fxa-checkbox/',
-          dest: '<%= yeoman.dist %>/bower_components/fxa-checkbox/',
-          // fxa-checkbox
-          expand: true,
-          src: ['*.js']
         },
         {
           cwd: '<%= yeoman.tmp %>/concat/scripts',

--- a/grunttasks/rev.js
+++ b/grunttasks/rev.js
@@ -8,7 +8,6 @@ module.exports = function (grunt) {
       files: {
         src: [
           '<%= yeoman.dist %>/bower_components/**/*.js',
-          '!<%= yeoman.dist %>/bower_components/jquery-ui/**/*.js',
           '<%= yeoman.dist %>/scripts/**/*.js',
           '<%= yeoman.dist %>/styles/{,*/}*.css',
           '<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',


### PR DESCRIPTION
No need to copy over jquery-ui, fxa-checkbox, and styles/fonts to dist.

These JS resources are included into the built bundle and not loaded dynamically. There is no need to copy these over.

Remove jquery-ui from the rev task.

issue #4177

@vladikoff and @jrgm - can you make sure I'm not losing it and that the built JS really does not need these files loaded separately?