### PR TITLE
fix(client): Canonicalize emails when going to /settings

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -259,15 +259,14 @@ define(function (require, exports, module) {
      */
     checkAuthorization () {
       if (this.mustAuth || this.mustVerify) {
-        var account = this.getSignedInAccount();
-        return account.sessionStatus()
-          .then((resp) => {
-            if (this.mustVerify && ! resp.verified) {
+        return this.user.sessionStatus()
+          .then((account) => {
+            if (this.mustVerify && ! account.get('verified')) {
               var targetScreen;
 
-              if (resp.verificationReason === VerificationReasons.SIGN_UP) {
+              if (account.get('verificationReason') === VerificationReasons.SIGN_UP) {
                 targetScreen = 'confirm';
-              } else if (resp.verificationReason === VerificationReasons.SIGN_IN) {
+              } else if (account.get('verificationReason') === VerificationReasons.SIGN_IN) {
                 targetScreen = 'confirm_signin';
               }
 

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -199,26 +199,31 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('account has a sessionToken', function () {
-        var resp;
+      describe('account has a sessionToken', () => {
+        let resp;
+        const CANONICAL_EMAIL = 'testuser@testuser.com';
 
-        beforeEach(function () {
-          account.set('sessionToken', 'session token');
-
-          sinon.stub(fxaClient, 'recoveryEmailStatus', function () {
-            return p({
-              verified: true
-            });
+        beforeEach(() => {
+          account.set({
+            email: CANONICAL_EMAIL.toUpperCase(),
+            sessionToken: 'session token'
           });
 
+          sinon.stub(fxaClient, 'recoveryEmailStatus', () => p({
+            email: CANONICAL_EMAIL,
+            verified: true
+          }));
+
           return account.sessionStatus()
-            .then(function (_resp) {
+            .then((_resp) => {
               resp = _resp;
             });
         });
 
-        it('resolves with the session information', function () {
-          assert.isTrue(resp.verified);
+        it('resolves with the session information, updates the model', () => {
+          assert.deepEqual(resp, { email: CANONICAL_EMAIL, verified: true });
+          assert.equal(account.get('email'), CANONICAL_EMAIL);
+          assert.isTrue(account.get('verified'));
         });
       });
     });
@@ -237,7 +242,6 @@ define(function (require, exports, module) {
 
         it('polls until /recovery_email/status returns `verified: true`', () => {
           assert.equal(account.sessionStatus.callCount, 3);
-          assert.isTrue(account.get('verified'));
         });
       });
 

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -190,17 +190,7 @@ define(function (require, exports, module) {
       });
 
       it('redirects to `/signin` if the user is not authenticated', function () {
-        var account = user.initAccount({
-          email: 'a@a.com',
-          sessionToken: 'abc123',
-          uid: 'uid'
-        });
-        sinon.stub(account, 'sessionStatus', function () {
-          return p.reject(AuthErrors.toError('INVALID_TOKEN'));
-        });
-        sinon.stub(view, 'getSignedInAccount', function () {
-          return account;
-        });
+        sinon.stub(user, 'sessionStatus', () => p.reject(AuthErrors.toError('INVALID_TOKEN')));
         sinon.spy(view, 'navigate');
 
         view.mustAuth = true;
@@ -217,17 +207,7 @@ define(function (require, exports, module) {
       it('redirects to `/force_auth` if the user is not authenticated and the relier specifies an email', function () {
         relier.set('email', 'a@a.com');
 
-        var account = user.initAccount({
-          email: 'a@a.com',
-          sessionToken: 'abc123',
-          uid: 'uid'
-        });
-        sinon.stub(account, 'sessionStatus', function () {
-          return p.reject(AuthErrors.toError('INVALID_TOKEN'));
-        });
-        sinon.stub(view, 'getSignedInAccount', function () {
-          return account;
-        });
+        sinon.stub(user, 'sessionStatus', () => p.reject(AuthErrors.toError('INVALID_TOKEN')));
         sinon.spy(view, 'navigate');
 
         view.mustAuth = true;
@@ -243,21 +223,16 @@ define(function (require, exports, module) {
 
       it('redirects to `/confirm` if mustVerify flag is set and account is unverified', function () {
         view.mustVerify = true;
-        var account = user.initAccount({
+        const account = user.initAccount({
           email: 'a@a.com',
           sessionToken: 'abc123',
-          uid: 'uid'
+          uid: 'uid',
+          verificationMethod: VerificationMethods.EMAIL,
+          verificationReason: VerificationReasons.SIGN_UP,
+          verified: false
         });
-        sinon.stub(account, 'sessionStatus', function () {
-          return p({
-            verificationMethod: VerificationMethods.EMAIL,
-            verificationReason: VerificationReasons.SIGN_UP,
-            verified: false,
-          });
-        });
-        sinon.stub(view, 'getSignedInAccount', function () {
-          return account;
-        });
+        sinon.stub(user, 'sessionStatus', () => p(account));
+
         sinon.spy(view, 'navigate');
         return view.render()
           .then(function () {
@@ -267,21 +242,16 @@ define(function (require, exports, module) {
 
       it('redirects to `/confirm_signin` if mustVerify flag is set and session is unverified', function () {
         view.mustVerify = true;
-        var account = user.initAccount({
+        const account = user.initAccount({
           email: 'a@a.com',
           sessionToken: 'abc123',
-          uid: 'uid'
+          uid: 'uid',
+          verificationMethod: VerificationMethods.EMAIL,
+          verificationReason: VerificationReasons.SIGN_IN,
+          verified: false
         });
-        sinon.stub(account, 'sessionStatus', function () {
-          return p({
-            verificationMethod: VerificationMethods.EMAIL,
-            verificationReason: VerificationReasons.SIGN_IN,
-            verified: false
-          });
-        });
-        sinon.stub(view, 'getSignedInAccount', function () {
-          return account;
-        });
+        sinon.stub(user, 'sessionStatus', () => p(account));
+
         sinon.spy(view, 'navigate');
         return view.render()
           .then(function () {
@@ -291,22 +261,16 @@ define(function (require, exports, module) {
 
       it('succeeds if mustVerify flag is set and account has verified since being stored', function () {
         view.mustVerify = true;
-        var account = user.initAccount({
+        const account = user.initAccount({
           email: 'a@a.com',
           sessionToken: 'abc123',
           uid: 'uid'
         });
-        sinon.stub(account, 'sessionStatus', function () {
-          return p({
-            verified: true
-          });
+        sinon.stub(user, 'sessionStatus', () => {
+          account.set('verified', true);
+          return p(account);
         });
-        sinon.stub(view, 'getSignedInAccount', function () {
-          return account;
-        });
-        sinon.stub(user, 'setAccount', function () {
-          return account;
-        });
+
         return view.render()
           .then(function (result) {
             assert.isTrue(result);
@@ -321,14 +285,8 @@ define(function (require, exports, module) {
           uid: 'uid',
           verified: true
         });
-        sinon.stub(account, 'sessionStatus', function () {
-          return p({
-            verified: true
-          });
-        });
-        sinon.stub(view, 'getSignedInAccount', function () {
-          return account;
-        });
+        sinon.stub(user, 'sessionStatus', () => p(account));
+
         return view.render()
           .then(function (result) {
             assert.isTrue(result);

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -156,31 +156,18 @@ define(function (require, exports, module) {
       it('clears session information if uid is not found', function () {
         var account = user.initAccount({});
 
-        sinon.stub(account, 'sessionStatus', function () {
-          return p.reject(AuthErrors.toError('INVALID_TOKEN'));
-        });
-
-        sinon.stub(user, 'getAccountByUid', function () {
-          return account;
-        });
-
+        sinon.stub(user, 'sessionStatus', () => p.reject(AuthErrors.toError('INVALID_TOKEN')));
+        sinon.stub(user, 'getAccountByUid', () => account);
         sinon.spy(user, 'clearSignedInAccount');
 
         relier.set('uid', UID);
 
         createSettingsView();
 
-        sinon.stub(view, 'getSignedInAccount', function () {
-          return account;
-        });
-
         return view.render()
           .then(function () {
-            $('#container').append(view.el);
-          })
-          .then(function () {
             assert.isTrue(user.getAccountByUid.calledWith(UID));
-            assert.isTrue(user.clearSignedInAccount.called);
+            assert.isTrue(user.clearSignedInAccount.calledOnce);
             assert.isTrue(view.navigate.calledWith('signin'));
           });
       });

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1171,6 +1171,7 @@ define([
    *
    * @param {string} selector
    * @param {string} expected
+   * @param {object} [options]
    * @returns {promise} rejects if test fails.
    */
   function testElementTextInclude(selector, expected) {
@@ -1474,6 +1475,32 @@ define([
     };
   }
 
+  /**
+   * Denormalize the email stored in an account. Sets the email to be all uppercase.
+   *
+   * @param   {string} email - email address to denormalize
+   * @returns {promise}
+   */
+  function denormalizeStoredEmail (email) {
+    return function () {
+      return this.parent
+        .execute((email) => {
+          // synthesize the user signing in before the email normalization fix went in (#4470)
+          var accounts = JSON.parse(localStorage.getItem('__fxa_storage.accounts'));
+          console.log('looking for email', email);
+
+          for (var uid in accounts) {
+            var account = accounts[uid];
+            if (account.email === email) {
+              console.log('will change email', email);
+              account.email = email.toUpperCase();
+            }
+          }
+          localStorage.setItem('__fxa_storage.accounts', JSON.stringify(accounts));
+        }, [ email ]);
+    };
+  }
+
   return {
     clearBrowserNotifications: clearBrowserNotifications,
     clearBrowserState: clearBrowserState,
@@ -1481,6 +1508,7 @@ define([
     click: click,
     closeCurrentWindow: closeCurrentWindow,
     createUser: createUser,
+    denormalizeStoredEmail: denormalizeStoredEmail,
     fetchAllMetrics: fetchAllMetrics,
     fillOutChangePassword: fillOutChangePassword,
     fillOutCompleteResetPassword: fillOutCompleteResetPassword,

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -20,6 +20,7 @@ define([
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
+  var denormalizeStoredEmail = FunctionalHelpers.denormalizeStoredEmail;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var focus = FunctionalHelpers.focus;
   var getFxaClient = FunctionalHelpers.getFxaClient;
@@ -101,6 +102,23 @@ define([
       return this.remote
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email.toUpperCase(), FIRST_PASSWORD))
+
+        .then(testElementExists('#fxa-settings-header'))
+        .then(testElementTextEquals('.card-header', email));
+    },
+
+    'sign in with incorrect email case before normalization fix, go to settings, canonical email form is used': function () {
+      return this.remote
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
+        .then(fillOutSignIn(email, FIRST_PASSWORD))
+
+        .then(testElementExists('#fxa-settings-header'))
+
+        // synthesize signin pre-#4470 with incorrect email case
+        .then(denormalizeStoredEmail(email))
+
+        // now, refresh to ensure the email is normalized
+        .refresh()
 
         .then(testElementExists('#fxa-settings-header'))
         .then(testElementTextEquals('.card-header', email));


### PR DESCRIPTION
Any time account.sessionStatus is called, update the account's email
address with the address returned by the server. This forces the
server's canonicalized email address to be used instead of any
uncanonicalized addresses from before this PR.

This is used by base.js for views that require a valid session or
verification, such as settings.

fixes #4463 

This builds on #4472 and should be reviewed afterwards.

A case *not* handled by this PR is a user that opens `/signin` with a cached email. Handling the case when the sessionToken was valid was easy, handling the case where the sessionToken was invalid was a big ball of mud, so I deferred it. Will open an issue about it.

@vladikoff - r?