### PR TITLE
feat(client): Pass the email address in the resume token.

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -11,13 +11,16 @@ define(function (require, exports, module) {
   const _ = require('underscore');
   const AuthErrors = require('lib/auth-errors');
   const Backbone = require('backbone');
+  const Cocktail = require('cocktail');
   const Constants = require('lib/constants');
   const MarketingEmailPrefs = require('models/marketing-email-prefs');
   const OAuthToken = require('models/oauth-token');
   const p = require('lib/promise');
   const ProfileErrors = require('lib/profile-errors');
   const ProfileImage = require('models/profile-image');
+  const ResumeTokenMixin = require('models/mixins/resume-token');
   const SignInReasons = require('lib/sign-in-reasons');
+  const vat = require('lib/vat');
 
   var NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;
 
@@ -97,6 +100,12 @@ define(function (require, exports, module) {
 
       this._boundOnChange = this.onChange.bind(this);
       this.on('change', this._boundOnChange);
+    },
+
+    resumeTokenFields: ['email'],
+
+    resumeTokenSchema: {
+      email: vat.email()
     },
 
     // Hydrate the account
@@ -929,6 +938,11 @@ define(function (require, exports, module) {
           });
       };
     });
+
+  Cocktail.mixin(
+    Account,
+    ResumeTokenMixin
+  );
 
   module.exports = Account;
 });

