### PR TITLE
chore(travis): disable Node 6 builds until fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 
 node_js:
   - "4"
-  - "6"
 
 addons:
   firefox: "46.0"


### PR DESCRIPTION
Ref: https://github.com/mozilla/fxa-content-server/issues/4507