### PR TITLE
fix(metrics): drop invalid utm_ params from flow data

### DIFF
--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -98,11 +98,10 @@ define([
           service: '1234567890abcdef',
           time: new Date(mocks.time - 1000).toISOString(),
           userAgent: mocks.request.headers['user-agent'],
-          utm_campaign: 'mock utm_campaign',
-          utm_content: 'mock utm_content',
-          utm_medium: 'mock utm_medium',
-          utm_source: 'mock utm_source',
-          utm_term: 'mock utm_term',
+          utm_campaign: '.-Mock%20utm_campaign',
+          utm_content: '.-Mock%20utm_content',
+          utm_medium: '.-Mock%20utm_medium',
+          utm_source: '.-Mock%20utm_source',
           v: 1
           /*eslint-enable camelcase*/
         });
@@ -110,21 +109,21 @@ define([
 
       'second call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[1][0]);
-        assert.lengthOf(Object.keys(arg), 18);
+        assert.lengthOf(Object.keys(arg), 17);
         assert.equal(arg.event, 'flow.signup.view');
         assert.equal(arg.time, new Date(mocks.time - 995).toISOString());
       },
 
       'third call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[2][0]);
-        assert.lengthOf(Object.keys(arg), 18);
+        assert.lengthOf(Object.keys(arg), 17);
         assert.equal(arg.event, 'flow.signup.good-offset-now');
         assert.equal(arg.time, new Date(mocks.time).toISOString());
       },
 
       'fourth call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[3][0]);
-        assert.lengthOf(Object.keys(arg), 18);
+        assert.lengthOf(Object.keys(arg), 17);
         assert.equal(arg.event, 'flow.signup.good-offset-oldest');
         assert.equal(arg.time, new Date(mocks.time - config.flow_id_expiry).toISOString());
       }
@@ -597,6 +596,70 @@ define([
         assert.isUndefined(arg.utm_source);
         assert.isUndefined(arg.utm_term);
       }
+    },
+
+    'call flowEvent with invalid utm_campaign': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          utm_campaign: '!' //eslint-disable-line camelcase
+        }, 1000);
+      },
+
+      'process.stderr.write was called correctly': () => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(Object.keys(arg), 16);
+        assert.isUndefined(arg.utm_campaign); //eslint-disable-line camelcase
+      }
+    },
+
+    'call flowEvent with invalid utm_content': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          utm_content: '"' //eslint-disable-line camelcase
+        }, 1000);
+      },
+
+      'process.stderr.write was called correctly': () => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(Object.keys(arg), 16);
+        assert.isUndefined(arg.utm_content); //eslint-disable-line camelcase
+      }
+    },
+
+    'call flowEvent with invalid utm_medium': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          utm_medium: ';' //eslint-disable-line camelcase
+        }, 1000);
+      },
+
+      'process.stderr.write was called correctly': () => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(Object.keys(arg), 16);
+        assert.isUndefined(arg.utm_medium); //eslint-disable-line camelcase
+      }
+    },
+
+    'call flowEvent with invalid utm_source': {
+      beforeEach () {
+        flowMetricsValidateResult = true;
+        setup({
+          utm_source: '>' //eslint-disable-line camelcase
+        }, 1000);
+      },
+
+      'process.stderr.write was called correctly': () => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0][0]);
+        assert.lengthOf(Object.keys(arg), 16);
+        assert.isUndefined(arg.utm_source); //eslint-disable-line camelcase
+      }
     }
   });
 
@@ -616,11 +679,11 @@ define([
         service: data.service || '1234567890abcdef',
         startTime: flowBeginTime - timeSinceFlowBegin,
         /*eslint-disable camelcase*/
-        utm_campaign: data.utm_campaign || 'mock utm_campaign',
-        utm_content: data.utm_content || 'mock utm_content',
-        utm_medium: data.utm_medium || 'mock utm_medium',
-        utm_source: data.utm_source || 'mock utm_source',
-        utm_term: data.utm_term || 'mock utm_term',
+        utm_campaign: data.utm_campaign || '.-Mock%20utm_campaign',
+        utm_content: data.utm_content || '.-Mock%20utm_content',
+        utm_medium: data.utm_medium || '.-Mock%20utm_medium',
+        utm_source: data.utm_source || '.-Mock%20utm_source',
+        utm_term: data.utm_term || '.-Mock%20utm_term',
         /*eslint-enable camelcase*/
         zignore: 'ignore me'
       }, mocks.time);


### PR DESCRIPTION
Fixes #4415, silently dropping `utm_*` parameters that contain any dodgy-looking characters. Note that this is different treatment than the rest of the flow data, where the whole event is dropped for invalid data. The values for those params are under our control, whereas these aren't.

Tested by manually adding `utm_campaign=GOOD_DATA&utm_content=BAD_DATA!` query params to the URL, which logs the following when landing on sign-in:

```
{"event":"flow.begin","flow_id":"5011c451aab97affc497c2bd51e56603c2f99dc15c083b03364831df3039ae01","flow_time":0,"hostname":"pbooth-22205.home","op":"flowEvent","pid":2947,"time":"2016-11-24T08:22:09.229Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync","utm_campaign":"GOOD_DATA"}
{"event":"flow.signin.view","flow_id":"5011c451aab97affc497c2bd51e56603c2f99dc15c083b03364831df3039ae01","flow_time":705,"hostname":"pbooth-22205.home","op":"flowEvent","pid":2947,"time":"2016-11-24T08:22:09.934Z","userAgent":"Firefox-iOS-FxA/5.3 (Firefox)","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync","utm_campaign":"GOOD_DATA"}
```

Any that contain invalid characters should not be present in the flow event.

There is also a secondary fix contained herein; we agreed to ditch `utm_term` entirely because it's completely free-form and we have don't envisage wanting to analyse it in this way.

@shane-tomlinson r?