### PR TITLE
refactor(tests): convert 2 sign-in functional test suites to use helpers.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1416,14 +1416,6 @@ define([
     };
   }
 
-  function verifyUser(user, index, client, accountData) {
-    return getEmailHeaders(user, index)
-      .then(function (headers) {
-        var code = headers['x-verify-code'];
-        return client.verifyCode(accountData.uid, code);
-      });
-  }
-
   return {
     clearBrowserNotifications: clearBrowserNotifications,
     clearBrowserState: clearBrowserState,
@@ -1491,7 +1483,6 @@ define([
     testUrlPathnameEquals: testUrlPathnameEquals,
     thenify: thenify,
     type: type,
-    verifyUser: verifyUser,
     visibleByQSA: visibleByQSA
   };
 });

--- a/tests/functional_oauth.js
+++ b/tests/functional_oauth.js
@@ -15,5 +15,6 @@ define([
   './functional/oauth_webchannel_keys',
   './functional/oauth_preverified_sign_up',
   './functional/oauth_force_auth',
-  './functional/oauth_permissions'
+  './functional/oauth_permissions',
+  './functional/oauth_sync_sign_in',
 ], function () {});


### PR DESCRIPTION
Convert both sign_in.js and oauth_sync_sign_in.js to use helpers. This
is to make adding functional tests easier for signin unblock.

oauth_sync_sign_in was never added to a test suite, so Iadded it
to functional_oauth

@vladikoff - r?