### PR TITLE
fix(text): Change `Damaged link` to `Link damaged` to consolidate strings

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -319,7 +319,7 @@ define(function (require, exports, module) {
     },
     DAMAGED_REJECT_UNBLOCK_LINK: {
       errno: 1045,
-      message: t('Damaged link')
+      message: t('Link damaged')
     }
   };
   /*eslint-enable sorting/sort-object-props*/


### PR DESCRIPTION
I only noticed the two distinct strings during the l10n extraction.