### PR TITLE
refactor(metrics): extract flow event logic from POST /metrics handler

### DIFF
--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -2,27 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var _ = require('lodash');
+const _ = require('lodash');
 const config = require('./configuration');
 const flowMetrics = require('./flow-metrics');
-var os = require('os');
+const os = require('os');
 
-var DNT_ALLOWED_DATA = [
+const DNT_ALLOWED_DATA = [
   'context',
   'entrypoint',
   'migration',
   'service',
 ];
-var NO_DNT_ALLOWED_DATA = DNT_ALLOWED_DATA.concat([
+const NO_DNT_ALLOWED_DATA = DNT_ALLOWED_DATA.concat([
   'utm_campaign',
   'utm_content',
   'utm_medium',
   'utm_source',
   'utm_term'
 ]);
-var HOSTNAME = os.hostname();
-var MAX_DATA_LENGTH = 100;
-var VERSION = 1;
+const HOSTNAME = os.hostname();
+const MAX_DATA_LENGTH = 100;
+const VERSION = 1;
 
 const FLOW_BEGIN_EVENT_TYPES = /^flow\.[a-z_-]+\.begin$/;
 const FLOW_ID_KEY = config.get('flow_id_key');

--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -82,7 +82,7 @@ function isValidFlowData (metrics, requestReceivedTime) {
     return false;
   }
 
-  if (! isValidTime(parseInt(metrics.flowBeginTime), requestReceivedTime)) {
+  if (! isValidTime(metrics.flowBeginTime, requestReceivedTime)) {
     return false;
   }
 
@@ -94,6 +94,10 @@ function isValidFlowData (metrics, requestReceivedTime) {
 }
 
 function isValidTime (time, requestReceivedTime) {
+  if (typeof time !== 'number') {
+    return false;
+  }
+
   const age = requestReceivedTime - time;
   if (age > FLOW_ID_EXPIRY || age < 0 || isNaN(age)) {
     return false;

--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -3,8 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var _ = require('lodash');
+const config = require('./configuration');
+const flowMetrics = require('./flow-metrics');
 var os = require('os');
-var Promise = require('bluebird');
 
 var DNT_ALLOWED_DATA = [
   'context',
@@ -23,7 +24,98 @@ var HOSTNAME = os.hostname();
 var MAX_DATA_LENGTH = 100;
 var VERSION = 1;
 
-module.exports = function (event, data, request) {
+const FLOW_BEGIN_EVENT_TYPES = /^flow\.[a-z_-]+\.begin$/;
+const FLOW_ID_KEY = config.get('flow_id_key');
+const FLOW_ID_EXPIRY = config.get('flow_id_expiry');
+
+const ENTRYPOINT_PATTERN = /^[\w\.-]+$/;
+const SERVICE_PATTERN = /^(sync|content-server|none|[0-9a-f]{16})$/;
+const VALID_FLOW_EVENT_PROPERTIES = [
+  { key: 'client_id', pattern: SERVICE_PATTERN },
+  { key: 'context', pattern: /^[0-9a-z_-]+$/ },
+  { key: 'entryPoint', pattern: ENTRYPOINT_PATTERN },
+  { key: 'entrypoint', pattern: ENTRYPOINT_PATTERN },
+  { key: 'flowId', pattern: /^[0-9a-f]{64}$/ },
+  { key: 'migration', pattern: /^(sync11|amo|none)$/ },
+  { key: 'service', pattern: SERVICE_PATTERN }
+];
+
+const IS_DISABLED = config.get('client_metrics').stderr_collector_disabled;
+
+module.exports = (req, metrics, requestReceivedTime) => {
+  if (IS_DISABLED || ! isValidFlowData(metrics, requestReceivedTime)) {
+    return;
+  }
+
+  const events = metrics.events || [];
+  const flowEvents = _.filter(events, event => {
+    return event.type.indexOf('flow.') === 0;
+  });
+
+  flowEvents.forEach(event => {
+    if (FLOW_BEGIN_EVENT_TYPES.test(event.type)) {
+      event.time = metrics.flowBeginTime;
+      event.flowTime = 0;
+    } else {
+      event.time = estimateTime({
+        /*eslint-disable sorting/sort-object-props*/
+        start: metrics.startTime,
+        offset: event.offset,
+        sent: metrics.flushTime,
+        received: requestReceivedTime
+        /*eslint-enable sorting/sort-object-props*/
+      });
+
+      if (! isValidTime(event.time, requestReceivedTime)) {
+        return;
+      }
+
+      event.flowTime = event.time - metrics.flowBeginTime;
+    }
+
+    logFlowEvent(event, metrics, req);
+  });
+};
+
+function isValidFlowData (metrics, requestReceivedTime) {
+  if (! metrics.flowId) {
+    return false;
+  }
+
+  if (! isValidTime(parseInt(metrics.flowBeginTime), requestReceivedTime)) {
+    return false;
+  }
+
+  if (! VALID_FLOW_EVENT_PROPERTIES.every(p => isValidProperty(metrics[p.key], p.pattern))) {
+    return false;
+  }
+
+  return flowMetrics.validate(FLOW_ID_KEY, metrics.flowId, metrics.flowBeginTime, metrics.agent);
+}
+
+function isValidTime (time, requestReceivedTime) {
+  const age = requestReceivedTime - time;
+  if (age > FLOW_ID_EXPIRY || age < 0 || isNaN(age)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isValidProperty (propertyValue, pattern) {
+  if (propertyValue) {
+    return pattern.test(propertyValue);
+  }
+
+  return true;
+}
+
+function estimateTime (times) {
+  var skew = times.received - times.sent;
+  return times.start + times.offset + skew;
+}
+
+function logFlowEvent (event, data, request) {
   var pickedData = _.pick(data, isDNT(request) ? DNT_ALLOWED_DATA : NO_DNT_ALLOWED_DATA);
   var eventData = _.assign({
     event: event.type,
@@ -32,7 +124,7 @@ module.exports = function (event, data, request) {
     hostname: HOSTNAME,
     op: 'flowEvent',
     pid: process.pid,
-    time: event.time,
+    time: new Date(event.time).toISOString(),
     userAgent: request.headers['user-agent'],
     v: VERSION
   }, _.mapValues(pickedData, sanitiseData));
@@ -40,18 +132,9 @@ module.exports = function (event, data, request) {
   optionallySetFallbackData(eventData, 'service', data.client_id);
   optionallySetFallbackData(eventData, 'entrypoint', data.entryPoint);
 
-  if (typeof eventData.time === 'number') {
-    eventData.time = new Date(eventData.time).toISOString();
-  }
-
-  return new Promise(function (resolve) {
-    setImmediate(function () {
-      // The data pipeline listens on stderr.
-      process.stderr.write(JSON.stringify(eventData) + '\n');
-      resolve();
-    });
-  });
-};
+  // The data pipeline listens on stderr.
+  process.stderr.write(JSON.stringify(eventData) + '\n');
+}
 
 function isDNT (request) {
   return request.headers.dnt === '1';

--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -149,7 +149,7 @@ function limitLength (data) {
 }
 
 function sanitiseData (data) {
-  if (data === 'none') {
+  if (! data || data === 'none') {
     return undefined;
   }
 

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -3,28 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-var _ = require('lodash');
 var config = require('../configuration');
 const flowEvent = require('../flow-event');
-const flowMetrics = require('../flow-metrics');
 var MetricsCollector = require('../metrics-collector-stderr');
 var StatsDCollector = require('../statsd-collector');
 var GACollector = require('../ga-collector');
 var logger = require('mozlog')('server.post-metrics');
 
 var DISABLE_CLIENT_METRICS_STDERR = config.get('client_metrics').stderr_collector_disabled;
-
-const FLOW_BEGIN_EVENT_TYPES = /^flow\.[a-z_-]+\.begin$/;
-const FLOW_ID_KEY = config.get('flow_id_key');
-const FLOW_ID_EXPIRY = config.get('flow_id_expiry');
-
-const VALID_METRICS_PROPERTIES = [
-  { key: 'context', pattern: /^[0-9a-z_-]+$/ },
-  { key: 'entrypoint', pattern: /^[\w\.-]+$/ },
-  { key: 'flowId', pattern: /^[0-9a-f]{64}$/ },
-  { key: 'migration', pattern: /^(sync11|amo|none)$/ },
-  { key: 'service', pattern: /^(sync|content-server|none|[0-9a-f]{16})$/ }
-];
 
 module.exports = function () {
   var metricsCollector = new MetricsCollector();
@@ -65,87 +51,9 @@ module.exports = function () {
         }
         ga.write(metrics);
 
-        optionallyLogFlowEvents(req, metrics, requestReceivedTime);
+        flowEvent(req, metrics, requestReceivedTime);
       });
     }
   };
 };
-
-function optionallyLogFlowEvents (req, metrics, requestReceivedTime) {
-  if (DISABLE_CLIENT_METRICS_STDERR) {
-    return;
-  }
-
-  if (! isValidFlowData(metrics, requestReceivedTime)) {
-    // Don't risk corrupting good data by attempting to fix bad.
-    return;
-  }
-
-  const events = metrics.events || [];
-  const flowEvents = _.filter(events, event => {
-    return event.type.indexOf('flow.') === 0;
-  });
-
-  flowEvents.forEach(event => {
-    if (FLOW_BEGIN_EVENT_TYPES.test(event.type)) {
-      event.time = metrics.flowBeginTime;
-      event.flowTime = 0;
-    } else {
-      event.time = estimateTime({
-        /*eslint-disable sorting/sort-object-props*/
-        start: metrics.startTime,
-        offset: event.offset,
-        sent: metrics.flushTime,
-        received: requestReceivedTime
-        /*eslint-enable sorting/sort-object-props*/
-      });
-
-      if (! isValidTime(event.time, requestReceivedTime)) {
-        return;
-      }
-
-      event.flowTime = event.time - metrics.flowBeginTime;
-    }
-
-    flowEvent(event, metrics, req);
-  });
-}
-
-function isValidFlowData (metrics, requestReceivedTime) {
-  if (! metrics.flowId) {
-    return false;
-  }
-
-  if (! isValidTime(parseInt(metrics.flowBeginTime), requestReceivedTime)) {
-    return false;
-  }
-
-  if (! VALID_METRICS_PROPERTIES.every(p => isValidProperty(metrics[p.key], p.pattern))) {
-    return false;
-  }
-
-  return flowMetrics.validate(FLOW_ID_KEY, metrics.flowId, metrics.flowBeginTime, metrics.agent);
-}
-
-function isValidTime (time, requestReceivedTime) {
-  const age = requestReceivedTime - time;
-  if (age > FLOW_ID_EXPIRY || age < 0 || isNaN(age)) {
-    return false;
-  }
-
-  return true;
-}
-
-function isValidProperty (property, pattern) {
-  if (property) {
-    return pattern.test(property);
-  }
-
-  return true;
-}
-
-function estimateTime (times) {
-  var skew = times.received - times.sent;
-  return times.start + times.offset + skew;
-}
 

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -148,6 +148,19 @@ define([
       }
     },
 
+    'call flowEvent with string flow begin time': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          flowBeginTime: `${mocks.time - 1000}`
+        }, 1000);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
+      }
+    },
+
     'call flowEvent with invalid context': {
       beforeEach () {
         flowMetricsValidateResult = true;

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -589,7 +589,7 @@ define([
         assert.isUndefined(arg.utm_source);
         assert.isUndefined(arg.utm_term);
       }
-    },
+    }
   });
 
   function setup (data, timeSinceFlowBegin) {

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -5,421 +5,582 @@
 define([
   'intern!object',
   'intern/chai!assert',
-  'intern/dojo/node!../../server/lib/flow-event',
+  'intern/dojo/node!lodash',
   'intern/dojo/node!os',
+  'intern/dojo/node!path',
+  'intern/dojo/node!proxyquire',
   'intern/dojo/node!sinon',
-], function (registerSuite, assert, flowEvent, os, sinon) {
-  var time, write;
+], (registerSuite, assert, _, os, path, proxyquire, sinon) => {
+  var config, sandbox, mocks, flowEvent, flowMetricsValidateResult;
 
   registerSuite({
     name: 'flow-event',
 
-    'interface is correct': function () {
+    beforeEach () {
+      config = {
+        /*eslint-disable camelcase*/
+        client_metrics: {
+          stderr_collector_disabled: false
+        },
+        flow_id_expiry: 7200000,
+        flow_id_key: 'foo'
+        /*eslint-enable camelcase*/
+      };
+      sandbox = sinon.sandbox.create();
+      sandbox.stub(process.stderr, 'write', () => {});
+      mocks = {
+        config: {
+          get (key) {
+            return config[key];
+          }
+        },
+        flowMetrics: {
+          validate: sandbox.spy(() => flowMetricsValidateResult)
+        },
+        request: {
+          headers: {
+            'user-agent': 'bar'
+          }
+        },
+        time: 1479127399349
+      };
+      flowEvent = proxyquire(path.resolve('server/lib/flow-event'), {
+        './configuration': mocks.config,
+        './flow-metrics': mocks.flowMetrics
+      });
+    },
+
+    afterEach () {
+      sandbox.restore();
+    },
+
+    'interface is correct': () => {
       assert.isFunction(flowEvent);
       assert.lengthOf(flowEvent, 3);
     },
 
-    'call flowEvent with service and entrypoint': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'mock flow time',
-          time: 'mock time',
-          type: 'mock event'
-        }, {
-          context: 'mock context',
-          entrypoint: 'mock entrypoint',
-          flowId: 'mock flow id',
-          migration: 'mock migration',
-          service: 'mock service',
+    'call flowEvent with valid flow data': {
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        flowMetricsValidateResult = true;
+        setup({
+          events: [
+            { offset: 5, type: 'wibble' },
+            { offset: 5, type: 'flow.signup.begin' },
+            { offset: timeSinceFlowBegin, type: 'flow.signup.good-offset-now' },
+            { offset: timeSinceFlowBegin + 1, type: 'flow.signup.bad-offset-future' },
+            { offset: timeSinceFlowBegin - config.flow_id_expiry - 1, type: 'flow.signup.bad-offset-expired' },
+            { offset: timeSinceFlowBegin - config.flow_id_expiry, type: 'flow.signup.good-offset-oldest' }
+          ],
+        }, timeSinceFlowBegin);
+      },
+
+      'process.stderr.write was called three times': () => {
+        assert.equal(process.stderr.write.callCount, 3);
+      },
+
+      'first call to process.stderr.write was correct': () => {
+        const args = process.stderr.write.args[0];
+        assert.lengthOf(args, 1);
+        assert.equal(args[0][args[0].length - 1], '\n');
+        assert.deepEqual(JSON.parse(args[0]), {
           /*eslint-disable camelcase*/
+          context: 'fx_desktop_v3',
+          entrypoint: 'menupanel',
+          event: 'flow.signup.begin',
+          flow_id: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flow_time: 0,
+          hostname: os.hostname(),
+          migration: 'sync11',
+          op: 'flowEvent',
+          pid: process.pid,
+          service: '1234567890abcdef',
+          time: new Date(mocks.time - 1000).toISOString(),
+          userAgent: mocks.request.headers['user-agent'],
           utm_campaign: 'mock utm_campaign',
           utm_content: 'mock utm_content',
           utm_medium: 'mock utm_medium',
           utm_source: 'mock utm_source',
           utm_term: 'mock utm_term',
+          v: 1
           /*eslint-enable camelcase*/
-          zignore: 'ignore me'
-        }, {
-          headers: { 'user-agent': 'foo' }
         });
       },
 
-      teardown: function () {
-        process.stderr.write = write;
+      'second call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[1][0]);
+        assert.lengthOf(Object.keys(arg), 18);
+        assert.equal(arg.event, 'flow.signup.good-offset-now');
+        assert.equal(arg.time, new Date(mocks.time).toISOString());
       },
 
-      'process.stderr.write was called correctly': function () {
+      'third call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[2][0]);
+        assert.lengthOf(Object.keys(arg), 18);
+        assert.equal(arg.event, 'flow.signup.good-offset-oldest');
+        assert.equal(arg.time, new Date(mocks.time - config.flow_id_expiry).toISOString());
+      }
+    },
+
+    'call flowEvent with invalid flow id': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          flowId: '1234567890abcdef1234567890abcdef'
+        }, 1000);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
+      }
+    },
+
+    'call flowEvent with invalid flow begin time': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          flowBeginTime: mocks.time + 1
+        }, 1000);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
+      }
+    },
+
+    'call flowEvent with invalid context': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          context: '!'
+        }, 1000);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
+      }
+    },
+
+    'call flowEvent with invalid entrypoint': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          entrypoint: '!'
+        }, 1000);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
+      }
+    },
+
+    'call flowEvent with invalid migration': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          migration: 'sync111'
+        }, 1000);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
+      }
+    },
+
+    'call flowEvent with invalid service': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          service: '1234567890abcdef1234567890abcdef'
+        }, 1000);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
+      }
+    },
+
+    'call flowEvent without optional flow data': {
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
+      },
+
+      'process.stderr.write was called once': () => {
         assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.isUndefined(arg.context);
+        assert.isUndefined(arg.entrypoint);
+        assert.isUndefined(arg.migration);
+        assert.isUndefined(arg.service);
+        assert.isUndefined(arg.utm_campaign);
+        assert.isUndefined(arg.utm_content);
+        assert.isUndefined(arg.utm_medium);
+        assert.isUndefined(arg.utm_source);
+        assert.isUndefined(arg.utm_term);
+      }
+    },
 
