### PR TITLE
chore(git): Update .gitignore to support nested .eslintrc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ app/bower_components
 .*
 !.gitignore
 !.git*
+!.eslintrc
 !.bowerrc
 !.editorconfig
 !.npmignore


### PR DESCRIPTION
Fixes #4408 