### PR TITLE
fix(test): Fix `oauth sign_in - verified, blocked, incorrect password`

### DIFF
--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -198,6 +198,11 @@ define([
         .then(testElementExists('#fxa-signin-unblock-header'))
         .then(fillOutSignInUnblock(email, 0))
 
+        // wait until at the signin page to check the URL to
+        // avoid latency problems with submitting the unblock code.
+        // w/o the wait, the URL can be checked before
+        // the submit completes.
+        .then(testElementExists('#fxa-signin-header'))
         .then(testUrlPathnameEquals('/oauth/signin'))
         .then(fillOutSignIn(this, email, PASSWORD))
 


### PR DESCRIPTION
Wait until the signin header appears before checking the URL to ensure
the unblock code submit has completed.

issue #4339 

@jrgm or @vladikoff - r?

This should also work for train-72 & stage.