### PR TITLE
fix(test): Fix the requireOnDemand unit tests in Fx 52.

### DIFF
--- a/app/scripts/lib/require-on-demand.js
+++ b/app/scripts/lib/require-on-demand.js
@@ -49,7 +49,15 @@ define(function (require, exports, module) {
   });
   /*eslint-enable sorting/sort-object-props*/
 
-  function requireOnDemand(resourceToGet) {
+  /**
+   * Require a dependency on demand
+   *
+   * @param {String} resourceToGet - path or URL of the resource to get.
+   * @param {Object} [win] - window object, useful to pass in for testing.
+   * Defaults to `window`
+   * @returns {Promise}
+   */
+  function requireOnDemand(resourceToGet, win = window) {
     return p().then(function () {
       var deferred = p.defer();
 
@@ -61,7 +69,7 @@ define(function (require, exports, module) {
       // the resource into the main bundle. Instead, the item will
       // be loaded on demand, and the module returned when the promise
       // resolves.
-      var getNow = window.require;
+      var getNow = win.require;
       getNow([resourceToGet], deferred.resolve.bind(deferred),
         function (requireErr) {
           // RequireJS errors described in

--- a/app/tests/spec/lib/require-on-demand.js
+++ b/app/tests/spec/lib/require-on-demand.js
@@ -15,25 +15,21 @@ define(function (require, exports, module) {
     var MockModule2 = {};
     var windowMock;
 
-    beforeEach(() => {
-      windowMock = {
-        require: function () {}
-      };
-    });
-
     describe('successful load', function () {
       beforeEach(function () {
-        sinon.stub(windowMock, 'require', function (moduleList, callback) {
-          // requirejs is asynchronous, add a setTimeout to mimic that behavior.
-          setTimeout(function () {
-            var requestedModule = moduleList[0];
-            if (requestedModule === 'module1') {
-              callback(MockModule1);
-            } else if (requestedModule === 'module2') {
-              callback(MockModule2);
-            }
-          }, 0);
-        });
+        windowMock = {
+          require: sinon.spy((moduleList, callback) => {
+            // requirejs is asynchronous, add a setTimeout to mimic that behavior.
+            setTimeout(() => {
+              var requestedModule = moduleList[0];
+              if (requestedModule === 'module1') {
+                callback(MockModule1);
+              } else if (requestedModule === 'module2') {
+                callback(MockModule2);
+              }
+            }, 0);
+          })
+        };
       });
 
       it('loads a module', function () {
@@ -60,15 +56,17 @@ define(function (require, exports, module) {
       var errType;
 
       beforeEach(function () {
-        sinon.stub(windowMock, 'require', function (moduleList, callback, errback) {
-          // requirejs is asynchronous, add a setTimeout to mimic that behavior.
-          setTimeout(function () {
-            errback({
-              requireModules: [moduleList],
-              requireType: errType
-            });
-          }, 0);
-        });
+        windowMock = {
+          require: sinon.spy((moduleList, callback, errback) => {
+            // requirejs is asynchronous, add a setTimeout to mimic that behavior.
+            setTimeout(() => {
+              errback({
+                requireModules: [moduleList],
+                requireType: errType
+              });
+            }, 0);
+          })
+        };
       });
 
       it('fails if there is a timeout fetching the resource', function () {


### PR DESCRIPTION
Unit tests blow up in Fx 52 when trying to stub window.require, saying
defining a non-configurable property on a WindowProxy is verboten.

Instead of working with the real window object, pass in a window mock

fixes #4274

@vbudhram and @philbooth - another one!
@seanmonstar - if you want to get in on the front-end action, have at it!