### PR TITLE
fix(metrics): drop invalid utm_ params from flow data

### DIFF
--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -17,8 +17,7 @@ const NO_DNT_ALLOWED_DATA = DNT_ALLOWED_DATA.concat([
   'utm_campaign',
   'utm_content',
   'utm_medium',
-  'utm_source',
-  'utm_term'
+  'utm_source'
 ]);
 const HOSTNAME = os.hostname();
 const MAX_DATA_LENGTH = 100;
@@ -28,7 +27,7 @@ const FLOW_BEGIN_EVENT_TYPES = /^flow\.[a-z_-]+\.begin$/;
 const FLOW_ID_KEY = config.get('flow_id_key');
 const FLOW_ID_EXPIRY = config.get('flow_id_expiry');
 
-const ENTRYPOINT_PATTERN = /^[\w\.-]+$/;
+const ENTRYPOINT_PATTERN = /^[\w.-]+$/;
 const SERVICE_PATTERN = /^(sync|content-server|none|[0-9a-f]{16})$/;
 const VALID_FLOW_EVENT_PROPERTIES = [
   { key: 'client_id', pattern: SERVICE_PATTERN },
@@ -39,6 +38,8 @@ const VALID_FLOW_EVENT_PROPERTIES = [
   { key: 'migration', pattern: /^(sync11|amo|none)$/ },
   { key: 'service', pattern: SERVICE_PATTERN }
 ];
+
+const UTM_PATTERN = /^[\w.%-]+$/;
 
 const IS_DISABLED = config.get('client_metrics').stderr_collector_disabled;
 
@@ -120,7 +121,6 @@ function estimateTime (times) {
 }
 
 function logFlowEvent (event, data, request) {
-  var pickedData = _.pick(data, isDNT(request) ? DNT_ALLOWED_DATA : NO_DNT_ALLOWED_DATA);
   var eventData = _.assign({
     event: event.type,
     flow_id: data.flowId, //eslint-disable-line camelcase
@@ -131,13 +131,30 @@ function logFlowEvent (event, data, request) {
     time: new Date(event.time).toISOString(),
     userAgent: request.headers['user-agent'],
     v: VERSION
-  }, _.mapValues(pickedData, sanitiseData));
+  }, _.mapValues(pickFlowData(data, request), sanitiseData));
 
   optionallySetFallbackData(eventData, 'service', data.client_id);
   optionallySetFallbackData(eventData, 'entrypoint', data.entryPoint);
 
   // The data pipeline listens on stderr.
   process.stderr.write(JSON.stringify(eventData) + '\n');
+}
+
+function pickFlowData (data, request) {
+  if (isDNT(request)) {
+    return _.pick(data, DNT_ALLOWED_DATA);
+  }
+
+  const pickedData = _.pick(data, NO_DNT_ALLOWED_DATA);
+
+  return _.pickBy(pickedData, (value, key) => {
+    if (key.indexOf('utm_') === 0) {
+      // Silently drop utm_ properties that contain unexpected characters.
+      return UTM_PATTERN.test(value);
+    }
+
+    return true;
+  });
 }
 
 function isDNT (request) {

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -97,11 +97,10 @@ define([
           service: '1234567890abcdef',
           time: new Date(mocks.time - 1000).toISOString(),
           userAgent: mocks.request.headers['user-agent'],
-          utm_campaign: 'mock utm_campaign',
-          utm_content: 'mock utm_content',
-          utm_medium: 'mock utm_medium',
-          utm_source: 'mock utm_source',
-          utm_term: 'mock utm_term',
+          utm_campaign: '.-Mock%20utm_campaign',
+          utm_content: '.-Mock%20utm_content',
+          utm_medium: '.-Mock%20utm_medium',
+          utm_source: '.-Mock%20utm_source',
           v: 1
           /*eslint-enable camelcase*/
         });
@@ -109,14 +108,14 @@ define([
 
       'second call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[1][0]);
-        assert.lengthOf(Object.keys(arg), 18);
+        assert.lengthOf(Object.keys(arg), 17);
         assert.equal(arg.event, 'flow.signup.good-offset-now');
         assert.equal(arg.time, new Date(mocks.time).toISOString());
       },
 
       'third call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[2][0]);
-        assert.lengthOf(Object.keys(arg), 18);
+        assert.lengthOf(Object.keys(arg), 17);
         assert.equal(arg.event, 'flow.signup.good-offset-oldest');
         assert.equal(arg.time, new Date(mocks.time - config.flow_id_expiry).toISOString());
       }
@@ -589,6 +588,70 @@ define([
         assert.isUndefined(arg.utm_source);
         assert.isUndefined(arg.utm_term);
       }
+    },
+
+    'call flowEvent with invalid utm_campaign': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          utm_campaign: '!' //eslint-disable-line camelcase
+        }, 1000);
+      },
+
+      'process.stderr.write was called correctly': () => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(Object.keys(arg), 16);
+        assert.isUndefined(arg.utm_campaign); //eslint-disable-line camelcase
+      }
+    },
+
+    'call flowEvent with invalid utm_content': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          utm_content: '"' //eslint-disable-line camelcase
+        }, 1000);
+      },
+
+      'process.stderr.write was called correctly': () => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(Object.keys(arg), 16);
+        assert.isUndefined(arg.utm_content); //eslint-disable-line camelcase
+      }
+    },
+
+    'call flowEvent with invalid utm_medium': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          utm_medium: ';' //eslint-disable-line camelcase
+        }, 1000);
+      },
+
+      'process.stderr.write was called correctly': () => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(Object.keys(arg), 16);
+        assert.isUndefined(arg.utm_medium); //eslint-disable-line camelcase
+      }
+    },
+
+    'call flowEvent with invalid utm_source': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          utm_source: '>' //eslint-disable-line camelcase
+        }, 1000);
+      },
+
+      'process.stderr.write was called correctly': () => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(Object.keys(arg), 16);
+        assert.isUndefined(arg.utm_source); //eslint-disable-line camelcase
+      }
     }
   });
 
