### PR TITLE
fix(l10n): do not delete translation files during extraction

### DIFF
--- a/grunttasks/clean.js
+++ b/grunttasks/clean.js
@@ -14,9 +14,7 @@ module.exports = function (grunt) {
           '!<%= yeoman.app %>/styles/fontello.css',
           // fonts are copied over every server run.
           '<%= yeoman.app %>/fonts/default',
-          '<%= yeoman.app %>/fonts/latin',
-          // local template files
-          'locale/templates/LC_MESSAGES/*.pot'
+          '<%= yeoman.app %>/fonts/latin'
         ]
       }]
     },


### PR DESCRIPTION
We need to keep those because they get merged with fxa-auth-mailer strings