### PR TITLE
refactor(client): Remove all direct fxaClient calls from the views.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -477,7 +477,6 @@ define(function (require, exports, module) {
         broker: self._authenticationBroker,
         createView: self.createView.bind(self),
         formPrefill: self._formPrefill,
-        fxaClient: self._fxaClient,
         interTabChannel: self._interTabChannel,
         language: self._config.language,
         metrics: self._metrics,

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -510,7 +510,6 @@ define(function (require, exports, module) {
      * it must be verified and by which method.
      *
      * @param {string} sessionToken
-     * @param {string} [uid]
      * @returns {promise} resolves with the account's current session
      * information if session is valid. Rejects with an INVALID_TOKEN error
      * if session is invalid.
@@ -522,8 +521,7 @@ define(function (require, exports, module) {
      *   verificationReason: <see lib/verification-reasons.js>
      * }
      */
-    recoveryEmailStatus: withClient(function (client, sessionToken, uid) {
-      var self = this;
+    recoveryEmailStatus: withClient(function (client, sessionToken) {
       return client.recoveryEmailStatus(sessionToken)
         .then(function (response) {
           if (! response.verified) {
@@ -546,23 +544,6 @@ define(function (require, exports, module) {
           // /recovery_email/status returns `emailVerified` and
           // `sessionVerified`, we don't want those.
           return _.pick(response, 'email', 'verified');
-        })
-        .fail(function (err) {
-          // The user's email may have bounced because it's invalid. Check
-          // if the account still exists, if it doesn't, it means the email
-          // bounced. Show a message allowing the user to sign up again.
-          if (uid && AuthErrors.is(err, 'INVALID_TOKEN')) {
-            return self.checkAccountExists(uid)
-              .then(function (accountExists) {
-                if (! accountExists) {
-                  throw AuthErrors.toError('SIGNUP_EMAIL_BOUNCE');
-                }
-
-                throw err;
-              });
-          }
-
-          throw err;
         });
     }),
 

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -123,7 +123,6 @@ define(function (require, exports, module) {
       this.broker = options.broker;
       this.currentPage = options.currentPage;
       this.model = options.model || new Backbone.Model();
-      this.fxaClient = options.fxaClient;
       this.metrics = options.metrics || nullMetrics;
       this.relier = options.relier;
       this.sentryMetrics = options.sentryMetrics || Raven;

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
         .then(() => this._startPolling());
     },
 
-    _startPolling: function () {
+    _startPolling () {
       var self = this;
 
       return self._waitForConfirmation()
@@ -158,27 +158,11 @@ define(function (require, exports, module) {
         });
     },
 
-    _waitForConfirmation: function () {
-      var self = this;
-      var account = self.getAccount();
-      return self.fxaClient.recoveryEmailStatus(
-          account.get('sessionToken'), account.get('uid'))
-        .then(function (result) {
-          if (result.verified) {
-            account.set('verified', true);
-            self.user.setAccount(account);
-            return true;
-          }
-
-          var deferred = p.defer();
-
-          // _waitForConfirmation will return a promise and the
-          // promise chain remains unbroken.
-          self.setTimeout(function () {
-            deferred.resolve(self._waitForConfirmation());
-          }, self.VERIFICATION_POLL_IN_MS);
-
-          return deferred.promise;
+    _waitForConfirmation () {
+      const account = this.getAccount();
+      return account.waitForSessionVerification(self.VERIFICATION_POLL_IN_MS)
+        .then(() => {
+          this.user.setAccount(account);
         });
     },
 

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -201,13 +201,16 @@ define(function (require, exports, module) {
     },
 
     _isWaitingForServerConfirmation: false,
-    _waitForServerConfirmation: function () {
-      var self = this;
+    _waitForServerConfirmation () {
       // only check if still waiting.
       this._isWaitingForServerConfirmation = true;
-      return self.fxaClient.isPasswordResetComplete(self.model.get('passwordForgotToken'))
-        .then(function (isComplete) {
-          if (! self._isWaitingForServerConfirmation) {
+
+      const email = this.model.get('email');
+      const account = this.user.initAccount({ email });
+      const token = this.model.get('passwordForgotToken');
+      return account.isPasswordResetComplete(token)
+        .then((isComplete) => {
+          if (! this._isWaitingForServerConfirmation) {
             // we no longer care about the response, the other tab has opened.
             // drop the response on the ground and never resolve.
             return p.defer().promise;
@@ -216,11 +219,11 @@ define(function (require, exports, module) {
           }
 
           var deferred = p.defer();
-          self._waitForServerConfirmationTimeout = self.setTimeout(function () {
-            if (self._isWaitingForServerConfirmation) {
-              deferred.resolve(self._waitForServerConfirmation());
+          this._waitForServerConfirmationTimeout = this.setTimeout(() => {
+            if (this._isWaitingForServerConfirmation) {
+              deferred.resolve(this._waitForServerConfirmation());
             }
-          }, self._verificationPollMS);
+          }, this._verificationPollMS);
 
           return deferred.promise;
         });

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -317,181 +317,106 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('with a sessionToken only', function () {
-        describe('valid session', function () {
-          describe('verified', function () {
-            describe('with auth server that returns `emailVerified` and `sessionVerified`', function () {
-              beforeEach(function () {
-                sinon.stub(clientMock, 'recoveryEmailStatus', function () {
-                  return p({
-                    email: 'testuser@testuser.com',
-                    emailVerified: true,
-                    sessionVerified: true,
-                    verified: true
-                  });
+      describe('valid session', function () {
+        describe('verified', function () {
+          describe('with auth server that returns `emailVerified` and `sessionVerified`', function () {
+            beforeEach(function () {
+              sinon.stub(clientMock, 'recoveryEmailStatus', function () {
+                return p({
+                  email: 'testuser@testuser.com',
+                  emailVerified: true,
+                  sessionVerified: true,
+                  verified: true
                 });
-
-                return client.recoveryEmailStatus('session token')
-                  .then(function (_accountInfo) {
-                    accountInfo = _accountInfo;
-                  });
               });
 
-              it('filters unexpected fields', function () {
-                assert.isTrue(clientMock.recoveryEmailStatus.calledWith('session token'));
-                assert.equal(accountInfo.email, 'testuser@testuser.com');
-                assert.isTrue(accountInfo.verified);
-                assert.notProperty(accountInfo, 'emailVerified');
-                assert.notProperty(accountInfo, 'sessionVerified');
-              });
-            });
-          });
-
-          describe('unverified', function () {
-            describe('with unverified email, unverified session', function () {
-              beforeEach(function () {
-                sinon.stub(clientMock, 'recoveryEmailStatus', function () {
-                  return p({
-                    emailVerified: false,
-                    sessionVerified: false,
-                    verified: false
-                  });
+              return client.recoveryEmailStatus('session token')
+                .then(function (_accountInfo) {
+                  accountInfo = _accountInfo;
                 });
-
-                return client.recoveryEmailStatus('session token')
-                  .then(function (_accountInfo) {
-                    accountInfo = _accountInfo;
-                  });
-              });
-
-              it('sets correct `verifiedReason` and `verifiedMethod`', function () {
-                assert.isTrue(clientMock.recoveryEmailStatus.calledWith('session token'));
-                assert.isFalse(accountInfo.verified);
-                assert.equal(accountInfo.verificationMethod, VerificationMethods.EMAIL);
-                assert.equal(accountInfo.verificationReason, VerificationReasons.SIGN_UP);
-              });
             });
 
-            describe('with verified email, unverified session', function () {
-              beforeEach(function () {
-                sinon.stub(clientMock, 'recoveryEmailStatus', function () {
-                  return p({
-                    emailVerified: true,
-                    sessionVerified: false,
-                    verified: false
-                  });
-                });
-
-                return client.recoveryEmailStatus('session token')
-                  .then(function (_accountInfo) {
-                    accountInfo = _accountInfo;
-                  });
-              });
-
-              it('sets correct `verifiedReason` and `verifiedMethod`', function () {
-                assert.isTrue(clientMock.recoveryEmailStatus.calledWith('session token'));
-                assert.isFalse(accountInfo.verified);
-                assert.equal(accountInfo.verificationMethod, VerificationMethods.EMAIL);
-                assert.equal(accountInfo.verificationReason, VerificationReasons.SIGN_IN);
-              });
+            it('filters unexpected fields', function () {
+              assert.isTrue(clientMock.recoveryEmailStatus.calledWith('session token'));
+              assert.equal(accountInfo.email, 'testuser@testuser.com');
+              assert.isTrue(accountInfo.verified);
+              assert.notProperty(accountInfo, 'emailVerified');
+              assert.notProperty(accountInfo, 'sessionVerified');
             });
           });
         });
 
-        describe('invalid session', function () {
-          beforeEach(function () {
-            sinon.stub(clientMock, 'recoveryEmailStatus', function () {
-              return p.reject(AuthErrors.toError('INVALID_TOKEN'));
+        describe('unverified', function () {
+          describe('with unverified email, unverified session', function () {
+            beforeEach(function () {
+              sinon.stub(clientMock, 'recoveryEmailStatus', function () {
+                return p({
+                  emailVerified: false,
+                  sessionVerified: false,
+                  verified: false
+                });
+              });
+
+              return client.recoveryEmailStatus('session token')
+                .then(function (_accountInfo) {
+                  accountInfo = _accountInfo;
+                });
             });
 
-            sinon.spy(clientMock, 'accountStatus');
+            it('sets correct `verifiedReason` and `verifiedMethod`', function () {
+              assert.isTrue(clientMock.recoveryEmailStatus.calledWith('session token'));
+              assert.isFalse(accountInfo.verified);
+              assert.equal(accountInfo.verificationMethod, VerificationMethods.EMAIL);
+              assert.equal(accountInfo.verificationReason, VerificationReasons.SIGN_UP);
+            });
+          });
 
-            return client.recoveryEmailStatus('session token')
-              .then(assert.fail, function (_err) {
-                err = _err;
+          describe('with verified email, unverified session', function () {
+            beforeEach(function () {
+              sinon.stub(clientMock, 'recoveryEmailStatus', function () {
+                return p({
+                  emailVerified: true,
+                  sessionVerified: false,
+                  verified: false
+                });
               });
-          });
 
-          it('rejects with an INVALID_TOKEN error', function () {
-            assert.isTrue(AuthErrors.is(err, 'INVALID_TOKEN'));
-          });
+              return client.recoveryEmailStatus('session token')
+                .then(function (_accountInfo) {
+                  accountInfo = _accountInfo;
+                });
+            });
 
-          it('does not call accountStatus', function () {
-            assert.isFalse(clientMock.accountStatus.called);
+            it('sets correct `verifiedReason` and `verifiedMethod`', function () {
+              assert.isTrue(clientMock.recoveryEmailStatus.calledWith('session token'));
+              assert.isFalse(accountInfo.verified);
+              assert.equal(accountInfo.verificationMethod, VerificationMethods.EMAIL);
+              assert.equal(accountInfo.verificationReason, VerificationReasons.SIGN_IN);
+            });
           });
         });
       });
 
-      describe('both a sessionToken and uid', function () {
-        describe('valid session', function () {
-          beforeEach(function () {
-            sinon.stub(clientMock, 'recoveryEmailStatus', function () {
-              return p({ email: 'testuser@testuser.com', emailVerified: true, sessionVerified: true, verified: true });
+      describe('invalid session', function () {
+        beforeEach(function () {
+          sinon.stub(clientMock, 'recoveryEmailStatus', function () {
+            return p.reject(AuthErrors.toError('INVALID_TOKEN'));
+          });
+
+          sinon.spy(clientMock, 'accountStatus');
+
+          return client.recoveryEmailStatus('session token')
+            .then(assert.fail, function (_err) {
+              err = _err;
             });
-
-            return client.recoveryEmailStatus('session token', 'uid')
-              .then(function (_accountInfo) {
-                accountInfo = _accountInfo;
-              });
-          });
-
-          it('resolves with the status information', function () {
-            assert.isTrue(clientMock.recoveryEmailStatus.calledWith('session token'));
-            assert.equal(accountInfo.email, 'testuser@testuser.com');
-            assert.isTrue(accountInfo.verified);
-            assert.notProperty(accountInfo, 'emailVerified');
-            assert.notProperty(accountInfo, 'sessionVerified');
-          });
         });
 
-        describe('invalid session', function () {
-          beforeEach(function () {
-            sinon.stub(clientMock, 'recoveryEmailStatus', function () {
-              return p.reject(AuthErrors.toError('INVALID_TOKEN'));
-            });
-          });
+        it('rejects with an INVALID_TOKEN error', function () {
+          assert.isTrue(AuthErrors.is(err, 'INVALID_TOKEN'));
+        });
 
-          describe('account exists', function () {
-            beforeEach(function () {
-              sinon.stub(clientMock, 'accountStatus', function () {
-                return p({ exists: true });
-              });
-
-              return client.recoveryEmailStatus('session token', 'uid')
-                .then(assert.fail, function (_err) {
-                  err = _err;
-                });
-            });
-
-            it('rejects with an INVALID_TOKEN error', function () {
-              assert.isTrue(AuthErrors.is(err, 'INVALID_TOKEN'));
-            });
-
-            it('calls accountStatus', function () {
-              assert.isTrue(clientMock.accountStatus.called);
-            });
-          });
-
-          describe('account does not exist', function () {
-            beforeEach(function () {
-              sinon.stub(clientMock, 'accountStatus', function () {
-                return p({ exists: false });
-              });
-
-              return client.recoveryEmailStatus('session token', 'uid')
-                .then(assert.fail, function (_err) {
-                  err = _err;
-                });
-            });
-
-            it('rejects with an SIGNUP_EMAIL_BOUNCE error', function () {
-              assert.isTrue(AuthErrors.is(err, 'SIGNUP_EMAIL_BOUNCE'));
-            });
-
-            it('calls accountStatus', function () {
-              assert.isTrue(clientMock.accountStatus.called);
-            });
-          });
+        it('does not call accountStatus', function () {
+          assert.isFalse(clientMock.accountStatus.called);
         });
       });
     });

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -50,7 +50,6 @@ define(function (require, exports, module) {
     function initView() {
       view = new View({
         broker: broker,
-        fxaClient: fxaClient,
         metrics: metrics,
         notifier: notifier,
         relier: relier,
@@ -404,13 +403,13 @@ define(function (require, exports, module) {
         view.$('[type=password]').val('password');
         view.enableForm();
 
-        sinon.stub(view.fxaClient, 'completePasswordReset', function () {
+        sinon.stub(fxaClient, 'completePasswordReset', function () {
           return p.reject(AuthErrors.toError('INVALID_TOKEN'));
         });
 
         // isPasswordResetComplete needs to be overridden as well for when
         // render is re-loaded the token needs to be expired.
-        view.fxaClient.isPasswordResetComplete = function () {
+        fxaClient.isPasswordResetComplete = function () {
           return p(true);
         };
 
@@ -424,7 +423,7 @@ define(function (require, exports, module) {
         view.$('[type=password]').val('password');
         view.enableForm();
 
-        sinon.stub(view.fxaClient, 'completePasswordReset', function () {
+        sinon.stub(fxaClient, 'completePasswordReset', function () {
           return p.reject(new Error('uh oh'));
         });
 

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -247,7 +247,7 @@ define(function (require, exports, module) {
         });
 
         var count = 0;
-        sinon.stub(view.fxaClient, 'recoveryEmailStatus', function () {
+        sinon.stub(fxaClient, 'recoveryEmailStatus', function () {
           // force at least one cycle through the poll
           count++;
           return p({ verified: count === 2 });
@@ -270,7 +270,7 @@ define(function (require, exports, module) {
       }
 
       it('displays an error message allowing the user to re-signup if their email bounces', function () {
-        sinon.stub(view.fxaClient, 'recoveryEmailStatus', function () {
+        sinon.stub(fxaClient, 'recoveryEmailStatus', function () {
           return p.reject(AuthErrors.toError('SIGNUP_EMAIL_BOUNCE'));
         });
 
@@ -278,20 +278,20 @@ define(function (require, exports, module) {
         return view.afterVisible()
           .then(function () {
             assert.isTrue(view.navigate.calledWith('signup', { bouncedEmail: 'a@a.com' }));
-            assert.isTrue(view.fxaClient.recoveryEmailStatus.called);
+            assert.isTrue(fxaClient.recoveryEmailStatus.called);
           });
       });
 
       it('displays an error when an unknown error occurs', function () {
         var unknownError = 'Something failed';
-        sinon.stub(view.fxaClient, 'recoveryEmailStatus', function () {
+        sinon.stub(fxaClient, 'recoveryEmailStatus', function () {
           return p.reject(new Error(unknownError));
         });
 
         sinon.spy(view, 'navigate');
         return view.afterVisible()
           .then(function () {
-            assert.isTrue(view.fxaClient.recoveryEmailStatus.called);
+            assert.isTrue(fxaClient.recoveryEmailStatus.called);
             assert.equal(view.$('.error').text(), unknownError);
           });
       });
@@ -301,8 +301,8 @@ define(function (require, exports, module) {
 
         beforeEach(function () {
           sandbox = sinon.sandbox.create();
-          sandbox.stub(view.fxaClient, 'recoveryEmailStatus', function () {
-            var callCount = view.fxaClient.recoveryEmailStatus.callCount;
+          sandbox.stub(fxaClient, 'recoveryEmailStatus', function () {
+            var callCount = fxaClient.recoveryEmailStatus.callCount;
             if (callCount < 2) {
               return p.reject(AuthErrors.toError('UNEXPECTED_ERROR'));
             } else {
@@ -326,7 +326,7 @@ define(function (require, exports, module) {
         });
 
         it('polls the auth server', function () {
-          assert.equal(view.fxaClient.recoveryEmailStatus.callCount, 2);
+          assert.equal(fxaClient.recoveryEmailStatus.callCount, 2);
         });
 
         it('captures the exception to Sentry', function () {
@@ -403,7 +403,7 @@ define(function (require, exports, module) {
 
     describe('complete', function () {
       beforeEach(function () {
-        sinon.stub(view.fxaClient, 'recoveryEmailStatus', function () {
+        sinon.stub(fxaClient, 'recoveryEmailStatus', function () {
           return p({
             verified: true
           });

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -57,6 +57,7 @@ define(function (require, exports, module) {
       });
 
       user = new User({
+        fxaClient: fxaClient,
         storage: Storage.factory('localStorage')
       });
 


### PR DESCRIPTION
Instead, go via the User and Account model.

Add two new functions to the Account model, `waitForSessionVerification` and
`isPasswordResetComplete`.

Remove `isVerified` from the Account model, it was an encapsulation that took
up more space than it replaced and didn't really have a reason to exist.

fixes #3243
Preparing for #4094
Preparing for #4193