### PR TITLE
feat(server): Babel can be disabled via config.

### DIFF
--- a/server/config/production.json
+++ b/server/config/production.json
@@ -5,5 +5,8 @@
   "csp": {
     "enabled": true,
     "reportOnly": true
+  },
+  "babel": {
+    "enabled": false
   }
 }

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -25,6 +25,13 @@ var conf = module.exports = convict({
     doc: 'Check if the resources are under the /dist directory',
     format: Boolean
   },
+  babel: {
+    enabled: {
+      default: true,
+      doc: 'Convert ES2015 JavaScript to ES5',
+      format: Boolean
+    }
+  },
   basket: {
     api_key: {
       default: 'test key please change',
@@ -570,4 +577,3 @@ var options = {
 
 // validate the configuration based on the above specification
 conf.validate(options);
-

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -28,7 +28,7 @@ var conf = module.exports = convict({
   babel: {
     enabled: {
       default: true,
-      doc: 'Convert ES2015 JavaScript to ES5',
+      doc: 'Convert ES2015 to ES5. Production builds do not use this setting',
       format: Boolean
     }
   },

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -75,7 +75,7 @@ module.exports = function (config, i18n) {
       res.redirect(removeVersionPrefix(req.originalUrl));
     });
 
-    if (config.get('env') === 'development') {
+    if (config.get('babel.enabled')) {
       // Compile ES2015 scripts to ES5 before serving to the client.
       // This is done for two reasons:
       // 1. The blanket code coverage tool does not understand ES6, only ES5.
@@ -91,7 +91,9 @@ module.exports = function (config, i18n) {
         exclude: ['scripts/{head|vendor}/**'],
         srcPath: path.join(__dirname, '..', '..', 'app')
       }));
+    }
 
+    if (config.get('env') === 'development') {
       // front end mocha tests
       app.get('/tests/index.html', function (req, res) {
         var checkCoverage = 'coverage' in req.query &&
@@ -189,4 +191,3 @@ module.exports = function (config, i18n) {
     });
   };
 };
-


### PR DESCRIPTION
Babel was always enabled in development mode, which is fine until trying
to use the Fx dev tools to step through the code with sourcemaps
enabled. Now babl is enabled if the `babel.config` configuration item is
set to `true`. It's set to `false` for production, `true` elsewhere.

@vladikoff - r?