### PR TITLE
fix(clients): Always sort the current device first.

### DIFF
--- a/app/scripts/models/attached-clients.js
+++ b/app/scripts/models/attached-clients.js
@@ -59,6 +59,9 @@ define(function (require, exports, module) {
       if (a.get('isCurrentDevice')) {
         return -1;
       }
+      if (b.get('isCurrentDevice')) {
+        return 1;
+      }
       // check lastAccessTime. If one has an access time and the other does
       // not, the one with the access time is automatically higher in the
       // list. If both have access times, sort in descending order, unless
@@ -83,11 +86,11 @@ define(function (require, exports, module) {
 
       if (aName < bName) {
         return -1;
-      } else if (a === b) {
-        return 0;
+      } else if (aName > bName) {
+        return 1;
       }
 
-      return 1;
+      return 0;
     }
 
   });

--- a/app/tests/spec/models/attached-clients.js
+++ b/app/tests/spec/models/attached-clients.js
@@ -27,11 +27,24 @@ define(function (require, exports, module) {
       });
     });
 
+    function shuffle(items) {
+      for (var i = items.length - 1; i > 0; i--) {
+        var j = Math.floor(Math.random() * (i + 1));
+        var tmp = items[i];
+        items[i] = items[j];
+        items[j] = tmp;
+      }
+      return items;
+    }
+
     describe('properly orders the attached clients', function () {
       var now = Date.now();
 
       beforeEach(function () {
-        attachedClients.set([
+        // We input the list of clients in a random order,
+        // so that the tests won't accidentally depend on implementation
+        // details of how the underlying sort algorithm works.
+        attachedClients.set(shuffle([
           {
             clientType: Constants.CLIENT_TYPE_DEVICE,
             isCurrentDevice: false,
@@ -79,7 +92,7 @@ define(function (require, exports, module) {
             lastAccessTime: null,
             name: 'an oauth'
           }
-        ]);
+        ]));
       });
 
       it('places the `current` device first', function () {


### PR DESCRIPTION
The client sorting logic was only putting the current device first if it happened to appear on the left-hand-side of a comparison.  This fixes it to detect the current device on either side.  It also fixes what looked like a typo in a later comparison (comparing `a` and `b` objects rather than `aName` and `bName` strings).

The tests were passing because the order of the input array happened to cause the current device to compare correctly, and I was in two minds about how to fix that issue.  We could write a separate test for "puts the current device first when it's in a variety of different positions in the input list" but that felt like a lot of repetition.  Randomizing the order of the input list seemed better on balance, because it would not depend on implementation details of the underlying sort, and because it would also capture other edge-cases that we haven't noticed.

But I'm aware that randomizing tests is not everyone's cup of tea, so let me know if you don't like it, and I'll replace it with a separate deterministic test case.

@vladikoff r?