### PR TITLE
Fix broken server-side flow event processing

### DIFF
--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -35,7 +35,7 @@ module.exports = function (event, data, request) {
     time: event.time,
     userAgent: request.headers['user-agent'],
     v: VERSION
-  }, _.mapValues(pickedData, limitLength));
+  }, _.mapValues(pickedData, sanitiseData));
 
   optionallySetFallbackData(eventData, 'service', data.client_id);
   optionallySetFallbackData(eventData, 'entrypoint', data.entryPoint);
@@ -63,6 +63,14 @@ function limitLength (data) {
   }
 
   return data;
+}
+
+function sanitiseData (data) {
+  if (data === 'none') {
+    return undefined;
+  }
+
+  return limitLength(data);
 }
 
 function optionallySetFallbackData (eventData, key, fallback) {

--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -6,13 +6,13 @@ var _ = require('lodash');
 var os = require('os');
 var Promise = require('bluebird');
 
-var DNT_ALLOWED_QUERY_PARAMS = [
+var DNT_ALLOWED_DATA = [
   'context',
   'entrypoint',
   'migration',
   'service',
 ];
-var NO_DNT_ALLOWED_QUERY_PARAMS = DNT_ALLOWED_QUERY_PARAMS.concat([
+var NO_DNT_ALLOWED_DATA = DNT_ALLOWED_DATA.concat([
   'utm_campaign',
   'utm_content',
   'utm_medium',
@@ -20,24 +20,25 @@ var NO_DNT_ALLOWED_QUERY_PARAMS = DNT_ALLOWED_QUERY_PARAMS.concat([
   'utm_term'
 ]);
 var HOSTNAME = os.hostname();
-var MAX_PARAM_LENGTH = 100;
+var MAX_DATA_LENGTH = 100;
 var VERSION = 1;
 
 module.exports = function (event, data, request) {
-  var queryParams = _.pick(request.query, isDNT(request) ?
-    DNT_ALLOWED_QUERY_PARAMS : NO_DNT_ALLOWED_QUERY_PARAMS);
-
+  var pickedData = _.pick(data, isDNT(request) ? DNT_ALLOWED_DATA : NO_DNT_ALLOWED_DATA);
   var eventData = _.assign({
-    event: event,
+    event: event.type,
+    flow_id: limitLength(data.flowId), //eslint-disable-line camelcase
+    flow_time: event.flowTime, //eslint-disable-line camelcase
     hostname: HOSTNAME,
     op: 'flowEvent',
     pid: process.pid,
+    time: event.time,
     userAgent: request.headers['user-agent'],
     v: VERSION
-  }, data, _.mapValues(queryParams, limitLength));
+  }, _.mapValues(pickedData, limitLength));
 
-  optionallySetFallbackData(eventData, 'service', request.query.client_id);
-  optionallySetFallbackData(eventData, 'entrypoint', request.query.entryPoint);
+  optionallySetFallbackData(eventData, 'service', data.client_id);
+  optionallySetFallbackData(eventData, 'entrypoint', data.entryPoint);
 
   if (typeof eventData.time === 'number') {
     eventData.time = new Date(eventData.time).toISOString();
@@ -56,12 +57,12 @@ function isDNT (request) {
   return request.headers.dnt === '1';
 }
 
-function limitLength (param) {
-  if (param && param.length > MAX_PARAM_LENGTH) {
-    return param.substr(0, MAX_PARAM_LENGTH);
+function limitLength (data) {
+  if (data && data.length > MAX_DATA_LENGTH) {
+    return data.substr(0, MAX_DATA_LENGTH);
   }
 
-  return param;
+  return data;
 }
 
 function optionallySetFallbackData (eventData, key, fallback) {

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -68,12 +68,12 @@ function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
     return event.type.indexOf('flow.') === 0;
   });
 
-  flowEvents.forEach(function (event) {
-    if (event.type === 'flow.begin') {
-      if (! metrics.flowBeginTime) {
-        // This will only kick in if something clobbered the data-flow-begin
-        // attribute in the DOM, i.e. hopefully never.
-        metrics.flowBeginTime = estimateFlowBeginTime({
+  if (! metrics.flowBeginTime) {
+    // This will only kick in if something clobbered the data-flow-begin
+    // attribute in the DOM, i.e. hopefully never.
+    flowEvents.some(function (event) {
+      if (event.type === 'flow.begin') {
+        metrics.flowBeginTime = estimateTime({
           /*eslint-disable sorting/sort-object-props*/
           start: metrics.startTime,
           offset: event.offset,
@@ -81,18 +81,37 @@ function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
           received: requestReceivedTime
           /*eslint-enable sorting/sort-object-props*/
         });
+
+        return true;
       }
+    });
+  }
+
+  flowEvents.forEach(function (event) {
+    if (event.type === 'flow.begin') {
+      event.time = metrics.flowBeginTime;
+      event.flow_time = 0;
+    } else {
+      event.time = estimateTime({
+        /*eslint-disable sorting/sort-object-props*/
+        start: metrics.startTime,
+        offset: event.offset,
+        sent: metrics.flushTime,
+        received: requestReceivedTime
+        /*eslint-enable sorting/sort-object-props*/
+      });
+      event.flow_time = event.time - metrics.flowBeginTime;
     }
 
     flowEvent(event.type, {
       flow_id: metrics.flowId, //eslint-disable-line camelcase
-      flow_time: 0, //eslint-disable-line camelcase
-      time: metrics.flowBeginTime
+      flow_time: event.flow_time, //eslint-disable-line camelcase
+      time: event.time
     }, req);
   });
 }
 
-function estimateFlowBeginTime (times) {
+function estimateTime (times) {
   var skew = times.received - times.sent;
   return times.start + times.offset + skew;
 }

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -90,7 +90,7 @@ function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
   flowEvents.forEach(function (event) {
     if (event.type === 'flow.begin') {
       event.time = metrics.flowBeginTime;
-      event.flow_time = 0;
+      event.flowTime = 0;
     } else {
       event.time = estimateTime({
         /*eslint-disable sorting/sort-object-props*/
@@ -100,14 +100,10 @@ function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
         received: requestReceivedTime
         /*eslint-enable sorting/sort-object-props*/
       });
-      event.flow_time = event.time - metrics.flowBeginTime;
+      event.flowTime = event.time - metrics.flowBeginTime;
     }
 
-    flowEvent(event.type, {
-      flow_id: metrics.flowId, //eslint-disable-line camelcase
-      flow_time: event.flow_time, //eslint-disable-line camelcase
-      time: event.time
-    }, req);
+    flowEvent(event, metrics, req);
   });
 }
 

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -263,6 +263,33 @@ define([
       }
     },
 
+    'call flowEvent with "none" data': {
+      setup: function () {
+        write = process.stderr.write;
+        process.stderr.write = sinon.spy();
+        return flowEvent({
+          flowTime: 'foo',
+          time: 'bar',
+          type: 'wibble'
+        }, {
+          migration: 'none'
+        }, {
+          headers: { 'user-agent': 'blee' }
+        });
+      },
+
+      teardown: function () {
+        process.stderr.write = write;
+      },
+
+      'process.stderr.write was called correctly': function () {
+        assert.equal(process.stderr.write.callCount, 1);
+
+        var eventData = JSON.parse(process.stderr.write.args[0][0]);
+        assert.equal(Object.keys(eventData).indexOf('migration'), -1);
+      }
+    },
+
     'call flowEvent with 101-character client_id': {
       setup: function () {
         write = process.stderr.write;

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -23,23 +23,26 @@ define([
       setup: function () {
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('mock event', { a: 'b', c: 'd', time: 'wibble' }, {
-          headers: { 'user-agent': 'foo' },
-          originalUrl: 'bar',
-          query: {
-            context: 'mock context',
-            entrypoint: 'mock entrypoint',
-            migration: 'mock migration',
-            service: 'mock service',
-            /*eslint-disable camelcase*/
-            utm_campaign: 'mock utm_campaign',
-            utm_content: 'mock utm_content',
-            utm_medium: 'mock utm_medium',
-            utm_source: 'mock utm_source',
-            utm_term: 'mock utm_term',
-            /*eslint-enable camelcase*/
-            zignore: 'ignore me'
-          }
+        return flowEvent({
+          flowTime: 'mock flow time',
+          time: 'mock time',
+          type: 'mock event'
+        }, {
+          context: 'mock context',
+          entrypoint: 'mock entrypoint',
+          flowId: 'mock flow id',
+          migration: 'mock migration',
+          service: 'mock service',
+          /*eslint-disable camelcase*/
+          utm_campaign: 'mock utm_campaign',
+          utm_content: 'mock utm_content',
+          utm_medium: 'mock utm_medium',
+          utm_source: 'mock utm_source',
+          utm_term: 'mock utm_term',
+          /*eslint-enable camelcase*/
+          zignore: 'ignore me'
+        }, {
+          headers: { 'user-agent': 'foo' }
         });
       },
 
@@ -63,9 +66,9 @@ define([
         assert.equal(eventData.v, 1);
         assert.equal(eventData.event, 'mock event');
         assert.equal(eventData.userAgent, 'foo');
-        assert.equal(eventData.a, 'b');
-        assert.equal(eventData.c, 'd');
-        assert.equal(eventData.time, 'wibble');
+        assert.equal(eventData.time, 'mock time');
+        assert.equal(eventData.flow_id, 'mock flow id');
+        assert.equal(eventData.flow_time, 'mock flow time');
         assert.equal(eventData.context, 'mock context');
         assert.equal(eventData.entrypoint, 'mock entrypoint');
         assert.equal(eventData.migration, 'mock migration');
@@ -84,13 +87,15 @@ define([
       setup: function () {
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('wibble', {}, {
-          headers: { 'user-agent': 'blee' },
-          originalUrl: '/',
-          query: {
-            client_id: 'mock client id', //eslint-disable-line camelcase
-            ignore: 'ignore me'
-          }
+        return flowEvent({
+          flowTime: 'foo',
+          time: 'bar',
+          type: 'wibble'
+        }, {
+          client_id: 'mock client id', //eslint-disable-line camelcase
+          ignore: 'ignore me'
+        }, {
+          headers: { 'user-agent': 'blee' }
         });
       },
 
@@ -102,13 +107,15 @@ define([
         assert.equal(process.stderr.write.callCount, 1);
 
         var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 7);
+        assert.lengthOf(Object.keys(eventData), 9);
         assert.equal(eventData.op, 'flowEvent');
         assert.equal(eventData.hostname, os.hostname());
         assert.equal(eventData.pid, process.pid);
         assert.equal(eventData.v, 1);
         assert.equal(eventData.event, 'wibble');
         assert.equal(eventData.userAgent, 'blee');
+        assert.equal(eventData.time, 'bar');
+        assert.equal(eventData.flow_time, 'foo');
         assert.equal(eventData.service, 'mock client id');
       }
     },
@@ -117,14 +124,16 @@ define([
       setup: function () {
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('wibble', {}, {
-          headers: { 'user-agent': 'blee' },
-          originalUrl: '/',
-          query: {
-            client_id: 'mock client id', //eslint-disable-line camelcase
-            service: 'mock service',
-            zignore: 'ignore me'
-          }
+        return flowEvent({
+          flowTime: 'foo',
+          time: 'bar',
+          type: 'wibble'
+        }, {
+          client_id: 'mock client id', //eslint-disable-line camelcase
+          service: 'mock service',
+          zignore: 'ignore me'
+        }, {
+          headers: { 'user-agent': 'blee' }
         });
       },
 
@@ -136,7 +145,7 @@ define([
         assert.equal(process.stderr.write.callCount, 1);
 
         var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 7);
+        assert.lengthOf(Object.keys(eventData), 9);
         assert.equal(eventData.service, 'mock service');
       }
     },
@@ -145,13 +154,15 @@ define([
       setup: function () {
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('wibble', {}, {
-          headers: { 'user-agent': 'blee' },
-          originalUrl: '/',
-          query: {
-            entryPoint: 'mock entryPoint', //eslint-disable-line camelcase
-            ignore: 'ignore me'
-          }
+        return flowEvent({
+          flowTime: 'foo',
+          time: 'bar',
+          type: 'wibble'
+        }, {
+          entryPoint: 'mock entryPoint', //eslint-disable-line camelcase
+          ignore: 'ignore me'
+        }, {
+          headers: { 'user-agent': 'blee' }
         });
       },
 
@@ -163,7 +174,7 @@ define([
         assert.equal(process.stderr.write.callCount, 1);
 
         var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 7);
+        assert.lengthOf(Object.keys(eventData), 9);
         assert.equal(eventData.entrypoint, 'mock entryPoint');
       }
     },
@@ -172,14 +183,16 @@ define([
       setup: function () {
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('wibble', {}, {
-          headers: { 'user-agent': 'blee' },
-          originalUrl: '/',
-          query: {
-            entryPoint: 'mock entryPoint', //eslint-disable-line camelcase
-            entrypoint: 'mock entrypoint',
-            zignore: 'ignore me'
-          }
+        return flowEvent({
+          flowTime: 'foo',
+          time: 'bar',
+          type: 'wibble'
+        }, {
+          entryPoint: 'mock entryPoint',
+          entrypoint: 'mock entrypoint',
+          ignore: 'ignore me'
+        }, {
+          headers: { 'user-agent': 'blee' }
         });
       },
 
@@ -191,21 +204,23 @@ define([
         assert.equal(process.stderr.write.callCount, 1);
 
         var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 7);
+        assert.lengthOf(Object.keys(eventData), 9);
         assert.equal(eventData.entrypoint, 'mock entrypoint');
       }
     },
 
-    'call flowEvent with 101-character query parameter': {
+    'call flowEvent with 101-character data': {
       setup: function () {
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('wibble', {}, {
-          headers: { 'user-agent': 'blee' },
-          originalUrl: '/',
-          query: {
-            context: (new Array(102)).join('0')
-          }
+        return flowEvent({
+          flowTime: 'foo',
+          time: 'bar',
+          type: 'wibble'
+        }, {
+          context: (new Array(102)).join('0')
+        }, {
+          headers: { 'user-agent': 'blee' }
         });
       },
 
@@ -221,16 +236,18 @@ define([
       }
     },
 
-    'call flowEvent with 100-character query parameter': {
+    'call flowEvent with 100-character data': {
       setup: function () {
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('wibble', {}, {
-          headers: { 'user-agent': 'blee' },
-          originalUrl: '/',
-          query: {
-            entrypoint: (new Array(101)).join('x')
-          }
+        return flowEvent({
+          flowTime: 'foo',
+          time: 'bar',
+          type: 'wibble'
+        }, {
+          entrypoint: (new Array(101)).join('x')
+        }, {
+          headers: { 'user-agent': 'blee' }
         });
       },
 
@@ -250,12 +267,14 @@ define([
       setup: function () {
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('wibble', {}, {
-          headers: { 'user-agent': 'blee' },
-          originalUrl: '/',
-          query: {
-            client_id: (new Array(102)).join(' ') //eslint-disable-line camelcase
-          }
+        return flowEvent({
+          flowTime: 'foo',
+          time: 'bar',
+          type: 'wibble'
+        }, {
+          client_id: (new Array(102)).join(' ') //eslint-disable-line camelcase
+        }, {
+          headers: { 'user-agent': 'blee' }
         });
       },
 
@@ -275,12 +294,14 @@ define([
       setup: function () {
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('wibble', {}, {
-          headers: { 'user-agent': 'blee' },
-          originalUrl: '/',
-          query: {
-            entryPoint: (new Array(102)).join(' ') //eslint-disable-line camelcase
-          }
+        return flowEvent({
+          flowTime: 'foo',
+          time: 'bar',
+          type: 'wibble'
+        }, {
+          entryPoint: (new Array(102)).join(' ') //eslint-disable-line camelcase
+        }, {
+          headers: { 'user-agent': 'blee' }
         });
       },
 
@@ -300,25 +321,27 @@ define([
       setup: function () {
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('mock event', {}, {
-          headers: { 'dnt': '1', 'user-agent': 'foo' },
-          originalUrl: 'bar',
-          query: {
-            client_id: 'mock client_id', //eslint-disable-line camelcase
-            context: 'mock context',
-            entryPoint: 'mock entryPoint',
-            entrypoint: 'mock entrypoint',
-            migration: 'mock migration',
-            service: 'mock service',
-            /*eslint-disable camelcase*/
-            utm_campaign: 'mock utm_campaign',
-            utm_content: 'mock utm_content',
-            utm_medium: 'mock utm_medium',
-            utm_source: 'mock utm_source',
-            utm_term: 'mock utm_term',
-            /*eslint-enable camelcase*/
-            zignore: 'ignore me'
-          }
+        return flowEvent({
+          flowTime: 'mock flow time',
+          time: 'mock time',
+          type: 'mock event'
+        }, {
+          client_id: 'mock client_id', //eslint-disable-line camelcase
+          context: 'mock context',
+          entryPoint: 'mock entryPoint',
+          entrypoint: 'mock entrypoint',
+          migration: 'mock migration',
+          service: 'mock service',
+          /*eslint-disable camelcase*/
+          utm_campaign: 'mock utm_campaign',
+          utm_content: 'mock utm_content',
+          utm_medium: 'mock utm_medium',
+          utm_source: 'mock utm_source',
+          utm_term: 'mock utm_term',
+          /*eslint-enable camelcase*/
+          zignore: 'ignore me'
+        }, {
+          headers: { 'dnt': '1', 'user-agent': 'foo' }
         });
       },
 
@@ -330,10 +353,15 @@ define([
         assert.equal(process.stderr.write.callCount, 1);
 
         var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 10);
+        assert.lengthOf(Object.keys(eventData), 12);
         assert.equal(eventData.op, 'flowEvent');
+        assert.equal(eventData.hostname, os.hostname());
+        assert.equal(eventData.pid, process.pid);
+        assert.equal(eventData.v, 1);
         assert.equal(eventData.event, 'mock event');
         assert.equal(eventData.userAgent, 'foo');
+        assert.equal(eventData.time, 'mock time');
+        assert.equal(eventData.flow_time, 'mock flow time');
         assert.equal(eventData.context, 'mock context');
         assert.equal(eventData.entrypoint, 'mock entrypoint');
         assert.equal(eventData.migration, 'mock migration');
@@ -346,10 +374,12 @@ define([
         time = Date.now();
         write = process.stderr.write;
         process.stderr.write = sinon.spy();
-        return flowEvent('wibble', { time: time }, {
-          headers: { 'user-agent': 'blee' },
-          originalUrl: '/',
-          query: {}
+        return flowEvent({
+          flowTime: 'foo',
+          time: time,
+          type: 'wibble'
+        }, {}, {
+          headers: { 'user-agent': 'blee' }
         });
       },
 
@@ -361,7 +391,6 @@ define([
         assert.equal(process.stderr.write.callCount, 1);
 
         var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 7);
         assert.equal(eventData.time, new Date(time).toISOString());
       }
     },

--- a/tests/server/routes/post-metrics.js
+++ b/tests/server/routes/post-metrics.js
@@ -80,23 +80,32 @@ define([
 
       'route.process': {
         setup: function () {
+          sinon.stub(Date, 'now', function () {
+            return 1000;
+          });
           setupMetricsHandlerTests({
+            /*eslint-disable sorting/sort-object-props*/
             data: {
               flowBeginTime: 42,
               flowId: 'qux',
-              isSampledUser: true
+              isSampledUser: true,
+              startTime: 10,
+              flushTime: 20
             },
             events: [
-              /*eslint-disable sorting/sort-object-props*/
               { type: 'foo', offset: 0 },
               { type: 'bar', offset: 1 },
               { type: 'flow.begin', offset: 2 },
               { type: 'baz', offset: 3 },
               { type: 'flow.signup.engage', offset: 4 }
-              /*eslint-enable sorting/sort-object-props*/
             ],
             userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
+            /*eslint-enable sorting/sort-object-props*/
           });
+        },
+
+        teardown: function () {
+          Date.now.restore();
         },
 
         'response.json was called correctly': function () {
@@ -130,7 +139,7 @@ define([
             var args = mocks.metricsCollector.write.args[0];
             assert.lengthOf(args, 1);
             assert.equal(args[0], mocks.request.body);
-            assert.lengthOf(Object.keys(args[0]), 5);
+            assert.lengthOf(Object.keys(args[0]), 7);
 
             assert.equal(args[0].agent, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0');
             assert.isArray(args[0].events);
@@ -144,20 +153,26 @@ define([
             assert.equal(args[0].events[1].type, 'bar');
             assert.equal(args[0].events[1].offset, 1);
             assert.isObject(args[0].events[2]);
-            assert.lengthOf(Object.keys(args[0].events[2]), 2);
+            assert.lengthOf(Object.keys(args[0].events[2]), 4);
             assert.equal(args[0].events[2].type, 'flow.begin');
             assert.equal(args[0].events[2].offset, 2);
+            assert.equal(args[0].events[2].time, 42);
+            assert.equal(args[0].events[2].flow_time, 0);
             assert.isObject(args[0].events[3]);
             assert.lengthOf(Object.keys(args[0].events[3]), 2);
             assert.equal(args[0].events[3].type, 'baz');
             assert.equal(args[0].events[3].offset, 3);
             assert.isObject(args[0].events[4]);
-            assert.lengthOf(Object.keys(args[0].events[4]), 2);
+            assert.lengthOf(Object.keys(args[0].events[4]), 4);
             assert.equal(args[0].events[4].type, 'flow.signup.engage');
             assert.equal(args[0].events[4].offset, 4);
+            assert.equal(args[0].events[4].time, 994);
+            assert.equal(args[0].events[4].flow_time, 952);
             assert.equal(args[0].flowId, 'qux');
             assert.equal(args[0].flowBeginTime, 42);
             assert.strictEqual(args[0].isSampledUser, true);
+            assert.strictEqual(args[0].startTime, 10);
+            assert.strictEqual(args[0].flushTime, 20);
           },
 
           'statsdCollector.write was called correctly': function () {
@@ -191,7 +206,8 @@ define([
             assert.isObject(args2[1]);
             assert.lengthOf(Object.keys(args2[1]), 3);
             assert.equal(args2[1].flow_id, 'qux');
-
+            assert.strictEqual(args2[1].flow_time, 952);
+            assert.equal(args2[1].time, 994);
           }
         }
       },
@@ -446,24 +462,25 @@ define([
       'route.process without flowBeginTime': {
         setup: function () {
           sinon.stub(Date, 'now', function () {
-            return 1000;
+            return 2000;
           });
           setupMetricsHandlerTests({
+            /*eslint-disable sorting/sort-object-props*/
             data: {
               flowId: 'qux',
-              flushTime: 100,
               isSampledUser: true,
-              startTime: 1
+              startTime: 1,
+              flushTime: 2
             },
             events: [
-              /*eslint-disable sorting/sort-object-props*/
-              { type: 'foo', offset: 0 },
-              { type: 'bar', offset: 1 },
-              { type: 'flow.begin', offset: 10 },
-              { type: 'baz', offset: 11 }
-              /*eslint-enable sorting/sort-object-props*/
+              { type: 'foo', offset: 10 },
+              { type: 'bar', offset: 20 },
+              { type: 'flow.begin', offset: 30 },
+              { type: 'baz', offset: 40 },
+              { type: 'flow.wibble', offset: 50 }
             ],
             userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
+            /*eslint-enable sorting/sort-object-props*/
           });
         },
 
@@ -501,12 +518,19 @@ define([
           },
 
           'flowEvent was called correctly': function () {
-            assert.strictEqual(mocks.flowEvent.callCount, 5);
+            assert.strictEqual(mocks.flowEvent.callCount, 6);
             var args = mocks.flowEvent.args[4];
             assert.lengthOf(args, 3);
             assert.equal(args[0], 'flow.begin');
             assert.lengthOf(Object.keys(args[1]), 3);
-            assert.equal(args[1].time, 911);
+            assert.equal(args[1].time, 2029);
+            assert.equal(args[1].flow_time, 0);
+            args = mocks.flowEvent.args[5];
+            assert.lengthOf(args, 3);
+            assert.equal(args[0], 'flow.wibble');
+            assert.lengthOf(Object.keys(args[1]), 3);
+            assert.equal(args[1].time, 2049);
+            assert.equal(args[1].flow_time, 20);
           }
         }
       }

--- a/tests/server/routes/post-metrics.js
+++ b/tests/server/routes/post-metrics.js
@@ -157,7 +157,7 @@ define([
             assert.equal(args[0].events[2].type, 'flow.begin');
             assert.equal(args[0].events[2].offset, 2);
             assert.equal(args[0].events[2].time, 42);
-            assert.equal(args[0].events[2].flow_time, 0);
+            assert.equal(args[0].events[2].flowTime, 0);
             assert.isObject(args[0].events[3]);
             assert.lengthOf(Object.keys(args[0].events[3]), 2);
             assert.equal(args[0].events[3].type, 'baz');
@@ -167,7 +167,7 @@ define([
             assert.equal(args[0].events[4].type, 'flow.signup.engage');
             assert.equal(args[0].events[4].offset, 4);
             assert.equal(args[0].events[4].time, 994);
-            assert.equal(args[0].events[4].flow_time, 952);
+            assert.equal(args[0].events[4].flowTime, 952);
             assert.equal(args[0].flowId, 'qux');
             assert.equal(args[0].flowBeginTime, 42);
             assert.strictEqual(args[0].isSampledUser, true);
@@ -192,22 +192,25 @@ define([
           'flowEvent was called correctly': function () {
             assert.strictEqual(mocks.flowEvent.callCount, 2);
             var args = mocks.flowEvent.args[0];
-            var args2 = mocks.flowEvent.args[1];
             assert.lengthOf(args, 3);
-            assert.equal(args[0], 'flow.begin');
+            assert.isObject(args[0]);
+            assert.equal(args[0].type, 'flow.begin');
+            assert.strictEqual(args[0].flowTime, 0);
+            assert.equal(args[0].time, 42);
             assert.isObject(args[1]);
-            assert.lengthOf(Object.keys(args[1]), 3);
-            assert.equal(args[1].flow_id, 'qux');
-            assert.strictEqual(args[1].flow_time, 0);
-            assert.equal(args[1].time, 42);
+            assert.equal(args[1].flowId, 'qux');
+            assert.strictEqual(args[1].flowBeginTime, 42);
             assert.equal(args[2], mocks.request);
             // second flowEvent
-            assert.equal(args2[0], 'flow.signup.engage');
-            assert.isObject(args2[1]);
-            assert.lengthOf(Object.keys(args2[1]), 3);
-            assert.equal(args2[1].flow_id, 'qux');
-            assert.strictEqual(args2[1].flow_time, 952);
-            assert.equal(args2[1].time, 994);
+            args = mocks.flowEvent.args[1];
+            assert.isObject(args[0]);
+            assert.equal(args[0].type, 'flow.signup.engage');
+            assert.strictEqual(args[0].flowTime, 952);
+            assert.equal(args[0].time, 994);
+            assert.isObject(args[1]);
+            assert.equal(args[1].flowId, 'qux');
+            assert.strictEqual(args[1].flowBeginTime, 42);
+            assert.equal(args[2], mocks.request);
           }
         }
       },
@@ -391,12 +394,13 @@ define([
             assert.strictEqual(mocks.flowEvent.callCount, 4);
             var args = mocks.flowEvent.args[3];
             assert.lengthOf(args, 3);
-            assert.equal(args[0], 'flow.begin');
+            assert.isObject(args[0]);
+            assert.equal(args[0].type, 'flow.begin');
+            assert.strictEqual(args[0].flowTime, 0);
+            assert.equal(args[0].time, 77);
             assert.isObject(args[1]);
-            assert.lengthOf(Object.keys(args[1]), 3);
-            assert.equal(args[1].flow_id, 'bar');
-            assert.strictEqual(args[1].flow_time, 0);
-            assert.equal(args[1].time, 77);
+            assert.equal(args[1].flowId, 'bar');
+            assert.strictEqual(args[1].flowBeginTime, 77);
             assert.equal(args[2], mocks.request);
           }
         }
@@ -521,16 +525,18 @@ define([
             assert.strictEqual(mocks.flowEvent.callCount, 6);
             var args = mocks.flowEvent.args[4];
             assert.lengthOf(args, 3);
-            assert.equal(args[0], 'flow.begin');
-            assert.lengthOf(Object.keys(args[1]), 3);
-            assert.equal(args[1].time, 2029);
-            assert.equal(args[1].flow_time, 0);
+            assert.equal(args[0].type, 'flow.begin');
+            assert.equal(args[0].time, 2029);
+            assert.equal(args[0].flowTime, 0);
+            assert.equal(args[1].flowId, 'qux');
+            assert.strictEqual(args[1].flowBeginTime, 2029);
             args = mocks.flowEvent.args[5];
             assert.lengthOf(args, 3);
-            assert.equal(args[0], 'flow.wibble');
-            assert.lengthOf(Object.keys(args[1]), 3);
-            assert.equal(args[1].time, 2049);
-            assert.equal(args[1].flow_time, 20);
+            assert.equal(args[0].type, 'flow.wibble');
+            assert.equal(args[0].time, 2049);
+            assert.equal(args[0].flowTime, 20);
+            assert.equal(args[1].flowId, 'qux');
+            assert.strictEqual(args[1].flowBeginTime, 2029);
           }
         }
       }


### PR DESCRIPTION
Fixes #4135.

In addition to the problem discussed in the linked issue, I found two others that were also breaking the flow event data.

The issues are as follows:

* None of the metrics context fields were being propagated to the event, because the code was mystifyingly trying to copy the data from non-existent query parameters instead of the request payload.

* Flow events were being emitted with their timestamp set to the `flowBeginTime` instead of the actual time of the event.

* Unset values on the metrics context data were being passed in with the default value `"none"`, which conflicts with how they are handled in the auth server.

The fixes for each issue should be quite straightforward but I'll also add some inline commentary in a jiffy.

Sample log lines showing the fixed event data:

```
{"event":"flow.begin","flow_id":"fa5a4b756213e2472e493aa4f3367efe2ba40dd957574ea529b87a448ca7f269","flow_time":0,"hostname":"pbooth-22205.home","op":"flowEvent","pid":10998,"time":"2016-10-04T18:19:00.997Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","v":1,"context":"fx_desktop_v3","entrypoint":"fxa:signup-complete","service":"sync"}
{"event":"flow.signin.engage","flow_id":"fa5a4b756213e2472e493aa4f3367efe2ba40dd957574ea529b87a448ca7f269","flow_time":5662,"hostname":"pbooth-22205.home","op":"flowEvent","pid":10998,"time":"2016-10-04T18:19:06.659Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","v":1,"context":"fx_desktop_v3","entrypoint":"fxa:signup-complete","service":"sync"}
{"event":"flow.signin.submit","flow_id":"fa5a4b756213e2472e493aa4f3367efe2ba40dd957574ea529b87a448ca7f269","flow_time":10382,"hostname":"pbooth-22205.home","op":"flowEvent","pid":10998,"time":"2016-10-04T18:19:11.379Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","v":1,"context":"fx_desktop_v3","entrypoint":"fxa:signup-complete","service":"sync"}
```

@vladikoff, this is the PR I mentioned in IRC earlier, can you give it an r?

If it looks okay, I'll rebase and update our other two flow event PRs tomorrow to try and get everything merged in time for train 71.