--- a/app/scripts/models/resume-token.js
+++ b/app/scripts/models/resume-token.js
@@ -15,6 +15,7 @@ define(function (require, exports, module) {
 
   var ResumeToken = Backbone.Model.extend({
     defaults: {
+      email: undefined,
       entrypoint: undefined,
       flowBegin: undefined,
       flowId: undefined,

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -186,12 +186,9 @@ define(function (require, exports, module) {
     // and clicks the "Resend" link.
     resend () {
       var account = this.user.getAccountByEmail(this._email);
-      return account.retrySignUp(
-        this.relier,
-        {
-          resume: this.getStringifiedResumeToken()
-        }
-      )
+      return account.retrySignUp(this.relier, {
+        resume: this.getStringifiedResumeToken(account)
+      })
       .fail((err) => {
         if (AuthErrors.is(err, 'INVALID_TOKEN')) {
           return this.navigate('signup', {

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -167,12 +167,10 @@ define(function (require, exports, module) {
     },
 
     resend () {
-      return this.getAccount().retrySignUp(
-        this.relier,
-        {
-          resume: this.getStringifiedResumeToken()
-        }
-      )
+      const account = this.getAccount();
+      return account.retrySignUp(this.relier, {
+        resume: this.getStringifiedResumeToken(account)
+      })
       .fail((err) => {
         if (AuthErrors.is(err, 'INVALID_TOKEN')) {
           return this.navigate('signup', {

--- a/app/scripts/views/mixins/password-reset-mixin.js
+++ b/app/scripts/views/mixins/password-reset-mixin.js
@@ -25,12 +25,9 @@ define(function (require, exports, module) {
      */
     resetPassword (email) {
       var account = this.user.initAccount({ email: email });
-      return account.resetPassword(
-        this.relier,
-        {
-          resume: this.getStringifiedResumeToken()
-        }
-      )
+      return account.resetPassword(this.relier, {
+        resume: this.getStringifiedResumeToken(account)
+      })
       .then((result) => {
         this.navigate('confirm_reset_password', {
           email: email,
@@ -52,13 +49,9 @@ define(function (require, exports, module) {
      */
     retryResetPassword (email, passwordForgotToken) {
       var account = this.user.initAccount({ email: email });
-      return account.retryResetPassword(
-        passwordForgotToken,
-        this.relier,
-        {
-          resume: this.getStringifiedResumeToken()
-        }
-      );
+      return account.retryResetPassword(passwordForgotToken, this.relier, {
+        resume: this.getStringifiedResumeToken(account)
+      });
     }
   }, ResumeTokenMixin);
 });

--- a/app/scripts/views/mixins/resume-token-mixin.js
+++ b/app/scripts/views/mixins/resume-token-mixin.js
@@ -15,22 +15,22 @@ define(function (require, exports, module) {
      * Get a ResumeToken model.
      *
      * @method getResumeToken
+     * @param {Object} account
      * @returns {ResumeToken}
      */
-    getResumeToken () {
-      // there might not be any relier if the resume token is being fetched
-      // for an account unlock request caused by changing the password.
+    getResumeToken (account) {
+      var accountInfo = account.pickResumeTokenInfo();
+      // flow is only available in views that mix in the flow-events-mixin
       var flowInfo = this.flow && this.flow.pickResumeTokenInfo();
-      var relierInfo = this.relier && this.relier.pickResumeTokenInfo();
-      var userInfo = this.user && this.user.pickResumeTokenInfo();
+      var relierInfo = this.relier.pickResumeTokenInfo();
+      var userInfo = this.user.pickResumeTokenInfo();
 
-      // When account or user fields are needed,
-      // they can be added as part of the resumeTokenInfo
       var resumeTokenInfo = _.extend(
         {},
         flowInfo,
         relierInfo,
-        userInfo
+        userInfo,
+        accountInfo
       );
 
       return new ResumeToken(resumeTokenInfo);
@@ -40,10 +40,11 @@ define(function (require, exports, module) {
      * Get a stringified ResumeToken that can be passed along in an email
      *
      * @method getStringifiedResumeToken
+     * @param {Object} account
      * @returns {String}
      */
-    getStringifiedResumeToken () {
-      return this.getResumeToken().stringify();
+    getStringifiedResumeToken (account) {
+      return this.getResumeToken(account).stringify();
     }
   };
 });

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
             // a resume token is passed in to allow
             // unverified account or session users to complete
             // email verification.
-            resume: this.getStringifiedResumeToken(),
+            resume: this.getStringifiedResumeToken(account),
             unblockCode: options.unblockCode
           });
         })

--- a/app/scripts/views/mixins/signup-mixin.js
+++ b/app/scripts/views/mixins/signup-mixin.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
           this.logFlowEvent('attempt', 'signup');
 
           return this.user.signUpAccount(account, password, this.relier, {
-            resume: this.getStringifiedResumeToken()
+            resume: this.getStringifiedResumeToken(account)
           });
         })
         .then((account) => {

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -6,9 +6,9 @@ define(function (require, exports, module) {
   'use strict';
 
   const Account = require('models/account');
+  const { assert } = require('chai');
   const Assertion = require('lib/assertion');
   const AuthErrors = require('lib/auth-errors');
-  const chai = require('chai');
   const Constants = require('lib/constants');
   const Device = require('models/device');
   const FxaClientWrapper = require('lib/fxa-client');
@@ -20,12 +20,11 @@ define(function (require, exports, module) {
   const ProfileClient = require('lib/profile-client');
   const ProfileErrors = require('lib/profile-errors');
   const Relier = require('models/reliers/relier');
+  const ResumeToken = require('models/resume-token');
   const SignInReasons = require('lib/sign-in-reasons');
   const sinon = require('sinon');
   const VerificationMethods = require('lib/verification-methods');
   const VerificationReasons = require('lib/verification-reasons');
-
-  var assert = chai.assert;
 
   describe('models/account', function () {
     var account;
@@ -1905,6 +1904,34 @@ define(function (require, exports, module) {
 
       it('delegates to the fxaClient', () => {
         assert.isTrue(fxaClient.rejectUnblockCode.calledWith(UID, 'code'));
+      });
+    });
+
+    describe('populateFromResumeToken', () => {
+      describe('ResumeToken contains `email`', () => {
+        beforeEach(() => {
+          let resumeToken = new ResumeToken({ email: EMAIL });
+
+          account.unset('email');
+          account.populateFromResumeToken(resumeToken);
+        });
+
+        it('populates `email`', () => {
+          assert.equal(account.get('email'), EMAIL);
+        });
+      });
+
+      describe('ResumeToken does not contain `email`', () => {
+        beforeEach(() => {
+          let resumeToken = new ResumeToken({});
+
+          account.unset('email');
+          account.populateFromResumeToken(resumeToken);
+        });
+
+        it('does not populate `email`', () => {
+          assert.isFalse(account.has('email'));
+        });
       });
     });
   });

--- a/app/tests/spec/models/resume-token.js
+++ b/app/tests/spec/models/resume-token.js
@@ -5,16 +5,16 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const chai = require('chai');
+  const { assert } = require('chai');
   const ResumeToken = require('models/resume-token');
 
-  var assert = chai.assert;
-
+  var EMAIL = 'testuser@testuser.com';
   var ENTRYPOINT = 'entrypoint';
   var VERIFICATION_REDIRECT = 'https://hello.firefox.com';
   var UNIQUE_USER_ID = 'uuid';
 
   var TOKEN_OBJ = {
+    email: EMAIL,
     entrypoint: ENTRYPOINT,
     resetPasswordConfirm: false,
     uniqueUserId: UNIQUE_USER_ID,

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -5,10 +5,10 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const { assert } = require('chai');
   const AuthErrors = require('lib/auth-errors');
   const Backbone = require('backbone');
   const Broker = require('models/auth_brokers/base');
-  const chai = require('chai');
   const Constants = require('lib/constants');
   const VerificationReasons = require('lib/verification-reasons');
   const MarketingEmailErrors = require('lib/marketing-email-errors');
@@ -21,8 +21,6 @@ define(function (require, exports, module) {
   const User = require('models/user');
   const View = require('views/complete_sign_up');
   const WindowMock = require('../../mocks/window');
-
-  var assert = chai.assert;
 
   describe('views/complete_sign_up', function () {
     var account;
@@ -538,28 +536,15 @@ define(function (require, exports, module) {
             uid: validUid
           });
 
-          sinon.stub(account, 'verifySignUp', function () {
-            return p();
-          });
-
-          sinon.stub(retrySignUpAccount, 'retrySignUp', function () {
-            return p();
-          });
-
-          sinon.stub(user, 'getAccountByUid', function () {
-            return account;
-          });
-
-          sinon.stub(user, 'getAccountByEmail', function () {
-            return retrySignUpAccount;
-          });
+          sinon.stub(account, 'verifySignUp', () => p());
+          sinon.stub(retrySignUpAccount, 'retrySignUp', () => p());
+          sinon.stub(user, 'getAccountByUid', () => account);
+          sinon.stub(user, 'getAccountByEmail', () => retrySignUpAccount);
 
           windowMock.location.search = '?code=' + validCode + '&uid=' + validUid;
           initView();
 
-          sinon.stub(view, 'getStringifiedResumeToken', function () {
-            return 'resume token';
-          });
+          sinon.stub(view, 'getStringifiedResumeToken', () => 'resume token');
 
           return view.render()
             .then(function () {
@@ -568,6 +553,8 @@ define(function (require, exports, module) {
         });
 
         it('tells the account to retry signUp', function () {
+          assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+          assert.isTrue(view.getStringifiedResumeToken.calledWith(retrySignUpAccount));
           assert.isTrue(retrySignUpAccount.retrySignUp.calledWith(
             relier,
             {

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -323,15 +323,13 @@ define(function (require, exports, module) {
 
     describe('resend', function () {
       it('resends the confirmation email', function () {
-        sinon.stub(account, 'retrySignUp', function () {
-          return p();
-        });
-        sinon.stub(view, 'getStringifiedResumeToken', function () {
-          return 'resume token';
-        });
+        sinon.stub(account, 'retrySignUp', () => p());
+        sinon.stub(view, 'getStringifiedResumeToken', () => 'resume token');
 
         return view.resend()
-          .then(function () {
+          .then(() => {
+            assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+            assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
             assert.isTrue(account.retrySignUp.calledWith(
               relier,
               {

--- a/app/tests/spec/views/mixins/password-reset-mixin.js
+++ b/app/tests/spec/views/mixins/password-reset-mixin.js
@@ -34,9 +34,7 @@ define(function (require, exports, module) {
         relier = {};
 
         view = {
-          getStringifiedResumeToken: sinon.spy(function () {
-            return 'resume token';
-          }),
+          getStringifiedResumeToken: sinon.spy(() => 'resume token'),
           navigate: sinon.spy(),
           relier: relier,
           user: {
@@ -50,6 +48,8 @@ define(function (require, exports, module) {
       });
 
       it('initiates an account and calls the expected account method', function () {
+        assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+        assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
         assert.isTrue(view.user.initAccount.calledWith({ email: email }));
         assert.isTrue(account.resetPassword.calledWith(
           relier,
@@ -88,9 +88,7 @@ define(function (require, exports, module) {
         relier = {};
 
         view = {
-          getStringifiedResumeToken: sinon.spy(function () {
-            return 'resume token';
-          }),
+          getStringifiedResumeToken: sinon.spy(() => 'resume token'),
           navigate: sinon.spy(),
           relier: relier,
           user: {
@@ -104,7 +102,9 @@ define(function (require, exports, module) {
           view, email, passwordForgotToken);
       });
 
-      it('initiates an account and calls the expected account method', function () {
+      it('initiates an account and calls the expected account method', () => {
+        assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+        assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
         assert.isTrue(view.user.initAccount.calledWith({ email: email }));
         assert.isTrue(account.retryResetPassword.calledWith(
           passwordForgotToken,

--- a/app/tests/spec/views/mixins/resume-token-mixin.js
+++ b/app/tests/spec/views/mixins/resume-token-mixin.js
@@ -5,18 +5,22 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const { assert } = require('chai');
   const BaseView = require('views/base');
-  const chai = require('chai');
   const Cocktail = require('cocktail');
-  const Relier = require('models/reliers/relier');
   const ResumeToken = require('models/resume-token');
   const ResumeTokenMixin = require('views/mixins/resume-token-mixin');
+  const sinon = require('sinon');
   const TestTemplate = require('stache!templates/test_template');
 
-  var assert = chai.assert;
+  const TestView = BaseView.extend({
+    template: TestTemplate,
 
-  var TestView = BaseView.extend({
-    template: TestTemplate
+    initialize (options = {}) {
+      this.flow = options.flow;
+      this.relier = options.relier;
+      this.user = options.user;
+    }
   });
 
   Cocktail.mixin(
@@ -25,14 +29,33 @@ define(function (require, exports, module) {
   );
 
   describe('views/mixins/resume-token-mixin', function () {
-    var view;
-    var relier;
+    let account;
+    let flow;
+    let relier;
+    let user;
+    let view;
 
     beforeEach(function () {
-      relier = new Relier();
+      account = {
+        pickResumeTokenInfo: sinon.spy()
+      };
+
+      flow = {
+        pickResumeTokenInfo: sinon.spy()
+      };
+
+      relier = {
+        pickResumeTokenInfo: sinon.spy()
+      };
+
+      user = {
+        pickResumeTokenInfo: sinon.spy()
+      };
 
       view = new TestView({
-        relier: relier
+        flow,
+        relier,
+        user
       });
 
       return view.render();
@@ -44,13 +67,23 @@ define(function (require, exports, module) {
 
     describe('getResumeToken', function () {
       it('returns a ResumeToken model', function () {
-        assert.instanceOf(view.getResumeToken(), ResumeToken);
+        assert.instanceOf(view.getResumeToken(account), ResumeToken);
+
+        assert.isTrue(account.pickResumeTokenInfo.calledOnce);
+        assert.isTrue(flow.pickResumeTokenInfo.calledOnce);
+        assert.isTrue(relier.pickResumeTokenInfo.calledOnce);
+        assert.isTrue(user.pickResumeTokenInfo.calledOnce);
       });
     });
 
     describe('getStringifiedResumeToken', function () {
       it('returns a stringified resume token', function () {
-        assert.typeOf(view.getStringifiedResumeToken(), 'string');
+        assert.typeOf(view.getStringifiedResumeToken(account), 'string');
+
+        assert.isTrue(account.pickResumeTokenInfo.calledOnce);
+        assert.isTrue(flow.pickResumeTokenInfo.calledOnce);
+        assert.isTrue(relier.pickResumeTokenInfo.calledOnce);
+        assert.isTrue(user.pickResumeTokenInfo.calledOnce);
       });
     });
   });

--- a/app/tests/spec/views/mixins/signin-mixin.js
+++ b/app/tests/spec/views/mixins/signin-mixin.js
@@ -61,9 +61,7 @@ define(function (require, exports, module) {
           currentPage: 'force_auth',
           displayError: sinon.spy(),
           flow: flow,
-          getStringifiedResumeToken: sinon.spy(function () {
-            return RESUME_TOKEN;
-          }),
+          getStringifiedResumeToken: sinon.spy(() => RESUME_TOKEN),
           invokeBrokerMethod: sinon.spy(function () {
             return p();
           }),
@@ -95,6 +93,8 @@ define(function (require, exports, module) {
         });
 
         it('signs in the user', function () {
+          assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+          assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
           assert.isTrue(
             user.signInAccount.calledWith(account, 'password', relier));
           assert.equal(user.signInAccount.args[0][3].resume, RESUME_TOKEN);
@@ -191,6 +191,8 @@ define(function (require, exports, module) {
         });
 
         it('signs in the user', function () {
+          assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+          assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
           assert.isTrue(
             user.signInAccount.calledWith(account, 'password', relier));
           assert.equal(user.signInAccount.args[0][3].resume, RESUME_TOKEN);
@@ -225,6 +227,8 @@ define(function (require, exports, module) {
         });
 
         it('signs in the user', function () {
+          assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+          assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
           assert.isTrue(
             user.signInAccount.calledWith(account, 'password', relier));
           assert.equal(user.signInAccount.args[0][3].resume, RESUME_TOKEN);
@@ -327,4 +331,3 @@ define(function (require, exports, module) {
     });
   });
 });
-

--- a/app/tests/spec/views/mixins/signup-mixin.js
+++ b/app/tests/spec/views/mixins/signup-mixin.js
@@ -22,11 +22,12 @@ define(function (require, exports, module) {
     });
 
     describe('signUp', function () {
-      var account;
-      var broker;
-      var flow;
-      var relier;
-      var view;
+      let account;
+      let broker;
+      let flow;
+      let relier;
+      let user;
+      let view;
 
       beforeEach(function () {
         account = new Account({
@@ -36,14 +37,17 @@ define(function (require, exports, module) {
         broker = new Broker();
         flow = {};
         relier = new Relier();
+        user = {
+          signUpAccount: sinon.spy((account) => p(account))
+        };
 
         view = {
           _formPrefill: {
             clear: sinon.spy()
           },
-          broker: broker,
-          flow: flow,
-          getStringifiedResumeToken: sinon.spy(),
+          broker,
+          flow,
+          getStringifiedResumeToken: sinon.spy(() => 'resume token'),
           invokeBrokerMethod: sinon.spy(function () {
             return p();
           }),
@@ -53,13 +57,9 @@ define(function (require, exports, module) {
           logViewEvent: sinon.spy(),
           navigate: sinon.spy(),
           onSignUpSuccess: SignUpMixin.onSignUpSuccess,
-          relier: relier,
+          relier,
           signUp: SignUpMixin.signUp,
-          user: {
-            signUpAccount: sinon.spy(function (account) {
-              return p(account);
-            })
-          }
+          user
         };
       });
 
@@ -70,6 +70,15 @@ define(function (require, exports, module) {
           });
 
           return view.signUp(account, 'password');
+        });
+
+        it('calls user.signUpAccount correctly', () => {
+          assert.isTrue(user.signUpAccount.calledOnce);
+          assert.isTrue(user.signUpAccount.calledWith(
+            account, 'password', relier, { resume: 'resume token' }));
+
+          assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+          assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
         });
 
         it('redirects to the `signup_permissions` screen', function () {
@@ -95,6 +104,15 @@ define(function (require, exports, module) {
           return view.signUp(account, 'password');
         });
 
+        it('calls user.signUpAccount correctly', () => {
+          assert.isTrue(user.signUpAccount.calledOnce);
+          assert.isTrue(user.signUpAccount.calledWith(
+            account, 'password', relier, { resume: 'resume token' }));
+
+          assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+          assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
+        });
+
         it('redirects to the `choose_what_to_sync` screen', function () {
           assert.isTrue(view.navigate.calledOnce);
 
@@ -114,6 +132,15 @@ define(function (require, exports, module) {
           account.set('verified', true);
 
           return view.signUp(account, 'password');
+        });
+
+        it('calls user.signUpAccount correctly', () => {
+          assert.isTrue(user.signUpAccount.calledOnce);
+          assert.isTrue(user.signUpAccount.calledWith(
+            account, 'password', relier, { resume: 'resume token' }));
+
+          assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+          assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
         });
 
         it('calls view.logViewEvent correctly', function () {
@@ -162,6 +189,15 @@ define(function (require, exports, module) {
           account.set('verified', false);
 
           return view.signUp(account, 'password');
+        });
+
+        it('calls user.signUpAccount correctly', () => {
+          assert.isTrue(user.signUpAccount.calledOnce);
+          assert.isTrue(user.signUpAccount.calledWith(
+            account, 'password', relier, { resume: 'resume token' }));
+
+          assert.isTrue(view.getStringifiedResumeToken.calledOnce);
+          assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
         });
 
         it('calls view.logViewEvent correctly', function () {
@@ -215,4 +251,3 @@ define(function (require, exports, module) {
     });
   });
 });
-


### PR DESCRIPTION
This is in preparation for "connect another device" where we'll need
the email address in the resume token to be able to connect a 2nd
instance of Firefox if the user verifies their email there.