### PR TITLE
fix(build): Bring back SRI.

### DIFF
--- a/grunttasks/sriify.js
+++ b/grunttasks/sriify.js
@@ -146,8 +146,7 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.registerTask('sriify', 'Add SRI integrity attributes to static resources', function (taskName, subtaskName) {
-
+  grunt.registerTask('sriify', 'Add SRI integrity attributes to static resources', function (subtaskName) {
     // sri is run twice. The first time to find the sri hashes for
     // the resources embedded in main.js. This will modify main.js
     // so sri must be called again to find the final sri value for


### PR DESCRIPTION
Grunt.registerTask acts differently in Node 0.10.x and Node 4.x. In
Node 0.10.x, the second parameter is the subtask name, in Node 4.x, the
first parameter is.

fixes #4347

@vladikoff - this fixes the problem, I have not yet added tests, I'm not sure the best way of doing so. Not all of our HTML files include main.js, though I suppose I could scan for `<md5>.main.js`, then look for an `integrity` attribute. Or, I could fetch `/`, which we know should contain `<md5>.main.js`, ensure the script is located as well as the integrity attribute.

We could also pull `<md5>.main.js` and ensure `sriConfig` is not `{}`, which is the default.