### PR TITLE
refactor(client): Configurable marketing-snippet and marketing-mixin.

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -112,8 +112,12 @@ define(function (require, exports, module) {
     // Login delay for iOS broker
     IOS_V1_LOGIN_MESSAGE_DELAY_MS: 10000,
 
-    UNBLOCK_CODE_LENGTH: 8
+    UNBLOCK_CODE_LENGTH: 8,
+
+    MARKETING_ID_SPRING_2015: 'spring-2015-android-ios-sync',
+
+    DOWNLOAD_LINK_TEMPLATE_ANDROID: 'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=android',
+    DOWNLOAD_LINK_TEMPLATE_IOS: 'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=ios&fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&ct=adjust_tracker&mt=8' //eslint-disable-line max-len
   };
   /*eslint-enable sorting/sort-object-props*/
 });
-

--- a/app/scripts/lib/user-agent.js
+++ b/app/scripts/lib/user-agent.js
@@ -46,6 +46,33 @@ define(function (require, exports, module) {
        */
       isFirefox () {
         return this.browser.name === 'Firefox';
+      },
+
+      /**
+       * Check if the browser is Firefox for Android
+       *
+       * @returns {Boolean}
+       */
+      isFirefoxAndroid () {
+        return this.isFirefox() && this.isAndroid();
+      },
+
+      /**
+       * Check if the browser is Firefox for iOS
+       *
+       * @returns {Boolean}
+       */
+      isFirefoxIos () {
+        return this.isFirefox() && this.isIos();
+      },
+
+      /**
+       * Check if the browser is Firefox desktop
+       *
+       * @returns {Boolean}
+       */
+      isFirefoxDesktop () {
+        return this.isFirefox() && ! this.isFirefoxIos() && ! this.isFirefoxAndroid();
       }
     });
 