-        var args = process.stderr.write.args[0];
-        assert.lengthOf(args, 1);
-        assert.equal(args[0][args[0].length - 1], '\n');
+    'call flowEvent without flow id': {
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
+      },
 
-        var eventData = JSON.parse(args[0]);
-        assert.isObject(eventData);
-        assert.lengthOf(Object.keys(eventData), 18);
-        assert.equal(eventData.op, 'flowEvent');
-        assert.equal(eventData.hostname, os.hostname());
-        assert.equal(eventData.pid, process.pid);
-        assert.equal(eventData.v, 1);
-        assert.equal(eventData.event, 'mock event');
-        assert.equal(eventData.userAgent, 'foo');
-        assert.equal(eventData.time, 'mock time');
-        assert.equal(eventData.flow_id, 'mock flow id');
-        assert.equal(eventData.flow_time, 'mock flow time');
-        assert.equal(eventData.context, 'mock context');
-        assert.equal(eventData.entrypoint, 'mock entrypoint');
-        assert.equal(eventData.migration, 'mock migration');
-        assert.equal(eventData.service, 'mock service');
-        /*eslint-disable camelcase*/
-        assert.equal(eventData.utm_campaign, 'mock utm_campaign');
-        assert.equal(eventData.utm_content, 'mock utm_content');
-        assert.equal(eventData.utm_medium, 'mock utm_medium');
-        assert.equal(eventData.utm_source, 'mock utm_source');
-        assert.equal(eventData.utm_term, 'mock utm_term');
-        /*eslint-enable camelcase*/
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
+      }
+    },
+
+    'call flowEvent without flow begin time': {
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
+      }
+    },
+
+    'call flowEvent with valid-seeming flow data but flowMetrics.validate returns false': {
+      beforeEach () {
+        flowMetricsValidateResult = false;
+        setup({}, 1000);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
+      }
+    },
+
+    'call flowEvent without flow event': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          events: [
+            { offset: 0, type: 'blargh' }
+          ]
+        }, 1000);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
       }
     },
 
     'call flowEvent with client_id': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'foo',
