### PR TITLE
fix(client): pass correct OAuth client id to certificateSign

### DIFF
--- a/app/scripts/lib/assertion.js
+++ b/app/scripts/lib/assertion.js
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
   }
 
 
-  function certificate(audience, sessionToken) {
+  function certificate(audience, sessionToken, service) {
     //TODO: check for a valid cert in localStorage first?
     return generateKeyPair.call(this)
       .then((kp) => {
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
         // assertion here on the machine
         return P.all([
           this._fxaClient.certificateSign(
-            kp.publicKey.toSimpleObject(), CERT_DURATION_MS, sessionToken),
+            kp.publicKey.toSimpleObject(), CERT_DURATION_MS, sessionToken, service),
           assertion(this._jwcrypto, kp.secretKey, audience)
         ]);
       });
@@ -73,11 +73,11 @@ define(function (require, exports, module) {
     }, secretKey);
   }
 
-  function bundle(sessionToken, audience) {
+  function bundle(sessionToken, audience, service) {
     return requireOnDemand('jwcrypto')
       .then((jwcrypto) => {
         this._jwcrypto = jwcrypto;
-        return certificate.call(this, audience || this._audience, sessionToken);
+        return certificate.call(this, audience || this._audience, sessionToken, service);
       })
       .spread((cert, ass) => {
         return this._jwcrypto.cert.bundle([cert.cert], ass);

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -483,13 +483,13 @@ define(function (require, exports, module) {
       return client.accountDestroy(email, password);
     }),
 
-    certificateSign: withClient((client, pubkey, duration, sessionToken) => {
+    certificateSign: withClient((client, pubkey, duration, sessionToken, service) => {
       return client.certificateSign(
         sessionToken,
         pubkey,
         duration,
         {
-          service: Constants.CONTENT_SERVER_SERVICE
+          service: service || Constants.CONTENT_SERVER_SERVICE
         }
       );
     }),

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -82,12 +82,13 @@ define(function (require, exports, module) {
         return p.reject(AuthErrors.toError('INVALID_TOKEN'));
       }
 
-      return this._assertionLibrary.generate(account.get('sessionToken'))
+      const relier = this.relier;
+      const clientId = relier.get('clientId');
+      return this._assertionLibrary.generate(account.get('sessionToken'), null, clientId)
         .then((assertion) => {
-          var relier = this.relier;
           var oauthParams = {
             assertion: assertion,
-            client_id: relier.get('clientId'), //eslint-disable-line camelcase
+            client_id: clientId, //eslint-disable-line camelcase
             scope: relier.get('scope'),
             state: relier.get('state')
           };

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -1150,6 +1150,33 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('certificateSign with service argument', () => {
+      it('signs certificate', () => {
+        const publicKey = {
+          algorithm: 'RS',
+          e: '65537',
+          n: '47593859672356105035714943391967496145446066925677857909539347' +
+             '68202714280652973091341316862993582789079872007974809511698859' +
+             '885077002492642203267408776123'
+        };
+        const duration = 86400000;
+
+        sinon.stub(realClient, 'certificateSign', () => {
+          return p('cert_is_returned');
+        });
+
+        return client.certificateSign(publicKey, duration, null, 'foo')
+          .then(cert => {
+            assert.ok(cert);
+
+            assert.equal(realClient.certificateSign.callCount, 1);
+            const args = realClient.certificateSign.args[0];
+            assert.lengthOf(args, 4);
+            assert.deepEqual(args[3], { service: 'foo' });
+          });
+      });
+    });
+
     describe('isSignedIn', function () {
       it('resolves to false if no sessionToken passed in', function () {
         return client.isSignedIn()

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -222,7 +222,7 @@ define(function (require, exports, module) {
       it('gets an object with the OAuth login information', function () {
         return broker.getOAuthResult(account)
           .then(function (result) {
-            assert.isTrue(assertionLibrary.generate.calledWith(account.get('sessionToken')));
+            assert.isTrue(assertionLibrary.generate.calledWith(account.get('sessionToken'), null, 'clientId'));
             assert.equal(result.redirect, VALID_OAUTH_CODE_REDIRECT_URL);
             assert.equal(result.state, 'state');
             assert.equal(result.code, VALID_OAUTH_CODE);


### PR DESCRIPTION
Fixes #4376.

I've taken the simplest possible approach to fixing this, just whacking an extra argument in at each point of the call stack from the OAuth broker down to `fxa-client::certificiateSign`.

Is that acceptable? I'm happy to do something else if not.

Here is a log line showing the `account.signed` flow event from the auth server, with the `service` property set for 123done:

```
flowEvent {"event":"account.signed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:51.0) Gecko/20100101 Firefox/51.0","time":1479399085892,"flow_id":"35973425de3ef9f4956b21bd2bc390bd49a6d358166c74e56186c2a2d80835fe","flow_time":30539,"flowCompleteSignal":"account.verified","context":"oauth","service":"dcdb5ae7add825d2"}
```

Before this change, that flow event was not emitted because the auth server does not emit flow events for `account.signed` requests from the content server.
