### PR TITLE
fix(test): Fix the reset password functional tests.

### DIFF
--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -34,7 +34,6 @@ define([
   var openPasswordResetLinkDifferentBrowser = thenify(FunctionalHelpers.openPasswordResetLinkDifferentBrowser);
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var testElementExists = FunctionalHelpers.testElementExists;
-  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
   var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
   var type = FunctionalHelpers.type;
@@ -71,7 +70,7 @@ define([
         .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         .then(testElementExists('#fxa-reset-password-complete-header'))
-        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
+        .then(testElementExists('.account-ready-service'))
         .then(closeCurrentWindow())
 
         .then(testSuccessWasShown(this))
@@ -161,7 +160,7 @@ define([
         .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         .then(testElementExists('#fxa-reset-password-complete-header'))
-        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'));
+        .then(testElementExists('.account-ready-service'));
     }
   });
 

--- a/tests/functional/sync_v2_reset_password.js
+++ b/tests/functional/sync_v2_reset_password.js
@@ -28,7 +28,6 @@ define([
   var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkInNewTab = thenify(FunctionalHelpers.openVerificationLinkInNewTab);
   var testElementExists = FunctionalHelpers.testElementExists;
-  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
   var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
 
@@ -63,7 +62,7 @@ define([
         .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
         .then(testElementExists('#fxa-reset-password-complete-header'))
-        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
+        .then(testElementExists('.account-ready-service'))
 
         // the verification tab sends the WebChannel message. This fixes
         // two problems: 1) initiating tab is closed, 2) The initiating


### PR DESCRIPTION
Some reset password tests checked for "Firefox Sync" in the
account-ready text. These tests are remnants from when we dynamically
injected the service, we no longer do this, so no real need to test
for it.

fixes #4540 

@vbudhram or @vladikoff - r?