### PR TITLE
fix(routes): Redirect *_complete to *_verified

### DIFF
--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -34,7 +34,8 @@ module.exports = function (config, i18n) {
     require('./routes/get-metrics-errors')(),
     require('./routes/get-version.json'),
     require('./routes/post-metrics')(),
-    require('./routes/post-metrics-errors')()
+    require('./routes/post-metrics-errors')(),
+    require('./routes/redirect-complete-to-verified')()
   ];
 
   if (config.get('csp.enabled')) {

--- a/server/lib/routes/redirect-complete-to-verified.js
+++ b/server/lib/routes/redirect-complete-to-verified.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Redirect /*_complete to /*_verified. /*_complete was removed
+ * in #4306, this ensures that users who somehow make it to these pages
+ * are redirected to some content that is available.
+ */
+
+var url = require('url');
+
+module.exports = function () {
+  var route = {};
+
+  route.method = 'get';
+  route.path = /(signin|signup|reset_password)_complete/;
+
+  route.process = function (req, res) {
+    // The _complete screens were displayed in both the action initiating tabs
+    // as well as the verification tab. To keep life simple, assume everyone
+    // who did this action is in the verification tab and send them to the
+    // _verified screen.
+    var urlObj = url.parse(req.originalUrl);
+    urlObj.pathname = urlObj.pathname.replace('_complete', '_verified');
+    var redirectTo = url.format(urlObj);
+    // Use a 302 until we are sure this train won't be rolled back to avoid
+    // rollback and permanent redirect issues, I'm not sure how it could
+    // happen, but it seems feasible the user tries to load a _complete screen,
+    // after seeing a 301 redirect but we rolled back, and is redirected to
+    // _verified screen.
+    // Once we are sure we won't regress, this can be changed to a 301.
+    res.redirect(302, redirectTo);
+  };
+
+  return route;
+
+};

--- a/tests/functional/pages.js
+++ b/tests/functional/pages.js
@@ -42,6 +42,7 @@ define([
     'report_signin',
     'reset_password',
     'reset_password_confirmed',
+    'reset_password_complete', // redirects to reset_password_verified
     'reset_password_verified',
     'settings',
     'settings/avatar',
@@ -57,12 +58,14 @@ define([
     'settings/display_name',
     'signin',
     'signin_confirmed',
+    'signin_complete', // redirects to signin_verified
     'signin_permissions',
     'signin_reported',
     'signin_unblock',
     'signin_verified',
     'signup',
     'signup_confirmed',
+    'signup_complete', // redirects to signup_verified
     'signup_permissions',
     'signup_verified',
     'verify_email',


### PR DESCRIPTION
@jrgm - here's a proposed solution, 302 all the _complete screens to the _verified screens so *some* content is displayed. Maybe once these requests trail off, we can 410 the routes.