### PR TITLE
fix(client): Use open in webmail button on reset sent page (#4096 )

### DIFF
--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -10,6 +10,12 @@
     <div class="graphic graphic-mail">{{#t}}Email Sent{{/t}}</div>
 
     <p class="verification-email-message">{{#t}}Click on the link we've emailed you at %(email)s within the next hour to create a new password.{{/t}}</p>
+    
+    {{#isOpenWebmailButtonVisible}}
+      <div class="button-row">
+        <a href="{{{ unsafeWebmailLink }}}" data-webmail-type="{{webmailType}}" class="button" target="_blank" id="open-webmail" type="button">{{webmailButtonText}}</a>
+      </div>
+    {{/isOpenWebmailButtonVisible}}
 
     <ul class="links">
       {{#isSignInEnabled}}

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -10,6 +10,7 @@ define(function (require, exports, module) {
   const Cocktail = require('cocktail');
   const ConfirmView = require('views/confirm');
   const Notifier = require('lib/channels/notifier');
+  const OpenConfirmationEmailMixin = require('views/mixins/open-webmail-mixin');
   const p = require('lib/promise');
   const PasswordResetMixin = require('views/mixins/password-reset-mixin');
   const ResendMixin = require('views/mixins/resend-mixin');
@@ -275,6 +276,7 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     View,
+    OpenConfirmationEmailMixin,
     PasswordResetMixin,
     ResendMixin,
     ServiceMixin


### PR DESCRIPTION
add the open in webmail button to confirm_reset_password page
fix for https://github.com/mozilla/fxa-content-server/issues/4096