### PR TITLE
fix(metrics): use server-side timestamps on flow events

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -484,10 +484,16 @@ define(function (require, exports, module) {
 
     logFlowEvent (eventName, viewName) {
       this.logEvent(marshallFlowEvent(eventName, viewName));
+      // We need to use server-side timestamps on flow events,
+      // so flush them to the server immediately.
+      this.flush();
     },
 
     logFlowEventOnce (eventName, viewName) {
       this.logEventOnce(marshallFlowEvent(eventName, viewName));
+      // We need to use server-side timestamps on flow events,
+      // so flush them to the server immediately.
+      this.flush();
     },
 
     getFlowEventMetadata () {

--- a/app/tests/spec/views/oauth_sign_up.js
+++ b/app/tests/spec/views/oauth_sign_up.js
@@ -71,6 +71,7 @@ define(function (require, exports, module) {
 
       windowMock = new WindowMock();
       metrics = new Metrics();
+      metrics.flush = sinon.spy();
       relier = new OAuthRelier({
         window: windowMock
       });

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -43,6 +43,7 @@ define(function (require, exports, module) {
       email = TestHelpers.createEmail();
       formPrefill = new FormPrefill();
       metrics = new Metrics();
+      metrics.flush = sinon.spy();
       model = new Backbone.Model();
       notifier = new Notifier();
       relier = new Relier();

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -82,6 +82,7 @@ define(function (require, exports, module) {
       formPrefill = new FormPrefill();
       fxaClient = new FxaClient();
       metrics = new Metrics();
+      metrics.flush = sinon.spy();
       model = new Backbone.Model();
       notifier = new Notifier();
       relier = new Relier();

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -80,23 +80,11 @@ function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
       event.time = metrics.flowBeginTime;
       event.flowTime = 0;
     } else {
-      event.time = estimateTime({
-        /*eslint-disable sorting/sort-object-props*/
-        start: metrics.startTime,
-        offset: event.offset,
-        sent: metrics.flushTime,
-        received: requestReceivedTime
-        /*eslint-enable sorting/sort-object-props*/
-      });
+      event.time = requestReceivedTime;
       event.flowTime = event.time - metrics.flowBeginTime;
     }
 
     flowEvent(event, metrics, req);
   });
-}
-
-function estimateTime (times) {
-  var skew = times.received - times.sent;
-  return times.start + times.offset + skew;
 }
 

--- a/tests/server/routes/post-metrics.js
+++ b/tests/server/routes/post-metrics.js
@@ -166,8 +166,8 @@ define([
             assert.lengthOf(Object.keys(args[0].events[4]), 4);
             assert.equal(args[0].events[4].type, 'flow.signup.engage');
             assert.equal(args[0].events[4].offset, 4);
-            assert.equal(args[0].events[4].time, 994);
-            assert.equal(args[0].events[4].flowTime, 952);
+            assert.equal(args[0].events[4].time, 1000);
+            assert.equal(args[0].events[4].flowTime, 958);
             assert.equal(args[0].flowId, 'qux');
             assert.equal(args[0].flowBeginTime, 42);
             assert.strictEqual(args[0].isSampledUser, true);
@@ -205,8 +205,8 @@ define([
             args = mocks.flowEvent.args[1];
             assert.isObject(args[0]);
             assert.equal(args[0].type, 'flow.signup.engage');
-            assert.strictEqual(args[0].flowTime, 952);
-            assert.equal(args[0].time, 994);
+            assert.strictEqual(args[0].flowTime, 958);
+            assert.equal(args[0].time, 1000);
             assert.isObject(args[1]);
             assert.equal(args[1].flowId, 'qux');
             assert.strictEqual(args[1].flowBeginTime, 42);


### PR DESCRIPTION
Fixes #4350.

Replaces #4361, which I closed pending a discussion with @shane-tomlinson about whether he's okay with us flushing metrics to the server like this. That discussion has now happened.

So, just to restate the point of this change, we know that bad clients are sending us garbage flow event data that corrupts analysis and impedes the import job. If approved, #4383 will solve a big chunk of that by validating the flow id and expiring old flow begin times. However, the non-begin flow events might still contain a bad timestamp, which our skew-correction code has proven insufficient to handle.

It's preferable to simply generate all timestamps on the server and leave the client out of it entirely.

@shane-tomlinson and @vladikoff, tagging you both for approval as you've both looked at it before. But it's only a small one, hopefully shouldn't be too taxing to review.

Can I get an r?
