### PR TITLE
fix(client): Flush metrics before redirecting to an external link.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -137,6 +137,12 @@ define(function (require, exports, module) {
       this.navigator = options.navigator || this.window.navigator || navigator;
       this.translator = options.translator || this.window.translator;
 
+      // `events` are defined on child views without extending
+      // BaseView's events. Defining events on BaseView (or any
+      // of its mixins) results in a clobbered events hash.
+      // Just mix the ExternalLinksMixin's events in.
+      _.extend(this.events, ExternalLinksMixin.events);
+
       /**
        * Prefer the `viewName` set on the object prototype. ChildViews
        * define their viewName on the prototype to avoid taking the

--- a/app/scripts/views/mixins/signup-mixin.js
+++ b/app/scripts/views/mixins/signup-mixin.js
@@ -90,19 +90,8 @@ define(function (require, exports, module) {
         });
     },
 
-    /**
-     * interceptor function. Flushes metrics before redirecting
-     * @param {Event} event - click event
-     */
-    onSuggestSyncClick (event) {
-      event.preventDefault();
-
+    onSuggestSyncClick () {
       this.logViewEvent('sync-suggest.clicked');
-
-      this.metrics.flush()
-        .then(() => {
-          this.window.location = event.target.href;
-        });
     }
   };
 });

--- a/app/tests/spec/views/mixins/external-links-mixin.js
+++ b/app/tests/spec/views/mixins/external-links-mixin.js
@@ -5,33 +5,39 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const { assert } = require('chai');
   const BaseView = require('views/base');
   const Broker = require('models/auth_brokers/base');
-  const Chai = require('chai');
   const Cocktail = require('cocktail');
   const ExternalLinksMixin = require('views/mixins/external-links-mixin');
+  const Metrics = require('lib/metrics');
+  const p = require('lib/promise');
+  const sinon = require('sinon');
   const TestTemplate = require('stache!templates/test_template');
   const WindowMock = require('../../../mocks/window');
 
