### PR TITLE
fix(test): Remove `before` in the OAuth functional tests.

### DIFF
--- a/tests/functional/oauth_choose_redirect.js
+++ b/tests/functional/oauth_choose_redirect.js
@@ -26,19 +26,19 @@ define([
   registerSuite({
     name: 'oauth choose redirect',
 
-    before: function () {
+    beforeEach: function () {
+      email = TestHelpers.createEmail();
+
+      return this.remote.then(clearBrowserState());
+    },
+
+    'get client_id for other tests': function () {
       return this.remote
         .then(openFxaFromRp(this, 'signup'))
         .then(getQueryParamValue('client_id'))
         .then(function (clientId) {
           oAuthUrl += clientId;
         });
-    },
-
-    beforeEach: function () {
-      email = TestHelpers.createEmail();
-
-      return this.remote.then(clearBrowserState());
     },
 
     'oauth endpoint redirects to signup with an unregistered email': function () {

--- a/tests/functional/oauth_query_param_validation.js
+++ b/tests/functional/oauth_query_param_validation.js
@@ -53,7 +53,14 @@ define([
   registerSuite({
     name: 'oauth query parameter validation',
 
-    before: function () {
+    beforeEach: function () {
+      return this.remote
+        .then(clearBrowserState({
+          contentServer: true
+        }));
+    },
+
+    'get client_id for other tests': function () {
       // get the trusted and untrusted client IDs by opening
       // FxA from the reliers. This is done instead of hard coding
       // the values because the client_ids change depending on
@@ -69,13 +76,6 @@ define([
         .then(function (clientId) {
           UNTRUSTED_CLIENT_ID = clientId;
         });
-    },
-
-    beforeEach: function () {
-      return this.remote
-        .then(clearBrowserState({
-          contentServer: true
-        }));
     },
 
     'invalid access_type': function () {


### PR DESCRIPTION
Using `before` in the OAuth functional tests meant that these before
functions were run whether the suite was or not, which was really
annoying. Instead, rename the before functions something that indicates
they have side effects that are used by other tests in the suite.


@vladikoff - r?