### PR TITLE
fix(l10n): fix string extraction in server syntax

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -185,9 +185,9 @@
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
               "dependencies": {
                 "globals": {
-                  "version": "9.13.0",
+                  "version": "9.14.0",
                   "from": "globals@>=9.0.0 <10.0.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.13.0.tgz"
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.2",
@@ -228,9 +228,9 @@
               }
             },
             "babylon": {
-              "version": "6.14.0",
+              "version": "6.14.1",
               "from": "babylon@>=6.11.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
             },
             "convert-source-map": {
               "version": "1.3.0",
@@ -238,9 +238,9 @@
               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
             },
             "debug": {
-              "version": "2.3.2",
+              "version": "2.3.3",
               "from": "debug@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.2",
@@ -525,7 +525,7 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
@@ -587,7 +587,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -611,7 +611,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -712,14 +712,14 @@
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
                     },
                     "babylon": {
-                      "version": "6.14.0",
+                      "version": "6.14.1",
                       "from": "babylon@>=6.11.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                     },
                     "debug": {
-                      "version": "2.3.2",
+                      "version": "2.3.3",
                       "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.2",
@@ -729,9 +729,9 @@
                       }
                     },
                     "globals": {
-                      "version": "9.13.0",
+                      "version": "9.14.0",
                       "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.13.0.tgz"
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
@@ -761,13 +761,13 @@
                 },
                 "babel-template": {
                   "version": "6.16.0",
-                  "from": "babel-template@>=6.8.0 <7.0.0",
+                  "from": "babel-template@>=6.16.0 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
                   "dependencies": {
                     "babylon": {
-                      "version": "6.14.0",
+                      "version": "6.14.1",
                       "from": "babylon@>=6.11.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                     }
                   }
                 }
@@ -792,7 +792,7 @@
             },
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -816,7 +816,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -840,7 +840,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -886,13 +886,13 @@
             },
             "babel-template": {
               "version": "6.16.0",
-              "from": "babel-template@>=6.14.0 <7.0.0",
+              "from": "babel-template@>=6.16.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
               "dependencies": {
                 "babylon": {
-                  "version": "6.14.0",
+                  "version": "6.14.1",
                   "from": "babylon@>=6.11.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                 }
               }
             },
@@ -965,14 +965,14 @@
                   }
                 },
                 "babylon": {
-                  "version": "6.14.0",
+                  "version": "6.14.1",
                   "from": "babylon@>=6.11.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                 },
                 "debug": {
-                  "version": "2.3.2",
+                  "version": "2.3.3",
                   "from": "debug@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.2",
@@ -982,9 +982,9 @@
                   }
                 },
                 "globals": {
-                  "version": "9.13.0",
+                  "version": "9.14.0",
                   "from": "globals@>=9.0.0 <10.0.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.13.0.tgz"
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.2",
@@ -1137,14 +1137,14 @@
                       }
                     },
                     "babylon": {
-                      "version": "6.14.0",
+                      "version": "6.14.1",
                       "from": "babylon@>=6.11.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                     },
                     "debug": {
-                      "version": "2.3.2",
+                      "version": "2.3.3",
                       "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.2",
@@ -1154,9 +1154,9 @@
                       }
                     },
                     "globals": {
-                      "version": "9.13.0",
+                      "version": "9.14.0",
                       "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.13.0.tgz"
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
@@ -1190,9 +1190,9 @@
                   "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
                   "dependencies": {
                     "babylon": {
-                      "version": "6.14.0",
+                      "version": "6.14.1",
                       "from": "babylon@>=6.11.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                     }
                   }
                 },
@@ -1217,7 +1217,7 @@
             },
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -1258,7 +1258,7 @@
             },
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -1319,7 +1319,7 @@
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.3",
-                              "from": "chalk@>=1.1.1 <2.0.0",
+                              "from": "chalk@>=1.1.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "dependencies": {
                                 "ansi-styles": {
@@ -1381,14 +1381,14 @@
                           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
                         },
                         "babylon": {
-                          "version": "6.14.0",
+                          "version": "6.14.1",
                           "from": "babylon@>=6.11.0 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                         },
                         "debug": {
-                          "version": "2.3.2",
+                          "version": "2.3.3",
                           "from": "debug@>=2.2.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.2",
@@ -1398,9 +1398,9 @@
                           }
                         },
                         "globals": {
-                          "version": "9.13.0",
+                          "version": "9.14.0",
                           "from": "globals@>=9.0.0 <10.0.0",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-9.13.0.tgz"
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                         },
                         "invariant": {
                           "version": "2.2.2",
@@ -1434,13 +1434,13 @@
             },
             "babel-template": {
               "version": "6.16.0",
-              "from": "babel-template@>=6.16.0 <7.0.0",
+              "from": "babel-template@>=6.15.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
               "dependencies": {
                 "babylon": {
-                  "version": "6.14.0",
+                  "version": "6.14.1",
                   "from": "babylon@>=6.11.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.19.0",
@@ -1516,9 +1516,9 @@
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
                     },
                     "debug": {
-                      "version": "2.3.2",
+                      "version": "2.3.3",
                       "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.2",
@@ -1528,9 +1528,9 @@
                       }
                     },
                     "globals": {
-                      "version": "9.13.0",
+                      "version": "9.14.0",
                       "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.13.0.tgz"
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
@@ -1574,7 +1574,7 @@
             },
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -1598,7 +1598,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -1639,7 +1639,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -1685,7 +1685,7 @@
             },
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -1733,7 +1733,7 @@
             },
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -1786,7 +1786,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -1810,7 +1810,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -1906,14 +1906,14 @@
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
                 },
                 "babylon": {
-                  "version": "6.14.0",
+                  "version": "6.14.1",
                   "from": "babylon@>=6.11.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                 },
                 "debug": {
-                  "version": "2.3.2",
+                  "version": "2.3.3",
                   "from": "debug@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.2",
@@ -1923,9 +1923,9 @@
                   }
                 },
                 "globals": {
-                  "version": "9.13.0",
+                  "version": "9.14.0",
                   "from": "globals@>=9.0.0 <10.0.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.13.0.tgz"
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.2",
@@ -1967,13 +1967,13 @@
             },
             "babel-template": {
               "version": "6.16.0",
-              "from": "babel-template@>=6.14.0 <7.0.0",
+              "from": "babel-template@>=6.16.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
               "dependencies": {
                 "babylon": {
-                  "version": "6.14.0",
+                  "version": "6.14.1",
                   "from": "babylon@>=6.11.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                 }
               }
             },
@@ -2020,7 +2020,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -2116,14 +2116,14 @@
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
                 },
                 "babylon": {
-                  "version": "6.14.0",
+                  "version": "6.14.1",
                   "from": "babylon@>=6.11.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                 },
                 "debug": {
-                  "version": "2.3.2",
+                  "version": "2.3.3",
                   "from": "debug@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.2",
@@ -2133,9 +2133,9 @@
                   }
                 },
                 "globals": {
-                  "version": "9.13.0",
+                  "version": "9.14.0",
                   "from": "globals@>=9.0.0 <10.0.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.13.0.tgz"
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.2",
@@ -2177,19 +2177,19 @@
             },
             "babel-template": {
               "version": "6.16.0",
-              "from": "babel-template@>=6.16.0 <7.0.0",
+              "from": "babel-template@>=6.15.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
               "dependencies": {
                 "babylon": {
-                  "version": "6.14.0",
+                  "version": "6.14.1",
                   "from": "babylon@>=6.11.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -2213,7 +2213,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -2254,7 +2254,7 @@
             },
             "babel-runtime": {
               "version": "6.18.0",
-              "from": "babel-runtime@>=6.0.0 <7.0.0",
+              "from": "babel-runtime@>=6.9.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -2271,17 +2271,17 @@
             },
             "babel-template": {
               "version": "6.16.0",
-              "from": "babel-template@>=6.16.0 <7.0.0",
+              "from": "babel-template@>=6.15.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
               "dependencies": {
                 "babylon": {
-                  "version": "6.14.0",
+                  "version": "6.14.1",
                   "from": "babylon@>=6.11.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.19.0",
-                  "from": "babel-traverse@>=6.18.0 <7.0.0",
+                  "from": "babel-traverse@>=6.16.0 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
                   "dependencies": {
                     "babel-code-frame": {
@@ -2353,9 +2353,9 @@
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
                     },
                     "debug": {
-                      "version": "2.3.2",
+                      "version": "2.3.3",
                       "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.2",
@@ -2365,9 +2365,9 @@
                       }
                     },
                     "globals": {
-                      "version": "9.13.0",
+                      "version": "9.14.0",
                       "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.13.0.tgz"
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
@@ -2485,23 +2485,23 @@
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "http-errors": {
-          "version": "1.5.0",
+          "version": "1.5.1",
           "from": "http-errors@>=1.5.0 <1.6.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
           "dependencies": {
             "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.3",
+              "from": "inherits@2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "setprototypeof": {
-              "version": "1.0.1",
-              "from": "setprototypeof@1.0.1",
-              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+              "version": "1.0.2",
+              "from": "setprototypeof@1.0.2",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
             },
             "statuses": {
               "version": "1.3.1",
-              "from": "statuses@>=1.3.0 <2.0.0",
+              "from": "statuses@>=1.3.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
             }
           }
@@ -2541,9 +2541,9 @@
           }
         },
         "type-is": {
-          "version": "1.6.13",
+          "version": "1.6.14",
           "from": "type-is@>=1.6.13 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -2551,14 +2551,14 @@
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.12",
-              "from": "mime-types@>=2.1.11 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "version": "2.1.13",
+              "from": "mime-types@>=2.1.13 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                  "version": "1.25.0",
+                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                 }
               }
             }
@@ -2673,7 +2673,7 @@
       "dependencies": {
         "vary": {
           "version": "1.1.0",
-          "from": "vary@>=1.1.0 <1.2.0",
+          "from": "vary@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
         }
       }
@@ -2689,14 +2689,14 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.1.12",
+              "version": "2.1.13",
               "from": "mime-types@>=2.1.11 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                  "version": "1.25.0",
+                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                 }
               }
             },
