### PR TITLE
fix(logging): ensure flow begin events get correct flow_time

### DIFF
--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -13,6 +13,8 @@ var logger = require('mozlog')('server.post-metrics');
 
 var DISABLE_CLIENT_METRICS_STDERR = config.get('client_metrics').stderr_collector_disabled;
 
+var FLOW_BEGIN_EVENT_TYPES = /^flow\.[a-z_-]+\.begin$/;
+
 module.exports = function () {
   var metricsCollector = new MetricsCollector();
   var statsd = new StatsDCollector();
@@ -72,7 +74,7 @@ function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
     // This will only kick in if something clobbered the data-flow-begin
     // attribute in the DOM, i.e. hopefully never.
     flowEvents.some(function (event) {
-      if (event.type === 'flow.begin') {
+      if (FLOW_BEGIN_EVENT_TYPES.test(event.type)) {
         metrics.flowBeginTime = estimateTime({
           /*eslint-disable sorting/sort-object-props*/
           start: metrics.startTime,
@@ -88,7 +90,7 @@ function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
   }
 
   flowEvents.forEach(function (event) {
-    if (event.type === 'flow.begin') {
+    if (FLOW_BEGIN_EVENT_TYPES.test(event.type)) {
       event.time = metrics.flowBeginTime;
       event.flowTime = 0;
     } else {

--- a/tests/server/routes/post-metrics.js
+++ b/tests/server/routes/post-metrics.js
@@ -95,7 +95,7 @@ define([
             events: [
               { type: 'foo', offset: 0 },
               { type: 'bar', offset: 1 },
-              { type: 'flow.begin', offset: 2 },
+              { type: 'flow.signup.begin', offset: 2 },
               { type: 'baz', offset: 3 },
               { type: 'flow.signup.engage', offset: 4 }
             ],
@@ -154,7 +154,7 @@ define([
             assert.equal(args[0].events[1].offset, 1);
             assert.isObject(args[0].events[2]);
             assert.lengthOf(Object.keys(args[0].events[2]), 4);
-            assert.equal(args[0].events[2].type, 'flow.begin');
+            assert.equal(args[0].events[2].type, 'flow.signup.begin');
             assert.equal(args[0].events[2].offset, 2);
             assert.equal(args[0].events[2].time, 42);
             assert.equal(args[0].events[2].flowTime, 0);
@@ -194,7 +194,7 @@ define([
             var args = mocks.flowEvent.args[0];
             assert.lengthOf(args, 3);
             assert.isObject(args[0]);
-            assert.equal(args[0].type, 'flow.begin');
+            assert.equal(args[0].type, 'flow.signup.begin');
             assert.strictEqual(args[0].flowTime, 0);
             assert.equal(args[0].time, 42);
             assert.isObject(args[1]);
@@ -280,7 +280,7 @@ define([
               /*eslint-disable sorting/sort-object-props*/
               { type: 'foo', offset: 0 },
               { type: 'bar', offset: 1 },
-              { type: 'flow.begin', offset: 2 },
+              { type: 'flow.signin.begin', offset: 2 },
               { type: 'baz', offset: 3 }
               /*eslint-enable sorting/sort-object-props*/
             ],
@@ -334,7 +334,7 @@ define([
             },
             events: [
               /*eslint-disable sorting/sort-object-props*/
-              { type: 'flow.begin', offset: 2 },
+              { type: 'flow.force_auth.begin', offset: 2 },
               { type: 'foo', offset: 3 }
               /*eslint-enable sorting/sort-object-props*/
             ],
@@ -395,7 +395,7 @@ define([
             var args = mocks.flowEvent.args[3];
             assert.lengthOf(args, 3);
             assert.isObject(args[0]);
-            assert.equal(args[0].type, 'flow.begin');
+            assert.equal(args[0].type, 'flow.force_auth.begin');
             assert.strictEqual(args[0].flowTime, 0);
             assert.equal(args[0].time, 77);
             assert.isObject(args[1]);
@@ -417,7 +417,7 @@ define([
             },
             events: [
               /*eslint-disable sorting/sort-object-props*/
-              { type: 'flow.begin', offset: 2 },
+              { type: 'flow.wibble.begin', offset: 2 },
               { type: 'foo', offset: 3 }
               /*eslint-enable sorting/sort-object-props*/
             ],
@@ -479,7 +479,7 @@ define([
             events: [
               { type: 'foo', offset: 10 },
               { type: 'bar', offset: 20 },
-              { type: 'flow.begin', offset: 30 },
+              { type: 'flow.wibble.begin', offset: 30 },
               { type: 'baz', offset: 40 },
               { type: 'flow.wibble', offset: 50 }
             ],
@@ -525,7 +525,7 @@ define([
             assert.strictEqual(mocks.flowEvent.callCount, 6);
             var args = mocks.flowEvent.args[4];
             assert.lengthOf(args, 3);
-            assert.equal(args[0].type, 'flow.begin');
+            assert.equal(args[0].type, 'flow.wibble.begin');
             assert.equal(args[0].time, 2029);
             assert.equal(args[0].flowTime, 0);
             assert.equal(args[1].flowId, 'qux');


### PR DESCRIPTION
This fixes an issue that crept in because #4224 got merged prematurely. I'd moved the issue out of the review column back into active, but should have made it clearer that it wasn't ready to go.

Flow begin events are being emitted with a non-zero `flow_time`. These events should always have a `flow_time` of zero because they always signify the start of the flow. This PR fixes the problem by updating the server-side code to recognise the new flow begin event names introduced in #4224.

Here are some sample log lines captured prior to this PR, demonstrating the issue:

```
{"event":"flow.signup.begin","flow_id":"ecc19f315c5808fc21f186c4e29d6082da266b98eef01c740e35d5a27b5c4c33","flow_time":725,"hostname":"pbooth-22205.home","op":"flowEvent","pid":42754,"time":"2016-10-05T07:37:52.235Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
{"event":"flow.signup.engage","flow_id":"ecc19f315c5808fc21f186c4e29d6082da266b98eef01c740e35d5a27b5c4c33","flow_time":2248,"hostname":"pbooth-22205.home","op":"flowEvent","pid":42754,"time":"2016-10-05T07:37:53.758Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
```

And here are some sample log lines captured with this PR applied, demonstrating the fix:

```
{"event":"flow.signup.begin","flow_id":"1166697f91730e3c51599dae8c4663f2082c6d1158530af576e492032fea895e","flow_time":0,"hostname":"pbooth-22205.home","op":"flowEvent","pid":48514,"time":"2016-10-05T07:45:51.349Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
{"event":"flow.signup.engage","flow_id":"1166697f91730e3c51599dae8c4663f2082c6d1158530af576e492032fea895e","flow_time":2003,"hostname":"pbooth-22205.home","op":"flowEvent","pid":48514,"time":"2016-10-05T07:45:53.352Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
```

@shane-tomlinson r?