-          time: 'bar',
-          type: 'wibble'
-        }, {
-          client_id: 'mock client id', //eslint-disable-line camelcase
-          ignore: 'ignore me'
-        }, {
-          headers: { 'user-agent': 'blee' }
-        });
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          client_id: 'deadbeefbaadf00d', //eslint-disable-line camelcase
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
       },
 
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
+      'process.stderr.write was called correctly': () => {
         assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.equal(arg.service, 'deadbeefbaadf00d');
+      }
+    },
 
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 9);
-        assert.equal(eventData.op, 'flowEvent');
-        assert.equal(eventData.hostname, os.hostname());
-        assert.equal(eventData.pid, process.pid);
-        assert.equal(eventData.v, 1);
-        assert.equal(eventData.event, 'wibble');
-        assert.equal(eventData.userAgent, 'blee');
-        assert.equal(eventData.time, 'bar');
-        assert.equal(eventData.flow_time, 'foo');
-        assert.equal(eventData.service, 'mock client id');
+    'call flowEvent with invalid client_id': {
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          client_id: 'deadbeef', //eslint-disable-line camelcase
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
       }
     },
 
     'call flowEvent with service and client_id': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'foo',
-          time: 'bar',
-          type: 'wibble'
-        }, {
-          client_id: 'mock client id', //eslint-disable-line camelcase
-          service: 'mock service',
-          zignore: 'ignore me'
-        }, {
-          headers: { 'user-agent': 'blee' }
-        });
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          client_id: 'deadbeefbaadf00d', //eslint-disable-line camelcase
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          service: '1234567890abcdef',
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
       },
 
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
+      'process.stderr.write was called correctly': () => {
         assert.equal(process.stderr.write.callCount, 1);
-
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 9);
-        assert.equal(eventData.service, 'mock service');
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.equal(arg.service, '1234567890abcdef');
       }
     },
 
     'call flowEvent with entryPoint': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'foo',
