### PR TITLE
refactor(test): bounced email takes care of its own prerequisites.

### DIFF
--- a/tests/functional/bounced_email.js
+++ b/tests/functional/bounced_email.js
@@ -12,6 +12,7 @@ define([
 ], function (intern, registerSuite, nodeXMLHttpRequest, FxaClient, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
+  var SIGNIN_URL = config.fxaContentRoot + 'signin';
 
   var bouncedEmail;
   var deliveredEmail;
@@ -19,6 +20,7 @@ define([
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
+  var openPage = FunctionalHelpers.openPage;
 
   registerSuite({
     name: 'sign_up with an email that bounces',
@@ -26,7 +28,13 @@ define([
     beforeEach: function () {
       bouncedEmail = TestHelpers.createEmail();
       deliveredEmail = TestHelpers.createEmail();
-      return this.remote.then(clearBrowserState());
+      return this.remote
+        .then(clearBrowserState())
+        // ensure a fresh signup page is loaded. If this suite is
+        // run after a Sync suite, these tests try to use a Sync broker
+        // which results in a channel timeout.
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'));
+
     },
 
     afterEach: function () {

--- a/tests/functional/cookies_disabled.js
+++ b/tests/functional/cookies_disabled.js
@@ -57,8 +57,7 @@ define([
 
     'visit verify page with localStorage disabled': function () {
       return this.remote
-        .then(openPage(VERIFY_COOKIES_DISABLED_URL, '#fxa-cookies-disabled-header'))
-        .end();
+        .then(openPage(VERIFY_COOKIES_DISABLED_URL, '#fxa-cookies-disabled-header'));
     }
   });
 });

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -12,8 +12,6 @@ define([
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_fennec_v1&service=sync';
 
-  var SIGNIN_URL = config.fxaContentRoot + 'signin';
-
   var email;
   var PASSWORD = '12345678';
 
@@ -34,12 +32,7 @@ define([
 
     afterEach: function () {
       return this.remote
-        .then(FunctionalHelpers.clearBrowserState())
-        // ensure the next test suite (bounced_email) loads a fresh
-        // signup page. If a fresh signup page is not forced, the
-        // bounced_email tests try to sign up using the Sync broker,
-        // resulting in a channel timeout.
-        .then(openPage(SIGNIN_URL, '#fxa-signin-header'));
+        .then(FunctionalHelpers.clearBrowserState());
     },
 
     'sign up, verify same browser': function () {

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -12,8 +12,6 @@ define([
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=iframe&service=sync';
 
-  var SIGNIN_URL = config.fxaContentRoot + 'signin';
-
   var email;
   var PASSWORD = '12345678';
 
@@ -33,12 +31,7 @@ define([
 
     afterEach: function () {
       return this.remote
-        .then(clearBrowserState())
-        // ensure the next test suite (bounced_email) loads a fresh
-        // signup page. If a fresh signup page is not forced, the
-        // bounced_email tests try to sign up using the Sync broker,
-        // resulting in a channel timeout.
-        .then(openPage(SIGNIN_URL, '#fxa-signin-header'));
+        .then(clearBrowserState());
     },
 
     'sign up, verify same browser in a different tab': function () {

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -12,8 +12,6 @@ define([
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_firstrun_v2&service=sync';
 
-  var SIGNIN_URL = config.fxaContentRoot + 'signin';
-
   var email;
   var PASSWORD = '12345678';
 
@@ -34,12 +32,7 @@ define([
 
     afterEach: function () {
       return this.remote
-        .then(FunctionalHelpers.clearBrowserState())
-        // ensure the next test suite (bounced_email) loads a fresh
-        // signup page. If a fresh signup page is not forced, the
-        // bounced_email tests try to sign up using the Sync broker,
-        // resulting in a channel timeout.
-        .then(openPage(SIGNIN_URL, '#fxa-signin-header'));
+        .then(FunctionalHelpers.clearBrowserState());
     },
 
     'sign up, verify same browser': function () {

--- a/tests/functional/fx_ios_v1_sign_up.js
+++ b/tests/functional/fx_ios_v1_sign_up.js
@@ -12,7 +12,6 @@ define([
 ], function (intern, assert, registerSuite, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_ios_v1&service=sync';
-  var SIGNIN_URL = config.fxaContentRoot + 'signin';
 
   var email;
   var PASSWORD = '12345678';
@@ -35,12 +34,7 @@ define([
 
     afterEach: function () {
       return this.remote
-        .then(clearBrowserState())
-        // ensure the next test suite (bounced_email) loads a fresh
-        // signup page. If a fresh signup page is not forced, the
-        // bounced_email tests try to sign up using the Sync broker,
-        // resulting in a channel timeout.
-        .then(openPage(SIGNIN_URL, '#fxa-signin-header'));
+        .then(clearBrowserState());
     },
 
     'sign up, verify same browser': function () {

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -18,8 +18,6 @@ define([
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_desktop_v1&service=sync';
   var PAGE_URL_WITH_MIGRATION = PAGE_URL + '&migration=sync11';
 
-  var SIGNIN_URL = config.fxaContentRoot + 'signin';
-
   var AUTH_SERVER_ROOT = config.fxaAuthRoot;
 
   var client;
@@ -48,18 +46,7 @@ define([
     },
 
     afterEach: function () {
-      return this.remote.then(clearBrowserState())
-        .then(function () {
-          // ensure the next test suite (bounced_email) loads a fresh
-          // signup page. If a fresh signup page is not forced, the
-          // bounced_email tests try to sign up using the Sync broker,
-          // resulting in a channel timeout.
-          return this.parent
-            .get(require.toUrl(SIGNIN_URL))
-
-            .findByCssSelector('#fxa-signin-header')
-            .end();
-        });
+      return this.remote.then(clearBrowserState());
     },
 
     'sign up, verify same browser': function () {

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -6,14 +6,11 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_desktop_v2&service=sync&forceAboutAccounts=true';
-
-  var SIGNIN_URL = config.fxaContentRoot + 'signin';
 
   var email;
   var PASSWORD = '12345678';
@@ -36,20 +33,7 @@ define([
     },
 
     afterEach: function () {
-      var self = this;
-
-      return this.remote.then(clearBrowserState())
-        .then(function () {
-          // ensure the next test suite (bounced_email) loads a fresh
-          // signup page. If a fresh signup page is not forced, the
-          // bounced_email tests try to signup using the Sync broker,
-          // resulting in a channel timeout.
-          return self.remote
-            .get(require.toUrl(SIGNIN_URL))
-
-            .findByCssSelector('#fxa-signin-header')
-            .end();
-        });
+      return this.remote.then(clearBrowserState());
     },
 
     'signup, verify same browser': function () {

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -6,14 +6,11 @@ define([
   'intern',
   'intern!object',
   'intern/chai!assert',
-  'require',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, assert, require, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
-
-  var SIGNIN_URL = config.fxaContentRoot + 'signin';
 
   var email;
   var PASSWORD = '12345678';
@@ -35,20 +32,7 @@ define([
     },
 
     afterEach: function () {
-      var self = this;
-
-      return this.remote.then(clearBrowserState())
-        .then(function () {
-          // ensure the next test suite (bounced_email) loads a fresh
-          // signup page. If a fresh signup page is not forced, the
-          // bounced_email tests try to sign up using the Sync broker,
-          // resulting in a channel timeout.
-          return self.remote
-            .get(require.toUrl(SIGNIN_URL))
-
-            .findByCssSelector('#fxa-signin-header')
-            .end();
-        });
+      return this.remote.then(clearBrowserState());
     },
 
     'sign up, verify same browser': function () {


### PR DESCRIPTION
Other tests should not need to go to `/signin` to ensure the
bounced_email suite passes. Instead, bounced_email should take
care of ensuring the correct page is loaded. Now it does.