### PR TITLE
refactor(test): Remove `context` from `openExternalSite`

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -435,9 +435,14 @@ define([
     };
   }
 
-  function openExternalSite(context) {
+  /**
+   * Open an external site.
+   *
+   * @returns {promise} resolves when complete
+   */
+  function openExternalSite() {
     return function () {
-      return getRemote(context)
+      return this.parent
         .get(require.toUrl(EXTERNAL_SITE_URL))
           .findByPartialLinkText(EXTERNAL_SITE_LINK_TEXT)
         .end();

--- a/tests/functional/oauth_reset_password.js
+++ b/tests/functional/oauth_reset_password.js
@@ -94,7 +94,7 @@ define([
         .then(testElementExists('#fxa-confirm-reset-password-header'))
 
         // user browses to another site.
-        .then(openExternalSite(this))
+        .then(openExternalSite())
         .then(openVerificationLinkInNewTab(this, email, 0))
 
         .switchToWindow('newwindow')

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -124,7 +124,7 @@ define([
         // user browses to another site.
         .switchToFrame(null)
 
-        .then(FunctionalHelpers.openExternalSite(self))
+        .then(FunctionalHelpers.openExternalSite())
 
         .then(openVerificationLinkInNewTab(self, email, 0))
 

--- a/tests/functional/oauth_sign_up_verification_redirect.js
+++ b/tests/functional/oauth_sign_up_verification_redirect.js
@@ -71,7 +71,7 @@ define([
         .end()
 
         // closes the original tab
-        .then(FunctionalHelpers.openExternalSite(self))
+        .then(FunctionalHelpers.openExternalSite())
 
         .then(function () {
           return FunctionalHelpers.openVerificationLinkInNewTab(self, email, 0);

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -322,7 +322,7 @@ define([
         .then(testElementExists('#fxa-confirm-reset-password-header'))
 
         // user browses to another site.
-        .then(FunctionalHelpers.openExternalSite(self))
+        .then(FunctionalHelpers.openExternalSite())
 
         .then(function () {
           return FunctionalHelpers.openVerificationLinkInNewTab(

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -101,7 +101,7 @@ define([
         .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
 
-        .then(FunctionalHelpers.openExternalSite(this))
+        .then(FunctionalHelpers.openExternalSite())
         .then(openVerificationLinkInNewTab(this, email, 0))
 
         .switchToWindow('newwindow')

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -87,7 +87,7 @@ define([
         .then(testElementExists('#fxa-confirm-reset-password-header'))
 
         // user browses to another site.
-        .then(openExternalSite(this))
+        .then(openExternalSite())
         .then(openVerificationLinkInNewTab(this, email, 0))
         .switchToWindow('newwindow')
 

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -117,7 +117,7 @@ define([
         .findByCssSelector('#fxa-confirm-header')
         .end()
 
-        .then(FunctionalHelpers.openExternalSite(self))
+        .then(FunctionalHelpers.openExternalSite())
 
         .then(function () {
           return FunctionalHelpers.openVerificationLinkInNewTab(


### PR DESCRIPTION
Keeping the HI flight series in motion.

@mozilla/fxa-devs - r?