-  var assert = Chai.assert;
-
-  var View = BaseView.extend({
+  const View = BaseView.extend({
     template: TestTemplate
   });
-  Cocktail.mixin(View, ExternalLinksMixin);
+  Cocktail.mixin(
+    View,
+    ExternalLinksMixin
+  );
 
   describe('views/mixins/external-links-mixin', function () {
-    var broker;
-    var view;
-    var windowMock;
+    let broker;
+    let metrics;
+    let view;
+    let windowMock;
 
     beforeEach(function () {
       broker = new Broker();
+      metrics = new Metrics();
       windowMock = new WindowMock();
-      windowMock.navigator.userAgent = 'mocha';
 
       view = new View({
-        broker: broker,
+        broker,
+        metrics,
         window: windowMock
       });
     });
@@ -40,54 +46,195 @@ define(function (require, exports, module) {
       return view.destroy();
     });
 
-    describe('broker does not support convertExternalLinksToText', function () {
-      beforeEach(function () {
-        return view.render();
+    describe('link conversion', () => {
+      describe('broker does not support convertExternalLinksToText', function () {
+        beforeEach(function () {
+          return view.render();
+        });
+
+        it('does not convert any links', function () {
+          assert.isFalse(view.$('#external-link').hasClass('visible-url'));
+          assert.isFalse(view.$('#internal-link').hasClass('visible-url'));
+        });
       });
 
-      it('does not convert external links', function () {
-        assert.isFalse(view.$('#external-link').hasClass('visible-url'));
-      });
+      describe('broker supports convertExternalLinksToText', function () {
+        beforeEach(function () {
+          broker.setCapability('convertExternalLinksToText', true);
+          return view.render();
+        });
 
-      it('does not convert internal links', function () {
-        assert.isFalse(view.$('#internal-link').hasClass('visible-url'));
-      });
-    });
-
-    describe('broker supports convertExternalLinksToText', function () {
-      beforeEach(function () {
-        broker.setCapability('convertExternalLinksToText', true);
-        return view.render();
-      });
-
-      it('converts external links', function () {
-        var $externalLink = view.$('#external-link');
-        assert.isTrue($externalLink.hasClass('visible-url'));
-        assert.equal(
+        it('converts external links, adding rel to links', function () {
+          var $externalLink = view.$('#external-link');
+          assert.isTrue($externalLink.hasClass('visible-url'));
+          assert.equal(
           $externalLink.attr('data-visible-url'), $externalLink.attr('href'));
-      });
+          assert.equal(
+           $externalLink.attr('rel'),'noopener noreferrer');
+        });
 
-      it('does not convert internal links', function () {
-        assert.isFalse(view.$('#internal-link').hasClass('visible-url'));
-      });
-
-      it('adds rel in external links', function () {
-        var $externalLink = view.$('#external-link');
-        assert.equal(
-         $externalLink.attr('rel'),'noopener noreferrer');
-      });
-
-      it('does not add rel in internal links', function () {
-        var $internalLink = view.$('#internal-link');
-        assert.notEqual(
+        it('does not convert internal links, does not add rel', function () {
+          var $internalLink = view.$('#internal-link');
+          assert.isFalse($internalLink.hasClass('visible-url'));
+          assert.notEqual(
          $internalLink.attr('rel'),'noopener noreferrer');
-      });
+        });
 
-      it('does not convert if text and the href are the same', () => {
-        assert.equal(
+        it('does not convert if text and the href are the same', () => {
+          assert.equal(
           typeof view.$('#data-visible-url-not-added').attr('data-visible-url'),
           'undefined'
         );
+        });
+      });
+    });
+
+    describe('_onExternalLinkClick', () => {
+      it('does nothing of the link is ignored', () => {
+        sinon.stub(view, '_shouldIgnoreClick', () => true);
+        sinon.stub(view, '_flushMetricsThenRedirect', () => p());
+
+        const event = {
+          preventDefault: sinon.spy(),
+          stopImmediatePropagation: sinon.spy()
+        };
+
+        return view._onExternalLinkClick(event)
+          .then(() => {
+            assert.isFalse(event.preventDefault.called);
+            assert.isFalse(event.stopImmediatePropagation.called);
+            assert.isFalse(view._flushMetricsThenRedirect.called);
+          });
+      });
+
+      it('handles links that should be handled (cancel event, flush metrics)', () => {
+        sinon.stub(view, '_shouldIgnoreClick', () => false);
+        sinon.stub(view, '_flushMetricsThenRedirect', () => p());
+
+        const event = {
+          currentTarget: {
+            href: 'url'
+          },
+          preventDefault: sinon.spy(),
+          stopImmediatePropagation: sinon.spy(),
+        };
+
+        return view._onExternalLinkClick(event)
+          .then(() => {
+            assert.isTrue(event.preventDefault.calledOnce);
+            assert.isTrue(event.stopImmediatePropagation.calledOnce);
+            assert.isTrue(view._flushMetricsThenRedirect.calledOnce);
+            assert.isTrue(view._flushMetricsThenRedirect.calledWith('url'));
+          });
+      });
+    });
+
+    describe('_shouldIgnoreClick', () => {
+      it('returns `true` if event is modified or prevented', () => {
+        sinon.stub(view, '_isEventModifiedOrPrevented', () => true);
+        sinon.stub(view, '_doesLinkOpenInAnotherTab', () => false);
+        const event = { currentTarget: {} };
+        assert.isTrue(view._shouldIgnoreClick(event));
+      });
+
+      it('returns `true` if event opens in another tab', () => {
+        sinon.stub(view, '_isEventModifiedOrPrevented', () => false);
+        sinon.stub(view, '_doesLinkOpenInAnotherTab', () => true);
+        const event = { currentTarget: {} };
+        assert.isTrue(view._shouldIgnoreClick(event));
+      });
+
+      it('returns `false` otherwise', () => {
+        sinon.stub(view, '_isEventModifiedOrPrevented', () => false);
+        sinon.stub(view, '_doesLinkOpenInAnotherTab', () => false);
+        const event = { currentTarget: {} };
+        assert.isFalse(view._shouldIgnoreClick(event));
+      });
+    });
+
+
+    describe('_isEventModifiedOrPrevented', () => {
+      it('returns `true` if default is prevented', () => {
+        const event = {
+          altKey: false,
+          ctlKey: false,
+          isDefaultPrevented: () => true,
+          metaKey: false,
+          shiftKey: false
+        };
+
+        assert.isTrue(view._isEventModifiedOrPrevented(event));
+      });
+
+      function testSpecialKeyDepressed (which) {
+        const event = {
+          altKey: false,
+          ctlKey: false,
+          isDefaultPrevented: () => false,
+          metaKey: false,
+          shiftKey: false,
+          [ which ]: true
+        };
+
+        assert.isTrue(view._isEventModifiedOrPrevented(event));
+      }
+
+      it('returns `true` if alt key is depressed', () => {
+        testSpecialKeyDepressed('altKey');
+      });
+
+      it('returns `true` if ctrl key is depressed', () => {
+        testSpecialKeyDepressed('ctrlKey');
+      });
+
+      it('returns `true` if meta key is depressed', () => {
+        testSpecialKeyDepressed('metaKey');
+      });
+
+      it('returns `true` if shift key is depressed', () => {
+        testSpecialKeyDepressed('shiftKey');
+      });
+
+      it('returns `false` otherwise', () => {
+        const event = {
+          altKey: false,
+          ctlKey: false,
+          isDefaultPrevented: () => false,
+          metaKey: false,
+          shiftKey: false
+        };
+
+        assert.isFalse(view._isEventModifiedOrPrevented(event));
+      });
+    });
+
+    describe('_doesLinkOpenInAnotherTab', () => {
+      it('returns `true` if element has a `currentTarget`', () => {
+        const $targetEl = {
+          attr: () => '_blank'
+        };
+
+        assert.isTrue(view._doesLinkOpenInAnotherTab($targetEl));
+      });
+
+      it('returns `false` if element does not have a `currentTarget`', () => {
+        const $targetEl = {
+          attr: () => {}
+        };
+
+        assert.isFalse(view._doesLinkOpenInAnotherTab($targetEl));
+      });
+    });
+
+    describe('_flushMetricsThenRedirect', () => {
+      it('flushes the metrics, then redirects', () => {
+        sinon.stub(metrics, 'flush', () => p());
+
+        return view._flushMetricsThenRedirect('url')
+          .then(() => {
+            assert.isTrue(metrics.flush.calledOnce);
+            assert.equal(windowMock.location, 'url');
+          });
       });
     });
   });


### PR DESCRIPTION
Safari for iOS cannot flush metrics in an `unload` or `beforeunload`
handler. We had code in the `signup-mixin` to flush metrics for the
"Looking for Sync" button, but not elsewhere. This is problematic for
the App Store links that cause a redirect, but do not flush metrics.

This PR ensures all redirecting external links flush metrics before
doing the redirect.

fixes #4458

@vladikoff or @vbudhram - mind reviewing?

Here's a video to contrast with the bug report:

![metrics-reported](https://cloud.githubusercontent.com/assets/848085/20631146/0b84651a-b32d-11e6-8df4-2dad1e8de3c5.gif)
