### PR TITLE
feat(metrics): Log the number of stored accounts on the /signin page.

### DIFF
--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -69,6 +69,14 @@ define(function (require, exports, module) {
       });
     },
 
+    /**
+     * Log the number of stored accounts
+     */
+    logNumStoredAccounts () {
+      const numAccounts = Object.keys(this._accounts()).length;
+      this._metrics.logEventOnce(`num.accounts.${numAccounts}`);
+    },
+
     _accounts () {
       return this._storage.get('accounts') || {};
     },

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -74,7 +74,7 @@ define(function (require, exports, module) {
      */
     logNumStoredAccounts () {
       const numAccounts = Object.keys(this._accounts()).length;
-      this._metrics.logEventOnce(`num.accounts.${numAccounts}`);
+      this._metrics.logNumStoredAccounts(numAccounts);
     },
 
     _accounts () {

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -36,6 +36,15 @@ define(function (require, exports, module) {
       options = options || {};
 
       this._formPrefill = options.formPrefill;
+
+      // The number of stored accounts is logged to see if we can simplify
+      // the User model. User grew a lot of complexity to support a user
+      // being able to sign in using more than one email address, and we
+      // want to see if this is being used in reality. If not, the model
+      // can probably be vastly simplified. # of users is only logged from
+      // the sign_in view because these are the users that are most likely
+      // to have stored accounts, users that visit /signup probably not.
+      this.user.logNumStoredAccounts();
     },
 
     beforeRender () {

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -51,6 +51,7 @@ define(function (require, exports, module) {
     beforeEach(function () {
       fxaClientMock = new FxaClient();
       metrics = {
+        logEventOnce: sinon.spy(),
         setFlowModel: sinon.spy()
       };
       notifier = new Notifier();
@@ -1157,6 +1158,30 @@ define(function (require, exports, module) {
       it('delegates to the account', () => {
         assert.isTrue(account.rejectUnblockCode.calledOnce);
         assert.isTrue(account.rejectUnblockCode.calledWith(UNBLOCK_CODE));
+      });
+    });
+
+    describe('logNumStoredAccounts', () => {
+      let account;
+
+      beforeEach(() => {
+        account = user.initAccount({
+          email: 'testuser@testuser.com',
+          uid: 'uid'
+        });
+      });
+
+      it('logs the number of stored accounts', () => {
+        // no accounts to begin with.
+        user.logNumStoredAccounts();
+        assert.equal(metrics.logEventOnce.callCount, 1);
+        assert.isTrue(metrics.logEventOnce.calledWith('num.accounts.0'));
+
+        // add an account to storage.
+        user._persistAccount(account);
+        user.logNumStoredAccounts();
+        assert.equal(metrics.logEventOnce.callCount, 2);
+        assert.isTrue(metrics.logEventOnce.calledWith('num.accounts.1'));
       });
     });
   });

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
     beforeEach(function () {
       fxaClientMock = new FxaClient();
       metrics = {
-        logEventOnce: sinon.spy(),
+        logNumStoredAccounts: sinon.spy(),
         setFlowModel: sinon.spy()
       };
       notifier = new Notifier();
@@ -1174,14 +1174,14 @@ define(function (require, exports, module) {
       it('logs the number of stored accounts', () => {
         // no accounts to begin with.
         user.logNumStoredAccounts();
-        assert.equal(metrics.logEventOnce.callCount, 1);
-        assert.isTrue(metrics.logEventOnce.calledWith('num.accounts.0'));
+        assert.equal(metrics.logNumStoredAccounts.callCount, 1);
+        assert.isTrue(metrics.logNumStoredAccounts.calledWith(0));
 
         // add an account to storage.
         user._persistAccount(account);
         user.logNumStoredAccounts();
-        assert.equal(metrics.logEventOnce.callCount, 2);
-        assert.isTrue(metrics.logEventOnce.calledWith('num.accounts.1'));
+        assert.equal(metrics.logNumStoredAccounts.callCount, 2);
+        assert.isTrue(metrics.logNumStoredAccounts.calledWith(1));
       });
     });
   });

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -46,7 +46,8 @@ define(function (require, exports, module) {
       notifier = new Notifier();
       relier = new Relier();
       user = new User({
-        notifier: notifier
+        metrics,
+        notifier
       });
       user.getSignedInAccount().set('uid', 'foo');
 

--- a/app/tests/spec/views/oauth_sign_in.js
+++ b/app/tests/spec/views/oauth_sign_in.js
@@ -52,11 +52,12 @@ define(function (require, exports, module) {
         window: windowMock
       });
       fxaClient = new FxaClient();
-      user = new User({
-        fxaClient: fxaClient,
-        notifier: notifier
-      });
       metrics = new Metrics();
+      user = new User({
+        fxaClient,
+        metrics,
+        notifier
+      });
       profileClientMock = TestHelpers.stubbedProfileClient();
       formPrefill = new FormPrefill();
       notifier = new Notifier();

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -53,7 +53,8 @@ define(function (require, exports, module) {
       });
 
       user = new User({
-        notifier: notifier
+        metrics,
+        notifier
       });
 
       Session.clear();
@@ -820,13 +821,12 @@ define(function (require, exports, module) {
       });
     });
 
+    it('logs the number of stored accounts on creation', () => {
+      sinon.stub(user, 'logNumStoredAccounts', () => {});
 
-    it('logs the submit event', () => {
-      view.$('#submit-btn').click();
-      assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.signin.submit'));
-      view.enableForm();
-      view.$('#submit-btn').click();
-      assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signin.submit'));
+      initView();
+
+      assert.isTrue(user.logNumStoredAccounts.calledOnce);
     });
   });
 });

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -79,6 +79,9 @@ Contains:
 
 See https://developer.mozilla.org/docs/Navigation_timing for more information.
 
+### numStoredAccounts
+The number of accounts the user has stored in localStorage. Only sent once from the /signin page.
+
 ### referrer
 Where the user came from. Not set if the `referrer` header cannot be read.
 
@@ -286,7 +289,6 @@ The event stream is a log of events and the time they occurred while the user is
 * error.signin.auth.1023 - user entered an email address that was invalid
 * flow.signin.engage - user engaged the form
 * flow.signin.submit - user submit the form with front-end validation passing
-* num.accounts.<n> - number of stored accounts - when viewing the signin page
 * signin.ask-password.skipped - skipped asking for password thanks to existing session token
 * signin.ask-password.shown.account-unknown - asked for password due to missing account data
 * signin.ask-password.shown.email-mismatch - asked for password due to using a different email

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -286,6 +286,7 @@ The event stream is a log of events and the time they occurred while the user is
 * error.signin.auth.1023 - user entered an email address that was invalid
 * flow.signin.engage - user engaged the form
 * flow.signin.submit - user submit the form with front-end validation passing
+* num.accounts.<n> - number of stored accounts - when viewing the signin page
 * signin.ask-password.skipped - skipped asking for password thanks to existing session token
 * signin.ask-password.shown.account-unknown - asked for password due to missing account data
 * signin.ask-password.shown.email-mismatch - asked for password due to using a different email

--- a/server/lib/statsd-collector.js
+++ b/server/lib/statsd-collector.js
@@ -186,7 +186,7 @@ function sendNumStoredAccounts(context, numStoredAccounts, tags) {
       // by tag. Convert the count to a tag so we can see which tag has
       // the most values.
       context.increment(
-        type, ['has:' + reportedNumStoredAccounts].concat(tags));
+        type, ['num_stored_accounts:' + reportedNumStoredAccounts].concat(tags));
     } else {
       logOutOfRange(type, numStoredAccounts, 0, STORED_ACCOUNTS_MAX_COUNT);
     }

--- a/server/lib/statsd-collector.js
+++ b/server/lib/statsd-collector.js
@@ -12,6 +12,12 @@ var uaParser = require('node-uap');
 var NAVIGATION_TIMING_MAX_OFFSET = 2 * 60 * 1000;
 var USER_ACTION_MAX_OFFSET = Infinity;
 
+const STORED_ACCOUNTS_MAX_COUNT = Infinity;
+// To avoid outliers, place an artificial upper limit on the
+// stored accounts count. If the reported count is higher,
+// use this instead.
+const STORED_ACCOUNTS_MAX_REPORTED_COUNT = 2;
+
 var STATSD_PREFIX = 'fxa.content.';
 var TIMING_POSTFIX = '.time';
 var TIMED_EVENTS = [
@@ -99,15 +105,18 @@ function isEventOffsetValid(value) {
   return typeof value === 'number';
 }
 
-function isEventOffsetInRange(value, min, max) {
+function isInRange(value, min, max) {
   return value >= min && value <= max;
 }
 
-function logOutOfRangeOffset(type, offset, min, max) {
+function logOutOfRange(type, offset, min, max) {
   logger.error('Out of range (%s): %s [%s, %s]',
       type, offset, min, max);
 }
 
+function isCountValid(value) {
+  return typeof value === 'number';
+}
 
 function getImpressionTags(impression) {
   return [
@@ -126,10 +135,10 @@ function sendEvents(context, events, tags) {
 
         var offset = event.offset;
         if (isTimedEvent(type) && isEventOffsetValid(offset)) {
-          if (isEventOffsetInRange(offset, 0, USER_ACTION_MAX_OFFSET)) {
+          if (isInRange(offset, 0, USER_ACTION_MAX_OFFSET)) {
             context.timing(type, offset, tags);
           } else {
-            logOutOfRangeOffset(type, offset, 0, USER_ACTION_MAX_OFFSET);
+            logOutOfRange(type, offset, 0, USER_ACTION_MAX_OFFSET);
           }
         }
       }
@@ -157,12 +166,29 @@ function sendNavigationTiming(context, navigationTiming, tags) {
       if (isEventOffsetValid(offset)) {
         var type = 'navigationTiming.' + key;
 
-        if (isEventOffsetInRange(offset, 0, NAVIGATION_TIMING_MAX_OFFSET)) {
+        if (isInRange(offset, 0, NAVIGATION_TIMING_MAX_OFFSET)) {
           context.timing(type, offset, tags);
         } else {
-          logOutOfRangeOffset(type, offset, 0, NAVIGATION_TIMING_MAX_OFFSET);
+          logOutOfRange(type, offset, 0, NAVIGATION_TIMING_MAX_OFFSET);
         }
       }
+    }
+  }
+}
+
+function sendNumStoredAccounts(context, numStoredAccounts, tags) {
+  if (isCountValid(numStoredAccounts)) {
+    const type = 'num_stored_accounts';
+    if (isInRange(numStoredAccounts, 0, STORED_ACCOUNTS_MAX_COUNT)) {
+      const reportedNumStoredAccounts =
+        Math.min(numStoredAccounts, STORED_ACCOUNTS_MAX_REPORTED_COUNT);
+      // DataDog distribution graphs allow a particular event to be segmented
+      // by tag. Convert the count to a tag so we can see which tag has
+      // the most values.
+      context.increment(
+        type, ['has:' + reportedNumStoredAccounts].concat(tags));
+    } else {
+      logOutOfRange(type, numStoredAccounts, 0, STORED_ACCOUNTS_MAX_COUNT);
     }
   }
 }
@@ -212,6 +238,7 @@ StatsDCollector.prototype = {
       sendEvents(this, body.events, tags);
       sendMarketingImpressions(this, body.marketing, tags);
       sendNavigationTiming(this, body.navigationTiming, tags);
+      sendNumStoredAccounts(this, body.numStoredAccounts, tags);
     }
   },
 

--- a/tests/server/expected/statsd_count_body_numStoredAccounts.txt
+++ b/tests/server/expected/statsd_count_body_numStoredAccounts.txt
@@ -1,1 +1,1 @@
-fxa.content.num_stored_accounts:1|c|#has:2,context:web,broker:fx-desktop-v1,entrypoint:none,migration:none,lang:en,service:none,agent_ua_family:Chrome,agent_ua_version:42.0.2311,agent_ua_version_major:42,agent_os_version:10.10.3,agent_os_family:Mac OS X,agent_os_major:10
+fxa.content.num_stored_accounts:1|c|#num_stored_accounts:2,context:web,broker:fx-desktop-v1,entrypoint:none,migration:none,lang:en,service:none,agent_ua_family:Chrome,agent_ua_version:42.0.2311,agent_ua_version_major:42,agent_os_version:10.10.3,agent_os_family:Mac OS X,agent_os_major:10

--- a/tests/server/expected/statsd_count_body_numStoredAccounts.txt
+++ b/tests/server/expected/statsd_count_body_numStoredAccounts.txt
@@ -1,0 +1,1 @@
+fxa.content.num_stored_accounts:1|c|#has:2,context:web,broker:fx-desktop-v1,entrypoint:none,migration:none,lang:en,service:none,agent_ua_family:Chrome,agent_ua_version:42.0.2311,agent_ua_version_major:42,agent_os_version:10.10.3,agent_os_family:Mac OS X,agent_os_major:10

--- a/tests/server/fixtures/statsd_body_1.json
+++ b/tests/server/fixtures/statsd_body_1.json
@@ -43,6 +43,7 @@
         "loadEventStart": 689,
         "loadEventEnd": 689
     },
+    "numStoredAccounts": 4,
     "screen": {
         "devicePixelRatio": 2,
         "clientWidth": 819,

--- a/tests/server/fixtures/statsd_body_filter_out_of_range.json
+++ b/tests/server/fixtures/statsd_body_filter_out_of_range.json
@@ -47,6 +47,7 @@
         "loadEventStart": 120001,
         "loadEventEnd": -689
     },
+    "numStoredAccounts": -1,
     "screen": {
         "devicePixelRatio": 2,
         "clientWidth": 819,

--- a/tests/server/statsd-collector.js
+++ b/tests/server/statsd-collector.js
@@ -58,6 +58,7 @@ define([
     var MESSAGES_TO_TEST = {
       'fxa.content.loaded.time': 'statsd_timer_body_login.txt',
       'fxa.content.marketing.impression': 'statsd_impression_body_marketing.txt',
+      'fxa.content.num_stored_accounts': 'statsd_count_body_numStoredAccounts.txt',
       'fxa.content.signup.success': 'statsd_event_body_signup_success.txt',
       'fxa.content.signup.success.time': 'statsd_timer_body_signup_success.txt'
     };


### PR DESCRIPTION
The User model became very complex to support allowing users to sign in
to reliers using more than one address. This is to see how many accounts
the normal user has whenever they first visit the signin page to see
how often this capability is actually being used. If a very low number
of people make use of this, I'd like to vastly simplify the User model.

@vladikoff or @rfk - r?