### PR TITLE
fix(metrics): round flow time down before emitting

### DIFF
--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -135,7 +135,7 @@ function logFlowEvent (event, data, request) {
   var eventData = _.assign({
     event: event.type,
     flow_id: data.flowId, //eslint-disable-line camelcase
-    flow_time: event.flowTime, //eslint-disable-line camelcase
+    flow_time: Math.floor(event.flowTime), //eslint-disable-line camelcase
     hostname: HOSTNAME,
     op: 'flowEvent',
     pid: process.pid,

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -67,7 +67,7 @@ define([
           events: [
             { offset: 5, type: 'wibble' },
             { offset: 5, type: 'flow.begin' },
-            { offset: 5, type: 'screen.signup' },
+            { offset: 5.9, type: 'screen.signup' },
             { offset: timeSinceFlowBegin, type: 'flow.signup.good-offset-now' },
             { offset: timeSinceFlowBegin + 1, type: 'flow.signup.bad-offset-future' },
             { offset: timeSinceFlowBegin - config.flow_id_expiry - 1, type: 'flow.signup.bad-offset-expired' },
@@ -112,6 +112,7 @@ define([
         const arg = JSON.parse(process.stderr.write.args[1][0]);
         assert.lengthOf(Object.keys(arg), 18);
         assert.equal(arg.event, 'flow.signup.view');
+        assert.equal(arg.flow_time, 5);
         assert.equal(arg.time, new Date(mocks.time - 995).toISOString());
       },
 


### PR DESCRIPTION
Not entirely sure what conditions led to this but, amongst all our flow data, there is a single line that has a floating point value for `flow_time` and fails the import for that day (21st October).

This change rounds it *down* to an integer because that matches the `Date.toISOString` behaviour, which governs the value of the `time` property on the same object (and we want the values to match up, obviously):

```
> new Date(0.9).toISOString()
'1970-01-01T00:00:00.000Z'
> new Date(1).toISOString()
'1970-01-01T00:00:00.001Z'
```

@shane-tomlinson, another one for you sorry, but it's only a tiddler. r?