### PR TITLE
refactor(test): remove `context` from `openSettingsInNewTab`

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -584,12 +584,22 @@ define([
       });
   }
 
-  function openSettingsInNewTab(context, windowName, panel) {
+  /**
+   * Open the settings page in a new tab.
+   *
+   * @param   {string} windowName name of new tab
+   * @param   {string} [panel] pathname of panel to open. Open `/settings` if not given.
+   * @returns {promise} resolves when complete
+   */
+  function openSettingsInNewTab(windowName, panel) {
     var url = SETTINGS_URL;
     if (panel) {
       url += '/' + panel;
     }
-    return getRemote(context).execute(openWindow, [ url, windowName ]);
+    return function () {
+      return this.parent
+        .execute(openWindow, [ url, windowName ]);
+    };
   }
 
   function openSignInInNewTab(context, windowName) {

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -31,7 +31,7 @@ define([
   var openFxaFromTrustedRp = thenify(FunctionalHelpers.openFxaFromRp);
   var openFxaFromUntrustedRp = thenify(FunctionalHelpers.openFxaFromUntrustedRp);
   var openPage = FunctionalHelpers.openPage;
-  var openSettingsInNewTab = thenify(FunctionalHelpers.openSettingsInNewTab);
+  var openSettingsInNewTab = FunctionalHelpers.openSettingsInNewTab;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
@@ -220,7 +220,7 @@ define([
 
         .then(click('#logout'))
 
-        .then(openSettingsInNewTab(this, 'settings', 'display_name'))
+        .then(openSettingsInNewTab('settings', 'display_name'))
         .switchToWindow('settings')
 
         .then(type('#display-name input[type=text]', 'test user'))

--- a/tests/functional/settings.js
+++ b/tests/functional/settings.js
@@ -14,8 +14,6 @@ define([
   var SIGNIN_URL = config.fxaContentRoot + 'signin';
   var SETTINGS_URL = config.fxaContentRoot + 'settings';
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
@@ -25,7 +23,7 @@ define([
   var focus = FunctionalHelpers.focus;
   var getFxaClient = FunctionalHelpers.getFxaClient;
   var openPage = FunctionalHelpers.openPage;
-  var openSettingsInNewTab = thenify(FunctionalHelpers.openSettingsInNewTab);
+  var openSettingsInNewTab = FunctionalHelpers.openSettingsInNewTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextEquals = FunctionalHelpers.testElementTextEquals;
   var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
@@ -202,7 +200,7 @@ define([
         // the user is asked to sign in.
         .then(testElementExists('#fxa-settings-header'))
 
-        .then(openSettingsInNewTab(this, windowName))
+        .then(openSettingsInNewTab(windowName))
         .switchToWindow(windowName)
         .then(testElementExists('#fxa-settings-header'))
         .then(click('#signout'))


### PR DESCRIPTION
@mozilla/fxa-devs - r?

I'm gonna guess we're half way through the series. But, once the whole thing is merged, no more inconsistencies in the helper signatures, at least relating to `context`!