### PR TITLE
fix(logging): identify the view in flow.begin event

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -467,12 +467,12 @@ define(function (require, exports, module) {
       return this._isSampledUser;
     },
 
-    logFlowBegin: function (flowId, flowBeginTime) {
+    logFlowBegin (flowId, flowBeginTime, viewName) {
       // Don't emit a new flow.begin event unless flowId has changed.
       if (flowId !== this._flowId) {
         this._flowId = flowId;
         this._flowBeginTime = flowBeginTime;
-        this.logEvent('flow.begin');
+        this.logEvent(`flow.${viewName}.begin`);
       }
     },
 

--- a/app/scripts/views/mixins/flow-begin-mixin.js
+++ b/app/scripts/views/mixins/flow-begin-mixin.js
@@ -7,25 +7,23 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var Flow = require('models/flow');
+  const Flow = require('models/flow');
 
   module.exports = {
-    afterRender: function () {
-      var self = this;
-
-      self.flow = new Flow({
-        sentryMetrics: self.sentryMetrics,
-        window: self.window
+    afterRender () {
+      this.flow = new Flow({
+        sentryMetrics: this.sentryMetrics,
+        window: this.window
       });
 
-      var flowId = self.flow.get('flowId');
-      var flowBegin = self.flow.get('flowBegin');
+      const flowId = this.flow.get('flowId');
+      const flowBegin = this.flow.get('flowBegin');
 
-      self.metrics.setFlowEventMetadata({
+      this.metrics.setFlowEventMetadata({
         flowBeginTime: flowBegin,
         flowId: flowId
       });
-      self.metrics.logFlowBegin(flowId, flowBegin);
+      this.metrics.logFlowBegin(flowId, flowBegin, this.viewName);
     }
   };
 });

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -176,7 +176,7 @@ define(function (require, exports, module) {
       describe('log events', function () {
         beforeEach(function () {
           metrics.logEvent('foo');
-          metrics.logFlowBegin('bar', 'baz');
+          metrics.logFlowBegin('bar', 'baz', 'wibble');
           metrics.logEvent('qux');
         });
 
@@ -217,7 +217,7 @@ define(function (require, exports, module) {
               assert.isArray(data.events);
               assert.lengthOf(data.events, 3);
               assert.equal(data.events[0].type, 'foo');
-              assert.equal(data.events[1].type, 'flow.begin');
+              assert.equal(data.events[1].type, 'flow.wibble.begin');
               assert.equal(data.events[2].type, 'qux');
               assert.equal(data.flowId, 'bar');
               assert.equal(data.flowBeginTime, 'baz');
@@ -251,7 +251,7 @@ define(function (require, exports, module) {
 
             describe('log a second flow.begin event with same flowId', function () {
               beforeEach(function () {
-                metrics.logFlowBegin('bar', 'blee');
+                metrics.logFlowBegin('bar', 'blee', 'hong');
                 metrics.logEvent('wibble');
                 return metrics.flush();
               });
@@ -336,7 +336,7 @@ define(function (require, exports, module) {
               assert.isArray(data.events);
               assert.lengthOf(data.events, 4);
               assert.equal(data.events[0].type, 'foo');
-              assert.equal(data.events[1].type, 'flow.begin');
+              assert.equal(data.events[1].type, 'flow.wibble.begin');
               assert.equal(data.events[2].type, 'qux');
               assert.equal(data.events[3].type, 'baz');
             });
@@ -408,7 +408,7 @@ define(function (require, exports, module) {
             assert.lengthOf(Object.keys(data), 25);
             assert.lengthOf(data.events, 4);
             assert.equal(data.events[0].type, 'foo');
-            assert.equal(data.events[1].type, 'flow.begin');
+            assert.equal(data.events[1].type, 'flow.wibble.begin');
             assert.equal(data.events[2].type, 'qux');
             assert.equal(data.events[3].type, 'wibble');
           });
@@ -432,7 +432,7 @@ define(function (require, exports, module) {
             assert.lengthOf(Object.keys(data), 25);
             assert.lengthOf(data.events, 4);
             assert.equal(data.events[0].type, 'foo');
-            assert.equal(data.events[1].type, 'flow.begin');
+            assert.equal(data.events[1].type, 'flow.wibble.begin');
             assert.equal(data.events[2].type, 'qux');
             assert.equal(data.events[3].type, 'blee');
           });

--- a/app/tests/spec/views/mixins/flow-begin-mixin.js
+++ b/app/tests/spec/views/mixins/flow-begin-mixin.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
         flowBeginMixin.logError = sinon.spy();
         $('body').data('flowId', FLOW_ID);
         $('body').data('flowBegin', 42);
+        flowBeginMixin.viewName = 'wibble';
         flowBeginMixin.afterRender();
       });
 
@@ -51,9 +52,10 @@ define(function (require, exports, module) {
       it('called metrics.logFlowBegin correctly', function () {
         assert.strictEqual(flowBeginMixin.metrics.logFlowBegin.callCount, 1);
         var args = flowBeginMixin.metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 2);
+        assert.lengthOf(args, 3);
         assert.strictEqual(args[0], FLOW_ID);
         assert.strictEqual(args[1], 42);
+        assert.strictEqual(args[2], 'wibble');
       });
 
       it('did not call view.logError', function () {

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -779,9 +779,10 @@ define(function (require, exports, module) {
       it('called metrics.logFlowBegin correctly', function () {
         assert.equal(metrics.logFlowBegin.callCount, 1);
         var args = metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 2);
+        assert.lengthOf(args, 3);
         assert.equal(args[0], FLOW_ID);
         assert.equal(args[1], -1);
+        assert.equal(args[2], 'signin');
       });
     });
 

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -412,9 +412,10 @@ define(function (require, exports, module) {
       it('called metrics.logFlowBegin correctly', function () {
         assert.equal(metrics.logFlowBegin.callCount, 1);
         var args = metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 2);
+        assert.lengthOf(args, 3);
         assert.equal(args[0], FLOW_ID);
         assert.equal(args[1], 3);
+        assert.equal(args[2], 'signup');
       });
     });
 


### PR DESCRIPTION
Fixes #4217.

I decided to opt for including the view name in the event, to be consistent with the `flow.engage` events. It also has the benefit of not requiring changes to the Heka filter, which would not be the case if we added a new metadata field to the event.

@vladikoff r?