### PR TITLE
fix(test): Sync reset password, verify different browser.

### DIFF
--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -131,12 +131,9 @@ define([
         .then(type('#password', PASSWORD))
         .then(click('button[type=submit]'))
 
-        .then(testIsBrowserNotifiedOfLogin(this, email, { checkVerified: false }))
-
-        // user verified the reset password in another browser, they must
-        // re-verify they want to sign in on this device to avoid
-        // opening up an attack vector.
-        .then(testElementExists('#fxa-confirm-signin-header'));
+        // User verified from the same IP address so does not
+        // have to go through signin confirmation.
+        .then(testIsBrowserNotifiedOfLogin(this, email, { checkVerified: true }));
     },
 
     'reset password, verify different browser - from new browser\'s P.O.V.': function () {


### PR DESCRIPTION
With https://github.com/mozilla/fxa-auth-server/pull/1525, users that
sign in for Sync from the same IP address do not have to go through
signin confirmation. Update the test to reflect that.

fixes #4399 

@philbooth - r?