### PR TITLE
fix(client): Fix signup confirmation poll.

### DIFF
--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -160,7 +160,7 @@ define(function (require, exports, module) {
 
     _waitForConfirmation () {
       const account = this.getAccount();
-      return account.waitForSessionVerification(self.VERIFICATION_POLL_IN_MS)
+      return account.waitForSessionVerification(this.VERIFICATION_POLL_IN_MS)
         .then(() => {
           this.user.setAccount(account);
         });


### PR DESCRIPTION
`window.self` is a thing, and that screwed us up. We had an
undefined `self` which we then dereferenced to get the poll interval,
which caused the interval to be `undefined`. Calling `setTimeout` with
a timeout of `undefined` caused the poll to occur extremely rapidly.

The tests didn't check for a valid time when calling the polling function.

The `views/confirm` tests are also updated to ditch all references
to `fxaClient`, instead interface with the account.

fixes #4237 

@jrgm, @vladikoff - this needs to be a part of train 71 or else the auth server is going to fall over as soon as the content server is deployed.

@philbooth - mind reviewing?