### PR TITLE
feat(metrics): Always send a metricsContext.context from the content server.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -262,18 +262,19 @@ define(function (require, exports, module) {
     initializeRelier () {
       if (! this._relier) {
         let relier;
+        const context = this._getContext();
 
         if (this._isServiceSync()) {
           // Use the SyncRelier for sync verification so that
           // the service name is translated correctly.
-          relier = new SyncRelier({
+          relier = new SyncRelier({ context }, {
             isVerification: this._isVerification(),
             sentryMetrics: this._sentryMetrics,
             translator: this._translator,
             window: this._window
           });
         } else if (this._isOAuth()) {
-          relier = new OAuthRelier({
+          relier = new OAuthRelier({ context }, {
             isVerification: this._isVerification(),
             oAuthClient: this._oAuthClient,
             sentryMetrics: this._sentryMetrics,
@@ -281,7 +282,7 @@ define(function (require, exports, module) {
             window: this._window
           });
         } else {
-          relier = new Relier({
+          relier = new Relier({ context }, {
             isVerification: this._isVerification(),
             sentryMetrics: this._sentryMetrics,
             window: this._window
@@ -661,12 +662,10 @@ define(function (require, exports, module) {
 
     _getContext () {
       if (this._isVerification()) {
-        this._context = this._getVerificationContext();
-      } else {
-        this._context = this._searchParam('context') || Constants.DIRECT_CONTEXT;
+        return this._getVerificationContext();
       }
 
-      return this._context;
+      return this._searchParam('context');
     },
 
     _getVerificationContext () {
@@ -675,7 +674,7 @@ define(function (require, exports, module) {
       // the same capabilities as the signup tab.
       // If verifying in a separate browser, fall back to the default context.
       const verificationInfo = this._getSameBrowserVerificationModel('context');
-      return verificationInfo.get('context') || Constants.DIRECT_CONTEXT;
+      return verificationInfo.get('context');
     },
 
     _getSameBrowserVerificationModel (namespace) {

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
     SESSION_TOKEN_USED_FOR_SYNC: 'fx_desktop_v1',
 
     // Users that sign in to the content server directly
-    CONTENT_SERVER_CONTEXT: 'content-server',
+    CONTENT_SERVER_CONTEXT: 'web',
     FX_DESKTOP_V1_CONTEXT: 'fx_desktop_v1',
     FX_DESKTOP_V2_CONTEXT: 'fx_desktop_v2',
     FX_DESKTOP_V3_CONTEXT: 'fx_desktop_v3',

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -27,7 +27,8 @@ define(function (require, exports, module) {
     // set of users to disconnect from Sync.
     SESSION_TOKEN_USED_FOR_SYNC: 'fx_desktop_v1',
 
-    DIRECT_CONTEXT: 'direct',
+    // Users that sign in to the content server directly
+    CONTENT_SERVER_CONTEXT: 'content-server',
     FX_DESKTOP_V1_CONTEXT: 'fx_desktop_v1',
     FX_DESKTOP_V2_CONTEXT: 'fx_desktop_v2',
     FX_DESKTOP_V3_CONTEXT: 'fx_desktop_v3',
@@ -37,6 +38,7 @@ define(function (require, exports, module) {
     FX_FIRSTRUN_V2_CONTEXT: 'fx_firstrun_v2',
     FX_IOS_V1_CONTEXT: 'fx_ios_v1',
     IFRAME_CONTEXT: 'iframe',
+    OAUTH_CONTEXT: 'oauth',
 
     CONTENT_SERVER_SERVICE: 'content-server',
     SYNC_SERVICE: 'sync',

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -17,23 +17,24 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var $ = require('jquery');
-  var _ = require('underscore');
-  var FlowEventMetadata = require('models/flow-event-metadata');
-  var Backbone = require('backbone');
-  var Duration = require('duration');
-  var Environment = require('lib/environment');
-  var p = require('lib/promise');
-  var speedTrap = require('speedTrap');
-  var Strings = require('lib/strings');
-  var xhr = require('lib/xhr');
+  const $ = require('jquery');
+  const _ = require('underscore');
+  const Constants = require('lib/constants');
+  const FlowEventMetadata = require('models/flow-event-metadata');
+  const Backbone = require('backbone');
+  const Duration = require('duration');
+  const Environment = require('lib/environment');
+  const p = require('lib/promise');
+  const speedTrap = require('speedTrap');
+  const Strings = require('lib/strings');
+  const xhr = require('lib/xhr');
 
   // Speed trap is a singleton, convert it
   // to an instantiable function.
-  var SpeedTrap = function () {};
+  const SpeedTrap = function () {};
   SpeedTrap.prototype = speedTrap;
 
-  var ALLOWED_FIELDS = [
+  const ALLOWED_FIELDS = [
     'broker',
     'context',
     'duration',
@@ -74,9 +75,7 @@ define(function (require, exports, module) {
     }, []);
   }
 
-  function Metrics (options) {
-    options = options || {};
-
+  function Metrics (options = {}) {
     // by default, send the metrics to the content server.
     this._collector = options.collector || '';
 
@@ -92,7 +91,7 @@ define(function (require, exports, module) {
     this._window = options.window || window;
 
     this._lang = options.lang || 'unknown';
-    this._context = options.context || 'web';
+    this._context = options.context || Constants.CONTENT_SERVER_CONTEXT;
     this._entrypoint = options.entrypoint || NOT_REPORTED_VALUE;
     this._migration = options.migration || NOT_REPORTED_VALUE;
     this._service = options.service || NOT_REPORTED_VALUE;

--- a/app/scripts/models/reliers/base.js
+++ b/app/scripts/models/reliers/base.js
@@ -14,7 +14,9 @@ define(function (require, exports, module) {
   var p = require('lib/promise');
 
   var Relier = Backbone.Model.extend({
-    defaults: {},
+    defaults: {
+      context: null,
+    },
 
     fetch: function () {
       return p(true);

--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -61,6 +61,7 @@ define(function (require, exports, module) {
     defaults: _.extend({}, Relier.prototype.defaults, {
       accessType: null,
       clientId: null,
+      context: Constants.OAUTH_CONTEXT,
       // whether to fetch and derive relier-specific keys
       keys: false,
       // permissions are individual scopes
@@ -86,10 +87,8 @@ define(function (require, exports, module) {
       Relier.prototype.resumeTokenFields
     ),
 
-    initialize: function (options) {
-      options = options || {};
-
-      Relier.prototype.initialize.call(this, options);
+    initialize: function (attributes, options = {}) {
+      Relier.prototype.initialize.call(this, attributes, options);
 
       this._session = options.session;
       this._oAuthClient = options.oAuthClient;

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -68,6 +68,10 @@ define(function (require, exports, module) {
   var Relier = BaseRelier.extend({
     defaults: {
       allowCachedCredentials: true,
+      // This ensures for non-oauth reliers, SOME context is sent to the auth
+      // server to let the auth server know requests come from the content
+      // server and not some other service.
+      context: Constants.CONTENT_SERVER_CONTEXT,
       email: null,
       entrypoint: null,
       migration: null,
@@ -83,9 +87,7 @@ define(function (require, exports, module) {
       utmTerm: null
     },
 
-    initialize: function (options) {
-      options = options || {};
-
+    initialize: function (attributes, options = {}) {
       this._queryParameterSchema = options.isVerification ?
         VERIFICATION_QUERY_PARAMETER_SCHEMA : QUERY_PARAMETER_SCHEMA;
 

--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -29,16 +29,13 @@ define(function (require, exports, module) {
 
   var SyncRelier = Relier.extend({
     defaults: _.extend({}, Relier.prototype.defaults, {
-      context: null,
       customizeSync: false
     }),
 
-    initialize: function (options) {
-      options = options || {};
-
+    initialize: function (attributes, options = {}) {
       this._translator = options.translator;
 
-      Relier.prototype.initialize.call(this, options);
+      Relier.prototype.initialize.call(this, attributes, options);
     },
 
     fetch: function () {

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -822,8 +822,8 @@ define(function (require, exports, module) {
             });
           });
 
-          it('returns the `direct` context', function () {
-            assert.equal(appStart._getContext(), Constants.DIRECT_CONTEXT);
+          it('returns `undefined`', function () {
+            assert.isUndefined(appStart._getContext());
           });
         });
       });
@@ -873,9 +873,8 @@ define(function (require, exports, module) {
           });
         });
 
-        it('returns the `direct` context', function () {
-          assert.equal(appStart._getVerificationContext(),
-              Constants.DIRECT_CONTEXT);
+        it('returns `undefined`', function () {
+          assert.isUndefined(appStart._getVerificationContext());
         });
       });
     });

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -7,18 +7,17 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var $ = require('jquery');
-  var _ = require('underscore');
-  var AuthErrors = require('lib/auth-errors');
-  var chai = require('chai');
-  var Environment = require('lib/environment');
-  var Metrics = require('lib/metrics');
-  var p = require('lib/promise');
-  var sinon = require('sinon');
-  var TestHelpers = require('../../lib/helpers');
-  var WindowMock = require('../../mocks/window');
-
-  var assert = chai.assert;
+  const $ = require('jquery');
+  const _ = require('underscore');
+  const { assert } = require('chai');
+  const AuthErrors = require('lib/auth-errors');
+  const Constants = require('lib/constants');
+  const Environment = require('lib/environment');
+  const Metrics = require('lib/metrics');
+  const p = require('lib/promise');
+  const sinon = require('sinon');
+  const TestHelpers = require('../../lib/helpers');
+  const WindowMock = require('../../mocks/window');
 
   describe('lib/metrics', function () {
     var metrics;
@@ -211,7 +210,7 @@ define(function (require, exports, module) {
               var data = JSON.parse(windowMock.navigator.sendBeacon.getCall(0).args[1]);
               assert.lengthOf(Object.keys(data), 25);
               assert.equal(data.broker, 'none');
-              assert.equal(data.context, 'web');
+              assert.equal(data.context, Constants.CONTENT_SERVER_CONTEXT);
               assert.isNumber(data.duration);
               assert.equal(data.entrypoint, 'none');
               assert.isArray(data.events);

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
 
       user = new User();
 
-      relier = new OAuthRelier({
+      relier = new OAuthRelier({}, {
         oAuthClient: oAuthClient,
         session: Session,
         window: windowMock
@@ -88,6 +88,9 @@ define(function (require, exports, module) {
 
         return relier.fetch()
           .then(function () {
+            // context is not imported from query params
+            assert.equal(relier.get('context'), Constants.OAUTH_CONTEXT);
+
             assert.equal(relier.get('preVerifyToken'), PREVERIFY_TOKEN);
             assert.equal(relier.get('prompt'), PROMPT);
             assert.equal(relier.get('service'), SERVICE);

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
     beforeEach(function () {
       windowMock = new WindowMock();
 
-      relier = new Relier({
+      relier = new Relier({}, {
         window: windowMock
       });
     });
@@ -70,9 +70,11 @@ define(function (require, exports, module) {
 
       return relier.fetch()
         .then(function () {
-          // not imported from the search parameters, but is set manually.
+          // Next two are not imported from the search parameters, but is set manually.
           assert.isTrue(relier.get('allowCachedCredentials'));
+          assert.equal(relier.get('context'), Constants.CONTENT_SERVER_CONTEXT);
 
+          // The rest are imported from search parameters
           assert.equal(relier.get('preVerifyToken'), PREVERIFY_TOKEN);
           assert.equal(relier.get('service'), SERVICE);
           assert.equal(relier.get('email'), EMAIL);
@@ -146,7 +148,7 @@ define(function (require, exports, module) {
 
     describe('email verification flow', function () {
       beforeEach(function () {
-        relier = new Relier({
+        relier = new Relier({}, {
           isVerification: true,
           window: windowMock
         });
@@ -183,7 +185,7 @@ define(function (require, exports, module) {
 
     describe('uid verification flow', function () {
       beforeEach(function () {
-        relier = new Relier({
+        relier = new Relier({}, {
           isVerification: true,
           window: windowMock
         });

--- a/app/tests/spec/models/reliers/sync.js
+++ b/app/tests/spec/models/reliers/sync.js
@@ -5,24 +5,22 @@
 define(function (require, exports, module) {
   'use strict';
 
-  var AuthErrors = require('lib/auth-errors');
-  var chai = require('chai');
-  var Relier = require('models/reliers/sync');
-  var TestHelpers = require('../../../lib/helpers');
-  var Translator = require('lib/translator');
-  var WindowMock = require('../../../mocks/window');
+  const { assert } = require('chai');
+  const AuthErrors = require('lib/auth-errors');
+  const Relier = require('models/reliers/sync');
+  const TestHelpers = require('../../../lib/helpers');
+  const Translator = require('lib/translator');
+  const WindowMock = require('../../../mocks/window');
 
-  var assert = chai.assert;
+  const CONTEXT = 'fx_desktop_v1';
+  const SYNC_MIGRATION = 'sync11';
+  const SYNC_SERVICE = 'sync';
 
   describe('models/reliers/sync', function () {
-    var err;
-    var relier;
-    var translator;
-    var windowMock;
-
-    var CONTEXT = 'fx_desktop_v1';
-    var SYNC_MIGRATION = 'sync11';
-    var SYNC_SERVICE = 'sync';
+    let err;
+    let relier;
+    let translator;
+    let windowMock;
 
     function fetchExpectError () {
       return relier.fetch()
@@ -36,6 +34,8 @@ define(function (require, exports, module) {
       windowMock = new WindowMock();
 
       relier = new Relier({
+        context: CONTEXT
+      }, {
         translator: translator,
         window: windowMock
       });
@@ -67,9 +67,8 @@ define(function (require, exports, module) {
             return relier.fetch();
           });
 
-          it('succeeds', function () {
-            // it's OK
-            assert.isFalse(relier.has('context'));
+          it('falls back to passed in `context', function () {
+            assert.equal(relier.get('context'), CONTEXT);
           });
         });
 

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -185,7 +185,7 @@ define(function (require, exports, module) {
       describe('if service is available in the URL', function () {
         beforeEach(function () {
           windowMock.location.search = '?code=' + validCode + '&uid=' + validUid + '&service=' + validService;
-          relier = new Relier({
+          relier = new Relier({}, {
             window: windowMock
           });
           relier.fetch();
@@ -204,7 +204,7 @@ define(function (require, exports, module) {
       describe('if reminder is available in the URL', function () {
         beforeEach(function () {
           windowMock.location.search = '?code=' + validCode + '&uid=' + validUid + '&reminder=' + validReminder;
-          relier = new Relier({
+          relier = new Relier({}, {
             window: windowMock
           });
           relier.fetch();
@@ -224,7 +224,7 @@ define(function (require, exports, module) {
         beforeEach(function () {
           windowMock.location.search = '?code=' + validCode + '&uid=' + validUid +
             '&service=' + validService + '&reminder=' + validReminder;
-          relier = new Relier({
+          relier = new Relier({}, {
             window: windowMock
           });
           relier.fetch();

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
       user = new User();
       windowMock = new WindowMock();
 
-      relier = new Relier({
+      relier = new Relier({}, {
         window: windowMock
       });
 

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -3,7 +3,16 @@
 ## Top level
 
 ### context
-The context will be `fx_desktop_v1` if the user is signing up for sync, `iframe` if the user is signing up in an iframe, `web` otherwise.
+The context will be one of:
+
+* `content-server` Interact w/ content server w/o signing into a relier.
+* `fx_desktop_v1` Fx Desktop Sync v1 (Uses CustomEvents to communicate)
+* `fx_desktop_v2` Fx Desktop Sync v2 (Uses WebChannels to communicate)
+* `fx_desktop_v3` Fx Desktop Sync v3 (Enables CWTS on the web)
+* `fx_fennec_v1` Fx Fennec v1
+* `fx_firstrun_v2` Fx Desktop firstrun v2
+* `iframe` Fx Desktop firstrun v1
+* `oauth` OAuth relier
 
 ### broker
 The broker used to coordinate behavior between FxA and the relier.

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -5,7 +5,6 @@
 ### context
 The context will be one of:
 
-* `content-server` Interact w/ content server w/o signing into a relier.
 * `fx_desktop_v1` Fx Desktop Sync v1 (Uses CustomEvents to communicate)
 * `fx_desktop_v2` Fx Desktop Sync v2 (Uses WebChannels to communicate)
 * `fx_desktop_v3` Fx Desktop Sync v3 (Enables CWTS on the web)
@@ -13,6 +12,7 @@ The context will be one of:
 * `fx_firstrun_v2` Fx Desktop firstrun v2
 * `iframe` Fx Desktop firstrun v1
 * `oauth` OAuth relier
+* `web` Interact w/ content server w/o signing into a relier.
 
 ### broker
 The broker used to coordinate behavior between FxA and the relier.


### PR DESCRIPTION
* If signing into the content server directly, send `content-server`
* If signing into an oauth relier, send `content-server-oauth`

As a refactor, convert Relier to conform to Backbone.Model conventions
where the first argument is attributes, the second options.

When creating Reliers in app-start.js, pass in the `context` so that
contexts loaded from VerificationInfo are correctly captured.

The purpose of this PR is to enable features like signin unblock on the
auth server for flows where currently no context is sent in the
`metricsContext` bundle.