### PR TITLE
fix(test): Fix the "focus" test

### DIFF
--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -582,6 +582,7 @@ define(function (require, exports, module) {
 
     describe('focus', () => {
       it('focuses an element, sets the cursor position', (done) => {
+        $('html').addClass('no-touch');
         requiresFocus(() => {
           // webkit fails unless focusing another element first.
           $('#otherElement').focus();


### PR DESCRIPTION
For focus to work, the html element has to have the `no-touch` class.
The tests did not ensure this.

fixes #4227 

@vbudhram or @philbooth - r?