-          time: 'bar',
-          type: 'wibble'
-        }, {
-          entryPoint: 'mock entryPoint', //eslint-disable-line camelcase
-          ignore: 'ignore me'
-        }, {
-          headers: { 'user-agent': 'blee' }
-        });
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          entryPoint: 'menubar',
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
       },
 
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
+      'process.stderr.write was called correctly': () => {
         assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.equal(arg.entrypoint, 'menubar');
+      }
+    },
 
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 9);
-        assert.equal(eventData.entrypoint, 'mock entryPoint');
+    'call flowEvent with invalid entryPoint': {
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          entryPoint: '!',
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
+      },
+
+      'process.stderr.write was not called': () => {
+        assert.equal(process.stderr.write.callCount, 0);
       }
     },
 
     'call flowEvent with entrypoint and entryPoint': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'foo',
-          time: 'bar',
-          type: 'wibble'
-        }, {
-          entryPoint: 'mock entryPoint',
-          entrypoint: 'mock entrypoint',
-          ignore: 'ignore me'
-        }, {
-          headers: { 'user-agent': 'blee' }
-        });
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          entryPoint: 'menubar',
+          entrypoint: 'menupanel',
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
       },
 
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
+      'process.stderr.write was called correctly': () => {
         assert.equal(process.stderr.write.callCount, 1);
-
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 9);
-        assert.equal(eventData.entrypoint, 'mock entrypoint');
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.equal(arg.entrypoint, 'menupanel');
       }
     },
 
     'call flowEvent with 101-character data': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'foo',
