### PR TITLE
fix(logging): validate flow id before emitting events

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -126,6 +126,12 @@ var conf = module.exports = convict({
       doc: 'poll the experiments git repo for changes'
     }
   },
+  flow_id_expiry: {
+    default: '2 hours',
+    doc: 'Time after which flow ids are considered stale',
+    env: 'FLOW_ID_EXPIRY',
+    format: 'duration'
+  },
   flow_id_key: {
     default: 'YOU MUST CHANGE ME',
     doc: 'HMAC key used to verify flow event data',

--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -27,7 +27,7 @@ module.exports = function (event, data, request) {
   var pickedData = _.pick(data, isDNT(request) ? DNT_ALLOWED_DATA : NO_DNT_ALLOWED_DATA);
   var eventData = _.assign({
     event: event.type,
-    flow_id: limitLength(data.flowId), //eslint-disable-line camelcase
+    flow_id: data.flowId, //eslint-disable-line camelcase
     flow_time: event.flowTime, //eslint-disable-line camelcase
     hostname: HOSTNAME,
     op: 'flowEvent',

--- a/server/lib/flow-metrics.js
+++ b/server/lib/flow-metrics.js
@@ -29,7 +29,7 @@ module.exports = {
    * @param userAgent String
    * @returns Boolean
    */
-  check (key, flowId, flowBeginTime, userAgent) {
+  validate (key, flowId, flowBeginTime, userAgent) {
     const salt = flowId.substr(0, SALT_STRING_LENGTH);
     const expected = createFlowEventData(key, salt, flowBeginTime, userAgent);
 

--- a/server/lib/flow-metrics.js
+++ b/server/lib/flow-metrics.js
@@ -4,29 +4,58 @@
 
 var crypto = require('crypto');
 
-/**
- *
- * @param key String flow_id_key
- * @param userAgent String request user agent string
- * @returns {{flowBeginTime: number, flowId: string}}
- */
-module.exports = function flowEventData(key, userAgent) {
-  var flowId = crypto.randomBytes(16).toString('hex');
-  var flowBeginTime = Date.now();
+const SALT_SIZE = 16;
+const SALT_STRING_LENGTH = SALT_SIZE * 2;
 
+module.exports = {
+  /**
+   * Create flow data.
+   *
+   * @param key String
+   * @param userAgent String
+   * @returns {{flowBeginTime: number, flowId: string}}
+   */
+  create (key, userAgent) {
+    const salt = crypto.randomBytes(SALT_SIZE).toString('hex');
+    return createFlowEventData(key, salt, Date.now(), userAgent);
+  },
+
+  /**
+   * Check whether a flowId is valid.
+   *
+   * @param key String
+   * @param flowId String
+   * @param flowBeginTime Number
+   * @param userAgent String
+   * @returns Boolean
+   */
+  check (key, flowId, flowBeginTime, userAgent) {
+    const salt = flowId.substr(0, SALT_STRING_LENGTH);
+    const expected = createFlowEventData(key, salt, flowBeginTime, userAgent);
+
+    return getFlowSignature(flowId) === getFlowSignature(expected.flowId);
+  }
+};
+
+function createFlowEventData(key, salt, flowBeginTime, userAgent) {
   // Incorporate a hash of request metadata into the flow id,
   // so that receiving servers can cross-check the metrics bundle.
   var flowSignature = crypto.createHmac('sha256', key)
     .update([
-      flowId,
+      salt,
       flowBeginTime.toString(16),
       userAgent
     ].join('\n'))
     .digest('hex')
-    .substr(0, 32);
+    .substr(0, SALT_STRING_LENGTH);
 
   return {
     flowBeginTime: flowBeginTime,
-    flowId: flowId + flowSignature
+    flowId: salt + flowSignature
   };
-};
+}
+
+function getFlowSignature (flowId) {
+  return flowId.substr(SALT_STRING_LENGTH);
+}
+

--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -35,7 +35,7 @@ module.exports = function (config) {
   route.path = '/';
 
   route.process = function (req, res) {
-    var flowEventData = flowMetrics(FLOW_ID_KEY, req.headers['user-agent']);
+    const flowEventData = flowMetrics.create(FLOW_ID_KEY, req.headers['user-agent']);
 
     res.render('index', {
       config: serializedConfig,

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -124,7 +124,7 @@ function isValidFlowData (metrics, requestReceivedTime) {
     return false;
   }
 
-  return flowMetrics.check(FLOW_ID_KEY, metrics.flowId, metrics.flowBeginTime, metrics.agent);
+  return flowMetrics.validate(FLOW_ID_KEY, metrics.flowId, metrics.flowBeginTime, metrics.agent);
 }
 
 function isValidTime (time, requestReceivedTime) {

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -5,7 +5,8 @@
 
 var _ = require('lodash');
 var config = require('../configuration');
-var flowEvent = require('../flow-event');
+const flowEvent = require('../flow-event');
+const flowMetrics = require('../flow-metrics');
 var MetricsCollector = require('../metrics-collector-stderr');
 var StatsDCollector = require('../statsd-collector');
 var GACollector = require('../ga-collector');
@@ -13,7 +14,17 @@ var logger = require('mozlog')('server.post-metrics');
 
 var DISABLE_CLIENT_METRICS_STDERR = config.get('client_metrics').stderr_collector_disabled;
 
-var FLOW_BEGIN_EVENT_TYPES = /^flow\.[a-z_-]+\.begin$/;
+const FLOW_BEGIN_EVENT_TYPES = /^flow\.[a-z_-]+\.begin$/;
+const FLOW_ID_KEY = config.get('flow_id_key');
+const FLOW_ID_EXPIRY = config.get('flow_id_expiry');
+
+const VALID_METRICS_PROPERTIES = [
+  { key: 'context', pattern: /^[0-9a-z_-]+$/ },
+  { key: 'entrypoint', pattern: /^[\w\.-]+$/ },
+  { key: 'flowId', pattern: /^[0-9a-f]{64}$/ },
+  { key: 'migration', pattern: /^(sync11|amo|none)$/ },
+  { key: 'service', pattern: /^(sync|content-server|none|[0-9a-f]{16})$/ }
+];
 
 module.exports = function () {
   var metricsCollector = new MetricsCollector();
@@ -65,7 +76,7 @@ function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
     return;
   }
 
-  if (! metrics.flowBeginTime) {
+  if (! isValidFlowData(metrics, requestReceivedTime)) {
     // Don't risk corrupting good data by attempting to fix bad.
     return;
   }
@@ -88,11 +99,49 @@ function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
         received: requestReceivedTime
         /*eslint-enable sorting/sort-object-props*/
       });
+
+      if (! isValidTime(event.time, requestReceivedTime)) {
+        return;
+      }
+
       event.flowTime = event.time - metrics.flowBeginTime;
     }
 
     flowEvent(event, metrics, req);
   });
+}
+
+function isValidFlowData (metrics, requestReceivedTime) {
+  if (! metrics.flowId) {
+    return false;
+  }
+
+  if (! isValidTime(parseInt(metrics.flowBeginTime), requestReceivedTime)) {
+    return false;
+  }
+
+  if (! VALID_METRICS_PROPERTIES.every(p => isValidProperty(metrics[p.key], p.pattern))) {
+    return false;
+  }
+
+  return flowMetrics.check(FLOW_ID_KEY, metrics.flowId, metrics.flowBeginTime, metrics.agent);
+}
+
+function isValidTime (time, requestReceivedTime) {
+  const age = requestReceivedTime - time;
+  if (age > FLOW_ID_EXPIRY || age < 0 || isNaN(age)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isValidProperty (property, pattern) {
+  if (property) {
+    return pattern.test(property);
+  }
+
+  return true;
 }
 
 function estimateTime (times) {

--- a/tests/server/flow-metrics.js
+++ b/tests/server/flow-metrics.js
@@ -42,11 +42,11 @@ define([
     Date.now.restore();
   };
 
-  suite['create and check functions are exported'] = () => {
+  suite['create and validate functions are exported'] = () => {
     assert.isObject(flowMetrics);
     assert.lengthOf(Object.keys(flowMetrics), 2);
     assert.equal(typeof flowMetrics.create, 'function');
-    assert.equal(typeof flowMetrics.check, 'function');
+    assert.equal(typeof flowMetrics.validate, 'function');
   };
 
   suite['create returns current timestamp for flowBeginTime'] = () => {
@@ -118,14 +118,14 @@ define([
     assert.notEqual(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
   };
 
-  suite['check returns true for good data'] = () => {
+  suite['validate returns true for good data'] = () => {
     // Force the mocks to return bad data to be sure it really works
     mockDateNow = 1478626838531;
     mockFlowIdKey = 'foo';
     mockUserAgent = 'bar';
     mockRandomBytes = 'baz';
 
-    const result = flowMetrics.check(
+    const result = flowMetrics.validate(
       // Good data is from the create test
       'S3CR37',
       '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
@@ -136,14 +136,14 @@ define([
     assert.strictEqual(result, true);
   };
 
-  suite['check returns false for a bad flow id'] = () => {
+  suite['validate returns false for a bad flow id'] = () => {
     // Force the mocks to return good data to be sure it really works
     mockDateNow = 1451566800000;
     mockFlowIdKey = 'S3CR37';
     mockUserAgent = 'Firefox';
     mockRandomBytes = 'MozillaFirefox!!';
 
-    const result = flowMetrics.check(
+    const result = flowMetrics.validate(
       'S3CR37',
       'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
       1451566800000,
@@ -153,14 +153,14 @@ define([
     assert.strictEqual(result, false);
   };
 
-  suite['check returns false for a bad key'] = () => {
+  suite['validate returns false for a bad key'] = () => {
     // Force the mocks to return good data to be sure it really works
     mockDateNow = 1451566800000;
     mockFlowIdKey = 'S3CR37';
     mockUserAgent = 'Firefox';
     mockRandomBytes = 'MozillaFirefox!!';
 
-    const result = flowMetrics.check(
+    const result = flowMetrics.validate(
       'foo',
       '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
       1451566800000,
@@ -170,14 +170,14 @@ define([
     assert.strictEqual(result, false);
   };
 
-  suite['check returns false for a bad flow begin time'] = () => {
+  suite['validate returns false for a bad flow begin time'] = () => {
     // Force the mocks to return good data to be sure it really works
     mockDateNow = 1451566800000;
     mockFlowIdKey = 'S3CR37';
     mockUserAgent = 'Firefox';
     mockRandomBytes = 'MozillaFirefox!!';
 
-    const result = flowMetrics.check(
+    const result = flowMetrics.validate(
       'S3CR37',
       '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
       1478626838531,
@@ -187,14 +187,14 @@ define([
     assert.strictEqual(result, false);
   };
 
-  suite['check returns false for a bad user agent string'] = () => {
+  suite['validate returns false for a bad user agent string'] = () => {
     // Force the mocks to return good data to be sure it really works
     mockDateNow = 1451566800000;
     mockFlowIdKey = 'S3CR37';
     mockUserAgent = 'Firefox';
     mockRandomBytes = 'MozillaFirefox!!';
 
-    const result = flowMetrics.check(
+    const result = flowMetrics.validate(
       'S3CR37',
       '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
       1451566800000,

--- a/tests/server/flow-metrics.js
+++ b/tests/server/flow-metrics.js
@@ -42,13 +42,20 @@ define([
     Date.now.restore();
   };
 
-  suite['returns current timestamp for flowBeginTime'] = function () {
+  suite['create and check functions are exported'] = () => {
+    assert.isObject(flowMetrics);
+    assert.lengthOf(Object.keys(flowMetrics), 2);
+    assert.equal(typeof flowMetrics.create, 'function');
+    assert.equal(typeof flowMetrics.check, 'function');
+  };
+
+  suite['create returns current timestamp for flowBeginTime'] = () => {
     mockDateNow = 42;
-    var flowEventData = flowMetrics(mockFlowIdKey, mockUserAgent);
+    var flowEventData = flowMetrics.create(mockFlowIdKey, mockUserAgent);
     assert.equal(flowEventData.flowBeginTime, 42);
   };
 
-  suite['correctly generates a known test vector'] = function () {
+  suite['create correctly generates a known test vector'] = () => {
     mockDateNow = 1451566800000;
     mockFlowIdKey = 'S3CR37';
     mockUserAgent = 'Firefox';
@@ -67,48 +74,134 @@ define([
     var expectedSalt = '4d6f7a696c6c6146697265666f782121';
     var expectedHmac = 'c89d56556d22039fbbf54d34e0baf206';
 
-    var flowEventData = flowMetrics(mockFlowIdKey, mockUserAgent);
+    var flowEventData = flowMetrics.create(mockFlowIdKey, mockUserAgent);
 
     assert.equal(flowEventData.flowBeginTime, 1451566800000);
     assert.equal(flowEventData.flowId, expectedSalt + expectedHmac);
   };
 
-  suite['generates different flowIds for different keys'] = function () {
-    var flowEventData1 = flowMetrics('key1', mockUserAgent);
-    var flowEventData2 = flowMetrics('key2', mockUserAgent);
+  suite['create generates different flowIds for different keys'] = () => {
+    var flowEventData1 = flowMetrics.create('key1', mockUserAgent);
+    var flowEventData2 = flowMetrics.create('key2', mockUserAgent);
 
     assert.notEqual(flowEventData1.flowId, flowEventData2.flowId);
     assert.equal(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
   };
 
-  suite['generates different flowIds for different user agents'] = function () {
-    var flowEventData1 = flowMetrics(mockFlowIdKey, 'Firefox');
-    var flowEventData2 = flowMetrics(mockFlowIdKey, 'Chrome');
+  suite['create generates different flowIds for different user agents'] = () => {
+    var flowEventData1 = flowMetrics.create(mockFlowIdKey, 'Firefox');
+    var flowEventData2 = flowMetrics.create(mockFlowIdKey, 'Chrome');
 
     assert.notEqual(flowEventData1.flowId, flowEventData2.flowId);
     assert.equal(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
   };
 
-  suite['generates different flowIds for different random salts'] = function () {
+  suite['create generates different flowIds for different random salts'] = () => {
     mockRandomBytes = 'MozillaFirefox!!';
-    var flowEventData1 = flowMetrics(mockFlowIdKey, mockUserAgent);
+    var flowEventData1 = flowMetrics.create(mockFlowIdKey, mockUserAgent);
 
     mockRandomBytes = 'AllHailSeaMonkey';
-    var flowEventData2 = flowMetrics(mockFlowIdKey, mockUserAgent);
+    var flowEventData2 = flowMetrics.create(mockFlowIdKey, mockUserAgent);
 
     assert.notEqual(flowEventData1.flowId, flowEventData2.flowId);
     assert.equal(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
   };
 
-  suite['generates different flowIds for different timestamps'] = function () {
+  suite['create generates different flowIds for different timestamps'] = () => {
     mockDateNow = +(new Date(2016, 0, 1));
-    var flowEventData1 = flowMetrics(mockFlowIdKey, mockUserAgent);
+    var flowEventData1 = flowMetrics.create(mockFlowIdKey, mockUserAgent);
 
     mockDateNow = +(new Date(2016, 1, 29));
-    var flowEventData2 = flowMetrics(mockFlowIdKey, mockUserAgent);
+    var flowEventData2 = flowMetrics.create(mockFlowIdKey, mockUserAgent);
 
     assert.notEqual(flowEventData1.flowId, flowEventData2.flowId);
     assert.notEqual(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
+  };
+
+  suite['check returns true for good data'] = () => {
+    // Force the mocks to return bad data to be sure it really works
+    mockDateNow = 1478626838531;
+    mockFlowIdKey = 'foo';
+    mockUserAgent = 'bar';
+    mockRandomBytes = 'baz';
+
+    const result = flowMetrics.check(
+      // Good data is from the create test
+      'S3CR37',
+      '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
+      1451566800000,
+      'Firefox'
+    );
+
+    assert.strictEqual(result, true);
+  };
+
+  suite['check returns false for a bad flow id'] = () => {
+    // Force the mocks to return good data to be sure it really works
+    mockDateNow = 1451566800000;
+    mockFlowIdKey = 'S3CR37';
+    mockUserAgent = 'Firefox';
+    mockRandomBytes = 'MozillaFirefox!!';
+
+    const result = flowMetrics.check(
+      'S3CR37',
+      'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+      1451566800000,
+      'Firefox'
+    );
+
+    assert.strictEqual(result, false);
+  };
+
+  suite['check returns false for a bad key'] = () => {
+    // Force the mocks to return good data to be sure it really works
+    mockDateNow = 1451566800000;
+    mockFlowIdKey = 'S3CR37';
+    mockUserAgent = 'Firefox';
+    mockRandomBytes = 'MozillaFirefox!!';
+
+    const result = flowMetrics.check(
+      'foo',
+      '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
+      1451566800000,
+      'Firefox'
+    );
+
+    assert.strictEqual(result, false);
+  };
+
+  suite['check returns false for a bad flow begin time'] = () => {
+    // Force the mocks to return good data to be sure it really works
+    mockDateNow = 1451566800000;
+    mockFlowIdKey = 'S3CR37';
+    mockUserAgent = 'Firefox';
+    mockRandomBytes = 'MozillaFirefox!!';
+
+    const result = flowMetrics.check(
+      'S3CR37',
+      '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
+      1478626838531,
+      'Firefox'
+    );
+
+    assert.strictEqual(result, false);
+  };
+
+  suite['check returns false for a bad user agent string'] = () => {
+    // Force the mocks to return good data to be sure it really works
+    mockDateNow = 1451566800000;
+    mockFlowIdKey = 'S3CR37';
+    mockUserAgent = 'Firefox';
+    mockRandomBytes = 'MozillaFirefox!!';
+
+    const result = flowMetrics.check(
+      'S3CR37',
+      '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
+      1451566800000,
+      'foo'
+    );
+
+    assert.strictEqual(result, false);
   };
 
   registerSuite(suite);

--- a/tests/server/routes/post-metrics.js
+++ b/tests/server/routes/post-metrics.js
@@ -12,7 +12,7 @@ define([
   'intern/dojo/node!sinon',
   'intern/dojo/node!../helpers/init-logging'
 ], function (registerSuite, assert, Promise, _, path, proxyquire, sinon, initLogging) {
-  var mocks, route, instance, flowMetricsCheckResult, sandbox;
+  var mocks, route, instance, flowMetricsValidateResult, sandbox;
 
   registerSuite({
     name: 'routes/post-metrics',
@@ -40,8 +40,8 @@ define([
         },
         flowEvent: sandbox.spy(),
         flowMetrics: {
-          check: sandbox.spy(() => flowMetricsCheckResult),
-          create: sandbox.spy()
+          create: sandbox.spy(),
+          validate: sandbox.spy(() => flowMetricsValidateResult)
         },
         gaCollector: {
           write: sandbox.spy()
@@ -151,7 +151,7 @@ define([
 
         'process.nextTick callback': {
           setup: function () {
-            flowMetricsCheckResult = true;
+            flowMetricsValidateResult = true;
             mocks.nextTick.args[0][0]();
           },
 
@@ -258,6 +258,7 @@ define([
 
       'route.process with invalid flow id': {
         setup () {
+          flowMetricsValidateResult = true;
           sinon.stub(Date, 'now', () => {
             return 1000;
           });
@@ -291,44 +292,14 @@ define([
           sandbox.reset();
         },
 
-        'response.json was called': () => {
-          assert.equal(mocks.response.json.callCount, 1);
-        },
-
-        'process.nextTick was called': () => {
-          assert.equal(mocks.nextTick.callCount, 1);
-        },
-
-        'process.nextTick callback': {
-          setup () {
-            flowMetricsCheckResult = true;
-            mocks.nextTick.args[0][0]();
-          },
-
-          'mozlog.error was not called': () => {
-            assert.strictEqual(mocks.mozlog.error.callCount, 0);
-          },
-
-          'metricsCollector.write was called': () => {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
-          },
-
-          'statsdCollector.write was called': () => {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
-          },
-
-          'gaCollector.write was called': () => {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
-          },
-
-          'flowEvent was not called': () => {
-            assert.strictEqual(mocks.flowEvent.callCount, 0);
-          }
+        'flow event was not emitted': () => {
+          assertFlowEventCallCount(0);
         }
       },
 
       'route.process with invalid flow begin time': {
         setup () {
+          flowMetricsValidateResult = true;
           sinon.stub(Date, 'now', () => {
             return 41;
           });
@@ -362,44 +333,14 @@ define([
           sandbox.reset();
         },
 
-        'response.json was called': () => {
-          assert.equal(mocks.response.json.callCount, 1);
-        },
-
-        'process.nextTick was called': () => {
-          assert.equal(mocks.nextTick.callCount, 1);
-        },
-
-        'process.nextTick callback': {
-          setup () {
-            flowMetricsCheckResult = true;
-            mocks.nextTick.args[0][0]();
-          },
-
-          'mozlog.error was not called': () => {
-            assert.strictEqual(mocks.mozlog.error.callCount, 0);
-          },
-
-          'metricsCollector.write was called': () => {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
-          },
-
-          'statsdCollector.write was called': () => {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
-          },
-
-          'gaCollector.write was called': () => {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
-          },
-
-          'flowEvent was not called': () => {
-            assert.strictEqual(mocks.flowEvent.callCount, 0);
-          }
+        'flow event was not emitted': () => {
+          assertFlowEventCallCount(0);
         }
       },
 
       'route.process with invalid context': {
         setup () {
+          flowMetricsValidateResult = true;
           sinon.stub(Date, 'now', () => {
             return 1000;
           });
@@ -433,44 +374,14 @@ define([
           sandbox.reset();
         },
 
-        'response.json was called': () => {
-          assert.equal(mocks.response.json.callCount, 1);
-        },
-
-        'process.nextTick was called': () => {
-          assert.equal(mocks.nextTick.callCount, 1);
-        },
-
-        'process.nextTick callback': {
-          setup () {
-            flowMetricsCheckResult = true;
-            mocks.nextTick.args[0][0]();
-          },
-
-          'mozlog.error was not called': () => {
-            assert.strictEqual(mocks.mozlog.error.callCount, 0);
-          },
-
-          'metricsCollector.write was called': () => {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
-          },
-
-          'statsdCollector.write was called': () => {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
-          },
-
-          'gaCollector.write was called': () => {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
-          },
-
-          'flowEvent was not called': () => {
-            assert.strictEqual(mocks.flowEvent.callCount, 0);
-          }
+        'flow event was not emitted': () => {
+          assertFlowEventCallCount(0);
         }
       },
 
       'route.process with invalid entrypoint': {
         setup () {
+          flowMetricsValidateResult = true;
           sinon.stub(Date, 'now', () => {
             return 1000;
           });
@@ -504,44 +415,14 @@ define([
           sandbox.reset();
         },
 
-        'response.json was called': () => {
-          assert.equal(mocks.response.json.callCount, 1);
-        },
-
-        'process.nextTick was called': () => {
-          assert.equal(mocks.nextTick.callCount, 1);
-        },
-
-        'process.nextTick callback': {
-          setup () {
-            flowMetricsCheckResult = true;
-            mocks.nextTick.args[0][0]();
-          },
-
-          'mozlog.error was not called': () => {
-            assert.strictEqual(mocks.mozlog.error.callCount, 0);
-          },
-
-          'metricsCollector.write was called': () => {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
-          },
-
-          'statsdCollector.write was called': () => {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
-          },
-
-          'gaCollector.write was called': () => {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
-          },
-
-          'flowEvent was not called': () => {
-            assert.strictEqual(mocks.flowEvent.callCount, 0);
-          }
+        'flow event was not emitted': () => {
+          assertFlowEventCallCount(0);
         }
       },
 
       'route.process with invalid migration': {
         setup () {
+          flowMetricsValidateResult = true;
           sinon.stub(Date, 'now', () => {
             return 1000;
           });
@@ -575,44 +456,14 @@ define([
           sandbox.reset();
         },
 
-        'response.json was called': () => {
-          assert.equal(mocks.response.json.callCount, 1);
-        },
-
-        'process.nextTick was called': () => {
-          assert.equal(mocks.nextTick.callCount, 1);
-        },
-
-        'process.nextTick callback': {
-          setup () {
-            flowMetricsCheckResult = true;
-            mocks.nextTick.args[0][0]();
-          },
-
-          'mozlog.error was not called': () => {
-            assert.strictEqual(mocks.mozlog.error.callCount, 0);
-          },
-
-          'metricsCollector.write was called': () => {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
-          },
-
-          'statsdCollector.write was called': () => {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
-          },
-
-          'gaCollector.write was called': () => {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
-          },
-
-          'flowEvent was not called': () => {
-            assert.strictEqual(mocks.flowEvent.callCount, 0);
-          }
+        'flow event was not emitted': () => {
+          assertFlowEventCallCount(0);
         }
       },
 
       'route.process with invalid service': {
         setup () {
+          flowMetricsValidateResult = true;
           sinon.stub(Date, 'now', () => {
             return 1000;
           });
@@ -646,44 +497,14 @@ define([
           sandbox.reset();
         },
 
-        'response.json was called': () => {
-          assert.equal(mocks.response.json.callCount, 1);
-        },
-
-        'process.nextTick was called': () => {
-          assert.equal(mocks.nextTick.callCount, 1);
-        },
-
-        'process.nextTick callback': {
-          setup () {
-            flowMetricsCheckResult = true;
-            mocks.nextTick.args[0][0]();
-          },
-
-          'mozlog.error was not called': () => {
-            assert.strictEqual(mocks.mozlog.error.callCount, 0);
-          },
-
-          'metricsCollector.write was called': () => {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
-          },
-
-          'statsdCollector.write was called': () => {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
-          },
-
-          'gaCollector.write was called': () => {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
-          },
-
-          'flowEvent was not called': () => {
-            assert.strictEqual(mocks.flowEvent.callCount, 0);
-          }
+        'flow event was not emitted': () => {
+          assertFlowEventCallCount(0);
         }
       },
 
       'route.process without optional flow data': {
         setup: function () {
+          flowMetricsValidateResult = true;
           sinon.stub(Date, 'now', function () {
             return 1000;
           });
@@ -714,44 +535,14 @@ define([
           sandbox.reset();
         },
 
-        'response.json was called': function () {
-          assert.equal(mocks.response.json.callCount, 1);
-        },
-
-        'process.nextTick was called': function () {
-          assert.equal(mocks.nextTick.callCount, 1);
-        },
-
-        'process.nextTick callback': {
-          setup: function () {
-            flowMetricsCheckResult = true;
-            mocks.nextTick.args[0][0]();
-          },
-
-          'mozlog.error was not called': function () {
-            assert.strictEqual(mocks.mozlog.error.callCount, 0);
-          },
-
-          'metricsCollector.write was called': function () {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
-          },
-
-          'statsdCollector.write was called': function () {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
-          },
-
-          'gaCollector.write was called': function () {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
-          },
-
-          'flowEvent was called': function () {
-            assert.strictEqual(mocks.flowEvent.callCount, 2);
-          }
+        'two flow events were emitted': () => {
+          assertFlowEventCallCount(2);
         }
       },
 
-      'route.process with valid-seeming flow data but flowMetrics.check returns false': {
+      'route.process with valid-seeming flow data but flowMetrics.validate returns false': {
         setup () {
+          flowMetricsValidateResult = false;
           sinon.stub(Date, 'now', () => {
             return 1000;
           });
@@ -781,39 +572,8 @@ define([
           sandbox.reset();
         },
 
-        'response.json was called': () => {
-          assert.equal(mocks.response.json.callCount, 1);
-        },
-
-        'process.nextTick was called': () => {
-          assert.equal(mocks.nextTick.callCount, 1);
-        },
-
-        'process.nextTick callback': {
-          setup () {
-            flowMetricsCheckResult = false;
-            mocks.nextTick.args[0][0]();
-          },
-
-          'mozlog.error was not called': () => {
-            assert.strictEqual(mocks.mozlog.error.callCount, 0);
-          },
-
-          'metricsCollector.write was called': () => {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
-          },
-
-          'statsdCollector.write was called': () => {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
-          },
-
-          'gaCollector.write was called': () => {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
-          },
-
-          'flowEvent was not called': () => {
-            assert.strictEqual(mocks.flowEvent.callCount, 0);
-          }
+        'flow event was not emitted': () => {
+          assertFlowEventCallCount(0);
         }
       },
 
@@ -840,43 +600,14 @@ define([
           sandbox.reset();
         },
 
-        'response.json was called': function () {
-          assert.equal(mocks.response.json.callCount, 1);
-        },
-
-        'process.nextTick was called': function () {
-          assert.equal(mocks.nextTick.callCount, 1);
-        },
-
-        'process.nextTick callback': {
-          setup: function () {
-            mocks.nextTick.args[0][0]();
-          },
-
-          'mozlog.error was not called': function () {
-            assert.strictEqual(mocks.mozlog.error.callCount, 0);
-          },
-
-          'metricsCollector.write was called': function () {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
-          },
-
-          'statsdCollector.write was called': function () {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
-          },
-
-          'gaCollector.write was called': function () {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
-          },
-
-          'flowEvent was not called': function () {
-            assert.strictEqual(mocks.flowEvent.callCount, 0);
-          }
+        'flow event was not emitted': () => {
+          assertFlowEventCallCount(0);
         }
       },
 
       'route.process without isSampledUser': {
         setup: function () {
+          flowMetricsValidateResult = true;
           sinon.stub(Date, 'now', function () {
             return 1000;
           });
@@ -912,7 +643,7 @@ define([
 
         'process.nextTick callback': {
           setup: function () {
-            flowMetricsCheckResult = true;
+            flowMetricsValidateResult = true;
             mocks.nextTick.args[0][0]();
           },
 
@@ -976,7 +707,7 @@ define([
 
         'process.nextTick callback': {
           setup: function () {
-            flowMetricsCheckResult = true;
+            flowMetricsValidateResult = true;
             mocks.nextTick.args[0][0]();
           },
 
@@ -1059,7 +790,7 @@ define([
 
         'process.nextTick callback': {
           setup: function () {
-            flowMetricsCheckResult = true;
+            flowMetricsValidateResult = true;
             mocks.nextTick.args[0][0]();
           },
 
@@ -1184,5 +915,18 @@ define([
     process.nextTick = mocks.nextTick;
     instance.process(mocks.request, mocks.response);
     process.nextTick = nextTickCopy;
+  }
+
+  function assertFlowEventCallCount (count) {
+    assert.equal(mocks.response.json.callCount, 1, 'response.json was called once');
+    assert.equal(mocks.nextTick.callCount, 1, 'process.nextTick was called once');
+
+    mocks.nextTick.args[0][0]();
+
+    assert.strictEqual(mocks.mozlog.error.callCount, 0, 'mozlog.error was not called');
+    assert.strictEqual(mocks.metricsCollector.write.callCount, 1, 'metricsCollector.write was called once');
+    assert.strictEqual(mocks.statsdCollector.write.callCount, 1, 'statsdCollector.write was called once');
+    assert.strictEqual(mocks.gaCollector.write.callCount, 1, 'gaCollector.write was called once');
+    assert.strictEqual(mocks.flowEvent.callCount, count, `flowEvent was called ${count} times`);
   }
 });

--- a/tests/server/routes/post-metrics.js
+++ b/tests/server/routes/post-metrics.js
@@ -12,36 +12,55 @@ define([
   'intern/dojo/node!sinon',
   'intern/dojo/node!../helpers/init-logging'
 ], function (registerSuite, assert, Promise, _, path, proxyquire, sinon, initLogging) {
-  var mocks, route, instance;
+  var mocks, route, instance, flowMetricsCheckResult, sandbox;
 
   registerSuite({
     name: 'routes/post-metrics',
 
     setup: function () {
+      sandbox = sinon.sandbox.create();
       mocks = {
         config: {
-          get: sinon.spy(function () {
-            return false;
-          })
+          get (key) {
+            switch (key) {
+              /*eslint-disable indent*/
+              case 'client_metrics':
+                return {
+                  stderr_collector_disabled: false //eslint-disable-line camelcase
+                };
+              case 'flow_id_key':
+                return 'foo';
+              case 'flow_id_expiry':
+                return 7200000;
+              /*eslint-enable indent*/
+            }
+
+            return {};
+          }
         },
-        flowEvent: sinon.spy(),
+        flowEvent: sandbox.spy(),
+        flowMetrics: {
+          check: sandbox.spy(() => flowMetricsCheckResult),
+          create: sandbox.spy()
+        },
         gaCollector: {
-          write: sinon.spy()
+          write: sandbox.spy()
         },
         metricsCollector: {
-          write: sinon.spy()
+          write: sandbox.spy()
         },
         mozlog: {
-          error: sinon.spy()
+          error: sandbox.spy()
         },
         statsdCollector: {
-          init: sinon.spy(),
-          write: sinon.spy()
+          init: sandbox.spy(),
+          write: sandbox.spy()
         }
       };
       route = proxyquire(
         path.join(process.cwd(), 'server/lib/routes/post-metrics'), {
           '../flow-event': mocks.flowEvent,
+          '../flow-metrics': mocks.flowMetrics,
           '../configuration': mocks.config,
           '../ga-collector': function () {
             return mocks.gaCollector;
@@ -78,7 +97,7 @@ define([
         assert.lengthOf(instance.process, 2);
       },
 
-      'route.process': {
+      'route.process with valid flow data': {
         setup: function () {
           sinon.stub(Date, 'now', function () {
             return 1000;
@@ -86,9 +105,13 @@ define([
           setupMetricsHandlerTests({
             /*eslint-disable sorting/sort-object-props*/
             data: {
+              context: 'fx_desktop_v3',
+              entrypoint: 'menupanel',
               flowBeginTime: 42,
-              flowId: 'qux',
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
               isSampledUser: true,
+              migration: 'sync11',
+              service: '1234567890abcdef',
               startTime: 10,
               flushTime: 20
             },
@@ -97,7 +120,8 @@ define([
               { type: 'bar', offset: 1 },
               { type: 'flow.signup.begin', offset: 2 },
               { type: 'baz', offset: 3 },
-              { type: 'flow.signup.engage', offset: 4 }
+              { type: 'flow.signup.engage', offset: 11 },
+              { type: 'flow.signup.submit', offset: 4 }
             ],
             userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
             /*eslint-enable sorting/sort-object-props*/
@@ -106,6 +130,7 @@ define([
 
         teardown: function () {
           Date.now.restore();
+          sandbox.reset();
         },
 
         'response.json was called correctly': function () {
@@ -126,6 +151,7 @@ define([
 
         'process.nextTick callback': {
           setup: function () {
+            flowMetricsCheckResult = true;
             mocks.nextTick.args[0][0]();
           },
 
@@ -139,11 +165,11 @@ define([
             var args = mocks.metricsCollector.write.args[0];
             assert.lengthOf(args, 1);
             assert.equal(args[0], mocks.request.body);
-            assert.lengthOf(Object.keys(args[0]), 7);
+            assert.lengthOf(Object.keys(args[0]), 11);
 
             assert.equal(args[0].agent, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0');
             assert.isArray(args[0].events);
-            assert.lengthOf(args[0].events, 5);
+            assert.lengthOf(args[0].events, 6);
             assert.isObject(args[0].events[0]);
             assert.lengthOf(Object.keys(args[0].events[0]), 2);
             assert.equal(args[0].events[0].type, 'foo');
@@ -163,14 +189,23 @@ define([
             assert.equal(args[0].events[3].type, 'baz');
             assert.equal(args[0].events[3].offset, 3);
             assert.isObject(args[0].events[4]);
-            assert.lengthOf(Object.keys(args[0].events[4]), 4);
+            assert.lengthOf(Object.keys(args[0].events[4]), 3);
             assert.equal(args[0].events[4].type, 'flow.signup.engage');
-            assert.equal(args[0].events[4].offset, 4);
-            assert.equal(args[0].events[4].time, 994);
-            assert.equal(args[0].events[4].flowTime, 952);
-            assert.equal(args[0].flowId, 'qux');
+            assert.equal(args[0].events[4].offset, 11);
+            assert.equal(args[0].events[4].time, 1001);
+            assert.isObject(args[0].events[5]);
+            assert.lengthOf(Object.keys(args[0].events[5]), 4);
+            assert.equal(args[0].events[5].type, 'flow.signup.submit');
+            assert.equal(args[0].events[5].offset, 4);
+            assert.equal(args[0].events[5].time, 994);
+            assert.equal(args[0].events[5].flowTime, 952);
+            assert.equal(args[0].flowId, '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef');
             assert.equal(args[0].flowBeginTime, 42);
             assert.strictEqual(args[0].isSampledUser, true);
+            assert.strictEqual(args[0].context, 'fx_desktop_v3');
+            assert.strictEqual(args[0].entrypoint, 'menupanel');
+            assert.strictEqual(args[0].migration, 'sync11');
+            assert.strictEqual(args[0].service, '1234567890abcdef');
             assert.strictEqual(args[0].startTime, 10);
             assert.strictEqual(args[0].flushTime, 20);
           },
@@ -198,19 +233,586 @@ define([
             assert.strictEqual(args[0].flowTime, 0);
             assert.equal(args[0].time, 42);
             assert.isObject(args[1]);
-            assert.equal(args[1].flowId, 'qux');
+            assert.equal(args[1].flowId, '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef');
             assert.strictEqual(args[1].flowBeginTime, 42);
+            assert.strictEqual(args[1].context, 'fx_desktop_v3');
+            assert.strictEqual(args[1].service, '1234567890abcdef');
             assert.equal(args[2], mocks.request);
             // second flowEvent
             args = mocks.flowEvent.args[1];
             assert.isObject(args[0]);
-            assert.equal(args[0].type, 'flow.signup.engage');
+            assert.equal(args[0].type, 'flow.signup.submit');
             assert.strictEqual(args[0].flowTime, 952);
             assert.equal(args[0].time, 994);
             assert.isObject(args[1]);
-            assert.equal(args[1].flowId, 'qux');
+            assert.equal(args[1].flowId, '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef');
             assert.strictEqual(args[1].flowBeginTime, 42);
+            assert.strictEqual(args[1].context, 'fx_desktop_v3');
+            assert.strictEqual(args[1].entrypoint, 'menupanel');
+            assert.strictEqual(args[1].migration, 'sync11');
+            assert.strictEqual(args[1].service, '1234567890abcdef');
             assert.equal(args[2], mocks.request);
+          }
+        }
+      },
+
+      'route.process with invalid flow id': {
+        setup () {
+          sinon.stub(Date, 'now', () => {
+            return 1000;
+          });
+          setupMetricsHandlerTests({
+            /*eslint-disable sorting/sort-object-props*/
+            data: {
+              context: 'fx_desktop_v3',
+              entrypoint: 'menupanel',
+              flowBeginTime: 42,
+              flowId: '1234567890abcdef1234567890abcdef',
+              isSampledUser: true,
+              migration: 'sync11',
+              service: '1234567890abcdef',
+              startTime: 10,
+              flushTime: 20
+            },
+            events: [
+              { type: 'foo', offset: 0 },
+              { type: 'bar', offset: 1 },
+              { type: 'flow.signup.begin', offset: 2 },
+              { type: 'baz', offset: 3 },
+              { type: 'flow.signup.engage', offset: 4 }
+            ],
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
+            /*eslint-enable sorting/sort-object-props*/
+          });
+        },
+
+        teardown () {
+          Date.now.restore();
+          sandbox.reset();
+        },
+
+        'response.json was called': () => {
+          assert.equal(mocks.response.json.callCount, 1);
+        },
+
+        'process.nextTick was called': () => {
+          assert.equal(mocks.nextTick.callCount, 1);
+        },
+
+        'process.nextTick callback': {
+          setup () {
+            flowMetricsCheckResult = true;
+            mocks.nextTick.args[0][0]();
+          },
+
+          'mozlog.error was not called': () => {
+            assert.strictEqual(mocks.mozlog.error.callCount, 0);
+          },
+
+          'metricsCollector.write was called': () => {
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
+          },
+
+          'statsdCollector.write was called': () => {
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
+          },
+
+          'gaCollector.write was called': () => {
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
+          },
+
+          'flowEvent was not called': () => {
+            assert.strictEqual(mocks.flowEvent.callCount, 0);
+          }
+        }
+      },
+
+      'route.process with invalid flow begin time': {
+        setup () {
+          sinon.stub(Date, 'now', () => {
+            return 41;
+          });
+          setupMetricsHandlerTests({
+            /*eslint-disable sorting/sort-object-props*/
+            data: {
+              context: 'fx_desktop_v3',
+              entrypoint: 'menupanel',
+              flowBeginTime: 42,
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              isSampledUser: true,
+              migration: 'sync11',
+              service: '1234567890abcdef',
+              startTime: 10,
+              flushTime: 20
+            },
+            events: [
+              { type: 'foo', offset: 0 },
+              { type: 'bar', offset: 1 },
+              { type: 'flow.signup.begin', offset: 2 },
+              { type: 'baz', offset: 3 },
+              { type: 'flow.signup.engage', offset: 4 }
+            ],
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
+            /*eslint-enable sorting/sort-object-props*/
+          });
+        },
+
+        teardown () {
+          Date.now.restore();
+          sandbox.reset();
+        },
+
+        'response.json was called': () => {
+          assert.equal(mocks.response.json.callCount, 1);
+        },
+
+        'process.nextTick was called': () => {
+          assert.equal(mocks.nextTick.callCount, 1);
+        },
+
+        'process.nextTick callback': {
+          setup () {
+            flowMetricsCheckResult = true;
+            mocks.nextTick.args[0][0]();
+          },
+
+          'mozlog.error was not called': () => {
+            assert.strictEqual(mocks.mozlog.error.callCount, 0);
+          },
+
+          'metricsCollector.write was called': () => {
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
+          },
+
+          'statsdCollector.write was called': () => {
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
+          },
+
+          'gaCollector.write was called': () => {
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
+          },
+
+          'flowEvent was not called': () => {
+            assert.strictEqual(mocks.flowEvent.callCount, 0);
+          }
+        }
+      },
+
+      'route.process with invalid context': {
+        setup () {
+          sinon.stub(Date, 'now', () => {
+            return 1000;
+          });
+          setupMetricsHandlerTests({
+            /*eslint-disable sorting/sort-object-props*/
+            data: {
+              context: '!',
+              entrypoint: 'menupanel',
+              flowBeginTime: 42,
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              isSampledUser: true,
+              migration: 'sync11',
+              service: '1234567890abcdef',
+              startTime: 10,
+              flushTime: 20
+            },
+            events: [
+              { type: 'foo', offset: 0 },
+              { type: 'bar', offset: 1 },
+              { type: 'flow.signup.begin', offset: 2 },
+              { type: 'baz', offset: 3 },
+              { type: 'flow.signup.engage', offset: 4 }
+            ],
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
+            /*eslint-enable sorting/sort-object-props*/
+          });
+        },
+
+        teardown () {
+          Date.now.restore();
+          sandbox.reset();
+        },
+
+        'response.json was called': () => {
+          assert.equal(mocks.response.json.callCount, 1);
+        },
+
+        'process.nextTick was called': () => {
+          assert.equal(mocks.nextTick.callCount, 1);
+        },
+
+        'process.nextTick callback': {
+          setup () {
+            flowMetricsCheckResult = true;
+            mocks.nextTick.args[0][0]();
+          },
+
+          'mozlog.error was not called': () => {
+            assert.strictEqual(mocks.mozlog.error.callCount, 0);
+          },
+
+          'metricsCollector.write was called': () => {
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
+          },
+
+          'statsdCollector.write was called': () => {
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
+          },
+
+          'gaCollector.write was called': () => {
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
+          },
+
+          'flowEvent was not called': () => {
+            assert.strictEqual(mocks.flowEvent.callCount, 0);
+          }
+        }
+      },
+
+      'route.process with invalid entrypoint': {
+        setup () {
+          sinon.stub(Date, 'now', () => {
+            return 1000;
+          });
+          setupMetricsHandlerTests({
+            /*eslint-disable sorting/sort-object-props*/
+            data: {
+              context: 'fx_desktop_v3',
+              entrypoint: '!',
+              flowBeginTime: 42,
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              isSampledUser: true,
+              migration: 'sync11',
+              service: '1234567890abcdef',
+              startTime: 10,
+              flushTime: 20
+            },
+            events: [
+              { type: 'foo', offset: 0 },
+              { type: 'bar', offset: 1 },
+              { type: 'flow.signup.begin', offset: 2 },
+              { type: 'baz', offset: 3 },
+              { type: 'flow.signup.engage', offset: 4 }
+            ],
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
+            /*eslint-enable sorting/sort-object-props*/
+          });
+        },
+
+        teardown () {
+          Date.now.restore();
+          sandbox.reset();
+        },
+
+        'response.json was called': () => {
+          assert.equal(mocks.response.json.callCount, 1);
+        },
+
+        'process.nextTick was called': () => {
+          assert.equal(mocks.nextTick.callCount, 1);
+        },
+
+        'process.nextTick callback': {
+          setup () {
+            flowMetricsCheckResult = true;
+            mocks.nextTick.args[0][0]();
+          },
+
+          'mozlog.error was not called': () => {
+            assert.strictEqual(mocks.mozlog.error.callCount, 0);
+          },
+
+          'metricsCollector.write was called': () => {
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
+          },
+
+          'statsdCollector.write was called': () => {
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
+          },
+
+          'gaCollector.write was called': () => {
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
+          },
+
+          'flowEvent was not called': () => {
+            assert.strictEqual(mocks.flowEvent.callCount, 0);
+          }
+        }
+      },
+
+      'route.process with invalid migration': {
+        setup () {
+          sinon.stub(Date, 'now', () => {
+            return 1000;
+          });
+          setupMetricsHandlerTests({
+            /*eslint-disable sorting/sort-object-props*/
+            data: {
+              context: 'fx_desktop_v3',
+              entrypoint: 'menupanel',
+              flowBeginTime: 42,
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              isSampledUser: true,
+              migration: 'foo',
+              service: '1234567890abcdef',
+              startTime: 10,
+              flushTime: 20
+            },
+            events: [
+              { type: 'foo', offset: 0 },
+              { type: 'bar', offset: 1 },
+              { type: 'flow.signup.begin', offset: 2 },
+              { type: 'baz', offset: 3 },
+              { type: 'flow.signup.engage', offset: 4 }
+            ],
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
+            /*eslint-enable sorting/sort-object-props*/
+          });
+        },
+
+        teardown () {
+          Date.now.restore();
+          sandbox.reset();
+        },
+
+        'response.json was called': () => {
+          assert.equal(mocks.response.json.callCount, 1);
+        },
+
+        'process.nextTick was called': () => {
+          assert.equal(mocks.nextTick.callCount, 1);
+        },
+
+        'process.nextTick callback': {
+          setup () {
+            flowMetricsCheckResult = true;
+            mocks.nextTick.args[0][0]();
+          },
+
+          'mozlog.error was not called': () => {
+            assert.strictEqual(mocks.mozlog.error.callCount, 0);
+          },
+
+          'metricsCollector.write was called': () => {
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
+          },
+
+          'statsdCollector.write was called': () => {
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
+          },
+
+          'gaCollector.write was called': () => {
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
+          },
+
+          'flowEvent was not called': () => {
+            assert.strictEqual(mocks.flowEvent.callCount, 0);
+          }
+        }
+      },
+
+      'route.process with invalid service': {
+        setup () {
+          sinon.stub(Date, 'now', () => {
+            return 1000;
+          });
+          setupMetricsHandlerTests({
+            /*eslint-disable sorting/sort-object-props*/
+            data: {
+              context: 'fx_desktop_v3',
+              entrypoint: 'menupanel',
+              flowBeginTime: 42,
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              isSampledUser: true,
+              migration: 'sync11',
+              service: '1234567890abcdef1234567890abcdef',
+              startTime: 10,
+              flushTime: 20
+            },
+            events: [
+              { type: 'foo', offset: 0 },
+              { type: 'bar', offset: 1 },
+              { type: 'flow.signup.begin', offset: 2 },
+              { type: 'baz', offset: 3 },
+              { type: 'flow.signup.engage', offset: 4 }
+            ],
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
+            /*eslint-enable sorting/sort-object-props*/
+          });
+        },
+
+        teardown () {
+          Date.now.restore();
+          sandbox.reset();
+        },
+
+        'response.json was called': () => {
+          assert.equal(mocks.response.json.callCount, 1);
+        },
+
+        'process.nextTick was called': () => {
+          assert.equal(mocks.nextTick.callCount, 1);
+        },
+
+        'process.nextTick callback': {
+          setup () {
+            flowMetricsCheckResult = true;
+            mocks.nextTick.args[0][0]();
+          },
+
+          'mozlog.error was not called': () => {
+            assert.strictEqual(mocks.mozlog.error.callCount, 0);
+          },
+
+          'metricsCollector.write was called': () => {
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
+          },
+
+          'statsdCollector.write was called': () => {
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
+          },
+
+          'gaCollector.write was called': () => {
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
+          },
+
+          'flowEvent was not called': () => {
+            assert.strictEqual(mocks.flowEvent.callCount, 0);
+          }
+        }
+      },
+
+      'route.process without optional flow data': {
+        setup: function () {
+          sinon.stub(Date, 'now', function () {
+            return 1000;
+          });
+          setupMetricsHandlerTests({
+            /*eslint-disable sorting/sort-object-props*/
+            data: {
+              flowBeginTime: 42,
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              isSampledUser: true,
+              startTime: 10,
+              flushTime: 20
+            },
+            events: [
+              { type: 'foo', offset: 0 },
+              { type: 'bar', offset: 1 },
+              { type: 'flow.signup.begin', offset: 2 },
+              { type: 'baz', offset: 3 },
+              { type: 'flow.signup.engage', offset: 11 },
+              { type: 'flow.signup.submit', offset: 4 }
+            ],
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
+            /*eslint-enable sorting/sort-object-props*/
+          });
+        },
+
+        teardown () {
+          Date.now.restore();
+          sandbox.reset();
+        },
+
+        'response.json was called': function () {
+          assert.equal(mocks.response.json.callCount, 1);
+        },
+
+        'process.nextTick was called': function () {
+          assert.equal(mocks.nextTick.callCount, 1);
+        },
+
+        'process.nextTick callback': {
+          setup: function () {
+            flowMetricsCheckResult = true;
+            mocks.nextTick.args[0][0]();
+          },
+
+          'mozlog.error was not called': function () {
+            assert.strictEqual(mocks.mozlog.error.callCount, 0);
+          },
+
+          'metricsCollector.write was called': function () {
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
+          },
+
+          'statsdCollector.write was called': function () {
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
+          },
+
+          'gaCollector.write was called': function () {
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
+          },
+
+          'flowEvent was called': function () {
+            assert.strictEqual(mocks.flowEvent.callCount, 2);
+          }
+        }
+      },
+
+      'route.process with valid-seeming flow data but flowMetrics.check returns false': {
+        setup () {
+          sinon.stub(Date, 'now', () => {
+            return 1000;
+          });
+          setupMetricsHandlerTests({
+            /*eslint-disable sorting/sort-object-props*/
+            data: {
+              flowBeginTime: 42,
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              isSampledUser: true,
+              startTime: 10,
+              flushTime: 20
+            },
+            events: [
+              { type: 'foo', offset: 0 },
+              { type: 'bar', offset: 1 },
+              { type: 'flow.signup.begin', offset: 2 },
+              { type: 'baz', offset: 3 },
+              { type: 'flow.signup.engage', offset: 4 }
+            ],
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
+            /*eslint-enable sorting/sort-object-props*/
+          });
+        },
+
+        teardown () {
+          Date.now.restore();
+          sandbox.reset();
+        },
+
+        'response.json was called': () => {
+          assert.equal(mocks.response.json.callCount, 1);
+        },
+
+        'process.nextTick was called': () => {
+          assert.equal(mocks.nextTick.callCount, 1);
+        },
+
+        'process.nextTick callback': {
+          setup () {
+            flowMetricsCheckResult = false;
+            mocks.nextTick.args[0][0]();
+          },
+
+          'mozlog.error was not called': () => {
+            assert.strictEqual(mocks.mozlog.error.callCount, 0);
+          },
+
+          'metricsCollector.write was called': () => {
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
+          },
+
+          'statsdCollector.write was called': () => {
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
+          },
+
+          'gaCollector.write was called': () => {
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
+          },
+
+          'flowEvent was not called': () => {
+            assert.strictEqual(mocks.flowEvent.callCount, 0);
           }
         }
       },
@@ -220,7 +822,7 @@ define([
           setupMetricsHandlerTests({
             data: {
               flowBeginTime: 42,
-              flowId: 'qux',
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
               isSampledUser: true
             },
             events: [
@@ -232,6 +834,10 @@ define([
             ],
             userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
           });
+        },
+
+        teardown () {
+          sandbox.reset();
         },
 
         'response.json was called': function () {
@@ -252,29 +858,32 @@ define([
           },
 
           'metricsCollector.write was called': function () {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 2);
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
           },
 
           'statsdCollector.write was called': function () {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 2);
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
           },
 
           'gaCollector.write was called': function () {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 2);
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
           },
 
           'flowEvent was not called': function () {
-            assert.strictEqual(mocks.flowEvent.callCount, 2);
+            assert.strictEqual(mocks.flowEvent.callCount, 0);
           }
         }
       },
 
       'route.process without isSampledUser': {
         setup: function () {
+          sinon.stub(Date, 'now', function () {
+            return 1000;
+          });
           setupMetricsHandlerTests({
             data: {
               flowBeginTime: 42,
-              flowId: 'qux'
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
             },
             events: [
               /*eslint-disable sorting/sort-object-props*/
@@ -288,6 +897,11 @@ define([
           });
         },
 
+        teardown () {
+          Date.now.restore();
+          sandbox.reset();
+        },
+
         'response.json was called': function () {
           assert.equal(mocks.response.json.callCount, 1);
         },
@@ -298,6 +912,7 @@ define([
 
         'process.nextTick callback': {
           setup: function () {
+            flowMetricsCheckResult = true;
             mocks.nextTick.args[0][0]();
           },
 
@@ -306,30 +921,33 @@ define([
           },
 
           'metricsCollector.write was not called': function () {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 2);
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 0);
           },
 
           'statsdCollector.write was not called': function () {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 2);
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 0);
           },
 
           'gaCollector.write was called': function () {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 3);
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
           },
 
           'flowEvent was called': function () {
-            assert.strictEqual(mocks.flowEvent.callCount, 3);
+            assert.strictEqual(mocks.flowEvent.callCount, 1);
           }
         }
       },
 
       'route.process with text/plain Content-Type': {
         setup: function () {
+          sinon.stub(Date, 'now', function () {
+            return 1000;
+          });
           setupMetricsHandlerTests({
             contentType: 'text/plain',
             data: {
               flowBeginTime: 77,
-              flowId: 'bar',
+              flowId: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
               isSampledUser: true
             },
             events: [
@@ -343,6 +961,11 @@ define([
           });
         },
 
+        teardown () {
+          Date.now.restore();
+          sandbox.reset();
+        },
+
         'response.json was called': function () {
           assert.equal(mocks.response.json.callCount, 1);
         },
@@ -353,6 +976,7 @@ define([
 
         'process.nextTick callback': {
           setup: function () {
+            flowMetricsCheckResult = true;
             mocks.nextTick.args[0][0]();
           },
 
@@ -361,9 +985,9 @@ define([
           },
 
           'metricsCollector.write was called correctly': function () {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 3);
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
 
-            var args = mocks.metricsCollector.write.args[2];
+            var args = mocks.metricsCollector.write.args[0];
             assert.lengthOf(args, 1);
             assert.isObject(args[0]);
             assert.lengthOf(Object.keys(args[0]), 5);
@@ -371,35 +995,35 @@ define([
             assert.equal(args[0].agent, 'baz');
             assert.isArray(args[0].events);
             assert.lengthOf(args[0].events, 2);
-            assert.equal(args[0].flowId, 'bar');
+            assert.equal(args[0].flowId, 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890');
             assert.equal(args[0].flowBeginTime, 77);
             assert.strictEqual(args[0].isSampledUser, true);
           },
 
           'statsdCollector.write was called correctly': function () {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 3);
-            var args = mocks.statsdCollector.write.args[2];
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
+            var args = mocks.statsdCollector.write.args[0];
             assert.lengthOf(args, 1);
             assert.isObject(args[0]);
           },
 
           'gaCollector.write was called correctly': function () {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 4);
-            var args = mocks.gaCollector.write.args[3];
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
+            var args = mocks.gaCollector.write.args[0];
             assert.lengthOf(args, 1);
             assert.isObject(args[0]);
           },
 
           'flowEvent was called correctly': function () {
-            assert.strictEqual(mocks.flowEvent.callCount, 4);
-            var args = mocks.flowEvent.args[3];
+            assert.strictEqual(mocks.flowEvent.callCount, 1);
+            var args = mocks.flowEvent.args[0];
             assert.lengthOf(args, 3);
             assert.isObject(args[0]);
             assert.equal(args[0].type, 'flow.force_auth.begin');
             assert.strictEqual(args[0].flowTime, 0);
             assert.equal(args[0].time, 77);
             assert.isObject(args[1]);
-            assert.equal(args[1].flowId, 'bar');
+            assert.equal(args[1].flowId, 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890');
             assert.strictEqual(args[1].flowBeginTime, 77);
             assert.equal(args[2], mocks.request);
           }
@@ -435,6 +1059,7 @@ define([
 
         'process.nextTick callback': {
           setup: function () {
+            flowMetricsCheckResult = true;
             mocks.nextTick.args[0][0]();
           },
 
@@ -446,19 +1071,19 @@ define([
           },
 
           'metricsCollector.write was not called': function () {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 3);
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 0);
           },
 
           'statsdCollector.write was not called': function () {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 3);
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 0);
           },
 
           'gaCollector.write was not called': function () {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 4);
+            assert.strictEqual(mocks.gaCollector.write.callCount, 0);
           },
 
           'flowEvent was not called': function () {
-            assert.strictEqual(mocks.flowEvent.callCount, 4);
+            assert.strictEqual(mocks.flowEvent.callCount, 0);
           }
         }
       },
@@ -471,7 +1096,7 @@ define([
           setupMetricsHandlerTests({
             /*eslint-disable sorting/sort-object-props*/
             data: {
-              flowId: 'qux',
+              flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
               isSampledUser: true,
               startTime: 1,
               flushTime: 2
@@ -490,6 +1115,7 @@ define([
 
         teardown: function () {
           Date.now.restore();
+          sandbox.reset();
         },
 
         'response.json was called': function () {
@@ -510,19 +1136,19 @@ define([
           },
 
           'metricsCollector.write was called': function () {
-            assert.strictEqual(mocks.metricsCollector.write.callCount, 4);
+            assert.strictEqual(mocks.metricsCollector.write.callCount, 1);
           },
 
           'statsdCollector.write was called': function () {
-            assert.strictEqual(mocks.statsdCollector.write.callCount, 4);
+            assert.strictEqual(mocks.statsdCollector.write.callCount, 1);
           },
 
           'gaCollector.write was called': function () {
-            assert.strictEqual(mocks.gaCollector.write.callCount, 5);
+            assert.strictEqual(mocks.gaCollector.write.callCount, 1);
           },
 
           'flowEvent was not called': function () {
-            assert.strictEqual(mocks.flowEvent.callCount, 4);
+            assert.strictEqual(mocks.flowEvent.callCount, 0);
           }
         }
       }
@@ -533,7 +1159,7 @@ define([
     options = options || {};
     mocks.request = {
       body: {},
-      get: sinon.spy(function (header) {
+      get: sandbox.spy(function (header) {
         switch (header.toLowerCase()) {
         case 'content-type':
           return options.contentType || 'application/json';
@@ -552,8 +1178,8 @@ define([
     if (options.isBodyJSON) {
       mocks.request.body = JSON.stringify(mocks.request.body);
     }
-    mocks.response = { json: sinon.spy() };
-    mocks.nextTick = sinon.spy();
+    mocks.response = { json: sandbox.spy() };
+    mocks.nextTick = sandbox.spy();
     var nextTickCopy = process.nextTick;
     process.nextTick = mocks.nextTick;
     instance.process(mocks.request, mocks.response);


### PR DESCRIPTION
Fixes #4379.

There are some obviously wrong flow ids that have derailed the flow event import to redshift. This PR adds simple validation, broadly analogous to what we already do in the auth server [here](https://github.com/mozilla/fxa-auth-server/blob/master/lib/metrics/context.js#L203-L216).

I tried to lean on the existing code in `server/lib/flow-metrics.js` as much as possible, hence the minor refactoring that's gone on in there. And I added some bonus validation of `context` and `service` just because we know those values come from a limited set, so it was another constraint we could easily apply.

I tested by manually hacking bad `data-flow-id` and `data-flow-begin` attributes into `server/templates/pages/src/index.html` to verify that no flow events were emitted in that case. And also by making sure the events are correctly emitted when the attributes are good, obviously.

@vladikoff r?

/cc @rfk, because it touches your flow id generation code.