### PR TITLE
fix(typo): fix ‘redundantly’ typo in validate.js

### DIFF
--- a/app/scripts/lib/validate.js
+++ b/app/scripts/lib/validate.js
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
   //     in the domain (https://github.com/mozilla/fxa-content-server/issues/2199)
   // IETF spec:
   //   * http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
-  // '/' in the character class is (reduntantly) backslash-escaped to produce
+  // '/' in the character class is (redundantly) backslash-escaped to produce
   // the same minimized form in node 4.x and node 0.10.
   const emailRegex = /^[\w.!#$%&’*+\/=?^`{|}~-]{1,64}@[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?(?:\.[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?)+$/i;
 


### PR DESCRIPTION
quick typo fix and test for new RDS db connections on fxa-dev boxes