### PR TITLE
fix(client): cookies_disabled.js's constructor is a function.

### DIFF
--- a/app/scripts/views/cookies_disabled.js
+++ b/app/scripts/views/cookies_disabled.js
@@ -13,7 +13,7 @@ define(function (require, exports, module) {
   const Template = require('stache!templates/cookies_disabled');
 
   var View = BaseView.extend({
-    constructor (options) {
+    constructor: function (options) {
       BaseView.call(this, options);
 
       this._Storage = options.Storage || Storage;


### PR DESCRIPTION
It was impossible to run unit tests w/ `babel.enabled: false` because
the browser would see the `constructor` function in cookies_disabled.js
and think that was an ES2015 `constructor`. Babel converts the
constructor to a function and allows the unit tests to run. Instead of
depending on Babel, make the `constructor` a function and allow the unit
tests to run w/o babel.

Not attached to any issue.

@mozilla/fxa-devs - r?