### PR TITLE
fix(client): Use open in webmail button on reset sent page

### DIFF
--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -11,6 +11,12 @@
 
     <p class="verification-email-message">{{#t}}Click on the link we've emailed you at %(email)s within the next hour to create a new password.{{/t}}</p>
 
+    {{#isOpenWebmailButtonVisible}}
+      <div class="button-row">
+        <a href="{{{ unsafeWebmailLink }}}" data-webmail-type="{{webmailType}}" class="button" target="_blank" id="open-webmail" type="button">{{webmailButtonText}}</a>
+      </div>
+    {{/isOpenWebmailButtonVisible}}
+
     <ul class="links">
       {{#isSignInEnabled}}
         {{#forceAuth}}

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -12,6 +12,7 @@ define(function (require, exports, module) {
   const Notifier = require('lib/channels/notifier');
   const p = require('lib/promise');
   const PasswordResetMixin = require('views/mixins/password-reset-mixin');
+  const OpenResetPasswordEmailMixin = require('views/mixins/open-webmail-mixin');
   const ResendMixin = require('views/mixins/resend-mixin');
   const ServiceMixin = require('views/mixins/service-mixin');
   const Session = require('lib/session');
@@ -276,6 +277,7 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     PasswordResetMixin,
+    OpenResetPasswordEmailMixin,
     ResendMixin,
     ServiceMixin
   );

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -38,7 +38,6 @@ define([
   var fillOutResetPassword = FunctionalHelpers.fillOutResetPassword;
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = FunctionalHelpers.openPage;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   var type = FunctionalHelpers.type;
@@ -268,35 +267,6 @@ define([
         .then(openCompleteResetPassword(
           this, 'invalidemail', token, code, '#fxa-reset-link-damaged-header'
         ));
-    },
-
-    'sign up with a gmail address, get the open gmail button': function () {
-      var email = 'signin' + Math.random() + '@gmail.com';
-      var RESET_PASSWORD_URL = intern.config.fxaContentRoot + 'reset_password?context=fx_desktop_v2&service=sync';
-      this.timeout = 90000;
-
-      return this.remote
-        .then(openPage(this, RESET_PASSWORD_URL, '#fxa-confirm-reset-password-header'))
-        .then(createUser(email, PASSWORD, { preVerified: true } ))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
-
-        .then(fillOutResetPassword(this, email))
-
-        .then(testElementExists('#choose-what-to-sync'))
-        .then(click('button[type="submit"]'))
-
-        .then(testElementExists('#fxa-confirm-reset-password-header'))
-        .then(click('[data-webmail-type="gmail"]'))
-
-        .getAllWindowHandles()
-          .then(function (handles) {
-            return this.parent.switchToWindow(handles[1]);
-          })
-
-        .then(testElementExists('.google-header-bar'))
-        .then(closeCurrentWindow())
-
-        .then(testElementExists('#fxa-confirm-reset-password-header'));
     },
 
     'reset password, verify same browser': function () {


### PR DESCRIPTION
fixes #4096

This is a re-open of #4268. I asked @divyabiyani to put the tests in the wrong test file and that caused a bunch of confusion because there is no consistency with the functional test helpers. I shifted the functional tests to the correct file and removed a couple of unnecessary lines and everything worked as expected.