### PR TITLE
fix(metrics): propagate metrics context data to /account/reset

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -424,6 +424,7 @@ define(function (require, exports, module) {
         keys: wantsKeys(relier),
         sessionToken: true
       };
+      setMetricsContext(accountResetOptions, options);
 
       var passwordVerifyCodeOptions = {};
       setMetricsContext(passwordVerifyCodeOptions, options);

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -855,17 +855,17 @@ define(function (require, exports, module) {
       });
 
       it('passes along an optional `metricsContext`', function () {
-        var options = {
-          metricsContext: {}
+        const metricsContext = {
+          flowBeginTime: 'foo',
+          flowId: 'bar'
         };
 
-        return client.completePasswordReset(email, password, token, code, relier, options)
+        return client.completePasswordReset(email, password, token, code, relier, { metricsContext })
           .then(function () {
-            var params = {
-              metricsContext: options.metricsContext
-            };
             assert.isTrue(realClient.passwordForgotVerifyCode.calledWith(
-              code, token, params));
+              code, token, { metricsContext }));
+            assert.isTrue(realClient.accountReset.calledWith(
+                trim(email), password, 'reset_token', { keys: true, metricsContext, sessionToken: true }));
           });
       });
     });


### PR DESCRIPTION
Fixes #4477.

Final piece of the jigsaw. Without this change the following flow events don't show up in the auth server when resetting a password:

```
flowEvent {"event":"password.forgot.verify_code.start","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1480630319062,"flow_id":"7fb73ecc4496954860c7c26d097036309c1821ab6ece63c267e399597958439c","flow_time":34605}
flowEvent {"event":"password.forgot.verify_code.completed","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0","time":1480630319079,"flow_id":"7fb73ecc4496954860c7c26d097036309c1821ab6ece63c267e399597958439c","flow_time":34622}
```

With this change they do.

@vladikoff r?