### PR TITLE
feat(client): Add iOS App banner to pages

### DIFF
--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var flowMetrics = require('../flow-metrics');
-var uaParser = require('node-uap');
 
 module.exports = function (config) {
   var ALLOWED_PARENT_ORIGINS = config.get('allowed_parent_origins');
@@ -11,10 +10,6 @@ module.exports = function (config) {
   var CLIENT_ID = config.get('oauth_client_id');
   var ENV = config.get('env');
   var FLOW_ID_KEY = config.get('flow_id_key');
-  var FIREFOX_IOS_DOWNLOAD_LINK = 'https://app.adjust.com/2uo1qc?' +
-    'campaign=fxa-devices-page&adgroup=ios&creative=button' +
-    '&fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&ct=adjust_tracker&mt=8';
-  var IOS_BANNER_META = '<meta name="apple-itunes-app" content="app-id=989804926, app-argument=' + FIREFOX_IOS_DOWNLOAD_LINK + '">';
   var MARKETING_EMAIL_API_URL = config.get('marketing_email.api_url');
   var MARKETING_EMAIL_PREFERENCES_URL = config.get('marketing_email.preferences_url');
   var OAUTH_SERVER_URL = config.get('oauth_url');
@@ -43,7 +38,6 @@ module.exports = function (config) {
     var userAgent = req.headers['user-agent'];
     var flowEventData = flowMetrics(FLOW_ID_KEY, userAgent);
 
-    // Render options
     var renderOptions = {
       config: serializedConfig,
       flowBeginTime: flowEventData.flowBeginTime,
@@ -51,12 +45,6 @@ module.exports = function (config) {
       // Note that staticResourceUrl is added to templates as a build step
       staticResourceUrl: STATIC_RESOURCE_URL
     };
-
-    // Display Firefox iOS install banner if on compatible device
-    var agent = uaParser.parse(userAgent);
-    if (agent && agent.os.family === 'iOS') {
-      renderOptions.iOSBannerMetaTag = IOS_BANNER_META;
-    }
 
     res.render('index', renderOptions);
   };

--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var flowMetrics = require('../flow-metrics');
+var uaParser = require('node-uap');
 
 module.exports = function (config) {
   var ALLOWED_PARENT_ORIGINS = config.get('allowed_parent_origins');
@@ -10,6 +11,10 @@ module.exports = function (config) {
   var CLIENT_ID = config.get('oauth_client_id');
   var ENV = config.get('env');
   var FLOW_ID_KEY = config.get('flow_id_key');
+  var FIREFOX_IOS_DOWNLOAD_LINK = 'https://app.adjust.com/2uo1qc?' +
+    'campaign=fxa-devices-page&adgroup=ios&creative=button' +
+    '&fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&ct=adjust_tracker&mt=8';
+  var IOS_BANNER_META = '<meta name="apple-itunes-app" content="app-id=989804926, app-argument=' + FIREFOX_IOS_DOWNLOAD_LINK + '">';
   var MARKETING_EMAIL_API_URL = config.get('marketing_email.api_url');
   var MARKETING_EMAIL_PREFERENCES_URL = config.get('marketing_email.preferences_url');
   var OAUTH_SERVER_URL = config.get('oauth_url');
@@ -35,15 +40,25 @@ module.exports = function (config) {
   route.path = '/';
 
   route.process = function (req, res) {
-    var flowEventData = flowMetrics(FLOW_ID_KEY, req.headers['user-agent']);
+    var userAgent = req.headers['user-agent'];
+    var flowEventData = flowMetrics(FLOW_ID_KEY, userAgent);
 
-    res.render('index', {
+    // Render options
+    var renderOptions = {
       config: serializedConfig,
       flowBeginTime: flowEventData.flowBeginTime,
       flowId: flowEventData.flowId,
       // Note that staticResourceUrl is added to templates as a build step
       staticResourceUrl: STATIC_RESOURCE_URL
-    });
+    };
+
+    // Display Firefox iOS install banner if on compatible device
+    var agent = uaParser.parse(userAgent);
+    if (agent && agent.os.family === 'iOS') {
+      renderOptions.iOSBannerMetaTag = IOS_BANNER_META;
+    }
+
+    res.render('index', renderOptions);
   };
 
   return route;

--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -35,18 +35,15 @@ module.exports = function (config) {
   route.path = '/';
 
   route.process = function (req, res) {
-    var userAgent = req.headers['user-agent'];
-    var flowEventData = flowMetrics(FLOW_ID_KEY, userAgent);
+    var flowEventData = flowMetrics(FLOW_ID_KEY, req.headers['user-agent']);
 
-    var renderOptions = {
+    res.render('index', {
       config: serializedConfig,
       flowBeginTime: flowEventData.flowBeginTime,
       flowId: flowEventData.flowId,
       // Note that staticResourceUrl is added to templates as a build step
       staticResourceUrl: STATIC_RESOURCE_URL
-    };
-
-    res.render('index', renderOptions);
+    });
   };
 
   return route;

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -11,6 +11,8 @@
         <meta name="robots" content="noindex,nofollow">
         <meta name="fxa-content-server/config" content="{{ config }}" />
 
+        {{{iOSBannerMetaTag}}}
+
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">
         <link rel="stylesheet" href="/styles/fontello.css">

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -11,7 +11,8 @@
         <meta name="robots" content="noindex,nofollow">
         <meta name="fxa-content-server/config" content="{{ config }}" />
 
-        {{{iOSBannerMetaTag}}}
+        <!--iOS Smart Banner-->
+        <meta name="apple-itunes-app" content="app-id=989804926, affiliate-data=ct=smartbanner-fxa">
 
         <!-- build:css(.tmp) /styles/{{ locale }}.css -->
         <link rel="stylesheet" href="/bower_components/normalize-css/normalize.css">


### PR DESCRIPTION
This is an example of how the Firefox iOS app banner would look in Safari. I am not sure which pages we should display this on, maybe only account confirmed? @ryanfeeley Thoughts about the look and feel?

<img src="https://cloud.githubusercontent.com/assets/1295288/20009826/4b4d99a8-a27c-11e6-98c4-26c317e524ad.PNG" alt="Drawing" style="height: 100px;"/>
<img src="https://cloud.githubusercontent.com/assets/1295288/20009829/4d52d3d0-a27c-11e6-8b7e-76d8a783b38f.PNG" alt="Drawing" style="height: 100px;"/>
