### PR TITLE
fix(styles): adjust modal h2 styles

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -469,6 +469,10 @@ body.settings #main-content.card {
 section.modal-panel {
   text-align: center;
 
+  h2 {
+    font-weight: normal;
+  }
+
   .button-row {
     margin-bottom: 0;
 


### PR DESCRIPTION
Fixes #4291

## Before

![](https://cloud.githubusercontent.com/assets/68213/19452869/b07ee75a-9480-11e6-9fb5-4c8a027ecc79.png)

## After 

![image](https://cloud.githubusercontent.com/assets/128755/19659376/a56a86e8-99f9-11e6-80d7-ab4d8971bfec.png)


@vbudhram r?