-          time: 'bar',
-          type: 'wibble'
-        }, {
-          context: (new Array(102)).join('0')
-        }, {
-          headers: { 'user-agent': 'blee' }
-        });
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          context: new Array(102).join('0'),
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
       },
 
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
+      'process.stderr.write was called correctly': () => {
         assert.equal(process.stderr.write.callCount, 1);
-
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(eventData.context, 100);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(arg.context, 100);
       }
     },
 
     'call flowEvent with 100-character data': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'foo',
-          time: 'bar',
-          type: 'wibble'
-        }, {
-          entrypoint: (new Array(101)).join('x')
-        }, {
-          headers: { 'user-agent': 'blee' }
-        });
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          entrypoint: new Array(101).join('0'),
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
       },
 
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
+      'process.stderr.write was called correctly': () => {
         assert.equal(process.stderr.write.callCount, 1);
-
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(eventData.entrypoint, 100);
-      }
-    },
-
-    'call flowEvent with "none" data': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'foo',
-          time: 'bar',
-          type: 'wibble'
-        }, {
-          migration: 'none'
-        }, {
-          headers: { 'user-agent': 'blee' }
-        });
-      },
-
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
-        assert.equal(process.stderr.write.callCount, 1);
-
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.equal(Object.keys(eventData).indexOf('migration'), -1);
-      }
-    },
-
-    'call flowEvent with 101-character client_id': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'foo',
-          time: 'bar',
-          type: 'wibble'
-        }, {
-          client_id: (new Array(102)).join(' ') //eslint-disable-line camelcase
-        }, {
-          headers: { 'user-agent': 'blee' }
-        });
-      },
-
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
-        assert.equal(process.stderr.write.callCount, 1);
-
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(eventData.service, 100);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(arg.entrypoint, 100);
       }
     },
 
     'call flowEvent with 101-character entryPoint': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'foo',
