### PR TITLE
fix(config): Strip any trailing '/v1' from `auth_server_base_url`.

### DIFF
--- a/server/lib/routes/get-fxa-client-configuration.js
+++ b/server/lib/routes/get-fxa-client-configuration.js
@@ -8,6 +8,12 @@ function normalizeUrl(url) {
   return url;
 }
 
+function stripV1Suffix(url) {
+  // Strip the /v1 suffix, if present.
+  url = url.replace(/\/+v1$/, '');
+  return url;
+}
+
 module.exports = function (config) {
   var route = {};
   route.method = 'get';
@@ -15,7 +21,9 @@ module.exports = function (config) {
 
   var fxaClientConfig = {
     /*eslint-disable camelcase */
-    auth_server_base_url: normalizeUrl(config.get('fxaccount_url')),
+    // The content-server can accept fxaccount_url URL with or without
+    // a /v1 suffix, but Firefox client code expects it without.
+    auth_server_base_url: stripV1Suffix(normalizeUrl(config.get('fxaccount_url'))),
     oauth_server_base_url: normalizeUrl(config.get('oauth_url')),
     profile_server_base_url: normalizeUrl(config.get('profile_url')),
     sync_tokenserver_base_url: normalizeUrl(config.get('sync_tokenserver_url'))

--- a/tests/server/routes/get-fxa-client-configuration.js
+++ b/tests/server/routes/get-fxa-client-configuration.js
@@ -58,9 +58,9 @@ define([
       assert.lengthOf(route.process, 2);
     },
 
-    'route.process strips trailing slashes from URLs in config': function () {
+    'route.process strips trailing slashes and suffixes from URLs in config': function () {
       /*eslint-disable camelcase*/
-      mocks.config.fxaccount_url += '//';
+      mocks.config.fxaccount_url += '//v1/';
       mocks.config.oauth_url += '/path/component/';
       mocks.config.profile_url += '/path/component';
       /*eslint-enable camelcase*/
@@ -136,9 +136,7 @@ define([
 
         var conf = intern.config;
         var expectAuthRoot = conf.fxaAuthRoot;
-        if (conf.fxaDevBox || ! conf.fxaProduction) {
-          expectAuthRoot = expectAuthRoot.replace(/\/v1$/, '');
-        }
+        expectAuthRoot = expectAuthRoot.replace(/\/v1$/, '');
 
         assert.equal(result.auth_server_base_url, expectAuthRoot);
         assert.equal(result.oauth_server_base_url, conf.fxaOAuthRoot);


### PR DESCRIPTION
Firefox desktop expects it to be the raw base url, but content-server config sometimes includes the /v1 suffix.  See https://bugzilla.mozilla.org/show_bug.cgi?id=1313731#c6