### PR TITLE
fix(build): Ensure revs/filenames are correctly created.

### DIFF
--- a/grunttasks/build.js
+++ b/grunttasks/build.js
@@ -55,23 +55,38 @@ module.exports = function (grunt) {
 
     'uglify',
 
-    // static file asset revisioning through content hashing
-    'rev',
+    // rev leaf nodes in the dependency tree. Leaf nodes are revved first
+    // so the URLs to leaf nodes in internal nodes can be updated. Internal
+    // nodes are revved after the URLs have been updated.
+    'rev:no_children',
 
-    // replaces the blocks by the file they reference,
-    // and replaces all references to assets by their revisioned version if it is found on the disk
-    'usemin',
+    // Update child requireOnDemand URLs in the main JS bundle.
+    'replace:require_on_demand',
+
+    // Add subresource integrity values of dependent resources
+    // to the main JS bundle.
+    'sriify:js',
+
+    // Update leaf node font and image URLs in the CSS bundle.
+    'usemin:css',
+
+    // URLs inside the resources with children have been updated
+    // and SRI hashes added to the main JS bundle. These files
+    // are in their final state and can now be revved.
+    'rev:with_children',
+
+    // replaces blocks in the HTML by the final rev of the inodes.
+    'usemin:html',
+
+    // update the HTML with the SRI value of the final JS bundle.
+    'sriify:html',
+
     // copy the non-minified main.js script file for sourcemap purposes
     'copy:build',
     // copy the non-minified head.js script file for sourcemap purposes
     'copy:head',
     // update the sourcemap path to match the hosted files
     'sourcemap-source',
-
-    'replace:require_on_demand',
-
-    // Add subresource integrity attributes to static resources.
-    'sriify',
 
     // Add FQDN to static resources referenced in the HTML so resources
     // can be deployed to a CDN.

--- a/grunttasks/copy.js
+++ b/grunttasks/copy.js
@@ -40,24 +40,9 @@ module.exports = function (grunt) {
             '*.{ico,png,txt}',
             '.htaccess',
             'images/{,*/}*.{webp,gif,svg,jpg,jpeg,png}',
-            'styles/fonts/{,*/}*.*',
             'fonts/**/*.{woff,woff2,eot,ttf,svg,ofl}',
             'i18n/{,*/}{,*/}*.*'
           ]
-        },
-        {
-          cwd: '<%= yeoman.app %>/bower_components/jquery-ui',
-          dest: '<%= yeoman.dist %>/bower_components/jquery-ui',
-          // jquery ui
-          expand: true,
-          src: ['**/*.js']
-        },
-        {
-          cwd: '<%= yeoman.app %>/bower_components/fxa-checkbox/',
-          dest: '<%= yeoman.dist %>/bower_components/fxa-checkbox/',
-          // fxa-checkbox
-          expand: true,
-          src: ['*.js']
         },
         {
           cwd: '<%= yeoman.tmp %>/concat/scripts',

--- a/grunttasks/rev.js
+++ b/grunttasks/rev.js
@@ -4,16 +4,34 @@
 
 module.exports = function (grunt) {
   grunt.config('rev', {
-    dist: {
+    // These files contain no references to other files and are
+    // revved first.
+    no_children: { //eslint-disable-line camelcase
       files: {
         src: [
           '<%= yeoman.dist %>/bower_components/**/*.js',
-          '<%= yeoman.dist %>/scripts/**/*.js',
-          '<%= yeoman.dist %>/styles/{,*/}*.css',
+          '<%= yeoman.dist %>/scripts/vendor/**/*.js',
           '<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
           '!<%= yeoman.dist %>/images/apple_app_store_button/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
           '!<%= yeoman.dist %>/images/google_play_store_button/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
           '<%= yeoman.dist %>/fonts/{,*/}*.{woff,woff2,svg,ofl,eot,ttf}'
+        ]
+      }
+    },
+    // These files contain references to other files and must be
+    // revved after internal URLs have been updated or else
+    // different revs of the file with different contents
+    // can have the same name because the rev was created before
+    // internal URLs were updated.
+    with_children: { //eslint-disable-line camelcase
+      files: {
+        src: [
+          // JS bundle has references to vendor and bower_components
+          // for requireOnDemand
+          '<%= yeoman.dist %>/scripts/**/*.js',
+          '!<%= yeoman.dist %>/scripts/vendor/**/*.js',
+          // CSS has references to images and fonts
+          '<%= yeoman.dist %>/styles/**/*.css'
         ]
       }
     }

--- a/grunttasks/rev.js
+++ b/grunttasks/rev.js
@@ -8,7 +8,6 @@ module.exports = function (grunt) {
       files: {
         src: [
           '<%= yeoman.dist %>/bower_components/**/*.js',
-          '!<%= yeoman.dist %>/bower_components/jquery-ui/**/*.js',
           '<%= yeoman.dist %>/scripts/**/*.js',
           '<%= yeoman.dist %>/styles/{,*/}*.css',
           '<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',

--- a/grunttasks/sriify.js
+++ b/grunttasks/sriify.js
@@ -146,12 +146,16 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.registerTask('sriify', 'Add SRI integrity attributes to static resources', function () {
+  grunt.registerTask('sriify', 'Add SRI integrity attributes to static resources', function (taskName, subtaskName) {
 
     // sri is run twice. The first time to find the sri hashes for
     // the resources embedded in main.js. This will modify main.js
     // so sri must be called again to find the final sri value for
     // main.js in the html.
-    grunt.task.run('sri', 'sri-update-js', 'sri', 'sri-update-html');
+    if (subtaskName === 'js') {
+      grunt.task.run('sri', 'sri-update-js');
+    } else if (subtaskName === 'html') {
+      grunt.task.run('sri', 'sri-update-html');
+    }
   });
 };


### PR DESCRIPTION
Also contains #4186.

The main CSS and JS bundle reference URLs to other static resources that
are themselves revved. We erroneously revved the main CSS and JS bundle
before updating the referenced URLs with the revved variants and
updating the JS bundle with SRI hashes. This led to files across two
trains having different content but the same filename.

Instead, we do a two phase approach to revving/SRI hash generation:

1) rev all the leaf node resources. Update references in the main JS and
   CSS bundle. Generate SRI hashes for revved JS. Insert SRI values into
   main JS bundle.
2) rev the resources with dependencies. Generate SRI hash for the main
   JS bundle. Update URL references in the HTML. Update SRI values in
   the HTML.

fixes #4189