### PR TITLE
fix(tests): Fix the `oauth query parameter validation` functional tests.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1157,6 +1157,7 @@ define([
     return function () {
       return this.parent
         .findByCssSelector(selector)
+        .then(visibleByQSA(selector))
         .getVisibleText()
         .then(function (resultText) {
           assert.equal(resultText, expected);
@@ -1176,6 +1177,7 @@ define([
     return function () {
       return this.parent
         .findByCssSelector(selector)
+        .then(visibleByQSA(selector))
         .getVisibleText()
         .then(function (resultText) {
           assert.include(resultText.toLowerCase(), expected.toLowerCase());


### PR DESCRIPTION
They sometimes fail because the `.error` text is reported to be empty,
but it's possible to check the element before it's visible.

@philbooth - mind an r?