### PR TITLE
refactor(test): Remove `context` from `fillOutCompleteResetPassword`

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -798,24 +798,22 @@ define([
     };
   }
 
-  function fillOutCompleteResetPassword(context, password, vpassword) {
-    return getRemote(context)
+  /**
+   * Fill out and submit the complete reset password form
+   * @param {String} password - new password
+   * @param {String} vpassword - new verification password
+   * @returns {promise}
+   */
+  function fillOutCompleteResetPassword(password, vpassword) {
+    return function () {
+      return this.parent
       .setFindTimeout(intern.config.pageLoadTimeout)
 
-      .findByCssSelector('#fxa-complete-reset-password-header')
-      .end()
-
-      .findByCssSelector('#password')
-        .type(password)
-      .end()
-
-      .findByCssSelector('#vpassword')
-        .type(vpassword)
-      .end()
-
-      .findByCssSelector('button[type="submit"]')
-        .click()
-      .end();
+      .then(testElementExists('#fxa-complete-reset-password-header'))
+      .then(type('#password', password))
+      .then(type('#vpassword', vpassword))
+      .then(click('button[type="submit"]'));
+    };
   }
 
   /**

--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -18,7 +18,7 @@ define([
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
-  var fillOutCompleteResetPassword = thenify(FunctionalHelpers.fillOutCompleteResetPassword);
+  var fillOutCompleteResetPassword = FunctionalHelpers.fillOutCompleteResetPassword;
   var fillOutResetPassword = FunctionalHelpers.fillOutResetPassword;
   var openExternalSite = FunctionalHelpers.openExternalSite;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
@@ -73,7 +73,7 @@ define([
         // Complete the reset password in the new tab
         .switchToWindow('newwindow')
         .then(testElementExists('#fxa-complete-reset-password-header'))
-        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         // this tab's success is seeing the reset password complete header.
         .then(testElementExists('#fxa-reset-password-complete-header'))
@@ -99,7 +99,7 @@ define([
 
         .switchToWindow('newwindow')
 
-        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
         .then(testElementExists('#fxa-reset-password-complete-header'))
 
         // switch to the original window
@@ -116,7 +116,7 @@ define([
         .then(testElementExists('#fxa-confirm-reset-password-header'))
 
         .then(openVerificationLinkInSameTab(email, 0))
-        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         .then(testElementExists('#loggedin'));
     },
@@ -161,7 +161,7 @@ define([
         .then(openVerificationLinkInSameTab(email, 0))
 
         .then(testElementExists('#fxa-complete-reset-password-header'))
-        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         .then(testElementExists('#fxa-reset-password-complete-header'))
         // user sees the name of the rp, but cannot redirect

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -34,7 +34,7 @@ define([
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
-  var fillOutCompleteResetPassword = thenify(FunctionalHelpers.fillOutCompleteResetPassword);
+  var fillOutCompleteResetPassword = FunctionalHelpers.fillOutCompleteResetPassword;
   var fillOutResetPassword = FunctionalHelpers.fillOutResetPassword;
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = FunctionalHelpers.openPage;
@@ -299,7 +299,7 @@ define([
 
         .then(testElementExists('#fxa-complete-reset-password-header'))
 
-        .then(fillOutCompleteResetPassword(self, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         // this tab's success is seeing the reset password complete header.
         .then(function () {
@@ -331,7 +331,7 @@ define([
 
         .switchToWindow('newwindow')
 
-        .then(fillOutCompleteResetPassword(self, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         // this tab's success is seeing the reset password complete header.
         .then(function () {
@@ -359,7 +359,7 @@ define([
             .then(openPage(verificationLink, '#fxa-complete-reset-password-header'));
         })
 
-        .then(fillOutCompleteResetPassword(self, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         // this tab's success is seeing the reset password complete header.
         .then(function () {
@@ -416,7 +416,7 @@ define([
             .then(openPage(verificationLink, '#fxa-complete-reset-password-header'));
         })
 
-        .then(fillOutCompleteResetPassword(self, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         .then(function () {
           return testAtSettingsWithVerifiedMessage(self);
@@ -441,12 +441,11 @@ define([
     'complete reset, then re-open verification link, click resend': function () {
       this.timeout = TIMEOUT;
 
-      var self = this;
       return this.remote
         .then(openCompleteResetPassword(
           email, token, code, '#fxa-complete-reset-password-header'
         ))
-        .then(fillOutCompleteResetPassword(self, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'))
 

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -25,7 +25,7 @@ define([
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
-  var fillOutCompleteResetPassword = thenify(FunctionalHelpers.fillOutCompleteResetPassword);
+  var fillOutCompleteResetPassword = FunctionalHelpers.fillOutCompleteResetPassword;
   var fillOutResetPassword = FunctionalHelpers.fillOutResetPassword;
   var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
@@ -68,7 +68,7 @@ define([
         .switchToWindow('newwindow')
 
         .then(testElementExists('#fxa-complete-reset-password-header'))
-        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         .then(testElementExists('#fxa-reset-password-complete-header'))
         .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
@@ -91,7 +91,7 @@ define([
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
 
-        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
         .then(testElementExists('#fxa-reset-password-complete-header'))
 
         .then(closeCurrentWindow());
@@ -111,7 +111,7 @@ define([
           return self.remote.get(require.toUrl(verificationLink));
         })
 
-        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
         .then(testElementExists('#fxa-reset-password-complete-header'));
     },
 
@@ -158,7 +158,7 @@ define([
           return self.remote.get(require.toUrl(url));
         })
         .then(testElementExists('#fxa-complete-reset-password-header'))
-        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         .then(testElementExists('#fxa-reset-password-complete-header'))
         .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'));

--- a/tests/functional/sync_v2_reset_password.js
+++ b/tests/functional/sync_v2_reset_password.js
@@ -23,7 +23,7 @@ define([
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
   var fillOutResetPassword = FunctionalHelpers.fillOutResetPassword;
-  var fillOutCompleteResetPassword = thenify(FunctionalHelpers.fillOutCompleteResetPassword);
+  var fillOutCompleteResetPassword = FunctionalHelpers.fillOutCompleteResetPassword;
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
@@ -60,7 +60,7 @@ define([
         .switchToWindow('newwindow')
 
         .then(testElementExists('#fxa-complete-reset-password-header'))
-        .then(fillOutCompleteResetPassword(this, PASSWORD, PASSWORD))
+        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         .then(testElementExists('#fxa-reset-password-complete-header'))
         .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))


### PR DESCRIPTION
Second installment of the HI flight series. Once this series has fully merged, no more `context` in the functional tests!

@mozilla/fxa-devs - r?