@@ -2856,19 +2856,19 @@
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
             },
             "http-errors": {
-              "version": "1.5.0",
+              "version": "1.5.1",
               "from": "http-errors@>=1.5.0 <1.6.0",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "inherits@2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "setprototypeof": {
-                  "version": "1.0.1",
-                  "from": "setprototypeof@1.0.1",
-                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+                  "version": "1.0.2",
+                  "from": "setprototypeof@1.0.2",
+                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
                 }
               }
             },
@@ -2890,9 +2890,9 @@
           }
         },
         "type-is": {
-          "version": "1.6.13",
+          "version": "1.6.14",
           "from": "type-is@>=1.6.13 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -2900,14 +2900,14 @@
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.12",
+              "version": "2.1.13",
               "from": "mime-types@>=2.1.11 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                  "version": "1.25.0",
+                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                 }
               }
             }
@@ -2992,9 +2992,9 @@
                   "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
                 },
                 "browser-pack": {
-                  "version": "6.0.1",
+                  "version": "6.0.2",
                   "from": "browser-pack@>=6.0.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
                   "dependencies": {
                     "combine-source-map": {
                       "version": "0.7.2",
@@ -4081,9 +4081,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.16.0",
+                          "version": "2.17.0",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.16.0.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.0.tgz"
                         }
                       }
                     }
