### PR TITLE
fix(metrics): use server-side timestamps on flow events

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -75,6 +75,16 @@ define(function (require, exports, module) {
     }, []);
   }
 
+  function marshallFlowEvent (eventName, viewName) {
+    if (! viewName) {
+      return `flow.${eventName}`;
+    }
+
+    // Strip out the `oauth.` prefix if present because
+    // OAuthiness is already encoded in the service property.
+    return `flow.${viewName.replace(/^oauth\./, '')}.${eventName}`;
+  }
+
   function Metrics (options = {}) {
     // by default, send the metrics to the content server.
     this._collector = options.collector || '';
@@ -468,8 +478,22 @@ define(function (require, exports, module) {
       if (flowId !== this._flowId) {
         this._flowId = flowId;
         this._flowBeginTime = flowBeginTime;
-        this.logEvent(`flow.${viewName}.begin`);
+        this.logFlowEvent('begin', viewName);
       }
+    },
+
+    logFlowEvent (eventName, viewName) {
+      this.logEvent(marshallFlowEvent(eventName, viewName));
+      // We need to use server-side timestamps on flow events,
+      // so flush them to the server immediately.
+      this.flush();
+    },
+
+    logFlowEventOnce (eventName, viewName) {
+      this.logEventOnce(marshallFlowEvent(eventName, viewName));
+      // We need to use server-side timestamps on flow events,
+      // so flush them to the server immediately.
+      this.flush();
     },
 
     getFlowEventMetadata () {

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -679,6 +679,26 @@ define(function (require, exports, module) {
       this.metrics.logViewEvent(this.getViewName(), eventName);
     },
 
+    /**
+     * Log a flow event to the event stream
+     *
+     * @param {String} eventName
+     * @param {String} viewName
+     */
+    logFlowEvent (eventName, viewName) {
+      this.metrics.logFlowEvent(eventName, viewName);
+    },
+
+    /**
+     * Log a flow event once per page load
+     *
+     * @param {String} eventName
+     * @param {String} viewName
+     */
+    logFlowEventOnce (eventName, viewName) {
+      this.metrics.logFlowEventOnce(eventName, viewName);
+    },
+
     hideError () {
       this.$('.error').slideUp(STATUS_MESSAGE_ANIMATION_MS);
       this._isErrorVisible = false;

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
      * @return {Object} promise
      */
     signIn (account, password, options = {}) {
-      this.logEvent(`flow.${this.signInSubmitContext}.submit`);
+      this.logFlowEvent('submit', this.signInSubmitContext);
 
       if (! account ||
             account.isDefault() ||
@@ -152,14 +152,14 @@ define(function (require, exports, module) {
         if (target === 'have-account') {
           // if the user clicks on 'have-account' we count that as flow event instead of the 'engage' event.
           // Details: https://github.com/mozilla/fxa-content-server/pull/4221
-          this.logEvent('flow.have-account');
+          this.logFlowEvent('have-account');
           return;
         }
       }
 
       // user has engaged with the sign in, sign up or force auth form
       // the flow event will be different depending on the view name
-      this.logEventOnce(`flow.${this.viewName}.engage`);
+      this.logFlowEvent('engage', this.viewName);
     }
   };
 });

--- a/app/scripts/views/mixins/signup-mixin.js
+++ b/app/scripts/views/mixins/signup-mixin.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
      * @return {Object} promise
      */
     signUp (account, password) {
-      this.logEvent('flow.signup.submit');
+      this.logFlowEvent('submit', 'signup');
 
       return this.invokeBrokerMethod('beforeSignIn', account)
         .then(() => {

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -175,8 +175,7 @@ define(function (require, exports, module) {
       describe('log events', function () {
         beforeEach(function () {
           metrics.logEvent('foo');
-          metrics.logFlowBegin('bar', 'baz', 'wibble');
-          metrics.logEvent('qux');
+          metrics.logEvent('bar');
         });
 
         describe('has sendBeacon', function () {
@@ -208,18 +207,15 @@ define(function (require, exports, module) {
               assert.equal(windowMock.navigator.sendBeacon.getCall(0).args[0], '/metrics');
 
               var data = JSON.parse(windowMock.navigator.sendBeacon.getCall(0).args[1]);
-              assert.lengthOf(Object.keys(data), 25);
+              assert.lengthOf(Object.keys(data), 23);
               assert.equal(data.broker, 'none');
               assert.equal(data.context, Constants.CONTENT_SERVER_CONTEXT);
               assert.isNumber(data.duration);
               assert.equal(data.entrypoint, 'none');
               assert.isArray(data.events);
-              assert.lengthOf(data.events, 3);
+              assert.lengthOf(data.events, 2);
               assert.equal(data.events[0].type, 'foo');
-              assert.equal(data.events[1].type, 'flow.wibble.begin');
-              assert.equal(data.events[2].type, 'qux');
-              assert.equal(data.flowId, 'bar');
-              assert.equal(data.flowBeginTime, 'baz');
+              assert.equal(data.events[1].type, 'bar');
               assert.equal(data.isSampledUser, false);
               assert.equal(data.lang, 'unknown');
               assert.isArray(data.marketing);
@@ -247,24 +243,6 @@ define(function (require, exports, module) {
             it('clears the event stream', function () {
               assert.equal(metrics.getFilteredData().events.length, 0);
             });
-
-            describe('log a second flow.begin event with same flowId', function () {
-              beforeEach(function () {
-                metrics.logFlowBegin('bar', 'blee', 'hong');
-                metrics.logEvent('wibble');
-                return metrics.flush();
-              });
-
-              it('calls sendBeacon correctly', function () {
-                assert.equal(windowMock.navigator.sendBeacon.callCount, 2);
-                var data = JSON.parse(windowMock.navigator.sendBeacon.args[1][1]);
-                assert.isArray(data.events);
-                assert.lengthOf(data.events, 1);
-                assert.equal(data.events[0].type, 'wibble');
-                assert.equal(data.flowId, 'bar');
-                assert.equal(data.flowBeginTime, 'baz');
-              });
-            });
           });
 
           describe('flush, sendBeacon fails', function () {
@@ -289,7 +267,7 @@ define(function (require, exports, module) {
             });
 
             it('does not clear the event stream', function () {
-              assert.equal(metrics.getFilteredData().events.length, 3);
+              assert.equal(metrics.getFilteredData().events.length, 2);
             });
           });
         });
@@ -331,13 +309,12 @@ define(function (require, exports, module) {
               assert.equal(settings.contentType, 'application/json');
 
               var data = JSON.parse(settings.data);
-              assert.lengthOf(Object.keys(data), 25);
+              assert.lengthOf(Object.keys(data), 23);
               assert.isArray(data.events);
-              assert.lengthOf(data.events, 4);
+              assert.lengthOf(data.events, 3);
               assert.equal(data.events[0].type, 'foo');
-              assert.equal(data.events[1].type, 'flow.wibble.begin');
-              assert.equal(data.events[2].type, 'qux');
-              assert.equal(data.events[3].type, 'baz');
+              assert.equal(data.events[1].type, 'bar');
+              assert.equal(data.events[2].type, 'baz');
             });
 
             it('resolves to true', function () {
@@ -384,7 +361,7 @@ define(function (require, exports, module) {
             });
 
             it('does not clear the event stream', function () {
-              assert.equal(metrics.getFilteredData().events.length, 3);
+              assert.equal(metrics.getFilteredData().events.length, 2);
             });
           });
         });
@@ -404,12 +381,11 @@ define(function (require, exports, module) {
             assert.isTrue(metrics._send.getCall(0).args[1]);
 
             var data = metrics._send.getCall(0).args[0];
-            assert.lengthOf(Object.keys(data), 25);
-            assert.lengthOf(data.events, 4);
+            assert.lengthOf(Object.keys(data), 23);
+            assert.lengthOf(data.events, 3);
             assert.equal(data.events[0].type, 'foo');
-            assert.equal(data.events[1].type, 'flow.wibble.begin');
-            assert.equal(data.events[2].type, 'qux');
-            assert.equal(data.events[3].type, 'wibble');
+            assert.equal(data.events[1].type, 'bar');
+            assert.equal(data.events[2].type, 'wibble');
           });
         });
 
@@ -428,12 +404,11 @@ define(function (require, exports, module) {
             assert.isTrue(metrics._send.getCall(0).args[1]);
 
             var data = metrics._send.getCall(0).args[0];
-            assert.lengthOf(Object.keys(data), 25);
-            assert.lengthOf(data.events, 4);
+            assert.lengthOf(Object.keys(data), 23);
+            assert.lengthOf(data.events, 3);
             assert.equal(data.events[0].type, 'foo');
-            assert.equal(data.events[1].type, 'flow.wibble.begin');
-            assert.equal(data.events[2].type, 'qux');
-            assert.equal(data.events[3].type, 'blee');
+            assert.equal(data.events[1].type, 'bar');
+            assert.equal(data.events[2].type, 'blee');
           });
         });
 
@@ -584,6 +559,58 @@ define(function (require, exports, module) {
         metrics.logExperiment(experiment, group);
         assert.equal(Object.keys(metrics._activeExperiments).length, 1);
         assert.isDefined(metrics._activeExperiments['mailcheck']);
+      });
+    });
+
+    describe('flow events', () => {
+      beforeEach(() => {
+        sinon.stub(metrics, 'flush', () => {});
+      });
+
+      afterEach(() => {
+        metrics.flush.restore();
+      });
+
+      it('metrics.logFlowBegin', () => {
+        metrics.logFlowBegin('foo', 'bar', 'signin');
+        metrics.logFlowBegin('foo', 'baz', 'signup');
+
+        const data = metrics.getFilteredData();
+        assert.equal(data.events.length, 1);
+        assert.equal(data.events[0].type, 'flow.signin.begin');
+        assert.equal(data.flowId, 'foo');
+        assert.equal(data.flowBeginTime, 'bar');
+
+        assert.equal(metrics.flush.callCount, 1);
+      });
+
+      it('metrics.logFlowEvent', () => {
+        metrics.logFlowEvent('foo', 'signin');
+        metrics.logFlowEvent('foo', 'signin');
+        metrics.logFlowEvent('bar', 'oauth.signin');
+        metrics.logFlowEvent('baz');
+
+        const events = metrics.getFilteredData().events;
+        assert.equal(events.length, 4);
+        assert.equal(events[0].type, 'flow.signin.foo');
+        assert.equal(events[1].type, 'flow.signin.foo');
+        assert.equal(events[2].type, 'flow.signin.bar');
+        assert.equal(events[3].type, 'flow.baz');
+
+        assert.equal(metrics.flush.callCount, 4);
+      });
+
+      it('metrics.logFlowEventOnce', () => {
+        metrics.logFlowEventOnce('foo', 'signin');
+        metrics.logFlowEventOnce('foo', 'signin');
+        metrics.logFlowEventOnce('foo', 'signup');
+
+        const events = metrics.getFilteredData().events;
+        assert.equal(events.length, 2);
+        assert.equal(events[0].type, 'flow.signin.foo');
+        assert.equal(events[1].type, 'flow.signup.foo');
+
+        assert.equal(metrics.flush.callCount, 3);
       });
     });
   });

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -786,6 +786,26 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('logFlowEvent', () => {
+      beforeEach(() => {
+        view.logFlowEvent('foo', 'bar');
+      });
+
+      it('logs the correct event', () => {
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.bar.foo'));
+      });
+    });
+
+    describe('logFlowEventOnce', () => {
+      beforeEach(() => {
+        view.logFlowEventOnce('baz', 'qux');
+      });
+
+      it('logs the correct event', () => {
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.qux.baz'));
+      });
+    });
+
     describe('logViewEvent', function () {
       beforeEach(function () {
         view.logViewEvent('event1');

--- a/app/tests/spec/views/mixins/signin-mixin.js
+++ b/app/tests/spec/views/mixins/signin-mixin.js
@@ -67,6 +67,8 @@ define(function (require, exports, module) {
           }),
           logEvent: sinon.spy(),
           logEventOnce: sinon.spy(),
+          logFlowEvent: sinon.spy(),
+          logFlowEventOnce: sinon.spy(),
           logViewEvent: sinon.spy(),
           model: model,
           navigate: sinon.spy(),
@@ -194,7 +196,11 @@ define(function (require, exports, module) {
           assert.isTrue(
             user.signInAccount.calledWith(account, 'password', relier));
           assert.equal(user.signInAccount.args[0][3].resume, RESUME_TOKEN);
-          assert.equal(view.logEvent.args[0], 'flow.signin.submit', 'correct submit event');
+          assert.equal(view.logFlowEvent.callCount, 1);
+          const args = view.logFlowEvent.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'submit');
+          assert.equal(args[1], 'signin');
         });
 
         it('calls view.navigate correctly', function () {

--- a/app/tests/spec/views/mixins/signup-mixin.js
+++ b/app/tests/spec/views/mixins/signup-mixin.js
@@ -49,6 +49,8 @@ define(function (require, exports, module) {
           }),
           logEvent: sinon.spy(),
           logEventOnce: sinon.spy(),
+          logFlowEvent: sinon.spy(),
+          logFlowEventOnce: sinon.spy(),
           logViewEvent: sinon.spy(),
           navigate: sinon.spy(),
           onSignUpSuccess: SignUpMixin.onSignUpSuccess,

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -71,6 +71,7 @@ define(function (require, exports, module) {
 
       windowMock = new WindowMock();
       metrics = new Metrics();
+      metrics.flush = sinon.spy();
       relier = new OAuthRelier({
         window: windowMock
       });

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -43,6 +43,7 @@ define(function (require, exports, module) {
       email = TestHelpers.createEmail();
       formPrefill = new FormPrefill();
       metrics = new Metrics();
+      metrics.flush = sinon.spy();
       model = new Backbone.Model();
       notifier = new Notifier();
       relier = new Relier();

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -82,6 +82,7 @@ define(function (require, exports, module) {
       formPrefill = new FormPrefill();
       fxaClient = new FxaClient();
       metrics = new Metrics();
+      metrics.flush = sinon.spy();
       model = new Backbone.Model();
       notifier = new Notifier();
       relier = new Relier();

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -80,23 +80,11 @@ function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
       event.time = metrics.flowBeginTime;
       event.flowTime = 0;
     } else {
-      event.time = estimateTime({
-        /*eslint-disable sorting/sort-object-props*/
-        start: metrics.startTime,
-        offset: event.offset,
-        sent: metrics.flushTime,
-        received: requestReceivedTime
-        /*eslint-enable sorting/sort-object-props*/
-      });
+      event.time = requestReceivedTime;
       event.flowTime = event.time - metrics.flowBeginTime;
     }
 
     flowEvent(event, metrics, req);
   });
-}
-
-function estimateTime (times) {
-  var skew = times.received - times.sent;
-  return times.start + times.offset + skew;
 }
 

--- a/tests/server/routes/post-metrics.js
+++ b/tests/server/routes/post-metrics.js
@@ -166,8 +166,8 @@ define([
             assert.lengthOf(Object.keys(args[0].events[4]), 4);
             assert.equal(args[0].events[4].type, 'flow.signup.engage');
             assert.equal(args[0].events[4].offset, 4);
-            assert.equal(args[0].events[4].time, 994);
-            assert.equal(args[0].events[4].flowTime, 952);
+            assert.equal(args[0].events[4].time, 1000);
+            assert.equal(args[0].events[4].flowTime, 958);
             assert.equal(args[0].flowId, 'qux');
             assert.equal(args[0].flowBeginTime, 42);
             assert.strictEqual(args[0].isSampledUser, true);
@@ -205,8 +205,8 @@ define([
             args = mocks.flowEvent.args[1];
             assert.isObject(args[0]);
             assert.equal(args[0].type, 'flow.signup.engage');
-            assert.strictEqual(args[0].flowTime, 952);
-            assert.equal(args[0].time, 994);
+            assert.strictEqual(args[0].flowTime, 958);
+            assert.equal(args[0].time, 1000);
             assert.isObject(args[1]);
             assert.equal(args[1].flowId, 'qux');
             assert.strictEqual(args[1].flowBeginTime, 42);


### PR DESCRIPTION
Fixes #4350.

It came up in discussion with @rfk earlier that we'd like to include this fix in a 73.1 tag, if possible. As things stand, spoiled flow event timestamps have made the metrics pipeline go crazy and are effectively blocking analysis of flow data until we ship a fix.

Note that this PR shares a fair amount of code in common with #4317. Depending on the order they get merged in, either that one or this one will require a rebase and some merge conflict resolution. So if some of the event-handling here seems wrong to anyone familiar with that PR, it's just because I wanted to get this reviewed independently in case that change doesn't make it. I took the bits needed to get this working, the rest can follow as it gets reviewed (likewise, some of the unit test improvements from that PR aren't present here either).

The ultimate plan is for all of the client-side event-handling from that PR to over-write what's here. So the engage, submit and attempt events in the other PR, that stuff all remains valid.

The main changes you can see in this PR are:

* Flow events are flushed to the server immediately.

* The server always generates a flow event timestamp.

@vladikoff r?

/cc @shane-tomlinson