### PR TITLE
fix(client): Stop using able to get the account blocked SUMO link.

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -113,6 +113,7 @@ define(function (require, exports, module) {
     // Login delay for iOS broker
     IOS_V1_LOGIN_MESSAGE_DELAY_MS: 10000,
 
+    BLOCKED_SIGNIN_SUPPORT_URL: 'https://support.mozilla.org/kb/accounts-blocked',
     UNBLOCK_CODE_LENGTH: 8,
 
     MARKETING_ID_SPRING_2015: 'spring-2015-android-ios-sync',

--- a/app/scripts/views/report_sign_in.js
+++ b/app/scripts/views/report_sign_in.js
@@ -9,6 +9,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const AuthErrors = require('lib/auth-errors');
+  const Constants = require('lib/constants');
   const FormView = require('views/form');
   const Template = require('stache!templates/report_sign_in');
   const SignInToReport = require('models/verification/report-sign-in');
@@ -18,7 +19,6 @@ define(function (require, exports, module) {
     template: Template,
 
     initialize (options = {}) {
-      this._able = options.able;
       this._signInToReport = new SignInToReport(this.getSearchParams());
     },
 
@@ -59,10 +59,9 @@ define(function (require, exports, module) {
      * @returns {String}
      */
     _getSupportLink () {
-      return this._able.choose('blockedSigninSupportUrl');
+      return Constants.BLOCKED_SIGNIN_SUPPORT_URL;
     }
   });
 
   module.exports = View;
 });
-

--- a/app/scripts/views/sign_in_unblock.js
+++ b/app/scripts/views/sign_in_unblock.js
@@ -18,17 +18,9 @@ define(function (require, exports, module) {
   const SignInMixin = require('views/mixins/signin-mixin');
   const Template = require('stache!templates/sign_in_unblock');
 
-  const proto = FormView.prototype;
-
   const View = FormView.extend({
     template: Template,
     className: 'sign-in-unblock',
-
-    initialize(options = {}) {
-      this._able = options.able;
-
-      return proto.initialize.call(this, options);
-    },
 
     getAccount () {
       return this.model.get('account');
@@ -103,7 +95,7 @@ define(function (require, exports, module) {
      * @returns {String}
      */
     _getSupportLink () {
-      return this._able.choose('blockedSigninSupportUrl');
+      return Constants.BLOCKED_SIGNIN_SUPPORT_URL;
     }
   });
 


### PR DESCRIPTION
We used able so that we could cause the link to be displayed mid-train,
as soon as the content was ready. Now that the content is ready, no
real need to use able anymore.

fixes #4588