-          time: 'bar',
-          type: 'wibble'
-        }, {
-          entryPoint: (new Array(102)).join(' ') //eslint-disable-line camelcase
-        }, {
-          headers: { 'user-agent': 'blee' }
-        });
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          entryPoint: new Array(102).join('x'), //eslint-disable-line camelcase
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
       },
 
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
+      'process.stderr.write was called correctly': () => {
         assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(arg.entrypoint, 100);
+      }
+    },
 
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(eventData.entrypoint, 100);
+    'call flowEvent with "none" data': {
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          migration: 'none',
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
+      },
+
+      'process.stderr.write was called correctly': () => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.isUndefined(arg.migration);
       }
     },
 
     'call flowEvent with DNT header': {
-      setup: function () {
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'mock flow time',
-          time: 'mock time',
-          type: 'mock event'
-        }, {
-          client_id: 'mock client_id', //eslint-disable-line camelcase
-          context: 'mock context',
-          entryPoint: 'mock entryPoint',
-          entrypoint: 'mock entrypoint',
-          migration: 'mock migration',
-          service: 'mock service',
-          /*eslint-disable camelcase*/
-          utm_campaign: 'mock utm_campaign',
-          utm_content: 'mock utm_content',
-          utm_medium: 'mock utm_medium',
-          utm_source: 'mock utm_source',
-          utm_term: 'mock utm_term',
-          /*eslint-enable camelcase*/
-          zignore: 'ignore me'
-        }, {
-          headers: { 'dnt': '1', 'user-agent': 'foo' }
-        });
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        mocks.request.headers.dnt = '1';
+        setup({}, 1000);
       },
 
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
+      'process.stderr.write was called correctly': () => {
         assert.equal(process.stderr.write.callCount, 1);
-
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.lengthOf(Object.keys(eventData), 12);
-        assert.equal(eventData.op, 'flowEvent');
-        assert.equal(eventData.hostname, os.hostname());
-        assert.equal(eventData.pid, process.pid);
-        assert.equal(eventData.v, 1);
-        assert.equal(eventData.event, 'mock event');
-        assert.equal(eventData.userAgent, 'foo');
-        assert.equal(eventData.time, 'mock time');
-        assert.equal(eventData.flow_time, 'mock flow time');
-        assert.equal(eventData.context, 'mock context');
-        assert.equal(eventData.entrypoint, 'mock entrypoint');
-        assert.equal(eventData.migration, 'mock migration');
-        assert.equal(eventData.service, 'mock service');
-      }
-    },
-
-    'call flowEvent with numeric time': {
-      setup: function () {
-        time = Date.now();
-        write = process.stderr.write;
-        process.stderr.write = sinon.spy();
-        return flowEvent({
-          flowTime: 'foo',
-          time: time,
-          type: 'wibble'
-        }, {}, {
-          headers: { 'user-agent': 'blee' }
-        });
-      },
-
-      teardown: function () {
-        process.stderr.write = write;
-      },
-
-      'process.stderr.write was called correctly': function () {
-        assert.equal(process.stderr.write.callCount, 1);
-
-        var eventData = JSON.parse(process.stderr.write.args[0][0]);
-        assert.equal(eventData.time, new Date(time).toISOString());
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        console.log(process.stderr.write.args[0][0]);
+        assert.isUndefined(arg.utm_campaign);
+        assert.isUndefined(arg.utm_content);
+        assert.isUndefined(arg.utm_medium);
+        assert.isUndefined(arg.utm_source);
+        assert.isUndefined(arg.utm_term);
       }
     },
   });
