### PR TITLE
fix(client): Fix the `Open Gmail` button on confirm_reset_password

### DIFF
--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -13,7 +13,7 @@
 
     {{#isOpenWebmailButtonVisible}}
       <div class="button-row">
-        <a href="{{{ unsafeWebmailLink }}}" data-webmail-type="{{webmailType}}" class="button" target="_blank" id="open-webmail" type="button">{{webmailButtonText}}</a>
+        <a href="{{{ escapedWebmailLink }}}" data-webmail-type="{{webmailType}}" class="button" target="_blank" id="open-webmail" type="button">{{webmailButtonText}}</a>
       </div>
     {{/isOpenWebmailButtonVisible}}
 


### PR DESCRIPTION
The template was not updated to write in `escapedWebmailLink`, it still had `unsafeWebmailLink`.

The tangential changes are to clean/speed up the tests a tad bit.

fixes #4327 

@philbooth - mind an r?