### PR TITLE
refactor(tests): Remove `context` from `clearBrowserState`

### DIFF
--- a/tests/functional/alternative_styles.js
+++ b/tests/functional/alternative_styles.js
@@ -16,7 +16,7 @@ define([
     name: 'alternate styles',
 
     beforeEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(FunctionalHelpers.clearBrowserState());
     },
 
     'the `chromeless` style is not applied if not iframed sync': function () {

--- a/tests/functional/amo_sign_up.js
+++ b/tests/functional/amo_sign_up.js
@@ -16,6 +16,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -26,7 +27,7 @@ define([
     name: 'oauth amo sign up',
 
     beforeEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'as a migrating user': function () {

--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -24,7 +24,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -40,7 +40,7 @@ define([
   function signUp(context, email) {
     return context.remote
       .then(createUser(email, PASSWORD, { preVerified: true }))
-      .then(clearBrowserState(context))
+      .then(clearBrowserState())
 
       .then(openPage(context, SIGNIN_URL, '#fxa-signin-header'))
       .then(fillOutSignIn(context, email, PASSWORD))
@@ -57,7 +57,7 @@ define([
     },
 
     afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'go to settings then avatar change': function () {

--- a/tests/functional/bounced_email.js
+++ b/tests/functional/bounced_email.js
@@ -17,17 +17,19 @@ define([
   var deliveredEmail;
   var PASSWORD = '12345678';
 
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
+
   registerSuite({
     name: 'sign_up with an email that bounces',
 
     beforeEach: function () {
       bouncedEmail = TestHelpers.createEmail();
       deliveredEmail = TestHelpers.createEmail();
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'sign up, bounce email, allow user to restart flow but force a different email': function () {

--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -19,7 +19,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
@@ -40,13 +40,13 @@ define([
 
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(fillOutSignIn(this, email, FIRST_PASSWORD))
         .then(testElementExists('#fxa-settings-header'));
     },
 
     afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'sign in, try to change password with an incorrect old password': function () {

--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -23,7 +23,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
@@ -59,7 +59,7 @@ define([
       email = TestHelpers.createEmail('sync{id}');
       user = TestHelpers.emailToUser(email);
       return this.remote
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(setupTest(this, true));
     },
 

--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -15,7 +15,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
@@ -31,8 +31,7 @@ define([
 
     beforeEach: function () {
       // clear localStorage to avoid polluting other tests.
-      return this.remote
-        .then(clearBrowserState(this));
+      return this.remote.then(clearBrowserState());
     },
 
     'visit confirmation screen without initiating sign up, user is redirected to /signup': function () {

--- a/tests/functional/delete_account.js
+++ b/tests/functional/delete_account.js
@@ -3,20 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
-  'intern',
   'intern!object',
-  'intern/browser_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, nodeXMLHttpRequest,
-      FxaClient, TestHelpers, FunctionalHelpers)  {
-  var config = intern.config;
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
-
+], function (registerSuite, TestHelpers, FunctionalHelpers)  {
   var PASSWORD = 'password';
   var email;
-  var client;
+
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
+  var createUser = FunctionalHelpers.createUser;
 
   registerSuite({
     name: 'delete_account',
@@ -24,19 +19,13 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail();
 
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
-
-      var self = this;
-      return client.signUp(email, PASSWORD, { preVerified: true })
-        .then(function () {
-          return FunctionalHelpers.clearBrowserState(self);
-        });
+      return this.remote
+        .then(clearBrowserState())
+        .then(createUser(email, PASSWORD, { preVerified: true }));
     },
 
     afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'sign in, delete account': function () {

--- a/tests/functional/email_opt_in.js
+++ b/tests/functional/email_opt_in.js
@@ -19,7 +19,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -62,12 +62,12 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail();
       return this.remote
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     afterEach: function () {
       return this.remote
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     'opt-in on signup': function () {

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -9,6 +9,7 @@ define([
 ], function (registerSuite, TestHelpers, FunctionalHelpers) {
   var thenify = FunctionalHelpers.thenify;
 
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
@@ -36,7 +37,7 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail();
 
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'with a missing email': function () {

--- a/tests/functional/force_auth_blocked.js
+++ b/tests/functional/force_auth_blocked.js
@@ -15,7 +15,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
@@ -37,12 +37,12 @@ define([
 
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     afterEach: function () {
       return this.remote
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     'valid code entered': function () {

--- a/tests/functional/fx_fennec_v1_force_auth.js
+++ b/tests/functional/fx_fennec_v1_force_auth.js
@@ -9,7 +9,7 @@ define([
 ], function (registerSuite, TestHelpers, FunctionalHelpers) {
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
@@ -33,7 +33,7 @@ define([
 
 
     return this.parent
-      .then(clearBrowserState(this.parent))
+      .then(clearBrowserState())
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openForceAuth({ query: {
         context: 'fx_fennec_v1',

--- a/tests/functional/fx_fennec_v1_settings.js
+++ b/tests/functional/fx_fennec_v1_settings.js
@@ -11,7 +11,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
   var fillOutDeleteAccount = thenify(FunctionalHelpers.fillOutDeleteAccount);
@@ -43,7 +43,7 @@ define([
 
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(this, email, FIRST_PASSWORD))

--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -16,7 +16,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -33,7 +33,7 @@ define([
     options = options || {};
 
     return this.parent
-      .then(clearBrowserState(this.parent))
+      .then(clearBrowserState())
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(this.parent, PAGE_URL, '#fxa-signin-header'))
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -26,13 +26,15 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState());
     },
 
     afterEach: function () {
       var self = this;
 
-      return FunctionalHelpers.clearBrowserState(this)
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState())
         .then(function () {
           // ensure the next test suite (bounced_email) loads a fresh
           // signup page. If a fresh signup page is not forced, the

--- a/tests/functional/fx_firstrun_v1_settings.js
+++ b/tests/functional/fx_firstrun_v1_settings.js
@@ -11,7 +11,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -40,7 +40,7 @@ define([
 
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(this, email, FIRST_PASSWORD))

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -17,7 +17,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var clearBrowserNotifications = FunctionalHelpers.clearBrowserNotifications;
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -52,7 +52,7 @@ define([
       email = TestHelpers.createEmail('sync{id}');
 
       return this.remote
-        .then(clearBrowserState(this, {
+        .then(clearBrowserState({
           force: true
         }));
     },

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -18,6 +18,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
@@ -32,7 +33,8 @@ define([
     afterEach: function () {
       var self = this;
 
-      return FunctionalHelpers.clearBrowserState(this)
+      return this.remote
+        .then(clearBrowserState())
         .then(function () {
           // ensure the next test suite (bounced_email) loads a fresh
           // signup page. If a fresh signup page is not forced, the

--- a/tests/functional/fx_firstrun_v2_settings.js
+++ b/tests/functional/fx_firstrun_v2_settings.js
@@ -11,7 +11,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -40,7 +40,7 @@ define([
 
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(this, email, FIRST_PASSWORD))

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -27,13 +27,15 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState());
     },
 
     afterEach: function () {
       var self = this;
 
-      return FunctionalHelpers.clearBrowserState(this)
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState())
         .then(function () {
           // ensure the next test suite (bounced_email) loads a fresh
           // signup page. If a fresh signup page is not forced, the

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -18,7 +18,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -63,7 +63,7 @@ define([
       email = TestHelpers.createEmail('sync{id}');
 
       return this.remote
-        .then(clearBrowserState(this, { force: true }));
+        .then(clearBrowserState({ force: true }));
     },
 
     'verified, verify same browser': function () {

--- a/tests/functional/fx_ios_v1_sign_up.js
+++ b/tests/functional/fx_ios_v1_sign_up.js
@@ -17,7 +17,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
-
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
@@ -28,13 +28,14 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     afterEach: function () {
       var self = this;
 
-      return FunctionalHelpers.clearBrowserState(this)
+      return this.remote
+        .then(clearBrowserState())
         .then(function () {
           // ensure the next test suite (bounced_email) loads a fresh
           // signup page. If a fresh signup page is not forced, the

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -35,37 +35,38 @@ define([
     return context.remote || context.parent || context;
   }
 
-  function clearBrowserState(context, options) {
-    options = options || {};
+  function clearBrowserState(options) {
+    return function () {
+      options = options || {};
+      if (! ('contentServer' in options)) {
+        options.contentServer = true;
+      }
 
-    if (! ('contentServer' in options)) {
-      options.contentServer = true;
-    }
+      if (! ('123done' in options)) {
+        options['123done'] = false;
+      }
 
-    if (! ('123done' in options)) {
-      options['123done'] = false;
-    }
+      if (! ('321done' in options)) {
+        options['321done'] = false;
+      }
 
-    if (! ('321done' in options)) {
-      options['321done'] = false;
-    }
-
-    return getRemote(context)
-      .then(function () {
-        if (options.contentServer) {
-          return clearContentServerState(context, options);
-        }
-      })
-      .then(function () {
-        if (options['123done']) {
-          return clear123DoneState(context);
-        }
-      })
-      .then(function () {
-        if (options['321done']) {
-          return clear123DoneState(context, true);
-        }
-      });
+      return this.parent
+        .then(function () {
+          if (options.contentServer) {
+            return clearContentServerState(this.parent, options);
+          }
+        })
+        .then(function () {
+          if (options['123done']) {
+            return clear123DoneState(this.parent);
+          }
+        })
+        .then(function () {
+          if (options['321done']) {
+            return clear123DoneState(this.parent, true);
+          }
+        });
+    };
   }
 
   function clearContentServerState(context, options) {

--- a/tests/functional/oauth_choose_redirect.js
+++ b/tests/functional/oauth_choose_redirect.js
@@ -13,6 +13,8 @@ define([
   var PASSWORD = 'password';
 
   var thenify = FunctionalHelpers.thenify;
+
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var getQueryParamValue = FunctionalHelpers.getQueryParamValue;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
   var openPage = FunctionalHelpers.openPage;
@@ -36,7 +38,7 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail();
 
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'oauth endpoint redirects to signup with an unregistered email': function () {

--- a/tests/functional/oauth_force_auth.js
+++ b/tests/functional/oauth_force_auth.js
@@ -13,7 +13,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
@@ -37,7 +37,7 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail();
       return this.remote
-        .then(clearBrowserState(this, {
+        .then(clearBrowserState({
           '123done': true,
           contentServer: true
         }));

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -46,10 +46,11 @@ define([
       email = TestHelpers.createEmail();
       user = TestHelpers.emailToUser(email);
 
-      return FunctionalHelpers.clearBrowserState(this, {
-        '321done': true,
-        contentServer: true
-      });
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState({
+          '321done': true,
+          contentServer: true
+        }));
     },
 
     'signin verified': function () {
@@ -348,10 +349,11 @@ define([
       email = TestHelpers.createEmail();
       user = TestHelpers.emailToUser(email);
 
-      return FunctionalHelpers.clearBrowserState(this, {
-        '123done': true,
-        contentServer: true
-      });
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState({
+          '123done': true,
+          contentServer: true
+        }));
     },
 
     'signup without `prompt=consent`': function () {

--- a/tests/functional/oauth_preverified_sign_up.js
+++ b/tests/functional/oauth_preverified_sign_up.js
@@ -23,10 +23,11 @@ define([
       // clear localStorage to avoid polluting other tests.
       // Without the clear, /signup tests fail because of the info stored
       // in prefillEmail
-      return FunctionalHelpers.clearBrowserState(this, {
-        '123done': true,
-        contentServer: true
-      });
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState({
+          '123done': true,
+          contentServer: true
+        }));
     },
 
     'preverified sign up': function () {

--- a/tests/functional/oauth_query_param_validation.js
+++ b/tests/functional/oauth_query_param_validation.js
@@ -67,9 +67,10 @@ define([
     },
 
     beforeEach: function () {
-      return FunctionalHelpers.clearBrowserState(this, {
-        contentServer: true
-      });
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState({
+          contentServer: true
+        }));
     },
 
     'invalid access_type': function () {

--- a/tests/functional/oauth_settings_clients.js
+++ b/tests/functional/oauth_settings_clients.js
@@ -18,7 +18,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
   var click = FunctionalHelpers.click;
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -37,7 +37,7 @@ define([
       email = TestHelpers.createEmail();
 
       return this.remote
-        .then(clearBrowserState(this, {
+        .then(clearBrowserState({
           '123done': true,
           contentServer: true
         }));

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -51,10 +51,11 @@ define([
       email = TestHelpers.createEmail();
       user = TestHelpers.emailToUser(email);
 
-      return FunctionalHelpers.clearBrowserState(this, {
-        '123done': true,
-        contentServer: true
-      });
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState({
+          '123done': true,
+          contentServer: true
+        }));
     },
 
     'with missing client_id': function () {

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -23,7 +23,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
@@ -60,7 +60,7 @@ define([
       // Without the clear, /signup tests fail because of the info stored
       // in prefillEmail
       return this.remote
-        .then(clearBrowserState(this, {
+        .then(clearBrowserState({
           '123done': true,
           contentServer: true
         }));
@@ -181,7 +181,7 @@ define([
         .end()
 
         // clear browser state to simulate opening link in a new browser
-        .then(clearBrowserState(self, {
+        .then(clearBrowserState({
           '123done': true,
           contentServer: true
         }))

--- a/tests/functional/oauth_sign_up_verification_redirect.js
+++ b/tests/functional/oauth_sign_up_verification_redirect.js
@@ -22,10 +22,11 @@ define([
       // clear localStorage to avoid polluting other tests.
       // Without the clear, /signup tests fail because of the info stored
       // in prefillEmail
-      return FunctionalHelpers.clearBrowserState(this, {
-        '123done': true,
-        contentServer: true
-      });
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState({
+          '123done': true,
+          contentServer: true
+        }));
     },
 
     'signup, same browser same window, verification_redirect=always': function () {
@@ -139,13 +140,11 @@ define([
         .findByCssSelector('#fxa-confirm-header')
         .end()
 
-        .then(function () {
-          // clear browser state to simulate opening link in a new browser
-          return FunctionalHelpers.clearBrowserState(self, {
-            '123done': true,
-            contentServer: true
-          });
-        })
+        // clear browser state to simulate opening link in a new browser
+        .then(FunctionalHelpers.clearBrowserState({
+          '123done': true,
+          contentServer: true
+        }))
 
         .then(function () {
           return FunctionalHelpers.getVerificationLink(email, 0);

--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -41,17 +41,19 @@ define([
       email2 = TestHelpers.createEmail();
 
       // clear localStorage to avoid pollution from other tests.
-      return FunctionalHelpers.clearBrowserState(this, {
-        '123done': true,
-        contentServer: true
-      });
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState({
+          '123done': true,
+          contentServer: true
+        }));
     },
 
     afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this, {
-        '123done': true,
-        contentServer: true
-      });
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState({
+          '123done': true,
+          contentServer: true
+        }));
     },
 
     'sign in to OAuth with Sync creds': function () {

--- a/tests/functional/password_visibility.js
+++ b/tests/functional/password_visibility.js
@@ -12,6 +12,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var mousedown = FunctionalHelpers.mousedown;
   var mouseup = FunctionalHelpers.mouseup;
   var openPage = thenify(FunctionalHelpers.openPage);
@@ -22,7 +23,7 @@ define([
     name: 'password visibility',
 
     beforeEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'show password ended with mouseup': function () {

--- a/tests/functional/pp.js
+++ b/tests/functional/pp.js
@@ -16,7 +16,8 @@ define([
     name: 'pp',
 
     beforeEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote
+        .then(FunctionalHelpers.clearBrowserState());
     },
 
     'start at signup': function () {

--- a/tests/functional/refreshes_metrics.js
+++ b/tests/functional/refreshes_metrics.js
@@ -7,16 +7,19 @@ define([
   'intern!object',
   'require',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, require, TestHelpers) {
+], function (intern, registerSuite, require, FunctionalHelpers) {
   var AUTOMATED = '?automatedBrowser=true';
   var url = intern.config.fxaContentRoot + 'signup' + AUTOMATED;
   var signin = intern.config.fxaContentRoot + 'signin' + AUTOMATED;
+
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
 
   registerSuite({
     name: 'refreshing a screen logs a refresh event',
 
     beforeEach: function () {
-      return TestHelpers.clearBrowserState(this);
+      return this.remote
+        .then(clearBrowserState());
     },
 
     'refreshing the signup screen': function () {
@@ -38,7 +41,7 @@ define([
         .findById('fxa-signin-header')
 
         .then(function () {
-          return TestHelpers.testAreEventsLogged(self, ['screen.signup',
+          return FunctionalHelpers.testAreEventsLogged(self, ['screen.signup',
           'screen.signup', 'signup.refresh']);
         })
         .end();

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -30,7 +30,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
@@ -124,7 +124,7 @@ define([
       email = TestHelpers.createEmail();
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     'visit confirmation screen without initiating reset_password, user is redirected to /reset_password': function () {
@@ -389,7 +389,7 @@ define([
 
         // clear all browser state, simulate opening in
         // a new browser
-        .then(clearBrowserState(this, { contentServer: true }))
+        .then(clearBrowserState({ contentServer: true }))
 
         .then(function () {
           return FunctionalHelpers.getVerificationLink(email, 0);
@@ -420,7 +420,7 @@ define([
           .then(function () {
             return initiateResetPassword(self, email, 0);
           })
-          .then(clearBrowserState(this));
+          .then(clearBrowserState());
     },
 
     'complete reset, then re-open verification link, click resend': function () {
@@ -453,7 +453,7 @@ define([
       email = TestHelpers.createEmail();
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     'browse directly to page with email on query params': function () {
@@ -486,7 +486,7 @@ define([
 
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     'original page transitions after completion': function () {
@@ -512,7 +512,7 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail();
       return this.remote
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     'open /reset_password page, enter unknown email, wait for error': function () {

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -16,7 +16,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -41,11 +41,11 @@ define([
         .then(function (result) {
           accountData = result;
         })
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'with an invalid email': function () {
@@ -204,7 +204,7 @@ define([
 
       return this.remote
         .then(createUser(email, FIRST_PASSWORD))
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(fillOutSignIn(this, email, FIRST_PASSWORD))
         .then(testElementExists('#fxa-confirm-header'));
     },
@@ -224,7 +224,7 @@ define([
 
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this, { force: true }))
+        .then(clearBrowserState({ force: true }))
         .then(fillOutSignIn(this, email, FIRST_PASSWORD))
         .then(testElementExists('#fxa-settings-header'))
         .execute(function () {
@@ -242,7 +242,7 @@ define([
     afterEach: function () {
       // browser state must be cleared or the tests that follow fail.
       return this.remote
-        .then(clearBrowserState(this, { force: true }));
+        .then(clearBrowserState({ force: true }));
     },
 
     'a focus on the settings page after session expires redirects to signin': function () {

--- a/tests/functional/settings_clients.js
+++ b/tests/functional/settings_clients.js
@@ -6,15 +6,11 @@ define([
   'intern',
   'intern/chai!assert',
   'intern!object',
-  'intern/browser_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, assert, registerSuite, nodeXMLHttpRequest,
-      FxaClient, TestHelpers, FunctionalHelpers) {
+], function (intern, assert, registerSuite, TestHelpers, FunctionalHelpers) {
 
   var config = intern.config;
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
   var SIGNIN_URL_DEVICE_LIST = SIGNIN_URL + '?forceDeviceList=1';
 
@@ -28,28 +24,28 @@ define([
   var client;
   var accountData;
 
-  var testElementExists = FunctionalHelpers.testElementExists;
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
+  var createUser = FunctionalHelpers.createUser;
   var pollUntilGoneByQSA = FunctionalHelpers.pollUntilGoneByQSA;
+  var testElementExists = FunctionalHelpers.testElementExists;
 
   registerSuite({
     name: 'settings clients',
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
-      var self = this;
-      return client.signUp(email, FIRST_PASSWORD, {preVerified: true})
+      client = FunctionalHelpers.getFxaClient();
+      return this.remote
+        .then(createUser(email, FIRST_PASSWORD, {preVerified: true}))
         .then(function (result) {
           accountData = result;
-          return FunctionalHelpers.clearBrowserState(self);
-        });
+        })
+        .then(clearBrowserState());
     },
 
     afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'device panel is not visible without query param': function () {

--- a/tests/functional/settings_common.js
+++ b/tests/functional/settings_common.js
@@ -24,7 +24,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var openPage = thenify(FunctionalHelpers.openPage);
@@ -51,7 +51,7 @@ define([
       email = TestHelpers.createEmail();
 
       return this.remote
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(createUser(email, PASSWORD));
     }
   };
@@ -80,7 +80,7 @@ define([
       });
 
       return this.remote
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(function (result) {
           accountData = result;
@@ -92,7 +92,7 @@ define([
     var url = SETTINGS_URL + page;
     suite['visit settings' + page + ' with an invalid sessionToken redirects to signin'] = function () {
       return this.remote
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(function () {
           // invalidate the session token
           return client.sessionDestroy(accountData.sessionToken);

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -16,7 +16,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
@@ -38,12 +38,11 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail();
 
-      return this.remote
-        .then(clearBrowserState(this));
+      return this.remote.then(clearBrowserState());
     },
 
     afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'with an invalid email': function () {

--- a/tests/functional/sign_in_blocked.js
+++ b/tests/functional/sign_in_blocked.js
@@ -15,7 +15,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
@@ -39,12 +39,12 @@ define([
 
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     afterEach: function () {
       return this.remote
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     'valid code entered': function () {

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -28,7 +28,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var clearSessionStorage = thenify(FunctionalHelpers.clearSessionStorage);
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
@@ -51,7 +51,7 @@ define([
       email = TestHelpers.createEmail('sync{id}');
       email2 = TestHelpers.createEmail();
       return this.remote
-        .then(clearBrowserState(this, { force: true }))
+        .then(clearBrowserState({ force: true }))
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(createUser(email2, PASSWORD, { preVerified: true }));
     },

--- a/tests/functional/sync_force_auth.js
+++ b/tests/functional/sync_force_auth.js
@@ -10,7 +10,7 @@ define([
 ], function (registerSuite, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
@@ -35,7 +35,7 @@ define([
                             '#fxa-confirm-header';
 
     return this.parent
-      .then(clearBrowserState(this.parent))
+      .then(clearBrowserState())
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openForceAuth({ query: {
         context: 'fx_desktop_v1',

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -21,7 +21,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
@@ -52,7 +52,7 @@ define([
 
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     'reset password, verify same browser': function () {
@@ -152,7 +152,7 @@ define([
 
         // clear all browser state, simulate opening in a new
         // browser
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(getVerificationLink(user, 0))
         .then(function (url) {
           return self.remote.get(require.toUrl(url));

--- a/tests/functional/sync_settings.js
+++ b/tests/functional/sync_settings.js
@@ -13,7 +13,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
   var fillOutDeleteAccount = thenify(FunctionalHelpers.fillOutDeleteAccount);
@@ -39,7 +39,7 @@ define([
   var setupTest = thenify(function (shouldVerifySignin) {
     return this.parent
       .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
-      .then(clearBrowserState(this.parent))
+      .then(clearBrowserState())
       .then(openPage(this.parent, SIGNIN_URL, '#fxa-signin-header'))
       .execute(listenForFxaCommands)
       .then(fillOutSignIn(this.parent, email, FIRST_PASSWORD))

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -20,7 +20,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
@@ -64,7 +64,7 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail('sync{id}');
       return this.remote
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     'verified, verify same browser': function () {

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -26,6 +26,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
@@ -42,19 +43,17 @@ define([
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });
 
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     afterEach: function () {
-      var self = this;
-
-      return FunctionalHelpers.clearBrowserState(this)
+      return this.remote.then(clearBrowserState())
         .then(function () {
           // ensure the next test suite (bounced_email) loads a fresh
           // signup page. If a fresh signup page is not forced, the
           // bounced_email tests try to sign up using the Sync broker,
           // resulting in a channel timeout.
-          return self.remote
+          return this.parent
             .get(require.toUrl(SIGNIN_URL))
 
             .findByCssSelector('#fxa-signin-header')
@@ -244,9 +243,7 @@ define([
 
         // clear local/sessionStorage to synthesize continuing in
         // a separate browser.
-        .then(function () {
-          return FunctionalHelpers.clearBrowserState(self);
-        })
+        .then(clearBrowserState())
 
         // verify the user
         .then(function () {

--- a/tests/functional/sync_v2_force_auth.js
+++ b/tests/functional/sync_v2_force_auth.js
@@ -12,7 +12,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
@@ -43,7 +43,7 @@ define([
                             '#fxa-confirm-header';
 
     return this.parent
-      .then(clearBrowserState(this.parent))
+      .then(clearBrowserState())
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openForceAuth(forceAuthOptions))
       .then(noSuchBrowserNotification(this.parent, 'fxaccounts:logout'))

--- a/tests/functional/sync_v2_reset_password.js
+++ b/tests/functional/sync_v2_reset_password.js
@@ -19,6 +19,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutResetPassword = thenify(FunctionalHelpers.fillOutResetPassword);
@@ -39,12 +40,12 @@ define([
       this.timeout = 90000;
 
       email = TestHelpers.createEmail();
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     teardown: function () {
       // clear localStorage to avoid polluting other tests.
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'reset password, verify same browser': function () {

--- a/tests/functional/sync_v2_settings.js
+++ b/tests/functional/sync_v2_settings.js
@@ -11,7 +11,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -40,7 +40,7 @@ define([
 
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(this, email, FIRST_PASSWORD))

--- a/tests/functional/sync_v2_sign_in.js
+++ b/tests/functional/sync_v2_sign_in.js
@@ -16,7 +16,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
@@ -37,7 +37,7 @@ define([
                             '#fxa-confirm-header';
 
     return this.parent
-      .then(clearBrowserState(this.parent, { force: true }))
+      .then(clearBrowserState({ force: true }))
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(this.parent, PAGE_URL, '#fxa-signin-header'))
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -18,6 +18,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
@@ -29,13 +30,13 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     afterEach: function () {
       var self = this;
 
-      return FunctionalHelpers.clearBrowserState(this)
+      return this.remote.then(clearBrowserState())
         .then(function () {
           // ensure the next test suite (bounced_email) loads a fresh
           // signup page. If a fresh signup page is not forced, the

--- a/tests/functional/sync_v3_settings.js
+++ b/tests/functional/sync_v3_settings.js
@@ -11,7 +11,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
   var fillOutDeleteAccount = thenify(FunctionalHelpers.fillOutDeleteAccount);
@@ -43,7 +43,7 @@ define([
 
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
-        .then(clearBrowserState(this))
+        .then(clearBrowserState())
         .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(this, email, FIRST_PASSWORD))

--- a/tests/functional/sync_v3_sign_in.js
+++ b/tests/functional/sync_v3_sign_in.js
@@ -16,7 +16,7 @@ define([
 
   var thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserState = thenify(FunctionalHelpers.clearBrowserState);
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
@@ -41,7 +41,7 @@ define([
                             '#fxa-confirm-header';
 
     return this.parent
-      .then(clearBrowserState(this.parent, { force: true }))
+      .then(clearBrowserState({ force: true }))
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(this.parent, PAGE_URL, '#fxa-signin-header'))
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
@@ -66,7 +66,7 @@ define([
       email = TestHelpers.createEmail('sync{id}');
 
       return this.remote
-        .then(clearBrowserState(this));
+        .then(clearBrowserState());
     },
 
     'verified, verify same browser': function () {

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -18,6 +18,7 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
@@ -28,13 +29,13 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     afterEach: function () {
       var self = this;
 
-      return FunctionalHelpers.clearBrowserState(this)
+      return this.remote.then(clearBrowserState())
         .then(function () {
           // ensure the next test suite (bounced_email) loads a fresh
           // signup page. If a fresh signup page is not forced, the

--- a/tests/functional/tos.js
+++ b/tests/functional/tos.js
@@ -16,7 +16,7 @@ define([
     name: 'tos',
 
     beforeEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(FunctionalHelpers.clearBrowserState());
     },
 
     'start at signup': function () {

--- a/tests/functional/upgrade_storage_formats.js
+++ b/tests/functional/upgrade_storage_formats.js
@@ -25,11 +25,11 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      return clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     after: function () {
-      return clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'Upgrade from Session w/o cached credentials, session invalid': function () {

--- a/tests/functional/verification_experiments.js
+++ b/tests/functional/verification_experiments.js
@@ -14,6 +14,7 @@ define([
   var EXP_CONTROL = '&forceExperimentGroup=control';
   var EXP_TREATMENT = '&forceExperimentGroup=treatment';
 
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var testElementExists = FunctionalHelpers.testElementExists;
 
@@ -21,11 +22,11 @@ define([
     name: 'verification_experiments - mailcheck',
 
     beforeEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'treatment works': function () {
@@ -76,11 +77,11 @@ define([
     name: 'verification_experiments - showPassword',
 
     beforeEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     afterEach: function () {
-      return FunctionalHelpers.clearBrowserState(this);
+      return this.remote.then(clearBrowserState());
     },
 
     'treatment works': function () {


### PR DESCRIPTION
Not attached to any issue. A long standing goal is to make all functional helpers not require `thenify` and to stop passing `context` as the first parameter. This is one step in that direction.