+
+  function setup (data, timeSinceFlowBegin) {
+    try {
+      const flowBeginTime = data.flowBeginTime || mocks.time - timeSinceFlowBegin;
+      flowEvent(mocks.request, {
+        context: data.context || 'fx_desktop_v3',
+        entrypoint: data.entrypoint || 'menupanel',
+        events: data.events || [
+          { offset: 0, type: 'flow.signup.begin' }
+        ],
+        flowBeginTime,
+        flowId: data.flowId || '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        flushTime: flowBeginTime,
+        migration: data.migration || 'sync11',
+        service: data.service || '1234567890abcdef',
+        startTime: flowBeginTime - timeSinceFlowBegin,
+        /*eslint-disable camelcase*/
+        utm_campaign: data.utm_campaign || 'mock utm_campaign',
+        utm_content: data.utm_content || 'mock utm_content',
+        utm_medium: data.utm_medium || 'mock utm_medium',
+        utm_source: data.utm_source || 'mock utm_source',
+        utm_term: data.utm_term || 'mock utm_term',
+        /*eslint-enable camelcase*/
+        zignore: 'ignore me'
+      }, mocks.time);
+    } catch (err) {
+      console.error(err.stack);
+    }
+  }
 });

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -535,6 +535,30 @@ define([
       }
     },
 
