### PR TITLE
fix(client): Use the server returned email when signing in.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -214,6 +214,9 @@ define(function (require, exports, module) {
      *   @param {String} [options.sessionTokenContext] - The context for which
      *                   the session token is being created. Defaults to the
      *                   relier's context.
+     *   @param {Boolean} [options.skipCaseError] - if set to true, INCCORECT_EMAIL_CASE
+     *                   errors will be returned to be handled locally instead of automatically
+     *                   being retried in the fxa-js-client.
      *   @param {String} [options.unblockCode] - Unblock code.
      * @returns {Promise}
      */
@@ -241,6 +244,10 @@ define(function (require, exports, module) {
 
       if (options.resume) {
         signInOptions.resume = options.resume;
+      }
+
+      if (options.skipCaseError) {
+        signInOptions.skipCaseError = options.skipCaseError;
       }
 
       setMetricsContext(signInOptions, options);
@@ -609,4 +616,3 @@ define(function (require, exports, module) {
     }
   }
 });
-

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -647,7 +647,6 @@ define(function (require, exports, module) {
           return p({});
         });
 
-
         return client.signIn(email, password, relier, { resume: 'resume token' })
           .then(function () {
             assert.isTrue(realClient.signIn.calledWith(trim(email), password, {
@@ -677,6 +676,23 @@ define(function (require, exports, module) {
             reason: SignInReasons.SIGN_IN,
             service: NON_SYNC_SERVICE
           });
+        });
+      });
+
+      it('passes along an optional `skipCaseError`', () => {
+        sinon.stub(realClient, 'signIn', () => p({}));
+
+        return client.signIn(email, password, relier, {
+          skipCaseError: true
+        })
+        .then(() => {
+          assert.isTrue(realClient.signIn.calledWith(trim(email), password, {
+            keys: false,
+            reason: SignInReasons.SIGN_IN,
+            redirectTo: REDIRECT_TO,
+            service: SYNC_SERVICE,
+            skipCaseError: true
+          }));
         });
       });
     });
@@ -1298,4 +1314,3 @@ define(function (require, exports, module) {
     });
   });
 });
-

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -26,6 +26,7 @@ define([
   var openPage = FunctionalHelpers.openPage;
   var openSettingsInNewTab = thenify(FunctionalHelpers.openSettingsInNewTab);
   var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementTextEquals = FunctionalHelpers.testElementTextEquals;
   var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
 
   var FIRST_PASSWORD = 'password';
@@ -94,6 +95,15 @@ define([
         // success is going to the signin page
         .findById('fxa-signin-header')
         .end();
+    },
+
+    'sign in with incorrect email case, go to settings, canonical email form is used': function () {
+      return this.remote
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
+        .then(fillOutSignIn(email.toUpperCase(), FIRST_PASSWORD))
+
+        .then(testElementExists('#fxa-settings-header'))
+        .then(testElementTextEquals('.card-header', email));
     },
 
     'sign in, go to settings with setting param set to avatar redirects to avatar change page ': function () {

--- a/tests/functional/sync_v3_sign_in.js
+++ b/tests/functional/sync_v3_sign_in.js
@@ -35,6 +35,8 @@ define([
 
   var setupTest = thenify(function (options) {
     options = options || {};
+    const signInEmail = options.signInEmail || email;
+    const signUpEmail = options.signUpEmail || email;
 
     const successSelector = options.blocked ? '#fxa-signin-unblock-header' :
                             options.preVerified ? '#fxa-confirm-signin-header' :
@@ -42,10 +44,10 @@ define([
 
     return this.parent
       .then(clearBrowserState({ force: true }))
-      .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
+      .then(createUser(signUpEmail, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(PAGE_URL, '#fxa-signin-header'))
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
-      .then(fillOutSignIn(email, PASSWORD))
+      .then(fillOutSignIn(signInEmail, PASSWORD))
 
       .then(testIsBrowserNotified(this.parent, 'fxaccounts:can_link_account'))
 
@@ -147,6 +149,30 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
+        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+
+        // about:accounts will take over post-verification, no transition
+        .then(noPageTransition('#fxa-signin-unblock-header'));
+    },
+
+    'verified, blocked, incorrect email case': function () {
+      const signUpEmail = TestHelpers.createEmail('blocked{id}');
+      const signInEmail = signUpEmail.toUpperCase();
+      return this.remote
+        .then(setupTest({
+          blocked: true,
+          preVerified: true,
+          signInEmail: signInEmail,
+          signUpEmail: signUpEmail
+        }))
+
+        // a second `can_link_account` request is sent to the browser after the
+        // unblock code is filled in, this time with the canonicalized email address.
+        // If a different user was signed in to the browser, two "merge" dialogs
+        // are presented, the first for the non-canonicalized email, the 2nd for
+        // the canonicalized email. Ugly UX, but at least the user can proceed.
+        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(fillOutSignInUnblock(signUpEmail, 0))
         .then(testIsBrowserNotified(this, 'fxaccounts:login'))
 
         // about:accounts will take over post-verification, no transition


### PR DESCRIPTION
Signin unblock is broken if the user types their email using different
casing to when they signed up. The auth server returns an error that
says "Feature not enabled". This fixes that by updating the model
with the email that is returned by the server if it returns an
INCORRECT_EMAIL_CASE error.

fixes #3893
fixes #4467

@vladikoff - r?