@@ -4105,9 +4105,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.16.0",
+                          "version": "2.17.0",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.16.0.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.0.tgz"
                         }
                       }
                     }
@@ -4205,9 +4205,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.16.0",
+                          "version": "2.17.0",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.16.0.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.0.tgz"
                         }
                       }
                     }
@@ -4270,9 +4270,9 @@
                           "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
                         },
                         "moment": {
-                          "version": "2.16.0",
+                          "version": "2.17.0",
                           "from": "moment@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.16.0.tgz"
+                          "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.0.tgz"
                         }
                       }
                     }
@@ -4659,7 +4659,7 @@
           "dependencies": {
             "object-assign": {
               "version": "4.1.0",
-              "from": "object-assign@>=4.1.0 <5.0.0",
+              "from": "object-assign@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             },
             "pinkie-promise": {
@@ -4899,9 +4899,9 @@
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
-                              "version": "4.1.10",
+                              "version": "4.1.11",
                               "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
@@ -4959,9 +4959,9 @@
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
-                              "version": "4.1.10",
+                              "version": "4.1.11",
                               "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
@@ -5274,9 +5274,9 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.13",
+          "version": "0.4.15",
           "from": "iconv-lite@>=0.4.13 <0.5.0",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
         },
         "js-yaml": {
           "version": "3.5.5",
@@ -5304,7 +5304,7 @@
         },
         "minimatch": {
           "version": "3.0.3",
-          "from": "minimatch@>=3.0.0 <3.1.0",
+          "from": "minimatch@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dependencies": {
             "brace-expansion": {
@@ -5371,9 +5371,9 @@
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000581",
+              "version": "1.0.30000587",
               "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000581.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000587.tgz"
             }
           }
         },
@@ -5384,7 +5384,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
@@ -5471,7 +5471,7 @@
       "dependencies": {
         "babel-core": {
           "version": "6.18.2",
-          "from": "babel-core@>=6.9.1 <7.0.0",
+          "from": "babel-core@>=6.0.12 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.18.2.tgz",
           "dependencies": {
             "babel-code-frame": {
@@ -5647,9 +5647,9 @@
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
               "dependencies": {
                 "globals": {
-                  "version": "9.13.0",
+                  "version": "9.14.0",
                   "from": "globals@>=9.0.0 <10.0.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.13.0.tgz"
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.2",
@@ -5690,9 +5690,9 @@
               }
             },
             "babylon": {
-              "version": "6.14.0",
+              "version": "6.14.1",
               "from": "babylon@>=6.11.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.0.tgz"
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
             },
             "convert-source-map": {
               "version": "1.3.0",
@@ -5700,9 +5700,9 @@
               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
             },
             "debug": {
-              "version": "2.3.2",
+              "version": "2.3.3",
               "from": "debug@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.2",
@@ -5926,7 +5926,7 @@
                 },
                 "object-assign": {
                   "version": "4.1.0",
-                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                 },
                 "read-pkg-up": {
@@ -5969,9 +5969,9 @@
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
-                              "version": "4.1.10",
+                              "version": "4.1.11",
                               "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
@@ -6029,9 +6029,9 @@
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
-                              "version": "4.1.10",
+                              "version": "4.1.11",
                               "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
@@ -6128,7 +6128,7 @@
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "isarray@1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
@@ -6574,7 +6574,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -6893,9 +6893,9 @@
                               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.10",
+                                  "version": "4.1.11",
                                   "from": "graceful-fs@>=4.1.2 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
@@ -6953,9 +6953,9 @@
                               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.10",
+                                  "version": "4.1.11",
                                   "from": "graceful-fs@>=4.1.2 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                                 },
                                 "pify": {
                                   "version": "2.3.0",
@@ -7048,7 +7048,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -7224,7 +7224,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "typedarray": {
@@ -7742,9 +7742,9 @@
                               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.10",
+                                  "version": "4.1.11",
                                   "from": "graceful-fs@>=4.1.2 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
@@ -7802,9 +7802,9 @@
                               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.10",
+                                  "version": "4.1.11",
                                   "from": "graceful-fs@>=4.1.2 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                                 },
                                 "pify": {
                                   "version": "2.3.0",
@@ -8090,9 +8090,9 @@
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "dependencies": {
                     "iconv-lite": {
-                      "version": "0.4.13",
+                      "version": "0.4.15",
                       "from": "iconv-lite@>=0.4.13 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
                     }
                   }
                 }
@@ -8663,9 +8663,9 @@
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
-                              "version": "4.1.10",
+                              "version": "4.1.11",
                               "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
@@ -8723,9 +8723,9 @@
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
-                              "version": "4.1.10",
+                              "version": "4.1.11",
                               "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
@@ -8818,9 +8818,9 @@
                   }
                 },
                 "graceful-fs": {
-                  "version": "4.1.10",
+                  "version": "4.1.11",
                   "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.3",
@@ -9025,9 +9025,9 @@
                       "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
                       "dependencies": {
                         "debug": {
-                          "version": "2.3.2",
+                          "version": "2.3.3",
                           "from": "debug@>=2.2.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.2",
@@ -9106,9 +9106,9 @@
               }
             },
             "npmlog": {
-              "version": "4.0.0",
+              "version": "4.0.1",
               "from": "npmlog@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.1.tgz",
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
@@ -9170,9 +9170,9 @@
                   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
                 },
                 "gauge": {
-                  "version": "2.6.0",
-                  "from": "gauge@>=2.6.0 <2.7.0",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                  "version": "2.7.1",
+                  "from": "gauge@>=2.7.1 <2.8.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.1.tgz",
                   "dependencies": {
                     "aproba": {
                       "version": "1.0.4",
@@ -9245,9 +9245,9 @@
               }
             },
             "request": {
-              "version": "2.78.0",
+              "version": "2.79.0",
               "from": "request@>=2.61.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
@@ -9433,9 +9433,9 @@
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                         },
                         "dashdash": {
-                          "version": "1.14.0",
+                          "version": "1.14.1",
                           "from": "dashdash@>=1.12.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                         },
                         "getpass": {
                           "version": "0.1.6",
@@ -9487,21 +9487,16 @@
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.12",
+                  "version": "2.1.13",
                   "from": "mime-types@>=2.1.7 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.24.0",
-                      "from": "mime-db@>=1.24.0 <1.25.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                      "version": "1.25.0",
+                      "from": "mime-db@>=1.25.0 <1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                     }
                   }
-                },
-                "node-uuid": {
-                  "version": "1.4.7",
-                  "from": "node-uuid@>=1.4.7 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
@@ -9534,6 +9529,11 @@
                   "version": "0.4.3",
                   "from": "tunnel-agent@>=0.4.1 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+                },
+                "uuid": {
+                  "version": "3.0.0",
+                  "from": "uuid@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
                 }
               }
             },
@@ -9640,9 +9640,9 @@
                               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.10",
+                                  "version": "4.1.11",
                                   "from": "graceful-fs@>=4.1.2 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
@@ -9753,9 +9753,9 @@
                               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
-                                  "version": "4.1.10",
+                                  "version": "4.1.11",
                                   "from": "graceful-fs@>=4.1.2 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                                 },
                                 "pify": {
                                   "version": "2.3.0",
@@ -9950,9 +9950,9 @@
           }
         },
         "debug": {
-          "version": "2.3.2",
+          "version": "2.3.3",
           "from": "debug@>=2.1.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.2",
@@ -9984,9 +9984,9 @@
           "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-2.4.10.tgz",
           "dependencies": {
             "request": {
-              "version": "2.78.0",
+              "version": "2.79.0",
               "from": "request@>=2.39.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
@@ -10218,9 +10218,9 @@
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                         },
                         "dashdash": {
-                          "version": "1.14.0",
+                          "version": "1.14.1",
                           "from": "dashdash@>=1.12.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                         },
                         "getpass": {
                           "version": "0.1.6",
@@ -10272,21 +10272,16 @@
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.12",
+                  "version": "2.1.13",
                   "from": "mime-types@>=2.1.7 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.24.0",
-                      "from": "mime-db@>=1.24.0 <1.25.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                      "version": "1.25.0",
+                      "from": "mime-db@>=1.25.0 <1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                     }
                   }
-                },
-                "node-uuid": {
-                  "version": "1.4.7",
-                  "from": "node-uuid@>=1.4.7 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
@@ -10319,6 +10314,11 @@
                   "version": "0.4.3",
                   "from": "tunnel-agent@>=0.4.1 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+                },
+                "uuid": {
+                  "version": "3.0.0",
+                  "from": "uuid@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
                 }
               }
             }
@@ -10417,7 +10417,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "align-text@>=0.1.3 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -10704,9 +10704,9 @@
                   "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                   "dependencies": {
                     "iconv-lite": {
-                      "version": "0.4.13",
+                      "version": "0.4.15",
                       "from": "iconv-lite@>=0.4.13 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
                     }
                   }
                 }
@@ -11091,13 +11091,13 @@
       }
     },
     "jsxgettext-recursive": {
-      "version": "0.0.5",
-      "from": "jsxgettext-recursive@0.0.5",
-      "resolved": "https://registry.npmjs.org/jsxgettext-recursive/-/jsxgettext-recursive-0.0.5.tgz",
+      "version": "0.1.0",
+      "from": "jsxgettext-recursive@0.1.0",
+      "resolved": "https://registry.npmjs.org/jsxgettext-recursive/-/jsxgettext-recursive-0.1.0.tgz",
       "dependencies": {
         "walk": {
           "version": "2.3.9",
-          "from": "walk@>=2.3.1 <3.0.0",
+          "from": "walk@>=2.3.9 <3.0.0",
           "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
           "dependencies": {
             "foreachasync": {
@@ -11108,77 +11108,142 @@
           }
         },
         "jsxgettext": {
-          "version": "0.4.10",
-          "from": "jsxgettext@>=0.4.8 <0.5.0",
-          "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.4.10.tgz",
+          "version": "0.9.0",
+          "from": "jsxgettext@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/jsxgettext/-/jsxgettext-0.9.0.tgz",
           "dependencies": {
             "acorn": {
-              "version": "0.5.0",
-              "from": "acorn@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.5.0.tgz"
+              "version": "3.3.0",
+              "from": "acorn@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
             },
-            "gettext-parser": {
-              "version": "0.2.0",
-              "from": "gettext-parser@0.2.0",
-              "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-0.2.0.tgz",
+            "acorn-jsx": {
+              "version": "3.0.1",
+              "from": "acorn-jsx@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
+            },
+            "commander": {
+              "version": "2.9.0",
+              "from": "commander@>=2.9.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
-                "encoding": {
-                  "version": "0.1.12",
-                  "from": "encoding@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-                  "dependencies": {
-                    "iconv-lite": {
-                      "version": "0.4.13",
-                      "from": "iconv-lite@>=0.4.13 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-                    }
-                  }
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
-            "nomnom": {
-              "version": "1.5.2",
-              "from": "nomnom@1.5.2",
-              "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "gettext-parser": {
+              "version": "1.2.0",
+              "from": "gettext-parser@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.2.0.tgz",
               "dependencies": {
-                "underscore": {
-                  "version": "1.1.7",
-                  "from": "underscore@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
-                },
-                "colors": {
-                  "version": "0.5.1",
-                  "from": "colors@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
+                "encoding": {
+                  "version": "0.1.12",
+                  "from": "encoding@>=0.1.12 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                  "dependencies": {
+                    "iconv-lite": {
+                      "version": "0.4.15",
+                      "from": "iconv-lite@>=0.4.13 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
+                    }
+                  }
                 }
               }
             },
             "jade": {
-              "version": "0.30.0",
-              "from": "jade@0.30.0",
-              "resolved": "https://registry.npmjs.org/jade/-/jade-0.30.0.tgz",
+              "version": "1.11.0",
+              "from": "jade@>=1.11.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
               "dependencies": {
-                "commander": {
-                  "version": "1.1.1",
-                  "from": "commander@>=1.1.1 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+                "character-parser": {
+                  "version": "1.2.1",
+                  "from": "character-parser@1.2.1",
+                  "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
+                },
+                "clean-css": {
+                  "version": "3.4.21",
+                  "from": "clean-css@>=3.1.9 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.21.tgz",
                   "dependencies": {
-                    "keypress": {
-                      "version": "0.1.0",
-                      "from": "keypress@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
+                    "commander": {
+                      "version": "2.8.1",
+                      "from": "commander@>=2.8.0 <2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.4.4",
+                      "from": "source-map@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.1",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                        }
+                      }
                     }
                   }
                 },
-                "mkdirp": {
-                  "version": "0.3.5",
-                  "from": "mkdirp@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                "commander": {
+                  "version": "2.6.0",
+                  "from": "commander@>=2.6.0 <2.7.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+                },
+                "constantinople": {
+                  "version": "3.0.2",
+                  "from": "constantinople@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
+                  "dependencies": {
+                    "acorn": {
+                      "version": "2.7.0",
+                      "from": "acorn@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+                    }
+                  }
+                },
+                "jstransformer": {
+                  "version": "0.0.2",
+                  "from": "jstransformer@0.0.2",
+                  "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
+                  "dependencies": {
+                    "is-promise": {
+                      "version": "2.1.0",
+                      "from": "is-promise@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
+                    },
+                    "promise": {
+                      "version": "6.1.0",
+                      "from": "promise@>=6.0.1 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+                      "dependencies": {
+                        "asap": {
+                          "version": "1.0.0",
+                          "from": "asap@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "transformers": {
-                  "version": "2.0.1",
-                  "from": "transformers@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.0.1.tgz",
+                  "version": "2.1.0",
+                  "from": "transformers@2.1.0",
+                  "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
                   "dependencies": {
                     "promise": {
                       "version": "2.0.0",
@@ -11242,60 +11307,10 @@
                     }
                   }
                 },
-                "character-parser": {
-                  "version": "1.0.2",
-                  "from": "character-parser@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz"
-                },
-                "monocle": {
-                  "version": "0.1.50",
-                  "from": "monocle@>=0.1.46 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
-                  "dependencies": {
-                    "readdirp": {
-                      "version": "0.2.5",
-                      "from": "readdirp@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
-                      "dependencies": {
-                        "minimatch": {
-                          "version": "3.0.3",
-                          "from": "minimatch@>=0.2.4",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.6",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.4.2",
-                                  "from": "balanced-match@>=0.4.1 <0.5.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "swig": {
-              "version": "1.3.2",
-              "from": "swig@1.3.2",
-              "resolved": "https://registry.npmjs.org/swig/-/swig-1.3.2.tgz",
-              "dependencies": {
                 "uglify-js": {
-                  "version": "2.4.24",
-                  "from": "uglify-js@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+                  "version": "2.7.4",
+                  "from": "uglify-js@>=2.4.19 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.4.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
@@ -11303,16 +11318,9 @@
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "source-map": {
-                      "version": "0.1.34",
-                      "from": "source-map@0.1.34",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.1",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-                        }
-                      }
+                      "version": "0.5.6",
+                      "from": "source-map@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
@@ -11320,14 +11328,103 @@
                       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                     },
                     "yargs": {
-                      "version": "3.5.4",
-                      "from": "yargs@>=3.5.4 <3.6.0",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                      "version": "3.10.0",
+                      "from": "yargs@>=3.10.0 <3.11.0",
+                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
                           "from": "camelcase@>=1.0.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                        },
+                        "cliui": {
+                          "version": "2.1.0",
+                          "from": "cliui@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                          "dependencies": {
+                            "center-align": {
+                              "version": "0.1.3",
+                              "from": "center-align@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.4",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.0.4",
+                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.4",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.6.1",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                    }
+                                  }
+                                },
+                                "lazy-cache": {
+                                  "version": "1.0.4",
+                                  "from": "lazy-cache@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                                }
+                              }
+                            },
+                            "right-align": {
+                              "version": "0.1.3",
+                              "from": "right-align@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.4",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.0.4",
+                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.4",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.6.1",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "from": "wordwrap@0.0.2",
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                            }
+                          }
                         },
                         "decamelize": {
                           "version": "1.2.0",
@@ -11338,39 +11435,41 @@
                           "version": "0.1.0",
                           "from": "window-size@0.1.0",
                           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     }
                   }
                 },
-                "optimist": {
-                  "version": "0.6.1",
-                  "from": "optimist@>=0.6.0 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                "void-elements": {
+                  "version": "2.0.1",
+                  "from": "void-elements@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
+                },
+                "with": {
+                  "version": "4.0.3",
+                  "from": "with@>=4.0.0 <4.1.0",
+                  "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
                   "dependencies": {
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    "acorn": {
+                      "version": "1.2.2",
+                      "from": "acorn@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                     },
-                    "minimist": {
-                      "version": "0.0.10",
-                      "from": "minimist@>=0.0.1 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    "acorn-globals": {
+                      "version": "1.0.9",
+                      "from": "acorn-globals@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+                      "dependencies": {
+                        "acorn": {
+                          "version": "2.7.0",
+                          "from": "acorn@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+                        }
+                      }
                     }
                   }
                 }
               }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.1",
-              "from": "escape-string-regexp@1.0.1",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz"
             }
           }
         }
@@ -11410,7 +11509,7 @@
             },
             "minimatch": {
               "version": "3.0.3",
-              "from": "minimatch@>=3.0.0 <3.1.0",
+              "from": "minimatch@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "dependencies": {
                 "brace-expansion": {
@@ -11708,7 +11807,7 @@
         "uap-core": {
           "version": "0.5.0",
           "from": "git://github.com/ua-parser/uap-core.git",
-          "resolved": "git://github.com/ua-parser/uap-core.git#6711c34d5b02b260774408f01b81b5e34530dc7a"
+          "resolved": "git://github.com/ua-parser/uap-core.git#f6253f215bebab625d80e5287aa089318ff3c4e8"
         },
         "uap-ref-impl": {
           "version": "0.2.0",
@@ -11734,7 +11833,7 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+          "from": "json-stringify-safe@>=5.0.1 <6.0.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "lsmod": {
@@ -11805,19 +11904,19 @@
               "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
             },
             "http-errors": {
-              "version": "1.5.0",
+              "version": "1.5.1",
               "from": "http-errors@>=1.5.0 <1.6.0",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "setprototypeof": {
-                  "version": "1.0.1",
-                  "from": "setprototypeof@1.0.1",
-                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+                  "version": "1.0.2",
+                  "from": "setprototypeof@1.0.2",
+                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
                 }
               }
             },
@@ -11982,9 +12081,9 @@
       "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.2.tgz",
       "dependencies": {
         "request": {
-          "version": "2.78.0",
+          "version": "2.79.0",
           "from": "request@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
@@ -12037,7 +12136,7 @@
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
-                  "from": "chalk@>=1.1.0 <2.0.0",
+                  "from": "chalk@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "dependencies": {
                     "ansi-styles": {
@@ -12216,9 +12315,9 @@
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "dashdash": {
-                      "version": "1.14.0",
+                      "version": "1.14.1",
                       "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                     },
                     "getpass": {
                       "version": "0.1.6",
@@ -12266,18 +12365,18 @@
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "from": "json-stringify-safe@>=5.0.1 <6.0.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.1.12",
+              "version": "2.1.13",
               "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                  "version": "1.25.0",
+                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                 }
               }
             },
@@ -12312,6 +12411,11 @@
               "version": "0.4.3",
               "from": "tunnel-agent@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+            },
+            "uuid": {
+              "version": "3.0.0",
+              "from": "uuid@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "handlebars": "4.0.5",
     "helmet": "2.1.2",
     "i18n-abide": "0.0.25",
-    "jsxgettext-recursive": "0.0.5",
+    "jsxgettext-recursive": "0.1.0",
     "load-grunt-tasks": "3.5.0",
     "lodash": "4.14.2",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
Fixes #4406 

@shane-tomlinson @vbudhram r?

before ```grunt jsxextract``` would fail, but with this change it is fine now (™)
