### PR TITLE
refactor(test): openPage no longer takes a context.

### DIFF
--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -28,7 +28,7 @@ define([
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
 
@@ -42,7 +42,7 @@ define([
       .then(createUser(email, PASSWORD, { preVerified: true }))
       .then(clearBrowserState())
 
-      .then(openPage(context, SIGNIN_URL, '#fxa-signin-header'))
+      .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
       .then(fillOutSignIn(email, PASSWORD))
       .then(testElementExists('#fxa-settings-header'));
   }
@@ -62,7 +62,7 @@ define([
 
     'go to settings then avatar change': function () {
       return this.remote
-        .then(openPage(this, SETTINGS_URL, '#fxa-settings-header'))
+        .then(openPage(SETTINGS_URL, '#fxa-settings-header'))
 
         // go to change avatar
         .then(click(CHANGE_AVATAR_BUTTON_SELECTOR))
@@ -73,7 +73,7 @@ define([
 
     'go to settings with an email selected to see change link then click on avatar to change': function () {
       return this.remote
-        .then(openPage(this, SETTINGS_URL, '#fxa-settings-header'))
+        .then(openPage(SETTINGS_URL, '#fxa-settings-header'))
 
         // go to change avatar
         .then(click('a.change-avatar'))
@@ -84,7 +84,7 @@ define([
 
     'go to settings with an email selected to see change link then click on text link to change': function () {
       return this.remote
-        .then(openPage(this, SETTINGS_URL, '#fxa-settings-header'))
+        .then(openPage(SETTINGS_URL, '#fxa-settings-header'))
 
         // go to change avatar
         .then(click(CHANGE_AVATAR_BUTTON_SELECTOR))
@@ -95,7 +95,7 @@ define([
 
     'visit gravatar with gravatar set': function () {
       return this.remote
-        .then(openPage(this, AVATAR_CHANGE_URL_AUTOMATED, '#gravatar'))
+        .then(openPage(AVATAR_CHANGE_URL_AUTOMATED, '#gravatar'))
 
         // go to gravatar change
         .then(click('#gravatar'))
@@ -129,7 +129,7 @@ define([
 
     'visit gravatar with gravatar set then cancel': function () {
       return this.remote
-        .then(openPage(this, AVATAR_CHANGE_URL_AUTOMATED, '#gravatar'))
+        .then(openPage(AVATAR_CHANGE_URL_AUTOMATED, '#gravatar'))
         // go to change avatar
         .then(click('#gravatar'))
 
@@ -159,7 +159,7 @@ define([
 
     'visit gravatar with no gravatar set': function () {
       return this.remote
-        .then(openPage(this, AVATAR_CHANGE_URL, '#gravatar'))
+        .then(openPage(AVATAR_CHANGE_URL, '#gravatar'))
 
         // go to change avatar
         .then(click('#gravatar'))
@@ -182,7 +182,7 @@ define([
 
     'attempt to use webcam for avatar': function () {
       return this.remote
-        .then(openPage(this, AVATAR_CHANGE_URL_AUTOMATED, '#camera'))
+        .then(openPage(AVATAR_CHANGE_URL_AUTOMATED, '#camera'))
         .then(click('#camera'))
 
         .then(click('.modal-panel #submit-btn'))
@@ -195,7 +195,7 @@ define([
 
     'attempt to use webcam for avatar, then cancel': function () {
       return this.remote
-        .then(openPage(this, AVATAR_CHANGE_URL_AUTOMATED, '#camera'))
+        .then(openPage(AVATAR_CHANGE_URL_AUTOMATED, '#camera'))
 
         // go to change avatar
         .then(click('#camera'))
@@ -209,7 +209,7 @@ define([
 
     'upload a profile image': function () {
       return this.remote
-        .then(openPage(this, AVATAR_CHANGE_URL, '#imageLoader'))
+        .then(openPage(AVATAR_CHANGE_URL, '#imageLoader'))
 
         // Selenium's way of interacting with a file picker
         .findByCssSelector('#imageLoader')
@@ -232,7 +232,7 @@ define([
 
     'cancel uploading a profile image': function () {
       return this.remote
-        .then(openPage(this, AVATAR_CHANGE_URL, '#imageLoader'))
+        .then(openPage(AVATAR_CHANGE_URL, '#imageLoader'))
 
         // Selenium's way of interacting with a file picker
         .findByCssSelector('#imageLoader')

--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -25,7 +25,7 @@ define([
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var noSuchElementDisplayed = FunctionalHelpers.noSuchElementDisplayed;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var testElementDisplayed = FunctionalHelpers.testElementDisplayed;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
@@ -83,7 +83,7 @@ define([
         .then(testElementExists('#fxa-settings-header'))
         .then(testSuccessWasShown(this))
 
-        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(click('.use-different'))
         .then(fillOutSignIn(email, SECOND_PASSWORD))
 

--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -28,7 +28,7 @@ define([
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noSuchElement = thenify(FunctionalHelpers.noSuchElement);
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfMessage);
   var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
@@ -38,7 +38,7 @@ define([
   var setupTest = thenify(function (context) {
     return this.parent
       .then(createUser(email, PASSWORD, {preVerified: true}))
-      .then(openPage(context, PAGE_SIGNIN_URL, '#fxa-signin-header'))
+      .then(openPage(PAGE_SIGNIN_URL, '#fxa-signin-header'))
       .execute(listenForFxaCommands)
       .then(fillOutSignIn(email, PASSWORD))
       .then(testIsBrowserNotified(context, 'can_link_account'))
@@ -68,7 +68,7 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(this, url, '#fxa-verification-link-damaged-header'))
+        .then(openPage(url, '#fxa-verification-link-damaged-header'))
 
         // a successful user is immediately redirected to the
         // sign-in-complete page.
@@ -81,7 +81,7 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(this, url, '#fxa-verification-link-reused-header'))
+        .then(openPage(url, '#fxa-verification-link-reused-header'))
 
         // Ensure that a link expired error message is displayed
         // rather than a damaged link error
@@ -94,7 +94,7 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(this, url, '#fxa-verification-link-damaged-header'))
+        .then(openPage(url, '#fxa-verification-link-damaged-header'))
 
         // a successful user is immediately redirected to the
         // sign-in-complete page.
@@ -107,7 +107,7 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(this, url, '#fxa-verification-link-expired-header'))
+        .then(openPage(url, '#fxa-verification-link-expired-header'))
 
         // Ensure that a link expired error message is displayed
         // rather than a damaged link error
@@ -119,7 +119,7 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(this, url, '#fxa-settings-profile-header'))
+        .then(openPage(url, '#fxa-settings-profile-header'))
 
         // a successful user is immediately redirected to the
         // sign-in-complete page.

--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -15,14 +15,12 @@ define([
 
   var email;
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
@@ -42,14 +40,14 @@ define([
         // user is immediately redirected to /signup if they have no
         // sessionToken.
         // Success is showing the screen
-        .then(openPage(this, CONFIRM_URL, '#fxa-signup-header'));
+        .then(openPage(CONFIRM_URL, '#fxa-signup-header'));
     },
 
     'sign up, wait for confirmation screen, click resend': function () {
       var email = 'test_signin' + Math.random() + '@mailinator.com';
 
       return this.remote
-        .then(openPage(this, SIGNUP_URL, '#fxa-signup-header'))
+        .then(openPage(SIGNUP_URL, '#fxa-signup-header'))
         .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#fxa-confirm-header'))
@@ -69,7 +67,7 @@ define([
       this.timeout = 90000;
 
       return this.remote
-        .then(openPage(this, SIGNUP_URL, '#fxa-signup-header'))
+        .then(openPage(SIGNUP_URL, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
 
         .then(fillOutSignUp(email, PASSWORD))

--- a/tests/functional/cookies_disabled.js
+++ b/tests/functional/cookies_disabled.js
@@ -19,13 +19,15 @@ define([
 
   var COOKIES_DISABLED_URL = config.fxaContentRoot + 'cookies_disabled';
 
+  var openPage = FunctionalHelpers.openPage;
+
   registerSuite({
     name: 'cookies_disabled',
 
     'visit signup page with localStorage disabled': function () {
       var self = this;
-      return FunctionalHelpers.openPage(
-            this, SIGNUP_COOKIES_DISABLED_URL, '#fxa-cookies-disabled-header')
+      return this.remote
+        .then(openPage(SIGNUP_COOKIES_DISABLED_URL, '#fxa-cookies-disabled-header'))
         // try again, cookies are still disabled.
         .findById('submit-btn')
           .click()
@@ -36,16 +38,12 @@ define([
     },
 
     'synthesize enabling cookies by visiting the sign up page, then cookies_disabled, then clicking "try again"': function () {
-      var self = this;
       // wd has no way of disabling/enabling cookies, so we have to
       // manually seed history.
-      return FunctionalHelpers.openPage(
-            self, SIGNUP_COOKIES_ENABLED_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(SIGNUP_COOKIES_ENABLED_URL, '#fxa-signup-header'))
 
-        .then(function () {
-          return FunctionalHelpers.openPage(
-              self, COOKIES_DISABLED_URL, '#fxa-cookies-disabled-header');
-        })
+        .then(openPage(COOKIES_DISABLED_URL, '#fxa-cookies-disabled-header'))
 
         // try again, cookies are enabled.
         .findById('submit-btn')
@@ -58,8 +56,8 @@ define([
     },
 
     'visit verify page with localStorage disabled': function () {
-      return FunctionalHelpers.openPage(
-            this, VERIFY_COOKIES_DISABLED_URL, '#fxa-cookies-disabled-header')
+      return this.remote
+        .then(openPage(VERIFY_COOKIES_DISABLED_URL, '#fxa-cookies-disabled-header'))
         .end();
     }
   });

--- a/tests/functional/email_opt_in.js
+++ b/tests/functional/email_opt_in.js
@@ -24,7 +24,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var testAttributeEquals = FunctionalHelpers.testAttributeEquals;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -76,7 +76,7 @@ define([
       // passed to basket. See a43061d3
       email = TestHelpers.createEmail('signup{id}+extra');
       return this.remote
-        .then(openPage(this, SIGNUP_PAGE_URL, '#fxa-signup-header'))
+        .then(openPage(SIGNUP_PAGE_URL, '#fxa-signup-header'))
         .then(fillOutSignUp(email, PASSWORD, { optInToMarketingEmail: true }))
 
         .then(testElementExists('#fxa-confirm-header'))
@@ -116,8 +116,9 @@ define([
 
     'do not opt-in on signup': function () {
       return this.remote
-        .then(openPage(this, SIGNUP_PAGE_URL, '#fxa-signup-header'))
+        .then(openPage(SIGNUP_PAGE_URL, '#fxa-signup-header'))
         .then(fillOutSignUp(email, PASSWORD, { optInToMarketingEmail: false }))
+
         .then(testElementExists('#fxa-confirm-header'))
         .then(openVerificationLinkInSameTab(email, 0))
 
@@ -132,7 +133,7 @@ define([
     'opt in from settings after sign-in': function () {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#communication-preferences.basket-ready'))

--- a/tests/functional/force_auth_blocked.js
+++ b/tests/functional/force_auth_blocked.js
@@ -13,13 +13,11 @@ define([
   var PASSWORD = 'password';
   var email;
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
@@ -47,7 +45,7 @@ define([
 
     'valid code entered': function () {
       return this.remote
-        .then(openPage(this, forceAuthPageUrl, '#fxa-force-auth-header'))
+        .then(openPage(forceAuthPageUrl, '#fxa-force-auth-header'))
         .then(fillOutForceAuth(PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -59,7 +57,7 @@ define([
 
     'incorrect password entered': function () {
       return this.remote
-        .then(openPage(this, forceAuthPageUrl, '#fxa-force-auth-header'))
+        .then(openPage(forceAuthPageUrl, '#fxa-force-auth-header'))
         .then(fillOutForceAuth('incorrect'))
 
         .then(testElementExists('#fxa-signin-unblock-header'))

--- a/tests/functional/fx_fennec_v1_settings.js
+++ b/tests/functional/fx_fennec_v1_settings.js
@@ -18,7 +18,7 @@ define([
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -44,7 +44,7 @@ define([
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
-        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
@@ -61,7 +61,7 @@ define([
           return accounts.length === 1 ? true : null;
         }, [], 10000))
 
-        .then(openPage(this, SETTINGS_URL, '#fxa-settings-header'));
+        .then(openPage(SETTINGS_URL, '#fxa-settings-header'));
     },
 
 
@@ -76,7 +76,7 @@ define([
 
     'sign in, change the password by browsing directly to settings': function () {
       return this.remote
-        .then(openPage(this, SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
+        .then(openPage(SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
         .then(noSuchBrowserNotification(this, 'fxaccounts:change_password'))

--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -21,7 +21,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
@@ -35,7 +35,7 @@ define([
     return this.parent
       .then(clearBrowserState())
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
-      .then(openPage(this.parent, PAGE_URL, '#fxa-signin-header'))
+      .then(openPage(PAGE_URL, '#fxa-signin-header'))
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(email, PASSWORD))
       .then(testIsBrowserNotified(this.parent, 'fxaccounts:can_link_account'))

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -19,6 +19,7 @@ define([
 
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
+  var openPage = FunctionalHelpers.openPage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -32,23 +33,20 @@ define([
     },
 
     afterEach: function () {
-      var self = this;
-
       return this.remote
         .then(FunctionalHelpers.clearBrowserState())
-        .then(function () {
-          // ensure the next test suite (bounced_email) loads a fresh
-          // signup page. If a fresh signup page is not forced, the
-          // bounced_email tests try to sign up using the Sync broker,
-          // resulting in a channel timeout.
-          return FunctionalHelpers.openPage(self, SIGNIN_URL, '#fxa-signin-header');
-        });
+        // ensure the next test suite (bounced_email) loads a fresh
+        // signup page. If a fresh signup page is not forced, the
+        // bounced_email tests try to sign up using the Sync broker,
+        // resulting in a channel timeout.
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'));
     },
 
     'sign up, verify same browser': function () {
       var self = this;
 
-      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
 
         .then(FunctionalHelpers.noSuchElement(self, '#customize-sync'))

--- a/tests/functional/fx_firstrun_v1_settings.js
+++ b/tests/functional/fx_firstrun_v1_settings.js
@@ -15,7 +15,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -41,7 +41,7 @@ define([
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
-        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
@@ -56,7 +56,7 @@ define([
           return accounts.length === 1 ? true : null;
         }, [], 10000))
 
-        .then(openPage(this, SETTINGS_URL, '#fxa-settings-header'));
+        .then(openPage(SETTINGS_URL, '#fxa-settings-header'));
     },
 
     'sign in, change the password': function () {
@@ -70,7 +70,7 @@ define([
 
     'sign in, change the password by browsing directly to settings': function () {
       return this.remote
-        .then(openPage(this, SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
+        .then(openPage(SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -24,7 +24,7 @@ define([
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
@@ -37,7 +37,7 @@ define([
 
     return this.parent
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
-      .then(openPage(this.parent, options.pageUrl || PAGE_URL, '.email'))
+      .then(openPage(options.pageUrl || PAGE_URL, '.email'))
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: options.canLinkAccountResponse !== false }))
       // delay for the webchannel message
       .sleep(500)

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -6,10 +6,9 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=iframe&service=sync';
 
@@ -21,6 +20,7 @@ define([
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
+  var openPage = FunctionalHelpers.openPage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -32,27 +32,20 @@ define([
     },
 
     afterEach: function () {
-      var self = this;
-
       return this.remote
         .then(clearBrowserState())
-        .then(function () {
-          // ensure the next test suite (bounced_email) loads a fresh
-          // signup page. If a fresh signup page is not forced, the
-          // bounced_email tests try to sign up using the Sync broker,
-          // resulting in a channel timeout.
-          return self.remote
-            .get(require.toUrl(SIGNIN_URL))
-
-            .findByCssSelector('#fxa-signin-header')
-            .end();
-        });
+        // ensure the next test suite (bounced_email) loads a fresh
+        // signup page. If a fresh signup page is not forced, the
+        // bounced_email tests try to sign up using the Sync broker,
+        // resulting in a channel timeout.
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'));
     },
 
     'sign up, verify same browser in a different tab': function () {
       var self = this;
 
-      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 
@@ -96,7 +89,8 @@ define([
 
     'sign up, cancel merge warning': function () {
       var self = this;
-      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: false } ))
         .then(fillOutSignUp(email, PASSWORD))
 

--- a/tests/functional/fx_firstrun_v2_settings.js
+++ b/tests/functional/fx_firstrun_v2_settings.js
@@ -15,7 +15,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -41,7 +41,7 @@ define([
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
-        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
@@ -56,7 +56,7 @@ define([
           return accounts.length === 1 ? true : null;
         }, [], 10000))
 
-        .then(openPage(this, SETTINGS_URL, '#fxa-settings-header'));
+        .then(openPage(SETTINGS_URL, '#fxa-settings-header'));
     },
 
     'sign in, change the password': function () {
@@ -70,7 +70,7 @@ define([
 
     'sign in, change the password by browsing directly to settings': function () {
       return this.remote
-        .then(openPage(this, SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
+        .then(openPage(SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -6,10 +6,9 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_firstrun_v2&service=sync';
 
@@ -18,11 +17,9 @@ define([
   var email;
   var PASSWORD = '12345678';
 
-  var thenify = FunctionalHelpers.thenify;
-
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -36,28 +33,20 @@ define([
     },
 
     afterEach: function () {
-      var self = this;
-
       return this.remote
         .then(FunctionalHelpers.clearBrowserState())
-        .then(function () {
-          // ensure the next test suite (bounced_email) loads a fresh
-          // signup page. If a fresh signup page is not forced, the
-          // bounced_email tests try to sign up using the Sync broker,
-          // resulting in a channel timeout.
-          return self.remote
-            .get(require.toUrl(SIGNIN_URL))
-
-            .findByCssSelector('#fxa-signin-header')
-            .end();
-        });
+        // ensure the next test suite (bounced_email) loads a fresh
+        // signup page. If a fresh signup page is not forced, the
+        // bounced_email tests try to sign up using the Sync broker,
+        // resulting in a channel timeout.
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'));
     },
 
     'sign up, verify same browser': function () {
       var self = this;
 
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signup-header'))
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
 
         .then(fillOutSignUp(email, PASSWORD))

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -25,7 +25,7 @@ define([
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -43,7 +43,7 @@ define([
 
     return this.parent
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
-      .then(openPage(this.parent, PAGE_URL, '#fxa-signin-header'))
+      .then(openPage(PAGE_URL, '#fxa-signin-header'))
       .execute(listenForFxaCommands)
       .then(fillOutSignIn(email, PASSWORD))
       .then(testIsBrowserNotified(this.parent, 'can_link_account'))
@@ -107,13 +107,13 @@ define([
 
     'signup link is enabled': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(testElementExists('a[href="/signup"]'));
     },
 
     'signin with an unknown account does not allow the user to sign up': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .execute(listenForFxaCommands)
 
         .then(fillOutSignIn(email, PASSWORD))

--- a/tests/functional/fx_ios_v1_sign_up.js
+++ b/tests/functional/fx_ios_v1_sign_up.js
@@ -21,6 +21,7 @@ define([
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  var openPage = FunctionalHelpers.openPage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
 
@@ -33,23 +34,20 @@ define([
     },
 
     afterEach: function () {
-      var self = this;
-
       return this.remote
         .then(clearBrowserState())
-        .then(function () {
-          // ensure the next test suite (bounced_email) loads a fresh
-          // signup page. If a fresh signup page is not forced, the
-          // bounced_email tests try to sign up using the Sync broker,
-          // resulting in a channel timeout.
-          return FunctionalHelpers.openPage(self, SIGNIN_URL, '#fxa-signin-header');
-        });
+        // ensure the next test suite (bounced_email) loads a fresh
+        // signup page. If a fresh signup page is not forced, the
+        // bounced_email tests try to sign up using the Sync broker,
+        // resulting in a channel timeout.
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'));
     },
 
     'sign up, verify same browser': function () {
       var self = this;
 
-      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .execute(listenForFxaCommands)
         .then(FunctionalHelpers.noSuchElement(self, '#customize-sync'))
         .then(fillOutSignUp(email, PASSWORD))

--- a/tests/functional/legal.js
+++ b/tests/functional/legal.js
@@ -10,12 +10,15 @@ define([
 ], function (intern, registerSuite, assert, FunctionalHelpers) {
   var url = intern.config.fxaContentRoot + 'legal';
 
+  var openPage = FunctionalHelpers.openPage;
+
   registerSuite({
     name: 'legal',
 
     'start at legal page': function () {
 
-      return FunctionalHelpers.openPage(this, url, '#fxa-legal-header')
+      return this.remote
+        .then(openPage(url, '#fxa-legal-header'))
 
         .findByCssSelector('a[href="/legal/terms"]')
           .click()
@@ -41,7 +44,8 @@ define([
 
     'start at terms page': function () {
 
-      return FunctionalHelpers.openPage(this, url + '/terms', '#fxa-tos-header')
+      return this.remote
+        .then(openPage(url + '/terms', '#fxa-tos-header'))
 
         .then(FunctionalHelpers.visibleByQSA('#legal-copy[data-shown]'))
         .findByCssSelector('#legal-copy[data-shown]')
@@ -56,7 +60,8 @@ define([
 
     'start at privacy page': function () {
 
-      return FunctionalHelpers.openPage(this, url + '/privacy', '#fxa-pp-header')
+      return this.remote
+        .then(openPage(url + '/privacy', '#fxa-pp-header'))
 
         .then(FunctionalHelpers.visibleByQSA('#legal-copy[data-shown]'))
         .findByCssSelector('#legal-copy[data-shown]')

--- a/tests/functional/oauth_choose_redirect.js
+++ b/tests/functional/oauth_choose_redirect.js
@@ -42,24 +42,19 @@ define([
     },
 
     'oauth endpoint redirects to signup with an unregistered email': function () {
-      var self = this;
-
       var invalidAccountUrl = oAuthUrl + '&email=' + email;
 
-      return openPage(self, invalidAccountUrl, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(invalidAccountUrl, '#fxa-signup-header'))
         .then(testElementValueEquals('input[type=email]', email));
     },
 
     'oauth endpoint redirects to signin with a registered email': function () {
-      var self = this;
-
       var validAccountUrl = oAuthUrl + '&email=' + email;
 
-      return self.remote
+      return this.remote
         .then(FunctionalHelpers.createUser(email, PASSWORD, { preVerified: true}))
-        .then(function () {
-          return openPage(self, validAccountUrl, '#fxa-signin-header');
-        })
+        .then(openPage(validAccountUrl, '#fxa-signin-header'))
         .then(testElementValueEquals('input[type=email]', email));
     }
   });

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -110,7 +110,8 @@ define([
         .then(getVerificationLink(user, 1))
         .then(function (verifyUrl) {
           // user verifies in the same tab, so they are logged in to the RP.
-          return openPage(this, verifyUrl, '#loggedin');
+          return this.parent
+            .then(openPage(verifyUrl, '#loggedin'));
         });
     },
 
@@ -153,7 +154,8 @@ define([
       var SIGNUP_URL = UNTRUSTED_OAUTH_APP + 'api/preverified-signup?' +
                         'email=' + encodeURIComponent(email);
 
-      return openPage(this, SIGNUP_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(SIGNUP_URL, '#fxa-signup-header'))
 
         .then(type('input[type=password]', PASSWORD))
         .then(type('#age', 24))

--- a/tests/functional/oauth_preverified_sign_up.js
+++ b/tests/functional/oauth_preverified_sign_up.js
@@ -12,6 +12,8 @@ define([
   var config = intern.config;
   var OAUTH_APP = config.fxaOauthApp;
 
+  var openPage = FunctionalHelpers.openPage;
+
   var PASSWORD = 'password';
   var email;
 
@@ -31,12 +33,11 @@ define([
     },
 
     'preverified sign up': function () {
-      var self = this;
-
       var SIGNUP_URL = OAUTH_APP + 'api/preverified-signup?' +
                         'email=' + encodeURIComponent(email);
 
-      return FunctionalHelpers.openPage(self, SIGNUP_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(SIGNUP_URL, '#fxa-signup-header'))
 
         .findByCssSelector('form input.password')
           .click()

--- a/tests/functional/oauth_query_param_validation.js
+++ b/tests/functional/oauth_query_param_validation.js
@@ -20,25 +20,30 @@ define([
 
 
   var thenify = FunctionalHelpers.thenify;
+
+  var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var getQueryParamValue = FunctionalHelpers.getQueryParamValue;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
   var openFxaFromUntrustedRp = thenify(FunctionalHelpers.openFxaFromUntrustedRp);
   var openPage = FunctionalHelpers.openPage;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
 
-  var openPageWithQueryParams = function (context, queryParams, expectedHeader) {
+  var openPageWithQueryParams = thenify(function (queryParams, expectedHeader) {
     var queryParamsString = '?' + Querystring.stringify(queryParams || {});
 
-    return openPage(context, SIGNUP_ROOT + queryParamsString, expectedHeader);
-  };
+    return this.parent
+      .then(openPage(SIGNUP_ROOT + queryParamsString, expectedHeader));
+  });
 
-  var openSignUpExpect200 = function (context, queryParams) {
-    return openPageWithQueryParams(context, queryParams, '#fxa-signup-header');
-  };
+  var openSignUpExpect200 = thenify(function (queryParams) {
+    return this.parent
+      .then(openPageWithQueryParams(queryParams, '#fxa-signup-header'));
+  });
 
-  var openSignUpExpect400 = function (context, queryParams) {
-    return openPageWithQueryParams(context, queryParams, '#fxa-400-header');
-  };
+  var openSignUpExpect400 = thenify(function (queryParams) {
+    return this.parent
+      .then(openPageWithQueryParams(queryParams, '#fxa-400-header'));
+  });
 
   var testErrorInclude = function (expected) {
     return testElementTextInclude('.error', expected);
@@ -68,280 +73,311 @@ define([
 
     beforeEach: function () {
       return this.remote
-        .then(FunctionalHelpers.clearBrowserState({
+        .then(clearBrowserState({
           contentServer: true
         }));
     },
 
     'invalid access_type': function () {
-      return openSignUpExpect400(this, {
-        access_type: 'invalid',
-        client_id: TRUSTED_CLIENT_ID,
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('access_type'));
+      return this.remote
+        .then(openSignUpExpect400({
+          access_type: 'invalid',
+          client_id: TRUSTED_CLIENT_ID,
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('access_type'));
     },
 
     'valid access_type (offline)': function () {
-      return openSignUpExpect200(this, {
-        access_type: 'offline',
-        client_id: TRUSTED_CLIENT_ID,
-        scope: TRUSTED_SCOPE
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          access_type: 'offline',
+          client_id: TRUSTED_CLIENT_ID,
+          scope: TRUSTED_SCOPE
+        }));
     },
 
     'valid access_type (online)': function () {
-      return openSignUpExpect200(this, {
-        access_type: 'online',
-        client_id: TRUSTED_CLIENT_ID,
-        scope: TRUSTED_SCOPE
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          access_type: 'online',
+          client_id: TRUSTED_CLIENT_ID,
+          scope: TRUSTED_SCOPE
+        }));
     },
 
     'missing client_id': function () {
-      return openSignUpExpect400(this, {
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('missing'))
-      .then(testErrorInclude('client_id'));
+      return this.remote
+        .then(openSignUpExpect400({
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('missing'))
+        .then(testErrorInclude('client_id'));
     },
 
     'empty client_id': function () {
-      return openSignUpExpect400(this, {
-        client_id: '',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('client_id'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: '',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('client_id'));
     },
 
     'space client_id': function () {
-      return openSignUpExpect400(this, {
-        client_id: ' ',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('client_id'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: ' ',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('client_id'));
     },
 
     'invalid client_id': function () {
-      return openSignUpExpect400(this, {
-        client_id: 'invalid_client_id',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('client_id'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: 'invalid_client_id',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('client_id'));
     },
 
     'unknown client_id': function () {
-      return openSignUpExpect400(this, {
-        client_id: 'deadbeef',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('unknown client'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: 'deadbeef',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('unknown client'));
     },
 
     'missing keys': function () {
-      return openSignUpExpect200(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        scope: TRUSTED_SCOPE
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          client_id: TRUSTED_CLIENT_ID,
+          scope: TRUSTED_SCOPE
+        }));
     },
 
     'empty keys': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        keys: '',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('keys'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          keys: '',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('keys'));
     },
 
     'space keys': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        keys: ' ',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('keys'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          keys: ' ',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('keys'));
     },
 
     'invalid keys': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        keys: 'asdf',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('keys'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          keys: 'asdf',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('keys'));
     },
 
     'valid keys (true)': function () {
-      return openSignUpExpect200(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        keys: 'true',
-        scope: TRUSTED_SCOPE
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          client_id: TRUSTED_CLIENT_ID,
+          keys: 'true',
+          scope: TRUSTED_SCOPE
+        }));
     },
 
     'valid keys (false)': function () {
-      return openSignUpExpect200(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        keys: 'false',
-        scope: TRUSTED_SCOPE
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          client_id: TRUSTED_CLIENT_ID,
+          keys: 'false',
+          scope: TRUSTED_SCOPE
+        }));
     },
 
     'empty prompt': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        prompt: '',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('prompt'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          prompt: '',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('prompt'));
     },
 
     'space prompt': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        prompt: ' ',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('prompt'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          prompt: ' ',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('prompt'));
     },
 
     'invalid prompt': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        prompt: 'invalid',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('prompt'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          prompt: 'invalid',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('prompt'));
     },
 
     'valid prompt (consent)': function () {
-      return openSignUpExpect200(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        prompt: 'consent',
-        scope: TRUSTED_SCOPE
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          client_id: TRUSTED_CLIENT_ID,
+          prompt: 'consent',
+          scope: TRUSTED_SCOPE
+        }));
     },
 
     'invalid redirectTo (url)': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        redirectTo: '127.0.0.1',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('redirectTo'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          redirectTo: '127.0.0.1',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('redirectTo'));
     },
 
     'valid redirectTo (url)': function () {
-      return openSignUpExpect200(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        redirectTo: 'http://127.0.0.1',
-        scope: TRUSTED_SCOPE
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          client_id: TRUSTED_CLIENT_ID,
+          redirectTo: 'http://127.0.0.1',
+          scope: TRUSTED_SCOPE
+        }));
     },
 
     'invalid redirect_uri (url)': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        redirect_uri: '127.0.0.1',
-        scope: TRUSTED_SCOPE
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('redirect_uri'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          redirect_uri: '127.0.0.1',
+          scope: TRUSTED_SCOPE
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('redirect_uri'));
     },
 
     'valid redirect_uri (url)': function () {
-      return openSignUpExpect200(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        redirect_uri: 'http://127.0.0.1',
-        scope: TRUSTED_SCOPE
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          client_id: TRUSTED_CLIENT_ID,
+          redirect_uri: 'http://127.0.0.1',
+          scope: TRUSTED_SCOPE
+        }));
     },
 
     'missing scope': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID
-      })
-      .then(testErrorInclude('missing'))
-      .then(testErrorInclude('scope'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID
+        }))
+        .then(testErrorInclude('missing'))
+        .then(testErrorInclude('scope'));
     },
 
     'empty scope': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        scope: ''
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('scope'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          scope: ''
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('scope'));
     },
 
     'space scope': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        scope: ' '
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('scope'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          scope: ' '
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('scope'));
     },
 
     'no valid scopes (untrusted)': function () {
-      return openSignUpExpect400(this, {
-        client_id: UNTRUSTED_CLIENT_ID,
-        scope: UNTRUSTED_NO_VALID_SCOPES
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('scope'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: UNTRUSTED_CLIENT_ID,
+          scope: UNTRUSTED_NO_VALID_SCOPES
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('scope'));
     },
 
     'valid scope (trusted)': function () {
-      return openSignUpExpect200(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        scope: TRUSTED_SCOPE
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          client_id: TRUSTED_CLIENT_ID,
+          scope: TRUSTED_SCOPE
+        }));
     },
 
     'valid scope (untrusted)': function () {
-      return openSignUpExpect200(this, {
-        client_id: UNTRUSTED_CLIENT_ID,
-        scope: UNTRUSTED_SCOPE
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          client_id: UNTRUSTED_CLIENT_ID,
+          scope: UNTRUSTED_SCOPE
+        }));
     },
 
     'invalid verification_redirect': function () {
-      return openSignUpExpect400(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        scope: TRUSTED_SCOPE,
-        verification_redirect: 'invalid'
-      })
-      .then(testErrorInclude('invalid'))
-      .then(testErrorInclude('verification_redirect'));
+      return this.remote
+        .then(openSignUpExpect400({
+          client_id: TRUSTED_CLIENT_ID,
+          scope: TRUSTED_SCOPE,
+          verification_redirect: 'invalid'
+        }))
+        .then(testErrorInclude('invalid'))
+        .then(testErrorInclude('verification_redirect'));
     },
 
     'valid verification_redirect (always)': function () {
-      return openSignUpExpect200(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        scope: TRUSTED_SCOPE,
-        verification_redirect: 'always'
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          client_id: TRUSTED_CLIENT_ID,
+          scope: TRUSTED_SCOPE,
+          verification_redirect: 'always'
+        }));
     },
 
     'valid verification_redirect (no)': function () {
-      return openSignUpExpect200(this, {
-        client_id: TRUSTED_CLIENT_ID,
-        scope: TRUSTED_SCOPE,
-        verification_redirect: 'no'
-      });
+      return this.remote
+        .then(openSignUpExpect200({
+          client_id: TRUSTED_CLIENT_ID,
+          scope: TRUSTED_SCOPE,
+          verification_redirect: 'no'
+        }));
     }
   });
   /*eslint-enable camelcase */

--- a/tests/functional/oauth_settings_clients.js
+++ b/tests/functional/oauth_settings_clients.js
@@ -52,12 +52,14 @@ define([
         .then(testElementExists('#fxa-confirm-header'))
         .then(getVerificationLink(email, 0))
         .then(function (verificationLink) {
-          return openPage(self, verificationLink, '#loggedin');
+          return this.parent
+            .then(openPage(verificationLink, '#loggedin'));
         })
 
         // lists the first client
         .then(function () {
-          return openPage(self, APPS_SETTINGS_URL, '.client-disconnect');
+          return this.parent
+            .then(openPage(APPS_SETTINGS_URL, '.client-disconnect'));
         })
 
         // sign in into another app

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -26,7 +26,7 @@ define([
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testUrlPathnameEquals = FunctionalHelpers.testUrlPathnameEquals;
   var type = FunctionalHelpers.type;
@@ -60,17 +60,17 @@ define([
 
     'with missing client_id': function () {
       return this.remote
-        .then(openPage(this, SIGNIN_ROOT + '?scope=profile', '#fxa-400-header'));
+        .then(openPage(SIGNIN_ROOT + '?scope=profile', '#fxa-400-header'));
     },
 
     'with missing scope': function () {
       return this.remote
-        .then(openPage(this, SIGNIN_ROOT + '?client_id=client_id', '#fxa-400-header'));
+        .then(openPage(SIGNIN_ROOT + '?client_id=client_id', '#fxa-400-header'));
     },
 
     'with invalid client_id': function () {
       return this.remote
-        .then(openPage(this, SIGNIN_ROOT + '?client_id=invalid_client_id&scope=profile', '#fxa-400-header'));
+        .then(openPage(SIGNIN_ROOT + '?client_id=invalid_client_id&scope=profile', '#fxa-400-header'));
     },
 
     'verified': function () {
@@ -124,7 +124,7 @@ define([
         .then(function (verifyUrl) {
           return this.parent
             // user verifies in the same tab, so they are logged in to the RP.
-            .then(openPage(this.parent, verifyUrl, '#loggedin'));
+            .then(openPage(verifyUrl, '#loggedin'));
         });
 
     },
@@ -153,7 +153,7 @@ define([
 
     'oauth endpoint chooses the right auth flows': function () {
       return this.remote
-        .then(openPage(this, OAUTH_APP, '.ready #splash'))
+        .then(openPage(OAUTH_APP, '.ready #splash'))
 
         // use the 'Choose my sign-in flow for me' button
         .then(click('.ready #splash .sign-choose'))

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -149,7 +149,8 @@ define([
 
         .then(getVerificationLink(email, 0))
         .then(function (verificationLink) {
-          return openPage(self, verificationLink, '#loggedin');
+          return this.parent
+            .then(openPage(verificationLink, '#loggedin'));
         });
     },
 
@@ -189,8 +190,8 @@ define([
         .then(getVerificationLink(email, 0))
         .then(function (verificationLink) {
           // new browser dead ends at the 'account verified' screen.
-          return openPage(self, verificationLink,
-            '#fxa-sign-up-complete-header');
+          return this.parent
+            .then(openPage(verificationLink, '#fxa-sign-up-complete-header'));
         })
 
         .findByCssSelector('.account-ready-service')

--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -26,7 +26,7 @@ define([
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextEquals = FunctionalHelpers.testElementTextEquals;
@@ -59,7 +59,7 @@ define([
     'sign in to OAuth with Sync creds': function () {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .execute(listenForFxaCommands)
 
         .then(fillOutSignIn(email, PASSWORD))

--- a/tests/functional/password_visibility.js
+++ b/tests/functional/password_visibility.js
@@ -10,14 +10,12 @@ define([
   var config = intern.config;
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var mousedown = FunctionalHelpers.mousedown;
   var mouseup = FunctionalHelpers.mouseup;
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var noSuchElementDisplayed = FunctionalHelpers.noSuchElementDisplayed;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var testAttributeEquals = FunctionalHelpers.testAttributeEquals;
   var testElementExists = FunctionalHelpers.testElementExists;
   var type = FunctionalHelpers.type;
@@ -32,7 +30,7 @@ define([
 
     'show password ended with mouseup': function () {
       return this.remote
-        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         // show-password button only appears once user types in a character.
         .then(noSuchElement(this, '.show-password-label'))
         .then(type('#password', 'p'))

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -67,16 +67,16 @@ define([
    * Programatically initiate a reset password using the
    * FxA Client. Saves the token and code.
    */
-  function initiateResetPassword(context, emailAddress, emailNumber) {
+  var initiateResetPassword = thenify(function(emailAddress, emailNumber) {
     ensureFxaJSClient();
 
     return client.passwordForgotSendCode(emailAddress)
       .then(function () {
         return setTokenAndCodeFromEmail(emailAddress, emailNumber);
       });
-  }
+  });
 
-  var openCompleteResetPassword = thenify(function (context, email, token, code, header) {
+  var openCompleteResetPassword = thenify(function (email, token, code, header) {
     var url = COMPLETE_PAGE_URL_ROOT + '?';
 
     var queryParams = [];
@@ -93,7 +93,8 @@ define([
     }
 
     url += queryParams.join('&');
-    return openPage(context, url, header);
+    return this.parent
+      .then(openPage(url, header));
   });
 
   function testAtSettingsWithVerifiedMessage(context) {
@@ -116,7 +117,7 @@ define([
   }
 
   registerSuite({
-    name: 'reset password',
+    name: 'reset_password',
 
     beforeEach: function () {
       this.timeout = TIMEOUT;
@@ -131,11 +132,13 @@ define([
       // user is immediately redirected to /reset_password if they have no
       // sessionToken.
       // Success is showing the screen
-      return openPage(this, CONFIRM_PAGE_URL, '#fxa-reset-password-header');
+      return this.remote
+        .then(openPage(CONFIRM_PAGE_URL, '#fxa-reset-password-header'));
     },
 
     'open /reset_password page from /signin': function () {
-      return openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header')
+      return this.remote
+        .then(openPage(SIGNIN_PAGE_URL, '#fxa-signin-header'))
 
         .then(type('input[type=email]', email))
 
@@ -192,80 +195,88 @@ define([
     },
 
     'open complete page with missing token shows damaged screen': function () {
-      return initiateResetPassword(this, email, 0)
+      return this.remote
+        .then(initiateResetPassword(email, 0))
         .then(openCompleteResetPassword(
-          this, email, null, code, '#fxa-reset-link-damaged-header'
+          email, null, code, '#fxa-reset-link-damaged-header'
         ));
     },
 
     'open complete page with malformed token shows damaged screen': function () {
-      var self = this;
-      return initiateResetPassword(this, email, 0)
+      return this.remote
+        .then(initiateResetPassword(email, 0))
         .then(function () {
           var malformedToken = createRandomHexString(token.length - 1);
           return openCompleteResetPassword(
-            self, email, malformedToken, code, '#fxa-reset-link-damaged-header')();
+            email, malformedToken, code, '#fxa-reset-link-damaged-header').call(this);
         });
     },
 
     'open complete page with invalid token shows expired screen': function () {
-      var self = this;
-      return initiateResetPassword(this, email, 0)
+      return this.remote
+        .then(initiateResetPassword(email, 0))
         .then(function () {
           var invalidToken = createRandomHexString(token.length);
           return openCompleteResetPassword(
-            self, email, invalidToken, code, '#fxa-reset-link-expired-header')();
+            email, invalidToken, code, '#fxa-reset-link-expired-header').call(this);
         });
     },
 
     'open complete page with empty token shows damaged screen': function () {
-      return initiateResetPassword(this, email, 0)
+      return this.remote
+        .then(initiateResetPassword(email, 0))
         .then(openCompleteResetPassword(
-          this, email, '', code, '#fxa-reset-link-damaged-header'
+          email, '', code, '#fxa-reset-link-damaged-header'
         ));
     },
 
     'open complete page with missing code shows damaged screen': function () {
-      return initiateResetPassword(this, email, 0)
+      return this.remote
+        .then(initiateResetPassword(email, 0))
         .then(openCompleteResetPassword(
-          this, email, token, null, '#fxa-reset-link-damaged-header'
+          email, token, null, '#fxa-reset-link-damaged-header'
         ));
     },
 
     'open complete page with empty code shows damaged screen': function () {
-      return initiateResetPassword(this, email, 0)
+      return this.remote
+        .then(initiateResetPassword(email, 0))
         .then(openCompleteResetPassword(
-          this, email, token, '', '#fxa-reset-link-damaged-header'
+          email, token, '', '#fxa-reset-link-damaged-header'
         ));
     },
 
     'open complete page with malformed code shows damaged screen': function () {
-      return initiateResetPassword(this, email, 0)
+      return this.remote
+        .then(initiateResetPassword(email, 0))
         .then(function () {
           var malformedCode = createRandomHexString(code.length - 1);
           return openCompleteResetPassword(
-            this, email, token, malformedCode, '#fxa-reset-link-damaged-header');
+            email, token, malformedCode, '#fxa-reset-link-damaged-header').call(this);
         });
     },
 
     'open complete page with missing email shows damaged screen': function () {
-      return initiateResetPassword(this, email, 0)
+      return this.remote
+        .then(initiateResetPassword(email, 0))
         .then(openCompleteResetPassword(
-          this, null, token, code, '#fxa-reset-link-damaged-header'
+          null, token, code, '#fxa-reset-link-damaged-header'
         ));
     },
 
     'open complete page with empty email shows damaged screen': function () {
-      return initiateResetPassword(this, email, 0)
+      return this.remote
+        .then(initiateResetPassword(email, 0))
         .then(openCompleteResetPassword(
-          this, '', token, code, '#fxa-reset-link-damaged-header'
+          '', token, code, '#fxa-reset-link-damaged-header'
         ));
     },
 
     'open complete page with malformed email shows damaged screen': function () {
-      return initiateResetPassword(this, email, 0)
+      return this.remote
+        .then(initiateResetPassword(email, 0))
         .then(openCompleteResetPassword(
-          this, 'invalidemail', token, code, '#fxa-reset-link-damaged-header'
+          'invalidemail', token, code, '#fxa-reset-link-damaged-header'
         ));
     },
 
@@ -344,7 +355,8 @@ define([
           return FunctionalHelpers.getVerificationLink(email, 0);
         })
         .then(function (verificationLink) {
-          return openPage(self, verificationLink, '#fxa-complete-reset-password-header');
+          return this.parent
+            .then(openPage(verificationLink, '#fxa-complete-reset-password-header'));
         })
 
         .then(fillOutCompleteResetPassword(self, PASSWORD, PASSWORD))
@@ -400,7 +412,8 @@ define([
           return FunctionalHelpers.getVerificationLink(email, 0);
         })
         .then(function (verificationLink) {
-          return openPage(self, verificationLink, '#fxa-complete-reset-password-header');
+          return this.parent
+            .then(openPage(verificationLink, '#fxa-complete-reset-password-header'));
         })
 
         .then(fillOutCompleteResetPassword(self, PASSWORD, PASSWORD))
@@ -419,12 +432,9 @@ define([
       this.timeout = TIMEOUT;
       email = TestHelpers.createEmail();
 
-      var self = this;
       return this.remote
           .then(createUser(email, PASSWORD, { preVerified: true }))
-          .then(function () {
-            return initiateResetPassword(self, email, 0);
-          })
+          .then(initiateResetPassword(email, 0))
           .then(clearBrowserState());
     },
 
@@ -434,14 +444,14 @@ define([
       var self = this;
       return this.remote
         .then(openCompleteResetPassword(
-          this, email, token, code, '#fxa-complete-reset-password-header'
+          email, token, code, '#fxa-complete-reset-password-header'
         ))
         .then(fillOutCompleteResetPassword(self, PASSWORD, PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'))
 
         .then(openCompleteResetPassword(
-          this, email, token, code, '#fxa-reset-link-expired-header'
+          email, token, code, '#fxa-reset-link-expired-header'
         ))
 
         .then(click('#resend'))
@@ -463,7 +473,8 @@ define([
 
     'browse directly to page with email on query params': function () {
       var url = RESET_PAGE_URL + '?email=' + email;
-      return openPage(this, url, '#fxa-reset-password-header')
+      return this.remote
+        .then(openPage(url, '#fxa-reset-password-header'))
 
         // email address should not be pre-filled from the query param.
         .then(testElementValueEquals('input[type=email]', ''))

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -23,7 +23,7 @@ define([
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var focus = FunctionalHelpers.focus;
   var getFxaClient = FunctionalHelpers.getFxaClient;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openSettingsInNewTab = thenify(FunctionalHelpers.openSettingsInNewTab);
   var testElementExists = FunctionalHelpers.testElementExists;
   var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
@@ -51,31 +51,36 @@ define([
     },
 
     'with an invalid email': function () {
-      return FunctionalHelpers.openPage(this, SETTINGS_URL + '?email=invalid', '#fxa-400-header')
+      return this.remote
+        .then(openPage(SETTINGS_URL + '?email=invalid', '#fxa-400-header'))
         .then(testErrorTextInclude('invalid'))
         .then(testErrorTextInclude('email'));
     },
 
     'with an empty email': function () {
-      return FunctionalHelpers.openPage(this, SETTINGS_URL + '?email=', '#fxa-400-header')
+      return this.remote
+        .then(openPage(SETTINGS_URL + '?email=', '#fxa-400-header'))
         .then(testErrorTextInclude('invalid'))
         .then(testErrorTextInclude('email'));
     },
 
     'with an invalid uid': function () {
-      return FunctionalHelpers.openPage(this, SETTINGS_URL + '?uid=invalid', '#fxa-400-header')
+      return this.remote
+        .then(openPage(SETTINGS_URL + '?uid=invalid', '#fxa-400-header'))
         .then(testErrorTextInclude('invalid'))
         .then(testErrorTextInclude('uid'));
     },
 
     'with an empty uid': function () {
-      return FunctionalHelpers.openPage(this, SETTINGS_URL + '?uid=', '#fxa-400-header')
+      return this.remote
+        .then(openPage(SETTINGS_URL + '?uid=', '#fxa-400-header'))
         .then(testErrorTextInclude('invalid'))
         .then(testErrorTextInclude('uid'));
     },
 
     'sign in, go to settings, sign out': function () {
-      return FunctionalHelpers.openPage(this, SIGNIN_URL, '#fxa-signin-header')
+      return this.remote
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
 
         .findByCssSelector('#fxa-settings-header')
@@ -92,16 +97,13 @@ define([
     },
 
     'sign in, go to settings with setting param set to avatar redirects to avatar change page ': function () {
-      var self = this;
       return this.remote
         .then(fillOutSignIn(email, FIRST_PASSWORD, true))
 
         .findById('fxa-settings-header')
         .end()
 
-        .then(function () {
-          return FunctionalHelpers.openPage(self, SETTINGS_URL + '?setting=avatar', '#avatar-options');
-        })
+        .then(openPage(SETTINGS_URL + '?setting=avatar', '#avatar-options'))
 
         .findByCssSelector('.modal-panel button.cancel')
           .click()
@@ -113,16 +115,13 @@ define([
     },
 
     'sign in, go to settings with setting param and additional params redirects to avatar change page ': function () {
-      var self = this;
       return this.remote
         .then(fillOutSignIn(email, FIRST_PASSWORD, true))
 
         .findById('fxa-settings-header')
         .end()
 
-        .then(function () {
-          return FunctionalHelpers.openPage(self, SETTINGS_URL + '?setting=avatar&uid=' + accountData.uid, '#avatar-options');
-        })
+        .then(openPage(SETTINGS_URL + '?setting=avatar&uid=' + accountData.uid, '#avatar-options'))
 
         .findByCssSelector('.modal-panel button.cancel')
           .click()
@@ -134,16 +133,16 @@ define([
     },
 
     'sign in with setting param set to avatar redirects to avatar change page ': function () {
-      var self = this;
-      return FunctionalHelpers.openPage(self, SIGNIN_URL + '?setting=avatar', '#fxa-signin-header')
+      return this.remote
+        .then(openPage(SIGNIN_URL + '?setting=avatar', '#fxa-signin-header'))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .findById('avatar-options')
         .end();
     },
 
     'sign in with setting param and additional params redirects to avatar change page ': function () {
-      var self = this;
-      return FunctionalHelpers.openPage(self, SIGNIN_URL + '?setting=avatar&uid=' + accountData.uid, '#fxa-signin-header')
+      return this.remote
+        .then(openPage(SIGNIN_URL + '?setting=avatar&uid=' + accountData.uid, '#fxa-signin-header'))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .findById('avatar-options')
         .end();
@@ -204,7 +203,7 @@ define([
     'visit settings page with an unverified account redirects to confirm': function () {
       return this.remote
         // Expect to get redirected to confirm since the account is unverified
-        .then(openPage(this, SETTINGS_URL, '#fxa-confirm-header'));
+        .then(openPage(SETTINGS_URL, '#fxa-confirm-header'));
     }
   });
 

--- a/tests/functional/settings_clients.js
+++ b/tests/functional/settings_clients.js
@@ -23,14 +23,12 @@ define([
   var client;
   var accountData;
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var pollUntil = FunctionalHelpers.pollUntil;
   var pollUntilGoneByQSA = FunctionalHelpers.pollUntilGoneByQSA;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -56,7 +54,7 @@ define([
 
     'device panel is not visible without query param': function () {
       return this.remote
-        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'))
@@ -68,7 +66,7 @@ define([
       var testDeviceId;
 
       return this.remote
-        .then(openPage(this, SIGNIN_URL_DEVICE_LIST, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL_DEVICE_LIST, '#fxa-signin-header'))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'))

--- a/tests/functional/settings_common.js
+++ b/tests/functional/settings_common.js
@@ -22,12 +22,10 @@ define([
   var client;
   var accountData;
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var testElementExists = FunctionalHelpers.testElementExists;
 
   var SETTINGS_PAGES = {
@@ -65,7 +63,7 @@ define([
         .then(testElementExists('#fxa-confirm-header'))
 
         // Expect to get redirected to confirm since the account is unverified
-        .then(openPage(this, url, '#fxa-confirm-header'));
+        .then(openPage(url, '#fxa-confirm-header'));
     };
   }
 
@@ -99,29 +97,29 @@ define([
         })
         // Expect to get redirected to sign in since the
         // sessionToken is invalid
-        .then(openPage(this, url, '#fxa-signin-header'));
+        .then(openPage(url, '#fxa-signin-header'));
     };
 
     suite['visit settings' + page + ' with an unknown uid parameter redirects to signin'] = function () {
       return this.remote
-        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'))
 
         // Expect to get redirected to sign in since the uid is unknown
-        .then(openPage(this, url + '?uid=' + TestHelpers.createUID(), '#fxa-signin-header'));
+        .then(openPage(url + '?uid=' + TestHelpers.createUID(), '#fxa-signin-header'));
     };
 
     suite['visit settings' + page + ' with a known uid does not redirect'] = function () {
       return this.remote
-        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'))
 
         // Expect to get redirected to sign in since the uid is unknown
-        .then(openPage(this, url + '?uid=' + accountData.uid + AUTOMATED, '#' + pageHeader));
+        .then(openPage(url + '?uid=' + accountData.uid + AUTOMATED, '#' + pageHeader));
     };
   }
 

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -21,7 +21,7 @@ define([
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openSignInInNewTab = thenify(FunctionalHelpers.openSignInInNewTab);
   var openSignUpInNewTab = thenify(FunctionalHelpers.openSignUpInNewTab);
   var testAttributeMatches = FunctionalHelpers.testAttributeMatches;
@@ -47,7 +47,7 @@ define([
 
     'with an invalid email': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL + '?email=invalid', '#fxa-400-header'))
+        .then(openPage(PAGE_URL + '?email=invalid', '#fxa-400-header'))
         .then(testErrorTextInclude('invalid'))
         .then(testErrorTextInclude('email'));
     },
@@ -55,7 +55,7 @@ define([
     'sign in unverified': function () {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: false }))
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testElementTextInclude('.verification-email-message', email));
     },
@@ -63,7 +63,7 @@ define([
     'redirect to requested page after sign in verified with correct password': function () {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(openPage(this, AVATAR_URL, '#fxa-signin-header'))
+        .then(openPage(AVATAR_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testElementExists('#avatar-change'));
     },
@@ -149,7 +149,7 @@ define([
       var windowName = 'sign-in inter-tab functional test';
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(openSignInInNewTab(this, windowName))
         .switchToWindow(windowName)
 
@@ -183,7 +183,7 @@ define([
 
     'data-flow-begin attribute is set': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(testAttributeMatches('body', 'data-flow-begin', /^[1-9][0-9]{12,}$/));
     }
   });
@@ -193,7 +193,7 @@ define([
     var password = '12345678';
 
     return this.remote
-      .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+      .then(openPage(PAGE_URL, '#fxa-signin-header'))
       .then(type('input[type=email]', email))
       .then(type('input[type=password]', password))
 

--- a/tests/functional/sign_in_blocked.js
+++ b/tests/functional/sign_in_blocked.js
@@ -13,8 +13,6 @@ define([
   var PASSWORD = 'password';
   var email;
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
@@ -22,7 +20,7 @@ define([
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
   var getUnblockInfo = FunctionalHelpers.getUnblockInfo;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openTab = FunctionalHelpers.openTab;
   var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
@@ -49,7 +47,7 @@ define([
 
     'valid code entered': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -61,7 +59,7 @@ define([
 
     'valid code with whitespace at the beginning entered': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -78,7 +76,7 @@ define([
 
     'valid code with whitespace at the end entered': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -95,7 +93,7 @@ define([
 
     'invalid code entered': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -109,7 +107,7 @@ define([
 
     'incorrect code entered': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -130,7 +128,7 @@ define([
 
     'incorrect password entered': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, 'incorrect'))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -157,7 +155,7 @@ define([
 
     'resend': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -173,7 +171,7 @@ define([
     'report signin success': function () {
       var unblockCode;
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -205,7 +203,7 @@ define([
     'report signin link unblockCode broken': function () {
       var unblockCode;
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -234,7 +232,7 @@ define([
     'report signin link uid broken': function () {
       var unblockCode;
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -263,7 +261,7 @@ define([
     'report link opened after code used': function () {
       var reportSignInLink;
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
@@ -279,7 +277,7 @@ define([
 
         .then(function () {
           return this.parent
-            .then(openPage(this, reportSignInLink, '#fxa-report-sign-in-header'));
+            .then(openPage(reportSignInLink, '#fxa-report-sign-in-header'));
         })
         // report link is expired and can no longer be used.
         .then(click('button[type=submit]'))
@@ -292,7 +290,7 @@ define([
 
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: false }))
-        .then(openPage(this, PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-signin-unblock-header'))

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -34,7 +34,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -58,14 +58,14 @@ define([
 
     'sign in twice, on second attempt email will be cached': function () {
       return this.remote
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'))
         // reset prefill and context
         .then(clearSessionStorage(this))
 
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         .then(type('input[type=password]', PASSWORD))
         .then(click('button[type="submit"]'))
 
@@ -74,7 +74,7 @@ define([
 
     'sign in first in sync context, on second attempt credentials will be cached': function () {
       return this.remote
-        .then(openPage(this, PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
 
@@ -82,7 +82,7 @@ define([
         .then(testElementExists('#fxa-confirm-signin-header'))
         .then(openVerificationLinkDifferentBrowser(email))
 
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
 
         .then(click('.use-logged-in'))
         .then(testElementExists('#fxa-settings-header'));
@@ -90,12 +90,12 @@ define([
 
     'sign in once, use a different account': function () {
       return this.remote
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'))
 
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         // testing to make sure "Use different account" button works
         .then(click('.use-different'))
 
@@ -107,18 +107,18 @@ define([
         .then(testElementExists('#fxa-settings-header'))
 
         // testing to make sure cached signin comes back after a refresh
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
 
         .then(click('.use-different'))
         .then(testElementExists('input[type=email]'))
 
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         .then(testElementValueEquals('input[type=email]', ''));
     },
 
     'sign in with cached credentials but with an expired session': function () {
       return this.remote
-        .then(openPage(this, PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
@@ -131,7 +131,7 @@ define([
           return true;
         })
 
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         .then(click('.use-logged-in'))
 
         // Session expired error should show.
@@ -146,7 +146,7 @@ define([
     'unverified cached signin with sync context redirects to confirm email': function () {
       var email = TestHelpers.createEmail();
       return this.remote
-        .then(openPage(this, PAGE_SIGNUP_DESKTOP, '#fxa-signup-header'))
+        .then(openPage(PAGE_SIGNUP_DESKTOP, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 
@@ -157,7 +157,7 @@ define([
         // reset prefill and context
         .then(clearSessionStorage(this))
 
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         // cached login should still go to email confirmation screen for unverified accounts
         .then(click('.use-logged-in'))
 
@@ -168,12 +168,12 @@ define([
       var email = TestHelpers.createEmail();
 
       return this.remote
-        .then(openPage(this, PAGE_SIGNUP, '#fxa-signup-header'))
+        .then(openPage(PAGE_SIGNUP, '#fxa-signup-header'))
         .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#fxa-confirm-header'))
 
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         .then(type('input[type=password]', PASSWORD))
         .then(click('button[type="submit"]'))
 
@@ -183,13 +183,13 @@ define([
 
     'sign in on desktop then sign in with prefill does not show picker': function () {
       return this.remote
-        .then(openPage(this, PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
         .then(testElementExists('#fxa-confirm-signin-header'))
 
-        .then(openPage(this, PAGE_SIGNIN + '?email=' + email2, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN + '?email=' + email2, '#fxa-signin-header'))
         /*.then(testElementValueEquals('input.email.prefilled', email2))*/
         .then(type('input[type=password]', PASSWORD))
         .then(click('button[type="submit"]'))
@@ -200,7 +200,7 @@ define([
         .then(clearSessionStorage(this))
 
         // testing to make sure cached signin comes back after a refresh
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         .then(testElementTextEquals('.prefillEmail', email))
         .then(click('.use-different'))
 
@@ -209,7 +209,7 @@ define([
 
     'sign in with desktop context then no context, desktop credentials should not persist': function () {
       return this.remote
-        .then(openPage(this, PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
@@ -217,7 +217,7 @@ define([
 
         // ensure signin page is visible otherwise credentials might
         // not be cleared by clicking .use-different
-        .then(openPage(this, PAGE_SIGNIN, '.use-different'))
+        .then(openPage(PAGE_SIGNIN, '.use-different'))
         .then(visibleByQSA('#fxa-signin-header'))
         // This will clear the desktop credentials
         .then(click('.use-different'))
@@ -232,7 +232,7 @@ define([
         .then(clearSessionStorage(this))
 
         // testing to make sure cached signin comes back after a refresh
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         .then(testElementTextEquals('.prefillEmail', email2))
 
         .refresh()
@@ -243,14 +243,14 @@ define([
 
     'overrule cached credentials': function () {
       return this.remote
-        .then(openPage(this, PAGE_SIGNIN, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'))
         // reset prefill and context
         .then(clearSessionStorage(this))
 
-        .then(openPage(this, PAGE_SIGNIN_NO_CACHED_CREDS, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN_NO_CACHED_CREDS, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'));

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -66,19 +66,22 @@ define([
     },
 
     'with an invalid email': function () {
-      return FunctionalHelpers.openPage(this, PAGE_URL + '?email=invalid', '#fxa-400-header')
+      return this.remote
+        .then(openPage(PAGE_URL + '?email=invalid', '#fxa-400-header'))
         .then(testErrorTextInclude('invalid'))
         .then(testErrorTextInclude('email'));
     },
 
     'with an empty email': function () {
-      return FunctionalHelpers.openPage(this, PAGE_URL + '?email=', '#fxa-400-header')
+      return this.remote
+        .then(openPage(PAGE_URL + '?email=', '#fxa-400-header'))
         .then(testErrorTextInclude('invalid'))
         .then(testErrorTextInclude('email'));
     },
 
     'signup, verify same browser': function () {
-      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .then(visibleByQSA('#suggest-sync'))
         .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
@@ -456,12 +459,14 @@ define([
     },
 
     'data-flow-begin attribute is set': function () {
-      return openPage(this, PAGE_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .then(testAttributeMatches('body', 'data-flow-begin', /^[1-9][0-9]{12,}$/));
     },
 
     'integrity attribute is set on scripts and css': function () {
-      return openPage(this, PAGE_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .then(testAttributeMatches('script', 'integrity', /^sha512-/))
         .then(testAttributeMatches('link', 'integrity', /^sha512-/))
         .catch(function (err) {
@@ -474,7 +479,8 @@ define([
   });
 
   function testRepopulateFields(dest, header) {
-    return openPage(this, PAGE_URL, '#fxa-signup-header')
+    return this.remote
+      .then(openPage(PAGE_URL, '#fxa-signup-header'))
 
       .then(fillOutSignUp(email, PASSWORD, { submit: false }))
 

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -30,7 +30,7 @@ define([
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var openExternalSite = FunctionalHelpers.openExternalSite;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openPasswordResetLinkDifferentBrowser = thenify(FunctionalHelpers.openPasswordResetLinkDifferentBrowser);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -58,7 +58,7 @@ define([
     'reset password, verify same browser': function () {
       // verify account
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-reset-password-header'))
+        .then(openPage(PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
         .then(fillOutResetPassword(email))
 
@@ -80,7 +80,7 @@ define([
 
     'reset password, verify same browser with original tab closed': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-reset-password-header'))
+        .then(openPage(PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
         .then(fillOutResetPassword(email))
 
@@ -100,7 +100,7 @@ define([
     'reset password, verify same browser by replacing the original tab': function () {
       var self = this;
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-reset-password-header'))
+        .then(openPage(PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
         .then(fillOutResetPassword(email))
 
@@ -118,7 +118,7 @@ define([
     'reset password, verify different browser - from original tab\'s P.O.V.': function () {
       // verify account
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-reset-password-header'))
+        .then(openPage(PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
         .then(fillOutResetPassword(email))
         .then(testElementExists('#fxa-confirm-reset-password-header'))
@@ -145,7 +145,7 @@ define([
 
       // verify account
       return this.remote
-        .then(openPage(this, PAGE_URL, '#fxa-reset-password-header'))
+        .then(openPage(PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
         .then(fillOutResetPassword(email))
         .then(testElementExists('#fxa-confirm-reset-password-header'))

--- a/tests/functional/sync_settings.js
+++ b/tests/functional/sync_settings.js
@@ -20,7 +20,7 @@ define([
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
@@ -40,7 +40,7 @@ define([
     return this.parent
       .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
       .then(clearBrowserState())
-      .then(openPage(this.parent, SIGNIN_URL, '#fxa-signin-header'))
+      .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
       .execute(listenForFxaCommands)
       .then(fillOutSignIn(email, FIRST_PASSWORD))
       .then(testIsBrowserNotifiedOfLogin(this.parent, email, { checkVerified: false }))
@@ -50,7 +50,7 @@ define([
           return this.parent
             .then(openVerificationLinkDifferentBrowser(email))
 
-            .then(openPage(this.parent, SETTINGS_URL, '#fxa-settings-header'))
+            .then(openPage(SETTINGS_URL, '#fxa-settings-header'))
             .execute(listenForFxaCommands);
         }
       });
@@ -96,7 +96,7 @@ define([
       return this.remote
         .then(setupTest(false))
         // the user did not confirm signin and must do so
-        .then(openPage(this, SETTINGS_URL, '#fxa-confirm-signin-header'));
+        .then(openPage(SETTINGS_URL, '#fxa-confirm-signin-header'));
     }
   });
 });

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -28,7 +28,7 @@ define([
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -45,7 +45,7 @@ define([
 
     return this.parent
       .then(createUser(email, PASSWORD, { preVerified: !! options.preVerified }))
-      .then(openPage(this.parent, options.pageUrl || PAGE_URL, '#fxa-signin-header'))
+      .then(openPage(options.pageUrl || PAGE_URL, '#fxa-signin-header'))
       .execute(listenForFxaCommands)
       .then(fillOutSignIn(email, PASSWORD))
       .then(testIsBrowserNotified(this.parent, 'can_link_account'))
@@ -111,7 +111,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(openPage(this, ROOT_URL, '#fxa-confirm-signin-header'));
+        .then(openPage(ROOT_URL, '#fxa-confirm-signin-header'));
     },
 
     'unverified': function () {
@@ -123,12 +123,12 @@ define([
       return this.remote
         .then(setupTest({ preVerified: false }))
 
-        .then(openPage(this, ROOT_URL, '#fxa-confirm-header'));
+        .then(openPage(ROOT_URL, '#fxa-confirm-header'));
     },
 
     'as a migrating user': function () {
       return this.remote
-        .then(openPage(this, PAGE_URL_WITH_MIGRATION, '#fxa-signin-header'))
+        .then(openPage(PAGE_URL_WITH_MIGRATION, '#fxa-signin-header'))
         .then(visibleByQSA('.info.nudge'));
     },
 

--- a/tests/functional/sync_v2_reset_password.js
+++ b/tests/functional/sync_v2_reset_password.js
@@ -25,7 +25,7 @@ define([
   var fillOutResetPassword = FunctionalHelpers.fillOutResetPassword;
   var fillOutCompleteResetPassword = thenify(FunctionalHelpers.fillOutCompleteResetPassword);
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
@@ -50,7 +50,7 @@ define([
 
     'reset password, verify same browser': function () {
       return this.remote
-        .then(openPage(this, RESET_PASSWORD_URL, '#fxa-reset-password-header'))
+        .then(openPage(RESET_PASSWORD_URL, '#fxa-reset-password-header'))
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(fillOutResetPassword(email))
 
@@ -81,7 +81,7 @@ define([
       this.timeout = 90000;
 
       return this.remote
-        .then(openPage(this, RESET_PASSWORD_URL, '#fxa-reset-password-header'))
+        .then(openPage(RESET_PASSWORD_URL, '#fxa-reset-password-header'))
         .then(createUser(email, PASSWORD, { preVerified: true } ))
         .then(fillOutResetPassword(email))
 

--- a/tests/functional/sync_v2_settings.js
+++ b/tests/functional/sync_v2_settings.js
@@ -15,7 +15,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = thenify(FunctionalHelpers.fillOutChangePassword);
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -41,7 +41,7 @@ define([
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
-        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
@@ -56,7 +56,7 @@ define([
           return accounts.length === 1 ? true : null;
         }, [], 10000))
 
-        .then(openPage(this, SETTINGS_URL, '#fxa-settings-header'));
+        .then(openPage(SETTINGS_URL, '#fxa-settings-header'));
     },
 
     'sign in, change the password': function () {
@@ -70,7 +70,7 @@ define([
 
     'sign in, change the password by browsing directly to settings': function () {
       return this.remote
-        .then(openPage(this, SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
+        .then(openPage(SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 

--- a/tests/functional/sync_v2_sign_in.js
+++ b/tests/functional/sync_v2_sign_in.js
@@ -22,7 +22,7 @@ define([
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
   var noPageTransition = FunctionalHelpers.noPageTransition;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
@@ -39,7 +39,7 @@ define([
     return this.parent
       .then(clearBrowserState({ force: true }))
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
-      .then(openPage(this.parent, PAGE_URL, '#fxa-signin-header'))
+      .then(openPage(PAGE_URL, '#fxa-signin-header'))
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(email, PASSWORD))
 

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -22,6 +22,7 @@ define([
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noPageTransition = FunctionalHelpers.noPageTransition;
+  var openPage = FunctionalHelpers.openPage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testAttributeExists = FunctionalHelpers.testAttributeExists;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
@@ -54,7 +55,8 @@ define([
     'signup, verify same browser': function () {
       var self = this;
 
-      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 

--- a/tests/functional/sync_v3_settings.js
+++ b/tests/functional/sync_v3_settings.js
@@ -18,7 +18,7 @@ define([
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -44,7 +44,7 @@ define([
       return this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
-        .then(openPage(this, SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
@@ -59,7 +59,7 @@ define([
           return accounts.length === 1 ? true : null;
         }, [], 10000))
 
-        .then(openPage(this, SETTINGS_URL, '#fxa-settings-header'));
+        .then(openPage(SETTINGS_URL, '#fxa-settings-header'));
     },
 
     'sign in, change the password': function () {
@@ -73,7 +73,7 @@ define([
 
     'sign in, change the password by browsing directly to settings': function () {
       return this.remote
-        .then(openPage(this, SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
+        .then(openPage(SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
         .then(noSuchBrowserNotification(this, 'fxaccounts:change_password'))

--- a/tests/functional/sync_v3_sign_in.js
+++ b/tests/functional/sync_v3_sign_in.js
@@ -24,7 +24,7 @@ define([
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
   var noEmailExpected = FunctionalHelpers.noEmailExpected;
   var noPageTransition = FunctionalHelpers.noPageTransition;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
@@ -43,7 +43,7 @@ define([
     return this.parent
       .then(clearBrowserState({ force: true }))
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
-      .then(openPage(this.parent, PAGE_URL, '#fxa-signin-header'))
+      .then(openPage(PAGE_URL, '#fxa-signin-header'))
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(email, PASSWORD))
 

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -22,6 +22,7 @@ define([
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noPageTransition = FunctionalHelpers.noPageTransition;
+  var openPage = FunctionalHelpers.openPage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
 
@@ -53,7 +54,8 @@ define([
     'sign up, verify same browser': function () {
       var self = this;
 
-      return FunctionalHelpers.openPage(this, PAGE_URL, '#fxa-signup-header')
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
         .then(FunctionalHelpers.noSuchElement(this, '#suggest-sync'))
         .then(fillOutSignUp(email, PASSWORD))

--- a/tests/functional/upgrade_storage_formats.js
+++ b/tests/functional/upgrade_storage_formats.js
@@ -11,11 +11,9 @@ define([
   var config = intern.config;
   var SIGNIN_PAGE_URL = config.fxaContentRoot + 'signin';
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var openPage = FunctionalHelpers.openPage;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
 
   var email;
@@ -44,7 +42,7 @@ define([
           localStorage.setItem(namespace, JSON.stringify(userData));
 
         }, [ email ])
-        .then(openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_PAGE_URL, '#fxa-signin-header'))
 
         // sessionToken was invalid, email should be cleared
         .then(testElementValueEquals('input[type=email]', ''));
@@ -65,7 +63,7 @@ define([
           }, [email, accountInfo.sessionToken]);
         })
 
-        .then(openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_PAGE_URL, '#fxa-signin-header'))
 
         // sessionToken was valid, email should be pre-filled
         .then(testElementValueEquals('input[type=email]', email));
@@ -90,7 +88,7 @@ define([
             localStorage.setItem('__fxa_session', JSON.stringify(userData));
           }, [ email, accountInfo.sessionToken ]);
         })
-        .then(openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_PAGE_URL, '#fxa-signin-header'))
 
         // Sync creds take precedence
         .then(testElementValueEquals('input[type=email]', email));
@@ -156,7 +154,7 @@ define([
 
         }, [ email ])
         // success is not going to the 500 page.
-        .then(openPage(this, SIGNIN_PAGE_URL, '#fxa-signin-header'));
+        .then(openPage(SIGNIN_PAGE_URL, '#fxa-signin-header'));
     }
   });
 });

--- a/tests/functional/verification_experiments.js
+++ b/tests/functional/verification_experiments.js
@@ -11,11 +11,10 @@ define([
   var EXP_CONTROL = '&forceExperimentGroup=control';
   var EXP_TREATMENT = '&forceExperimentGroup=treatment';
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
-  var openPage = thenify(FunctionalHelpers.openPage);
+  var noSuchElement = FunctionalHelpers.noSuchElement;
+  var openPage = FunctionalHelpers.openPage;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   var type = FunctionalHelpers.type;
 
@@ -35,7 +34,7 @@ define([
       var CORRECTED_EMAIL = 'something@gmail.com';
 
       return this.remote
-        .then(openPage(this, EXP_MAILCHECK_URL + EXP_TREATMENT, '#fxa-signup-header'))
+        .then(openPage(EXP_MAILCHECK_URL + EXP_TREATMENT, '#fxa-signup-header'))
         .then(type('.email', BAD_EMAIL))
         .then(click('.password'))
         .then(click('.tooltip-suggest > span:nth-child(1)'))
@@ -47,11 +46,10 @@ define([
       var BAD_EMAIL = 'something@gnail.com';
 
       return this.remote
-        .then(openPage(this, EXP_MAILCHECK_URL + EXP_CONTROL, '#fxa-signup-header'))
-
+        .then(openPage(EXP_MAILCHECK_URL + EXP_CONTROL, '#fxa-signup-header'))
         .then(type('.email', BAD_EMAIL))
         .then(click('.password'))
-        .then(FunctionalHelpers.noSuchElement(this, '.tooltip-suggest'));
+        .then(noSuchElement(this, '.tooltip-suggest'));
     }
   });
 });


### PR DESCRIPTION
The last of the Toronto flight test refactors. This time for FunctionalHelpers.openPage - it no longer takes a context.

@mozilla/fxa-devs - r?