### PR TITLE
feat(client): Stringify WebChannel payloads in Fx Desktop >= 50.

### DIFF
--- a/app/scripts/lib/channels/senders/web-channel.js
+++ b/app/scripts/lib/channels/senders/web-channel.js
@@ -11,26 +11,32 @@ define(function (require, exports, module) {
   'use strict';
 
   const p = require('lib/promise');
+  const UserAgent = require('lib/user-agent');
 
   function WebChannelSender() {
     // nothing to do here.
   }
 
   WebChannelSender.prototype = {
-    initialize (options) {
-      options = options || {};
-
+    initialize (options = {}) {
       this._window = options.window;
       this._webChannelId = options.webChannelId;
     },
 
+    /**
+     * Send a WebChannel message.
+     *
+     * @param {String} command command name
+     * @param {Objet} data payload
+     * @param {String} messageId messageId browser will respond with.
+     * @returns {Promise}
+     */
     send (command, data, messageId) {
       return p().then(() => {
         // save command name for testing purposes
         this._saveEventName(command);
-
-        var event = createEvent(
-          this._window, this._webChannelId, command, data, messageId);
+        const eventDetail = createEventDetail(this._webChannelId, command, data, messageId);
+        const event = createEvent(this._window, eventDetail);
         this._window.dispatchEvent(event);
       });
     },
@@ -38,8 +44,14 @@ define(function (require, exports, module) {
     teardown () {
     },
 
+    /**
+     * Save the name of the event into sessionStorage, used for testing.
+     *
+     * @param {String} command
+     * @private
+     */
     _saveEventName (command) {
-      var storedEvents;
+      let storedEvents;
       try {
         storedEvents = JSON.parse(this._window.sessionStorage.getItem('webChannelEvents')) || [];
       } catch (e) {
@@ -54,20 +66,57 @@ define(function (require, exports, module) {
     }
   };
 
-  function createEvent(win, webChannelId, command, data, messageId) {
+  /**
+   * Create a WebChannelMessageToChrome event with the given `eventDetail`
+   *
+   * @param {Object} win recipient of the WebChannel event.
+   * @param {Object} eventDetail `detail` property of the event.
+   * @returns {Event} WebChannelMessageToChrome event.
+   */
+  function createEvent(win, eventDetail) {
     return new win.CustomEvent('WebChannelMessageToChrome', {
-      detail: {
-        id: webChannelId,
-        message: {
-          command: command,
-          data: data,
-          messageId: messageId
-        }
-      }
+      detail: formatEventDetail(win, eventDetail)
     });
+  }
+
+  /**
+   * Create an object for the `detail` field of a WebChannelMessageToChrome event.
+   *
+   * @param {String} webChannelId ID of the receiving WebChannel
+   * @param {String} command command name
+   * @param {Objet} data payload
+   * @param {String} messageId messageId browser will respond with.
+   * @returns {Object}
+   */
+  function createEventDetail(webChannelId, command, data, messageId) {
+    return {
+      id: webChannelId,
+      message: {
+        command,
+        data,
+        messageId
+      }
+    };
+  }
+
+  /**
+   * Format the `detail` payload for the current browser.
+   *
+   * @param {Object} win receiving window
+   * @param {Object} eventDetail `detail` payload
+   * @returns {String|Object}
+   */
+  function formatEventDetail(win, eventDetail) {
+    const userAgent = new UserAgent(win.navigator.userAgent);
+    // Firefox Desktop >= 50 expects the detail to be sent as a string.
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1275616 and
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1238128
+    if (userAgent.isFirefoxDesktop() && userAgent.browser.version >= 50) {
+      return JSON.stringify(eventDetail);
+    } else {
+      return eventDetail;
+    }
   }
 
   module.exports = WebChannelSender;
 });
-
-

--- a/app/scripts/lib/channels/senders/web-channel.js
+++ b/app/scripts/lib/channels/senders/web-channel.js
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
      * Send a WebChannel message.
      *
      * @param {String} command command name
-     * @param {Objet} data payload
+     * @param {Object} data payload
      * @param {String} messageId messageId browser will respond with.
      * @returns {Promise}
      */
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
    *
    * @param {String} webChannelId ID of the receiving WebChannel
    * @param {String} command command name
-   * @param {Objet} data payload
+   * @param {Object} data payload
    * @param {String} messageId messageId browser will respond with.
    * @returns {Object}
    */

--- a/app/scripts/lib/channels/senders/web-channel.js
+++ b/app/scripts/lib/channels/senders/web-channel.js
@@ -108,10 +108,12 @@ define(function (require, exports, module) {
    */
   function formatEventDetail(win, eventDetail) {
     const userAgent = new UserAgent(win.navigator.userAgent);
-    // Firefox Desktop >= 50 expects the detail to be sent as a string.
+    // Firefox Desktop and Fennec >= 50 expect the detail to be
+    // sent as a string.
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=1275616 and
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1238128
-    if (userAgent.isFirefoxDesktop() && userAgent.browser.version >= 50) {
+    if ((userAgent.isFirefoxDesktop() || userAgent.isFirefoxAndroid()) &&
+        userAgent.browser.version >= 50) {
       return JSON.stringify(eventDetail);
     } else {
       return eventDetail;

--- a/app/tests/spec/lib/channels/senders/web-channel.js
+++ b/app/tests/spec/lib/channels/senders/web-channel.js
@@ -29,8 +29,37 @@ define(function (require, exports, module) {
       sender.teardown();
     });
 
-    describe('send', function () {
-      it('dispatches a CustomEvent to the window', function () {
+    function testStringifiedDetail(userAgent) {
+      it('dispatches a CustomEvent with a stringified `detail` to the window', function () {
+        windowMock.navigator.userAgent = userAgent;
+
+        sinon.spy(windowMock, 'dispatchEvent');
+        sinon.spy(windowMock, 'CustomEvent');
+
+        var messageId = Date.now();
+        return sender.send('ping', { key: 'value' }, messageId)
+          .then(function () {
+            assert.isTrue(windowMock.dispatchEvent.called);
+
+            var eventType = windowMock.CustomEvent.args[0][0];
+            assert.equal(eventType, 'WebChannelMessageToChrome');
+
+            var detail = windowMock.CustomEvent.args[0][1].detail;
+            assert.isString(detail);
+
+            var eventData = JSON.parse(detail);
+            assert.equal(eventData.id, 'channel_id');
+            assert.equal(eventData.message.messageId, messageId);
+            assert.equal(eventData.message.command, 'ping');
+            assert.equal(eventData.message.data.key, 'value');
+          });
+      });
+    }
+
+    function testNonStringifiedDetail(userAgent) {
+      it('dispatches a CustomEvent with a non-stringified `detail` to the window', function () {
+        windowMock.navigator.userAgent = userAgent;
+
         sinon.spy(windowMock, 'dispatchEvent');
         sinon.spy(windowMock, 'CustomEvent');
 
@@ -48,6 +77,23 @@ define(function (require, exports, module) {
             assert.equal(eventData.message.command, 'ping');
             assert.equal(eventData.message.data.key, 'value');
           });
+      });
+    }
+
+    describe('send', function () {
+      describe('Fx Dekstop >= 50', () => {
+        testStringifiedDetail(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0');
+      });
+
+      describe('Fx Desktop < 50', () => {
+        testNonStringifiedDetail(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0');
+      });
+
+      describe('Fx Android', () => {
+        testNonStringifiedDetail(
+          'Mozilla/5.0 (Android 4.4; Mobile; rv:43.0) Gecko/41.0 Firefox/43.0');
       });
     });
 

--- a/app/tests/spec/lib/channels/senders/web-channel.js
+++ b/app/tests/spec/lib/channels/senders/web-channel.js
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
     }
 
     describe('send', function () {
-      describe('Fx Dekstop >= 50', () => {
+      describe('Fx Desktop >= 50', () => {
         testStringifiedDetail(
           'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0');
       });
@@ -91,9 +91,14 @@ define(function (require, exports, module) {
           'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0');
       });
 
-      describe('Fx Android', () => {
+      describe('Fx Android >= 50', () => {
+        testStringifiedDetail(
+          'Mozilla/5.0 (Android 4.4; Mobile; rv:50.0) Gecko/50.0 Firefox/50.0');
+      });
+
+      describe('Fx Android < 50', () => {
         testNonStringifiedDetail(
-          'Mozilla/5.0 (Android 4.4; Mobile; rv:43.0) Gecko/41.0 Firefox/43.0');
+          'Mozilla/5.0 (Android 4.4; Mobile; rv:49.0) Gecko/49.0 Firefox/49.0');
       });
     });
 

--- a/app/tests/spec/lib/channels/web.js
+++ b/app/tests/spec/lib/channels/web.js
@@ -18,6 +18,8 @@ define(function (require, exports, module) {
 
     beforeEach(function () {
       windowMock = new WindowMock();
+      windowMock.navigator.userAgent =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:49.0) Gecko/20100101 Firefox/49.0';
     });
 
 
@@ -69,9 +71,7 @@ define(function (require, exports, module) {
         channel.initialize({
           window: windowMock
         });
-
         sinon.stub(windowMock, 'dispatchEvent', function (dispatched) {
-          console.log('dispatched: %s', JSON.stringify(dispatched));
           channel._receiver.trigger('message', {
             command: 'can_link_account',
             data: { ok: true },


### PR DESCRIPTION
Fx Desktop >= 50 expects to see the `detail` property of WebChannel
message payloads sent as strings. This makes it so.

fixes #4577 

@rfk, @mhammond - r?

@mhammond - I was unsure whether Fennec >= 50 has the same behavior, so I only send strings for Fx Desktop at the moment.