--- a/app/scripts/templates/marketing_snippet.mustache
+++ b/app/scripts/templates/marketing_snippet.mustache
@@ -1,4 +1,5 @@
-  {{#showSignUpMarketing}}
+{{#showSignUpMarketing}}
+  {{#isSpring2015}}
     <aside class="marketing-ios">
       {{#isIos}}
         <p>
@@ -6,7 +7,7 @@
           <br>
           {{#t}}Download Firefox for iOS!{{/t}}
         </p>
-        <a class="marketing-link marketing-link-ios" href="https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&adgroup=ios&creative=button&fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&ct=adjust_tracker&mt=8" data-marketing-id="spring-2015-android-ios-sync"><img width="152" height="53" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+        <a class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="53" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
       {{/isIos}}
 
       {{#isAndroid}}
@@ -15,7 +16,7 @@
           <br>
           {{#t}}Download Firefox for Android.{{/t}}
         </p>
-        <a class="marketing-link marketing-link-android" href="https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&adgroup=android&creative=button" data-marketing-id="spring-2015-android-ios-sync"><img width="152" height="45" src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}"></a>
+        <a class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45" src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}"></a>
       {{/isAndroid}}
 
       {{#isOther}}
@@ -28,13 +29,14 @@
 
           <ul>
             <li>
-              <a class="marketing-link marketing-link-ios" href="https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&adgroup=ios&creative=button&fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&ct=adjust_tracker&mt=8" data-marketing-id="spring-2015-android-ios-sync"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+              <a class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
             </li>
             <li>
-              <a class="marketing-link marketing-link-android" href="https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&adgroup=android&creative=button" data-marketing-id="spring-2015-android-ios-sync"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}"></a>
+              <a class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
             </li>
           </ul>
         </div>
       {{/isOther}}
     </aside>
-  {{/showSignUpMarketing}}
+  {{/isSpring2015}}
+{{/showSignUpMarketing}}

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -931,12 +931,24 @@ define(function (require, exports, module) {
     },
 
     /**
-     * Get the current window's search params
+     * Get a value from the URL search parameter
      *
+     * @param {String} paramName - name of the search parameter to get
+     * @returns {String}
+     */
+    getSearchParam (paramName) {
+      return Url.searchParam(paramName, this.window.location.search);
+    },
+
+    /**
+     * Get values from the URL search parameters.
+     *
+     * @param {String[]} [paramNames] - name of the search parameters
+     * to return. If not provided, all params are returned.
      * @returns {Object}
      */
-    getSearchParams () {
-      return Url.searchParams(this.window.location.search);
+    getSearchParams (paramNames) {
+      return Url.searchParams(this.window.location.search, paramNames);
     }
   });
 

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -134,7 +134,7 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     View,
-    MarketingMixin,
+    MarketingMixin({ marketingId: Constants.MARKETING_ID_SPRING_2015 }),
     ServiceMixin,
     VerificationReasonMixin
   );

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -14,18 +14,22 @@ define(function (require, exports, module) {
   const preventDefaultThen = require('views/base').preventDefaultThen;
   const SettingsPanelMixin = require('views/mixins/settings-panel-mixin');
   const SignedOutNotificationMixin = require('views/mixins/signed-out-notification-mixin');
-  const t = require('views/base').t;
+  const Strings = require('lib/strings');
+  const { t } = require('views/base');
   const Template = require('stache!templates/settings/clients');
   const Url = require('lib/url');
 
   const DEVICE_REMOVED_ANIMATION_MS = 150;
   const UTM_PARAMS = '?utm_source=accounts.firefox.com&utm_medium=referral&utm_campaign=fxa-devices';
   const DEVICES_SUPPORT_URL = 'https://support.mozilla.org/kb/fxa-managing-devices' + UTM_PARAMS;
-  const FIREFOX_ANDROID_DOWNLOAD_LINK = 'https://app.adjust.com/2uo1qc' +
-    '?campaign=fxa-devices-page&adgroup=android&creative=button';
-  const FIREFOX_IOS_DOWNLOAD_LINK = 'https://app.adjust.com/2uo1qc?' +
-    'campaign=fxa-devices-page&adgroup=ios&creative=button' +
-    '&fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&ct=adjust_tracker&mt=8';
+  const FIREFOX_ANDROID_DOWNLOAD_LINK = Strings.interpolate(Constants.DOWNLOAD_LINK_TEMPLATE_ANDROID, {
+    campaign: 'fxa-devices-page',
+    creative: 'button'
+  });
+  const FIREFOX_IOS_DOWNLOAD_LINK = Strings.interpolate(Constants.DOWNLOAD_LINK_TEMPLATE_IOS, {
+    campaign: 'fxa-devices-page',
+    creative: 'button'
+  });
   const FORCE_DEVICE_LIST_VIEW = 'forceDeviceList';
 
   var View = FormView.extend({
@@ -188,4 +192,3 @@ define(function (require, exports, module) {
 
   module.exports = View;
 });
-

--- a/app/tests/spec/lib/user-agent.js
+++ b/app/tests/spec/lib/user-agent.js
@@ -141,7 +141,130 @@ define(function (require, exports, module) {
           assert.isFalse(uap.isFirefox());
         });
       });
+    });
 
+    describe('isFirefoxAndroid', () => {
+      it('returns `true` if it detects Fennec', () => {
+        const fennecUserAgents = [
+          'Mozilla/5.0 (Android 4.4; Mobile; rv:46.0) Gecko/46.0 Firefox/46.0',
+          'Mozilla/5.0 (Android 4.4; Tablet; rv:46.0) Gecko/46.0 Firefox/46.0'
+        ];
+
+        fennecUserAgents.forEach((userAgentString) => {
+          let uap = new UserAgent(userAgentString);
+          assert.isTrue(uap.isFirefoxAndroid(), userAgentString);
+        });
+      });
+
+      it('returns `false` if not Fennec', () => {
+        const notFennecUserAgents = [
+          // fx desktop
+          'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:46.0) Gecko/20100101 Firefox/46.0',
+          // Chrome desktop
+          'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 ' +
+              '(KHTML, like Gecko) Chrome/55.0.2883.35 Safari/537.36',
+          // Edge
+          'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia ' +
+              '640 XL LTE) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+              'Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/12.10166',
+          // Chrome Android
+          'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) ' +
+              'AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19'
+        ];
+
+        notFennecUserAgents.forEach((userAgentString) => {
+          let uap = new UserAgent(userAgentString);
+          assert.isFalse(uap.isFirefoxAndroid(), userAgentString);
+        });
+      });
+    });
+
+    describe('isFirefoxIos', () => {
+      it('returns `true` if it detects Fx on iOS', () => {
+        const fxIosUserAgents = [
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) ' +
+              'AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4'
+        ];
+
+        fxIosUserAgents.forEach((userAgentString) => {
+          let uap = new UserAgent(userAgentString);
+          assert.isTrue(uap.isFirefoxIos(), userAgentString);
+        });
+      });
+
+      it('returns `false` if not Fx on iOS', () => {
+        const notFxIosUserAgents = [
+          // fx desktop
+          'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:46.0) Gecko/20100101 Firefox/46.0',
+          // fennec
+          'Mozilla/5.0 (Android 4.4; Mobile; rv:46.0) Gecko/46.0 Firefox/46.0',
+          'Mozilla/5.0 (Android 4.4; Tablet; rv:46.0) Gecko/46.0 Firefox/46.0',
+          // Chrome desktop
+          'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 ' +
+              '(KHTML, like Gecko) Chrome/55.0.2883.35 Safari/537.36',
+          // Edge
+          'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia ' +
+              '640 XL LTE) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+              'Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/12.10166',
+          // Chrome Android
+          'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) ' +
+              'AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19'
+        ];
+
+        notFxIosUserAgents.forEach((userAgentString) => {
+          let uap = new UserAgent(userAgentString);
+          assert.isFalse(uap.isFirefoxIos(), userAgentString);
+        });
+      });
+    });
+
+    describe('isFirefoxDesktop', () => {
+      it('returns `true` if it detects Fx Desktop', () => {
+        const fxDesktopUserAgents = [
+          // windows
+          'Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0',
+          'Mozilla/5.0 (Windows NT x.y; Win64; x64; rv:10.0) Gecko/20100101 Firefox/10.0',
+          'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:46.0) Gecko/20100101 Firefox/46.0',
+          // mac
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:10.0) Gecko/20100101 Firefox/10.0',
+          'Mozilla/5.0 (Macintosh; PPC Mac OS X x.y; rv:10.0) Gecko/20100101 Firefox/10.0',
+          // linux
+          'Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0',
+          'Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0',
+          'Mozilla/5.0 (X11; Linux i686 on x86_64; rv:10.0) Gecko/20100101 Firefox/10.0'
+        ];
+
+        fxDesktopUserAgents.forEach((userAgentString) => {
+          let uap = new UserAgent(userAgentString);
+          assert.isTrue(uap.isFirefoxDesktop(), userAgentString);
+        });
+      });
+
+      it('returns `false` if not Fx Desktop', () => {
+        const notFxDesktopUserAgents = [
+          // fx ios
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) ' +
+              'AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
+          // fennec
+          'Mozilla/5.0 (Android 4.4; Mobile; rv:46.0) Gecko/46.0 Firefox/46.0',
+          'Mozilla/5.0 (Android 4.4; Tablet; rv:46.0) Gecko/46.0 Firefox/46.0',
+          // Chrome desktop
+          'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 ' +
+              '(KHTML, like Gecko) Chrome/55.0.2883.35 Safari/537.36',
+          // Edge
+          'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia ' +
+              '640 XL LTE) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+              'Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/12.10166',
+          // Chrome Android
+          'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) ' +
+              'AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19'
+        ];
+
+        notFxDesktopUserAgents.forEach((userAgentString) => {
+          let uap = new UserAgent(userAgentString);
+          assert.isFalse(uap.isFirefoxDesktop(), userAgentString);
+        });
+      });
     });
 
     describe('isMobileSafari', () => {
@@ -180,7 +303,6 @@ define(function (require, exports, module) {
           assert.isFalse(uap.isMobileSafari());
         });
       });
-
     });
   });
 });

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -1026,13 +1026,27 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('getSearchParam', () => {
+      it('fetches a search parameter', () => {
+        windowMock.location.search = '?search=1&another=2';
+
+        assert.equal(view.getSearchParam('search'), '1');
+        assert.equal(view.getSearchParam('another'), '2');
+        assert.isUndefined(view.getSearchParam('non-existent'));
+      });
+    });
+
     describe('getSearchParams', () => {
       it('returns an object representation of window.location.search', () => {
-        const searchString = '?search=1';
+        windowMock.location.search = '?search=1&another=2';
 
-        windowMock.location.search = searchString;
         const searchParams = view.getSearchParams();
         assert.equal(searchParams.search, '1');
+        assert.equal(searchParams.another, '2');
+
+        const filteredSearchParams = view.getSearchParams('another');
+        assert.notProperty(filteredSearchParams, 'search');
+        assert.equal(filteredSearchParams.another, '2');
       });
     });
   });

--- a/app/tests/spec/views/marketing_snippet.js
+++ b/app/tests/spec/views/marketing_snippet.js
@@ -7,33 +7,47 @@ define(function (require, exports, module) {
 
   const Able = require('lib/able');
   const { assert } = require('chai');
+  const BaseBroker = require('models/auth_brokers/base');
+  const Constants = require('lib/constants');
   const Metrics = require('lib/metrics');
+  const Notifier = require('lib/channels/notifier');
   const sinon = require('sinon');
   const View = require('views/marketing_snippet');
   const WindowMock = require('../../mocks/window');
   const VerificationReasons = require('lib/verification-reasons');
 
   describe('views/marketing_snippet', function () {
+    let broker;
     let metrics;
+    let notifier;
     let view;
     let windowMock;
 
     function createView(options = {}) {
+      options.broker = broker;
+      options.lang = options.lang || 'en';
       options.service = 'sync';
       options.type = VerificationReasons.SIGN_UP;
-      options.lang = options.lang || 'en';
-
       options.window = windowMock;
 
       metrics = new Metrics();
       options.metrics = metrics;
+
+      notifier = new Notifier();
+      options.notifier = notifier;
 
       options.able = new Able();
       view = new View(options);
     }
 
     beforeEach(function () {
+      broker = new BaseBroker({});
+      broker.setCapability('emailVerificationMarketingSnippet', true);
+
       windowMock = new WindowMock();
+      // set a known userAgent that will display both buttons to begin with.
+      windowMock.navigator.userAgent =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0';
     });
 
     afterEach(function () {
@@ -42,88 +56,127 @@ define(function (require, exports, module) {
       view = windowMock = null;
     });
 
-    describe('render', function () {
-      it('normally shows sign up marketing material to non-FxMobile sync users', function () {
-        windowMock.navigator.userAgent = 'Mozilla/5.0 (Windows NT x.y; rv:31.0) Gecko/20100101 Firefox/31.0';
+    testMarketingCampaign(Constants.MARKETING_ID_SPRING_2015);
 
-        createView();
+    function testMarketingCampaign (marketingId) {
+      function assertLinkHasExpectedIdAndType(view, expectedId, expectedType) {
+        const $linkEl = view.$(`.marketing-link-${expectedType}`);
+        assert.lengthOf($linkEl, 1);
+        assert.equal($linkEl.data('marketing-id'), expectedId);
+        assert.equal($linkEl.data('marketing-type'), expectedType);
+      }
 
-        return view.render()
+      describe(`render for ${marketingId}`, function () {
+        it('shows no marketing to Fx Mobile users', () => {
+          windowMock.navigator.userAgent = 'Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0';
+
+          createView({ marketingId });
+
+          return view.render()
           .then(() => {
-            assert.lengthOf(view.$('.marketing-ios'), 1);
+            assert.lengthOf(view.$('.marketing-link-ios'), 0);
+            assert.lengthOf(view.$('.marketing-link-android'), 0);
           });
-      });
+        });
 
-      it('shows only iOS button to iOS users', function () {
-        windowMock.navigator.userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone ' +
+        it('override for Fx Mobile users', () => {
+          windowMock.navigator.userAgent = 'Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0';
+
+          createView({ marketingId, which: View.WHICH.BOTH });
+
+          return view.render()
+          .then(() => {
+            assert.lengthOf(view.$('.marketing-link-ios'), 1);
+            assert.lengthOf(view.$('.marketing-link-android'), 1);
+          });
+        });
+
+        it('shows only iOS button to iOS users', function () {
+          windowMock.navigator.userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone ' +
           'OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) ' +
           'Version/5.1 Mobile/9A334 Safari/7534.48.3';
 
-        createView();
+          createView({ marketingId });
 
-        return view.render()
+          return view.render()
           .then(() => {
-            assert.lengthOf(view.$('.marketing-link-ios'), 1);
+            assertLinkHasExpectedIdAndType(view, marketingId, 'ios');
             assert.lengthOf(view.$('.marketing-link-android'), 0);
           });
-      });
+        });
 
-      it('shows only Android button to Android users', function () {
-        windowMock.navigator.userAgent = 'Mozilla/5.0 (Linux; U; Android 2.3; en-us) AppleWebKit/999+ (KHTML, like Gecko) Safari/999.9';
+        it('shows only Android button to Android users', function () {
+          windowMock.navigator.userAgent = 'Mozilla/5.0 (Linux; U; Android 2.3; en-us) AppleWebKit/999+ (KHTML, like Gecko) Safari/999.9';
 
-        createView();
+          createView({ marketingId });
 
-        return view.render()
+          return view.render()
           .then(() => {
             assert.lengthOf(view.$('.marketing-link-ios'), 0);
-            assert.lengthOf(view.$('.marketing-link-android'), 1);
+            assertLinkHasExpectedIdAndType(view, marketingId, 'android');
           });
-      });
+        });
 
-      it('shows iOS and Android buttons to non-iOS, non-Android users', function () {
-        windowMock.navigator.userAgent = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)';
+        it('shows iOS and Android buttons to non-iOS, non-Android users', function () {
+          windowMock.navigator.userAgent = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)';
 
-        createView();
+          createView({ marketingId });
 
-        return view.render()
+          return view.render()
           .then(() => {
-            assert.lengthOf(view.$('.marketing-link-ios'), 1);
-            assert.lengthOf(view.$('.marketing-link-android'), 1);
+            assertLinkHasExpectedIdAndType(view, marketingId, 'ios');
+            assertLinkHasExpectedIdAndType(view, marketingId, 'android');
           });
-      });
+        });
 
-      it('shows localized buttons for supported languages', function () {
-        createView({ lang: 'de' });
+        it('shows localized buttons for supported languages', function () {
+          createView({ lang: 'de', marketingId });
 
-        return view.render()
+          return view.render()
           .then(() => {
             // de.png for play store
             assert.lengthOf(view.$('img[src*="/de."]'), 2);
           });
-      });
+        });
 
-      it('shows en-US buttons for unsupported languages', function () {
-        createView({ lang: 'klingon' });
+        it('shows en-US buttons for unsupported languages', function () {
+          createView({ lang: 'klingon', marketingId });
 
-        return view.render()
+          return view.render()
           .then(() => {
             // en.png for play store
             assert.lengthOf(view.$('img[src*="/en."]'), 2);
           });
-      });
+        });
 
-      it('shows high-res Android image to users with high-dpi displays', function () {
-        createView();
+        it('shows high-res Android image to users with high-dpi displays', function () {
+          createView({ marketingId });
 
-        sinon.stub(view, '_isHighRes', () => true);
+          sinon.stub(view, '_isHighRes', () => true);
 
-        return view.render()
+          return view.render()
           .then(() => {
             // en@2x.png for play store. (app store images are SVG)
             assert.lengthOf(view.$('img[src*="/en@2x.png"]'), 1);
           });
+        });
+
+        describe('_storeLink', () => {
+          function testStoreLink(which) {
+            it(`attaches the expected query parameters for ${which}`, () => {
+              createView({ marketingId });
+
+              const link = view._storeLink(Constants[which]);
+              assert.include(link, `creative=${View.BUTTON_IDS[marketingId]}`);
+              assert.include(link, 'campaign=fxa-conf-page');
+            });
+          }
+
+          testStoreLink('DOWNLOAD_LINK_TEMPLATE_ANDROID');
+          testStoreLink('DOWNLOAD_LINK_TEMPLATE_IOS');
+        });
       });
-    });
+    }
 
     describe('a click on the marketing material', function () {
       it('is logged', function () {


### PR DESCRIPTION
This is an extraction from #4370 to make both simpler to review. For
that PR, we need to be able to configure which app store logos are
displayed to the user. This allows us to do so.

The marketing-mixin module, instead of returning a mixin, returns
a function that must be called with configuration options, the function
returns the actual mixin.

The marketing_snippet module allows two additional configuration
options:
* `marketingId` is the id used to log impressions and clicks
* `which` forces specific logo(s) to be displayed. If not specified,
uses default behavior.

The Adjust links are extracted into Constants.js and shared between
marketing_snippet.js and settings/clients.js.

base.js->getSearchParam has been added to fetch
a single search parameter.

Add `isFirefoxAndroid`, `isFirefoxIos` and `isFirefoxDesktop` to
user-agent.

@vladikoff - r?