### PR TITLE
feat(client): Add AMO specific help text on signin/signup.

### DIFF
--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -19,8 +19,11 @@
     {{^error}}
       <div class="error"></div>
       <div class="success"></div>
+      {{#isAmoMigration}}
+        <div class="info nudge pad" id="amo-migration">{{#unsafeTranslate}}Looking for your Add-ons data? <a href="/signup">Sign up</a> for a Firefox Account with your old Add-ons account email address.{{/unsafeTranslate}}</div>
+      {{/isAmoMigration}}
       {{#isSyncMigration}}
-          <div class="info nudge" id="sync-migration">{{#unsafeTranslate}}Migrate your sync data by signing in to your Firefox&nbsp;Account.{{/unsafeTranslate}}</div>
+        <div class="info nudge" id="sync-migration">{{#unsafeTranslate}}Migrate your sync data by signing in to your Firefox&nbsp;Account.{{/unsafeTranslate}}</div>
       {{/isSyncMigration}}
 
       {{#suggestedAccount}}

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -21,7 +21,7 @@
     <div class="success"></div>
 
     {{#showSyncSuggestion}}
-    <div class="info nudge" id="suggest-sync">{{#unsafeTranslate}}Looking for Firefox Sync? <a href="%(escapedSyncSuggestionUrl)s">Get started here</a>{{/unsafeTranslate}}</div>
+      <div class="info nudge" id="suggest-sync">{{#unsafeTranslate}}Looking for Firefox Sync? <a href="%(escapedSyncSuggestionUrl)s">Get started here</a>{{/unsafeTranslate}}</div>
     {{/showSyncSuggestion}}
 
     {{#isSyncMigration}}
@@ -29,7 +29,7 @@
     {{/isSyncMigration}}
 
     {{#isAmoMigration}}
-        <div class="info nudge pad" id="amo-migration">{{#unsafeTranslate}}Have an account with a different email? <a href="%(escapedSignInUri)s">Sign in</a>{{/unsafeTranslate}}</div>
+        <div class="info nudge pad" id="amo-migration">{{#t}}Looking for your Add-ons data? Sign up for a Firefox Account with your old Add-ons account email address.{{/t}}</div>
     {{/isAmoMigration}}
 
     <form novalidate>

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -81,6 +81,7 @@ define(function (require, exports, module) {
         chooserAskForPassword: this._suggestedAccountAskPassword(suggestedAccount),
         email: email,
         error: this.error,
+        isAmoMigration: this.isAmoMigration(),
         isSyncMigration: this.isSyncMigration(),
         password: this._formPrefill.get('password'),
         serviceName: this.relier.get('serviceName'),
@@ -149,7 +150,14 @@ define(function (require, exports, module) {
     },
 
     _suggestSignUp (err) {
-      err.forceMessage = t('Unknown account. <a href="/signup">Sign up</a>');
+      if (this.isAmoMigration()) {
+        err.forceMessage =
+          t('Unknown Firefox Account. <a href="/signup">Sign up</a> using your previous Add-ons account email address to access your Add-ons data.');
+        this.$('#amo-migration').hide();
+      } else {
+        err.forceMessage = t('Unknown account. <a href="/signup">Sign up</a>');
+      }
+
       return this.unsafeDisplayError(err);
     },
 

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -264,57 +264,46 @@ define(function (require, exports, module) {
     describe('migration', function () {
       it('does not display migration message if no migration', function () {
         return view.render()
-          .then(function () {
+          .then(() => {
+            assert.lengthOf(view.$('#amo-migration'), 0);
             assert.lengthOf(view.$('#sync-migration'), 0);
             assert.lengthOf(view.$('#suggest-sync'), 1);
           });
       });
 
       it('displays migration message if isSyncMigration returns true', function () {
-        sinon.stub(view, 'isSyncMigration', function () {
-          return true;
-        });
+        sinon.stub(view, 'isSyncMigration', () => true);
 
         return view.render()
-          .then(function () {
-            assert.equal(view.$('#sync-migration').html(), 'Migrate your sync data by creating a new Firefox&nbsp;Account.');
-            view.isSyncMigration.restore();
+          .then(() => {
+            assert.lengthOf(view.$('#sync-migration'), 1);
           });
       });
 
       it('does not display migration message if isSyncMigration returns false', function () {
-        sinon.stub(view, 'isSyncMigration', function () {
-          return false;
-        });
+        sinon.stub(view, 'isSyncMigration', () => false);
 
         return view.render()
-          .then(function () {
+          .then(() => {
             assert.lengthOf(view.$('#sync-migration'), 0);
-            view.isSyncMigration.restore();
           });
       });
 
       it('displays migration message if isAmoMigration returns true', function () {
-        sinon.stub(view, 'isAmoMigration', function () {
-          return true;
-        });
+        sinon.stub(view, 'isAmoMigration', () => true);
 
         return view.render()
-          .then(function () {
-            assert.equal(view.$('#amo-migration').html(), 'Have an account with a different email? <a href="/signin">Sign in</a>');
-            view.isAmoMigration.restore();
+          .then(() => {
+            assert.lengthOf(view.$('#amo-migration'), 1);
           });
       });
 
       it('does not display migration message if isAmoMigration returns false', function () {
-        sinon.stub(view, 'isAmoMigration', function () {
-          return false;
-        });
+        sinon.stub(view, 'isAmoMigration', () => false);
 
         return view.render()
-          .then(function () {
+          .then(() => {
             assert.lengthOf(view.$('#amo-migration'), 0);
-            view.isAmoMigration.restore();
           });
       });
     });

--- a/tests/functional/amo_sign_up.js
+++ b/tests/functional/amo_sign_up.js
@@ -4,11 +4,11 @@
 
 define([
   'intern!object',
+  'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (registerSuite, FunctionalHelpers) {
+], function (registerSuite, TestHelpers, FunctionalHelpers) {
 
   var QUERY_PARAMS = {
-    email: 'fakeemail@restmail.com',
     migration: 'amo',
     scope: 'profile',
     state: 'state'
@@ -18,26 +18,46 @@ define([
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
+  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var openFxaFromRp = thenify(FunctionalHelpers.openFxaFromRp);
   var testElementExists = FunctionalHelpers.testElementExists;
-  var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   registerSuite({
-    name: 'oauth amo sign up',
+    name: 'oauth amo authentication',
 
     beforeEach: function () {
       return this.remote.then(clearBrowserState());
     },
 
-    'as a migrating user': function () {
+    'sign up as a migrating user': function () {
       return this.remote
         .then(openFxaFromRp(this, 'signup', { query: QUERY_PARAMS }))
-        .then(visibleByQSA('.info.nudge'))
-        .then(click('.info.nudge a'))
+        .then(visibleByQSA('#amo-migration'));
+    },
 
-        .then(testElementExists('#fxa-signin-header'))
-        .then(testElementValueEquals('input[type="email"]', ''));
+    'open sign in as a migrating user, click `/signup` from help text': function () {
+      return this.remote
+        .then(openFxaFromRp(this, 'signin', { query: QUERY_PARAMS }))
+        .then(visibleByQSA('#amo-migration'))
+        .then(click('#amo-migration a'))
+
+        .then(testElementExists('#fxa-signup-header'));
+    },
+
+    'open sign in as a migrating user, click `/signup` from error text': function () {
+      var email = TestHelpers.createEmail();
+
+      return this.remote
+        .then(openFxaFromRp(this, 'signin', { query: QUERY_PARAMS }))
+        .then(visibleByQSA('#amo-migration'))
+
+        .then(fillOutSignIn(email, 'password'))
+
+        .then(visibleByQSA('.error'))
+        .then(click('.error a'))
+
+        .then(testElementExists('#fxa-signup-header'));
     }
   });
 });


### PR DESCRIPTION
AMO will open FxA with the `migration=amo` query parameter to indicate
FxA should display some AMO specific help text on signin and signup. If
the user signs in with a non-existent account, show an AMO specific
error message.

fixes #4302 

@vladikoff, @ryanfeeley - r?