+    'call flowEvent with falsy data': {
+      beforeEach () {
+        const timeSinceFlowBegin = 1000;
+        const flowBeginTime = mocks.time - timeSinceFlowBegin;
+        flowMetricsValidateResult = true;
+        flowEvent(mocks.request, {
+          events: [
+            { offset: 0, type: 'flow.signup.begin' }
+          ],
+          flowBeginTime,
+          flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          flushTime: flowBeginTime,
+          service: 0,
+          startTime: flowBeginTime - timeSinceFlowBegin,
+        }, mocks.time);
+      },
+
+      'process.stderr.write was called correctly': () => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.isUndefined(arg.service);
+      }
+    },
+
     'call flowEvent with DNT header': {
       beforeEach () {
         flowMetricsValidateResult = true;


### PR DESCRIPTION
Fixes #4396.

Last week I merged #4383 before it was fully reviewed. This PR addresses the feedback that arrived afterwards:

* All of the flow event logic is pushed down from `server/lib/routes/post-metrics.js` to `server/lib/flow-event.js`. This represents the meat of the change, hence the commit message.

* The array `VALID_PROPERTIES` was renamed to `VALID_FLOW_EVENT_PROPERTIES`. Although fwiw, now that it has been moved into the dedicated flow event module, it may have been fine to leave it as it was.

* Exhaustive chains of asserts against big object structures have been replaced with `deepEquals`. Note that the non-exhaustive, differential asserts against these objects have been left as they were.

* Some duplicate setup code has been extracted to a common function.

Note that there is one item of feedback I elected not to address:

> If the property value is falsey, then `isValidProperty` will always return true? That seems like all falsey values will be let through, even if invalid. Should `if (property) {` be `if (typeof property !== 'undefined') {`?

Falsy values aren't invalid here. The empty string is fine and others like `null` and `NaN` get purged during the course of the metrics pipeline anyway. Additionally, explicitly testing for `undefined` felt like coupling to an implementation detail of the metrics framework. What if that legitimately changed to `null` in some future iteration and we then dropped valid flow events as a result?

Ultimately, this validation exists to fix the problem of malicious or garbage data breaking the metrics pipeline. In that light, I don't think specifying this test to `undefined` adds value.

@shane-tomlinson r?