### PR TITLE
fix(metrics): separate the begin and view flow events

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -473,12 +473,12 @@ define(function (require, exports, module) {
       return this._isSampledUser;
     },
 
-    logFlowBegin (flowId, flowBeginTime, viewName) {
+    logFlowBegin (flowId, flowBeginTime) {
       // Don't emit a new flow.begin event unless flowId has changed.
       if (flowId !== this._flowId) {
         this._flowId = flowId;
         this._flowBeginTime = flowBeginTime;
-        this.logFlowEvent('begin', viewName);
+        this.logFlowEvent('begin');
       }
     },
 

--- a/app/scripts/views/app.js
+++ b/app/scripts/views/app.js
@@ -92,12 +92,6 @@ define(function (require, exports, module) {
         var viewToShow = this._createView(View, options);
         this._currentView = viewToShow;
 
-        // logView is done outside of the view itself because the settings
-        // page renders many child views at once. If the view took care of
-        // logging itself, each child view would be logged at the same time.
-        // We only want to log the screen being displayed, child views will
-        // be logged when they are opened.
-        viewToShow.logView();
         return viewToShow.render()
           .then((isShown) => {
             // render will return false if the view could not be
@@ -121,6 +115,13 @@ define(function (require, exports, module) {
             this.setTitle(viewToShow.titleFromView());
 
             this.writeToDOM(viewToShow.el);
+
+            // logView is done outside of the view itself because the settings
+            // page renders many child views at once. If the view took care of
+            // logging itself, each child view would be logged at the same time.
+            // We only want to log the screen being displayed, child views will
+            // be logged when they are opened.
+            viewToShow.logView();
 
             viewToShow.afterVisible();
 

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -469,6 +469,9 @@ define(function (require, exports, module) {
       }
 
       this.focusAutofocusElement();
+
+      this.logFlowEvent('view', this.viewName);
+
       return p();
     },
 

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -469,9 +469,6 @@ define(function (require, exports, module) {
       }
 
       this.focusAutofocusElement();
-
-      this.logFlowEvent('view', this.viewName);
-
       return p();
     },
 

--- a/app/scripts/views/mixins/flow-begin-mixin.js
+++ b/app/scripts/views/mixins/flow-begin-mixin.js
@@ -13,7 +13,7 @@ define(function (require, exports, module) {
       const flowId = this.flow.get('flowId');
       const flowBegin = this.flow.get('flowBegin');
 
-      this.metrics.logFlowBegin(flowId, flowBegin, this.viewName);
+      this.metrics.logFlowBegin(flowId, flowBegin);
     }
   };
 });

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -175,7 +175,7 @@ define(function (require, exports, module) {
       describe('log events', function () {
         beforeEach(function () {
           metrics.logEvent('foo');
-          metrics.logFlowBegin('bar', 'baz', 'wibble');
+          metrics.logFlowBegin('bar', 'baz');
           metrics.logEvent('qux');
         });
 
@@ -216,7 +216,7 @@ define(function (require, exports, module) {
               assert.isArray(data.events);
               assert.lengthOf(data.events, 3);
               assert.equal(data.events[0].type, 'foo');
-              assert.equal(data.events[1].type, 'flow.wibble.begin');
+              assert.equal(data.events[1].type, 'flow.begin');
               assert.equal(data.events[2].type, 'qux');
               assert.equal(data.flowId, 'bar');
               assert.equal(data.flowBeginTime, 'baz');
@@ -250,7 +250,7 @@ define(function (require, exports, module) {
 
             describe('log a second flow.begin event with same flowId', function () {
               beforeEach(function () {
-                metrics.logFlowBegin('bar', 'blee', 'hong');
+                metrics.logFlowBegin('bar', 'blee');
                 metrics.logEvent('wibble');
                 return metrics.flush();
               });
@@ -335,7 +335,7 @@ define(function (require, exports, module) {
               assert.isArray(data.events);
               assert.lengthOf(data.events, 4);
               assert.equal(data.events[0].type, 'foo');
-              assert.equal(data.events[1].type, 'flow.wibble.begin');
+              assert.equal(data.events[1].type, 'flow.begin');
               assert.equal(data.events[2].type, 'qux');
               assert.equal(data.events[3].type, 'baz');
             });
@@ -407,7 +407,7 @@ define(function (require, exports, module) {
             assert.lengthOf(Object.keys(data), 25);
             assert.lengthOf(data.events, 4);
             assert.equal(data.events[0].type, 'foo');
-            assert.equal(data.events[1].type, 'flow.wibble.begin');
+            assert.equal(data.events[1].type, 'flow.begin');
             assert.equal(data.events[2].type, 'qux');
             assert.equal(data.events[3].type, 'wibble');
           });
@@ -431,7 +431,7 @@ define(function (require, exports, module) {
             assert.lengthOf(Object.keys(data), 25);
             assert.lengthOf(data.events, 4);
             assert.equal(data.events[0].type, 'foo');
-            assert.equal(data.events[1].type, 'flow.wibble.begin');
+            assert.equal(data.events[1].type, 'flow.begin');
             assert.equal(data.events[2].type, 'qux');
             assert.equal(data.events[3].type, 'blee');
           });

--- a/app/tests/spec/views/app.js
+++ b/app/tests/spec/views/app.js
@@ -157,8 +157,8 @@ define(function (require, exports, module) {
           assert.isNull(displayedView);
         });
 
-        it('logs the view', function () {
-          assert.isTrue(isLogged);
+        it('does not log the view', function () {
+          assert.isFalse(isLogged);
         });
 
         it('destroys the view', function () {

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -568,8 +568,9 @@ define(function (require, exports, module) {
           });
       });
 
-      it('logs the begin event', () => {
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.force-auth.begin'));
+      it('logs the begin and view events', () => {
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.begin'));
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.force-auth.view'));
       });
 
       it('logs the engage event (click)', () => {

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -568,9 +568,8 @@ define(function (require, exports, module) {
           });
       });
 
-      it('logs the begin and view events', () => {
+      it('logs the begin event', () => {
         assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.begin'));
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.force-auth.view'));
       });
 
       it('logs the engage event (click)', () => {

--- a/app/tests/spec/views/mixins/flow-begin-mixin.js
+++ b/app/tests/spec/views/mixins/flow-begin-mixin.js
@@ -31,10 +31,9 @@ define((require, exports, module) => {
       it('called metrics.logFlowBegin correctly', () => {
         assert.strictEqual(flowBeginMixin.metrics.logFlowBegin.callCount, 1);
         const args = flowBeginMixin.metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 3);
+        assert.lengthOf(args, 2);
         assert.strictEqual(args[0], 'mock flowId');
         assert.strictEqual(args[1], 'mock flowBegin');
-        assert.strictEqual(args[2], 'wibble');
       });
     });
   });

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -773,9 +773,8 @@ define(function (require, exports, module) {
         view.afterVisible();
       });
 
-      it('logs the begin and view events', () => {
+      it('logs the begin event', () => {
         assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.begin'));
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signin.view'));
       });
 
       it('logs the engage event (click)', () => {

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -762,10 +762,9 @@ define(function (require, exports, module) {
       it('called metrics.logFlowBegin correctly', function () {
         assert.equal(metrics.logFlowBegin.callCount, 1);
         var args = metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 3);
+        assert.lengthOf(args, 2);
         assert.equal(args[0], FLOW_ID);
         assert.equal(args[1], -1);
-        assert.equal(args[2], 'signin');
       });
     });
 
@@ -774,8 +773,9 @@ define(function (require, exports, module) {
         view.afterVisible();
       });
 
-      it('logs the begin event', () => {
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signin.begin'));
+      it('logs the begin and view events', () => {
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.begin'));
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signin.view'));
       });
 
       it('logs the engage event (click)', () => {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -393,10 +393,9 @@ define(function (require, exports, module) {
       it('called metrics.logFlowBegin correctly', function () {
         assert.equal(metrics.logFlowBegin.callCount, 1);
         var args = metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 3);
+        assert.lengthOf(args, 2);
         assert.equal(args[0], FLOW_ID);
         assert.equal(args[1], 3);
-        assert.equal(args[2], 'signup');
       });
     });
 
@@ -1366,8 +1365,9 @@ define(function (require, exports, module) {
         view.afterVisible();
       });
 
-      it('logs the begin event', () => {
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signup.begin'));
+      it('logs the begin and view events', () => {
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.begin'));
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signup.view'));
       });
 
       it('logs the engage event (click)', () => {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -1365,9 +1365,8 @@ define(function (require, exports, module) {
         view.afterVisible();
       });
 
-      it('logs the begin and view events', () => {
+      it('logs the begin event', () => {
         assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.begin'));
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signup.view'));
       });
 
       it('logs the engage event (click)', () => {

--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -24,7 +24,7 @@ const HOSTNAME = os.hostname();
 const MAX_DATA_LENGTH = 100;
 const VERSION = 1;
 
-const FLOW_BEGIN_EVENT_TYPES = /^flow\.[a-z_-]+\.begin$/;
+const FLOW_BEGIN_EVENT = 'flow.begin';
 const FLOW_ID_KEY = config.get('flow_id_key');
 const FLOW_ID_EXPIRY = config.get('flow_id_expiry');
 
@@ -53,7 +53,7 @@ module.exports = (req, metrics, requestReceivedTime) => {
   });
 
   flowEvents.forEach(event => {
-    if (FLOW_BEGIN_EVENT_TYPES.test(event.type)) {
+    if (event.type === FLOW_BEGIN_EVENT) {
       event.time = metrics.flowBeginTime;
       event.flowTime = 0;
     } else {

--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -48,9 +48,20 @@ module.exports = (req, metrics, requestReceivedTime) => {
   }
 
   const events = metrics.events || [];
-  const flowEvents = _.filter(events, event => {
-    return event.type.indexOf('flow.') === 0;
-  });
+  const flowEvents = _.filter(
+    _.map(events, event => {
+      if (event.type.indexOf('screen.') !== 0) {
+        return event;
+      }
+
+      return _.assign({}, event, {
+        type: `flow.${event.type.substr(7)}.view`
+      });
+    }),
+    event => {
+      return event.type.indexOf('flow.') === 0;
+    }
+  );
 
   flowEvents.forEach(event => {
     if (event.type === FLOW_BEGIN_EVENT) {

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -67,6 +67,7 @@ define([
           events: [
             { offset: 5, type: 'wibble' },
             { offset: 5, type: 'flow.begin' },
+            { offset: 5, type: 'screen.signup' },
             { offset: timeSinceFlowBegin, type: 'flow.signup.good-offset-now' },
             { offset: timeSinceFlowBegin + 1, type: 'flow.signup.bad-offset-future' },
             { offset: timeSinceFlowBegin - config.flow_id_expiry - 1, type: 'flow.signup.bad-offset-expired' },
@@ -75,8 +76,8 @@ define([
         }, timeSinceFlowBegin);
       },
 
-      'process.stderr.write was called three times': () => {
-        assert.equal(process.stderr.write.callCount, 3);
+      'process.stderr.write was called four times': () => {
+        assert.equal(process.stderr.write.callCount, 4);
       },
 
       'first call to process.stderr.write was correct': () => {
@@ -110,12 +111,19 @@ define([
       'second call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[1][0]);
         assert.lengthOf(Object.keys(arg), 18);
-        assert.equal(arg.event, 'flow.signup.good-offset-now');
-        assert.equal(arg.time, new Date(mocks.time).toISOString());
+        assert.equal(arg.event, 'flow.signup.view');
+        assert.equal(arg.time, new Date(mocks.time - 995).toISOString());
       },
 
       'third call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[2][0]);
+        assert.lengthOf(Object.keys(arg), 18);
+        assert.equal(arg.event, 'flow.signup.good-offset-now');
+        assert.equal(arg.time, new Date(mocks.time).toISOString());
+      },
+
+      'fourth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[3][0]);
         assert.lengthOf(Object.keys(arg), 18);
         assert.equal(arg.event, 'flow.signup.good-offset-oldest');
         assert.equal(arg.time, new Date(mocks.time - config.flow_id_expiry).toISOString());

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -66,7 +66,7 @@ define([
         setup({
           events: [
             { offset: 5, type: 'wibble' },
-            { offset: 5, type: 'flow.signup.begin' },
+            { offset: 5, type: 'flow.begin' },
             { offset: timeSinceFlowBegin, type: 'flow.signup.good-offset-now' },
             { offset: timeSinceFlowBegin + 1, type: 'flow.signup.bad-offset-future' },
             { offset: timeSinceFlowBegin - config.flow_id_expiry - 1, type: 'flow.signup.bad-offset-expired' },
@@ -87,7 +87,7 @@ define([
           /*eslint-disable camelcase*/
           context: 'fx_desktop_v3',
           entrypoint: 'menupanel',
-          event: 'flow.signup.begin',
+          event: 'flow.begin',
           flow_id: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
           flow_time: 0,
           hostname: os.hostname(),
@@ -220,7 +220,7 @@ define([
         flowMetricsValidateResult = true;
         flowEvent(mocks.request, {
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -251,7 +251,7 @@ define([
         flowMetricsValidateResult = true;
         flowEvent(mocks.request, {
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flushTime: flowBeginTime,
@@ -271,7 +271,7 @@ define([
         flowMetricsValidateResult = true;
         flowEvent(mocks.request, {
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
           flushTime: flowBeginTime,
@@ -318,7 +318,7 @@ define([
         flowEvent(mocks.request, {
           client_id: 'deadbeefbaadf00d', //eslint-disable-line camelcase
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -342,7 +342,7 @@ define([
         flowEvent(mocks.request, {
           client_id: 'deadbeef', //eslint-disable-line camelcase
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -364,7 +364,7 @@ define([
         flowEvent(mocks.request, {
           client_id: 'deadbeefbaadf00d', //eslint-disable-line camelcase
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -389,7 +389,7 @@ define([
         flowEvent(mocks.request, {
           entryPoint: 'menubar',
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -413,7 +413,7 @@ define([
         flowEvent(mocks.request, {
           entryPoint: '!',
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -436,7 +436,7 @@ define([
           entryPoint: 'menubar',
           entrypoint: 'menupanel',
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -460,7 +460,7 @@ define([
         flowEvent(mocks.request, {
           context: new Array(102).join('0'),
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -484,7 +484,7 @@ define([
         flowEvent(mocks.request, {
           entrypoint: new Array(101).join('0'),
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -508,7 +508,7 @@ define([
         flowEvent(mocks.request, {
           entryPoint: new Array(102).join('x'), //eslint-disable-line camelcase
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -531,7 +531,7 @@ define([
         flowMetricsValidateResult = true;
         flowEvent(mocks.request, {
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -555,7 +555,7 @@ define([
         flowMetricsValidateResult = true;
         flowEvent(mocks.request, {
           events: [
-            { offset: 0, type: 'flow.signup.begin' }
+            { offset: 0, type: 'flow.begin' }
           ],
           flowBeginTime,
           flowId: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
@@ -599,7 +599,7 @@ define([
         context: data.context || 'fx_desktop_v3',
         entrypoint: data.entrypoint || 'menupanel',
         events: data.events || [
-          { offset: 0, type: 'flow.signup.begin' }
+          { offset: 0, type: 'flow.begin' }
         ],
         flowBeginTime,
         flowId: data.flowId || '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',


### PR DESCRIPTION
Related to mozilla/fxa-activity-metrics#19.

This PR makes two changes:

* `flow.${viewName}.begin` is renamed to `flow.begin` (yes, again).

* A new `flow.${viewName}.view` event is added.

The rationale is that we wanted to simplify the model for people writing queries in redash. And removing the view name from the `flow.begin` event makes it pleasingly symmetrical with the `flow.complete`, which is emitted by the auth server.

Adding the `flow.${viewName}.view` event enables us to more explicitly track which views any given flow travels through. And because it is emitted at the end of `afterVisible` its `flow_time` can be used as an approximation of the aggregated request time + initial client-side execution time, which may or may not be useful.

Here is an excerpt from the logs, showing what a flow looks like when a user lands on sign-in, then clicks on `Create account` to show the sign-up view, then clicks on `Have an account?` to go back to the sign-in view, then clicks on `Forgot password` to show the reset-password view:

```
{"event":"flow.begin","flow_id":"362c4127d4139f1303891b7dfe44cfe73eb7aa3c479bcae6ba38d866aa4ae94c","flow_time":0,"hostname":"pbooth-22205.local","op":"flowEvent","pid":34526,"time":"2016-11-23T12:27:45.739Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
{"event":"flow.signin.view","flow_id":"362c4127d4139f1303891b7dfe44cfe73eb7aa3c479bcae6ba38d866aa4ae94c","flow_time":721,"hostname":"pbooth-22205.local","op":"flowEvent","pid":34526,"time":"2016-11-23T12:27:46.460Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
{"event":"flow.signin.create-account","flow_id":"362c4127d4139f1303891b7dfe44cfe73eb7aa3c479bcae6ba38d866aa4ae94c","flow_time":10465,"hostname":"pbooth-22205.local","op":"flowEvent","pid":34526,"time":"2016-11-23T12:27:56.204Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
{"event":"flow.signup.view","flow_id":"362c4127d4139f1303891b7dfe44cfe73eb7aa3c479bcae6ba38d866aa4ae94c","flow_time":10521,"hostname":"pbooth-22205.local","op":"flowEvent","pid":34526,"time":"2016-11-23T12:27:56.260Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
{"event":"flow.signup.have-account","flow_id":"362c4127d4139f1303891b7dfe44cfe73eb7aa3c479bcae6ba38d866aa4ae94c","flow_time":19411,"hostname":"pbooth-22205.local","op":"flowEvent","pid":34526,"time":"2016-11-23T12:28:05.150Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
{"event":"flow.signin.view","flow_id":"362c4127d4139f1303891b7dfe44cfe73eb7aa3c479bcae6ba38d866aa4ae94c","flow_time":19450,"hostname":"pbooth-22205.local","op":"flowEvent","pid":34526,"time":"2016-11-23T12:28:05.189Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
{"event":"flow.signin.forgot-password","flow_id":"362c4127d4139f1303891b7dfe44cfe73eb7aa3c479bcae6ba38d866aa4ae94c","flow_time":23778,"hostname":"pbooth-22205.local","op":"flowEvent","pid":34526,"time":"2016-11-23T12:28:09.517Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
{"event":"flow.reset-password.view","flow_id":"362c4127d4139f1303891b7dfe44cfe73eb7aa3c479bcae6ba38d866aa4ae94c","flow_time":23796,"hostname":"pbooth-22205.local","op":"flowEvent","pid":34526,"time":"2016-11-23T12:28:09.535Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
```

@shane-tomlinson r?