@@ -608,11 +671,11 @@ define([
         service: data.service || '1234567890abcdef',
         startTime: flowBeginTime - timeSinceFlowBegin,
         /*eslint-disable camelcase*/
-        utm_campaign: data.utm_campaign || 'mock utm_campaign',
-        utm_content: data.utm_content || 'mock utm_content',
-        utm_medium: data.utm_medium || 'mock utm_medium',
-        utm_source: data.utm_source || 'mock utm_source',
-        utm_term: data.utm_term || 'mock utm_term',
+        utm_campaign: data.utm_campaign || '.-Mock%20utm_campaign',
+        utm_content: data.utm_content || '.-Mock%20utm_content',
+        utm_medium: data.utm_medium || '.-Mock%20utm_medium',
+        utm_source: data.utm_source || '.-Mock%20utm_source',
+        utm_term: data.utm_term || '.-Mock%20utm_term',
         /*eslint-enable camelcase*/
         zignore: 'ignore me'
       }, mocks.time);


### PR DESCRIPTION
Fixes #4415, silently dropping `utm_*` parameters that contain any dodgy-looking characters. Note that this is different treatment than the rest of the flow data, where the whole event is dropped for invalid data. The values for those params are under our control, whereas these aren't.

Can be tested by manually adding utm_ params to the URL. Those containing valid characters should show up in the flow event, like so:

```
{"event":"flow.signup.begin","flow_id":"698f1e55b51d763f4dc94fdecd8fc79e683b35e2dcbf48a5a942788c79cfc901","flow_time":0,"hostname":"pbooth-22205.local","op":"flowEvent","pid":58285,"time":"2016-11-21T14:18:07.774Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync","utm_campaign":"THIS_IS_GOOD_DATA"}
```

Any that contain invalid characters should not be present in the flow event.

There is also a secondary fix contained herein; we agreed to ditch `utm_term` entirely because it's completely free-form and we have don't envisage wanting to analyse it in this way.

@vladikoff r?