### PR TITLE
fix(links): open external links on about:accounts in new tabs

### DIFF
--- a/app/scripts/models/auth_brokers/fx-fennec-v1.js
+++ b/app/scripts/models/auth_brokers/fx-fennec-v1.js
@@ -28,7 +28,6 @@ define(function (require, exports, module) {
       chooseWhatToSyncWebV1: {
         engines: Constants.DEFAULT_DECLINED_ENGINES
       },
-      convertExternalLinksToText: true,
       emailVerificationMarketingSnippet: false
     }),
 

--- a/app/scripts/views/mixins/external-links-mixin.js
+++ b/app/scripts/views/mixins/external-links-mixin.js
@@ -38,8 +38,16 @@ define(function (require, exports, module) {
   module.exports = {
     afterRender () {
       const $externalLinks = this.$('a[href^=http]');
-      $externalLinks.each(function (index, el) {
-        $(el).attr('rel','noopener noreferrer');
+      const isAboutAccounts = this.broker &&
+        this.broker.environment && this.broker.environment.isAboutAccounts();
+
+      $externalLinks.each((index, el) => {
+        $(el).attr('rel', 'noopener noreferrer');
+        if (isAboutAccounts) {
+          // if env is aboutAccounts then we need to open links in new tabs
+          // otherwise we get a "No Connection" window. Issue #4448.
+          $(el).attr('target', '_blank');
+        }
       });
 
       if (shouldConvertExternalLinksToText(this.broker)) {

--- a/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -57,10 +57,6 @@ define(function (require, exports, module) {
       assert.isTrue(broker.hasCapability('chooseWhatToSyncWebV1'));
     });
 
-    it('has the `convertExternalLinksToText` capability by default, disables links on privacy pages', function () {
-      assert.isTrue(broker.hasCapability('convertExternalLinksToText'));
-    });
-
     it('does not have the `emailVerificationMarketingSnippet` capability by default', function () {
       assert.isFalse(broker.hasCapability('emailVerificationMarketingSnippet'));
     });

--- a/app/tests/spec/views/mixins/external-links-mixin.js
+++ b/app/tests/spec/views/mixins/external-links-mixin.js
@@ -87,6 +87,28 @@ define(function (require, exports, module) {
         );
         });
       });
+
+      it('uses opens external links in new tabs with about:accounts', () => {
+        sinon.stub(broker.environment, 'isAboutAccounts', function () {
+          return true;
+        });
+
+        return view.render()
+          .then(function () {
+            assert.equal(view.$('#external-link').attr('target'), '_blank');
+          });
+      });
+
+      it('has no target attr if not about:accounts', () => {
+        sinon.stub(broker.environment, 'isAboutAccounts', function () {
+          return false;
+        });
+
+        return view.render()
+          .then(function () {
+            assert.notOk(view.$('#external-link').attr('target'));
+          });
+      });
     });
 
     describe('_onExternalLinkClick', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-bugzilla-mirror/issues/185
Fixes https://github.com/mozilla/fxa-content-server/issues/4448

@philbooth r?

![fennec](https://cloud.githubusercontent.com/assets/128755/21571615/f61f873a-ce9e-11e6-9a4b-f493080c45c4.gif)
