### PR TITLE
refactor(client): skip rendering if `navigate` is called in beforeRender

### DIFF
--- a/app/scripts/views/choose_what_to_sync.js
+++ b/app/scripts/views/choose_what_to_sync.js
@@ -34,7 +34,6 @@ define(function (require, exports, module) {
       // user cannot proceed if they have not initiated a sign up/in.
       if (! this.getAccount().get('sessionToken')) {
         this.navigate('signup');
-        return false;
       }
     },
 

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -110,7 +110,7 @@ define(function (require, exports, module) {
 
             if (! this.relier.isDirectAccess()) {
               this._navigateToVerifiedScreen();
-              return false;
+              return;
             }
 
             return account.isSignedIn()
@@ -122,7 +122,6 @@ define(function (require, exports, module) {
                 } else {
                   this._navigateToVerifiedScreen();
                 }
-                return false;
               });
           })
           .fail((err) => {

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -85,7 +85,6 @@ define(function (require, exports, module) {
       // user cannot confirm if they have not initiated a sign up.
       if (! this.getAccount().get('sessionToken')) {
         this.navigate(this._getMissingSessionTokenScreen());
-        return false;
       }
     },
 

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -46,7 +46,6 @@ define(function (require, exports, module) {
       // user cannot confirm if they have not initiated a reset password
       if (! this.model.has('passwordForgotToken')) {
         this.navigate('reset_password');
-        return false;
       }
     },
 

--- a/app/scripts/views/permissions.js
+++ b/app/scripts/views/permissions.js
@@ -245,7 +245,7 @@ define(function (require, exports, module) {
       // user cannot proceed if they have not initiated a sign up/in.
       if (! this.getAccount().get('sessionToken')) {
         this.navigate(this._previousView());
-        return false;
+        return;
       }
 
       var account = this.getAccount();

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -113,7 +113,6 @@ define(function (require, exports, module) {
         this.navigate('settings/avatar/change', {
           error: AuthErrors.toError('NO_CAMERA')
         });
-        return false;
       }
     },
 

--- a/app/scripts/views/settings/avatar_crop.js
+++ b/app/scripts/views/settings/avatar_crop.js
@@ -41,7 +41,6 @@ define(function (require, exports, module) {
         this.navigate('settings/avatar/change', {
           error: AuthErrors.toMessage('UNUSABLE_IMAGE')
         });
-        return false;
       }
     },
 

--- a/app/scripts/views/settings/gravatar_permissions.js
+++ b/app/scripts/views/settings/gravatar_permissions.js
@@ -39,7 +39,6 @@ define(function (require, exports, module) {
       if (account.getClientPermission(GRAVATAR_MOCK_CLIENT_ID, GRAVATAR_PERMISSION)) {
         this.logViewEvent('already-accepted');
         this.navigate('settings/avatar/gravatar');
-        return false;
       }
     },
 

--- a/app/scripts/views/sign_in_unblock.js
+++ b/app/scripts/views/sign_in_unblock.js
@@ -37,7 +37,6 @@ define(function (require, exports, module) {
     beforeRender () {
       if (! this.model.get('account')) {
         this.navigate(this._getAuthPage());
-        return false;
       }
     },
 

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -172,6 +172,20 @@ define(function (require, exports, module) {
             });
       });
 
+      it('does not render if the view has already navigated', () => {
+        sinon.spy(view, 'renderTemplate');
+        sinon.spy(view, 'navigate');
+        sinon.stub(view, 'beforeRender', function () {
+          this.navigate('signin');
+        });
+
+        return view.render()
+          .then(() => {
+            assert.isTrue(view.navigate.called);
+            assert.isFalse(view.renderTemplate.called);
+          });
+      });
+
       it('redirects to `/signin` if the user is not authenticated', function () {
         var account = user.initAccount({
           email: 'a@a.com',

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -362,6 +362,8 @@ define(function (require, exports, module) {
       var password = 'password';
 
       beforeEach(function () {
+        // stub out `beforeRender` to ensure no redirect occurs.
+        sinon.stub(view, 'beforeRender', () => p());
         sinon.stub(view, '_signIn', function (account) {
           return p();
         });
@@ -558,9 +560,10 @@ define(function (require, exports, module) {
 
     describe('flow events', () => {
       beforeEach(() => {
+        // stub out `beforeRender` to ensure no redirection occurs.
+        sinon.stub(view, 'beforeRender', () => p());
         return view.render()
           .then(() => {
-            $('#container').html(view.el);
             view.afterVisible();
           });
       });
@@ -598,6 +601,7 @@ define(function (require, exports, module) {
       });
 
       it('logs the submit event', () => {
+        $('#container').html(view.el);
         view.$('#submit-btn').click();
         assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.force-auth.submit'));
         view.enableForm();

--- a/app/tests/spec/views/sign_in_unblock.js
+++ b/app/tests/spec/views/sign_in_unblock.js
@@ -5,7 +5,8 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const assert = require('chai').assert;
+  const _ = require('underscore');
+  const { assert } = require('chai');
   const Account = require('models/account');
   const AuthErrors = require('lib/auth-errors');
   const Backbone = require('backbone');
@@ -29,6 +30,7 @@ define(function (require, exports, module) {
     let broker;
     let metrics;
     let model;
+    let notifier;
     let relier;
     let view;
     let windowMock;
@@ -60,12 +62,15 @@ define(function (require, exports, module) {
         password: 'password'
       });
 
+      notifier = _.extend({}, Backbone.Events);
+
       view = new View({
         able,
         broker,
         canGoBack: true,
         metrics,
         model,
+        notifier,
         relier,
         viewName: 'sign-in-unblock',
         window: windowMock
@@ -92,7 +97,7 @@ define(function (require, exports, module) {
       describe('without an account', () => {
         beforeEach(() => {
           model.unset('account');
-          sinon.stub(view, 'navigate', () => {});
+          sinon.spy(view, 'navigate');
 
           return view.render();
         });


### PR DESCRIPTION
If a view called `navigate` in `beforeRender`, it also had to return
`false` to prevent rendering. The two always went hand in hand and seems
a bit silly, there are no cases where we want to navigate away from
the current view but still render the current view.

With this change, if `navigate` is called in `beforeRender`, rendering
is automatically skipped and `false` does not need to be returned.

@philbooth or @vbudhram - r?