### PR TITLE
fix(test): Fix flaky sign-in-cached functional test.

### DIFF
--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -219,10 +219,11 @@ define([
         // not be cleared by clicking .use-different
         .then(openPage(this, PAGE_SIGNIN, '.use-different'))
         .then(visibleByQSA('#fxa-signin-header'))
-        // need this sleep here, even with visible selectors the credentials are not cleared fast enough
-        .sleep(1500)
         // This will clear the desktop credentials
         .then(click('.use-different'))
+        // need to wait for the email field to be visible
+        // before attempting to sign-in.
+        .then(visibleByQSA('input[type=email]'))
 
         .then(fillOutSignIn(this, email2, PASSWORD))
         .then(testElementExists('#fxa-settings-header'))


### PR DESCRIPTION
Remove the .sleep in `sign in with desktop context then no context,
desktop credentials should not persist` and use a `visibleByQSA`
instead.