### PR TITLE
fix(teamcity): path location should be relative to the script

### DIFF
--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -18,7 +18,6 @@ function check_version {
   fi
 }
 
-ORIG_DIR=`pwd`
 BASENAME=$(basename $0)
 DIRNAME=$(dirname $0)
 
@@ -74,25 +73,25 @@ export npm_config_tmp=~/fxatemp
 
 set -o xtrace # echo the following commands
 
-node $ORIG_DIR/install-npm-deps.js  \
-  bluebird                           \
-  bower                              \
-  convict                            \
-  extend                             \
-  firefox-profile                    \
-  fxa-shared                         \
-  helmet                             \
-  htmlparser2                        \
-  intern                             \
-  lodash                             \
-  mozlog                             \
-  node-statsd                        \
-  proxyquire                         \
-  request                            \
-  node-uap                           \
-  sinon                              \
-  sync-exec                          \
-  universal-analytics                \
+node $DIRNAME/install-npm-deps.js \
+  bluebird                        \
+  bower                           \
+  convict                         \
+  extend                          \
+  firefox-profile                 \
+  fxa-shared                      \
+  helmet                          \
+  htmlparser2                     \
+  intern                          \
+  lodash                          \
+  mozlog                          \
+  node-statsd                     \
+  proxyquire                      \
+  request                         \
+  node-uap                        \
+  sinon                           \
+  sync-exec                       \
+  universal-analytics             \
   xmlhttprequest
 
 ./node_modules/.bin/intern-client \

--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -18,7 +18,6 @@ function check_version {
   fi
 }
 
-ORIG_DIR=`pwd`
 BASENAME=$(basename $0)
 DIRNAME=$(dirname $0)
 
@@ -77,14 +76,14 @@ export npm_config_tmp=~/fxatemp
 
 set -o xtrace # echo the following commands
 
-node $ORIG_DIR/install-npm-deps.js  \
-  bower                              \
-  convict                            \
-  firefox-profile                    \
-  fxa-shared                         \
-  intern                             \
-  request                            \
-  sync-exec                          \
+node $DIRNAME/install-npm-deps.js \
+  bower                           \
+  convict                         \
+  firefox-profile                 \
+  fxa-shared                      \
+  intern                          \
+  request                         \
+  sync-exec                       \
   xmlhttprequest
 
 node_modules/.bin/bower install --config.interactive=false


### PR DESCRIPTION
The location of `install-npm-deps.js` should be determined from the location of the running script, not from PWD of where is was invoked.