### PR TITLE
refactor(test): fillOutSignUp no longer takes a context.

### DIFF
--- a/tests/functional/bounced_email.js
+++ b/tests/functional/bounced_email.js
@@ -18,6 +18,7 @@ define([
   var PASSWORD = '12345678';
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
 
   registerSuite({
     name: 'sign_up with an email that bounces',
@@ -37,7 +38,8 @@ define([
         xhr: nodeXMLHttpRequest.XMLHttpRequest
       });
 
-      return FunctionalHelpers.fillOutSignUp(this, bouncedEmail, PASSWORD)
+      return this.remote
+        .then(fillOutSignUp(bouncedEmail, PASSWORD))
         .findById('fxa-confirm-header')
         .end()
 

--- a/tests/functional/complete_sign_up.js
+++ b/tests/functional/complete_sign_up.js
@@ -26,6 +26,7 @@ define([
   var uid;
 
   var createRandomHexString = TestHelpers.createRandomHexString;
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
 
   registerSuite({
     name: 'complete_sign_up',
@@ -180,9 +181,7 @@ define([
       return self.remote
         .setFindTimeout(intern.config.pageLoadTimeout)
         // Sign up and obtain a verification link
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
         .findById('fxa-confirm-header')
         .end()
 
@@ -194,9 +193,7 @@ define([
         })
 
         // Sign up again to invalidate the old verification link
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, 'different_password');
-        })
+        .then(fillOutSignUp(email, 'different_password'))
         .findById('fxa-confirm-header')
         .end()
 

--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -20,7 +20,7 @@ define([
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = thenify(FunctionalHelpers.openPage);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
@@ -50,7 +50,7 @@ define([
 
       return this.remote
         .then(openPage(this, SIGNUP_URL, '#fxa-signup-header'))
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#fxa-confirm-header'))
         .then(testElementTextInclude('.verification-email-message', email))
@@ -72,7 +72,7 @@ define([
         .then(openPage(this, SIGNUP_URL, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
 
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#choose-what-to-sync'))
         .then(click('button[type="submit"]'))

--- a/tests/functional/email_opt_in.js
+++ b/tests/functional/email_opt_in.js
@@ -23,7 +23,7 @@ define([
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var openPage = thenify(FunctionalHelpers.openPage);
   var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var testAttributeEquals = FunctionalHelpers.testAttributeEquals;
@@ -77,7 +77,7 @@ define([
       email = TestHelpers.createEmail('signup{id}+extra');
       return this.remote
         .then(openPage(this, SIGNUP_PAGE_URL, '#fxa-signup-header'))
-        .then(fillOutSignUp(this, email, PASSWORD, { optInToMarketingEmail: true }))
+        .then(fillOutSignUp(email, PASSWORD, { optInToMarketingEmail: true }))
 
         .then(testElementExists('#fxa-confirm-header'))
         .then(openVerificationLinkInSameTab(email, 0))
@@ -117,7 +117,7 @@ define([
     'do not opt-in on signup': function () {
       return this.remote
         .then(openPage(this, SIGNUP_PAGE_URL, '#fxa-signup-header'))
-        .then(fillOutSignUp(this, email, PASSWORD, { optInToMarketingEmail: false }))
+        .then(fillOutSignUp(email, PASSWORD, { optInToMarketingEmail: false }))
         .then(testElementExists('#fxa-confirm-header'))
         .then(openVerificationLinkInSameTab(email, 0))
 

--- a/tests/functional/force_auth.js
+++ b/tests/functional/force_auth.js
@@ -7,13 +7,11 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (registerSuite, TestHelpers, FunctionalHelpers) {
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var openForceAuth = FunctionalHelpers.openForceAuth;
   var testElementDisabled = FunctionalHelpers.testElementDisabled;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -127,7 +125,7 @@ define([
         .then(testElementValueEquals('input[type=email]', email))
         .then(testElementDisabled('input[type=email]'))
 
-        .then(fillOutSignUp(this, email, PASSWORD, { enterEmail: false }))
+        .then(fillOutSignUp(email, PASSWORD, { enterEmail: false }))
         .then(testElementExists('#fxa-confirm-header'));
     },
 

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -18,6 +18,7 @@ define([
   var PASSWORD = '12345678';
 
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -52,9 +53,7 @@ define([
 
         .then(FunctionalHelpers.noSuchElement(self, '#customize-sync'))
 
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
         // the login message is only sent after the confirm screen is shown.

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -20,6 +20,7 @@ define([
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -53,11 +54,7 @@ define([
 
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
-
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -101,11 +98,7 @@ define([
       var self = this;
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: false } ))
-
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
 

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -18,7 +18,11 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var thenify = FunctionalHelpers.thenify;
+
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
+  var openPage = thenify(FunctionalHelpers.openPage);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -52,12 +56,11 @@ define([
     'sign up, verify same browser': function () {
       var self = this;
 
-      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(this, PAGE_URL, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
 
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
 

--- a/tests/functional/fx_ios_v1_sign_up.js
+++ b/tests/functional/fx_ios_v1_sign_up.js
@@ -19,6 +19,7 @@ define([
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
@@ -50,12 +51,8 @@ define([
 
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
         .execute(listenForFxaCommands)
-
         .then(FunctionalHelpers.noSuchElement(self, '#customize-sync'))
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
           .then(function () {

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -687,7 +687,7 @@ define([
     };
   }
 
-  function fillOutSignUp(context, email, password, options) {
+  function fillOutSignUp(email, password, options) {
     options = options || {};
 
     var customizeSync = options.customizeSync || false;
@@ -696,45 +696,46 @@ define([
     var age = options.age || 24;
     var submit = options.submit !== false;
 
-    var remote = getRemote(context);
-    return remote
-      .getCurrentUrl()
-      .then(function (currentUrl) {
-        // only load the signup page if not already at a signup page.
-        // the leading [\/#] allows for either the standard redirect or iframe
-        // flow. The iframe flow must use the window hash for routing.
-        if (! /[\/#]signup(?:$|\?)/.test(currentUrl)) {
-          return remote
-            .get(require.toUrl(SIGNUP_URL))
-            .setFindTimeout(intern.config.pageLoadTimeout);
-        }
-      })
+    return function () {
+      return this.parent
+        .getCurrentUrl()
+        .then(function (currentUrl) {
+          // only load the signup page if not already at a signup page.
+          // the leading [\/#] allows for either the standard redirect or iframe
+          // flow. The iframe flow must use the window hash for routing.
+          if (! /[\/#]signup(?:$|\?)/.test(currentUrl)) {
+            return this.parent
+              .get(require.toUrl(SIGNUP_URL))
+              .setFindTimeout(intern.config.pageLoadTimeout);
+          }
+        })
 
-      .then(function () {
-        if (enterEmail) {
-          return type('input[type=email]', email).call(this);
-        }
-      })
-      .then(type('input[type=password]', password))
-      .then(type('#age', age || '24'))
+        .then(function () {
+          if (enterEmail) {
+            return type('input[type=email]', email).call(this);
+          }
+        })
+        .then(type('input[type=password]', password))
+        .then(type('#age', age || '24'))
 
-      .then(function () {
-        if (customizeSync) {
-          return click('form input.customize-sync').call(this);
-        }
-      })
+        .then(function () {
+          if (customizeSync) {
+            return click('form input.customize-sync').call(this);
+          }
+        })
 
-      .then(function () {
-        if (optInToMarketingEmail) {
-          return click('form input.marketing-email-optin').call(this);
-        }
-      })
+        .then(function () {
+          if (optInToMarketingEmail) {
+            return click('form input.marketing-email-optin').call(this);
+          }
+        })
 
-      .then(function () {
-        if (submit) {
-          return click('button[type="submit"]').call(this);
-        }
-      });
+        .then(function () {
+          if (submit) {
+            return click('button[type="submit"]').call(this);
+          }
+        });
+    };
   }
 
   function fillOutResetPassword(context, email, options) {

--- a/tests/functional/oauth_force_auth.js
+++ b/tests/functional/oauth_force_auth.js
@@ -18,7 +18,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var testElementDisabled = FunctionalHelpers.testElementDisabled;
@@ -65,7 +65,7 @@ define([
         // ensure the email is filled in, and not editible.
         .then(testElementValueEquals('input[type=email]', email))
         .then(testElementDisabled('input[type=email]'))
-        .then(fillOutSignUp(this, email, PASSWORD, { enterEmail: false }))
+        .then(fillOutSignUp(email, PASSWORD, { enterEmail: false }))
 
         .then(testElementExists('#fxa-confirm-header'))
         .then(openVerificationLinkInNewTab(this, email, 0))

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -25,7 +25,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openFxaFromTrustedRp = thenify(FunctionalHelpers.openFxaFromRp);
@@ -126,7 +126,7 @@ define([
           })
         .end()
 
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#fxa-permissions-header'))
         .then(click('#accept'))
@@ -177,7 +177,7 @@ define([
     'signup, then signin with no additional permissions': function () {
       return this.remote
         .then(openFxaFromUntrustedRp(this, 'signup'))
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#fxa-permissions-header'))
         .then(click('#accept'))
@@ -359,7 +359,7 @@ define([
     'signup without `prompt=consent`': function () {
       return this.remote
         .then(openFxaFromTrustedRp(this, 'signup'))
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         // no permissions asked for, straight to confirm
         .then(testElementExists('#fxa-confirm-header'));
@@ -368,7 +368,7 @@ define([
     'signup with `prompt=consent`': function () {
       return this.remote
         .then(openFxaFromTrustedRp(this, 'signup', { query: { prompt: 'consent' }}))
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         // permissions are asked for with `prompt=consent`
         .then(testElementExists('#fxa-permissions-header'))

--- a/tests/functional/oauth_settings_clients.js
+++ b/tests/functional/oauth_settings_clients.js
@@ -19,7 +19,7 @@ define([
   var thenify = FunctionalHelpers.thenify;
   var click = FunctionalHelpers.click;
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var testElementExists = FunctionalHelpers.testElementExists;
   var openFxaFromRp = FunctionalHelpers.openFxaFromRp;
@@ -48,7 +48,7 @@ define([
       self.timeout = 90 * 1000;
 
       return openFxaFromRp(this, 'signup')
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists('#fxa-confirm-header'))
         .then(getVerificationLink(email, 0))
         .then(function (verificationLink) {

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -24,7 +24,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
   var openPage = thenify(FunctionalHelpers.openPage);
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -135,7 +135,7 @@ define([
         .then(testElementExists('#fxa-signup-header'))
 
         // first, sign the user up to cache the login
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#fxa-confirm-header'))
 
@@ -159,7 +159,7 @@ define([
         .then(click('.ready #splash .sign-choose'))
 
         .then(testElementExists('#fxa-signup-header'))
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#fxa-confirm-header'))
 

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -26,7 +26,7 @@ define([
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var noEmailExpected = FunctionalHelpers.noEmailExpected;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
@@ -43,7 +43,7 @@ define([
       .then(function () {
         return openFxaFromRp(context, 'signup');
       })
-      .then(fillOutSignUp(context, email, secondPassword, options));
+      .then(fillOutSignUp(email, secondPassword, options));
   }
 
   registerSuite({
@@ -80,7 +80,7 @@ define([
         })
         .end()
 
-        .then(fillOutSignUp(self, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -116,7 +116,7 @@ define([
 
       return openFxaFromRp(self, 'signup')
 
-        .then(fillOutSignUp(self, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -142,7 +142,7 @@ define([
 
       return openFxaFromRp(self, 'signup')
 
-        .then(fillOutSignUp(self, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -157,7 +157,7 @@ define([
       var self = this;
 
       return openFxaFromRp(self, 'signup')
-        .then(fillOutSignUp(self, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -175,7 +175,7 @@ define([
       var self = this;
 
       return openFxaFromRp(self, 'signup')
-        .then(fillOutSignUp(self, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -273,7 +273,7 @@ define([
       });
 
       return openFxaFromRp(self, 'signup')
-        .then(fillOutSignUp(self, bouncedEmail, PASSWORD))
+        .then(fillOutSignUp(bouncedEmail, PASSWORD))
 
         .findById('fxa-confirm-header')
         .end()

--- a/tests/functional/oauth_sign_up_verification_redirect.js
+++ b/tests/functional/oauth_sign_up_verification_redirect.js
@@ -13,6 +13,7 @@ define([
   var email;
 
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
 
   registerSuite({
     name: 'oauth sign up verification_redirect',
@@ -38,9 +39,7 @@ define([
         .then(function (url) {
           return self.remote.get(require.toUrl(url + '&verification_redirect=always'));
         })
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -66,9 +65,7 @@ define([
         .then(function (url) {
           return self.remote.get(require.toUrl(url + '&verification_redirect=always'));
         })
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -99,9 +96,7 @@ define([
         .then(function (url) {
           return self.remote.get(require.toUrl(url + '&verification_redirect=always'));
         })
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -133,9 +128,7 @@ define([
         .then(function (url) {
           return self.remote.get(require.toUrl(url + '&verification_redirect=always'));
         })
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()

--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -23,7 +23,7 @@ define([
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
   var openPage = thenify(FunctionalHelpers.openPage);
@@ -74,7 +74,7 @@ define([
 
         // Sign up for a new account via OAuth
         .then(openFxaFromRp(this, 'signup'))
-        .then(fillOutSignUp(this, email2, PASSWORD))
+        .then(fillOutSignUp(email2, PASSWORD))
 
         .then(testElementExists('#fxa-confirm-header'))
         .then(openVerificationLinkInNewTab(this, email2, 0))

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -33,7 +33,7 @@ define([
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var openPage = thenify(FunctionalHelpers.openPage);
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
@@ -148,7 +148,7 @@ define([
       return this.remote
         .then(openPage(this, PAGE_SIGNUP_DESKTOP, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
         .then(click('button[type="submit"]'))
@@ -169,7 +169,7 @@ define([
 
       return this.remote
         .then(openPage(this, PAGE_SIGNUP, '#fxa-signup-header'))
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#fxa-confirm-header'))
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -23,7 +23,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = thenify(FunctionalHelpers.fillOutSignIn);
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
@@ -49,7 +49,7 @@ define([
   function signUpWithExistingAccount (context, email, firstPassword, secondPassword, options) {
     return context.remote
       .then(createUser(email, firstPassword, { preVerified: true }))
-      .then(fillOutSignUp(context, email, secondPassword, options));
+      .then(fillOutSignUp(email, secondPassword, options));
   }
 
   registerSuite({
@@ -79,7 +79,7 @@ define([
     'signup, verify same browser': function () {
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
         .then(visibleByQSA('#suggest-sync'))
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
         .then(openVerificationLinkInNewTab(this, email, 0))
 
@@ -94,7 +94,7 @@ define([
 
     'signup, verify same browser with original tab closed, sign out': function () {
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
 
         .then(FunctionalHelpers.openExternalSite(this))
@@ -125,7 +125,7 @@ define([
       this.timeout = 90000;
 
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
         .then(openVerificationLinkInSameTab(email, 0))
 
@@ -135,7 +135,7 @@ define([
 
         .then(testElementExists('#fxa-signin-header'))
 
-        .then(fillOutSignUp(this, secondEmail, PASSWORD))
+        .then(fillOutSignUp(secondEmail, PASSWORD))
         .then(testAtConfirmScreen(secondEmail))
         .then(openVerificationLinkInSameTab(secondEmail, 0))
 
@@ -150,7 +150,7 @@ define([
 
     'signup, verify same browser by replacing the original tab': function () {
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
         .then(openVerificationLinkInSameTab(email, 0))
 
@@ -160,7 +160,7 @@ define([
 
     'signup, verify different browser - from original tab\'s P.O.V.': function () {
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
 
         .then(openVerificationLinkDifferentBrowser(email))
@@ -173,7 +173,7 @@ define([
 
     'signup, verify different browser - from new browser\'s P.O.V.': function () {
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
 
         // clear local/sessionStorage to synthesize continuing in
@@ -190,7 +190,7 @@ define([
       var emailWithoutSpace = email;
       var emailWithSpace = ('   ' + email);
       return this.remote
-        .then(fillOutSignUp(this, emailWithSpace, PASSWORD))
+        .then(fillOutSignUp(emailWithSpace, PASSWORD))
         .then(testAtConfirmScreen(emailWithoutSpace))
         .then(clearBrowserState())
         .then(fillOutSignIn(this, emailWithoutSpace, PASSWORD))
@@ -204,7 +204,7 @@ define([
       var emailWithSpace = ('   ' + email);
 
       return this.remote
-        .then(fillOutSignUp(this, emailWithSpace, PASSWORD))
+        .then(fillOutSignUp(emailWithSpace, PASSWORD))
         .then(testAtConfirmScreen(emailWithoutSpace))
         .then(clearBrowserState())
         .then(fillOutSignIn(this, emailWithoutSpace, PASSWORD))
@@ -215,7 +215,7 @@ define([
 
     'signup with invalid email address': function () {
       return this.remote
-        .then(fillOutSignUp(this, email + '-', PASSWORD))
+        .then(fillOutSignUp(email + '-', PASSWORD))
 
         // wait five seconds to allow any errant navigation to occur
         .then(noPageTransition('#fxa-signup-header', 5000))
@@ -301,7 +301,7 @@ define([
 
     'signup with new account, coppa is empty': function () {
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD, { age: ' ' }))
+        .then(fillOutSignUp(email, PASSWORD, { age: ' ' }))
 
         // navigation should not occur
         .then(noPageTransition('#fxa-signup-header'))
@@ -330,7 +330,7 @@ define([
 
     'signup with new account, coppa is too young': function () {
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD, { age: 12 }))
+        .then(fillOutSignUp(email, PASSWORD, { age: 12 }))
 
         // should have navigated to cannot-create-account view
         .then(testElementExists('#fxa-cannot-create-account-header'));
@@ -339,17 +339,16 @@ define([
     'signup with a verified account signs the user in': function () {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
 
         // should have navigated to settings view
         .then(testElementExists('#fxa-settings-header'));
     },
 
     'signup with an unverified account and different password re-signs up user': function () {
-
       return this.remote
         .then(createUser(email, PASSWORD))
-        .then(fillOutSignUp(this, email, 'different password'))
+        .then(fillOutSignUp(email, 'different password'))
 
         // Being pushed to the confirmation screen is success.
         .then(testElementTextInclude('.verification-email-message', email));
@@ -365,7 +364,7 @@ define([
 
     'form prefill information is cleared after signup->sign out': function () {
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
 
         .then(openVerificationLinkDifferentBrowser(email))
@@ -385,7 +384,7 @@ define([
     'signup, open sign-in in second tab, verify in third tab': function () {
       var windowName = 'sign-up inter-tab functional test';
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
         .then(function () {
           return FunctionalHelpers.openSignInInNewTab(this.parent, windowName);
@@ -409,7 +408,7 @@ define([
     'signup, open sign-up in second tab, verify in original tab': function () {
       var windowName = 'sign-up inter-tab functional test';
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
         .then(function () {
           return FunctionalHelpers.openSignUpInNewTab(this.parent, windowName);
@@ -434,7 +433,7 @@ define([
 
     'signup, open verification link, open verification link again': function () {
       return this.remote
-        .then(fillOutSignUp(this, email, PASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
         .then(openVerificationLinkInNewTab(this, email, 0))
 
@@ -464,7 +463,7 @@ define([
   function testRepopulateFields(dest, header) {
     return openPage(this, PAGE_URL, '#fxa-signup-header')
 
-      .then(fillOutSignUp(this, email, PASSWORD, { submit: false }))
+      .then(fillOutSignUp(email, PASSWORD, { submit: false }))
 
       .then(click('a[href="' + dest + '"]'))
 

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -28,6 +28,7 @@ define([
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
@@ -72,10 +73,7 @@ define([
 
         .findByCssSelector('#fxa-signup-header')
         .end()
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
 
@@ -127,10 +125,7 @@ define([
 
         .findByCssSelector('#fxa-signup-header')
         .end()
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -166,10 +161,7 @@ define([
 
         .findByCssSelector('#fxa-signup-header')
         .end()
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
         .end()
@@ -196,10 +188,7 @@ define([
 
         .findByCssSelector('#fxa-signup-header')
         .end()
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
 
@@ -228,11 +217,7 @@ define([
 
         .findByCssSelector('#fxa-signup-header')
         .end()
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
-
+        .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
 
@@ -281,11 +266,7 @@ define([
             assert.isNull(checkedAttribute);
           })
         .end()
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(
-              self, email, PASSWORD, { customizeSync: true });
-        })
+        .then(fillOutSignUp(email, PASSWORD, { customizeSync: true }))
 
         .then(function () {
           return testIsBrowserNotifiedOfLogin(self, email);

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -20,6 +20,7 @@ define([
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testAttributeExists = FunctionalHelpers.testAttributeExists;
@@ -55,10 +56,7 @@ define([
 
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
 

--- a/tests/functional/sync_v3_force_auth.js
+++ b/tests/functional/sync_v3_force_auth.js
@@ -17,7 +17,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-  var fillOutSignUp = thenify(FunctionalHelpers.fillOutSignUp);
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var openForceAuth = FunctionalHelpers.openForceAuth;
@@ -148,7 +148,7 @@ define([
         // ensure the email is filled in, and not editible.
         .then(testElementValueEquals('input[type=email]', email))
         .then(testElementDisabled('input[type=email]'))
-        .then(fillOutSignUp(this, email, PASSWORD, { enterEmail: false }))
+        .then(fillOutSignUp(email, PASSWORD, { enterEmail: false }))
 
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
         .then(click('button[type=submit]'))

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -20,6 +20,7 @@ define([
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
@@ -55,10 +56,7 @@ define([
       return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
         .then(FunctionalHelpers.noSuchElement(this, '#suggest-sync'))
-
-        .then(function () {
-          return FunctionalHelpers.fillOutSignUp(self, email, PASSWORD);
-        })
+        .then(fillOutSignUp(email, PASSWORD))
 
         .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
 


### PR DESCRIPTION
I did this on the plane to Toronto, just opening a PR now. `FunctionalHelpers.fillOutSignUp` no longer takes a context. I'm working my way through the functional test helpers to get rid of context, one function at a time.

@mozilla/fxa-devs - r?