### PR TITLE
fix(metrics): prevent re-entrant flushing of duplicate data

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -167,6 +167,14 @@ define(function (require, exports, module) {
      * @returns {Promise}
      */
     flush (isPageUnloading) {
+      if (this._isFlushing) {
+        // Re-entrant flushing causes duplicate events to
+        // be emitted on the server, which we don't want.
+        return;
+      }
+
+      this._isFlushing = true;
+
       // Inactivity timer is restarted when the next event/timer comes in.
       // This avoids sending empty result sets if the tab is
       // just sitting there open with no activity.
@@ -186,6 +194,9 @@ define(function (require, exports, module) {
           }
 
           return sent;
+        })
+        .fin(() => {
+          this._isFlushing = false;
         });
     },
 

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -500,6 +500,24 @@ define(function (require, exports, module) {
           assert.isTrue(data.timers.foo[0].elapsed >= 4);
         });
       });
+
+      it('flush is not re-entrant', () => {
+        let flushCount = 0;
+
+        sandbox.stub(metrics, '_send', () => {
+          if (flushCount++ < 2) {
+            $(windowMock).trigger('blur');
+          } else {
+            assert.notOk(true, 'flush should not be re-entrant');
+          }
+          return p(true);
+        });
+
+        metrics.logEvent('wibble');
+        $(windowMock).trigger('blur');
+
+        assert.strictEqual(flushCount, 1, 'flush only sent data once');
+      });
     });
 
     describe('errorToId', function () {


### PR DESCRIPTION
Fixes #4468.

I think all of our metrics for this repo may be (a little bit) wrong, for two reasons.

1. Sometimes `metrics.flush` is re-entered, causing duplicate events and timers to be sent to the server. Essentially, whenever a `blur` or `unload` event occurs while a flush is in progress, then we have problems.

2. There is also a related problem that, any time an event or timer is recorded while a metrics request is in flight, it will later get clobbered when we clear the events and timers after the response is received from the server.

The changes here are a quick-and-dirty fix for the first problem. Mostly opened as a starting-point for discussion and to bring people's attention to it. I'm working on a better, slightly more complex fix at the moment, which will also address the second problem of events/timers being clobbered on flush completion.

/cc @shane-tomlinson @vladikoff, any thoughts on the above?

