### PR TITLE
fix(test): Fix the `sign in to OAuth with Sync creds` on latest.

### DIFF
--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -37,7 +37,7 @@ define([
     name: 'Sign in with OAuth after Sync',
 
     beforeEach: function () {
-      email = TestHelpers.createEmail();
+      email = TestHelpers.createEmail('sync{id}');
       email2 = TestHelpers.createEmail();
 
       // clear localStorage to avoid pollution from other tests.


### PR DESCRIPTION
Latest requires an restmail email to be prefixed with `sync` for
the user to go through signin confirmation.

Local testing does not because the signinConfirmation.sample_rate is set
to 1, which means as long as the context matches one on the list, the
user has to go through confirmation.