### PR TITLE
fix(style): Fix the modal vertical position on mobile devices.

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -469,7 +469,7 @@ body.settings #main-content.card {
 
   @include respond-to('small') {
     padding: 10px;
-    width: 320px;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
If the screen size went below 360px, the
fixed-width of the modal + paddings + margins added up to > 360px and
caused the modal to scroll off the bottom of the screen.

This fixes that problem by setting the modal width to 100% of the
available space in `small` mode. The width will resize with the
screen size below 320px.

fixes #4491

@mozilla/fxa-devs - r?