### PR TITLE
fix(client): All template writes are by default HTML escaped.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -320,7 +320,22 @@ define(function (require, exports, module) {
     DAMAGED_REJECT_UNBLOCK_LINK: {
       errno: 1045,
       message: t('Link damaged')
+    },
+    // logged when view.unsafeTranslate called with a string that
+    // contains a variable without an `escaped` prefix
+    UNSAFE_INTERPOLATION_VARIABLE_NAME: {
+      errno: 1046,
+      // not user facing, only used for logging, not wrapped in `t`
+      message: 'String contains variables that are not escaped: %(string)s'
+    },
+    // logged when view.translate called with a string that contains
+    // HTML.
+    HTML_WILL_BE_ESCAPED: {
+      errno: 1047,
+      // not user facing, only used for logging, not wrapped in `t`
+      message: 'HTML will be escaped: %(string)s'
     }
+
   };
   /*eslint-enable sorting/sort-object-props*/
 
@@ -361,6 +376,14 @@ define(function (require, exports, module) {
         } else if (this.is(err, 'MISSING_DATA_ATTRIBUTE')) {
           return {
             property: err.property
+          };
+        } else if (this.is(err, 'UNSAFE_INTERPOLATION_VARIABLE_NAME')) {
+          return {
+            string: err.string
+          };
+        } else if (this.is(err, 'HTML_WILL_BE_ESCAPED')) {
+          return {
+            string: err.string
           };
         } else if (this.is(err, 'THROTTLED')) {
           if (err.retryAfterLocalized) {

--- a/app/scripts/templates/cannot_create_account.mustache
+++ b/app/scripts/templates/cannot_create_account.mustache
@@ -5,7 +5,7 @@
 
   <section class="cannot-create-account-content">
     <p>
-      <strong>{{#t}}You must meet certain age requirements to create a Firefox&nbsp;Account.{{/t}}</strong>
+      <strong>{{#unsafeTranslate}}You must meet certain age requirements to create a Firefox&nbsp;Account.{{/unsafeTranslate}}</strong>
     </p>
     <p class="links">
       <a class="ftc" href="http://www.ftc.gov/news-events/media-resources/protecting-consumer-privacy/kids-privacy-coppa" {{#isSync}} target="_blank"{{/isSync}}>{{#t}}Learn more.{{/t}}</a>

--- a/app/scripts/templates/confirm.mustache
+++ b/app/scripts/templates/confirm.mustache
@@ -15,7 +15,7 @@
     <div class="graphic graphic-mail">{{#t}}Email Sent{{/t}}</div>
 
     {{#isSignUp}}
-    <p class="verification-email-message">{{#t}}A verification link has been sent&nbsp;to %(email)s{{/t}}</p>
+    <p class="verification-email-message">{{#unsafeTranslate}}A verification link has been sent&nbsp;to %(escapedEmail)s{{/unsafeTranslate}}</p>
     {{/isSignUp}}
     {{#isSignIn}}
     <p class="verification-email-message">{{#t}}To better protect your Firefox data, we've emailed a confirmation link to %(email)s{{/t}}</p>
@@ -23,7 +23,7 @@
 
     {{#isOpenWebmailButtonVisible}}
       <div class="button-row">
-        <a href="{{{ unsafeWebmailLink }}}" data-webmail-type="{{webmailType}}" class="button" target="_blank" id="open-webmail" type="button">{{webmailButtonText}}</a>
+        <a href="{{{ escapedWebmailLink }}}" data-webmail-type="{{webmailType}}" class="button" target="_blank" id="open-webmail" type="button">{{webmailButtonText}}</a>
       </div>
     {{/isOpenWebmailButtonVisible}}
 

--- a/app/scripts/templates/force_auth.mustache
+++ b/app/scripts/templates/force_auth.mustache
@@ -34,7 +34,7 @@
     </div>
 
     <div class="extra-links">
-      {{#t}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a> of Firefox cloud services.{{/t}}
+      {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a> of Firefox cloud services.{{/unsafeTranslate}}
     </div>
     {{/fatalError}}
   </section>

--- a/app/scripts/templates/settings.mustache
+++ b/app/scripts/templates/settings.mustache
@@ -23,7 +23,7 @@
       <h1 class="card-header">{{userEmail}}</h1>
       <h2 class="card-subheader"></h2>
     {{/displayName}}
-    
+
   </header>
   <div id="sub-panels"></div>
 </div>

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -20,7 +20,7 @@
       <div class="error"></div>
       <div class="success"></div>
       {{#isSyncMigration}}
-          <div class="info nudge" id="sync-migration">{{#t}}Migrate your sync data by signing in to your Firefox&nbsp;Account.{{/t}}</div>
+          <div class="info nudge" id="sync-migration">{{#unsafeTranslate}}Migrate your sync data by signing in to your Firefox&nbsp;Account.{{/unsafeTranslate}}</div>
       {{/isSyncMigration}}
 
       {{#suggestedAccount}}
@@ -89,7 +89,7 @@
       </div>
 
       <div class="extra-links">
-        {{#t}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a> of Firefox cloud services.{{/t}}
+        {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a> of Firefox cloud services.{{/unsafeTranslate}}
       </div>
       {{/suggestedAccount}}
 

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -21,15 +21,15 @@
     <div class="success"></div>
 
     {{#showSyncSuggestion}}
-      <div class="info nudge" id="suggest-sync">{{#t}}Looking for Firefox Sync? <a href="https://mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started">Get started here</a>{{/t}}</div>
+    <div class="info nudge" id="suggest-sync">{{#unsafeTranslate}}Looking for Firefox Sync? <a href="%(escapedSyncSuggestionUrl)s">Get started here</a>{{/unsafeTranslate}}</div>
     {{/showSyncSuggestion}}
 
     {{#isSyncMigration}}
-      <div class="info nudge" id="sync-migration">{{#t}}Migrate your sync data by creating a new Firefox&nbsp;Account.{{/t}}</div>
+      <div class="info nudge" id="sync-migration">{{#unsafeTranslate}}Migrate your sync data by creating a new Firefox&nbsp;Account.{{/unsafeTranslate}}</div>
     {{/isSyncMigration}}
 
     {{#isAmoMigration}}
-        <div class="info nudge pad" id="amo-migration">{{#t}}Have an account with a different email? <a href="%(signinUri)s">Sign in</a>{{/t}}</div>
+        <div class="info nudge pad" id="amo-migration">{{#unsafeTranslate}}Have an account with a different email? <a href="%(escapedSignInUri)s">Sign in</a>{{/unsafeTranslate}}</div>
     {{/isAmoMigration}}
 
     <form novalidate>
@@ -56,7 +56,7 @@
       </div>
 
       <div class="extra-links">
-        {{#t}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a> of Firefox cloud services.{{/t}}
+        {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a> of Firefox cloud services.{{/unsafeTranslate}}
       </div>
 
       {{#isEmailOptInVisible}}

--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -68,5 +68,5 @@
   <a id="external-link" href="http://external.com">External link</a>
   <a id="internal-link" href="/signin">Internal link</a>
   <a id="data-visible-url-not-added" href="https://mozilla.org">https://mozilla.org</a>
-  <a id="open-webmail" data-webmail-type="{{webmailType}}" href="{{{ unsafeWebmailLink }}}">{{webmailButtonText}}</a>
+  <a id="open-webmail" data-webmail-type="{{webmailType}}" href="{{{ escapedWebmailLink }}}">{{webmailButtonText}}</a>
 </div>

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const _ = require('underscore');
   const AuthErrors = require('lib/auth-errors');
   const BackMixin = require('views/mixins/back-mixin');
   const BaseView = require('views/base');
@@ -19,7 +20,7 @@ define(function (require, exports, module) {
   const Template = require('stache!templates/confirm');
   const VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
 
-  var t = BaseView.t;
+  const t = BaseView.t;
 
   const proto = BaseView.prototype;
   const View = BaseView.extend({
@@ -54,9 +55,10 @@ define(function (require, exports, module) {
         // it will since that's what happens on a bounced email, but that's
         // a discussion for another time.
         canGoBack: isSignIn && this.canGoBack(),
-        email: email,
-        isSignIn: isSignIn,
-        isSignUp: isSignUp
+        email,
+        escapedEmail: _.escape(email),
+        isSignIn,
+        isSignUp
       };
     },
 

--- a/app/scripts/views/mixins/account-reset-mixin.js
+++ b/app/scripts/views/mixins/account-reset-mixin.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
         t('Your account has been locked for security reasons') + '<br>' +
         '<a href="/confirm_reset_password">' + t('Reset password') + '</a>';
 
-      return this.displayErrorUnsafe(err);
+      return this.unsafeDisplayError(err);
     },
 
     /**

--- a/app/scripts/views/mixins/open-webmail-mixin.js
+++ b/app/scripts/views/mixins/open-webmail-mixin.js
@@ -75,7 +75,7 @@ define(function (require, exports, module) {
 
       if (email && isOpenWebmailButtonVisible) {
         _.extend(context, {
-          unsafeWebmailLink: this.getWebmailLink(email),
+          escapedWebmailLink: encodeURI(this.getWebmailLink(email)),
           // function.bind is used to avoid infinite recursion.
           // getWebmailButtonText calls this.translate which calls
           // this.context, which will call this.getContext since context is

--- a/app/scripts/views/mixins/password-prompt-mixin.js
+++ b/app/scripts/views/mixins/password-prompt-mixin.js
@@ -10,7 +10,7 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const t = require('views/base').t;
+  const { t } = require('views/base');
   const Tooltip = require('views/tooltip');
 
   // this link is not suitable for L10N and should be available in only `en` locales.
@@ -19,8 +19,7 @@ define(function (require, exports, module) {
   const TOOLTIP_MESSAGES = {
     FOCUS_PROMPT_MESSAGE: t('8 characters minimum, but longer if you plan to sync passwords.'),
     INITIAL_PROMPT_MESSAGE: t('A strong, unique password will keep your Firefox data safe from intruders.'),
-    WARNING_PROMPT_MESSAGE: t('This is a common password; please consider another one.'),
-    WARNING_PROMPT_MESSAGE_WITH_LINK: t('This is a common password; please consider another one.')
+    WARNING_PROMPT_MESSAGE: t('This is a common password; please consider another one.')
   };
 
   const PasswordPromptMixin = {
@@ -46,12 +45,8 @@ define(function (require, exports, module) {
     },
 
     displayPasswordWarningPrompt () {
-      let promptContent = TOOLTIP_MESSAGES.WARNING_PROMPT_MESSAGE;
-      if (this._isEnglishLocale()) {
-        promptContent = TOOLTIP_MESSAGES.WARNING_PROMPT_MESSAGE_WITH_LINK;
-      }
-
-      promptContent = this.translate(promptContent);
+      const promptContent =
+        this.translate(TOOLTIP_MESSAGES.WARNING_PROMPT_MESSAGE);
 
       const tooltip = new Tooltip({
         dismissible: false,

--- a/app/scripts/views/mixins/service-mixin.js
+++ b/app/scripts/views/mixins/service-mixin.js
@@ -19,8 +19,8 @@ define(function (require, exports, module) {
     },
 
     // override this method so we can fix signup/signin links in errors
-    displayErrorUnsafe (err) {
-      var result = BaseView.prototype.displayErrorUnsafe.call(this, err);
+    unsafeDisplayError (err) {
+      var result = BaseView.prototype.unsafeDisplayError.call(this, err);
 
       this.transformLinks();
 

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -69,7 +69,7 @@ define(function (require, exports, module) {
           Session.clear('oauth');
           if (AuthErrors.is(err, 'UNKNOWN_ACCOUNT')) {
             err.forceMessage = t('Unknown account. <a href="/signup">Sign up</a>');
-            return this.displayErrorUnsafe(err);
+            return this.unsafeDisplayError(err);
           } else if (AuthErrors.is(err, 'USER_CANCELED_LOGIN')) {
             this.logEvent('login.canceled');
             // if user canceled login, just stop

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -232,12 +232,12 @@ define(function (require, exports, module) {
       return BaseView.prototype.displaySuccess.apply(this, arguments);
     },
 
-    displaySuccessUnsafe () {
+    unsafeDisplaySuccess () {
       this.clearTimeout(this._successTimeout);
       this._successTimeout = this.setTimeout(() => {
         this.hideSuccess();
       }, this.SUCCESS_MESSAGE_DELAY_MS);
-      return BaseView.prototype.displaySuccessUnsafe.apply(this, arguments);
+      return BaseView.prototype.unsafeDisplaySuccess.apply(this, arguments);
     }
   });
 

--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
           this.updateProfileImage(new ProfileImage({ id: result.id, url: url }), account);
 
           this.navigate('settings', {
-            successUnsafe: t('Courtesy of <a href="https://www.gravatar.com">Gravatar</a>')
+            unsafeSuccess: t('Courtesy of <a href="https://www.gravatar.com">Gravatar</a>')
           });
           return result;
         });

--- a/app/scripts/views/settings/gravatar_permissions.js
+++ b/app/scripts/views/settings/gravatar_permissions.js
@@ -12,20 +12,25 @@ define(function (require, exports, module) {
   const ServiceMixin = require('views/mixins/service-mixin');
   const Template = require('stache!templates/settings/gravatar_permissions');
 
-  var GRAVATAR_MOCK_CLIENT_ID = 'gravatar';
-  var GRAVATAR_PERMISSION = 'profile:email';
+  const GRAVATAR_MOCK_CLIENT_ID = 'gravatar';
+  const GRAVATAR_PERMISSION = 'profile:email';
 
-  var View = FormView.extend({
+  const View = FormView.extend({
     template: Template,
     className: 'gravatar-permissions',
     viewName: 'settings.gravatar-permissions',
 
     context () {
-      var account = this.getSignedInAccount();
-      var serviceName = this.translator.get('Gravatar');
+      const email = this.getSignedInAccount().get('email');
+
+      // w/o a context, `this.translate` calls `this.getContext()` which
+      // calls this function, causing infinite recursion. Pass the
+      // context to avoid infinite recursion.
+      const serviceName = this.translate('Gravatar', {});
+
       return {
-        email: account.get('email'),
-        serviceName: serviceName
+        email,
+        serviceName
       };
     },
 

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -149,7 +149,7 @@ define(function (require, exports, module) {
 
     _suggestSignUp (err) {
       err.forceMessage = t('Unknown account. <a href="/signup">Sign up</a>');
-      return this.displayErrorUnsafe(err);
+      return this.unsafeDisplayError(err);
     },
 
     /**

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -157,6 +157,8 @@ define(function (require, exports, module) {
         chooseWhatToSyncCheckbox: this.broker.hasCapability('chooseWhatToSyncCheckbox'),
         email: prefillEmail,
         error: this.error,
+        escapedSignInUri: encodeURI(this.broker.transformLink('/signin')),
+        escapedSyncSuggestionUrl: encodeURI('https://mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started'), // eslint-disable-line max-len
         forceEmail: forceEmail,
         isAmoMigration: this.isAmoMigration(),
         isCustomizeSyncChecked: relier.isCustomizeSyncChecked(),
@@ -168,8 +170,7 @@ define(function (require, exports, module) {
         serviceName: relier.get('serviceName'),
         shouldFocusEmail: autofocusEl === 'email',
         shouldFocusPassword: autofocusEl === 'password',
-        showSyncSuggestion: this.isSyncSuggestionEnabled(),
-        signinUri: this.broker.transformLink('/signin')
+        showSyncSuggestion: this.isSyncSuggestionEnabled()
       };
 
       return context;
@@ -299,7 +300,7 @@ define(function (require, exports, module) {
 
     onEmailBlur () {
       if (this.isInExperiment('mailcheck')) {
-        mailcheck(this.$el.find('.email'), this.metrics, this.translator, this);
+        mailcheck(this.$el.find('.email'), this);
       }
     },
 
@@ -362,7 +363,7 @@ define(function (require, exports, module) {
 
     _suggestSignIn (err) {
       err.forceMessage = t('Account already exists. <a href="/signin">Sign in</a>');
-      return this.displayErrorUnsafe(err);
+      return this.unsafeDisplayError(err);
     },
 
     _isEmailOptInEnabled () {

--- a/app/scripts/views/tooltip.js
+++ b/app/scripts/views/tooltip.js
@@ -23,9 +23,10 @@ define(function (require, exports, module) {
     // tracks the type of a tooltip, used for metrics purposes
     type: 'generic',
 
-    initialize (options) {
-      options = options || {};
+    initialize (options = {}) {
       this.message = options.message || '';
+      this.unsafeMessage = options.unsafeMessage || '';
+
       this.dismissible  = options.dismissible || false;
       this.extraClassNames = options.extraClassNames || '';
 
@@ -37,7 +38,15 @@ define(function (require, exports, module) {
     },
 
     template () {
-      return this.translator.get(this.message);
+      // If both `message` and `unsafeMessage` are set, prefer `message`
+      // since it'll be HTML escaped.
+      if (this.message) {
+        return this.translate(this.message);
+      } else if (this.unsafeMessage) {
+        return this.unsafeTranslate(this.unsafeMessage);
+      }
+
+      return '';
     },
 
     afterRender () {

--- a/app/tests/spec/lib/mailcheck.js
+++ b/app/tests/spec/lib/mailcheck.js
@@ -8,33 +8,35 @@ define(function (require, exports, module) {
   'use strict';
 
   const $ = require('jquery');
-  const chai = require('chai');
+  const { assert } = require('chai');
   const mailcheck = require('lib/mailcheck');
+  const p = require('lib/promise');
   const sinon = require('sinon');
+  const Translator = require('lib/translator');
 
-  var assert = chai.assert;
-  var MAILCHECK_ID = 'mailcheck-test';
-  var MAILCHECK_SELECTOR = '#' + MAILCHECK_ID;
-  var TOOLTIP_SELECTOR = '.tooltip-suggest';
-  var BAD_EMAIL = 'something@gnail.com';
-  var CORRECTED_EMAIL = 'something@gmail.com';
-  var RESULT_TEXT = 'Did you mean gmail.com?✕';
+  const BAD_EMAIL = 'something@gnail.com';
+  const CORRECTED_EMAIL = 'something@gmail.com';
+  const MAILCHECK_ID = 'mailcheck-test';
+  const MAILCHECK_SELECTOR = '#' + MAILCHECK_ID;
+  const RESULT_TEXT = 'Did you mean gmail.com?✕';
+  const TOOLTIP_SELECTOR = '.tooltip-suggest';
 
   describe('lib/mailcheck', function () {
-    var mockTranslator = window.translator;
-    var mockMetrics = {
-      logEvent () {
-      }
-    };
-    var mockView;
+    let mockView;
+    let translator;
 
     beforeEach(function () {
+      translator = new Translator();
+
       mockView = {
         isInExperimentGroup () {
           return true;
         },
         notifier: {
           trigger: sinon.spy(function () {})
+        },
+        unsafeTranslate(msg, params) {
+          return translator.get(msg, params);
         }
       };
       $('body').append('<div class="input-row test-input"><input type=text id="' + MAILCHECK_ID + '"/></div>');
@@ -52,43 +54,45 @@ define(function (require, exports, module) {
       });
     });
 
-    it('works with attached elements and changes values', function (done) {
+    it('works with attached elements and changes values', function () {
       $(MAILCHECK_SELECTOR).blur(function () {
-        mailcheck(MAILCHECK_SELECTOR, mockMetrics, mockTranslator, mockView);
+        mailcheck(MAILCHECK_SELECTOR, mockView);
       });
 
 
       $(MAILCHECK_SELECTOR).val(BAD_EMAIL).blur();
       assert.isTrue(mockView.notifier.trigger.calledTwice, 'called trigger twice');
 
-      // wait for tooltip
-      setTimeout(function () {
-        assert.equal($(TOOLTIP_SELECTOR).text(), RESULT_TEXT);
-        $(TOOLTIP_SELECTOR).find('span').first().click();
-        // email should be corrected
-        assert.equal($(MAILCHECK_SELECTOR).val(), CORRECTED_EMAIL);
-        assert.isTrue(mockView.notifier.trigger.calledThrice, 'called trigger thrice');
-        done();
-      }, 50);
+      return p()
+        // wait for tooltip
+        .delay(50)
+        .then(() => {
+          assert.equal($(TOOLTIP_SELECTOR).text(), RESULT_TEXT);
+          $(TOOLTIP_SELECTOR).find('span').first().click();
+          // email should be corrected
+          assert.equal($(MAILCHECK_SELECTOR).val(), CORRECTED_EMAIL);
+          assert.isTrue(mockView.notifier.trigger.calledThrice, 'called trigger thrice');
+        });
     });
 
-    it('works with attached elements and can be dismissed', function (done) {
+    it('works with attached elements and can be dismissed', function () {
       $(MAILCHECK_SELECTOR).blur(function () {
-        mailcheck(MAILCHECK_SELECTOR, mockMetrics, mockTranslator, mockView);
+        mailcheck(MAILCHECK_SELECTOR, mockView);
       });
 
       $(MAILCHECK_SELECTOR).val(BAD_EMAIL).blur();
       assert.isTrue(mockView.notifier.trigger.calledTwice, 'called trigger twice');
 
-      // wait for tooltip
-      setTimeout(function () {
-        assert.equal($(TOOLTIP_SELECTOR).text(), RESULT_TEXT);
-        $(TOOLTIP_SELECTOR).find('span').eq(1).click();
-        // email should NOT be corrected
-        assert.equal($(MAILCHECK_SELECTOR).val(), BAD_EMAIL);
-        assert.isFalse(mockView.notifier.trigger.calledThrice, 'called trigger thrice');
-        done();
-      }, 50);
+      return p()
+        // wait for tooltip
+        .delay(50)
+        .then(() => {
+          assert.equal($(TOOLTIP_SELECTOR).text(), RESULT_TEXT);
+          $(TOOLTIP_SELECTOR).find('span').eq(1).click();
+          // email should NOT be corrected
+          assert.equal($(MAILCHECK_SELECTOR).val(), BAD_EMAIL);
+          assert.isFalse(mockView.notifier.trigger.calledThrice, 'called trigger thrice');
+        });
     });
 
   });

--- a/app/tests/spec/lib/strings.js
+++ b/app/tests/spec/lib/strings.js
@@ -65,6 +65,53 @@ define(function (require, exports, module) {
         assert.equal(interpolated, 'Hi testuser@testuser.com, you have been signed in since %s');
       });
     });
+
+    describe('hasHTML', () => {
+      it('returns `false` if the string contains no HTML', () => {
+        assert.isFalse(Strings.hasHTML(''));
+        assert.isFalse(Strings.hasHTML('contains no HTML'));
+        assert.isFalse(Strings.hasHTML('contains no <html'));
+        assert.isFalse(Strings.hasHTML('contains no >html'));
+      });
+
+      it('returns `true` if the string contains HTML', () => {
+        assert.isTrue(Strings.hasHTML('contains <html>'));
+        assert.isTrue(Strings.hasHTML('contains <html/>'));
+        assert.isTrue(Strings.hasHTML('contains < html/>'));
+        assert.isTrue(Strings.hasHTML('contains < html />'));
+        assert.isTrue(Strings.hasHTML('contains <html />'));
+        assert.isTrue(Strings.hasHTML('contains <> HTML like construct'));
+        assert.isTrue(Strings.hasHTML('contains </> HTML like construct'));
+        assert.isTrue(Strings.hasHTML('contains &nbsp; HTML escaped character'));
+        assert.isTrue(Strings.hasHTML('contains &#63; HTML escaped character'));
+      });
+    });
+
+    describe('hasUnsafeVariables', () => {
+      it('returns `false` if the string contains no variables', () => {
+        assert.isFalse(Strings.hasUnsafeVariables(''));
+        assert.isFalse(
+          Strings.hasUnsafeVariables('nothing to interpolate'));
+      });
+
+      it('returns `false` if variables are escaped', () => {
+        assert.isFalse(
+          Strings.hasUnsafeVariables('this has a %(escapedVariable)s'));
+        assert.isFalse(
+          Strings.hasUnsafeVariables('this has multiple %(escapedVariable)s, here %(escapedToo)s'));
+      });
+
+      it('returns `true` for unnamed variables', () => {
+        assert.isTrue(Strings.hasUnsafeVariables('%s'));
+      });
+
+      it('returns `true` for variables w/o an `escaped` prefix', () => {
+        assert.isTrue(
+          Strings.hasUnsafeVariables('this has an %(unsafeVariable)s'));
+        assert.isTrue(
+          Strings.hasUnsafeVariables('this has both %(escapedSafeVariable)s and %(unsafeVariable)s'));
+      });
+    });
   });
 });
 

--- a/app/tests/spec/views/mixins/account-reset-mixin.js
+++ b/app/tests/spec/views/mixins/account-reset-mixin.js
@@ -67,14 +67,14 @@ define(function (require, exports, module) {
 
     describe('notifyOfResetAccount', function () {
       beforeEach(function () {
-        sinon.spy(view, 'displayErrorUnsafe');
+        sinon.spy(view, 'unsafeDisplayError');
 
         view.notifyOfResetAccount(account);
       });
 
       it('displays an error with a `send reset email` link', function () {
-        assert.isTrue(view.displayErrorUnsafe.called);
-        var err = view.displayErrorUnsafe.args[0][0];
+        assert.isTrue(view.unsafeDisplayError.called);
+        var err = view.unsafeDisplayError.args[0][0];
         assert.isTrue(AuthErrors.is(err, 'ACCOUNT_RESET'));
 
         assert.include(view.$('.error').html(), '/confirm_reset_password');

--- a/app/tests/spec/views/mixins/password-prompt-mixin.js
+++ b/app/tests/spec/views/mixins/password-prompt-mixin.js
@@ -6,8 +6,9 @@ define(function (require, exports, module) {
   'use strict';
 
   const $ = require('jquery');
-  const chai = require('chai');
+  const { assert }  = require('chai');
   const Cocktail = require('cocktail');
+  const p = require('lib/promise');
   const PasswordPromptMixin = require('views/mixins/password-prompt-mixin');
   const PasswordStrengthMixin = require('views/mixins/password-strength-mixin');
   const sinon = require('sinon');
@@ -15,7 +16,7 @@ define(function (require, exports, module) {
   const FormView = require('views/form');
   const Template = require('stache!templates/test_template');
 
-  var TestView = FormView.extend({
+  const TestView = FormView.extend({
     template: Template
   });
 
@@ -25,9 +26,8 @@ define(function (require, exports, module) {
     PasswordStrengthMixin
   );
 
-  var TOOLTIP_SELECTOR = '.tooltip-warning';
+  const TOOLTIP_SELECTOR = '.tooltip-warning';
 
-  var assert = chai.assert;
 
   describe('views/mixins/password-prompt-mixin', function () {
     var view;
@@ -99,7 +99,7 @@ define(function (require, exports, module) {
         assert.isTrue(view.checkPasswordStrength.calledWith('charlie2'));
       });
 
-      it('displays tooltip when password is weak', function (done) {
+      it('displays tooltip when password is weak', function () {
         var password = 'charlie2';
         view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR).val(password);
         sinon.stub(view, 'checkPasswordStrength', function (password) {
@@ -107,45 +107,28 @@ define(function (require, exports, module) {
         });
         view.language = 'en-rr';
         view.onPasswordBlur();
-        // wait for tooltip
-        setTimeout(function () {
-          assert.equal(view.$(TOOLTIP_SELECTOR).length, 1);
-          done();
-        }, 50);
+        return p()
+          // wait for tooltip
+          .delay(50)
+          .then(() => {
+            assert.equal(view.$(TOOLTIP_SELECTOR).length, 1);
+          });
       });
 
-      it('does not display tooltip when password is strong', function (done) {
+      it('does not display tooltip when password is strong', function () {
         var password = 'imstronglol';
         view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR).val(password);
         sinon.stub(view, 'checkPasswordStrength', function (password) {
           // do nothing
         });
         view.onPasswordBlur();
-        // wait for tooltip
-        setTimeout(function () {
-          assert.equal(view.$(TOOLTIP_SELECTOR).length, 0);
-          done();
-        }, 50);
+        return p()
+          // wait for tooltip
+          .delay(50)
+          .then(() => {
+            assert.equal(view.$(TOOLTIP_SELECTOR).length, 0);
+          });
       });
-
-      it('tooltip has no link for non-english locales', function (done) {
-        var password = 'charlie2';
-        view.$(PasswordPromptMixin.CHECK_PASSWORD_FIELD_SELECTOR).val(password);
-        sinon.stub(view, 'checkPasswordStrength', function (password) {
-          view.displayPasswordWarningPrompt();
-        });
-        sinon.stub(view, '_isEnglishLocale', function () {
-          return false;
-        });
-        view.onPasswordBlur();
-        // wait for tooltip
-        setTimeout(function () {
-          assert.equal(view.$(TOOLTIP_SELECTOR + '> a').length, 0, 'does not have a link');
-          done();
-        }, 50);
-      });
-
     });
-
   });
 });

--- a/app/tests/spec/views/mixins/service-mixin.js
+++ b/app/tests/spec/views/mixins/service-mixin.js
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
       return view.render();
     });
 
-    describe('displayErrorUnsafe', function () {
+    describe('unsafeDisplayError', function () {
       describe('with a broker that munges links', function () {
         beforeEach(function () {
           sinon.stub(broker, 'transformLink', function (link) {
@@ -60,24 +60,24 @@ define(function (require, exports, module) {
         });
 
         it('converts /signin links to /oauth/signin', function () {
-          view.displayErrorUnsafe('<a href="/signin" id="replaceMe">error</a>');
+          view.unsafeDisplayError('<a href="/signin" id="replaceMe">error</a>');
           assert.equal(view.$('#replaceMe').attr('href'), '/oauth/signin');
         });
 
         it('converts /signup links to /oauth/signup', function () {
-          view.displayErrorUnsafe('<a href="/signup" id="replaceMe">error</a>');
+          view.unsafeDisplayError('<a href="/signup" id="replaceMe">error</a>');
           assert.equal(view.$('#replaceMe').attr('href'), '/oauth/signup');
         });
       });
 
       describe('with a broker that does not munge links', function () {
         it('leaves /signin alone', function () {
-          view.displayErrorUnsafe('<a href="/signin" id="replaceMe">error</a>');
+          view.unsafeDisplayError('<a href="/signin" id="replaceMe">error</a>');
           assert.equal(view.$('#replaceMe').attr('href'), '/signin');
         });
 
         it('leaves /signup alone', function () {
-          view.displayErrorUnsafe('<a href="/signup" id="replaceMe">error</a>');
+          view.unsafeDisplayError('<a href="/signup" id="replaceMe">error</a>');
           assert.equal(view.$('#replaceMe').attr('href'), '/signup');
         });
       });

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -439,13 +439,13 @@ define(function (require, exports, module) {
       });
 
       describe('hide success', function () {
-        it('displaySuccessUnsafe', function () {
+        it('unsafeDisplaySuccess', function () {
           view.SUCCESS_MESSAGE_DELAY_MS = 5;
           var spy = sinon.spy(view, 'hideSuccess');
 
           return view.render()
             .then(function () {
-              view.displaySuccessUnsafe('hi');
+              view.unsafeDisplaySuccess('hi');
               return p().delay(10);
             })
             .then(function () {

--- a/app/tests/spec/views/settings/avatar_gravatar.js
+++ b/app/tests/spec/views/settings/avatar_gravatar.js
@@ -148,7 +148,7 @@ define(function (require, exports, module) {
               assert.equal(view.updateProfileImage.args[0][1], account);
               assert.equal(result.id, 'foo');
               assert.isTrue(view.navigate.calledWith('settings'));
-              assert.equal(view.navigate.args[0][1].successUnsafe, 'Courtesy of <a href="https://www.gravatar.com">Gravatar</a>');
+              assert.equal(view.navigate.args[0][1].unsafeSuccess, 'Courtesy of <a href="https://www.gravatar.com">Gravatar</a>');
             });
         });
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -335,13 +335,13 @@ define(function (require, exports, module) {
             return p.reject(AuthErrors.toError('UNKNOWN_ACCOUNT'));
           });
 
-          sinon.spy(view, 'displayErrorUnsafe');
+          sinon.spy(view, 'unsafeDisplayError');
 
           return view.submit();
         });
 
         it('shows a link to the signup page', function () {
-          var err = view.displayErrorUnsafe.args[0][0];
+          var err = view.unsafeDisplayError.args[0][0];
           assert.isTrue(AuthErrors.is(err, 'UNKNOWN_ACCOUNT'));
           assert.include(err.forceMessage, '/signup');
         });

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -622,7 +622,7 @@ define(function (require, exports, module) {
         sandbox.spy(notifier, 'trigger');
 
         sandbox.spy(view, 'displayError');
-        sandbox.spy(view, 'displayErrorUnsafe');
+        sandbox.spy(view, 'unsafeDisplayError');
         sandbox.spy(view, 'logEvent');
         sandbox.spy(view, 'navigate');
 
@@ -678,7 +678,7 @@ define(function (require, exports, module) {
 
           it('does not display any errors', function () {
             assert.isFalse(view.displayError.called);
-            assert.isFalse(view.displayErrorUnsafe.called);
+            assert.isFalse(view.unsafeDisplayError.called);
           });
         });
 
@@ -776,7 +776,7 @@ define(function (require, exports, module) {
 
             it('does not display any errors', function () {
               assert.isFalse(view.displayError.called);
-              assert.isFalse(view.displayErrorUnsafe.called);
+              assert.isFalse(view.unsafeDisplayError.called);
             });
 
             describe('when the user revisits', function () {
@@ -834,9 +834,9 @@ define(function (require, exports, module) {
             assert.equal(args[0], 'signup.submit');
           });
 
-          it('calls view.displayErrorUnsafe correctly', function () {
-            assert.equal(view.displayErrorUnsafe.callCount, 1);
-            var args = view.displayErrorUnsafe.args[0];
+          it('calls view.unsafeDisplayError correctly', function () {
+            assert.equal(view.unsafeDisplayError.callCount, 1);
+            var args = view.unsafeDisplayError.args[0];
             assert.lengthOf(args, 1);
             var error = args[0];
             assert.include(error.forceMessage, 'href="/signin"');
@@ -867,7 +867,7 @@ define(function (require, exports, module) {
 
           it('does not display any errors', function () {
             assert.isFalse(view.displayError.called);
-            assert.isFalse(view.displayErrorUnsafe.called);
+            assert.isFalse(view.unsafeDisplayError.called);
           });
 
           it('calls view.logEvent correctly', function () {
@@ -985,7 +985,7 @@ define(function (require, exports, module) {
 
           it('does not display any errors', function () {
             assert.isFalse(view.displayError.called);
-            assert.isFalse(view.displayErrorUnsafe.called);
+            assert.isFalse(view.unsafeDisplayError.called);
           });
         });
 
@@ -1038,7 +1038,7 @@ define(function (require, exports, module) {
 
           it('does not display any errors', function () {
             assert.isFalse(view.displayError.called);
-            assert.isFalse(view.displayErrorUnsafe.called);
+            assert.isFalse(view.unsafeDisplayError.called);
           });
 
           it('calls view.logEvent correctly', function () {
@@ -1076,7 +1076,7 @@ define(function (require, exports, module) {
 
           it('does not display any errors', function () {
             assert.isFalse(view.displayError.called);
-            assert.isFalse(view.displayErrorUnsafe.called);
+            assert.isFalse(view.unsafeDisplayError.called);
           });
 
           it('fails correctly', function () {

--- a/app/tests/spec/views/tooltip.js
+++ b/app/tests/spec/views/tooltip.js
@@ -5,12 +5,11 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const _ = require('underscore');
   const $ = require('jquery');
-  const chai = require('chai');
+  const { assert } = require('chai');
   const KeyCodes = require('lib/key-codes');
   const Tooltip = require('views/tooltip');
-
-  var assert = chai.assert;
 
   function _createEvent(keyCode) {
     var keyEvent = $.Event('keydown');
@@ -20,14 +19,14 @@ define(function (require, exports, module) {
   }
 
   describe('views/tooltip', function () {
-    var tooltip;
+    let tooltip;
+    const htmlMessage = 'this is an <span>HTML tooltip</span>';
 
     beforeEach(function () {
       $('#container').html('<div class="input-row"><input id="focusMe" /></div>');
-
       tooltip = new Tooltip({
         invalidEl: '#focusMe',
-        message: 'this is a tooltip'
+        message: htmlMessage
       });
     });
 
@@ -37,27 +36,43 @@ define(function (require, exports, module) {
     });
 
     describe('render', function () {
-      it('renders and attaches the tooltip', function () {
-        return tooltip.render()
-            .then(function () {
-              assert.equal(tooltip.$el.text(), 'this is a tooltip');
-              assert.equal($('.tooltip').length, 1);
-            });
+      beforeEach(() => {
+        return tooltip.render();
+      });
+
+      it('HTML escapes and renders and attaches the tooltip', function () {
+        assert.equal(tooltip.$el.html(), _.escape(htmlMessage));
+        assert.equal($('.tooltip').length, 1);
       });
 
       it('only one tooltip can be rendered at a time', function () {
-        var tooltip2 = new Tooltip({
+        const tooltip2 = new Tooltip({
           invalidEl: '#focusMe',
           message: 'this is a second tooltip'
         });
 
-        return tooltip.render()
-            .then(function () {
-              return tooltip2.render();
-            })
-            .then(function () {
-              assert.equal($('.tooltip').length, 1);
-            });
+        return tooltip2.render()
+          .then(function () {
+            assert.equal($('.tooltip').length, 1);
+          });
+      });
+
+
+      describe('with `unsafeMessage`', () => {
+        beforeEach(() => {
+          $('#container').html('<div class="input-row"><input id="focusMe" /></div>');
+          tooltip = new Tooltip({
+            invalidEl: '#focusMe',
+            unsafeMessage: htmlMessage
+          });
+
+          return tooltip.render();
+        });
+
+        it('renders the tooltip as HTML', () => {
+          assert.equal(tooltip.$el.html(), htmlMessage);
+          assert.equal($('.tooltip').length, 1);
+        });
       });
     });
 

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -107,6 +107,9 @@ The event stream is a log of events and the time they occurred while the user is
 * error.&lt;resource&gt;.require-on-demand.1000 - resource dependency fetch has timed out.
 * error.&lt;resource&gt;.require-on-demand.1001 - resource dependency does not have a define.
 * error.&lt;resource&gt;.require-on-demand.1002 - resource dependency had a script error.
+* error.&lt;screen_name&gt;.auth.1046 - attempt to render HTML using a string that contains an unescaped interpolation variable.
+* error.&lt;screen_name&gt;.auth.1047 - attempt to render an escaped string
+    that contains HTML.
 * error.&lt;unexpected_origin&gt;.auth.1027 - a postMessage message was received from an unexpected origin.
 * error.&lt;image_url&gt;.profile.997 - a profile image could not load.
 * error.&lt;screen_name&gt;.&lt;service&gt;.998 - System unavailable.

--- a/grunttasks/l10n-extract.js
+++ b/grunttasks/l10n-extract.js
@@ -23,7 +23,7 @@ module.exports = function (grunt) {
     var clientWalker = extract({
       'input-dir': path.join(__dirname, '..', '.es5', 'scripts'),
       'join-existing': false,
-      'keyword': 't',
+      'keyword': ['t', 'unsafeTranslate'],
       'output': 'client.pot',
       'output-dir': messagesOutputPath,
       parsers: {
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
         exclude: /pages\/dist/,
         'input-dir': path.join(__dirname, '..', 'server'),
         'join-existing': true,
-        'keyword': 't',
+        'keyword': ['t', 'unsafeTranslate'],
         'output': 'server.pot',
         'output-dir': messagesOutputPath,
         parsers: {


### PR DESCRIPTION
A new Mustache helper function `unsafeTranslate`, has been added
for unsafe writes, to be used when inserting HTML.

All interpolation variables passed to `unsafeTranslate` must be
prefixed with `escaped` or else an exception is thrown. This is
to remind the developer to escape the variable in the most
appropriate way.

The `t` helper function now HTML escapes by default.

Rename some function/variable names for consistency:

* `displaySuccessUnsafe` => `unsafeDisplaySuccess`
* `displayErrorUnsafe` => `unsafeDisplayError`
* `successUnsafe` => `unsafeSuccess`