### PR TITLE
refactor(client): Use object shorthand for functions.

### DIFF
--- a/app/scripts/lib/able.js
+++ b/app/scripts/lib/able.js
@@ -20,7 +20,7 @@ define(function (require, exports, module) {
   }
 
   AbleWrapper.prototype = {
-    choose: function () {
+    choose () {
       var able = window.able;
       if (able) {
         return able.choose.apply(able, arguments);

--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -318,7 +318,7 @@ define(function (require, exports, module) {
      * @param {Error} err
      * @returns {Object}
      */
-    toInterpolationContext: function (err) {
+    toInterpolationContext (err) {
       // For data returned by backend, see
       // https://github.com/mozilla/fxa-auth-server/blob/master/error.js
       try {

--- a/app/scripts/lib/base64url.js
+++ b/app/scripts/lib/base64url.js
@@ -16,14 +16,14 @@ define(function (require, exports, module) {
 
   module.exports = {
 
-    encode: function (bits) {
+    encode (bits) {
       return sjcl.codec.base64.fromBits(bits)
         .replace(/\+/g, '-')
         .replace(/\//g, '_')
         .replace(/=/g, '');
     },
 
-    decode: function (chars) {
+    decode (chars) {
       return sjcl.codec.base64.toBits(
         chars.replace(/-/g, '+').replace(/_/g, '/')
       );

--- a/app/scripts/lib/channels/base.js
+++ b/app/scripts/lib/channels/base.js
@@ -15,13 +15,13 @@ define(function (require, exports, module) {
   }
 
   _.extend(BaseChannel.prototype, Backbone.Events, {
-    initialize: function () {
+    initialize () {
     },
 
-    teardown: function () {
+    teardown () {
     },
 
-    send: function (command, data, done) {
+    send (command, data, done) {
       if (done) {
         done();
       }

--- a/app/scripts/lib/channels/duplex.js
+++ b/app/scripts/lib/channels/duplex.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
   }
 
   OutstandingRequests.prototype = {
-    add: function (messageId, request) {
+    add (messageId, request) {
       // remove any old outstanding messages with the same messageId
       this.remove(messageId);
 
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
       this._requests[messageId] = request;
     },
 
-    remove: function (messageId) {
+    remove (messageId) {
       var outstanding = this.get(messageId);
       if (outstanding) {
         this._window.clearTimeout(outstanding.timeout);
@@ -48,11 +48,11 @@ define(function (require, exports, module) {
       }
     },
 
-    get: function (messageId) {
+    get (messageId) {
       return this._requests[messageId];
     },
 
-    clear: function () {
+    clear () {
       for (var messageId in this._requests) {
         this.remove(this._requests[messageId]);
       }
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
   }
 
   _.extend(DuplexChannel.prototype, new BaseChannel(), {
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._sender = options.sender;
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
       });
     },
 
-    teardown: function () {
+    teardown () {
       this._outstandingRequests.clear();
       if (this._sender) {
         this._sender.teardown();
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
      * @return {Promise}
      *        Promise will resolve whenever message is sent.
      */
-    send: function (command, data) {
+    send (command, data) {
       return p().then(() => {
         return this._sender.send(command, data, null);
       });
@@ -119,7 +119,7 @@ define(function (require, exports, module) {
      * @return {Promise}
      *        Promise will resolve when the response is received.
      */
-    request: function (command, data) {
+    request (command, data) {
       var messageId = this.createMessageId(command, data);
       var outstanding = {
         command: command,
@@ -153,11 +153,11 @@ define(function (require, exports, module) {
      * @param {Object} [data]
      * @return {String}
      */
-    createMessageId: function (command, data) {
+    createMessageId (command, data) {
       return Date.now();
     },
 
-    onMessageReceived: function (message) {
+    onMessageReceived (message) {
       var parsedMessage = this.parseMessage(message);
       var data = parsedMessage.data;
       var messageId = parsedMessage.messageId;
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
      *    a response.
      *    @param {Object} parsedMessage.data - data
      */
-    parseMessage: function (message) {
+    parseMessage (message) {
       return {
         command: message.command,
         data: message.data,

--- a/app/scripts/lib/channels/fx-desktop-v1.js
+++ b/app/scripts/lib/channels/fx-desktop-v1.js
@@ -18,7 +18,7 @@ define(function (require, exports, module) {
   }
 
   _.extend(FxDesktopV1Channel.prototype, new DuplexChannel(), {
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       var win = options.window || window;
@@ -41,7 +41,7 @@ define(function (require, exports, module) {
       });
     },
 
-    createMessageId: function (command) {
+    createMessageId (command) {
       // The browser does not return messageIds, it silently ignores any
       // that are sent. It will return a `status` field that is the same
       // as the command. Use the command (which is returned as status)
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
       return command;
     },
 
-    parseMessage: function (message) {
+    parseMessage (message) {
       if (! (message && message.content)) {
         throw new Error('malformed message');
       }

--- a/app/scripts/lib/channels/iframe.js
+++ b/app/scripts/lib/channels/iframe.js
@@ -45,11 +45,11 @@ define(function (require, exports, module) {
       });
     },
 
-    receiveEvent: function (event) {
+    receiveEvent (event) {
       return this._receiver.receiveEvent(event);
     },
 
-    parseMessage: function (message) {
+    parseMessage (message) {
       try {
         return IFrameChannel.parse(message);
       } catch (e) {

--- a/app/scripts/lib/channels/inter-tab.js
+++ b/app/scripts/lib/channels/inter-tab.js
@@ -38,16 +38,16 @@ define(function (require, exports, module) {
   }
 
   BroadcastChannelAdapter.prototype = {
-    onMessage: function (event) {
+    onMessage (event) {
       var envelope = JSON.parse(event.data);
       this.trigger(envelope.name, envelope.data);
     },
 
-    send: function (name, data) {
+    send (name, data) {
       this._broadcastChannel.postMessage(this.stringify(name, data));
     },
 
-    clear: function () {
+    clear () {
       // do nothing
     },
 
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
      * @param {Object} [data]
      * @returns {String}
      */
-    stringify: function (name, data) {
+    stringify (name, data) {
       return JSON.stringify({
         data: data || {},
         name: name
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
   }
 
   LocalStorageAdapter.prototype = {
-    send: function (name, data) {
+    send (name, data) {
       // Sensitive data is sent across the channel and should only
       // be in localStorage if absolutely necessary. Only send
       // data if another tab is listening.
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
       }
     },
 
-    on: function (name, callback) {
+    on (name, callback) {
       this._handlers[name] = this._handlers[name] || [];
       var sentMessageIds = this._sentMessageIds;
 
@@ -115,7 +115,7 @@ define(function (require, exports, module) {
       this._crosstab.util.events.on(name, callbackWrapper);
     },
 
-    off: function (name, callback) {
+    off (name, callback) {
       var handlersForName = this._handlers[name] || [];
       handlersForName.forEach(function (handler) {
         if (handler.callback === callback) {
@@ -124,7 +124,7 @@ define(function (require, exports, module) {
       }, this);
     },
 
-    clear: function () {
+    clear () {
       this._crosstab.util.clearMessages();
     }
   };
@@ -170,7 +170,7 @@ define(function (require, exports, module) {
      * @param {Object} [data]
      * @returns {undefined}
      */
-    send: function (name, data) {
+    send (name, data) {
       return this._adapter.send(name, data);
     },
 
@@ -183,7 +183,7 @@ define(function (require, exports, module) {
      *
      * @return {String} key - key used to unregister a listener
      */
-    on: function (name, callback) {
+    on (name, callback) {
       return this._adapter.on(name, callback);
     },
 
@@ -195,7 +195,7 @@ define(function (require, exports, module) {
      * @param {Function} callback
      * @returns {undefined}
      */
-    off: function (name, callback) {
+    off (name, callback) {
       return this._adapter.off(name, callback);
     },
 
@@ -205,7 +205,7 @@ define(function (require, exports, module) {
      * @method clear
      * @returns {undefined}
      */
-    clear: function () {
+    clear () {
       return this._adapter.clear();
     }
   };

--- a/app/scripts/lib/channels/notifier.js
+++ b/app/scripts/lib/channels/notifier.js
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
     COMMANDS: COMMAND_NAMES,
     SCHEMATA: SCHEMATA,
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       // internal:* messages are never sent outside of FxA. Messages
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
      * @param {Object} data
      * @param {Context} context
      */
-    triggerAll: function (command, data, context) {
+    triggerAll (command, data, context) {
       this.triggerRemote(command, data);
       this.trigger(command, data, context);
     },
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
      * @param {String} command
      * @param {Object} data
      */
-    triggerRemote: function (command, data) {
+    triggerRemote (command, data) {
       // Validation distinguishes between undefined values and values that are
       // set to undefined. And some channels don't serialise their payloads, so
       // values that are set to undefined get sent with the message. Mitigate
@@ -142,13 +142,13 @@ define(function (require, exports, module) {
     },
 
     // Listen for notifications from other fxa tabs or frames
-    _listen: function (tabChannel) {
+    _listen (tabChannel) {
       _.each(COMMAND_NAMES, (name) => {
         tabChannel.on(name, this.trigger.bind(this, name));
       });
     },
 
-    clear: function () {
+    clear () {
       if (this._tabChannel) {
         this._tabChannel.clear();
       }

--- a/app/scripts/lib/channels/receivers/null.js
+++ b/app/scripts/lib/channels/receivers/null.js
@@ -16,10 +16,10 @@ define(function (require, exports, module) {
     // nothing to do
   }
   _.extend(NullReceiver.prototype, Backbone.Events, {
-    initialize: function () {
+    initialize () {
     },
 
-    teardown: function () {
+    teardown () {
     }
   });
 

--- a/app/scripts/lib/channels/receivers/postmessage.js
+++ b/app/scripts/lib/channels/receivers/postmessage.js
@@ -18,7 +18,7 @@ define(function (require, exports, module) {
     // nothing to do
   }
   _.extend(PostMessageReceiver.prototype, Backbone.Events, {
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._origin = options.origin;
@@ -29,14 +29,14 @@ define(function (require, exports, module) {
       this._logger = new Logger(this._window);
     },
 
-    isOriginIgnored: function (origin) {
+    isOriginIgnored (origin) {
       // A lot of messages are sent with the origin `chrome://browser`, whether
       // these are from Firefox or addons, we are not sure. Completely ignore
       // these messages. See #3465
       return origin === 'chrome://browser';
     },
 
-    isOriginTrusted: function (origin) {
+    isOriginTrusted (origin) {
       // `message` events that come from the Fx Desktop browser have an
       // origin of the string constant 'null'. See
       // https://developer.mozilla.org/docs/Web/API/Window/postMessage#Using_win.postMessage_in_extensions
@@ -52,7 +52,7 @@ define(function (require, exports, module) {
       return this._origin === origin;
     },
 
-    receiveEvent: function (event) {
+    receiveEvent (event) {
       if (event.type !== 'message') {
         return; // not an expected type of event
       }
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
       }
     },
 
-    teardown: function () {
+    teardown () {
       this._window.removeEventListener('message', this._boundReceiveEvent, false);
     }
   });

--- a/app/scripts/lib/channels/receivers/web-channel.js
+++ b/app/scripts/lib/channels/receivers/web-channel.js
@@ -19,7 +19,7 @@ define(function (require, exports, module) {
     // nothing to do
   }
   _.extend(WebChannelReceiver.prototype, Backbone.Events, {
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._window = options.window;
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
       this._logger = new Logger(this._window);
     },
 
-    receiveMessage: function (event) {
+    receiveMessage (event) {
       var detail = event.detail;
 
       if (! (detail && detail.id)) {
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
       }
     },
 
-    teardown: function () {
+    teardown () {
       this._window.removeEventListener('WebChannelMessageToContent', this._boundReceiveMessage, true);
     }
   });

--- a/app/scripts/lib/channels/senders/fx-desktop-v1.js
+++ b/app/scripts/lib/channels/senders/fx-desktop-v1.js
@@ -16,25 +16,25 @@ define(function (require, exports, module) {
   }
 
   FxDesktopV1Sender.prototype = {
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._window = options.window;
     },
 
-    send: function (command, data, messageId) {
+    send (command, data, messageId) {
       return p().then(() => {
         return this.dispatchCommand(command, data, messageId);
       });
     },
 
-    dispatchCommand: function (command, data, messageId) {
+    dispatchCommand (command, data, messageId) {
       var win = this._window;
       var event = createEvent(win, command, data, messageId);
       win.dispatchEvent(event);
     },
 
-    teardown: function () {
+    teardown () {
       // nothing to do.
     }
   };

--- a/app/scripts/lib/channels/senders/null.js
+++ b/app/scripts/lib/channels/senders/null.js
@@ -16,14 +16,14 @@ define(function (require, exports, module) {
   }
 
   NullSender.prototype = {
-    initialize: function (/*options*/) {
+    initialize (/*options*/) {
     },
 
-    send: function (/*command, data, messageId*/) {
+    send (/*command, data, messageId*/) {
       return p();
     },
 
-    teardown: function () {
+    teardown () {
     }
   };
 

--- a/app/scripts/lib/channels/senders/postmessage.js
+++ b/app/scripts/lib/channels/senders/postmessage.js
@@ -30,21 +30,21 @@ define(function (require, exports, module) {
   }
 
   PostMessageSender.prototype = {
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._origin = options.origin;
       this._window = options.window;
     },
 
-    send: function (command, data, messageId) {
+    send (command, data, messageId) {
       return p().then(() => {
         var event = stringify(command, data, messageId);
         this._window.postMessage(event, this._origin);
       });
     },
 
-    teardown: function () {
+    teardown () {
     }
   };
 

--- a/app/scripts/lib/channels/senders/web-channel.js
+++ b/app/scripts/lib/channels/senders/web-channel.js
@@ -17,14 +17,14 @@ define(function (require, exports, module) {
   }
 
   WebChannelSender.prototype = {
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._window = options.window;
       this._webChannelId = options.webChannelId;
     },
 
-    send: function (command, data, messageId) {
+    send (command, data, messageId) {
       return p().then(() => {
         // save command name for testing purposes
         this._saveEventName(command);
@@ -35,10 +35,10 @@ define(function (require, exports, module) {
       });
     },
 
-    teardown: function () {
+    teardown () {
     },
 
-    _saveEventName: function (command) {
+    _saveEventName (command) {
       var storedEvents;
       try {
         storedEvents = JSON.parse(this._window.sessionStorage.getItem('webChannelEvents')) || [];

--- a/app/scripts/lib/channels/web.js
+++ b/app/scripts/lib/channels/web.js
@@ -23,7 +23,7 @@ define(function (require, exports, module) {
   }
 
   _.extend(WebChannel.prototype, new DuplexChannel(), {
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       var win = options.window || window;

--- a/app/scripts/lib/dom-writer.js
+++ b/app/scripts/lib/dom-writer.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
      * @param {Object} win
      * @param {String | Element} content
      */
-    write: function (win, content) {
+    write (win, content) {
       $('#loading-spinner').hide();
 
       // Two notes:

--- a/app/scripts/lib/error-utils.js
+++ b/app/scripts/lib/error-utils.js
@@ -24,7 +24,7 @@ define(function (require, exports, module) {
      * @param {Error} error - error for which to get error page URL
      * @returns {String}
      */
-    getErrorPageTemplate: function (error) {
+    getErrorPageTemplate (error) {
       if (AuthErrors.is(error, 'INVALID_PARAMETER') ||
           AuthErrors.is(error, 'MISSING_PARAMETER') ||
           OAuthErrors.is(error, 'INVALID_PARAMETER') ||
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
      * @param {Object} metrics
      * @param {Object} win
      */
-    captureError: function (error, sentryMetrics, metrics, win) {
+    captureError (error, sentryMetrics, metrics, win) {
       var logger = new Logger(win);
       logger.error(error);
 
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
      * @param {Object} win
      * @returns {Promise};
      */
-    captureAndFlushError: function (error, sentryMetrics, metrics, win) {
+    captureAndFlushError (error, sentryMetrics, metrics, win) {
       this.captureError(error, sentryMetrics, metrics, win);
       return p().then(function () {
         if (metrics) {
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
      * @param {Object} win
      * @param {Object} translator
      */
-    renderError: function (error, win, translator) {
+    renderError (error, win, translator) {
       var errorPageTemplate = this.getErrorPageTemplate(error);
       var errorMessage = this.getErrorMessage(error, translator);
       var errorHtml = errorPageTemplate({
@@ -111,7 +111,7 @@ define(function (require, exports, module) {
      * @param {Object} translator
      * @returns {Promise}
      */
-    fatalError: function (error, sentryMetrics, metrics, win, translator) {
+    fatalError (error, sentryMetrics, metrics, win, translator) {
       return p.all([
         this.captureAndFlushError(error, sentryMetrics, metrics, win),
         this.renderError(error, win, translator)
@@ -126,7 +126,7 @@ define(function (require, exports, module) {
      * @param {Object} [translator] - translator to translate error
      * @return {String} interpolated error text.
      */
-    getErrorMessage: function (error, translator) {
+    getErrorMessage (error, translator) {
       if (error && error.errorModule) {
         return error.errorModule.toInterpolatedMessage(error, translator);
       }

--- a/app/scripts/lib/errors.js
+++ b/app/scripts/lib/errors.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
      * @param {Error|Number|String} searchFor
      * @returns {Object}
      */
-    find: function (searchFor) {
+    find (searchFor) {
       var found;
       if (typeof searchFor.errno === 'number') {
         found = this.find(searchFor.errno);
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
      * @param {Error} err
      * @returns {String|Error}
      */
-    toMessage: function (err) {
+    toMessage (err) {
       if (! err) {
         // No error, assume no response from the backend and
         // the service is unavailable.
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
      * @param {Object} translator
      * @returns {String}
      */
-    toInterpolatedMessage: function (err, translator) {
+    toInterpolatedMessage (err, translator) {
       var msg = this.toMessage(err);
       var interpolationContext = this.toInterpolationContext(err);
       if (translator) {
@@ -87,7 +87,7 @@ define(function (require, exports, module) {
      *
      * @returns {Object}
      */
-    toInterpolationContext: function (/*err*/) {
+    toInterpolationContext (/*err*/) {
       return {};
     },
 
@@ -97,7 +97,7 @@ define(function (require, exports, module) {
      * @param {Error} err
      * @returns {Number|Error}
      */
-    toErrno: function (err) {
+    toErrno (err) {
       var errnoSource = this.find(err);
       // try to find an error with an errno.
       if (errnoSource && errnoSource.errno) {
@@ -115,7 +115,7 @@ define(function (require, exports, module) {
      * @param {String} [context]
      * @returns {Error}
      */
-    toError: function (type, context) {
+    toError (type, context) {
       var errno = this.toErrno(type);
       var message = this.toMessage(errno);
 
@@ -152,7 +152,7 @@ define(function (require, exports, module) {
      * @param {String} paramName
      * @returns {Error}
      */
-    toInvalidParameterError: function (paramName) {
+    toInvalidParameterError (paramName) {
       var err = this.toError('INVALID_PARAMETER');
       err.param = paramName;
       return err;
@@ -166,7 +166,7 @@ define(function (require, exports, module) {
      * @param {String} paramName
      * @returns {Error}
      */
-    toMissingParameterError: function (paramName) {
+    toMissingParameterError (paramName) {
       var err = this.toError('MISSING_PARAMETER');
       err.param = paramName;
       return err;
@@ -180,7 +180,7 @@ define(function (require, exports, module) {
      * @param {String} propertyName
      * @returns {Error}
      */
-    toInvalidResumeTokenPropertyError: function (propertyName) {
+    toInvalidResumeTokenPropertyError (propertyName) {
       var err = this.toError('INVALID_RESUME_TOKEN_PROPERTY');
       err.property = propertyName;
       return err;
@@ -194,7 +194,7 @@ define(function (require, exports, module) {
      * @param {String} propertyName
      * @returns {Error}
      */
-    toMissingResumeTokenPropertyError: function (propertyName) {
+    toMissingResumeTokenPropertyError (propertyName) {
       var err = this.toError('MISSING_RESUME_TOKEN_PROPERTY');
       err.property = propertyName;
       return err;
@@ -208,7 +208,7 @@ define(function (require, exports, module) {
      * @param {String} propertyName
      * @returns {Error}
      */
-    toInvalidDataAttributeError: function (propertyName) {
+    toInvalidDataAttributeError (propertyName) {
       var err = this.toError('INVALID_DATA_ATTRIBUTE');
       err.property = propertyName;
       return err;
@@ -222,7 +222,7 @@ define(function (require, exports, module) {
      * @param {String} propertyName
      * @returns {Error}
      */
-    toMissingDataAttributeError: function (propertyName) {
+    toMissingDataAttributeError (propertyName) {
       var err = this.toError('MISSING_DATA_ATTRIBUTE');
       err.property = propertyName;
       return err;
@@ -235,7 +235,7 @@ define(function (require, exports, module) {
      * @param {String} type
      * @returns {Boolean}
      */
-    is: function (error, type) {
+    is (error, type) {
       var code = this.toErrno(type);
       return error.errno === code;
     },
@@ -246,11 +246,11 @@ define(function (require, exports, module) {
      * @param {Object} error - error to check
      * @returns {Boolean} - true if from this module, false otw.
      */
-    created: function (error) {
+    created (error) {
       return error.namespace === this.NAMESPACE;
     },
 
-    normalizeXHRError: function (xhr) {
+    normalizeXHRError (xhr) {
       var err;
 
       if (! xhr || xhr.status === 0) {

--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
      * @param {String} experimentName
      * @return {Boolean}
      */
-    isInExperiment: function (experimentName) {
+    isInExperiment (experimentName) {
       return !! this._activeExperiments[experimentName];
     },
 
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
      * @param {String} groupName
      * @return {Boolean}
      */
-    isInExperimentGroup: function (experimentName, groupName) {
+    isInExperimentGroup (experimentName, groupName) {
       if (this.isInExperiment(experimentName)) {
         return this._activeExperiments[experimentName].isInGroup(groupName);
       }
@@ -94,7 +94,7 @@ define(function (require, exports, module) {
      *
      * Makes experiment of same independent.
      */
-    chooseExperiments: function () {
+    chooseExperiments () {
       if (this.initialized) {
         var choice = this.able.choose(CHOOSE_ABLE_EXPERIMENT, {
           forceExperiment: this.forceExperiment,

--- a/app/scripts/lib/experiments/base.js
+++ b/app/scripts/lib/experiments/base.js
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
      * @returns {boolean}
      *  Returns 'true' when the experiment successfully initialized. Otherwise 'false'.
      */
-    initialize: function (name, options) {
+    initialize (name, options) {
       this._initialized = false;
       // all experiments require these options
       if (! (name &&
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
       return true;
     },
 
-    delegateNotifications: function (notifications) {
+    delegateNotifications (notifications) {
       // based on delegateEvents from Backbone.View
       if (! (notifications || (notifications = _.result(this, 'notifications')))) {
         return false;
@@ -120,7 +120,7 @@ define(function (require, exports, module) {
      * @param {String} groupType
      * @returns {boolean}
      */
-    isInGroup: function (groupType) {
+    isInGroup (groupType) {
       return !! (groupType && groupType === this._groupType);
     },
 
@@ -130,7 +130,7 @@ define(function (require, exports, module) {
      * @method logEvent
      * @param {String} event
      */
-    logEvent: function (event) {
+    logEvent (event) {
       if (this._initialized && event) {
         this.metrics.logEvent(this._loggingNamespace + event);
       }
@@ -144,7 +144,7 @@ define(function (require, exports, module) {
      * @param {String} state
      * @returns {Boolean|undefined}
      */
-    saveState: function (state) {
+    saveState (state) {
       if (! state) {
         return false;
       }
@@ -169,7 +169,7 @@ define(function (require, exports, module) {
      * @param {String} state
      * @returns {boolean}
      */
-    hasState: function (state) {
+    hasState (state) {
       if (! state) {
         return null;
       }

--- a/app/scripts/lib/experiments/mailcheck.js
+++ b/app/scripts/lib/experiments/mailcheck.js
@@ -18,7 +18,7 @@ define(function (require, exports, module) {
       'verification.success': '_onVerificationSuccess'
     },
 
-    _onSignupSubmit: function (data, view) {
+    _onSignupSubmit (data, view) {
       var emailEl = view.$el.find('.email');
 
       var emailValue = emailEl.val();
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
       }
     },
 
-    _onVerificationSuccess: function () {
+    _onVerificationSuccess () {
       this.saveState('verified');
 
       if (this.hasState('clicked')) {

--- a/app/scripts/lib/experiments/show-password.js
+++ b/app/scripts/lib/experiments/show-password.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
       'verification.success': '_onVerificationSuccess'
     },
 
-    _onVerificationSuccess: function () {
+    _onVerificationSuccess () {
       this.saveState('verified');
 
       // user verified after using show password

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
   }
 
   FxaClientWrapper.prototype = {
-    _getClient: function () {
+    _getClient () {
       if (this._client) {
         return p(this._client);
       }
@@ -482,7 +482,7 @@ define(function (require, exports, module) {
       return client.sessionStatus(sessionToken);
     }),
 
-    isSignedIn: function (sessionToken) {
+    isSignedIn (sessionToken) {
       // Check if the user is signed in.
       if (! sessionToken) {
         return p(false);

--- a/app/scripts/lib/height-observer.js
+++ b/app/scripts/lib/height-observer.js
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
   _.extend(HeightObserver.prototype, Backbone.Events, {
     _delayMS: 50,
 
-    start: function () {
+    start () {
       if (this._observer) {
         throw new Error('Already started');
       }
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
     },
 
     _lastHeight: -Infinity,
-    _onMutation: function () {
+    _onMutation () {
       var currentHeight = this._targetEl.clientHeight;
       // An element's clientHeight can be misreported on some versions of
       // Fennec - see https://bugzilla.mozilla.org/show_bug.cgi?id=1071620
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
       }
     },
 
-    stop: function () {
+    stop () {
       var observer = this._observer;
       if (observer) {
         observer.disconnect();

--- a/app/scripts/lib/logger.js
+++ b/app/scripts/lib/logger.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
      * then prints info.
      *
      */
-    info: function () {
+    info () {
       if (this._window.console && this._window.console.info) {
         this._window.console.info.apply(this._window.console, arguments);
       }
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
      * trace.
      *
      */
-    trace: function () {
+    trace () {
       if (this._window.console && this._window.console.trace) {
         this._window.console.trace();
       }
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
      * then prints warn.
      *
      */
-    warn: function () {
+    warn () {
       if (this._window.console && this._window.console.warn) {
         this._window.console.warn.apply(this._window.console, arguments);
       }
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
      *
      * @param {Error} error Error object with optional errorModule.
      */
-    error: function (error) {
+    error (error) {
       if (this._window.console && this._window.console.error) {
         var errorMessage = '';
 

--- a/app/scripts/lib/mailcheck.js
+++ b/app/scripts/lib/mailcheck.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
         domains: DOMAINS,
         secondLevelDomains: SECOND_LEVEL_DOMAINS,
         topLevelDomains: TOP_LEVEL_DOMAINS,
-        suggested: function (element, suggestion) {
+        suggested (element, suggestion) {
           // avoid suggesting empty or incomplete domains
           var incompleteDomain = ! suggestion || ! suggestion.domain ||
             suggestion.domain.indexOf('.') === -1;

--- a/app/scripts/lib/marketing-email-client.js
+++ b/app/scripts/lib/marketing-email-client.js
@@ -23,7 +23,7 @@ define(function (require, exports, module) {
   }
 
   MarketingEmailClient.prototype = {
-    _request: function (method, endpoint, accessToken, data) {
+    _request (method, endpoint, accessToken, data) {
       var url = this._baseUrl + endpoint;
       return this._xhr.oauthAjax({
         accessToken: accessToken,
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
       });
     },
 
-    fetch: function (accessToken) {
+    fetch (accessToken) {
       return this._request('get', '/lookup-user', accessToken)
         .then((response) => {
           // TODO
@@ -52,13 +52,13 @@ define(function (require, exports, module) {
         });
     },
 
-    optIn: function (accessToken, newsletterId) {
+    optIn (accessToken, newsletterId) {
       return this._request('post', '/subscribe', accessToken, {
         newsletters: newsletterId
       });
     },
 
-    optOut: function (accessToken, newsletterId) {
+    optOut (accessToken, newsletterId) {
       return this._request('post', '/unsubscribe', accessToken, {
         newsletters: newsletterId
       });

--- a/app/scripts/lib/marketing-email-errors.js
+++ b/app/scripts/lib/marketing-email-errors.js
@@ -88,7 +88,7 @@ define(function (require, exports, module) {
   module.exports = _.extend({}, Errors, {
     ERRORS: ERRORS,
     NAMESPACE: 'basket-errors',
-    normalizeXHRError: function (xhr) {
+    normalizeXHRError (xhr) {
       var respJSON = xhr.responseJSON;
       if (respJSON && ! ('errno' in respJSON) && respJSON.code) {
         // the basket API returns code instead of errno. Convert.

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -133,7 +133,7 @@ define(function (require, exports, module) {
   _.extend(Metrics.prototype, Backbone.Events, {
     ALLOWED_FIELDS: ALLOWED_FIELDS,
 
-    init: function () {
+    init () {
       this._flush = _.bind(this.flush, this, true);
       $(this._window).on('unload', this._flush);
       // iOS will not send events once the window is in the background,
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
       this._resetInactivityFlushTimeout();
     },
 
-    destroy: function () {
+    destroy () {
       $(this._window).off('unload', this._flush);
       $(this._window).off('blur', this._flush);
       this._clearInactivityFlushTimeout();
@@ -158,7 +158,7 @@ define(function (require, exports, module) {
      * @param {String} isPageUnloading
      * @returns {Promise}
      */
-    flush: function (isPageUnloading) {
+    flush (isPageUnloading) {
       // Inactivity timer is restarted when the next event/timer comes in.
       // This avoids sending empty result sets if the tab is
       // just sitting there open with no activity.
@@ -181,16 +181,16 @@ define(function (require, exports, module) {
         });
     },
 
-    _isFlushRequired: function (data) {
+    _isFlushRequired (data) {
       return data.events.length !== 0 ||
         Object.keys(data.timers).length !== 0;
     },
 
-    _clearInactivityFlushTimeout: function () {
+    _clearInactivityFlushTimeout () {
       clearTimeout(this._inactivityFlushTimeout);
     },
 
-    _resetInactivityFlushTimeout: function () {
+    _resetInactivityFlushTimeout () {
       this._clearInactivityFlushTimeout();
 
       this._inactivityFlushTimeout =
@@ -206,7 +206,7 @@ define(function (require, exports, module) {
      *
      * @returns {Object}
      */
-    getAllData: function () {
+    getAllData () {
       var loadData = this._speedTrap.getLoad();
       var unloadData = this._speedTrap.getUnload();
 
@@ -250,7 +250,7 @@ define(function (require, exports, module) {
      *
      * @returns {Object}
      */
-    getFilteredData: function () {
+    getFilteredData () {
       var allowedData = _.pick(this.getAllData(), ALLOWED_FIELDS);
 
       return _.pick(allowedData, function (value, key) {
@@ -258,7 +258,7 @@ define(function (require, exports, module) {
       });
     },
 
-    _send: function (data, isPageUnloading) {
+    _send (data, isPageUnloading) {
       var url = this._collector + '/metrics';
       var payload = JSON.stringify(data);
 
@@ -294,7 +294,7 @@ define(function (require, exports, module) {
      *
      * @param {String} eventName
      */
-    logEvent: function (eventName) {
+    logEvent (eventName) {
       this._resetInactivityFlushTimeout();
       this.events.capture(eventName);
     },
@@ -304,7 +304,7 @@ define(function (require, exports, module) {
      *
      * @param {String} eventName
      */
-    logEventOnce: function (eventName) {
+    logEventOnce (eventName) {
       if (! this._eventMemory[eventName]) {
         this.logEvent(eventName);
         this._eventMemory[eventName] = true;
@@ -316,7 +316,7 @@ define(function (require, exports, module) {
      *
      * @param {String} timerName
      */
-    startTimer: function (timerName) {
+    startTimer (timerName) {
       this._resetInactivityFlushTimeout();
       this.timers.start(timerName);
     },
@@ -326,7 +326,7 @@ define(function (require, exports, module) {
      *
      * @param {String} timerName
      */
-    stopTimer: function (timerName) {
+    stopTimer (timerName) {
       this._resetInactivityFlushTimeout();
       this.timers.stop(timerName);
     },
@@ -336,7 +336,7 @@ define(function (require, exports, module) {
      *
      * @param {Error} error
      */
-    logError: function (error) {
+    logError (error) {
       this.logEvent(this.errorToId(error));
     },
 
@@ -346,7 +346,7 @@ define(function (require, exports, module) {
      * @param {Error} error
      * @returns {String}
      */
-    errorToId: function (error) {
+    errorToId (error) {
       var id = Strings.interpolate('error.%s.%s.%s', [
         error.context || 'unknown context',
         error.namespace || 'unknown namespace',
@@ -360,7 +360,7 @@ define(function (require, exports, module) {
      *
      * @param {String} viewName
      */
-    logView: function (viewName) {
+    logView (viewName) {
       this.logEvent(this.viewToId(viewName));
     },
 
@@ -370,7 +370,7 @@ define(function (require, exports, module) {
      * @param {String} viewName
      * @param {String} eventName
      */
-    logViewEvent: function (viewName, eventName) {
+    logViewEvent (viewName, eventName) {
       var event = Strings.interpolate('%(viewName)s.%(eventName)s', {
         eventName: eventName,
         viewName: viewName,
@@ -385,7 +385,7 @@ define(function (require, exports, module) {
      * @param {String} viewName
      * @return {String} identifier
      */
-    viewToId: function (viewName) {
+    viewToId (viewName) {
       // `screen.` is a legacy artifact from when each View was a screen.
       // The idenifier is kept to avoid updating all metrics queries.
       return 'screen.' + viewName;
@@ -396,7 +396,7 @@ define(function (require, exports, module) {
      * @param {String} choice - type of experiment
      * @param {String} group - the experiment group (treatment or control)
      */
-    logExperiment: function (choice, group) {
+    logExperiment (choice, group) {
       if (! choice || ! group) {
         return;
       }
@@ -419,7 +419,7 @@ define(function (require, exports, module) {
      * @param {String} campaignId - marketing campaign id
      * @param {String} url - url of marketing link
      */
-    logMarketingImpression: function (campaignId, url) {
+    logMarketingImpression (campaignId, url) {
       campaignId = campaignId || UNKNOWN_CAMPAIGN_ID;
 
       var impressions = this._marketingImpressions;
@@ -440,7 +440,7 @@ define(function (require, exports, module) {
      * @param {String} campaignId - marketing campaign id
      * @param {String} url - URL clicked.
      */
-    logMarketingClick: function (campaignId, url) {
+    logMarketingClick (campaignId, url) {
       campaignId = campaignId || UNKNOWN_CAMPAIGN_ID;
 
       var impression = this.getMarketingImpression(campaignId, url);
@@ -450,16 +450,16 @@ define(function (require, exports, module) {
       }
     },
 
-    getMarketingImpression: function (campaignId, url) {
+    getMarketingImpression (campaignId, url) {
       var impressions = this._marketingImpressions;
       return impressions[campaignId] && impressions[campaignId][url];
     },
 
-    setBrokerType: function (brokerType) {
+    setBrokerType (brokerType) {
       this._brokerType = brokerType;
     },
 
-    isCollectionEnabled: function () {
+    isCollectionEnabled () {
       return this._isSampledUser;
     },
 
@@ -472,11 +472,11 @@ define(function (require, exports, module) {
       }
     },
 
-    getFlowEventMetadata: function () {
+    getFlowEventMetadata () {
       return this._flowEventMetadata.attributes;
     },
 
-    setFlowEventMetadata: function () {
+    setFlowEventMetadata () {
       this._flowEventMetadata.set.apply(this._flowEventMetadata, arguments);
     }
   });

--- a/app/scripts/lib/oauth-client.js
+++ b/app/scripts/lib/oauth-client.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
   }
 
   OAuthClient.prototype = {
-    _request: function (method, endpoint, params) {
+    _request (method, endpoint, params) {
       return this._xhr[method](this._oAuthUrl + endpoint, params || null)
         .fail(function (xhr) {
           var err = OAuthErrors.normalizeXHRError(xhr);
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
      * @param {String} [params.ttl]
      * @returns {Promise}
      */
-    getToken: function (params = {}) {
+    getToken (params = {}) {
       // set authorization TTL to 5 minutes.
       // Docs: github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1authorization
       // Issue: #3982

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -119,7 +119,7 @@ define(function (require, exports, module) {
      * @param {Error} err
      * @returns {Object}
      */
-    toInterpolationContext: function (err) {
+    toInterpolationContext (err) {
       // For data returned by backend, see
       // https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#errors
       try {

--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -99,7 +99,7 @@ define(function (require, exports, module) {
       'verify_email(/)': createViewHandler(CompleteSignUpView, { type: VerificationReasons.SIGN_UP })
     },
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this.broker = options.broker;
@@ -115,17 +115,17 @@ define(function (require, exports, module) {
       this.storage = Storage.factory('sessionStorage', this.window);
     },
 
-    onNavigate: function (event) {
+    onNavigate (event) {
       this._nextViewModel = createViewModel(event.nextViewData);
       this.navigate(event.url, event.routerOptions);
     },
 
-    onNavigateBack: function (event) {
+    onNavigateBack (event) {
       this._nextViewModel = createViewModel(event.nextViewData);
       this.navigateBack();
     },
 
-    navigate: function (url, options) {
+    navigate (url, options) {
       options = options || {};
 
       if (! options.hasOwnProperty('trigger')) {
@@ -142,11 +142,11 @@ define(function (require, exports, module) {
       return Backbone.Router.prototype.navigate.call(this, url, options);
     },
 
-    navigateBack: function () {
+    navigateBack () {
       this.window.history.back();
     },
 
-    redirectToSignupOrSettings: function () {
+    redirectToSignupOrSettings () {
       var url = this.user.getSignedInAccount().get('sessionToken') ?
                   '/settings' : '/signup';
       this.navigate(url, { replace: true, trigger: true });
@@ -159,7 +159,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise}
      */
-    redirectToBestOAuthChoice: function () {
+    redirectToBestOAuthChoice () {
       // Attempt to get email address from relier
       var email = this.broker.relier.get('email');
 
@@ -206,7 +206,7 @@ define(function (require, exports, module) {
      * @param {Object} options - additional options
      * @returns {Object}
      */
-    getViewOptions: function (options) {
+    getViewOptions (options) {
       // passed in options block can override
       // default options.
       return _.extend({
@@ -217,19 +217,19 @@ define(function (require, exports, module) {
       }, options);
     },
 
-    canGoBack: function () {
+    canGoBack () {
       return !! this.storage.get('canGoBack');
     },
 
-    getCurrentPage: function () {
+    getCurrentPage () {
       return Backbone.history.fragment;
     },
 
-    getCurrentViewName: function () {
+    getCurrentViewName () {
       return this.fragmentToViewName(this.getCurrentPage());
     },
 
-    _afterFirstViewHasRendered: function () {
+    _afterFirstViewHasRendered () {
       // afterLoaded lets the relier know when the first screen has been
       // loaded. It does not expect a response, so no error handler
       // is attached and the promise is not returned.
@@ -245,7 +245,7 @@ define(function (require, exports, module) {
       this.storage.set('canGoBack', true);
     },
 
-    fragmentToViewName: function (fragment) {
+    fragmentToViewName (fragment) {
       fragment = fragment || '';
       // strip leading /
       return fragment.replace(/^\//, '')
@@ -265,7 +265,7 @@ define(function (require, exports, module) {
      * @param {Function} View - view constructor
      * @param {Object} [options]
      */
-    showView: function (View, options) {
+    showView (View, options) {
       this.notifier.trigger(
           'show-view', View, this.getViewOptions(options));
     },
@@ -278,7 +278,7 @@ define(function (require, exports, module) {
      *     the parent of the ChildView
      * @param {Object} [options]
      */
-    showChildView: function (ChildView, ParentView, options) {
+    showChildView (ChildView, ParentView, options) {
       this.notifier.trigger(
           'show-child-view', ChildView, ParentView, this.getViewOptions(options));
     },

--- a/app/scripts/lib/sentry.js
+++ b/app/scripts/lib/sentry.js
@@ -191,7 +191,7 @@ define(function (require, exports, module) {
      *
      * @param {Error} err
      */
-    captureException: function (err) {
+    captureException (err) {
       var tags = {};
 
       this._exceptionTags.forEach(function (tagName) {
@@ -217,7 +217,7 @@ define(function (require, exports, module) {
      *
      * window.onerror reverted back to normal, TraceKit disabled
      */
-    remove: function () {
+    remove () {
       Raven.uninstall();
     },
     // Private functions, exposed for testing

--- a/app/scripts/lib/session.js
+++ b/app/scripts/lib/session.js
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
      * @method load
      * @returns {Object}
      */
-    load: function () {
+    load () {
       var values = {};
 
       // Try parsing sessionStorage values
@@ -60,7 +60,7 @@ define(function (require, exports, module) {
      * if they no longer appear in sessionStorage or localStorage.
      * @method reload
      */
-    reload: function () {
+    reload () {
       var values = this.load();
       // Clear values that no longer exist in storage.
       _.each(this, function (value, key) {
@@ -82,7 +82,7 @@ define(function (require, exports, module) {
      * @param {String} [value]
      * @returns {undefined}
      */
-    set: function (key, value) {
+    set (key, value) {
       if (typeof value === 'undefined' && typeof key === 'object') {
         return _.each(key, function (value, key) {
           this.set(key, value);
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
      * Persist data to sessionStorage or localStorage
      * @method persist
      */
-    persist: function () {
+    persist () {
       // items on the blacklist do not get saved to sessionStorage.
       var toSaveToSessionStorage = {};
       var toSaveToLocalStorage = {};
@@ -131,7 +131,7 @@ define(function (require, exports, module) {
      * @param {String} key
      * @returns {Object}
      */
-    get: function (key) {
+    get (key) {
       return this[key];
     },
 
@@ -144,7 +144,7 @@ define(function (require, exports, module) {
      * @method clear
      * @param {String} [key]
      */
-    clear: function (key) {
+    clear (key) {
       // no key specified, clear everything.
       if (typeof key === 'undefined') {
         for (key in this) {
@@ -167,7 +167,7 @@ define(function (require, exports, module) {
      * @param {String} key
      * @private
      */
-    testRemove: function (key) {
+    testRemove (key) {
       if (this.hasOwnProperty(key)) {
         this[key] = null;
         delete this[key];
@@ -179,7 +179,7 @@ define(function (require, exports, module) {
      * @method testClear
      * @private
      */
-    testClear: function () {
+    testClear () {
       for (var key in this) {
         if (this.hasOwnProperty(key)) {
           this[key] = null;

--- a/app/scripts/lib/storage-metrics.js
+++ b/app/scripts/lib/storage-metrics.js
@@ -22,7 +22,7 @@ define(function (require, exports, module) {
   }
 
   _.extend(StorageMetrics.prototype, new Metrics(), {
-    _send: function (data) {
+    _send (data) {
       var metrics = storage.get('metrics_all');
 
       if (! Array.isArray(metrics)) {
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
       return p(data);
     },
 
-    isMetricsCollectionEnabled: function () {
+    isMetricsCollectionEnabled () {
       return false;
     }
   });

--- a/app/scripts/lib/transform.js
+++ b/app/scripts/lib/transform.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
      * @param {Object} Errors - Errors module used to create errors
      * @returns {Object} validation/transformation results
      */
-    transformUsingSchema: function (data, schema, Errors) {
+    transformUsingSchema (data, schema, Errors) {
       var result = Vat.validate(data, schema);
       var error = result.error;
       if (error instanceof ReferenceError) {

--- a/app/scripts/lib/translator.js
+++ b/app/scripts/lib/translator.js
@@ -20,12 +20,12 @@ define(function (require, exports, module) {
   };
 
   Translator.prototype = {
-    set: function (translations) {
+    set (translations) {
       this.translations = translations;
     },
 
     // Fetches our JSON translation file
-    fetch: function () {
+    fetch () {
       return xhr.getJSON('/i18n/client.json')
           .then((data) => {
             // Only update the translations if some came back
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
      * @param {String} context
      * @returns {String}
      */
-    get: function (key, context) {
+    get (key, context) {
       var translation = this.translations[key];
       /**
        * See http://www.lehman.cuny.edu/cgi-bin/man-cgi?msgfmt+1
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
      * @param {Object} [context] - context to pass to translator
      * @returns {Function}
      */
-    translateInTemplate: function (forceText, context) {
+    translateInTemplate (forceText, context) {
       return (templateText) => {
         return this.get(forceText || templateText, context);
       };

--- a/app/scripts/lib/url.js
+++ b/app/scripts/lib/url.js
@@ -32,13 +32,13 @@ define(function (require, exports, module) {
 
   module.exports = {
     searchParams: searchParams,
-    searchParam: function (name, str) {
+    searchParam (name, str) {
       const terms = searchParams(str);
 
       return terms[name];
     },
 
-    objToSearchString: function (obj) {
+    objToSearchString (obj) {
       const params = [];
       for (let paramName in obj) {
         const paramValue = obj[paramName];
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
       return '?' + params.join('&');
     },
 
-    getOrigin: function (url) {
+    getOrigin (url) {
       if (! url) {
         return '';
       }
@@ -96,18 +96,18 @@ define(function (require, exports, module) {
      * @param {String} uri
      * @returns {Boolean}
      */
-    isNavigable: function (uri) {
+    isNavigable (uri) {
       // validate that that given 'uri' is 'http:// or https://' and has characters after the protocol
       return /^https?:\/\/\w+/i.test(uri);
     },
 
-    removeParamFromSearchString: function (name, str) {
+    removeParamFromSearchString (name, str) {
       const params = this.searchParams(str);
       delete params[name];
       return this.objToSearchString(params);
     },
 
-    updateSearchString: function (uri, newParams) {
+    updateSearchString (uri, newParams) {
       let params = {};
       const startOfParams = uri.indexOf('?');
       if (startOfParams >= 0) {

--- a/app/scripts/lib/validate.js
+++ b/app/scripts/lib/validate.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
      * @param {String} email
      * @return {Boolean} true if email is valid, false otw.
      */
-    isEmailValid: function (email) {
+    isEmailValid (email) {
       if (typeof email !== 'string' || email.length > 256) {
         return false;
       }
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
      * @param {String} code
      * @returns {Boolean}
      */
-    isCodeValid: function (code) {
+    isCodeValid (code) {
       if (typeof code !== 'string') {
         return false;
       }
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
      * @param {String} code
      * @returns {Boolean}
      */
-    isOAuthCodeValid: function (code) {
+    isOAuthCodeValid (code) {
       if (typeof code !== 'string') {
         return false;
       }
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
      * @param {String} token
      * @returns {Boolean}
      */
-    isTokenValid: function (token) {
+    isTokenValid (token) {
       if (typeof token !== 'string') {
         return false;
       }
@@ -115,7 +115,7 @@ define(function (require, exports, module) {
      * @param {String} uid
      * @returns {Boolean}
      */
-    isUidValid: function (uid) {
+    isUidValid (uid) {
       if (typeof uid !== 'string') {
         return false;
       }
@@ -130,7 +130,7 @@ define(function (require, exports, module) {
      * @param {String} password
      * @returns {Boolean}
      */
-    isPasswordValid: function (password) {
+    isPasswordValid (password) {
       if (typeof password !== 'string') {
         return false;
       }
@@ -190,7 +190,7 @@ define(function (require, exports, module) {
      * @param {String} prompt
      * @returns {Boolean}
      */
-    isPromptValid: function (prompt) {
+    isPromptValid (prompt) {
       var valid = [
         Constants.OAUTH_PROMPT_CONSENT
       ];
@@ -237,7 +237,7 @@ define(function (require, exports, module) {
      * @param {String} uuid - uuid to check
      * @returns {Boolean}
      */
-    isUuidValid: function (uuid) {
+    isUuidValid (uuid) {
       return uuidRegEx.test(uuid);
     },
 

--- a/app/scripts/lib/xss.js
+++ b/app/scripts/lib/xss.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
 
   module.exports = {
     // only allow http or https URLs, encoding the URL.
-    href: function (text) {
+    href (text) {
       if (! _.isString(text)) {
         return;
       }

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
   var Account = Backbone.Model.extend({
     defaults: DEFAULTS,
 
-    initialize: function (accountData, options = {}) {
+    initialize (accountData, options = {}) {
       this._oAuthClientId = options.oAuthClientId;
       this._oAuthClient = options.oAuthClient;
       this._assertion = options.assertion;
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
     },
 
     // Hydrate the account
-    fetch: function () {
+    fetch () {
       if (! this.get('sessionToken') || this.get('verified')) {
         return p();
       }
@@ -117,7 +117,7 @@ define(function (require, exports, module) {
         });
     },
 
-    _invalidateSession: function () {
+    _invalidateSession () {
       // Invalid token can happen if user uses 'Disconnect'
       // in Firefox Desktop. Only 'set' will trigger model
       // change, using 'unset' will not.
@@ -132,14 +132,14 @@ define(function (require, exports, module) {
       });
     },
 
-    _fetchProfileOAuthToken: function () {
+    _fetchProfileOAuthToken () {
       return this.createOAuthToken(CONTENT_SERVER_OAUTH_SCOPE)
         .then((accessToken) => {
           this.set('accessToken', accessToken.get('token'));
         });
     },
 
-    profileClient: function () {
+    profileClient () {
       return this.fetch().then(() => {
         // If the account is not verified fail before attempting to fetch a token
         if (! this.get('verified')) {
@@ -151,12 +151,12 @@ define(function (require, exports, module) {
       .then(() => this._profileClient);
     },
 
-    isFromSync: function () {
+    isFromSync () {
       return this.get('sessionTokenContext') === Constants.SESSION_TOKEN_USED_FOR_SYNC;
     },
 
     // returns true if all attributes within ALLOWED_KEYS are defaults
-    isDefault: function () {
+    isDefault () {
       return ! _.find(ALLOWED_KEYS, (key) => {
         return this.get(key) !== DEFAULTS[key];
       });
@@ -164,11 +164,11 @@ define(function (require, exports, module) {
 
     // If we're verified and don't have an accessToken, we should
     // go ahead and get one.
-    _needsAccessToken: function () {
+    _needsAccessToken () {
       return this.get('verified') && ! this.get('accessToken');
     },
 
-    _generateAssertion: function () {
+    _generateAssertion () {
       var sessionToken = this.get('sessionToken');
 
       // assertions live for 25 years, they can be cached and reused while
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
       return assertionPromise;
     },
 
-    createOAuthToken: function (scope) {
+    createOAuthToken (scope) {
       return this._generateAssertion()
         .then((assertion) => {
           var params = {
@@ -220,7 +220,7 @@ define(function (require, exports, module) {
      *   verificationReason: <see lib/verification-reasons.js>
      * }
      */
-    sessionStatus: function () {
+    sessionStatus () {
       var sessionToken = this.get('sessionToken');
       if (! sessionToken) {
         return p.reject(AuthErrors.toError('INVALID_TOKEN'));
@@ -270,11 +270,11 @@ define(function (require, exports, module) {
         });
     },
 
-    isSignedIn: function () {
+    isSignedIn () {
       return this._fxaClient.isSignedIn(this.get('sessionToken'));
     },
 
-    toJSON: function () {
+    toJSON () {
       /*
        * toJSON is explicitly disabled because it fetches all attributes
        * on the model, making accidental data exposure easier than it
@@ -287,11 +287,11 @@ define(function (require, exports, module) {
       throw new Error('toJSON is explicitly disabled, use `.pick` instead');
     },
 
-    toPersistentJSON: function () {
+    toPersistentJSON () {
       return this.pick(ALLOWED_PERSISTENT_KEYS);
     },
 
-    setProfileImage: function (profileImage) {
+    setProfileImage (profileImage) {
       this.set({
         profileImageId: profileImage.get('id'),
         profileImageUrl: profileImage.get('url')
@@ -304,14 +304,14 @@ define(function (require, exports, module) {
       }
     },
 
-    onChange: function () {
+    onChange () {
       // if any data is set outside of the `fetchProfile` function,
       // clear the cache and force a reload of the profile the next time.
       delete this._profileFetchPromise;
     },
 
     _profileFetchPromise: null,
-    fetchProfile: function () {
+    fetchProfile () {
       // Avoid multiple views making profile requests by caching
       // the profile fetch request. Only allow one for a given account,
       // and then re-use the data after that. See #3053
@@ -337,7 +337,7 @@ define(function (require, exports, module) {
       return this._profileFetchPromise;
     },
 
-    fetchCurrentProfileImage: function () {
+    fetchCurrentProfileImage () {
       var profileImage = new ProfileImage();
 
       return this.getAvatar()
@@ -361,7 +361,7 @@ define(function (require, exports, module) {
      * email if user is unverified.
      * @returns {Promise} - resolves when complete
      */
-    signIn: function (password, relier, options = {}) {
+    signIn (password, relier, options = {}) {
       return p().then(() => {
         var email = this.get('email');
         var sessionToken = this.get('sessionToken');
@@ -396,7 +396,7 @@ define(function (require, exports, module) {
      * email if user is unverified.
      * @returns {Promise} - resolves when complete
      */
-    signUp: function (password, relier, options = {}) {
+    signUp (password, relier, options = {}) {
       return this._fxaClient.signUp(
         this.get('email'),
         password,
@@ -419,7 +419,7 @@ define(function (require, exports, module) {
      * @param {String} [options.resume] resume token
      * @returns {Promise} - resolves when complete
      */
-    retrySignUp: function (relier, options = {}) {
+    retrySignUp (relier, options = {}) {
       return this._fxaClient.signUpResend(
         relier,
         this.get('sessionToken'),
@@ -437,7 +437,7 @@ define(function (require, exports, module) {
      * @param {Object} [options.service] - the service issuing signup request
      * @returns {Promise} - resolves when complete
      */
-    verifySignUp: function (code, options = {}) {
+    verifySignUp (code, options = {}) {
       return this._fxaClient.verifyCode(
         this.get('uid'),
         code,
@@ -460,7 +460,7 @@ define(function (require, exports, module) {
      * @returns {Promise} resolves to `true` if email is registered,
      * `false` otw.
      */
-    checkEmailExists: function () {
+    checkEmailExists () {
       return this._fxaClient.checkAccountExistsByEmail(this.get('email'));
     },
 
@@ -470,7 +470,7 @@ define(function (require, exports, module) {
      * @returns {Promise} resolves to `true` if the uid is registered,
      * `false` otw.
      */
-    checkUidExists: function () {
+    checkUidExists () {
       return this._fxaClient.checkAccountExists(this.get('uid'));
     },
 
@@ -479,7 +479,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise} - resolves when complete
      */
-    signOut: function () {
+    signOut () {
       return this._fxaClient.signOut(this.get('sessionToken'));
     },
 
@@ -489,7 +489,7 @@ define(function (require, exports, module) {
      * @param {String} password - The user's password
      * @returns {Promise} - resolves when complete
      */
-    destroy: function (password) {
+    destroy (password) {
       return this._fxaClient.deleteAccount(
         this.get('email'),
         password
@@ -508,7 +508,7 @@ define(function (require, exports, module) {
      *
      * @private
      */
-    _upgradeGrantedPermissions: function () {
+    _upgradeGrantedPermissions () {
       if (this.has('grantedPermissions')) {
         var grantedPermissions = this.get('grantedPermissions');
 
@@ -539,7 +539,7 @@ define(function (require, exports, module) {
      * @param {String} clientId
      * @returns {Object}
      */
-    getClientPermissions: function (clientId) {
+    getClientPermissions (clientId) {
       var permissions = this.get('permissions') || {};
       return permissions[clientId] || {};
     },
@@ -551,7 +551,7 @@ define(function (require, exports, module) {
      * @param {String} permissionName
      * @returns {Boolean}
      */
-    getClientPermission: function (clientId, permissionName) {
+    getClientPermission (clientId, permissionName) {
       var clientPermissions = this.getClientPermissions(clientId);
       return clientPermissions[permissionName];
     },
@@ -567,7 +567,7 @@ define(function (require, exports, module) {
      * @param {String} clientId
      * @param {Object} clientPermissions
      */
-    setClientPermissions: function (clientId, clientPermissions) {
+    setClientPermissions (clientId, clientPermissions) {
       var allPermissions = this.get('permissions') || {};
       allPermissions[clientId] = clientPermissions;
       this.set('permissions', allPermissions);
@@ -582,7 +582,7 @@ define(function (require, exports, module) {
      * @returns {Boolean} `true` if client has seen all the permissions,
      *  `false` otw.
      */
-    hasSeenPermissions: function (clientId, permissions) {
+    hasSeenPermissions (clientId, permissions) {
       var seenPermissions = Object.keys(this.getClientPermissions(clientId));
       // without's signature is `array, *values)`,
       // *values cannot be an array, so convert to a form without can use.
@@ -598,7 +598,7 @@ define(function (require, exports, module) {
      * @param {String[]} permissionNames
      * @returns {String[]}
      */
-    getPermissionsWithValues: function (permissionNames) {
+    getPermissionsWithValues (permissionNames) {
       return permissionNames.map((permissionName) => {
         var accountKey = PERMISSIONS_TO_KEYS[permissionName];
 
@@ -616,7 +616,7 @@ define(function (require, exports, module) {
       }).filter((permissionName) => permissionName !== null);
     },
 
-    getMarketingEmailPrefs: function () {
+    getMarketingEmailPrefs () {
       var emailPrefs = new MarketingEmailPrefs({
         account: this,
         marketingEmailClient: this._marketingEmailClient
@@ -633,7 +633,7 @@ define(function (require, exports, module) {
      * @param {Object} relier
      * @returns {Promise}
      */
-    changePassword: function (oldPassword, newPassword, relier) {
+    changePassword (oldPassword, newPassword, relier) {
       // Try to sign the user in before checking whether the
       // passwords are the same. If the user typed the incorrect old
       // password, they should know that first.
@@ -692,7 +692,7 @@ define(function (require, exports, module) {
      * @param {Object} relier - relier being signed in to.
      * @returns {Promise} - resolves when complete
      */
-    completePasswordReset: function (password, token, code, relier) {
+    completePasswordReset (password, token, code, relier) {
       return this._fxaClient.completePasswordReset(
         this.get('email'),
         password,
@@ -708,7 +708,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise} - resolves when complete
      */
-    fetchDevices: function () {
+    fetchDevices () {
       return this._fxaClient.deviceList(this.get('sessionToken'))
         .then((devices) => {
           devices.map((item) => {
@@ -724,7 +724,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise} resolves when the action completes
      */
-    fetchOAuthApps: function () {
+    fetchOAuthApps () {
       return this._oAuthClient.fetchOAuthApps(this.get('accessToken'))
         .then((oAuthApps) => {
           oAuthApps.map((item) => {
@@ -741,7 +741,7 @@ define(function (require, exports, module) {
      * @param {Object} device - Device model to remove
      * @returns {Promise} - resolves when complete
      */
-    destroyDevice: function (device) {
+    destroyDevice (device) {
       var deviceId = device.get('id');
       var sessionToken = this.get('sessionToken');
 
@@ -758,7 +758,7 @@ define(function (require, exports, module) {
      * @param {Object} oAuthApp - OAuthApp model to remove
      * @returns {Promise} - resolves when complete
      */
-    destroyOAuthApp: function (oAuthApp) {
+    destroyOAuthApp (oAuthApp) {
       var oAuthAppId = oAuthApp.get('id');
       var accessToken = this.get('accessToken');
 
@@ -776,7 +776,7 @@ define(function (require, exports, module) {
      * @param {String} [options.resume] resume token
      * @returns {Promise}
      */
-    resetPassword: function (relier, options = {}) {
+    resetPassword (relier, options = {}) {
       return this._fxaClient.passwordReset(
         this.get('email'),
         relier,
@@ -795,7 +795,7 @@ define(function (require, exports, module) {
      * @param {String} [options.resume] resume token
      * @returns {Promise}
      */
-    retryResetPassword: function (passwordForgotToken, relier, options = {}) {
+    retryResetPassword (passwordForgotToken, relier, options = {}) {
       return this._fxaClient.passwordResetResend(
         this.get('email'),
         passwordForgotToken,
@@ -813,7 +813,7 @@ define(function (require, exports, module) {
      * @returns {Promise} that resolves with the account keys, if they
      *   can be generated, resolves with null otherwise.
      */
-    accountKeys: function () {
+    accountKeys () {
       if (! this.has('keyFetchToken') || ! this.has('unwrapBKey')) {
         return p(null);
       }
@@ -829,7 +829,7 @@ define(function (require, exports, module) {
      * @returns {Promise} that resolves with the relier keys, if they
      *   can be generated, resolves with null otherwise.
      */
-    relierKeys: function (relier) {
+    relierKeys (relier) {
       return this.accountKeys()
         .then((accountKeys) => {
           if (! accountKeys) {

--- a/app/scripts/models/attached-clients.js
+++ b/app/scripts/models/attached-clients.js
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
       }
     },
 
-    fetchClients: function (clientTypes = {}, user) {
+    fetchClients (clientTypes = {}, user) {
       var account = user.getSignedInAccount();
       var fetchItems = [];
 
@@ -52,7 +52,7 @@ define(function (require, exports, module) {
         });
     },
 
-    comparator: function (a, b) {
+    comparator (a, b) {
       // 1. the current device is first.
       // 2. those with lastAccessTime are sorted in descending order
       // 3. the rest sorted in alphabetical order.

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
   var BaseAuthenticationBroker = Backbone.Model.extend({
     type: 'base',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this.relier = options.relier;
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
      * @param {String} behaviorName
      * @param {Object} value
      */
-    setBehavior: function (behaviorName, value) {
+    setBehavior (behaviorName, value) {
       this._behaviors.set(behaviorName, value);
     },
 
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
      * @param {String} behaviorName
      * @return {Object}
      */
-    getBehavior: function (behaviorName) {
+    getBehavior (behaviorName) {
       if (! this._behaviors.has(behaviorName)) {
         throw new Error('behavior not found for: ' + behaviorName);
       }
@@ -88,7 +88,7 @@ define(function (require, exports, module) {
      * initialize the broker with any necessary data.
      * @returns {Promise}
      */
-    fetch: function () {
+    fetch () {
       return p().then(() => {
         this._isForceAuth = this._isForceAuthUrl();
         this.importSearchParamsUsingSchema(QUERY_PARAMETER_SCHEMA, AuthErrors);
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    canCancel: function () {
+    canCancel () {
       return false;
     },
 
@@ -109,7 +109,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise}
      */
-    cancel: function () {
+    cancel () {
       return p();
     },
 
@@ -119,7 +119,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise}
      */
-    afterLoaded: function () {
+    afterLoaded () {
       return p();
     },
 
@@ -130,7 +130,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    beforeSignIn: function (/* account */) {
+    beforeSignIn (/* account */) {
       return p(this.getBehavior('beforeSignIn'));
     },
 
@@ -141,7 +141,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterSignIn: function (/* account */) {
+    afterSignIn (/* account */) {
       return p(this.getBehavior('afterSignIn'));
     },
 
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterSignInConfirmationPoll: function (/* account */) {
+    afterSignInConfirmationPoll (/* account */) {
       return p(this.getBehavior('afterSignInConfirmationPoll'));
     },
 
@@ -163,7 +163,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterForceAuth: function (/* account */) {
+    afterForceAuth (/* account */) {
       return p(this.getBehavior('afterForceAuth'));
     },
 
@@ -175,7 +175,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    persistVerificationData: function (account) {
+    persistVerificationData (account) {
       return p().then(() => {
         // verification info is persisted to localStorage so that
         // the same `context` is used if the user verifies in the same browser.
@@ -198,7 +198,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    unpersistVerificationData: function (account) {
+    unpersistVerificationData (account) {
       return p().then(function () {
         clearSameBrowserVerificationModel(account, 'context');
       });
@@ -211,7 +211,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterSignUp: function (/* account */) {
+    afterSignUp (/* account */) {
       return p(this.getBehavior('afterSignUp'));
     },
 
@@ -223,7 +223,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    beforeSignUpConfirmationPoll: function (/* account */) {
+    beforeSignUpConfirmationPoll (/* account */) {
       return p(this.getBehavior('beforeSignUpConfirmationPoll'));
     },
 
@@ -235,7 +235,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterSignUpConfirmationPoll: function (/* account */) {
+    afterSignUpConfirmationPoll (/* account */) {
       return p(this.getBehavior('afterSignUpConfirmationPoll'));
     },
 
@@ -245,7 +245,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterCompleteSignUp: function (account) {
+    afterCompleteSignUp (account) {
       return this.unpersistVerificationData(account)
         .then(() => this.getBehavior('afterCompleteSignUp'));
     },
@@ -258,7 +258,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterResetPasswordConfirmationPoll: function (/* account */) {
+    afterResetPasswordConfirmationPoll (/* account */) {
       return p(this.getBehavior('afterResetPasswordConfirmationPoll'));
     },
 
@@ -268,7 +268,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterCompleteResetPassword: function (account) {
+    afterCompleteResetPassword (account) {
       return this.unpersistVerificationData(account)
         .then(() => this.getBehavior('afterCompleteResetPassword'));
     },
@@ -279,7 +279,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterChangePassword: function (/* account */) {
+    afterChangePassword (/* account */) {
       return p(this.getBehavior('afterChangePassword'));
     },
 
@@ -289,7 +289,7 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterDeleteAccount: function (/* account */) {
+    afterDeleteAccount (/* account */) {
       return p(this.getBehavior('afterDeleteAccount'));
     },
 
@@ -299,7 +299,7 @@ define(function (require, exports, module) {
      * @param {String} link
      * @returns {String}
      */
-    transformLink: function (link) {
+    transformLink (link) {
       return link;
     },
 
@@ -309,11 +309,11 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isForceAuth: function () {
+    isForceAuth () {
       return !! this._isForceAuth;
     },
 
-    _isForceAuthUrl: function () {
+    _isForceAuthUrl () {
       var pathname = this.window.location.pathname;
       return pathname === '/force_auth' || pathname === '/oauth/force_auth';
     },
@@ -323,7 +323,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isAutomatedBrowser: function () {
+    isAutomatedBrowser () {
       return !! this.get('automatedBrowser');
     },
 
@@ -374,7 +374,7 @@ define(function (require, exports, module) {
      * @param {String} capabilityName
      * @return {Boolean}
      */
-    hasCapability: function (capabilityName) {
+    hasCapability (capabilityName) {
       return this._capabilities.has(capabilityName) &&
              !! this._capabilities.get(capabilityName);
     },
@@ -385,7 +385,7 @@ define(function (require, exports, module) {
      * @param {String} capabilityName
      * @param {Variant} capabilityValue
      */
-    setCapability: function (capabilityName, capabilityValue) {
+    setCapability (capabilityName, capabilityValue) {
       this._capabilities.set(capabilityName, capabilityValue);
     },
 
@@ -394,7 +394,7 @@ define(function (require, exports, module) {
      *
      * @param {String} capabilityName
      */
-    unsetCapability: function (capabilityName) {
+    unsetCapability (capabilityName) {
       this._capabilities.unset(capabilityName);
     },
 
@@ -404,7 +404,7 @@ define(function (require, exports, module) {
      * @param {String} capabilityName
      * @return {Variant}
      */
-    getCapability: function (capabilityName) {
+    getCapability (capabilityName) {
       return this._capabilities.get(capabilityName);
     }
   });

--- a/app/scripts/models/auth_brokers/fx-desktop-v1.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v1.js
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
       beforeSignUpConfirmationPoll: new HaltBehavior()
     }),
 
-    createChannel: function () {
+    createChannel () {
       var channel = new FxDesktopChannel();
 
       channel.initialize({

--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
 
     type: 'fx-desktop-v2',
 
-    afterResetPasswordConfirmationPoll: function (/*account*/) {
+    afterResetPasswordConfirmationPoll (/*account*/) {
       // this is only called if the user verifies in the same browser.
       // With Fx's E10s enabled, the account data only contains an
       // unwrapBKey and keyFetchToken, not enough to sign in the user.
@@ -58,13 +58,13 @@ define(function (require, exports, module) {
       return p(new HaltBehavior());
     },
 
-    afterCompleteResetPassword: function (account) {
+    afterCompleteResetPassword (account) {
       // See the note in afterResetPasswordConfirmationPoll
       return this._notifyRelierOfLogin(account)
         .then(() => proto.afterCompleteResetPassword.call(this, account));
     },
 
-    fetch: function () {
+    fetch () {
       return proto.fetch.call(this).then(() => {
         if (! this.environment.isAboutAccounts()) {
           // The default behavior of FxDesktop brokers is to halt before

--- a/app/scripts/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/scripts/models/auth_brokers/fx-firstrun-v1.js
@@ -32,14 +32,14 @@ define(function (require, exports, module) {
       openWebmailButtonVisible: true
     }),
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._iframeChannel = options.iframeChannel;
       return proto.initialize.call(this, options);
     },
 
-    fetch: function () {
+    fetch () {
       return proto.fetch.call(this).then(() => {
         // Some settings do not work in an iframe due to x-frame and
         // same-origin policies. Allow the firstrun flow to decide whether
@@ -52,31 +52,31 @@ define(function (require, exports, module) {
       });
     },
 
-    afterLoaded: function () {
+    afterLoaded () {
       this._iframeChannel.send(this._iframeCommands.LOADED);
 
       return proto.afterLoaded.apply(this, arguments);
     },
 
-    afterSignIn: function () {
+    afterSignIn () {
       this._iframeChannel.send(this._iframeCommands.LOGIN);
 
       return proto.afterSignIn.apply(this, arguments);
     },
 
-    afterSignInConfirmationPoll: function () {
+    afterSignInConfirmationPoll () {
       this._iframeChannel.send(this._iframeCommands.VERIFICATION_COMPLETE);
 
       return proto.afterSignInConfirmationPoll.apply(this, arguments);
     },
 
-    afterResetPasswordConfirmationPoll: function () {
+    afterResetPasswordConfirmationPoll () {
       this._iframeChannel.send(this._iframeCommands.VERIFICATION_COMPLETE);
 
       return proto.afterResetPasswordConfirmationPoll.apply(this, arguments);
     },
 
-    beforeSignUpConfirmationPoll: function (account) {
+    beforeSignUpConfirmationPoll (account) {
       this._iframeChannel.send(this._iframeCommands.SIGNUP_MUST_VERIFY, {
         emailOptIn: !! account.get('needsOptedInToMarketingEmail')
       });
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
       return proto.beforeSignUpConfirmationPoll.apply(this, arguments);
     },
 
-    afterSignUpConfirmationPoll: function () {
+    afterSignUpConfirmationPoll () {
       this._iframeChannel.send(this._iframeCommands.VERIFICATION_COMPLETE);
 
       return proto.afterSignUpConfirmationPoll.apply(this, arguments);

--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -24,7 +24,7 @@ define(function (require, exports, module) {
       convertExternalLinksToText: true
     }),
 
-    _notifyRelierOfLogin: function (account) {
+    _notifyRelierOfLogin (account) {
       /**
        * As a workaround for sign-in/sign-up confirmation view disappearing
        * on iOS, delay the login message sent via the channel by LOGIN_MESSAGE_DELAY_MS.

--- a/app/scripts/models/auth_brokers/fx-sync-web-channel.js
+++ b/app/scripts/models/auth_brokers/fx-sync-web-channel.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
       SYNC_PREFERENCES: 'fxaccounts:sync_preferences'
     },
 
-    createChannel: function () {
+    createChannel () {
       var channel = new WebChannel(Constants.ACCOUNT_UPDATES_WEBCHANNEL_ID);
       channel.initialize({
         window: this.window

--- a/app/scripts/models/auth_brokers/fx-sync.js
+++ b/app/scripts/models/auth_brokers/fx-sync.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
       sendChangePasswordNotice: true
     }),
 
-    getCommand: function (commandName) {
+    getCommand (commandName) {
       if (! this.commands) {
         throw new Error('this.commands must be specified');
       }
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
      *        Channel used to send commands to remote listeners.
      * @returns {undefined}
      */
-    initialize: function (options = {}) {
+    initialize (options = {}) {
       this._logger = new Logger();
 
       // channel can be passed in for testing.
@@ -77,12 +77,12 @@ define(function (require, exports, module) {
       return proto.initialize.call(this, options);
     },
 
-    afterLoaded: function () {
+    afterLoaded () {
       return this.send(this.getCommand('LOADED'))
         .then(() => proto.afterLoaded.call(this));
     },
 
-    beforeSignIn: function (account) {
+    beforeSignIn (account) {
       var email = account.get('email');
       // This will send a message over the channel to determine whether
       // we should cancel the login to sync or not based on Desktop
@@ -105,17 +105,17 @@ define(function (require, exports, module) {
         });
     },
 
-    afterSignIn: function (account) {
+    afterSignIn (account) {
       return this._notifyRelierOfLogin(account)
         .then(() => proto.afterSignIn.call(this, account));
     },
 
-    afterForceAuth: function (account) {
+    afterForceAuth (account) {
       return this._notifyRelierOfLogin(account)
         .then(() => proto.afterForceAuth.apply(this, account));
     },
 
-    beforeSignUpConfirmationPoll: function (account) {
+    beforeSignUpConfirmationPoll (account) {
       // The Sync broker notifies the browser of an unverified login
       // before the user has verified her email. This allows the user
       // to close the original tab or open the verification link in
@@ -124,12 +124,12 @@ define(function (require, exports, module) {
         .then(() => proto.beforeSignUpConfirmationPoll.call(this, account));
     },
 
-    afterResetPasswordConfirmationPoll: function (account) {
+    afterResetPasswordConfirmationPoll (account) {
       return this._notifyRelierOfLogin(account)
         .then(() => proto.afterResetPasswordConfirmationPoll.call(this, account));
     },
 
-    afterChangePassword: function (account) {
+    afterChangePassword (account) {
       // If the message is sent over the WebChannel by the global WebChannel,
       // no need to send it from within the auth broker too.
       if (this.hasCapability('sendChangePasswordNotice')) {
@@ -145,7 +145,7 @@ define(function (require, exports, module) {
       }
     },
 
-    afterDeleteAccount: function (account) {
+    afterDeleteAccount (account) {
       return this.send(this.getCommand('DELETE_ACCOUNT'), {
         email: account.get('email'),
         uid: account.get('uid')
@@ -160,7 +160,7 @@ define(function (require, exports, module) {
      * @method getChannel
      * @returns {Object} channel
      */
-    getChannel: function () {
+    getChannel () {
       if (! this._channel) {
         this._channel = this.createChannel();
       }
@@ -175,11 +175,11 @@ define(function (require, exports, module) {
      * @method createChannel
      * @throws {Error}
      */
-    createChannel: function () {
+    createChannel () {
       throw new Error('createChannel must be overridden');
     },
 
-    _notifyRelierOfLogin: function (account) {
+    _notifyRelierOfLogin (account) {
       /**
        * Workaround for #3078. If the user signs up but does not verify
        * their account, then visit `/` or `/settings`, they are
@@ -203,13 +203,13 @@ define(function (require, exports, module) {
       return this.send(this.getCommand('LOGIN'), loginData);
     },
 
-    _hasRequiredLoginFields: function (loginData) {
+    _hasRequiredLoginFields (loginData) {
       var requiredFields = FxSyncAuthenticationBroker.REQUIRED_LOGIN_FIELDS;
       var loginFields = Object.keys(loginData);
       return ! _.difference(requiredFields, loginFields).length;
     },
 
-    _getLoginData: function (account) {
+    _getLoginData (account) {
       var ALLOWED_FIELDS = [
         'customizeSync',
         'declinedSyncEngines',
@@ -234,7 +234,7 @@ define(function (require, exports, module) {
      * @param {String} entryPoint - where Sync Preferences is opened from
      * @returns {Promise} resolves when notification is sent.
      */
-    openSyncPreferences: function (entryPoint) {
+    openSyncPreferences (entryPoint) {
       if (this.hasCapability('syncPreferencesNotification')) {
         return this.send(this.getCommand('SYNC_PREFERENCES'), {
           entryPoint: entryPoint

--- a/app/scripts/models/auth_brokers/mixins/channel.js
+++ b/app/scripts/models/auth_brokers/mixins/channel.js
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
      * @returns {Promise}
      *        The promise will resolve if the value was successfully sent.
      */
-    send: function (message, data) {
+    send (message, data) {
       var channel = this.getChannel();
       var send = ensureActionReturnsPromise(channel.send.bind(channel));
 
@@ -55,7 +55,7 @@ define(function (require, exports, module) {
      *        The promise will resolve with the value returned by the remote
      *        listener, or reject if there was an error.
      */
-    request: function (message, data) {
+    request (message, data) {
       var channel = this.getChannel();
       // only new channels have a request. If not, fall back to send.
       var action = (channel.request || channel.send).bind(channel);

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
       handleSignedInNotification: false
     }),
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this.session = options.session;
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
                   this, options);
     },
 
-    getOAuthResult: function (account) {
+    getOAuthResult (account) {
       if (! account || ! account.get('sessionToken')) {
         return p.reject(AuthErrors.toError('INVALID_TOKEN'));
       }
@@ -110,23 +110,23 @@ define(function (require, exports, module) {
      *
      * @returns {Promise}
      */
-    sendOAuthResultToRelier: function (/*result*/) {
+    sendOAuthResultToRelier (/*result*/) {
       return p.reject(new Error('subclasses must override sendOAuthResultToRelier'));
     },
 
-    finishOAuthSignInFlow: function (account, additionalResultData) {
+    finishOAuthSignInFlow (account, additionalResultData) {
       additionalResultData = additionalResultData || {};
       additionalResultData.action = Constants.OAUTH_ACTION_SIGNIN;
       return this.finishOAuthFlow(account, additionalResultData);
     },
 
-    finishOAuthSignUpFlow: function (account, additionalResultData) {
+    finishOAuthSignUpFlow (account, additionalResultData) {
       additionalResultData = additionalResultData || {};
       additionalResultData.action = Constants.OAUTH_ACTION_SIGNUP;
       return this.finishOAuthFlow(account, additionalResultData);
     },
 
-    finishOAuthFlow: function (account, additionalResultData) {
+    finishOAuthFlow (account, additionalResultData) {
       this.session.clear('oauth');
       return this.getOAuthResult(account)
         .then((result) => {
@@ -137,7 +137,7 @@ define(function (require, exports, module) {
         });
     },
 
-    persistVerificationData: function (account) {
+    persistVerificationData (account) {
       return p().then(() => {
         var relier = this.relier;
         this.session.set('oauth', {
@@ -154,12 +154,12 @@ define(function (require, exports, module) {
       });
     },
 
-    afterForceAuth: function (account, additionalResultData) {
+    afterForceAuth (account, additionalResultData) {
       return this.finishOAuthSignInFlow(account, additionalResultData)
         .then(() => proto.afterForceAuth.call(this, account));
     },
 
-    afterSignIn: function (account, additionalResultData) {
+    afterSignIn (account, additionalResultData) {
       return this.finishOAuthSignInFlow(account, additionalResultData)
         .then(() => proto.afterSignIn.call(this, account));
     },
@@ -169,16 +169,16 @@ define(function (require, exports, module) {
         .then(() => proto.afterSignInConfirmationPoll.call(this, account));
     },
 
-    afterSignUpConfirmationPoll: function (account) {
+    afterSignUpConfirmationPoll (account) {
       // The original tab always finishes the OAuth flow if it is still open.
       return this.finishOAuthSignUpFlow(account);
     },
 
-    afterResetPasswordConfirmationPoll: function (account) {
+    afterResetPasswordConfirmationPoll (account) {
       return this.finishOAuthSignInFlow(account);
     },
 
-    transformLink: function (link) {
+    transformLink (link) {
       if (link[0] !== '/') {
         link = '/' + link;
       }

--- a/app/scripts/models/auth_brokers/redirect.js
+++ b/app/scripts/models/auth_brokers/redirect.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
 
   var RedirectAuthenticationBroker = OAuthAuthenticationBroker.extend({
     type: 'redirect',
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._metrics = options.metrics;
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
       return proto.initialize.call(this, options);
     },
 
-    sendOAuthResultToRelier: function (result) {
+    sendOAuthResultToRelier (result) {
       var win = this.window;
       return this._metrics.flush()
         .then(function () {
@@ -46,19 +46,19 @@ define(function (require, exports, module) {
      * the original tab with the verification tab, then the OAuth flow
      * should complete and the user redirected to the RP.
      */
-    setOriginalTabMarker: function () {
+    setOriginalTabMarker () {
       this.window.sessionStorage.setItem('originalTab', '1');
     },
 
-    isOriginalTab: function () {
+    isOriginalTab () {
       return !! this.window.sessionStorage.getItem('originalTab');
     },
 
-    clearOriginalTabMarker: function () {
+    clearOriginalTabMarker () {
       this.window.sessionStorage.removeItem('originalTab');
     },
 
-    persistVerificationData: function (account) {
+    persistVerificationData (account) {
       // If the user replaces the current tab with the verification url,
       // finish the OAuth flow.
       return p().then(() => {
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
       });
     },
 
-    finishOAuthFlow: function (account, additionalResultData) {
+    finishOAuthFlow (account, additionalResultData) {
       return p().then(() => {
         // There are no ill side effects if the Original Tab Marker is
         // cleared in the a tab other than the original. Always clear it just
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
       });
     },
 
-    afterCompleteSignUp: function (account) {
+    afterCompleteSignUp (account) {
       // The user may have replaced the original tab with the verification
       // tab. If this is the case, send the OAuth result to the RP.
       //
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
         });
     },
 
-    canVerificationRedirect: function () {
+    canVerificationRedirect () {
       // checks if the relier is using the verificationRedirect option
       // then automatically redirects to the relier if an oauth session is present
       var verificationRedirect = this.relier.get('verificationRedirect');
@@ -104,7 +104,7 @@ define(function (require, exports, module) {
       return this.session.oauth && verificationRedirect === Constants.VERIFICATION_REDIRECT_ALWAYS;
     },
 
-    afterCompleteResetPassword: function (account) {
+    afterCompleteResetPassword (account) {
       // The user may have replaced the original tab with the verification
       // tab. If this is the case, send the OAuth result to the RP.
       return proto.afterCompleteResetPassword.call(this, account)

--- a/app/scripts/models/auth_brokers/web-channel.js
+++ b/app/scripts/models/auth_brokers/web-channel.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
       webChannelId: null
     }),
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       // channel can be passed in for testing.
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
       return proto.initialize.call(this, options);
     },
 
-    fetch: function () {
+    fetch () {
       return proto.fetch.call(this)
         .then(() => {
           if (this._isVerificationFlow()) {
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
         });
     },
 
-    sendOAuthResultToRelier: function (result) {
+    sendOAuthResultToRelier (result) {
       if (result.closeWindow !== true) {
         result.closeWindow = false;
       }
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
      * keys 'kAr' and 'kBr'.
      */
 
-    getOAuthResult: function (account) {
+    getOAuthResult (account) {
       return proto.getOAuthResult.call(this, account)
         .then((result) => {
           if (! this.relier.wantsKeys()) {
@@ -88,7 +88,7 @@ define(function (require, exports, module) {
         });
     },
 
-    afterSignIn: function (account, additionalResultData) {
+    afterSignIn (account, additionalResultData) {
       if (! additionalResultData) {
         additionalResultData = {};
       }
@@ -103,7 +103,7 @@ define(function (require, exports, module) {
                 this, account, additionalResultData);
     },
 
-    afterForceAuth: function (account, additionalResultData) {
+    afterForceAuth (account, additionalResultData) {
       if (! additionalResultData) {
         additionalResultData = {};
       }
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
                 this, account, additionalResultData);
     },
 
-    beforeSignUpConfirmationPoll: function (account) {
+    beforeSignUpConfirmationPoll (account) {
       // If the relier wants keys, the signup verification tab will need
       // to be able to fetch them in order to complete the flow.
       // Send them as part of the oauth session data.
@@ -138,19 +138,19 @@ define(function (require, exports, module) {
      * but it's unlikely to trigger in practice.
      */
 
-    hasPendingOAuthFlow: function () {
+    hasPendingOAuthFlow () {
       this.session.reload();
       return !! (this.session.oauth);
     },
 
-    afterSignUpConfirmationPoll: function (account) {
+    afterSignUpConfirmationPoll (account) {
       if (this.hasPendingOAuthFlow()) {
         return this.finishOAuthSignUpFlow(account);
       }
       return p();
     },
 
-    afterCompleteSignUp: function (account) {
+    afterCompleteSignUp (account) {
       // The original tab may be closed, so the verification tab should
       // send the OAuth result to the browser to ensure the flow completes.
       //
@@ -173,14 +173,14 @@ define(function (require, exports, module) {
         });
     },
 
-    afterResetPasswordConfirmationPoll: function (account) {
+    afterResetPasswordConfirmationPoll (account) {
       if (this.hasPendingOAuthFlow()) {
         return this.finishOAuthSignInFlow(account);
       }
       return p();
     },
 
-    afterCompleteResetPassword: function (account) {
+    afterCompleteResetPassword (account) {
       // The original tab may be closed, so the verification tab should
       // send the OAuth result to the browser to ensure the flow completes.
       //
@@ -198,7 +198,7 @@ define(function (require, exports, module) {
     },
 
     // used by the ChannelMixin to get a channel.
-    getChannel: function () {
+    getChannel () {
       if (this._channel) {
         return this._channel;
       }
@@ -211,15 +211,15 @@ define(function (require, exports, module) {
       return channel;
     },
 
-    _isVerificationFlow: function () {
+    _isVerificationFlow () {
       return !! this.getSearchParam('code');
     },
 
-    _setupSigninSignupFlow: function () {
+    _setupSigninSignupFlow () {
       this.importSearchParamsUsingSchema(QUERY_PARAMETER_SCHEMA, OAuthErrors);
     },
 
-    _setupVerificationFlow: function () {
+    _setupVerificationFlow () {
       var resumeObj = this.session.oauth;
 
       if (! resumeObj) {

--- a/app/scripts/models/cropper-image.js
+++ b/app/scripts/models/cropper-image.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
       width: 1
     },
 
-    initialize: function (options) {
+    initialize (options) {
       if (options &&
           (options.width < Constants.PROFILE_IMAGE_MIN_HEIGHT ||
            options.height < Constants.PROFILE_IMAGE_MIN_WIDTH)) {

--- a/app/scripts/models/device.js
+++ b/app/scripts/models/device.js
@@ -23,7 +23,7 @@ define(function (require, exports, module) {
       type: null
     },
 
-    destroy: function () {
+    destroy () {
       // Both a sessionToken and deviceId are needed to destroy a device.
       // An account `has a` device, therefore account destroys the device.
       this.trigger('destroy', this);

--- a/app/scripts/models/email-resend.js
+++ b/app/scripts/models/email-resend.js
@@ -19,12 +19,12 @@ define(function (require, exports, module) {
       tries: 0
     },
 
-    initialize: function (opt) {
+    initialize (opt) {
       opt = opt || {};
       this.maxTries = opt.maxTries || Constants.EMAIL_RESEND_MAX_TRIES;
     },
 
-    incrementRequestCount: function () {
+    incrementRequestCount () {
       var tries = this.get('tries') + 1;
       this.set('tries', tries);
 
@@ -33,11 +33,11 @@ define(function (require, exports, module) {
       }
     },
 
-    shouldResend: function () {
+    shouldResend () {
       return shouldResend(this.get('tries'), this.maxTries);
     },
 
-    reset: function () {
+    reset () {
       this.set('tries', 0);
     }
   });

--- a/app/scripts/models/flow-event-metadata.js
+++ b/app/scripts/models/flow-event-metadata.js
@@ -47,12 +47,12 @@ define(function (require, exports, module) {
   });
 
   module.exports = Backbone.Model.extend({
-    constructor: function (options) {
+    constructor (options) {
       Backbone.Model.call(this);
       this.initialize(options);
     },
 
-    initialize: function (options) {
+    initialize (options) {
       if (options) {
         this.set(_.pick(options, INITIAL_ATTRIBUTES));
       }

--- a/app/scripts/models/flow.js
+++ b/app/scripts/models/flow.js
@@ -24,7 +24,7 @@ define(function (require, exports, module) {
   const vat = require('lib/vat');
 
   var Model = Backbone.Model.extend({
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this.sentryMetrics = options.sentryMetrics;
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
       flowId: null
     },
 
-    populateFromDataAttribute: function (attribute) {
+    populateFromDataAttribute (attribute) {
       var data = $(this.window.document.body).data(attribute);
       if (! data) {
         this.logError(AuthErrors.toMissingDataAttributeError(attribute));
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
       }
     },
 
-    logError: function (error) {
+    logError (error) {
       return ErrorUtils.captureError(error, this.sentryMetrics);
     },
 

--- a/app/scripts/models/marketing-email-prefs.js
+++ b/app/scripts/models/marketing-email-prefs.js
@@ -24,14 +24,14 @@ define(function (require, exports, module) {
       token: null
     },
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._marketingEmailClient = options.marketingEmailClient;
       this._account = options.account;
     },
 
-    _withMarketingEmailClient: function (method) {
+    _withMarketingEmailClient (method) {
       var client = this._marketingEmailClient;
       var args = [].slice.call(arguments, 1);
       return p().then(() => this._account.createOAuthToken(SCOPES))
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
      * @method fetch
      * @returns {Promise}
      */
-    fetch: function () {
+    fetch () {
       return this._withMarketingEmailClient('fetch')
         .then((response) => {
           if (response) {
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
      * @param {String} newsletterId
      * @returns {Promise}
      */
-    optIn: function (newsletterId) {
+    optIn (newsletterId) {
       if (this.isOptedIn(newsletterId)) {
         return p();
       }
@@ -97,7 +97,7 @@ define(function (require, exports, module) {
      * @param {String} newsletterId
      * @returns {Promise}
      */
-    optOut: function (newsletterId) {
+    optOut (newsletterId) {
       if (! this.isOptedIn(newsletterId)) {
         return p();
       }
@@ -116,7 +116,7 @@ define(function (require, exports, module) {
      * @param {String} newsletterId
      * @returns {Boolean}
      */
-    isOptedIn: function (newsletterId) {
+    isOptedIn (newsletterId) {
       var newsletters = this.get('newsletters');
       return newsletters.indexOf(newsletterId) !== -1;
     }

--- a/app/scripts/models/mixins/resume-token.js
+++ b/app/scripts/models/mixins/resume-token.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
      * @method pickResumeTokenInfo
      * @returns {Object}
      */
-    pickResumeTokenInfo: function () {
+    pickResumeTokenInfo () {
       if (this.resumeTokenFields) {
         return this.pick(this.resumeTokenFields);
       }
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
      * @method populateFromStringifiedResumeToken
      * @param {String} stringifiedResumeToken
      */
-    populateFromStringifiedResumeToken: function (stringifiedResumeToken) {
+    populateFromStringifiedResumeToken (stringifiedResumeToken) {
       if (this.resumeTokenFields) {
         var resumeToken =
           ResumeToken.createFromStringifiedResumeToken(stringifiedResumeToken);
@@ -62,7 +62,7 @@ define(function (require, exports, module) {
      * @param {ResumeToken} resumeToken
      * @returns {undefined}
      */
-    populateFromResumeToken: function (resumeToken) {
+    populateFromResumeToken (resumeToken) {
       if (this.resumeTokenFields) {
         var pickedResumeToken = resumeToken.pick(this.resumeTokenFields);
 

--- a/app/scripts/models/mixins/search-param.js
+++ b/app/scripts/models/mixins/search-param.js
@@ -19,7 +19,7 @@ define(function (require, exports, module) {
      * @param {String} paramName - name of the search parameter to get
      * @returns {String}
      */
-    getSearchParam: function (paramName) {
+    getSearchParam (paramName) {
       return Url.searchParam(paramName, this.window.location.search);
     },
 
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
      * to get
      * @returns {Object}
      */
-    getSearchParams: function (paramNames) {
+    getSearchParams (paramNames) {
       return Url.searchParams(this.window.location.search, paramNames);
     },
 
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
      * `INVALID_PARAMETER` error is generated, with the error's
      * `param` field set to the invalid field's name.
      */
-    importSearchParamsUsingSchema: function (schema, Errors) {
+    importSearchParamsUsingSchema (schema, Errors) {
       var params = this.getSearchParams(Object.keys(schema));
       var result = Transform.transformUsingSchema(params, schema, Errors);
       this.set(result);

--- a/app/scripts/models/oauth-app.js
+++ b/app/scripts/models/oauth-app.js
@@ -20,7 +20,7 @@ define(function (require, exports, module) {
       name: null
     },
 
-    destroy: function () {
+    destroy () {
       this.trigger('destroy', this);
     }
   });

--- a/app/scripts/models/oauth-token.js
+++ b/app/scripts/models/oauth-token.js
@@ -18,14 +18,14 @@ define(function (require, exports, module) {
       token: undefined
     },
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._oAuthClient = options.oAuthClient;
       this.set('token', options.token);
     },
 
-    destroy: function () {
+    destroy () {
       return this._oAuthClient.destroyToken(this.get('token'));
     }
   });

--- a/app/scripts/models/profile-image.js
+++ b/app/scripts/models/profile-image.js
@@ -19,7 +19,7 @@ define(function (require, exports, module) {
       url: undefined
     },
 
-    fetch: function () {
+    fetch () {
       if (! this.has('url')) {
         return p();
       }
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
         });
     },
 
-    isDefault: function () {
+    isDefault () {
       return ! (this.has('url') && this.has('id') && this.has('img'));
     }
   });

--- a/app/scripts/models/refresh-observer.js
+++ b/app/scripts/models/refresh-observer.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
   }
 
   module.exports = Backbone.Model.extend({
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._metrics = options.metrics;
@@ -34,11 +34,11 @@ define(function (require, exports, module) {
       this._notifier.on('show-child-view', this._onShowChildView.bind(this));
     },
 
-    _onShowView: function (View, viewOptions) {
+    _onShowView (View, viewOptions) {
       this.logIfRefresh(viewOptions.viewName);
     },
 
-    _onShowChildView: function (ChildView, ParentView, viewOptions) {
+    _onShowChildView (ChildView, ParentView, viewOptions) {
       this.logIfRefresh(viewOptions.viewName);
     },
 
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
      *
      * @param {String} viewName
      */
-    logIfRefresh: function (viewName) {
+    logIfRefresh (viewName) {
       var refreshMetrics = this._storage.get('last_page_loaded');
 
       if (isRefresh(refreshMetrics, viewName)) {

--- a/app/scripts/models/reliers/base.js
+++ b/app/scripts/models/reliers/base.js
@@ -18,7 +18,7 @@ define(function (require, exports, module) {
       context: null,
     },
 
-    fetch: function () {
+    fetch () {
       return p(true);
     },
 
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
      * `true` if the user visits FxA without using
      * a relier
      */
-    isDirectAccess: function () {
+    isDirectAccess () {
       return ! this.has('service');
     },
 
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isOAuth: function () {
+    isOAuth () {
       return false;
     },
 
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isSync: function () {
+    isSync () {
       return false;
     },
 
@@ -57,7 +57,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isCustomizeSyncChecked: function () {
+    isCustomizeSyncChecked () {
       return false;
     },
 
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    wantsKeys: function () {
+    wantsKeys () {
       return false;
     },
 
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise}
      */
-    deriveRelierKeys: function (/* keys */) {
+    deriveRelierKeys (/* keys */) {
       return p({});
     },
 
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
      *
      * @returns {Object}
      */
-    pickResumeTokenInfo: function () {
+    pickResumeTokenInfo () {
       return {};
     },
 
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    allowCachedCredentials: function () {
+    allowCachedCredentials () {
       return true;
     },
 
@@ -104,7 +104,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isTrusted: function () {
+    isTrusted () {
       return true;
     },
 
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    accountNeedsPermissions: function (/* account */) {
+    accountNeedsPermissions (/* account */) {
       return false;
     }
   });

--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -87,14 +87,14 @@ define(function (require, exports, module) {
       Relier.prototype.resumeTokenFields
     ),
 
-    initialize: function (attributes, options = {}) {
+    initialize (attributes, options = {}) {
       Relier.prototype.initialize.call(this, attributes, options);
 
       this._session = options.session;
       this._oAuthClient = options.oAuthClient;
     },
 
-    fetch: function () {
+    fetch () {
       return Relier.prototype.fetch.call(this)
         .then(() => {
           if (this._isVerificationFlow()) {
@@ -118,7 +118,7 @@ define(function (require, exports, module) {
         });
     },
 
-    _normalizeScopesAndPermissions: function () {
+    _normalizeScopesAndPermissions () {
       var permissions = scopeStrToArray(this.get('scope'));
       if (this.isTrusted()) {
         // We have to normalize `profile` into is expanded sub-scopes
@@ -142,7 +142,7 @@ define(function (require, exports, module) {
       this.set('permissions', permissions);
     },
 
-    isOAuth: function () {
+    isOAuth () {
       return true;
     },
 
@@ -151,22 +151,22 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    wantsKeys: function () {
+    wantsKeys () {
       if (this.get('keys')) {
         return true;
       }
       return Relier.prototype.wantsKeys.call(this);
     },
 
-    deriveRelierKeys: function (keys, uid) {
+    deriveRelierKeys (keys, uid) {
       return RelierKeys.deriveRelierKeys(keys, uid, this.get('clientId'));
     },
 
-    _isVerificationFlow: function () {
+    _isVerificationFlow () {
       return !! this.getSearchParam('code');
     },
 
-    _setupVerificationFlow: function () {
+    _setupVerificationFlow () {
       var resumeObj = this._session.oauth;
       if (! resumeObj) {
         // The user is verifying in a second browser. `service` is
@@ -185,14 +185,14 @@ define(function (require, exports, module) {
       this.set(result);
     },
 
-    _setupSignInSignUpFlow: function () {
+    _setupSignInSignUpFlow () {
       // params listed in:
       // https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1authorization
       this.importSearchParamsUsingSchema(
           SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA, OAuthErrors);
     },
 
-    _setupOAuthRPInfo: function () {
+    _setupOAuthRPInfo () {
       var clientId = this.get('clientId');
 
       return this._oAuthClient.getClientInfo(clientId)
@@ -215,7 +215,7 @@ define(function (require, exports, module) {
         });
     },
 
-    isTrusted: function () {
+    isTrusted () {
       return this.get('trusted');
     },
 
@@ -224,7 +224,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean} `true` if relier asks for consent, false otw.
      */
-    wantsConsent: function () {
+    wantsConsent () {
       return this.get('prompt') === Constants.OAUTH_PROMPT_CONSENT;
     },
 
@@ -236,7 +236,7 @@ define(function (require, exports, module) {
      * @returns {Boolean} `true` if additional permissions
      *   are needed, false otw.
      */
-    accountNeedsPermissions: function (account) {
+    accountNeedsPermissions (account) {
       if (this.isTrusted() && ! this.wantsConsent()) {
         return false;
       }

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -87,7 +87,7 @@ define(function (require, exports, module) {
       utmTerm: null
     },
 
-    initialize: function (attributes, options = {}) {
+    initialize (attributes, options = {}) {
       this._queryParameterSchema = options.isVerification ?
         VERIFICATION_QUERY_PARAMETER_SCHEMA : QUERY_PARAMETER_SCHEMA;
 
@@ -102,7 +102,7 @@ define(function (require, exports, module) {
      *
      * e.g.
      *
-     * fetch: function () {
+     * fetch () {
      *   return Relier.prototype.fetch.call(this)
      *       .then(function () {
      *         // do overriding behavior here.
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
      * @method fetch
      * @returns {Promise}
      */
-    fetch: function () {
+    fetch () {
       return p().then(() => {
         // parse the resume token before importing any other data.
         // query parameters and server provided data override
@@ -141,7 +141,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    allowCachedCredentials: function () {
+    allowCachedCredentials () {
       return this.get('allowCachedCredentials');
     },
 

--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -32,13 +32,13 @@ define(function (require, exports, module) {
       customizeSync: false
     }),
 
-    initialize: function (attributes, options = {}) {
+    initialize (attributes, options = {}) {
       this._translator = options.translator;
 
       Relier.prototype.initialize.call(this, attributes, options);
     },
 
-    fetch: function () {
+    fetch () {
       return Relier.prototype.fetch.call(this)
         .then(() => {
           this.importSearchParamsUsingSchema(QUERY_PARAMETER_SCHEMA, AuthErrors);
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
         });
     },
 
-    isSync: function () {
+    isSync () {
       return true;
     },
 
@@ -56,11 +56,11 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    wantsKeys: function () {
+    wantsKeys () {
       return true;
     },
 
-    _setupServiceName: function () {
+    _setupServiceName () {
       var service = this.get('service');
       if (service) {
         var serviceNameTranslator = new ServiceNameTranslator(this._translator);
@@ -74,7 +74,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isCustomizeSyncChecked: function () {
+    isCustomizeSyncChecked () {
       return !! this.get('customizeSync');
     }
   });

--- a/app/scripts/models/resume-token.js
+++ b/app/scripts/models/resume-token.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
       verificationRedirect: undefined
     },
 
-    initialize: function (options) {
+    initialize (options) {
       this.allowedKeys = Object.keys(this.defaults);
 
       // get rid of any data in the options block that is not expected.
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
       this.set(allowedData);
     },
 
-    stringify: function () {
+    stringify () {
       return stringify(this.pick(this.allowedKeys));
     }
   });

--- a/app/scripts/models/unique-user-id.js
+++ b/app/scripts/models/unique-user-id.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
   const uuid = require('uuid');
 
   var Model = Backbone.Model.extend({
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this.sentryMetrics = options.sentryMetrics;
@@ -41,7 +41,7 @@ define(function (require, exports, module) {
       uniqueUserId: null
     },
 
-    fetch: function () {
+    fetch () {
       // Try to fetch the uniqueUserId from the resume token.
       // If unavailable there, fetch from localStorage.
       // If not in localStorage either, create a new uniqueUserId.

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
   const VerificationReasons = require('lib/verification-reasons');
 
   var User = Backbone.Model.extend({
-    initialize: function (options = {}) {
+    initialize (options = {}) {
       this._oAuthClientId = options.oAuthClientId;
       this._oAuthClient = options.oAuthClient;
       this._profileClient = options.profileClient;
@@ -63,17 +63,17 @@ define(function (require, exports, module) {
     },
 
     // Hydrate the model. Returns a promise.
-    fetch: function () {
+    fetch () {
       return p().then(() => {
         this.populateFromStringifiedResumeToken(this.getSearchParam('resume'));
       });
     },
 
-    _accounts: function () {
+    _accounts () {
       return this._storage.get('accounts') || {};
     },
 
-    _getAccount: function (uid) {
+    _getAccount (uid) {
       if (! uid) {
         return null;
       } else {
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
       }
     },
 
-    _setSignedInAccountUid: function (uid) {
+    _setSignedInAccountUid (uid) {
       this._storage.set('currentAccountUid', uid);
       // Clear the in-memory cache if the uid has changed
       if (this._cachedSignedInAccount && this._cachedSignedInAccount.get('uid') !== uid) {
@@ -89,17 +89,17 @@ define(function (require, exports, module) {
       }
     },
 
-    clearSignedInAccountUid: function () {
+    clearSignedInAccountUid () {
       this._storage.remove('currentAccountUid');
       this._cachedSignedInAccount = null;
     },
 
-    _getSignedInAccountData: function () {
+    _getSignedInAccountData () {
       return this._getAccount(this._storage.get('currentAccountUid'));
     },
 
     // persists account data
-    _persistAccount: function (accountData) {
+    _persistAccount (accountData) {
       var account = this.initAccount(accountData);
 
       var accounts = this._accounts();
@@ -110,7 +110,7 @@ define(function (require, exports, module) {
 
     // A convenience method that initializes an account instance from
     // raw account data.
-    initAccount: function (accountData) {
+    initAccount (accountData) {
       if (accountData instanceof Account) {
         // we already have an account instance
         return accountData;
@@ -127,11 +127,11 @@ define(function (require, exports, module) {
       });
     },
 
-    isSyncAccount: function (account) {
+    isSyncAccount (account) {
       return this.initAccount(account).isFromSync();
     },
 
-    getSignedInAccount: function () {
+    getSignedInAccount () {
       if (! this._cachedSignedInAccount) {
         this._cachedSignedInAccount = this.initAccount(this._getSignedInAccountData());
       }
@@ -139,22 +139,22 @@ define(function (require, exports, module) {
       return this._cachedSignedInAccount;
     },
 
-    isSignedInAccount: function (account) {
+    isSignedInAccount (account) {
       return account.get('uid') === this.getSignedInAccount().get('uid');
     },
 
-    setSignedInAccountByUid: function (uid) {
+    setSignedInAccountByUid (uid) {
       if (this._accounts()[uid]) {
         this._setSignedInAccountUid(uid);
       }
     },
 
-    getAccountByUid: function (uid) {
+    getAccountByUid (uid) {
       var account = this._accounts()[uid];
       return this.initAccount(account);
     },
 
-    getAccountByEmail: function (email) {
+    getAccountByEmail (email) {
       // Reverse the list so newest accounts are first
       var uids = Object.keys(this._accounts()).reverse();
       var accounts = this._accounts();
@@ -169,7 +169,7 @@ define(function (require, exports, module) {
     // Return the account selected in the account chooser.
     // Defaults to the last logged in account unless a desktop session
     // has been stored.
-    getChooserAccount: function () {
+    getChooserAccount () {
       var account = _.find(this._accounts(), (account) => {
         return this.isSyncAccount(account);
       }) || this.getSignedInAccount();
@@ -178,7 +178,7 @@ define(function (require, exports, module) {
     },
 
     // Used to clear the current account, but keeps the account details
-    clearSignedInAccount: function () {
+    clearSignedInAccount () {
       var uid = this.getSignedInAccount().get('uid');
       this.clearSignedInAccountUid();
       this._notifier.triggerRemote(this._notifier.COMMANDS.SIGNED_OUT, {
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
       });
     },
 
-    removeAllAccounts: function () {
+    removeAllAccounts () {
       this.clearSignedInAccountUid();
       this._storage.remove('accounts');
     },
@@ -198,7 +198,7 @@ define(function (require, exports, module) {
      * @param {Object} accountData - Account model or object representing
      *   account data.
      */
-    removeAccount: function (accountData) {
+    removeAccount (accountData) {
       var account = this.initAccount(accountData);
 
       if (this.isSignedInAccount(account)) {
@@ -219,7 +219,7 @@ define(function (require, exports, module) {
      * @param {String} password - the user's password
      * @return {Promise} - resolves when complete
      */
-    deleteAccount: function (accountData, password) {
+    deleteAccount (accountData, password) {
       var account = this.initAccount(accountData);
 
       return account.destroy(password)
@@ -232,7 +232,7 @@ define(function (require, exports, module) {
     },
 
     // Stores a new account and sets it as the current account.
-    setSignedInAccount: function (accountData) {
+    setSignedInAccount (accountData) {
       var account = this.initAccount(accountData);
       account.set('lastLogin', Date.now());
 
@@ -245,7 +245,7 @@ define(function (require, exports, module) {
     },
 
     // Hydrate the account then persist it
-    setAccount: function (accountData) {
+    setAccount (accountData) {
       var account = this.initAccount(accountData);
       return account.fetch()
         .then(() => {
@@ -257,7 +257,7 @@ define(function (require, exports, module) {
     // Old sessions store two accounts: The last account the
     // user logged in to FxA with, and the account they logged in to
     // Sync with. If they are different accounts, we'll save both accounts.
-    upgradeFromSession: function (Session, fxaClient) {
+    upgradeFromSession (Session, fxaClient) {
       return p().then(() => {
         if (! this.getSignedInAccount().isDefault()) {
           // We've already upgraded the session
@@ -308,7 +308,7 @@ define(function (require, exports, module) {
     // (12 Jan 2016), only allowed fields are allowed to be
     // set on an account, unexpected fields cause an error.
     // Update any accounts with unexpected data.
-    upgradeFromUnfilteredAccountData: function () {
+    upgradeFromUnfilteredAccountData () {
       return p().then(() => {
         var accountData = this._accounts();
         for (var userid in accountData) {
@@ -325,7 +325,7 @@ define(function (require, exports, module) {
     // Add the last signed in account (if it's different from the
     // Sync account). If the email is the same we assume it's the
     // same account since users can't change email yet.
-    _shouldAddOldSessionAccount: function (Session) {
+    _shouldAddOldSessionAccount (Session) {
       return (Session.email && Session.sessionToken &&
         (! Session.cachedCredentials ||
         Session.cachedCredentials.email !== Session.email));
@@ -340,7 +340,7 @@ define(function (require, exports, module) {
      * @param {Object} [options] - options
      * @returns {Promise} - resolves when complete
      */
-    signInAccount: function (account, password, relier, options) {
+    signInAccount (account, password, relier, options) {
       return account.signIn(password, relier, options)
         .then(() => {
           const isSignUp =
@@ -382,12 +382,12 @@ define(function (require, exports, module) {
      * @param {Object} [options] - options
      * @returns {Promise} - resolves when complete
      */
-    signUpAccount: function (account, password, relier, options) {
+    signUpAccount (account, password, relier, options) {
       return account.signUp(password, relier, options)
         .then(() => this.setSignedInAccount(account));
     },
 
-    signOutAccount: function (account) {
+    signOutAccount (account) {
       return account.signOut()
         .fin(() => {
           // Clear the session, even on failure. Everything is A-OK.
@@ -409,7 +409,7 @@ define(function (require, exports, module) {
      * @param {Object} [options.service] - the service issuing signup request
      * @returns {Promise} - resolves with the account when complete
      */
-    completeAccountSignUp: function (account, code, options) {
+    completeAccountSignUp (account, code, options) {
       // The original tab may no longer be open to notify other
       // windows the user is signed in. If the account has a `sessionToken`,
       // the user verified in the same browser. Notify any tabs that care.
@@ -447,7 +447,7 @@ define(function (require, exports, module) {
      * @return {Object} promise - resolves with the updated account
      * when complete.
      */
-    changeAccountPassword: function (account, oldPassword, newPassword, relier) {
+    changeAccountPassword (account, oldPassword, newPassword, relier) {
       return account.changePassword(oldPassword, newPassword, relier)
         .then(() => {
           return this.setSignedInAccount(account);
@@ -476,7 +476,7 @@ define(function (require, exports, module) {
      * @private
      * @param {Object} account
      */
-    _notifyOfAccountSignIn: function (account) {
+    _notifyOfAccountSignIn (account) {
       // Other tabs only need to know the account `uid` to load any
       // necessary info from localStorage
       this._notifier.triggerRemote(
@@ -494,7 +494,7 @@ define(function (require, exports, module) {
      * @param {Object} relier - relier being signed in to
      * @returns {Promise} - resolves when complete
      */
-    completeAccountPasswordReset: function (account, password, token, code, relier) {
+    completeAccountPasswordReset (account, password, token, code, relier) {
       return account.completePasswordReset(password, token, code, relier)
         .then(() => {
           this._notifyOfAccountSignIn(account);
@@ -508,7 +508,7 @@ define(function (require, exports, module) {
      * @param {Object} client - an attached client
      * @returns {Promise}
      */
-    destroyAccountClient: function (account, client) {
+    destroyAccountClient (account, client) {
       if (client.get('clientType') === Constants.CLIENT_TYPE_DEVICE) {
         return this.destroyAccountDevice(account, client);
       } else if (client.get('clientType') === Constants.CLIENT_TYPE_OAUTH_APP) {
@@ -524,7 +524,7 @@ define(function (require, exports, module) {
      * @param {Object} devices - Devices collection used to store list.
      * @returns {Promise} resolves when the action completes
      */
-    fetchAccountDevices: function (account, devices) {
+    fetchAccountDevices (account, devices) {
       return account.fetchDevices(devices);
     },
 
@@ -536,7 +536,7 @@ define(function (require, exports, module) {
      * @param {Object} oAuthApps - oAuthApps collection used to store list.
      * @returns {Promise} resolves when the action completes
      */
-    fetchAccountOAuthApps: function (account, oAuthApps) {
+    fetchAccountOAuthApps (account, oAuthApps) {
       return account.fetchOAuthApps(oAuthApps);
     },
 
@@ -548,7 +548,7 @@ define(function (require, exports, module) {
      * @param {Object} device - device to destroy
      * @returns {Promise} resolves when the action completes
      */
-    destroyAccountDevice: function (account, device) {
+    destroyAccountDevice (account, device) {
       return account.destroyDevice(device)
         .then(() => {
           if (this.isSignedInAccount(account) && device.get('isCurrentDevice')) {
@@ -564,7 +564,7 @@ define(function (require, exports, module) {
      * @param {Object} oAuthApp - OAuth App to disconnect
      * @returns {Promise} resolves when the action completes
      */
-    destroyAccountApp: function (account, oAuthApp) {
+    destroyAccountApp (account, oAuthApp) {
       return account.destroyOAuthApp(oAuthApp);
     },
 
@@ -575,7 +575,7 @@ define(function (require, exports, module) {
      * @param {Object} account - account to check
      * @returns {Promise} resolves to `true` if an account exists, `false` otw.
      */
-    checkAccountUidExists: function (account) {
+    checkAccountUidExists (account) {
       return account.checkUidExists()
         .then((exists) => {
           if (! exists) {
@@ -592,7 +592,7 @@ define(function (require, exports, module) {
      * @param {Object} account - account to check
      * @returns {Promise} resolves to `true` if an account exists, `false` otw.
      */
-    checkAccountEmailExists: function (account) {
+    checkAccountEmailExists (account) {
       return account.checkEmailExists()
         .then((exists) => {
           if (! exists) {

--- a/app/scripts/models/verification/base.js
+++ b/app/scripts/models/verification/base.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
   var proto = Backbone.Model.prototype;
 
   var VerificationInfo = Backbone.Model.extend({
-    initialize: function (options) {
+    initialize (options) {
       proto.initialize.call(this, options);
 
       // clean up any whitespace that was probably added by an MUA.
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
      * @returns {Boolean} `false` if a `validationError` is set, or if
      *   `validate` either throws or returns false. `true` otherwise.
      */
-    isValid: function () {
+    isValid () {
       var isValid;
 
       if (this.isDamaged()) {
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
      * @method validate
      * @param {Object} attributes
      */
-    validate: function (attributes) {
+    validate (attributes) {
       _.each(this.validation, function (validator, key) {
         if (! validator(attributes[key])) {
           throw new Error('invalid ' + key);
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
      * Mark the verification info as expired.
      * @method markExpired
      */
-    markExpired: function () {
+    markExpired () {
       this._isExpired = true;
     },
 
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
      * @method isExpired
      * @returns {Boolean} `true` if expired, `false` otw.
      */
-    isExpired: function () {
+    isExpired () {
       return !! this._isExpired;
     },
 
@@ -103,7 +103,7 @@ define(function (require, exports, module) {
      * Mark the verification info as used.
      * @method markUsed
      */
-    markUsed: function () {
+    markUsed () {
       this._isUsed = true;
     },
 
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
      * @method isUsed
      * @returns {Boolean} `true` if used, `false` otherwise.
      */
-    isUsed: function () {
+    isUsed () {
       return !! this._isUsed;
     },
 
@@ -122,7 +122,7 @@ define(function (require, exports, module) {
      * return `false`.
      * @method markDamaged
      */
-    markDamaged: function () {
+    markDamaged () {
       this._isDamaged = true;
     },
 
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
      * @method isDamaged
      * @returns {Boolean} `true` if damaged, `false` otw.
      */
-    isDamaged: function () {
+    isDamaged () {
       return !! this._isDamaged;
     }
   });

--- a/app/scripts/models/verification/same-browser.js
+++ b/app/scripts/models/verification/same-browser.js
@@ -26,7 +26,7 @@ define(function (require, exports, module) {
   var proto = Backbone.Model.prototype;
 
   var SameBrowserVerificationModel = Backbone.Model.extend({
-    initialize: function (attributes, options) {
+    initialize (attributes, options) {
       proto.initialize.call(this, attributes, options);
 
       this._email = options.email;
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
      * @returns {String}
      * @private
      */
-    _getUsersStorageId: function () {
+    _getUsersStorageId () {
       return this._uid || this._email;
     },
 
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
      * Persist verification info to localStorage. Info will be loaded on
      * verification in verification occurs in the same browser.
      */
-    persist: function () {
+    persist () {
       var id = this._getUsersStorageId();
       if (id) {
         var verificationInfo = this._storage.get(STORAGE_KEY) || {};
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
     /**
      * Load verification info for the current user from localStorage
      */
-    load: function () {
+    load () {
       var id = this._getUsersStorageId();
       if (id) {
         var usersStoredInfo = (this._storage.get(STORAGE_KEY) || {})[id];
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
     /**
      * Clear verification info from localStorage
      */
-    clear: function () {
+    clear () {
       var id = this._getUsersStorageId();
       if (id) {
         var verificationInfo = this._storage.get(STORAGE_KEY) || {};

--- a/app/scripts/views/app.js
+++ b/app/scripts/views/app.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
   const p = require('lib/promise');
 
   var AppView = BaseView.extend({
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._environment = options.environment;
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
       'click a[href^="/"]': 'onAnchorClick'
     },
 
-    onAnchorClick: function (event) {
+    onAnchorClick (event) {
       // if someone killed this event, or the user is holding a modifier
       // key, ignore the event.
       if (event.isDefaultPrevented() ||
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise}
      */
-    showView: function (View, options) {
+    showView (View, options) {
       return p().then(() => {
         options.model = options.model || new Backbone.Model();
 
@@ -136,7 +136,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise}
      */
-    showChildView: function (ChildView, ParentView, options) {
+    showChildView (ChildView, ParentView, options) {
       // If currentView is of the ParentView type, simply show the subView
       return p().then(() => {
         if (! (this._currentView instanceof ParentView)) {
@@ -167,7 +167,7 @@ define(function (require, exports, module) {
      *
      * @param {String} title
      */
-    setTitle: function (title) {
+    setTitle (title) {
       this.window.document.title = title;
     }
 

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -117,7 +117,7 @@ define(function (require, exports, module) {
      */
     viewName: '',
 
-    constructor: function (options) {
+    constructor (options) {
       options = options || {};
 
       this.broker = options.broker;
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise}
      */
-    render: function () {
+    render () {
       if (this.layoutClassName) {
         $('body').addClass(this.layoutClassName);
       }
@@ -214,7 +214,7 @@ define(function (require, exports, module) {
      * @param {String|Element} content
      * @returns {undefined}
      */
-    writeToDOM: function (content) {
+    writeToDOM (content) {
       return domWriter.write(this.window, content);
     },
 
@@ -225,7 +225,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise} resolves to true or false.
      */
-    checkAuthorization: function () {
+    checkAuthorization () {
       if (this.mustAuth || this.mustVerify) {
         var account = this.getSignedInAccount();
         return account.sessionStatus()
@@ -266,14 +266,14 @@ define(function (require, exports, module) {
     // If the user navigates to a page that requires auth and their session
     // is not currently cached, we ask them to sign in again. If the relier
     // specifies an email address, we force the user to use that account.
-    _reAuthPage: function () {
+    _reAuthPage () {
       if (this.relier && this.relier.get('email')) {
         return 'force_auth';
       }
       return 'signin';
     },
 
-    displayStatusMessages: function () {
+    displayStatusMessages () {
       var success = this.model.get('success');
       if (success) {
         this.displaySuccess(success);
@@ -293,7 +293,7 @@ define(function (require, exports, module) {
       }
     },
 
-    titleFromView: function (baseTitle) {
+    titleFromView (baseTitle) {
       var title = baseTitle || DEFAULT_TITLE;
       var titleText = this.$('header:first h1').text();
       var subText = this.$('header:first h2').text();
@@ -309,7 +309,7 @@ define(function (require, exports, module) {
       return title;
     },
 
-    getContext: function () {
+    getContext () {
       // use cached context, if available. This prevents the context()
       // function from being called multiple times per render.
       if (! this._context) {
@@ -323,7 +323,7 @@ define(function (require, exports, module) {
       return ctx;
     },
 
-    context: function () {
+    context () {
       // Implement in subclasses
     },
 
@@ -333,7 +333,7 @@ define(function (require, exports, module) {
      * @param {String} text - string to translate
      * @returns {String}
      */
-    translate: function (text) {
+    translate (text) {
       return this.translator.get(text, this.getContext());
     },
 
@@ -347,7 +347,7 @@ define(function (require, exports, module) {
      * @param {String} [text] - string to translate
      * @returns {Function}
      */
-    translateInTemplate: function (text) {
+    translateInTemplate (text) {
       if (text) {
         return this.translate.bind(this, text);
       } else {
@@ -411,7 +411,7 @@ define(function (require, exports, module) {
       return p();
     },
 
-    destroy: function (remove) {
+    destroy (remove) {
       this.trigger('destroy');
 
       if (this.beforeDestroy) {
@@ -437,7 +437,7 @@ define(function (require, exports, module) {
       this.trigger('destroyed');
     },
 
-    trackChildView: function (view) {
+    trackChildView (view) {
       if (! _.contains(this.childViews, view)) {
         this.childViews.push(view);
         view.on('destroyed', _.bind(this.untrackChildView, this, view));
@@ -446,19 +446,19 @@ define(function (require, exports, module) {
       return view;
     },
 
-    untrackChildView: function (view) {
+    untrackChildView (view) {
       this.childViews = _.without(this.childViews, view);
 
       return view;
     },
 
-    destroyChildViews: function () {
+    destroyChildViews () {
       _.invoke(this.childViews, 'destroy');
 
       this.childViews = [];
     },
 
-    isChildViewTracked: function (view) {
+    isChildViewTracked (view) {
       return _.indexOf(this.childViews, view) > -1;
     },
 
@@ -478,7 +478,7 @@ define(function (require, exports, module) {
      */
     displaySuccessUnsafe: _.partial(displaySuccess, 'html'),
 
-    hideSuccess: function () {
+    hideSuccess () {
       this.$('.success').slideUp(STATUS_MESSAGE_ANIMATION_MS);
       this._isSuccessVisible = false;
     },
@@ -488,7 +488,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isSuccessVisible: function () {
+    isSuccessVisible () {
       return !! this._isSuccessVisible;
     },
 
@@ -500,7 +500,7 @@ define(function (require, exports, module) {
      * @return {String} translated error text (if available), untranslated
      *   error text otw.
      */
-    translateError: function (err) {
+    translateError (err) {
       var errors = getErrorModule(err);
       var translated = errors.toInterpolatedMessage(err, this.translator);
 
@@ -513,7 +513,7 @@ define(function (require, exports, module) {
      *
      * @method disableErrors
      */
-    disableErrors: function () {
+    disableErrors () {
       this._areErrorsEnabled = false;
     },
 
@@ -547,7 +547,7 @@ define(function (require, exports, module) {
      *
      * @param {Error} err
      */
-    logError: function (err) {
+    logError (err) {
       err = this._normalizeError(err);
 
       // The error could already be logged, if so, abort mission.
@@ -571,7 +571,7 @@ define(function (require, exports, module) {
      * @param {Error} err
      * @returns {Promise}
      */
-    fatalError: function (err) {
+    fatalError (err) {
       return ErrorUtils.fatalError(
         err, this.sentryMetrics, this.metrics, this.window, this.translator);
     },
@@ -581,11 +581,11 @@ define(function (require, exports, module) {
      *
      * @returns {String}
      */
-    getViewName: function () {
+    getViewName () {
       return this.viewName;
     },
 
-    _normalizeError: function (err) {
+    _normalizeError (err) {
       var errors = getErrorModule(err);
       if (! err) {
         // likely an error in logic, display an unexpected error to the
@@ -609,7 +609,7 @@ define(function (require, exports, module) {
     /**
      * Log the current view
      */
-    logView: function () {
+    logView () {
       this.metrics.logView(this.getViewName());
     },
 
@@ -618,7 +618,7 @@ define(function (require, exports, module) {
      *
      * @param {String} eventName
      */
-    logEvent: function (eventName) {
+    logEvent (eventName) {
       this.metrics.logEvent(eventName);
     },
 
@@ -627,7 +627,7 @@ define(function (require, exports, module) {
      *
      * @param {String} eventName
      */
-    logEventOnce: function (eventName) {
+    logEventOnce (eventName) {
       this.metrics.logEventOnce(eventName);
     },
 
@@ -636,16 +636,16 @@ define(function (require, exports, module) {
      *
      * @param {String} eventName
      */
-    logViewEvent: function (eventName) {
+    logViewEvent (eventName) {
       this.metrics.logViewEvent(this.getViewName(), eventName);
     },
 
-    hideError: function () {
+    hideError () {
       this.$('.error').slideUp(STATUS_MESSAGE_ANIMATION_MS);
       this._isErrorVisible = false;
     },
 
-    isErrorVisible: function () {
+    isErrorVisible () {
       return !! this._isErrorVisible;
     },
 
@@ -656,7 +656,7 @@ define(function (require, exports, module) {
      * @param {Object} [nextViewData] - data to pass to the next view
      * @param {RouterOptions} [routerOptions] - options to pass to the router
      */
-    navigate: function (url, nextViewData, routerOptions) {
+    navigate (url, nextViewData, routerOptions) {
       nextViewData = nextViewData || {};
       routerOptions = routerOptions || {};
 
@@ -757,7 +757,7 @@ define(function (require, exports, module) {
      * @param {String|Function} handler
      * @returns {undefined}
      */
-    invokeHandler: function (handler/*, args...*/) {
+    invokeHandler (handler/*, args...*/) {
       // convert a name to a function.
       if (_.isString(handler)) {
         handler = this[handler];
@@ -785,7 +785,7 @@ define(function (require, exports, module) {
      *
      * @returns {Account}
      */
-    getSignedInAccount: function () {
+    getSignedInAccount () {
       return this.user.getSignedInAccount();
     },
 
@@ -793,7 +793,7 @@ define(function (require, exports, module) {
      * Returns the account that is active in the current view. It may not
      * be the currently logged in account.
      */
-    getAccount: function () {
+    getAccount () {
       // Implement in subclasses
     },
 
@@ -804,7 +804,7 @@ define(function (require, exports, module) {
      * @param {Object} [options] - options to send.
      * @returns {Promise} resolves when complete
      */
-    showChildView: function (/* ChildView, options */) {
+    showChildView (/* ChildView, options */) {
       // Implement in subclasses
       return p();
     },
@@ -816,7 +816,7 @@ define(function (require, exports, module) {
      * @param {String} methodName
      * @returns {Promise}
      */
-    invokeBrokerMethod: function (methodName/*, ...*/) {
+    invokeBrokerMethod (methodName/*, ...*/) {
       var args = [].slice.call(arguments, 1);
 
       var broker = this.broker;
@@ -833,7 +833,7 @@ define(function (require, exports, module) {
      * @returns {Variant} behavior's return value if behavior is a function,
      *         otherwise return the behavior.
      */
-    invokeBehavior: function (behavior) {
+    invokeBehavior (behavior) {
       if (_.isFunction(behavior)) {
         return behavior(this);
       }

--- a/app/scripts/views/cannot_create_account.js
+++ b/app/scripts/views/cannot_create_account.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
     template: CannotCreateAccountTemplate,
     className: 'cannot-create-account',
 
-    context: function () {
+    context () {
       return {
         isSync: this.relier.isSync()
       };

--- a/app/scripts/views/choose_what_to_sync.js
+++ b/app/scripts/views/choose_what_to_sync.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
     template: Template,
     className: 'choose-what-to-sync',
 
-    initialize: function () {
+    initialize () {
       // Account data is passed in from sign up flow.
       this._account = this.user.initAccount(this.model.get('account'));
 
@@ -26,11 +26,11 @@ define(function (require, exports, module) {
       this.onSubmitComplete = this.model.get('onSubmitComplete');
     },
 
-    getAccount: function () {
+    getAccount () {
       return this._account;
     },
 
-    beforeRender: function () {
+    beforeRender () {
       // user cannot proceed if they have not initiated a sign up/in.
       if (! this.getAccount().get('sessionToken')) {
         this.navigate('signup');
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
       }
     },
 
-    context: function () {
+    context () {
       var account = this.getAccount();
 
       return {
@@ -52,7 +52,7 @@ define(function (require, exports, module) {
       };
     },
 
-    submit: function () {
+    submit () {
       var account = this.getAccount();
       var declinedEngines = this._getDeclinedEngines();
 
@@ -74,7 +74,7 @@ define(function (require, exports, module) {
      * @returns {Boolean}
      * @private
      */
-    _isEngineSupported: function (engineName) {
+    _isEngineSupported (engineName) {
       var supportedEngines =
                 this.broker.getCapability('chooseWhatToSyncWebV1').engines;
       return supportedEngines.indexOf(engineName) > -1;
@@ -87,7 +87,7 @@ define(function (require, exports, module) {
      * @returns {Array}
      * @private
      */
-    _getDeclinedEngines: function () {
+    _getDeclinedEngines () {
       var uncheckedEngineEls =
             this.$el.find('input[name=sync-content]').not(':checked');
 
@@ -102,7 +102,7 @@ define(function (require, exports, module) {
      * @param {Array} declinedEngines
      * @private
      */
-    _trackUncheckedEngines: function (declinedEngines) {
+    _trackUncheckedEngines (declinedEngines) {
       if (_.isArray(declinedEngines)) {
         declinedEngines.forEach((engine) => {
           this.logViewEvent('engine-unchecked.' + engine);

--- a/app/scripts/views/clear_storage.js
+++ b/app/scripts/views/clear_storage.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
   var View = BaseView.extend({
     template: Template,
 
-    beforeRender: function () {
+    beforeRender () {
       try {
         localStorage.clear();
         sessionStorage.clear();

--- a/app/scripts/views/close_button.js
+++ b/app/scripts/views/close_button.js
@@ -23,7 +23,7 @@ define(function (require, exports, module) {
       'click': BaseView.preventDefaultThen('close')
     },
 
-    render: function () {
+    render () {
       return p().then(() => {
         var foxLogo = $('#fox-logo');
         foxLogo.after(this.template());
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
       });
     },
 
-    close: function () {
+    close () {
       this.logError(OAuthErrors.toError('USER_CANCELED_OAUTH_LOGIN'));
       return this.broker.cancel()
         .fail((err) => this.displayError(err));

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
     template: Template,
     className: 'complete-reset-password',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       var searchParams = Url.searchParams(this.window.location.search);
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
       return proto.afterVisible.call(this);
     },
 
-    context: function () {
+    context () {
       var verificationInfo = this._verificationInfo;
       var doesLinkValidate = verificationInfo.isValid();
       var isLinkExpired = verificationInfo.isExpired();
@@ -83,18 +83,18 @@ define(function (require, exports, module) {
       };
     },
 
-    isValidEnd: function () {
+    isValidEnd () {
       return this._getPassword() === this._getVPassword();
     },
 
-    showValidationErrorsEnd: function () {
+    showValidationErrorsEnd () {
       if (this._getPassword() !== this._getVPassword()) {
         var err = AuthErrors.toError('PASSWORDS_DO_NOT_MATCH');
         this.displayError(err);
       }
     },
 
-    submit: function () {
+    submit () {
       var verificationInfo = this._verificationInfo;
       var password = this._getPassword();
       var token = verificationInfo.get('token');
@@ -148,11 +148,11 @@ define(function (require, exports, module) {
         });
     },
 
-    _getPassword: function () {
+    _getPassword () {
       return this.$('#password').val();
     },
 
-    _getVPassword: function () {
+    _getVPassword () {
       return this.$('#vpassword').val();
     },
 

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
     template: CompleteSignUpTemplate,
     className: 'complete_sign_up',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       var searchParams = Url.searchParams(this.window.location.search);
@@ -57,11 +57,11 @@ define(function (require, exports, module) {
       this._email = this._account.get('email');
     },
 
-    getAccount: function () {
+    getAccount () {
       return this._account;
     },
 
-    _navigateToCompleteScreen: function () {
+    _navigateToCompleteScreen () {
       if (this.isSignUp()) {
         this.navigate('signup_complete');
       } else {
@@ -69,7 +69,7 @@ define(function (require, exports, module) {
       }
     },
 
-    beforeRender: function () {
+    beforeRender () {
       var verificationInfo = this._verificationInfo;
       if (! verificationInfo.isValid()) {
         // One or more parameters fails validation. Abort and show an
@@ -156,7 +156,7 @@ define(function (require, exports, module) {
           });
     },
 
-    context: function () {
+    context () {
       var verificationInfo = this._verificationInfo;
       return {
         canResend: this._canResend(),
@@ -168,7 +168,7 @@ define(function (require, exports, module) {
       };
     },
 
-    _canResend: function () {
+    _canResend () {
       // _getResendSessionToken is only returned if the user signed up in the
       // same browser in which they opened the verification link.
       return !! this._getResendSessionToken() && this.isSignUp();
@@ -178,7 +178,7 @@ define(function (require, exports, module) {
     // address. We intentionally don't cache it during view initialization so that
     // we can capture sessionTokens from accounts created (in this browser)
     // since the view was loaded.
-    _getResendSessionToken: function () {
+    _getResendSessionToken () {
       return this.user.getAccountByEmail(this._email).get('sessionToken');
     },
 

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
     // used by unit tests
     VERIFICATION_POLL_IN_MS: Constants.VERIFICATION_POLL_IN_MS,
 
-    initialize: function () {
+    initialize () {
       // Account data is passed in from sign up and sign in flows.
       // It's important for Sync flows where account data holds
       // ephemeral properties like unwrapBKey and keyFetchToken
@@ -38,11 +38,11 @@ define(function (require, exports, module) {
       this.flow = this.model.get('flow');
     },
 
-    getAccount: function () {
+    getAccount () {
       return this._account;
     },
 
-    context: function () {
+    context () {
       var email = this.getAccount().get('email');
       var isSignIn = this.isSignIn();
       var isSignUp = this.isSignUp();
@@ -60,18 +60,18 @@ define(function (require, exports, module) {
       };
     },
 
-    _bouncedEmailSignup: function () {
+    _bouncedEmailSignup () {
       this.navigate('signup', {
         bouncedEmail: this.getAccount().get('email')
       });
     },
 
-    _getMissingSessionTokenScreen: function () {
+    _getMissingSessionTokenScreen () {
       var screenUrl = this.isSignUp() ? 'signup' : 'signin';
       return this.broker.transformLink(screenUrl);
     },
 
-    _navigateToCompleteScreen: function () {
+    _navigateToCompleteScreen () {
       if (this.isSignUp()) {
         this.navigate('signup_complete');
       } else {
@@ -79,7 +79,7 @@ define(function (require, exports, module) {
       }
     },
 
-    beforeRender: function () {
+    beforeRender () {
       // user cannot confirm if they have not initiated a sign up.
       if (! this.getAccount().get('sessionToken')) {
         this.navigate(this._getMissingSessionTokenScreen());

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -23,13 +23,13 @@ define(function (require, exports, module) {
     template: Template,
     className: 'confirm-reset-password',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
       this._verificationPollMS = options.verificationPollMS ||
               this.VERIFICATION_POLL_IN_MS;
     },
 
-    context: function () {
+    context () {
       var email = this.model.get('email');
       var isSignInEnabled = this.relier.get('resetPasswordConfirm');
 
@@ -41,7 +41,7 @@ define(function (require, exports, module) {
       };
     },
 
-    beforeRender: function () {
+    beforeRender () {
       // user cannot confirm if they have not initiated a reset password
       if (! this.model.has('passwordForgotToken')) {
         this.navigate('reset_password');
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
       }
     },
 
-    afterVisible: function () {
+    afterVisible () {
       var account = this.user.initAccount({ email: this.model.get('email') });
       return this.broker.persistVerificationData(account)
         .then(() => {
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
         });
     },
 
-    _waitForConfirmation: function () {
+    _waitForConfirmation () {
       var confirmationDeferred = this._confirmationDeferred = p.defer();
       var confirmationPromise = this._confirmationPromise = confirmationDeferred.promise;
 
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
       return confirmationPromise;
     },
 
-    _finishPasswordResetSameBrowser: function (sessionInfo) {
+    _finishPasswordResetSameBrowser (sessionInfo) {
       // Only the account UID, unwrapBKey and keyFetchToken are passed
       // from the verification tab. Load other from localStorage
       var account = this.user.getAccountByUid(sessionInfo.uid);
@@ -181,11 +181,11 @@ define(function (require, exports, module) {
         });
     },
 
-    _getSignInRoute: function () {
+    _getSignInRoute () {
       return this.broker.transformLink('/signin').replace(/^\//, '');
     },
 
-    _finishPasswordResetDifferentBrowser: function () {
+    _finishPasswordResetDifferentBrowser () {
       // user verified in a different browser, make them sign in. OAuth
       // users will be redirected back to the RP, Sync users will be
       // taken to the Sync controlled completion page.
@@ -224,7 +224,7 @@ define(function (require, exports, module) {
         });
     },
 
-    _stopWaitingForServerConfirmation: function () {
+    _stopWaitingForServerConfirmation () {
       if (this._waitForServerConfirmationTimeout) {
         this.clearTimeout(this._waitForServerConfirmationTimeout);
       }
@@ -232,7 +232,7 @@ define(function (require, exports, module) {
     },
 
     _isWaitingForLoginMessage: false,
-    _waitForLoginMessage: function () {
+    _waitForLoginMessage () {
       var deferred = p.defer();
 
       this._isWaitingForLoginMessage = true;
@@ -242,7 +242,7 @@ define(function (require, exports, module) {
       return deferred.promise;
     },
 
-    _stopListeningForInterTabMessages: function () {
+    _stopListeningForInterTabMessages () {
       this._isWaitingForLoginMessage = false;
       this.notifier.off();
       // Sensitive data is passed between tabs using localStorage.
@@ -250,7 +250,7 @@ define(function (require, exports, module) {
       this.notifier.clear();
     },
 
-    _stopWaiting: function () {
+    _stopWaiting () {
       this._stopWaitingForServerConfirmation();
       this._stopListeningForInterTabMessages();
     },

--- a/app/scripts/views/cookies_disabled.js
+++ b/app/scripts/views/cookies_disabled.js
@@ -13,7 +13,7 @@ define(function (require, exports, module) {
   const Template = require('stache!templates/cookies_disabled');
 
   var View = BaseView.extend({
-    constructor: function (options) {
+    constructor (options) {
       BaseView.call(this, options);
 
       this._Storage = options.Storage || Storage;
@@ -26,7 +26,7 @@ define(function (require, exports, module) {
       'click #submit-btn': 'backIfLocalStorageEnabled'
     },
 
-    backIfLocalStorageEnabled: function () {
+    backIfLocalStorageEnabled () {
       if (! this._Storage.isLocalStorageEnabled()) {
         return this.displayError(AuthErrors.toError('COOKIES_STILL_DISABLED'));
       }

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
     afterSignInBrokerMethod: 'afterForceAuth',
     afterSignInNavigateData: { clearQueryParams: true },
 
-    _getAndValidateAccountData: function () {
+    _getAndValidateAccountData () {
       var fieldsToPick = ['email', 'uid'];
       var accountData = {};
       var relier = this.relier;
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
           accountData, RELIER_DATA_SCHEMA, AuthErrors);
     },
 
-    beforeRender: function () {
+    beforeRender () {
       var accountData;
 
       try {
@@ -109,7 +109,7 @@ define(function (require, exports, module) {
       }
     },
 
-    _signUpIfUidChangeSupported: function (account) {
+    _signUpIfUidChangeSupported (account) {
       if (this.broker.hasCapability('allowUidChange')) {
         return this._navigateToForceSignUp(account);
       } else {
@@ -117,7 +117,7 @@ define(function (require, exports, module) {
       }
     },
 
-    _signInIfUidChangeSupported: function (account) {
+    _signInIfUidChangeSupported (account) {
       // if the broker supports a UID change, use force_auth to sign in,
       // otherwise print a big error message.
       if (! this.broker.hasCapability('allowUidChange')) {
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
       }
     },
 
-    _navigateToForceSignUp: function (account) {
+    _navigateToForceSignUp (account) {
       // The default behavior of FxDesktop brokers is to halt before
       // the signup confirmation poll because about:accounts takes care
       // of polling and updating the UI. /force_auth is not opened in
@@ -141,13 +141,13 @@ define(function (require, exports, module) {
       });
     },
 
-    _navigateToForceResetPassword: function () {
+    _navigateToForceResetPassword () {
       return this.navigate(this.broker.transformLink('reset_password'), {
         forceEmail: this.relier.get('email')
       });
     },
 
-    context: function () {
+    context () {
       return {
         email: this.relier.get('email'),
         fatalError: this.model.get('error'),
@@ -159,11 +159,11 @@ define(function (require, exports, module) {
       'click a[href="/reset_password"]': BaseView.cancelEventThen('_navigateToForceResetPassword')
     }),
 
-    beforeDestroy: function () {
+    beforeDestroy () {
       this._formPrefill.set('password', this.getElementValue('.password'));
     },
 
-    onSignInError: function (account, password, error) {
+    onSignInError (account, password, error) {
       if (AuthErrors.is(error, 'UNKNOWN_ACCOUNT')) {
         if (this.relier.has('uid')) {
           if (this.broker.hasCapability('allowUidChange')) {
@@ -184,7 +184,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise}
      */
-    afterVisible: function () {
+    afterVisible () {
       var email = this.relier.get('email');
       var account = this.user.getAccountByEmail(email);
 

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -57,7 +57,7 @@ define(function (require, exports, module) {
     // Time to wait for a request to finish before showing a notice
     LONGER_THAN_EXPECTED: new Duration('10s').milliseconds(),
 
-    constructor: function (options) {
+    constructor (options) {
       BaseView.call(this, options);
 
       // attach events of the descendent view and this view.
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
      * @method getFormValues
      * @returns {Object}
      */
-    getFormValues: function () {
+    getFormValues () {
       var values = {};
       var inputEls = this.$('input,textarea,select');
 
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
       return values;
     },
 
-    enableSubmitIfValid: function () {
+    enableSubmitIfValid () {
       // the change event can be called after the form is already
       // submitted if the user presses "enter" in the form. If the
       // form is in the midst of being submitted, bail out now.
@@ -134,7 +134,7 @@ define(function (require, exports, module) {
     /**
      * TODO - this should be called disableSubmit
      */
-    disableForm: function () {
+    disableForm () {
       // the disabled class is used instead of the disabled attribute
       // so that the submit handler is still called. With the submit attribute
       // applied, no submit handler is fired, and the form validation does not
@@ -143,13 +143,13 @@ define(function (require, exports, module) {
       this._isFormEnabled = false;
     },
 
-    enableForm: function () {
+    enableForm () {
       this.$('button[type=submit]').removeClass('disabled');
       this._isFormEnabled = true;
     },
 
     _isFormEnabled: true,
-    isFormEnabled: function () {
+    isFormEnabled () {
       return !! this._isFormEnabled;
     },
 
@@ -234,7 +234,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isValid: function () {
+    isValid () {
       if (! this.isValidStart()) {
         return false;
       }
@@ -260,7 +260,7 @@ define(function (require, exports, module) {
      *
      * @return {Boolean} true if form is valid, false otw.
      */
-    isValidStart: function () {
+    isValidStart () {
       return true;
     },
 
@@ -272,7 +272,7 @@ define(function (require, exports, module) {
      *
      * @return {Boolean} true if form is valid, false otw.
      */
-    isValidEnd: function () {
+    isValidEnd () {
       return true;
     },
 
@@ -284,7 +284,7 @@ define(function (require, exports, module) {
      *
      * @returns {undefined}
      */
-    showValidationErrors: function () {
+    showValidationErrors () {
       this.hideError();
 
       if (this.showValidationErrorsStart()) {
@@ -315,7 +315,7 @@ define(function (require, exports, module) {
      * @param {String} el
      * @returns {String}
      */
-    getElementValue: function (el) {
+    getElementValue (el) {
       return this.$(el).val();
     },
 
@@ -327,7 +327,7 @@ define(function (require, exports, module) {
      *
      * @return {undefined} true if a validation error is displayed.
      */
-    showValidationErrorsStart: function () {
+    showValidationErrorsStart () {
     },
 
     /**
@@ -338,7 +338,7 @@ define(function (require, exports, module) {
      *
      * @return {undefined} true if a validation error is displayed.
      */
-    showValidationErrorsEnd: function () {
+    showValidationErrorsEnd () {
     },
 
     /**
@@ -348,7 +348,7 @@ define(function (require, exports, module) {
      * @param {Error} err
      * @returns {String}
      */
-    showValidationError: function (el, err) {
+    showValidationError (el, err) {
       this.logError(err);
 
       var invalidEl = this.$(el);
@@ -388,7 +388,7 @@ define(function (require, exports, module) {
      * @returns {Promise|Boolean|none} Return a promise if
      *   beforeSubmit is an asynchronous operation.
      */
-    beforeSubmit: function () {
+    beforeSubmit () {
       return this.disableForm();
     },
 
@@ -399,7 +399,7 @@ define(function (require, exports, module) {
      * and beforeSubmit does not return false.
      *
      */
-    submit: function () {
+    submit () {
     },
 
     /**
@@ -412,7 +412,7 @@ define(function (require, exports, module) {
      * @returns {Promise|none} Return a promise if afterSubmit is
      *   an asynchronous operation.
      */
-    afterSubmit: function (result) {
+    afterSubmit (result) {
       return p().then(() => {
         // the flow may be halted by an authentication broker after form
         // submission. Views may display an error without throwing an exception.
@@ -435,7 +435,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean} true if form is being submitted, false otw.
      */
-    isSubmitting: function () {
+    isSubmitting () {
       return this._isSubmitting;
     },
 
@@ -444,7 +444,7 @@ define(function (require, exports, module) {
      *
      * TODO - this should be named disableForm, but that name is already taken.
      */
-    halt: function () {
+    halt () {
       this.$('input,textarea,button').attr('disabled', 'disabled').blur();
       this._isHalted = true;
     },
@@ -454,7 +454,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean} true if the view is halted, false otw.
      */
-    isHalted: function () {
+    isHalted () {
       return this._isHalted;
     },
 
@@ -463,7 +463,7 @@ define(function (require, exports, module) {
      *
      * @returns {Object|null} the form values or null if they haven't changed.
      */
-    detectFormValueChanges: function () {
+    detectFormValueChanges () {
       // oldValues will be `undefined` the first time through.
       var oldValues = this._previousFormValues;
       var newValues = this.getFormValues();
@@ -481,7 +481,7 @@ define(function (require, exports, module) {
      *
      * @returns {Object|null} the form values or null if they haven't changed.
      */
-    updateFormValueChanges: function () {
+    updateFormValueChanges () {
       var newValues = this.detectFormValueChanges();
       if (newValues) {
         this._previousFormValues = newValues;

--- a/app/scripts/views/marketing_snippet.js
+++ b/app/scripts/views/marketing_snippet.js
@@ -22,13 +22,13 @@ define(function (require, exports, module) {
   var View = BaseView.extend({
     template: Template,
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._service = options.service;
     },
 
-    context: function () {
+    context () {
       var shouldShowMarketing = this._shouldShowSignUpMarketing();
 
       return {
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
       };
     },
 
-    _shouldShowSignUpMarketing: function () {
+    _shouldShowSignUpMarketing () {
       var isFirefoxMobile = this._isFirefoxMobile();
       var isSignUp = this.isSignUp();
       var isSignIn = this.isSignIn();
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
       return (isSignUp || isSignIn) && isSync && ! isFirefoxMobile;
     },
 
-    _isFirefoxMobile: function () {
+    _isFirefoxMobile () {
       // For UA information, see
       // https://developer.mozilla.org/docs/Gecko_user_agent_string_reference
 

--- a/app/scripts/views/marketing_snippet_ios.js
+++ b/app/scripts/views/marketing_snippet_ios.js
@@ -55,7 +55,7 @@ define(function (require, exports, module) {
   var View = MarketingSnippetView.extend({
     template: Template,
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       MarketingSnippetView.prototype.initialize.call(this, options);
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
       this._language = options.language;
     },
 
-    context: function () {
+    context () {
       var shouldShowMarketing = this._shouldShowSignUpMarketing();
       var isIos = this._isIos();
       var isAndroid = this._isAndroid();
@@ -80,17 +80,17 @@ define(function (require, exports, module) {
       };
     },
 
-    _isIos: function () {
+    _isIos () {
       var plat = this.window.navigator.platform;
 
       return /i(Phone|Pad|Pod)/.test(plat);
     },
 
-    _isAndroid: function () {
+    _isAndroid () {
       return /android/i.test(this.window.navigator.userAgent);
     },
 
-    _storeImage: function (buttonDir, imageFormat) {
+    _storeImage (buttonDir, imageFormat) {
       var buttonPath = _.contains(playStoreImageLanguages, this._language) ?
                           this._language : 'en';
 
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
       return '/images/' + buttonDir + '/' + buttonPath + '.' + imageFormat;
     },
 
-    _isHighRes: function () {
+    _isHighRes () {
       var win = this.window;
 
       return !! (win.matchMedia && win.matchMedia('(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 1.5dppx), (min-resolution: 144dpi)'));

--- a/app/scripts/views/mixins/account-reset-mixin.js
+++ b/app/scripts/views/mixins/account-reset-mixin.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
   var t = BaseView.t;
 
   var AccountResetMixin = {
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._session = options.session;
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
      * @param {Object} account - account that has been reset
      * @returns {String}
      */
-    notifyOfResetAccount: function (account) {
+    notifyOfResetAccount (account) {
       this._resetAccount = account;
 
       var err = AuthErrors.toError('ACCOUNT_RESET');
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise} - resolves when complete
      */
-    sendAccountResetEmail: function () {
+    sendAccountResetEmail () {
       return this.resetPassword(this._resetAccount.get('email'))
         .fail((err) => {
           this._session.clear('oauth');

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
       // populated below using event name aliases
     },
 
-    onProfileUpdate: function (/* data */) {
+    onProfileUpdate (/* data */) {
       // implement in view
     },
 
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
      *                    the profile image is loading.
      * @returns {Promise}
      */
-    displayAccountProfileImage: function (account, options) {
+    displayAccountProfileImage (account, options) {
       options = options || {};
 
       var avatarWrapperEl = this.$(options.wrapperClass || '.avatar-wrapper');
@@ -87,29 +87,29 @@ define(function (require, exports, module) {
         });
     },
 
-    hasDisplayedAccountProfileImage: function () {
+    hasDisplayedAccountProfileImage () {
       return this._displayedProfileImage && ! this._displayedProfileImage.isDefault();
     },
 
-    setDefaultPlaceholderAvatar: function (avatarWrapperEl) {
+    setDefaultPlaceholderAvatar (avatarWrapperEl) {
       avatarWrapperEl = avatarWrapperEl || $('.avatar-wrapper');
       avatarWrapperEl.addClass('with-default');
     },
 
     // Makes sure the account has an up-to-date image cache.
     // This should be called after fetching the current profile image.
-    _updateCachedProfileImage: function (profileImage, account) {
+    _updateCachedProfileImage (profileImage, account) {
       if (! account.isDefault()) {
         account.setProfileImage(profileImage);
         this.user.setAccount(account);
       }
     },
 
-    _shouldShowDefaultProfileImage: function (account) {
+    _shouldShowDefaultProfileImage (account) {
       return ! account.has('profileImageUrl');
     },
 
-    _addLoadingSpinner: function (spinnerWrapperEl) {
+    _addLoadingSpinner (spinnerWrapperEl) {
       if (spinnerWrapperEl) {
         return $('<span class="avatar-spinner"></span>').appendTo(spinnerWrapperEl.addClass('with-spinner'));
       }
@@ -117,7 +117,7 @@ define(function (require, exports, module) {
 
     // "Completes" the spinner, transitioning the semi-circle to a circle, and
     // then removes the spinner element.
-    _completeLoadingSpinner: function (spinnerEl) {
+    _completeLoadingSpinner (spinnerEl) {
       if (_.isUndefined(spinnerEl)) {
         return p();
       }
@@ -147,7 +147,7 @@ define(function (require, exports, module) {
       return deferred.promise;
     },
 
-    logAccountImageChange: function (account) {
+    logAccountImageChange (account) {
       // if the user already has an image set, then report a change event
       if (account.get('hadProfileImageSetBefore')) {
         this.logViewEvent('submit.change');
@@ -156,13 +156,13 @@ define(function (require, exports, module) {
       }
     },
 
-    updateProfileImage: function (profileImage, account) {
+    updateProfileImage (profileImage, account) {
       account.setProfileImage(profileImage);
       return this.user.setAccount(account)
         .then(_.bind(this._notifyProfileUpdate, this, account.get('uid')));
     },
 
-    deleteDisplayedAccountProfileImage: function (account) {
+    deleteDisplayedAccountProfileImage (account) {
       return account.deleteAvatar(this._displayedProfileImage.get('id'))
         .then(() => {
           // A blank image will clear the cache
@@ -170,14 +170,14 @@ define(function (require, exports, module) {
         });
     },
 
-    updateDisplayName: function (displayName) {
+    updateDisplayName (displayName) {
       var account = this.getSignedInAccount();
       account.set('displayName', displayName);
       return this.user.setAccount(account)
         .then(_.bind(this._notifyProfileUpdate, this, account.get('uid')));
     },
 
-    _notifyProfileUpdate: function (uid) {
+    _notifyProfileUpdate (uid) {
       this.notifier.triggerAll(Notifier.PROFILE_CHANGE, {
         uid: uid
       });

--- a/app/scripts/views/mixins/back-mixin.js
+++ b/app/scripts/views/mixins/back-mixin.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
 
   var BackMixin = {
     _canGoBack: false,
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._canGoBack = options.canGoBack;
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
      * @method getContext
      * @returns {Object}
      */
-    getContext: function () {
+    getContext () {
       var context = BaseView.prototype.getContext.call(this);
 
       if (! ('canGoBack' in context)) {
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
      * @method back
      * @param {Object} [nextViewData] - data to send to the next(last) view.
      */
-    back: function (nextViewData) {
+    back (nextViewData) {
       this.logViewEvent('back');
 
       this.notifier.trigger('navigate-back', {
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
      * @method backOnEnter
      * @param {Object} event
      */
-    backOnEnter: function (event) {
+    backOnEnter (event) {
       if (event.which === KeyCodes.ENTER) {
         this.back();
       }
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
      * @method canGoBack
      * @returns {Boolean}
      */
-    canGoBack: function () {
+    canGoBack () {
       return !! this._canGoBack;
     }
   };

--- a/app/scripts/views/mixins/checkbox-mixin.js
+++ b/app/scripts/views/mixins/checkbox-mixin.js
@@ -18,14 +18,14 @@ define(function (require, exports, module) {
       'change input[type=checkbox]': 'logCheckboxChange'
     },
 
-    afterRender: function () {
+    afterRender () {
       this.$el.find('.fxa-checkbox').get().forEach(function (el) {
         // FxaCheckbox enhances the native checkbox and provides custom styling
         new FxaCheckbox(el).init();
       });
     },
 
-    logCheckboxChange: function (event) {
+    logCheckboxChange (event) {
       var target = $(event.currentTarget);
       var isChecked = target.is(':checked');
       var checkedText = isChecked ? 'checked' : 'unchecked';

--- a/app/scripts/views/mixins/experiment-mixin.js
+++ b/app/scripts/views/mixins/experiment-mixin.js
@@ -8,7 +8,7 @@ define(function (require, exports, module) {
   const ExperimentInterface = require('lib/experiment');
 
   module.exports = {
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this.experiments = new ExperimentInterface({
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
      * @param {String} experimentName
      * @return {Boolean}
      */
-    isInExperiment: function (experimentName) {
+    isInExperiment (experimentName) {
       return this.experiments.isInExperiment(experimentName);
     },
 
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
      * @param {String} groupName
      * @return {Boolean}
      */
-    isInExperimentGroup: function (experimentName, groupName) {
+    isInExperimentGroup (experimentName, groupName) {
       return this.experiments.isInExperimentGroup(experimentName, groupName);
     }
   };

--- a/app/scripts/views/mixins/floating-placeholder-mixin.js
+++ b/app/scripts/views/mixins/floating-placeholder-mixin.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
       'input input[placeholder]': 'floatingPlaceholderMixinOnInput'
     },
 
-    afterRender: function () {
+    afterRender () {
       this.updateFormValueChanges();
     },
 
@@ -65,11 +65,11 @@ define(function (require, exports, module) {
       }
     },
 
-    focusLabelHelper: function (inputEl) {
+    focusLabelHelper (inputEl) {
       this.$el.find(inputEl).prev('.label-helper').addClass('focused');
     },
 
-    unfocusLabelHelper: function (inputEl) {
+    unfocusLabelHelper (inputEl) {
       this.$el.find(inputEl).prev('.label-helper').removeClass('focused');
     },
 
@@ -79,7 +79,7 @@ define(function (require, exports, module) {
      *
      * @param {Event} event
      */
-    floatingPlaceholderMixinOnInput: function (event) {
+    floatingPlaceholderMixinOnInput (event) {
       const $inputEl = $(event.currentTarget);
 
       // If no form values have changed, no need to show the
@@ -98,17 +98,17 @@ define(function (require, exports, module) {
      *
      * @param {Event} event
      */
-    floatingPlaceholderMixinOnSelect: function (event) {
+    floatingPlaceholderMixinOnSelect (event) {
       const $inputEl = $(event.currentTarget);
       this.showFloatingPlaceholder($inputEl, $inputEl.find('option:first').text());
       this.focusLabelHelper($inputEl);
     },
 
-    onInputFocus: function (event) {
+    onInputFocus (event) {
       this.focusLabelHelper($(event.currentTarget));
     },
 
-    onInputBlur: function (event) {
+    onInputBlur (event) {
       this.unfocusLabelHelper($(event.currentTarget));
     }
   };

--- a/app/scripts/views/mixins/loading-mixin.js
+++ b/app/scripts/views/mixins/loading-mixin.js
@@ -13,7 +13,7 @@ define(function (require, exports, module) {
   const loadingTemplate = require('stache!templates/loading');
 
   module.exports = {
-    initialize: function () {
+    initialize () {
       var loadingHTML = loadingTemplate({});
       this.writeToDOM(loadingHTML);
     }

--- a/app/scripts/views/mixins/marketing-mixin.js
+++ b/app/scripts/views/mixins/marketing-mixin.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
       'click .marketing-link': '_onMarketingClick'
     },
 
-    afterRender: function () {
+    afterRender () {
       this.$('.marketing-link').each((index, element) => {
         element = $(element);
 
@@ -34,12 +34,12 @@ define(function (require, exports, module) {
       });
     },
 
-    _onMarketingClick: function (event) {
+    _onMarketingClick (event) {
       var element = $(event.currentTarget);
       this._logMarketingClick(element);
     },
 
-    _logMarketingClick: function (element) {
+    _logMarketingClick (element) {
       var id = element.attr('data-marketing-id');
       var url = element.attr('href');
 

--- a/app/scripts/views/mixins/modal-settings-panel-mixin.js
+++ b/app/scripts/views/mixins/modal-settings-panel-mixin.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
   module.exports = {
     isModal: true,
 
-    initialize: function (options) {
+    initialize (options) {
       this.parentView = options.parentView;
     },
 
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
       'click .modal-panel #back': preventDefaultThen('_returnToAvatarChange')
     },
 
-    openPanel: function (event) {
+    openPanel (event) {
       $(this.el).modal({
         opacity: 0.75,
         showClose: false,
@@ -36,25 +36,25 @@ define(function (require, exports, module) {
       });
     },
 
-    _returnToAvatarChange: function () {
+    _returnToAvatarChange () {
       this.navigate('settings/avatar/change');
     },
 
-    _closePanelReturnToSettings: function () {
+    _closePanelReturnToSettings () {
       this.navigate('settings');
       this.closePanel();
     },
 
-    closePanel: function () {
+    closePanel () {
       this.destroy(true);
     },
 
-    closeModalPanel: function () {
+    closeModalPanel () {
       this.closePanel();
       $.modal.close();
     },
 
-    displaySuccess: function (msg) {
+    displaySuccess (msg) {
       this.parentView.displaySuccess(msg);
     }
   };

--- a/app/scripts/views/mixins/notifier-mixin.js
+++ b/app/scripts/views/mixins/notifier-mixin.js
@@ -17,7 +17,7 @@
  * ```js
  * ...
  * notifications: {
- *   'notification-1': function () {
+ *   'notification-1' () {
  *      // handle notification
  *   },
  *   'notification-2': '_handlerName'
@@ -55,7 +55,7 @@ define(function (require, exports, module) {
   }
 
   NotifierProxy.prototype = {
-    delegateNotifications: function (notifications) {
+    delegateNotifications (notifications) {
       var consumer = this._consumer;
       // based on delegateEvents from Backbone.View
       if (! (notifications || (notifications = _.result(consumer, 'notifications')))) {
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
      * @param {String} eventName
      * @param {Object} [data]
      */
-    trigger: function (eventName, data) {
+    trigger (eventName, data) {
       this._notifier.trigger(eventName, data, this._consumer);
     },
 
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
      * @param {String} eventName
      * @param {Object} [data]
      */
-    triggerAll: function (eventName, data) {
+    triggerAll (eventName, data) {
       this._notifier.triggerAll(eventName, data, this._consumer);
     },
 
@@ -102,7 +102,7 @@ define(function (require, exports, module) {
      * @param {String} eventName
      * @param {Object} [data]
      */
-    triggerRemote: function (eventName, data) {
+    triggerRemote (eventName, data) {
       this._notifier.triggerRemote(eventName, data);
     },
 
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
      * @param {String} eventName
      * @param {Function} callback
      */
-    on: function (eventName, callback) {
+    on (eventName, callback) {
       this._notifier.on(eventName, callback);
 
       this._notifierMessages.push({
@@ -128,7 +128,7 @@ define(function (require, exports, module) {
      * @param {String} [eventName]
      * @param {Function} [callback]
      */
-    off: function (eventName, callback) {
+    off (eventName, callback) {
       if (! eventName) {
         // unregister all callbacks for consumer.
         this._notifierMessages.forEach(function (envelope) {
@@ -149,13 +149,13 @@ define(function (require, exports, module) {
     /**
      * Clear any inter tab channel data
      */
-    clear: function () {
+    clear () {
       this._notifier.clear();
     }
   };
 
   var NotifierMixin = {
-    initialize: function (options) {
+    initialize (options) {
       this.notifier = new NotifierProxy({
         consumer: this,
         notifier: options.notifier

--- a/app/scripts/views/mixins/open-webmail-mixin.js
+++ b/app/scripts/views/mixins/open-webmail-mixin.js
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
       'click #open-webmail': '_webmailTabOpened'
     },
 
-    addUserInfo: function (providerLink, email) {
+    addUserInfo (providerLink, email) {
 
       if (this.getWebmailType(email) === 'gmail'){
         providerLink = providerLink.concat(encodeURIComponent(email));
@@ -55,7 +55,7 @@ define(function (require, exports, module) {
       return providerLink;
     },
 
-    _getService: function (email) {
+    _getService (email) {
       return _.find(WEBMAIL_SERVICES, function (service) {
         return service.regex.test(email);
       });
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
      * @method getContext
      * @returns {Object}
      */
-    getContext: function () {
+    getContext () {
       const context = BaseView.prototype.getContext.call(this);
       const email = context.email;
       const isOpenWebmailButtonVisible = this.isOpenWebmailButtonVisible(email);
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
       return context;
     },
 
-    getWebmailLink: function (email) {
+    getWebmailLink (email) {
       var providerLink = this._getService(email).link;
       return this.addUserInfo(providerLink, email);
     },
@@ -101,22 +101,22 @@ define(function (require, exports, module) {
      * @param {String} email
      * @returns {Boolean}
      */
-    isOpenWebmailButtonVisible: function (email) {
+    isOpenWebmailButtonVisible (email) {
       // The "Open webmail" button is only visible in certain contexts
       // we do not show it in mobile context because it performs worse
       return this.broker.hasCapability('openWebmailButtonVisible') &&
             !! this._getService(email);
     },
 
-    getWebmailButtonText: function (email) {
+    getWebmailButtonText (email) {
       return this.translate(this._getService(email).buttonName);
     },
 
-    getWebmailType: function (email) {
+    getWebmailType (email) {
       return this._getService(email).webmailType;
     },
 
-    _webmailTabOpened: function (event) {
+    _webmailTabOpened (event) {
       var webmailType = this.$el.find(event.target).data('webmailType');
       this.logViewEvent(webmailType + '_clicked');
     }

--- a/app/scripts/views/mixins/password-prompt-mixin.js
+++ b/app/scripts/views/mixins/password-prompt-mixin.js
@@ -31,21 +31,21 @@ define(function (require, exports, module) {
       'keyup .check-password': 'onInputKeyUp'
     },
 
-    afterRender: function () {
+    afterRender () {
       this.updateFormValueChanges();
     },
 
-    displayPasswordInitialPrompt: function (inputEl) {
+    displayPasswordInitialPrompt (inputEl) {
       this.$(inputEl).siblings(INPUT_HELP_FOCUSED).html(this.translate(TOOLTIP_MESSAGES.INITIAL_PROMPT_MESSAGE));
       this._logPromptExperimentEvent('INITIAL_PROMPT_MESSAGE');
     },
 
-    displayPasswordFocusPrompt: function (inputEl) {
+    displayPasswordFocusPrompt (inputEl) {
       this.$(inputEl).siblings(INPUT_HELP_FOCUSED).html(this.translate(TOOLTIP_MESSAGES.FOCUS_PROMPT_MESSAGE));
       this._logPromptExperimentEvent('FOCUS_PROMPT_MESSAGE');
     },
 
-    displayPasswordWarningPrompt: function () {
+    displayPasswordWarningPrompt () {
       let promptContent = TOOLTIP_MESSAGES.WARNING_PROMPT_MESSAGE;
       if (this._isEnglishLocale()) {
         promptContent = TOOLTIP_MESSAGES.WARNING_PROMPT_MESSAGE_WITH_LINK;
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
       this._logPromptExperimentEvent('WARNING_PROMPT_MESSAGE');
     },
 
-    showPasswordPrompt: function (inputEl) {
+    showPasswordPrompt (inputEl) {
       const length = this.$(inputEl).val().length;
       if (length === 0) {
         this.displayPasswordInitialPrompt(inputEl);
@@ -72,20 +72,20 @@ define(function (require, exports, module) {
       }
     },
 
-    onInputFocus: function (event) {
+    onInputFocus (event) {
       this.showPasswordPrompt(event.currentTarget);
     },
 
-    onInputKeyUp: function (event) {
+    onInputKeyUp (event) {
       this.showPasswordPrompt(event.currentTarget);
     },
 
-    onPasswordBlur: function () {
+    onPasswordBlur () {
       const password = this.getElementValue(CHECK_PASSWORD_FIELD_SELECTOR);
       this.checkPasswordStrength(password);
     },
 
-    _logPromptExperimentEvent: function (eventNameSuffix) {
+    _logPromptExperimentEvent (eventNameSuffix) {
       const eventName = 'experiment.pw_prompt.' + eventNameSuffix.toLowerCase();
       this.logEventOnce(eventName);
     },
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
      * @returns {Boolean}
      * @private
      */
-    _isEnglishLocale: function () {
+    _isEnglishLocale () {
       return !! (this.language && this.language.indexOf('en') === 0);
     },
 

--- a/app/scripts/views/mixins/password-reset-mixin.js
+++ b/app/scripts/views/mixins/password-reset-mixin.js
@@ -23,7 +23,7 @@ define(function (require, exports, module) {
      * @param {String} email
      * @return {Promise} - resolves with auth server response if successful.
      */
-    resetPassword: function (email) {
+    resetPassword (email) {
       var account = this.user.initAccount({ email: email });
       return account.resetPassword(
         this.relier,
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
      * @param {String} passwordForgotToken
      * @return {Promise} - resolves with auth server response if successful.
      */
-    retryResetPassword: function (email, passwordForgotToken) {
+    retryResetPassword (email, passwordForgotToken) {
       var account = this.user.initAccount({ email: email });
       return account.retryResetPassword(
         passwordForgotToken,

--- a/app/scripts/views/mixins/password-strength-mixin.js
+++ b/app/scripts/views/mixins/password-strength-mixin.js
@@ -13,12 +13,12 @@ define(function (require, exports, module) {
 
   var PasswordStrengthMixin = {
 
-    initialize: function (options) {
+    initialize (options) {
       this._able = options.able;
     },
 
     _isPasswordStrengthCheckEnabledValue: undefined,
-    isPasswordStrengthCheckEnabled: function () {
+    isPasswordStrengthCheckEnabled () {
       if (_.isUndefined(this._isPasswordStrengthCheckEnabledValue)) {
         var abData = {
           // the window parameter will override any ab testing features
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
     },
 
     _passwordStrengthCheckerPromise: undefined,
-    getPasswordStrengthChecker: function () {
+    getPasswordStrengthChecker () {
       // returns a promise that resolves once the library is loaded.
       if (! this._passwordStrengthCheckerPromise) {
         this._passwordStrengthCheckerPromise = requireOnDemand('passwordcheck')
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
      *
      * @returns {Promise}
      */
-    checkPasswordStrength: function (password) {
+    checkPasswordStrength (password) {
       if (! this.isPasswordStrengthCheckEnabled()) {
         return p('DISABLED');
       }
@@ -97,7 +97,7 @@ define(function (require, exports, module) {
         });
     },
 
-    _logStrengthExperimentEvent: function (eventNameSuffix) {
+    _logStrengthExperimentEvent (eventNameSuffix) {
       var eventName = 'experiment.pw_strength.' + eventNameSuffix.toLowerCase();
       this.logViewEvent(eventName);
     }

--- a/app/scripts/views/mixins/resume-token-mixin.js
+++ b/app/scripts/views/mixins/resume-token-mixin.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
      * @method getResumeToken
      * @returns {ResumeToken}
      */
-    getResumeToken: function () {
+    getResumeToken () {
       // there might not be any relier if the resume token is being fetched
       // for an account unlock request caused by changing the password.
       var flowInfo = this.flow && this.flow.pickResumeTokenInfo();
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
      * @method getStringifiedResumeToken
      * @returns {String}
      */
-    getStringifiedResumeToken: function () {
+    getStringifiedResumeToken () {
       return this.getResumeToken().stringify();
     }
   };

--- a/app/scripts/views/mixins/service-mixin.js
+++ b/app/scripts/views/mixins/service-mixin.js
@@ -11,7 +11,7 @@ define(function (require, exports, module) {
   const BaseView = require('views/base');
 
   module.exports = {
-    transformLinks: function () {
+    transformLinks () {
       this.$('a[href~="/signin"]').attr('href',
           this.broker.transformLink('/signin'));
       this.$('a[href~="/signup"]').attr('href',
@@ -19,7 +19,7 @@ define(function (require, exports, module) {
     },
 
     // override this method so we can fix signup/signin links in errors
-    displayErrorUnsafe: function (err) {
+    displayErrorUnsafe (err) {
       var result = BaseView.prototype.displayErrorUnsafe.call(this, err);
 
       this.transformLinks();

--- a/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/app/scripts/views/mixins/settings-panel-mixin.js
@@ -13,7 +13,7 @@ define(function (require, exports, module) {
   const KeyCodes = require('lib/key-codes');
 
   module.exports = {
-    initialize: function (options) {
+    initialize (options) {
       this.parentView = options.parentView;
     },
 
@@ -32,39 +32,39 @@ define(function (require, exports, module) {
         .removeAttr('autofocus');
     },
 
-    onKeyUp: function (event) {
+    onKeyUp (event) {
       if (event.which === KeyCodes.ESCAPE) {
         this.hidePanel();
       }
     },
 
-    _triggerPanel: function (event) {
+    _triggerPanel (event) {
       var href = event && $(event.currentTarget).data('href');
       if (href) {
         this.navigate(href);
       }
     },
 
-    openPanel: function () {
+    openPanel () {
       this.$('.settings-unit').addClass('open');
       this.focus(this.$('[data-autofocus-on-panel-open]'));
     },
 
-    hidePanel: function () {
+    hidePanel () {
       this._closePanelReturnToSettings();
     },
 
-    isPanelOpen: function () {
+    isPanelOpen () {
       return this.$('.settings-unit').hasClass('open');
     },
 
-    _closePanelReturnToSettings: function () {
+    _closePanelReturnToSettings () {
       this.navigate('settings');
       this.clearInput();
       this.closePanel();
     },
 
-    clearInput: function () {
+    clearInput () {
       const $inputEls = this.$('input');
 
       $inputEls.each((i, inputEl) => {
@@ -87,11 +87,11 @@ define(function (require, exports, module) {
       }
     },
 
-    closePanel: function () {
+    closePanel () {
       this.$('.settings-unit').removeClass('open');
     },
 
-    displaySuccess: function (msg) {
+    displaySuccess (msg) {
       if (! this.parentView) {
         return;
       }

--- a/app/scripts/views/mixins/signed-in-notification-mixin.js
+++ b/app/scripts/views/mixins/signed-in-notification-mixin.js
@@ -15,7 +15,7 @@ define(function (require, exports, module) {
       // populated below using event name aliases
     },
 
-    _navigateToSignedInView: function (event) {
+    _navigateToSignedInView (event) {
       if (this.broker.hasCapability('handleSignedInNotification')) {
         this.user.setSignedInAccountByUid(event.uid);
         this.navigate(this.model.get('redirectTo') || 'settings');

--- a/app/scripts/views/mixins/signed-out-notification-mixin.js
+++ b/app/scripts/views/mixins/signed-out-notification-mixin.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
       // populated below using event name aliases
     },
 
-    clearSessionAndNavigateToSignIn: function () {
+    clearSessionAndNavigateToSignIn () {
       // Unset uid otherwise it will henceforth be impossible
       // to sign in to different accounts inside this tab.
       this.relier.unset('uid');
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
       this.navigateToSignIn();
     },
 
-    navigateToSignIn: function () {
+    navigateToSignIn () {
       this.navigate('signin', {
         success: BaseView.t('Signed out successfully')
       }, {

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
      *  user is signing in with a sessionToken.
      * @return {Object} promise
      */
-    signIn: function (account, password) {
+    signIn (account, password) {
       this.logEvent(`flow.${this.signInSubmitContext}.submit`);
 
       if (! account ||
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
         });
     },
 
-    onSignInSuccess: function (account) {
+    onSignInSuccess (account) {
       if (! account.get('verified')) {
         var verificationMethod = account.get('verificationMethod');
         var verificationReason = account.get('verificationReason');

--- a/app/scripts/views/mixins/signup-mixin.js
+++ b/app/scripts/views/mixins/signup-mixin.js
@@ -14,7 +14,7 @@ define(function (require, exports, module) {
       'click #suggest-sync a': 'onSuggestSyncClick'
     },
 
-    isSyncSuggestionEnabled: function () {
+    isSyncSuggestionEnabled () {
       if (! this.relier.get('service')) {
         this.logViewEvent('sync-suggest.visible');
         return true;
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
      * @param {String} password
      * @return {Object} promise
      */
-    signUp: function (account, password) {
+    signUp (account, password) {
       this.logEvent('flow.signup.submit');
 
       return this.invokeBrokerMethod('beforeSignIn', account)
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
         });
     },
 
-    onSignUpSuccess: function (account) {
+    onSignUpSuccess (account) {
       this.logViewEvent('success');
       this.logViewEvent('signup.success');
 
@@ -91,7 +91,7 @@ define(function (require, exports, module) {
      * interceptor function. Flushes metrics before redirecting
      * @param {Event} event - click event
      */
-    onSuggestSyncClick: function (event) {
+    onSuggestSyncClick (event) {
       event.preventDefault();
 
       this.logViewEvent('sync-suggest.clicked');

--- a/app/scripts/views/mixins/timer-mixin.js
+++ b/app/scripts/views/mixins/timer-mixin.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
   const _ = require('underscore');
 
   var Mixin = {
-    setTimeout: function (callback, timeoutMS) {
+    setTimeout (callback, timeoutMS) {
       if (! this._timeouts) {
         this._timeouts = [];
         // clear all timeouts when the view is destroyed.
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
       return timeout;
     },
 
-    clearTimeout: function (timeout) {
+    clearTimeout (timeout) {
       var win = this.window || window;
       win.clearTimeout(timeout);
 

--- a/app/scripts/views/mixins/verification-reason-mixin.js
+++ b/app/scripts/views/mixins/verification-reason-mixin.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
   }
 
   module.exports = {
-    initialize: function (options) {
+    initialize (options) {
       if (! this.model.has('type')) {
         this.model.set('type', options.type || VerificationReasons.SIGN_UP);
       }
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isSignIn: function () {
+    isSignIn () {
       return this.model.get('type') === VerificationReasons.SIGN_IN;
     },
 
@@ -41,7 +41,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isSignUp: function () {
+    isSignUp () {
       return this.model.get('type') === VerificationReasons.SIGN_UP;
     },
 
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
      * @param {String} verificationReason
      * @returns {String}
      */
-    keyOfVerificationReason: function (verificationReason) {
+    keyOfVerificationReason (verificationReason) {
       return findKey(VerificationReasons, verificationReason);
     }
   };

--- a/app/scripts/views/permissions.js
+++ b/app/scripts/views/permissions.js
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
     template: Template,
     className: 'permissions',
 
-    initialize: function (options) {
+    initialize (options) {
       // Account data is passed in from sign up and sign in flows.
       this._account = this.user.initAccount(this.model.get('account'));
 
@@ -67,11 +67,11 @@ define(function (require, exports, module) {
       this._validatePermissions(this.relier.get('permissions') || []);
     },
 
-    getAccount: function () {
+    getAccount () {
       return this._account;
     },
 
-    context: function () {
+    context () {
       var account = this.getAccount();
       var requestedPermissions = this.relier.get('permissions');
       var applicablePermissions =
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
      * @private
      * @param {String} requestedPermissionNames
      */
-    _validatePermissions: function (requestedPermissionNames) {
+    _validatePermissions (requestedPermissionNames) {
       requestedPermissionNames.forEach(function (permissionName) {
         var permission = this._getPermissionConfig(permissionName);
         // log the invalid scope instead of throwing an error
@@ -110,7 +110,7 @@ define(function (require, exports, module) {
      * @returns {Object} permission, if found.
      * @throws if permission is invalid
      */
-    _getPermissionConfig: function (permissionName) {
+    _getPermissionConfig (permissionName) {
       var permission = _.findWhere(PERMISSIONS, { name: permissionName });
 
       if (! permission) {
@@ -129,7 +129,7 @@ define(function (require, exports, module) {
      * @param {String[]} requestedPermissionNames
      * @returns {Object[]} applicable permissions
      */
-    _getApplicablePermissions: function (account, requestedPermissionNames) {
+    _getApplicablePermissions (account, requestedPermissionNames) {
       // only show permissions that have corresponding values.
       var permissionsWithValues =
         account.getPermissionsWithValues(requestedPermissionNames);
@@ -155,7 +155,7 @@ define(function (require, exports, module) {
      * @param {String} permissionName
      * @returns {Number} permission index if found, -1 otw.
      */
-    _getPermissionIndex: function (permissionName) {
+    _getPermissionIndex (permissionName) {
       return _.findIndex(PERMISSIONS, function (permission) {
         return permission.name === permissionName;
       });
@@ -168,7 +168,7 @@ define(function (require, exports, module) {
      * @param {String[]} permissionNames
      * @returns {String[]} sorted permissionNames
      */
-    _sortPermissions: function (permissionNames) {
+    _sortPermissions (permissionNames) {
       return [].concat(permissionNames).sort((a, b) => {
         var aIndex = this._getPermissionIndex(a);
         var bIndex = this._getPermissionIndex(b);
@@ -184,7 +184,7 @@ define(function (require, exports, module) {
      * @param {String[]} permissionNames
      * @returns {String} HTML
      */
-    _getPermissionsHTML: function (account, permissionNames) {
+    _getPermissionsHTML (account, permissionNames) {
       var sortedPermissionNames = this._sortPermissions(permissionNames);
 
       // convert the permission names to HTML
@@ -230,7 +230,7 @@ define(function (require, exports, module) {
      * @private
      * @returns {Object}
      */
-    _getFormPermissions: function () {
+    _getFormPermissions () {
       var $permissionEls = this.$('.permission');
       var clientPermissions = {};
 
@@ -241,7 +241,7 @@ define(function (require, exports, module) {
       return clientPermissions;
     },
 
-    beforeRender: function () {
+    beforeRender () {
       // user cannot proceed if they have not initiated a sign up/in.
       if (! this.getAccount().get('sessionToken')) {
         this.navigate(this._previousView());
@@ -254,7 +254,7 @@ define(function (require, exports, module) {
       }
     },
 
-    submit: function () {
+    submit () {
       var account = this.getAccount();
 
       this.logViewEvent('accept');
@@ -266,7 +266,7 @@ define(function (require, exports, module) {
         .then(this.onSubmitComplete);
     },
 
-    _previousView: function () {
+    _previousView () {
       var page = this.isSignUp() ? '/signup' : '/signin';
       return this.broker.transformLink(page);
     }

--- a/app/scripts/views/progress_indicator.js
+++ b/app/scripts/views/progress_indicator.js
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
      * @method start
      * @param {String} progressEl
      */
-    start: function (progressEl) {
+    start (progressEl) {
       this._count++;
       if (this._count > 1) {
         // Already visible or waiting to become visible. Get outta here.
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
       }, SHOW_DELAY_MS);
     },
 
-    destroy: function () {
+    destroy () {
       this.done();
 
       this.trigger('destroy');
@@ -79,7 +79,7 @@ define(function (require, exports, module) {
      *
      * @method done
      */
-    done: function () {
+    done () {
       if (! this._count) {
         // Either already hidden or waiting to be hidden.
         // No need to hide the indicator again.
@@ -117,7 +117,7 @@ define(function (require, exports, module) {
      *
      * @param {String} progressEl
      */
-    showIndicator: function (progressEl) {
+    showIndicator (progressEl) {
       progressEl = $(progressEl);
       if (progressEl.length) {
         this._progressEl = progressEl;
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
      * @param {String} progressEl
      * @returns {undefined}
      */
-    removeIndicator: function (progressEl) {
+    removeIndicator (progressEl) {
       progressEl = this._progressEl;
       if (progressEl && progressEl.length) {
         progressEl.html(this._progressHTML);
@@ -144,7 +144,7 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isVisible: function () {
+    isVisible () {
       return !! this._count;
     }
   });

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
     template: Template,
     className: 'ready',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._able = options.able;
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
       this._templateInfo = TEMPLATE_INFO[this.keyOfVerificationReason(options.type)];
     },
 
-    context: function () {
+    context () {
       return {
         headerId: this._getHeaderId(),
         headerTitle: this._getHeaderTitle(),
@@ -86,27 +86,27 @@ define(function (require, exports, module) {
       };
     },
 
-    _getHeaderId: function () {
+    _getHeaderId () {
       return this._templateInfo.headerId;
     },
 
-    _getHeaderTitle: function () {
+    _getHeaderTitle () {
       var title = this._templateInfo.headerTitle;
       return this.translateInTemplate(title);
     },
 
-    _getReadyToSyncText: function () {
+    _getReadyToSyncText () {
       var readyToSyncText = this._templateInfo.readyToSyncText;
       return this.translateInTemplate(readyToSyncText);
     },
 
-    _submitForProceed: function () {
+    _submitForProceed () {
       return this.metrics.flush().then(() => {
         this.window.location.href = this.relier.get('redirectUri');
       });
     },
 
-    submit: function () {
+    submit () {
       if (this._shouldShowProceedButton()) {
         return this._submitForProceed();
       } else if (this._shouldShowSyncPreferencesButton()) {
@@ -114,7 +114,7 @@ define(function (require, exports, module) {
       }
     },
 
-    _submitForSyncPreferences: function () {
+    _submitForSyncPreferences () {
       return this.metrics.flush().then(() => {
         var entryPoint = 'fxa:' + this.getViewName();
         return this.broker.openSyncPreferences(entryPoint);
@@ -129,7 +129,7 @@ define(function (require, exports, module) {
      * @returns {Boolean}
      * @private
      */
-    _shouldShowProceedButton: function () {
+    _shouldShowProceedButton () {
       var redirectUri = this.relier.get('redirectUri');
       var verificationRedirect = this.relier.get('verificationRedirect');
 
@@ -145,7 +145,7 @@ define(function (require, exports, module) {
      * @returns {Boolean}
      * @private
      */
-    _shouldShowSyncPreferencesButton: function () {
+    _shouldShowSyncPreferencesButton () {
       return !! (this.relier.isSync() &&
                  this.broker.hasCapability('syncPreferencesNotification'));
     },

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -20,19 +20,19 @@ define(function (require, exports, module) {
     template: Template,
     className: 'reset_password',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._formPrefill = options.formPrefill;
     },
 
-    context: function () {
+    context () {
       return {
         forceEmail: this.model.get('forceEmail')
       };
     },
 
-    beforeRender: function () {
+    beforeRender () {
       var email = this.relier.get('email');
       var canSkip = this.relier.get('resetPasswordConfirm') === false;
       if (canSkip && email) {
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
       return FormView.prototype.beforeRender.call(this);
     },
 
-    afterRender: function () {
+    afterRender () {
       if (this.relier.isOAuth()) {
         this.transformLinks();
       }
@@ -54,15 +54,15 @@ define(function (require, exports, module) {
       FormView.prototype.afterRender.call(this);
     },
 
-    beforeDestroy: function () {
+    beforeDestroy () {
       this._formPrefill.set('email', this.getElementValue('.email'));
     },
 
-    submit: function () {
+    submit () {
       return this._resetPassword(this.getElementValue('.email'));
     },
 
-    _resetPassword: function (email) {
+    _resetPassword (email) {
       return this.resetPassword(email)
         .fail((err) => {
           // clear oauth session

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
 
     mustVerify: true,
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._able = options.able;
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
       'navigate-from-child-view': '_onNavigateFromChildView'
     },
 
-    _initializeSubPanels: function (options) {
+    _initializeSubPanels (options) {
       var areCommunicationPrefsVisible = false;
       var panelViews = options.panelViews || PANEL_VIEWS;
 
@@ -111,7 +111,7 @@ define(function (require, exports, module) {
       });
     },
 
-    context: function () {
+    context () {
       var account = this.getSignedInAccount();
 
       return {
@@ -126,17 +126,17 @@ define(function (require, exports, module) {
     },
 
     // Triggered by AvatarMixin
-    onProfileUpdate: function () {
+    onProfileUpdate () {
       this._showAvatar();
     },
 
-    showChildView: function (ChildView, options) {
+    showChildView (ChildView, options) {
       return this._subPanels.showChildView(ChildView, options);
     },
 
     // When we navigate to settings from a childView
     // close the modal, show any ephemeral messages passed to `navigate`
-    _onNavigateFromChildView: function () {
+    _onNavigateFromChildView () {
       if ($.modal.isActive()) {
         $.modal.close();
       }
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
       this._swapDisplayName();
     },
 
-    beforeRender: function () {
+    beforeRender () {
       var account = this.getSignedInAccount();
 
       return account.fetchProfile()
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
     // When the user adds, removes or changes a display name
     // this gets called and swaps out headers to reflect
     // the updated state of the account
-    _swapDisplayName: function () {
+    _swapDisplayName () {
       var account = this.getSignedInAccount();
       var displayName = account.get('displayName');
       var email = account.get('email');
@@ -191,17 +191,17 @@ define(function (require, exports, module) {
       }
     },
 
-    _setupAvatarChangeLinks: function () {
+    _setupAvatarChangeLinks () {
       this.$('.avatar-wrapper > *').wrap('<a href="/settings/avatar/change" class="change-avatar"></a>');
     },
 
-    _showAvatar: function () {
+    _showAvatar () {
       var account = this.getSignedInAccount();
       return this.displayAccountProfileImage(account)
         .then(() => this._setupAvatarChangeLinks());
     },
 
-    _areCommunicationPrefsVisible: function () {
+    _areCommunicationPrefsVisible () {
       return !! this._able.choose('communicationPrefsVisible', {
         lang: this.navigator.language
       });
@@ -224,7 +224,7 @@ define(function (require, exports, module) {
 
     SUCCESS_MESSAGE_DELAY_MS: new Duration('5s').milliseconds(),
 
-    displaySuccess: function () {
+    displaySuccess () {
       this.clearTimeout(this._successTimeout);
       this._successTimeout = this.setTimeout(() => {
         this.hideSuccess();
@@ -232,7 +232,7 @@ define(function (require, exports, module) {
       return BaseView.prototype.displaySuccess.apply(this, arguments);
     },
 
-    displaySuccessUnsafe: function () {
+    displaySuccessUnsafe () {
       this.clearTimeout(this._successTimeout);
       this._successTimeout = this.setTimeout(() => {
         this.hideSuccess();

--- a/app/scripts/views/settings/avatar.js
+++ b/app/scripts/views/settings/avatar.js
@@ -16,11 +16,11 @@ define(function (require, exports, module) {
     className: 'avatar',
     viewName: 'settings.avatar',
 
-    onProfileUpdate: function () {
+    onProfileUpdate () {
       this.render();
     },
 
-    context: function () {
+    context () {
       var account = this.getSignedInAccount();
       return {
         avatar: account.has('profileImageUrl')

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -35,13 +35,13 @@ define(function (require, exports, module) {
     className: 'avatar-camera',
     viewName: 'settings.avatar.camera',
 
-    context: function () {
+    context () {
       return {
         streaming: this.streaming
       };
     },
 
-    initialize: function (options) {
+    initialize (options) {
       this.exportLength = options.exportLength || EXPORT_LENGTH;
       this.displayLength = options.displayLength || DISPLAY_LENGTH;
       this.streaming = false;
@@ -55,14 +55,14 @@ define(function (require, exports, module) {
           this.enableSubmitIfValid();
         };
         this.stream = {
-          stop: function () {}
+          stop () {}
         };
 
         this.window.setTimeout(_.bind(this.onLoadedMetaData, this), ARTIFICIAL_DELAY);
       }
     },
 
-    startStream: function () {
+    startStream () {
       var constraints = {
         audio: false,
         video: true
@@ -82,7 +82,7 @@ define(function (require, exports, module) {
       );
     },
 
-    stopAndDestroyStream: function () {
+    stopAndDestroyStream () {
       if (this.stream) {
         var stream = this.stream;
         var previewEl = this.video;
@@ -106,7 +106,7 @@ define(function (require, exports, module) {
       }
     },
 
-    beforeRender: function () {
+    beforeRender () {
       var environment = new Environment(this.window);
       if (! environment.hasGetUserMedia()) {
         // no camera support, send user back to the change avatar page.
@@ -133,7 +133,7 @@ define(function (require, exports, module) {
       return proto.afterRender.call(this);
     },
 
-    onLoadedMetaData: function () {
+    onLoadedMetaData () {
       if (! this.streaming) {
         var vw = this.video.videoWidth;
         var vh = this.video.videoHeight;
@@ -168,11 +168,11 @@ define(function (require, exports, module) {
       }
     },
 
-    isValidEnd: function () {
+    isValidEnd () {
       return this.streaming;
     },
 
-    submit: function () {
+    submit () {
       var account = this.getSignedInAccount();
       this.logAccountImageChange(account);
 
@@ -189,7 +189,7 @@ define(function (require, exports, module) {
         });
     },
 
-    beforeDestroy: function () {
+    beforeDestroy () {
       this.stopAndDestroyStream();
     },
 
@@ -229,7 +229,7 @@ define(function (require, exports, module) {
 
     // Calculates the position offset needed to center a rectangular image
     // in a square container
-    centeredPos: function (w, h, max) {
+    centeredPos (w, h, max) {
       if (w > h) {
         return { left: (max - w) / 2, top: 0 };
       } else {

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -28,25 +28,25 @@ define(function (require, exports, module) {
       'click .remove': 'removeAvatar'
     },
 
-    initialize: function () {
+    initialize () {
       // override in tests
       this.FileReader = FileReader;
     },
 
-    getAccount: function () {
+    getAccount () {
       if (! this._account) {
         this._account = this.getSignedInAccount();
       }
       return this._account;
     },
 
-    beforeRender: function () {
+    beforeRender () {
       if (this.relier.get('setting') === 'avatar') {
         this.relier.unset('setting');
       }
     },
 
-    context: function () {
+    context () {
       var account = this.getSignedInAccount();
       return {
         'hasProfileImage': account.has('profileImageUrl')
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
       return proto.afterRender.call(this);
     },
 
-    removeAvatar: function () {
+    removeAvatar () {
       var account = this.getAccount();
       return this.deleteDisplayedAccountProfileImage(account)
         .then(() => {
@@ -84,11 +84,11 @@ define(function (require, exports, module) {
         });
     },
 
-    filePicker: function () {
+    filePicker () {
       this.$('#imageLoader').click();
     },
 
-    fileSet: function (e) {
+    fileSet (e) {
       var defer = p.defer();
       var file = e.target.files[0];
       var account = this.getAccount();

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -26,7 +26,7 @@ define(function (require, exports, module) {
     className: 'avatar-crop',
     viewName: 'settings.avatar.crop',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._cropImg = this.model.get('cropImg');
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
       }
     },
 
-    beforeRender: function () {
+    beforeRender () {
       if (! this._cropImg) {
         this.navigate('settings/avatar/change', {
           error: AuthErrors.toMessage('UNUSABLE_IMAGE')
@@ -45,12 +45,12 @@ define(function (require, exports, module) {
       }
     },
 
-    afterRender: function () {
+    afterRender () {
       this.canvas = this.$('canvas')[0];
       return proto.afterRender.call(this);
     },
 
-    afterVisible: function () {
+    afterVisible () {
       // Use pre-set dimensions if available
       var width = this._cropImg.get('width');
       var height = this._cropImg.get('height');
@@ -87,7 +87,7 @@ define(function (require, exports, module) {
       return proto.afterVisible.call(this);
     },
 
-    toBlob: function () {
+    toBlob () {
       var defer = p.defer();
 
       this.cropper.toBlob(function (data) {
@@ -98,7 +98,7 @@ define(function (require, exports, module) {
       return defer.promise;
     },
 
-    submit: function () {
+    submit () {
       var account = this.getSignedInAccount();
 
       this.logAccountImageChange(account);
@@ -114,23 +114,23 @@ define(function (require, exports, module) {
         });
     },
 
-    _onRotate: function () {
+    _onRotate () {
       this.logViewEvent('rotate.cw');
     },
 
-    _onTranslate: function () {
+    _onTranslate () {
       this.logViewEvent('translate');
     },
 
-    _onZoomIn: function () {
+    _onZoomIn () {
       this.logViewEvent('zoom.in');
     },
 
-    _onZoomOut: function () {
+    _onZoomOut () {
       this.logViewEvent('zoom.out');
     },
 
-    _onZoomRangeChange: function () {
+    _onZoomRangeChange () {
       this.logViewEvent('zoom.range');
     }
 

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
     className: 'avatar-gravatar',
     viewName: 'settings.avatar.gravatar',
 
-    context: function () {
+    context () {
       return {
         gravatar: this.gravatar
       };
@@ -52,18 +52,18 @@ define(function (require, exports, module) {
         .then(_.bind(this._found, this), _.bind(this._notFound, this));
     }, '.avatar-wrapper', '_gravatarProgressIndicator'),
 
-    _found: function () {
+    _found () {
       this.gravatar = this.gravatarUrl();
       this.render();
     },
 
-    _notFound: function () {
+    _notFound () {
       this.navigate('settings/avatar/change', {
         error: AuthErrors.toError('NO_GRAVATAR_FOUND')
       });
     },
 
-    gravatarUrl: function () {
+    gravatarUrl () {
       var hashedEmail = this.hashedEmail();
       if (this.broker.isAutomatedBrowser()) {
         // Don't return a 404 so we can test the success flow
@@ -72,12 +72,12 @@ define(function (require, exports, module) {
       return GRAVATAR_URL + hashedEmail + '?s=' + DISPLAY_LENGTH + '&d=404';
     },
 
-    hashedEmail: function () {
+    hashedEmail () {
       var email = this.getSignedInAccount().get('email');
       return email ? md5($.trim(email.toLowerCase())) : '';
     },
 
-    submit: function () {
+    submit () {
       var url = this.gravatarUrl();
       var account = this.getSignedInAccount();
 

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
       };
     },
 
-    submit: function () {
+    submit () {
       var account = this.getSignedInAccount();
       var oldPassword = this.$('#old_password').val();
       var newPassword = this.$('#new_password').val();

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
     className: 'clients',
     viewName: 'settings.clients',
 
-    initialize: function (options) {
+    initialize (options) {
       this._able = options.able;
       this._attachedClients = options.attachedClients;
 
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
       this.listenTo(this._attachedClients, 'remove', this._onItemRemoved);
     },
 
-    _formatAccessTime: function (items) {
+    _formatAccessTime (items) {
       return _.map(items, function (item) {
         if (item.lastAccessTimeFormatted) {
           item.lastAccessTimeFormatted = Strings.interpolate(
@@ -60,7 +60,7 @@ define(function (require, exports, module) {
       });
     },
 
-    context: function () {
+    context () {
       return {
         clients: this._formatAccessTime(this._attachedClients.toJSON()),
         clientsPanelManageString: this._getManageString(),
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
       'click .clients-refresh': preventDefaultThen('_onRefreshClientsList')
     },
 
-    _isPanelEnabled: function () {
+    _isPanelEnabled () {
       const account = this.user.getSignedInAccount();
 
       return this._able.choose('deviceListVisible', {
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
       });
     },
 
-    _getPanelTitle: function () {
+    _getPanelTitle () {
       var title = t('Devices');
 
       if (this._isAppsListVisible()) {
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
       return title;
     },
 
-    _getManageString: function () {
+    _getManageString () {
       var title = t('You can manage your devices below.');
 
       if (this._isAppsListVisible()) {
@@ -110,7 +110,7 @@ define(function (require, exports, module) {
       return title;
     },
 
-    _isAppsListVisible: function () {
+    _isAppsListVisible () {
       // OAuth Apps list is visible if `appsListVisible` chooses `true`.
       return this._able.choose('appsListVisible', {
         forceAppsList: Url.searchParam(FORCE_APPS_LIST_VIEW, this.window.location.search),
@@ -118,11 +118,11 @@ define(function (require, exports, module) {
       });
     },
 
-    _onItemAdded: function () {
+    _onItemAdded () {
       this.render();
     },
 
-    _onItemRemoved: function (item) {
+    _onItemRemoved (item) {
       var id = item.get('id');
       $('#' + id).slideUp(DEVICE_REMOVED_ANIMATION_MS, () => {
         // re-render in case the last device is removed and the
@@ -131,7 +131,7 @@ define(function (require, exports, module) {
       });
     },
 
-    _onDisconnectClient: function (event) {
+    _onDisconnectClient (event) {
       var client = this._attachedClients.get($(event.currentTarget).data('id'));
       var clientType = client.get('clientType');
       this.logViewEvent(clientType + '.disconnect');
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
       }
     },
 
-    _onRefreshClientsList: function () {
+    _onRefreshClientsList () {
       if (this.isPanelOpen()) {
         this.logViewEvent('refresh');
         // only refresh devices if panel is visible
@@ -157,12 +157,12 @@ define(function (require, exports, module) {
       }
     },
 
-    openPanel: function () {
+    openPanel () {
       this.logViewEvent('open');
       this._fetchAttachedClients();
     },
 
-    _fetchAttachedClients: function () {
+    _fetchAttachedClients () {
       return this._attachedClients.fetchClients({
         devices: true,
         oAuthApps: this._isAppsListVisible()

--- a/app/scripts/views/settings/communication_preferences.js
+++ b/app/scripts/views/settings/communication_preferences.js
@@ -23,13 +23,13 @@ define(function (require, exports, module) {
     className: 'communication-preferences',
     viewName: 'settings.communication-preferences',
 
-    enableSubmitIfValid: function () {
+    enableSubmitIfValid () {
       // overwrite this to prevent the default FormView method from hiding errors
       // after render
       this.enableForm();
     },
 
-    getMarketingEmailPrefs: function () {
+    getMarketingEmailPrefs () {
       if (! this._marketingEmailPrefs) {
         this._marketingEmailPrefs =
             this.getSignedInAccount().getMarketingEmailPrefs();
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
     // Selenium can proceed. See #3357 and #3061
     _isBasketReady: false,
 
-    afterVisible: function () {
+    afterVisible () {
       var emailPrefs = this.getMarketingEmailPrefs();
 
       // the email prefs fetch is done in afterVisible instead of a render
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
         });
     },
 
-    context: function () {
+    context () {
       var emailPrefs = this.getMarketingEmailPrefs();
       var isOptedIn = emailPrefs.isOptedIn(NEWSLETTER_ID);
       this.logViewEvent('newsletter.optin.' + String(isOptedIn));
@@ -93,12 +93,12 @@ define(function (require, exports, module) {
       };
     },
 
-    submit: function () {
+    submit () {
       var emailPrefs = this.getMarketingEmailPrefs();
       return this.setOptInStatus(NEWSLETTER_ID, ! emailPrefs.isOptedIn(NEWSLETTER_ID));
     },
 
-    setOptInStatus: function (newsletterId, isOptedIn) {
+    setOptInStatus (newsletterId, isOptedIn) {
       var method = isOptedIn ? 'optIn' : 'optOut';
       this.logViewEvent(method);
 

--- a/app/scripts/views/settings/delete_account.js
+++ b/app/scripts/views/settings/delete_account.js
@@ -22,13 +22,13 @@ define(function (require, exports, module) {
     className: 'delete-account',
     viewName: 'settings.delete-account',
 
-    context: function () {
+    context () {
       return {
         email: this.getSignedInAccount().get('email')
       };
     },
 
-    submit: function () {
+    submit () {
       var account = this.getSignedInAccount();
       var password = this.getElementValue('.password');
 

--- a/app/scripts/views/settings/display_name.js
+++ b/app/scripts/views/settings/display_name.js
@@ -20,17 +20,17 @@ define(function (require, exports, module) {
     className: 'display-name',
     viewName: 'settings.display-name',
 
-    onProfileUpdate: function () {
+    onProfileUpdate () {
       this.render();
     },
 
-    context: function () {
+    context () {
       return {
         displayName: this._displayName
       };
     },
 
-    beforeRender: function () {
+    beforeRender () {
       var account = this.getSignedInAccount();
       return account.fetchProfile()
         .then(() => {
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
         });
     },
 
-    submit: function () {
+    submit () {
       var account = this.getSignedInAccount();
       var displayName = this.getElementValue('input.display-name').trim();
 

--- a/app/scripts/views/settings/gravatar_permissions.js
+++ b/app/scripts/views/settings/gravatar_permissions.js
@@ -20,7 +20,7 @@ define(function (require, exports, module) {
     className: 'gravatar-permissions',
     viewName: 'settings.gravatar-permissions',
 
-    context: function () {
+    context () {
       var account = this.getSignedInAccount();
       var serviceName = this.translator.get('Gravatar');
       return {
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
       };
     },
 
-    beforeRender: function () {
+    beforeRender () {
       var account = this.getSignedInAccount();
       if (account.getClientPermission(GRAVATAR_MOCK_CLIENT_ID, GRAVATAR_PERMISSION)) {
         this.logViewEvent('already-accepted');
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
       }
     },
 
-    submit: function () {
+    submit () {
       var account = this.getSignedInAccount();
       this.logViewEvent('accept');
 

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -31,13 +31,13 @@ define(function (require, exports, module) {
     template: SignInTemplate,
     className: 'sign-in',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._formPrefill = options.formPrefill;
     },
 
-    beforeRender: function () {
+    beforeRender () {
       this._account = this._suggestedAccount();
 
       this._account.on('change:accessToken', () => {
@@ -53,25 +53,25 @@ define(function (require, exports, module) {
       });
     },
 
-    getAccount: function () {
+    getAccount () {
       return this._account;
     },
 
-    getPrefillEmail: function () {
+    getPrefillEmail () {
       // formPrefill.email comes first because users can edit the email,
       // go to another view, edit the email again, and come back here. We
       // want the last used email.
       return this._formPrefill.get('email') || this.relier.get('email');
     },
 
-    getEmail: function () {
+    getEmail () {
       var suggestedAccount = this.getAccount();
       var hasSuggestedAccount = suggestedAccount.get('email');
       return hasSuggestedAccount ?
         suggestedAccount.get('email') : this.getPrefillEmail();
     },
 
-    context: function () {
+    context () {
       var suggestedAccount = this.getAccount();
       var hasSuggestedAccount = suggestedAccount.get('email');
       var email = this.getEmail();
@@ -92,22 +92,22 @@ define(function (require, exports, module) {
       'click .use-logged-in': 'useLoggedInAccount'
     },
 
-    afterRender: function () {
+    afterRender () {
       this.transformLinks();
       return FormView.prototype.afterRender.call(this);
     },
 
-    afterVisible: function () {
+    afterVisible () {
       FormView.prototype.afterVisible.call(this);
       return this.displayAccountProfileImage(this.getAccount(), { spinner: true });
     },
 
-    beforeDestroy: function () {
+    beforeDestroy () {
       this._formPrefill.set('email', this.getElementValue('.email'));
       this._formPrefill.set('password', this.getElementValue('.password'));
     },
 
-    submit: function () {
+    submit () {
       var account = this.user.initAccount({
         email: this.getElementValue('.email')
       });
@@ -128,12 +128,12 @@ define(function (require, exports, module) {
      * @returns {Promise}
      * @private
      */
-    _signIn: function (account, password) {
+    _signIn (account, password) {
       return this.signIn(account, password)
         .fail(this.onSignInError.bind(this, account, password));
     },
 
-    onSignInError: function (account, password, err) {
+    onSignInError (account, password, err) {
       if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
         return this._suggestSignUp(err);
       } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
@@ -147,7 +147,7 @@ define(function (require, exports, module) {
       throw err;
     },
 
-    _suggestSignUp: function (err) {
+    _suggestSignUp (err) {
       err.forceMessage = t('Unknown account. <a href="/signup">Sign up</a>');
       return this.displayErrorUnsafe(err);
     },
@@ -191,7 +191,7 @@ define(function (require, exports, module) {
      *          Returns "null" if the current signin view must not suggest users.
      * @private
      */
-    _suggestedAccount: function () {
+    _suggestedAccount () {
       var account = this.user.getChooserAccount();
       var prefillEmail = this.getPrefillEmail();
 
@@ -215,7 +215,7 @@ define(function (require, exports, module) {
      * @returns {Boolean}
      * @private
      */
-    _suggestedAccountAskPassword: function (account) {
+    _suggestedAccountAskPassword (account) {
       // If there's no email, obviously we'll have to ask for the password.
       if (! account.get('email')) {
         this.logViewEvent('ask-password.shown.account-unknown');

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
     template: Template,
     className: 'sign-up',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._formPrefill = options.formPrefill;
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
       this._able = options.able;
     },
 
-    beforeRender: function () {
+    beforeRender () {
       if (document.cookie.indexOf('tooyoung') > -1) {
         this.navigate('cannot_create_account');
         return p(false);
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
       return FormView.prototype.beforeRender.call(this);
     },
 
-    _createCoppaView: function () {
+    _createCoppaView () {
       if (this._coppa) {
         return p();
       }
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
         });
     },
 
-    afterRender: function () {
+    afterRender () {
       this.logViewEvent('email-optin.visible.' +
           String(this._isEmailOptInEnabled()));
 
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
         });
     },
 
-    afterVisible: function () {
+    afterVisible () {
       if (this.model.get('bouncedEmail')) {
         this.showValidationError('input[type=email]',
                   AuthErrors.toError('SIGNUP_EMAIL_BOUNCE'));
@@ -129,14 +129,14 @@ define(function (require, exports, module) {
       'click #amo-migration a': 'onAmoSignIn'
     },
 
-    getPrefillEmail: function () {
+    getPrefillEmail () {
       // formPrefill.email comes first because users can edit the email,
       // go to another view, edit the email again, and come back here. We
       // want the last used email.
       return this._formPrefill.get('email') || this.relier.get('email');
     },
 
-    _selectAutoFocusEl: function () {
+    _selectAutoFocusEl () {
       var prefillEmail = this.model.get('forceEmail') || this.getPrefillEmail();
       var prefillPassword = this._formPrefill.get('password');
 
@@ -144,7 +144,7 @@ define(function (require, exports, module) {
             this.model.get('bouncedEmail'), prefillEmail, prefillPassword);
     },
 
-    context: function () {
+    context () {
       var autofocusEl = this._selectAutoFocusEl();
       var forceEmail = this.model.get('forceEmail');
       var prefillEmail = this.getPrefillEmail();
@@ -175,13 +175,13 @@ define(function (require, exports, module) {
       return context;
     },
 
-    beforeDestroy: function () {
+    beforeDestroy () {
       var formPrefill = this._formPrefill;
       formPrefill.set('email', this.getElementValue('.email'));
       formPrefill.set('password', this.getElementValue('.password'));
     },
 
-    isValidEnd: function () {
+    isValidEnd () {
       if (this._isEmailSameAsBouncedEmail()) {
         return false;
       }
@@ -196,7 +196,7 @@ define(function (require, exports, module) {
       return FormView.prototype.isValidEnd.call(this);
     },
 
-    showValidationErrorsEnd: function () {
+    showValidationErrorsEnd () {
       if (this._isEmailSameAsBouncedEmail()) {
         this.showValidationError('input[type=email]',
                 AuthErrors.toError('DIFFERENT_EMAIL_REQUIRED'));
@@ -206,7 +206,7 @@ define(function (require, exports, module) {
       }
     },
 
-    submit: function () {
+    submit () {
       this.notifier.trigger('signup.submit');
       /**
        * The semi-convoluted flow:
@@ -251,12 +251,12 @@ define(function (require, exports, module) {
       });
     },
 
-    _signUp: function (account, password) {
+    _signUp (account, password) {
       return this.signUp(account, password)
         .fail(this.onSignUpError.bind(this, account, password));
     },
 
-    onSignUpError: function (account, password, err) {
+    onSignUpError (account, password, err) {
       if (AuthErrors.is(err, 'ACCOUNT_ALREADY_EXISTS')) {
         // account exists and is verified,
         // attempt to sign in the user.
@@ -267,12 +267,12 @@ define(function (require, exports, module) {
       throw err;
     },
 
-    _signIn: function (account, password) {
+    _signIn (account, password) {
       return this.signIn(account, password)
         .fail(this.onSignInError.bind(this, account, password));
     },
 
-    onSignInError: function (account, password, err) {
+    onSignInError (account, password, err) {
       // only verified users who already have an account will see
       // the INCORRECT_PASSWORD error.
       if (AuthErrors.is(err, 'INCORRECT_PASSWORD')) {
@@ -297,31 +297,31 @@ define(function (require, exports, module) {
       throw err;
     },
 
-    onEmailBlur: function () {
+    onEmailBlur () {
       if (this.isInExperiment('mailcheck')) {
         mailcheck(this.$el.find('.email'), this.metrics, this.translator, this);
       }
     },
 
-    onAmoSignIn: function () {
+    onAmoSignIn () {
       // The user has chosen to sign in with a different email, clear the
       // email from the relier so it's not used again on the signin page.
       this.relier.unset('email');
       this.$('input[type=email]').val('');
     },
 
-    _isEmailSameAsBouncedEmail: function () {
+    _isEmailSameAsBouncedEmail () {
       var bouncedEmail = this.model.get('bouncedEmail');
 
       return bouncedEmail &&
              bouncedEmail === this.getElementValue('input[type=email]');
     },
 
-    _isUserOldEnough: function () {
+    _isUserOldEnough () {
       return this._coppa.isUserOldEnough();
     },
 
-    _isEmailFirefoxDomain: function () {
+    _isEmailFirefoxDomain () {
       var email = this.getElementValue('.email');
 
       // "@firefox" or "@firefox.com" email addresses are not valid
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
       return /@firefox(\.com)?$/.test(email);
     },
 
-    _cannotCreateAccount: function () {
+    _cannotCreateAccount () {
       // this is a session cookie. It will go away once:
       // 1. the user closes the tab
       // and
@@ -341,7 +341,7 @@ define(function (require, exports, module) {
       this.navigate('cannot_create_account');
     },
 
-    _initAccount: function () {
+    _initAccount () {
       var account = this.user.initAccount({
         customizeSync: this.$('.customize-sync').is(':checked'),
         email: this.getElementValue('.email'),
@@ -360,12 +360,12 @@ define(function (require, exports, module) {
       return account;
     },
 
-    _suggestSignIn: function (err) {
+    _suggestSignIn (err) {
       err.forceMessage = t('Account already exists. <a href="/signin">Sign in</a>');
       return this.displayErrorUnsafe(err);
     },
 
-    _isEmailOptInEnabled: function () {
+    _isEmailOptInEnabled () {
       return !! this._able.choose('communicationPrefsVisible', {
         lang: this.navigator.language
       });

--- a/app/scripts/views/sub_panels.js
+++ b/app/scripts/views/sub_panels.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
     template: Template,
     className: 'sub-panels',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
 
       this._panelViews = options.panelViews || [];
@@ -26,7 +26,7 @@ define(function (require, exports, module) {
       this._logger = new Logger();
     },
 
-    showChildView: function (ChildView, options) {
+    showChildView (ChildView, options) {
       if (this._panelViews.indexOf(ChildView) === -1) {
         this._logger.warn('Tried to show a view that is not a subpanel');
         return p(null);
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
         });
     },
 
-    _childViewInstanceFromClass: function (ChildView) {
+    _childViewInstanceFromClass (ChildView) {
       return this.childViews.filter(function (childView) {
         if (childView instanceof ChildView) {
           return true;
@@ -56,16 +56,16 @@ define(function (require, exports, module) {
       })[0];
     },
 
-    _isModalView: function (ChildView) {
+    _isModalView (ChildView) {
       return !! ChildView.prototype.isModal;
     },
 
-    _childViewClassName: function (ChildView) {
+    _childViewClassName (ChildView) {
       return ChildView.prototype.className;
     },
 
     // Render childView if an instance doesn't already exist
-    _createChildViewIfNeeded: function (ChildView, options) {
+    _createChildViewIfNeeded (ChildView, options) {
       options = options || {};
 
       var childView = this._childViewInstanceFromClass(ChildView);
@@ -103,7 +103,7 @@ define(function (require, exports, module) {
       return this.renderChildView(view);
     },
 
-    renderChildView: function (viewToShow) {
+    renderChildView (viewToShow) {
       return viewToShow.render()
         .then(function (shown) {
           if (! shown) {

--- a/app/scripts/views/tooltip.js
+++ b/app/scripts/views/tooltip.js
@@ -23,7 +23,7 @@ define(function (require, exports, module) {
     // tracks the type of a tooltip, used for metrics purposes
     type: 'generic',
 
-    initialize: function (options) {
+    initialize (options) {
       options = options || {};
       this.message = options.message || '';
       this.dismissible  = options.dismissible || false;
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
       this.invalidEl = $(options.invalidEl);
     },
 
-    template: function () {
+    template () {
       return this.translator.get(this.message);
     },
 
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
       return proto.afterRender.call(this);
     },
 
-    beforeDestroy: function () {
+    beforeDestroy () {
       displayedTooltip = null;
 
       // ditch the events we manually added to reduce interference
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
       invalidEl.find('option').off('click', this._destroy);
     },
 
-    setPosition: function () {
+    setPosition () {
       // by default, the position is above the input/select element
       // to show the tooltip below the element, we use JS to set
       // the top of the tooltip to be just below the element it is
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
       }
     },
 
-    bindDOMEvents: function () {
+    bindDOMEvents () {
       var invalidEl = this.invalidEl;
 
       // destroy the tooltip any time the user

--- a/app/tests/mocks/canvas.js
+++ b/app/tests/mocks/canvas.js
@@ -13,22 +13,22 @@ define(function (require, exports, module) {
   }
 
   CanvasMock.prototype = {
-    getContext: function () {
+    getContext () {
       this._context = {
-        translate: function () { },
-        rotate: function () { },
-        drawImage: function () {
+        translate () { },
+        rotate () { },
+        drawImage () {
           this._args = arguments;
         }
       };
 
       return this._context;
     },
-    toDataURL: function () {
+    toDataURL () {
       this._args = arguments;
       return 'data:image/jpeg';
     },
-    toBlob: function (cb) {
+    toBlob (cb) {
       this._args = arguments;
       setTimeout(function () {
         cb({ type: 'image/jpeg' });

--- a/app/tests/mocks/dom-event.js
+++ b/app/tests/mocks/dom-event.js
@@ -13,19 +13,19 @@ define(function (require, exports, module) {
   }
 
   DOMEventMock.prototype = {
-    preventDefault: function () {
+    preventDefault () {
       this._defaultPrevented = true;
     },
 
-    isDefaultPrevented: function () {
+    isDefaultPrevented () {
       return !! this._defaultPrevented;
     },
 
-    stopPropagation: function () {
+    stopPropagation () {
       this._propagationStopped = true;
     },
 
-    isPropagationStopped: function () {
+    isPropagationStopped () {
       return !! this._propagationStopped;
     }
   };

--- a/app/tests/mocks/file-reader.js
+++ b/app/tests/mocks/file-reader.js
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
   };
 
   FileReaderMock.prototype = {
-    readAsDataURL: function (file) {
+    readAsDataURL (file) {
       this.onload({
         target: {
           result: file._dataURL

--- a/app/tests/mocks/history.js
+++ b/app/tests/mocks/history.js
@@ -10,7 +10,7 @@ define(function (require, exports, module) {
   function History() {}
 
   History.prototype = {
-    start: function () {
+    start () {
     }
   };
 

--- a/app/tests/mocks/oauth_servers.js
+++ b/app/tests/mocks/oauth_servers.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
   }
 
   MockOAuthServers.prototype = {
-    destroy: function () {
+    destroy () {
       this.fakeServer.restore();
     }
   };

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -18,7 +18,7 @@ define(function (require, exports, module) {
       observe: sinon.spy(),
       disconnect: sinon.spy(),
       // test function to call notifier.
-      mockNotify: function (mutations) {
+      mockNotify (mutations) {
         notifier(mutations);
       }
     };
@@ -47,17 +47,17 @@ define(function (require, exports, module) {
     };
 
     this.history = {
-      back: function () {
+      back () {
         win.history.back.called = true;
       },
-      replaceState: function () {}
+      replaceState () {}
     };
 
     this.navigator = {
       userAgent: window.navigator.userAgent,
       mediaDevices: {
         // simulate the API presented by the WebRTC polyfill
-        getUserMedia: function (options) {
+        getUserMedia (options) {
           var deferred = p.defer();
 
           var nav = this;
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
 
           setTimeout(function () {
             var stream = {
-              stop: function () {
+              stop () {
               }
             };
             if (nav._error) {
@@ -81,11 +81,11 @@ define(function (require, exports, module) {
           return deferred.promise;
         }
       },
-      sendBeacon: function () {}
+      sendBeacon () {}
     };
 
     this.URL = {
-      createObjectURL: function (/*stream*/) {
+      createObjectURL (/*stream*/) {
         return '';
       }
     };
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
   }
 
   _.extend(WindowMock.prototype, Backbone.Events, {
-    dispatchEvent: function (event) {
+    dispatchEvent (event) {
       var msg = event.detail.command || event.detail.message;
 
       var listenerEvent = {
@@ -132,46 +132,48 @@ define(function (require, exports, module) {
       }
     },
 
-    isEventDispatched: function (eventName) {
+    isEventDispatched (eventName) {
       return !! (this.dispatchedEvents && this.dispatchedEvents[eventName]);
     },
 
-    addEventListener: function (msg, callback/*, bubbles*/) {
+    addEventListener (msg, callback/*, bubbles*/) {
       this.on(msg, callback);
     },
 
-    removeEventListener: function (msg, callback/*, bubbles*/) {
+    removeEventListener (msg, callback/*, bubbles*/) {
       this.off(msg, callback);
     },
 
+    // Cannot be converted to object shorthand notation
+    // because it's used as a constructor.
     CustomEvent: function (command, data) {
       return data;
     },
 
-    scrollTo: function (/*x, y*/) {
+    scrollTo (/*x, y*/) {
     },
 
-    setTimeout: function (/*callback, timeoutMS*/) {
+    setTimeout (/*callback, timeoutMS*/) {
       this._isTimeoutSet = true;
       return 'timeout';
     },
 
-    isTimeoutSet: function () {
+    isTimeoutSet () {
       return !! this._isTimeoutSet;
     },
 
-    clearTimeout: function (/*timeout*/) {
+    clearTimeout (/*timeout*/) {
     },
 
     navigator: {
       language: 'en-US'
     },
 
-    open: function (url/*, target, windowName*/) {
+    open (url/*, target, windowName*/) {
       console.log('window.open was called with', url);
     },
 
-    postMessage: function (/*msg, targetOrigin*/) {
+    postMessage (/*msg, targetOrigin*/) {
     }
   });
 

--- a/app/tests/spec/lib/able.js
+++ b/app/tests/spec/lib/able.js
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
 
       it('defers to window.able.choose if available', function () {
         window.able = {
-          choose: function () {
+          choose () {
             return 'value';
           }
         };

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -624,7 +624,7 @@ define(function (require, exports, module) {
         });
 
         appStart._iframeChannel = {
-          send: function (message, data) {
+          send (message, data) {
             TestHelpers.wrapAssertion(function () {
               assert.equal(message, 'resize');
               assert.typeOf(data.height, 'number');
@@ -839,7 +839,7 @@ define(function (require, exports, module) {
 
           sinon.stub(appStart, '_getSameBrowserVerificationModel', function () {
             return {
-              get: function () {
+              get () {
                 return 'fx_ios_v1';
               }
             };
@@ -866,7 +866,7 @@ define(function (require, exports, module) {
 
           sinon.stub(appStart, '_getSameBrowserVerificationModel', function () {
             return {
-              get: function () {
+              get () {
                 return undefined;
               }
             };

--- a/app/tests/spec/lib/experiment.js
+++ b/app/tests/spec/lib/experiment.js
@@ -25,10 +25,10 @@ define(function (require, exports, module) {
   var user;
   var UUID = 'a mock uuid';
   var mockExperiment = {
-    initialize: function () {
+    initialize () {
       return true;
     },
-    isInGroup: function () {
+    isInGroup () {
       return true;
     }
   };
@@ -112,7 +112,8 @@ define(function (require, exports, module) {
 
       it('choose experiments', function () {
         expInt._allExperiments = {
-          'mock': function () {
+          // Cannot use object shorthand because it's converts
+          mock: function () {
             return mockExperiment;
           }
         };

--- a/app/tests/spec/lib/experiments/base.js
+++ b/app/tests/spec/lib/experiments/base.js
@@ -159,7 +159,7 @@ define(function (require, exports, module) {
         experiment.notifications = {
           'one': Experiment.createSaveStateDelegate('thing'),
           'two': 'createSaveStateDelegate',
-          'three': function () {
+          'three' () {
             assert.ok(true, 'stringMethod called');
             done();
           }

--- a/app/tests/spec/lib/experiments/mailcheck.js
+++ b/app/tests/spec/lib/experiments/mailcheck.js
@@ -61,12 +61,12 @@ define(function (require, exports, module) {
       it('logs the corrected event', function () {
         var mockView = {
           $el: {
-            find: function () {
+            find () {
               return {
-                val: function () {
+                val () {
                   return 'a@gmail.com';
                 },
-                data: function () {
+                data () {
                   return 'a@gmail.com';
                 }
               };
@@ -80,12 +80,12 @@ define(function (require, exports, module) {
       it('does not log the corrected event if email value does not match', function () {
         var mockView = {
           $el: {
-            find: function () {
+            find () {
               return {
-                val: function () {
+                val () {
                   return 'a@snailmail.com';
                 },
-                data: function () {
+                data () {
                   return 'a@gmail.com';
                 }
               };

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -306,8 +306,8 @@ define(function (require, exports, module) {
 
       beforeEach(function () {
         clientMock = {
-          accountStatus: function () {},
-          recoveryEmailStatus: function () {}
+          accountStatus () {},
+          recoveryEmailStatus () {}
         };
 
         accountInfo = err = null;
@@ -751,13 +751,13 @@ define(function (require, exports, module) {
         var code = 'code';
 
         var relier = {
-          has: function () {
+          has () {
             return false;
           },
-          isSync: function () {
+          isSync () {
             return true;
           },
-          wantsKeys: function () {
+          wantsKeys () {
             return true;
           }
         };
@@ -901,13 +901,13 @@ define(function (require, exports, module) {
         var trimmedEmail = trim(email);
 
         var relier = {
-          has: function () {
+          has () {
             return false;
           },
-          isSync: function () {
+          isSync () {
             return true;
           },
-          wantsKeys: function () {
+          wantsKeys () {
             return true;
           }
         };

--- a/app/tests/spec/lib/mailcheck.js
+++ b/app/tests/spec/lib/mailcheck.js
@@ -23,14 +23,14 @@ define(function (require, exports, module) {
   describe('lib/mailcheck', function () {
     var mockTranslator = window.translator;
     var mockMetrics = {
-      logEvent: function () {
+      logEvent () {
       }
     };
     var mockView;
 
     beforeEach(function () {
       mockView = {
-        isInExperimentGroup: function () {
+        isInExperimentGroup () {
           return true;
         },
         notifier: {

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -156,7 +156,7 @@ define(function (require, exports, module) {
         metrics.destroy();
 
         sandbox = sinon.sandbox.create();
-        xhr = { ajax: function () {} };
+        xhr = { ajax () {} };
         environment = new Environment(windowMock);
         metrics = new Metrics({
           environment: environment,

--- a/app/tests/spec/lib/storage.js
+++ b/app/tests/spec/lib/storage.js
@@ -171,7 +171,7 @@ define(function (require, exports, module) {
       it('does not blow up if cookies are disabled', function () {
         var local;
         Object.defineProperty(windowMock, 'localStorage', {
-          get: function () {
+          get () {
             throw new Error('The operation is insecure.');
           }
         });

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
       fxaClient = new FxaClientWrapper();
       marketingEmailClient = new MarketingEmailClient();
       metrics = {
-        getFlowEventMetadata: function () {
+        getFlowEventMetadata () {
           return {
             baz: 'qux',
             foo: 'bar'

--- a/app/tests/spec/models/mixins/resume-token.js
+++ b/app/tests/spec/models/mixins/resume-token.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
     var MISSING_RESUME_DATA = {};
 
     var Model = Backbone.Model.extend({
-      initialize: function (options) {
+      initialize (options) {
         this.sentryMetrics = sentryMetrics;
         this.window = options.window;
       },

--- a/app/tests/spec/models/mixins/search-param.js
+++ b/app/tests/spec/models/mixins/search-param.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
     var model;
 
     var Model = Backbone.Model.extend({
-      initialize: function (options) {
+      initialize (options) {
         this.window = options.window;
       }
     });

--- a/app/tests/spec/models/verification/base.js
+++ b/app/tests/spec/models/verification/base.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
       uid: null
     },
 
-    validate: function (attributes) {
+    validate (attributes) {
       if (attributes.uid === null || attributes.code === null) {
         throw new Error('invalid');
       }

--- a/app/tests/spec/views/app.js
+++ b/app/tests/spec/views/app.js
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
         el: $('#container'),
         environment: environment,
         notifier: notifier,
-        createView: function (Constructor, options) {
+        createView (Constructor, options) {
           return new Constructor(options);
         },
         window: windowMock
@@ -131,15 +131,15 @@ define(function (require, exports, module) {
         var isLogged = false;
 
         var DoesNotRenderView = Backbone.View.extend({
-          render: function () {
+          render () {
             return p(false);
           },
 
-          destroy: function () {
+          destroy () {
             isDestroyed = true;
           },
 
-          logView: function () {
+          logView () {
             isLogged = true;
           }
         });
@@ -173,11 +173,11 @@ define(function (require, exports, module) {
           afterVisible: sinon.spy(),
           destroy: sinon.spy(),
           logView: sinon.spy(),
-          render: function () {
+          render () {
             this.$el.html('<div id="rendered-view"></div>');
             return p(true);
           },
-          titleFromView: function () {
+          titleFromView () {
             return 'the title';
           }
         });
@@ -231,7 +231,7 @@ define(function (require, exports, module) {
           render: sinon.spy(function () {
             return p(true);
           }),
-          titleFromView: function () {
+          titleFromView () {
             return 'the title';
           }
         });
@@ -243,7 +243,7 @@ define(function (require, exports, module) {
           render: sinon.spy(function () {
             return p(true);
           }),
-          titleFromView: function () {
+          titleFromView () {
             return 'the second title';
           }
         });
@@ -294,7 +294,7 @@ define(function (require, exports, module) {
           render: sinon.spy(function () {
             return p(true);
           }),
-          titleFromView: function () {
+          titleFromView () {
             return 'the title';
           }
         });
@@ -354,7 +354,7 @@ define(function (require, exports, module) {
           render: sinon.spy(function () {
             return p.reject(renderError);
           }),
-          titleFromView: function () {
+          titleFromView () {
             return 'the title';
           }
         });
@@ -387,7 +387,7 @@ define(function (require, exports, module) {
         showChildView: sinon.spy(function (ChildView, options) {
           return new ChildView(options);
         }),
-        titleFromView: function () {
+        titleFromView () {
           return 'the title';
         }
       });
@@ -400,7 +400,7 @@ define(function (require, exports, module) {
         render: sinon.spy(function () {
           return p(true);
         }),
-        titleFromView: function (base) {
+        titleFromView (base) {
           return base + ', the second title';
         }
       });

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
 
     beforeEach(function () {
       flow = {
-        pickResumeTokenInfo: function () {}
+        pickResumeTokenInfo () {}
       };
       metrics = new Metrics();
       model = new Backbone.Model();

--- a/app/tests/spec/views/decorators/progress_indicator.js
+++ b/app/tests/spec/views/decorators/progress_indicator.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
     var progressIndicator;
 
     var View = BaseView.extend({
-      template: function () {
+      template () {
         return '<button type="submit">Button</button>';
       },
       longRunningAction: showProgressIndicator(function () {

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -28,15 +28,15 @@ define(function (require, exports, module) {
     formIsValid: false,
     isFormSubmitted: false,
 
-    isValid: function () {
+    isValid () {
       return this.formIsValid;
     },
 
-    showValidationErrors: function () {
+    showValidationErrors () {
       return this.showValidationError('body', 'invalid form');
     },
 
-    submit: function () {
+    submit () {
       this.isFormSubmitted = true;
     }
   });

--- a/app/tests/spec/views/mixins/account-reset-mixin.js
+++ b/app/tests/spec/views/mixins/account-reset-mixin.js
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
 
   var AccountResetView = BaseView.extend({
     template: Template,
-    resetPassword: function () {
+    resetPassword () {
       return p();
     }
   });

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
     describe('displayAccountProfileImage with spinner', function () {
       var spinnerView;
       var SpinnerView = SettingsView.extend({
-        template: function () {
+        template () {
           return '<div class="avatar-wrapper"></div>';
         }
       });

--- a/app/tests/spec/views/mixins/experiment-mixin.js
+++ b/app/tests/spec/views/mixins/experiment-mixin.js
@@ -23,7 +23,7 @@ define(function (require, exports, module) {
   Cocktail.mixin(View, Mixin);
 
   var mockExperiment = {
-    isInGroup: function () {
+    isInGroup () {
       return true;
     }
   };

--- a/app/tests/spec/views/mixins/password-strength-mixin.js
+++ b/app/tests/spec/views/mixins/password-strength-mixin.js
@@ -37,13 +37,13 @@ define(function (require, exports, module) {
         view = new View({
           able: ableMock,
           metrics: {
-            isCollectionEnabled: function () {
+            isCollectionEnabled () {
               return true;
             },
             logViewEvent: sinon.spy()
           },
           user: {
-            get: function () {
+            get () {
               return 'userid';
             }
           },

--- a/app/tests/spec/views/pp.js
+++ b/app/tests/spec/views/pp.js
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
 
     beforeEach(function () {
       xhrMock = {
-        ajax: function () {
+        ajax () {
           return p(TEMPLATE_TEXT);
         }
       };

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
       able = new Able();
       metrics = {
         flush: sinon.spy(p),
-        logMarketingImpression: function () {}
+        logMarketingImpression () {}
       };
     }
 

--- a/app/tests/spec/views/settings/avatar_camera.js
+++ b/app/tests/spec/views/settings/avatar_camera.js
@@ -293,7 +293,7 @@ define(function (require, exports, module) {
 
         function mockStream() {
           view.stream = {
-            stop: function () {}
+            stop () {}
           };
         }
 

--- a/app/tests/spec/views/sub_panels.js
+++ b/app/tests/spec/views/sub_panels.js
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
         notifier: notifier,
         panelViews: panelViews,
         parent: parent,
-        createView: function (Constructor, options) {
+        createView (Constructor, options) {
           return new Constructor(options);
         }
       });

--- a/app/tests/spec/views/tos.js
+++ b/app/tests/spec/views/tos.js
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
 
     beforeEach(function () {
       xhrMock = {
-        ajax: function () {
+        ajax () {
           return p(TEMPLATE_TEXT);
         }
       };


### PR DESCRIPTION
Convert:

```js
  funcName: function (param) {
    // body
  }
```

to:

```js
  funcName (param) {
    //body
  }
```