### PR TITLE
fix(metrics): Only send navigationTiming data on the first flush. 

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -289,7 +289,11 @@ define(function (require, exports, module) {
     getFilteredData () {
       var allowedData = _.pick(this.getAllData(), ALLOWED_FIELDS);
 
-      return _.pick(allowedData, function (value, key) {
+      return _.pick(allowedData, (value, key) => {
+        // navigationTiming is sent in the first flush, no need to re-send it.
+        if (this._lastFlushedData && key === 'navigationTiming') {
+          return false;
+        }
         return ! _.isUndefined(value) && value !== '';
       });
     },

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -500,8 +500,13 @@ define(function (require, exports, module) {
             });
         });
 
-        it('sends data both times', function () {
+        it('sends data both times, navigationTiming data only sent on first flush', () => {
           assert.equal(windowMock.navigator.sendBeacon.callCount, 2);
+
+          const firstPayload = JSON.parse(windowMock.navigator.sendBeacon.args[0][1]);
+          assert.isObject(firstPayload.navigationTiming);
+          const secondPayload = JSON.parse(windowMock.navigator.sendBeacon.args[1][1]);
+          assert.notProperty(secondPayload, 'navigationTiming');
         });
       });
 


### PR DESCRIPTION
fixes #4601 

Builds on https://github.com/mozilla/fxa-content-server/pull/4602 and should be reviewed afterwards.