### PR TITLE
fix(client): Make the constructor a normal function in FlowEventMetadata

### DIFF
--- a/app/scripts/models/flow-event-metadata.js
+++ b/app/scripts/models/flow-event-metadata.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
   });
 
   module.exports = Backbone.Model.extend({
-    constructor (options) {
+    constructor: function (options) {
       Backbone.Model.call(this);
       this.initialize(options);
     },


### PR DESCRIPTION
Without the `: function(`, and without babel, Firefox interprets the
`constructor` as a JS class constructor instead of a normal function,
which causes a blowup saying FlowEventMetadata is not a constructor.
Babel transpiles that difference away. I often run without babel to
make debugging simpler in Firefox.

This fixes that problem.

@philbooth - r?

To test this, start the content server w/o babel by commenting out [this section in server/lib/routes.js](https://github.com/mozilla/fxa-content-server/blob/80b9999f0e1ecb69117d3bc2a6f66bf937efe517/server/lib/routes.js#L83:L92)