### PR TITLE
refactor(test): No `context` for some FxDesktop helpers.

### DIFF
--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -21,8 +21,6 @@ define([
   var code;
   var uid;
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
@@ -30,27 +28,10 @@ define([
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = FunctionalHelpers.openPage;
   var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfMessage);
-  var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
+  var testIsBrowserNotified = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
+  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
 
   var createRandomHexString = TestHelpers.createRandomHexString;
-
-  var setupTest = thenify(function (context) {
-    return this.parent
-      .then(createUser(email, PASSWORD, {preVerified: true}))
-      .then(openPage(PAGE_SIGNIN_URL, '#fxa-signin-header'))
-      .execute(listenForFxaCommands)
-      .then(fillOutSignIn(email, PASSWORD))
-      .then(testIsBrowserNotified(context, 'can_link_account'))
-      .then(testIsBrowserNotifiedOfLogin(context, email, {checkVerified: false}))
-      .then(testElementExists('#fxa-confirm-signin-header'))
-      .then(restmail(EMAIL_SERVER_ROOT + '/mail/' + user))
-      .then(function (emails) {
-        code = emails[0].headers['x-verify-code'];
-        uid = emails[0].headers['x-uid'];
-      });
-  });
-
 
   registerSuite({
     name: 'complete_sign_in',
@@ -60,7 +41,18 @@ define([
       user = TestHelpers.emailToUser(email);
       return this.remote
         .then(clearBrowserState())
-        .then(setupTest(this, true));
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(PAGE_SIGNIN_URL, '#fxa-signin-header'))
+        .execute(listenForFxaCommands)
+        .then(fillOutSignIn(email, PASSWORD))
+        .then(testIsBrowserNotified('can_link_account'))
+        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }))
+        .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(restmail(EMAIL_SERVER_ROOT + '/mail/' + user))
+        .then(function (emails) {
+          code = emails[0].headers['x-verify-code'];
+          uid = emails[0].headers['x-uid'];
+        });
     },
 
     'open verification link with malformed code': function () {

--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -49,7 +49,7 @@ define([
         .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }))
         .then(testElementExists('#fxa-confirm-signin-header'))
         .then(restmail(EMAIL_SERVER_ROOT + '/mail/' + user))
-        .then(function (emails) {
+        .then((emails) => {
           code = emails[0].headers['x-verify-code'];
           uid = emails[0].headers['x-uid'];
         });

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -30,8 +30,8 @@ define([
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
-  var testIsBrowserNotified = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfMessage);
-  var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
+  var testIsBrowserNotified = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
+  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   var setupTest = thenify(function (options) {
@@ -46,11 +46,11 @@ define([
       .then(openPage(PAGE_URL, '#fxa-signin-header'))
       .execute(listenForFxaCommands)
       .then(fillOutSignIn(email, PASSWORD))
-      .then(testIsBrowserNotified(this.parent, 'can_link_account'))
+      .then(testIsBrowserNotified('can_link_account'))
       .then(() => {
         if (! options.blocked) {
           return this.parent
-            .then(testIsBrowserNotifiedOfLogin(this.parent, email, { checkVerified: false }));
+            .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }));
         }
       })
       .then(testElementExists(successSelector));
@@ -131,7 +131,7 @@ define([
         .then(testElementTextInclude('.verification-email-message', email))
         .then(fillOutSignInUnblock(email, 0))
 
-        .then(testIsBrowserNotifiedOfLogin(this.remote, email, { checkVerified: true }))
+        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }))
         // about:accounts will take over post-unblock, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'));
     }

--- a/tests/functional/fx_ios_v1_sign_up.js
+++ b/tests/functional/fx_ios_v1_sign_up.js
@@ -40,8 +40,6 @@ define([
     },
 
     'sign up, verify same browser': function () {
-      var self = this;
-
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .execute(listenForFxaCommands)
@@ -49,10 +47,9 @@ define([
         .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
-          .then(function () {
-            return testIsBrowserNotifiedOfLogin(self, email);
-          })
         .end()
+
+        .then(testIsBrowserNotifiedOfLogin(email))
 
         // verify the user
         .then(openVerificationLinkInNewTab(email, 0))

--- a/tests/functional/fx_ios_v1_sign_up.js
+++ b/tests/functional/fx_ios_v1_sign_up.js
@@ -4,12 +4,11 @@
 
 define([
   'intern',
-  'intern/chai!assert',
   'intern!object',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'tests/functional/lib/fx-desktop'
-], function (intern, assert, registerSuite, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_ios_v1&service=sync';
 
@@ -23,6 +22,8 @@ define([
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
 
@@ -46,29 +47,18 @@ define([
         .then(noSuchElement('#customize-sync'))
         .then(fillOutSignUp(email, PASSWORD))
 
-        .findByCssSelector('#fxa-confirm-header')
-        .end()
-
+        .then(testElementExists('#fxa-confirm-header'))
         .then(testIsBrowserNotifiedOfLogin(email))
 
         // verify the user
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')
 
-        .findByCssSelector('#fxa-sign-up-complete-header')
-        .end()
-
-        .findByCssSelector('.account-ready-service')
-          .getVisibleText()
-          .then(function (text) {
-            assert.ok(text.indexOf('Firefox Sync') > -1);
-          })
-        .end()
-
+        .then(testElementExists('#fxa-sign-up-complete-header'))
+        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
         .then(closeCurrentWindow())
 
-        .findByCssSelector('#fxa-confirm-header')
-        .end()
+        .then(testElementExists('#fxa-confirm-header'))
 
         // A post-verification email should be sent, this is Sync.
         .then(testEmailExpected(email, 1));

--- a/tests/functional/lib/fx-desktop.js
+++ b/tests/functional/lib/fx-desktop.js
@@ -7,10 +7,6 @@ define([
   'intern/chai!assert'
 ], function (assert) {
 
-  function getRemote(context) {
-    return context.remote || context.parent || context;
-  }
-
   /**
    * Listens for FirefoxAccountsCommand events coming from FxA and
    * automatically responds so that no error messages are displayed
@@ -64,29 +60,50 @@ define([
     return true;
   }
 
-  function testIsBrowserNotifiedOfLogin(context, email, options) {
-    return getRemote(context)
-      .findByCssSelector('#message-login')
-        .getProperty('innerText')
-        .then(function (innerText) {
-          options = options || {};
-          var data = JSON.parse(innerText);
-          assert.equal(data.email, email);
-          assert.ok(data.unwrapBKey);
-          assert.ok(data.keyFetchToken);
-          if (options.checkVerified) {
-            assert.isTrue(data.verified);
-          } else {
-            assert.isFalse(data.verified);
-          }
-        })
-      .end();
+  /**
+   * Test if the browser has been notified of a CustomEvent login message.
+   *
+   * @param {string} email
+   * @param {object} [options]
+   *  @param {boolean} [options.expectVerified] - expected user verification status.
+   *   Defaults to `false`
+   * @returns {promise}
+   */
+  function testIsBrowserNotifiedOfLogin(email, options) {
+    return function () {
+      options = options || {};
+
+      return this.parent
+        .findByCssSelector('#message-login')
+          .getProperty('innerText')
+          .then(function (innerText) {
+            options = options || {};
+            var data = JSON.parse(innerText);
+            assert.equal(data.email, email);
+            assert.ok(data.unwrapBKey);
+            assert.ok(data.keyFetchToken);
+            if (options.expectVerified) {
+              assert.isTrue(data.verified);
+            } else {
+              assert.isFalse(data.verified);
+            }
+          })
+        .end();
+    };
   }
 
-  function testIsBrowserNotifiedOfMessage(context, message) {
-    return getRemote(context)
-      .findByCssSelector('#message-' + message)
-      .end();
+  /**
+   * Test if the browser has been notified of a CustomEvent message
+   *
+   * @param {string} message message to expect
+   * @returns {promise} rejects if message has not been sent.
+   */
+  function testIsBrowserNotifiedOfMessage(message) {
+    return function () {
+      return this.parent
+        .findByCssSelector('#message-' + message)
+        .end();
+    };
   }
 
   return {
@@ -95,5 +112,3 @@ define([
     testIsBrowserNotifiedOfMessage: testIsBrowserNotifiedOfMessage
   };
 });
-
-

--- a/tests/functional/lib/fx-desktop.js
+++ b/tests/functional/lib/fx-desktop.js
@@ -101,7 +101,8 @@ define([
   function testIsBrowserNotifiedOfMessage(message) {
     return function () {
       return this.parent
-        .then(testElementExists('#message-' + message));
+        .findByCssSelector('#message-' + message)
+        .end();
     };
   }
 

--- a/tests/functional/lib/fx-desktop.js
+++ b/tests/functional/lib/fx-desktop.js
@@ -76,7 +76,7 @@ define([
       return this.parent
         .findByCssSelector('#message-login')
           .getProperty('innerText')
-          .then(function (innerText) {
+          .then((innerText) => {
             options = options || {};
             var data = JSON.parse(innerText);
             assert.equal(data.email, email);
@@ -101,8 +101,7 @@ define([
   function testIsBrowserNotifiedOfMessage(message) {
     return function () {
       return this.parent
-        .findByCssSelector('#message-' + message)
-        .end();
+        .then(testElementExists('#message-' + message));
     };
   }
 

--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -17,8 +17,6 @@ define([
   var email2;
   var PASSWORD = '12345678';
 
-  var thenify = FunctionalHelpers.thenify;
-
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var createUser = FunctionalHelpers.createUser;
@@ -30,7 +28,7 @@ define([
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextEquals = FunctionalHelpers.testElementTextEquals;
-  var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
+  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   registerSuite({
@@ -63,7 +61,7 @@ define([
         .execute(listenForFxaCommands)
 
         .then(fillOutSignIn(email, PASSWORD))
-        .then(testIsBrowserNotifiedOfLogin(this, email))
+        .then(testIsBrowserNotifiedOfLogin(email))
 
         // Sync sign ins must be verified.
         .then(openVerificationLinkInNewTab(email, 0))

--- a/tests/functional/sync_force_auth.js
+++ b/tests/functional/sync_force_auth.js
@@ -21,8 +21,8 @@ define([
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfMessage);
-  var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
+  var testIsBrowserNotified = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
+  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
 
   var PASSWORD = 'password';
   var email;
@@ -44,11 +44,11 @@ define([
       }}))
       .execute(listenForFxaCommands)
       .then(fillOutForceAuth(PASSWORD))
-      .then(testIsBrowserNotified(this.parent, 'can_link_account'))
+      .then(testIsBrowserNotified('can_link_account'))
       .then(() => {
         if (! options.blocked) {
           return this.parent
-            .then(testIsBrowserNotifiedOfLogin(this.parent, email, { checkVerified: false }));
+            .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }));
         }
       })
 
@@ -97,7 +97,7 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
-        .then(testIsBrowserNotifiedOfLogin(this, email, { checkVerified: true }))
+        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'));

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -35,7 +35,7 @@ define([
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
-  var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
+  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
   var type = FunctionalHelpers.type;
 
 
@@ -74,7 +74,7 @@ define([
         .then(closeCurrentWindow())
 
         .then(testSuccessWasShown())
-        .then(testIsBrowserNotifiedOfLogin(this, email, { checkVerified: true }));
+        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }));
     },
 
     'reset password, verify same browser with original tab closed': function () {
@@ -130,7 +130,7 @@ define([
         .then(type('#password', PASSWORD))
         .then(click('button[type=submit]'))
 
-        .then(testIsBrowserNotifiedOfLogin(this, email, { checkVerified: false }))
+        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }))
 
         // user verified the reset password in another browser, they must
         // re-verify they want to sign in on this device to avoid

--- a/tests/functional/sync_settings.js
+++ b/tests/functional/sync_settings.js
@@ -23,8 +23,8 @@ define([
   var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
-  var testIsBrowserNotifiedOfMessage = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfMessage);
+  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+  var testIsBrowserNotifiedOfMessage = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   var config = intern.config;
@@ -43,7 +43,7 @@ define([
       .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
       .execute(listenForFxaCommands)
       .then(fillOutSignIn(email, FIRST_PASSWORD))
-      .then(testIsBrowserNotifiedOfLogin(this.parent, email, { checkVerified: false }))
+      .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }))
 
       .then(function () {
         if (shouldVerifySignin) {
@@ -70,7 +70,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotifiedOfMessage(this, 'change_password'));
+        .then(testIsBrowserNotifiedOfMessage('change_password'));
     },
 
     'sign in, delete the account': function () {
@@ -80,7 +80,7 @@ define([
         .then(visibleByQSA('#delete-account .settings-unit-details'))
 
         .then(fillOutDeleteAccount(FIRST_PASSWORD))
-        .then(testIsBrowserNotifiedOfMessage(this, 'delete_account'))
+        .then(testIsBrowserNotifiedOfMessage('delete_account'))
 
         .then(testElementExists('#fxa-signup-header'));
     },

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -32,8 +32,8 @@ define([
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfMessage);
-  var testIsBrowserNotifiedOfLogin = thenify(FxDesktopHelpers.testIsBrowserNotifiedOfLogin);
+  var testIsBrowserNotified = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
+  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   var setupTest = thenify(function (options) {
@@ -48,11 +48,11 @@ define([
       .then(openPage(options.pageUrl || PAGE_URL, '#fxa-signin-header'))
       .execute(listenForFxaCommands)
       .then(fillOutSignIn(email, PASSWORD))
-      .then(testIsBrowserNotified(this.parent, 'can_link_account'))
+      .then(testIsBrowserNotified('can_link_account'))
       .then(() => {
         if (! options.blocked) {
           return this.parent
-            .then(testIsBrowserNotifiedOfLogin(this.parent, email, { checkVerified: false }));
+            .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }));
         }
       })
       .then(testElementExists(successSelector));
@@ -139,7 +139,7 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
-        .then(testIsBrowserNotifiedOfLogin(this, email, { checkVerified: true }))
+        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'));

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -5,43 +5,40 @@
 define([
   'intern',
   'intern!object',
-  'intern/chai!assert',
-  'require',
-  'intern/browser_modules/dojo/node!xmlhttprequest',
-  'app/bower_components/fxa-js-client/fxa-client',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'tests/functional/lib/fx-desktop'
-], function (intern, registerSuite, assert, require, nodeXMLHttpRequest,
-        FxaClient, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_desktop_v1&service=sync';
   var PAGE_URL_WITH_MIGRATION = PAGE_URL + '&migration=sync11';
 
-  var AUTH_SERVER_ROOT = config.fxaAuthRoot;
-
-  var client;
   var email;
   var PASSWORD = '12345678';
+
+  var thenify = FunctionalHelpers.thenify;
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
+  var openPage = FunctionalHelpers.openPage;
+  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
+  var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
+  var testAttributeEquals = FunctionalHelpers.testAttributeEquals;
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+  var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   registerSuite({
     name: 'Firefox Desktop Sync sign_up',
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-
-      client = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
 
       return this.remote.then(clearBrowserState());
     },
@@ -52,16 +49,11 @@ define([
 
     'sign up, verify same browser': function () {
       return this.remote
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .execute(listenForFxaCommands)
-
-        .findByCssSelector('#fxa-signup-header')
-        .end()
         .then(fillOutSignUp(email, PASSWORD))
 
-        .findByCssSelector('#fxa-confirm-header')
-        .end()
+        .then(testElementExists('#fxa-confirm-header'))
 
         .then(testIsBrowserNotifiedOfLogin(email))
 
@@ -73,16 +65,8 @@ define([
         // In real life, the original browser window would show
         // a "welcome to sync!" screen that has a manage button
         // on it, and this screen should show the FxA success screen.
-        .findById('fxa-sign-up-complete-header')
-        .end()
-
-        .findByCssSelector('.account-ready-service')
-        .getVisibleText()
-        .then(function (text) {
-          assert.ok(text.indexOf('Firefox Sync') > -1);
-        })
-
-        .end()
+        .then(testElementExists('#fxa-sign-up-complete-header'))
+        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
         .then(closeCurrentWindow())
 
         // We do not expect the verification poll to occur. The poll
@@ -96,100 +80,56 @@ define([
 
     'signup, verify same browser with original tab closed': function () {
       return this.remote
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .execute(listenForFxaCommands)
-
-        .findByCssSelector('#fxa-signup-header')
-        .end()
         .then(fillOutSignUp(email, PASSWORD))
 
-        .findByCssSelector('#fxa-confirm-header')
-        .end()
-
+        .then(testElementExists('#fxa-confirm-header'))
         .then(FunctionalHelpers.openExternalSite())
 
         .then(openVerificationLinkInNewTab(email, 0))
 
         .switchToWindow('newwindow')
 
-        .findByCssSelector('#fxa-sign-up-complete-header')
-        .end()
-
-        .findByCssSelector('.account-ready-service')
-        .getVisibleText()
-        .then(function (text) {
-          assert.ok(text.indexOf('Firefox Sync') > -1);
-        })
-
+        .then(testElementExists('#fxa-sign-up-complete-header'))
+        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
         .then(closeCurrentWindow());
     },
 
     'signup, verify same browser by replacing the original tab': function () {
-      var self = this;
-
       return this.remote
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .execute(listenForFxaCommands)
-
-        .findByCssSelector('#fxa-signup-header')
-        .end()
         .then(fillOutSignUp(email, PASSWORD))
 
-        .findByCssSelector('#fxa-confirm-header')
-        .end()
+        .then(testElementExists('#fxa-confirm-header'))
 
-        .then(function () {
-          return FunctionalHelpers.getVerificationLink(email, 0);
-        })
-        .then(function (verificationLink) {
-          return self.remote.get(require.toUrl(verificationLink));
-        })
-
-        .findByCssSelector('#fxa-sign-up-complete-header')
-        .end();
+        .then(openVerificationLinkInSameTab(email, 0))
+        .then(testElementExists('#fxa-sign-up-complete-header'));
     },
 
 
     'signup, verify different browser - from original tab\'s P.O.V.': function () {
       return this.remote
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .execute(listenForFxaCommands)
-
-        .findByCssSelector('#fxa-signup-header')
-        .end()
         .then(fillOutSignUp(email, PASSWORD))
 
-        .findByCssSelector('#fxa-confirm-header')
-                .end()
-
+        .then(testElementExists('#fxa-confirm-header'))
         .then(testIsBrowserNotifiedOfLogin(email))
 
-        .then(function () {
-          return FunctionalHelpers.openVerificationLinkDifferentBrowser(client, email);
-        })
+        .then(openVerificationLinkDifferentBrowser(email, 0))
 
         // The original tab should not transition
-        .findByCssSelector('#fxa-confirm-header')
-        .end();
+        .then(noPageTransition('#fxa-confirm-header', 5000));
     },
 
     'signup, verify different browser - from new browser\'s P.O.V.': function () {
-      var self = this;
-
       return this.remote
-        .get(require.toUrl(PAGE_URL))
-        .setFindTimeout(intern.config.pageLoadTimeout)
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .execute(listenForFxaCommands)
-
-        .findByCssSelector('#fxa-signup-header')
-        .end()
         .then(fillOutSignUp(email, PASSWORD))
-
-        .findByCssSelector('#fxa-confirm-header')
-        .end()
+        .then(testElementExists('#fxa-confirm-header'))
 
         .then(testIsBrowserNotifiedOfLogin(email))
 
@@ -198,69 +138,39 @@ define([
         .then(clearBrowserState())
 
         // verify the user
-        .then(function () {
-          return FunctionalHelpers.getVerificationLink(email, 0);
-        })
-        .then(function (link) {
-          return self.remote.get(link);
-        })
+        .then(openVerificationLinkInSameTab(email, 0))
 
         // user should be redirected to "Success!" screen
-        .findById('fxa-sign-up-complete-header')
-        .end()
-
-        .findByCssSelector('.account-ready-service')
-        .getVisibleText()
-        .then(function (text) {
-          assert.ok(text.indexOf('Firefox Sync') > -1);
-        })
-
-        .end();
+        .then(testElementExists('#fxa-sign-up-complete-header'))
+        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'));
     },
 
     'choose option to customize sync': function () {
       return this.remote
-        .get(require.toUrl(PAGE_URL))
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .execute(listenForFxaCommands)
 
-        .findByCssSelector('#fxa-signup-header')
-        .end()
-
-        .findByCssSelector('#customize-sync')
-          .getAttribute('checked')
-          .then(function (checkedAttribute) {
-            assert.isNull(checkedAttribute);
-          })
-        .end()
+        .then(testAttributeEquals('#customize-sync', 'checked', null))
         .then(fillOutSignUp(email, PASSWORD, { customizeSync: true }))
 
         .then(testIsBrowserNotifiedOfLogin(email))
 
         // Being pushed to the confirmation screen is success.
-        .findById('fxa-confirm-header')
-        .end();
+        .then(testElementExists('#fxa-confirm-header'));
     },
 
     'force customize sync checkbox to be checked': function () {
       var url = (PAGE_URL += '&customizeSync=true');
       return this.remote
-        .get(require.toUrl(url))
+        .then(openPage(url, '#fxa-signup-header'))
 
-        .findByCssSelector('#customize-sync')
-          .getAttribute('checked')
-          .then(function (checkedAttribute) {
-            assert.equal(checkedAttribute, 'checked');
-          })
-        .end();
+        .then(testAttributeEquals('#customize-sync', 'checked', 'checked'));
     },
 
     'as a migrating user': function () {
       return this.remote
-        .get(require.toUrl(PAGE_URL_WITH_MIGRATION))
-        .setFindTimeout(intern.config.pageLoadTimeout)
-        .execute(listenForFxaCommands)
-        .then(FunctionalHelpers.visibleByQSA('.info.nudge'))
-        .end();
+        .then(openPage(PAGE_URL_WITH_MIGRATION, '#fxa-signup-header'))
+        .then(visibleByQSA('.info.nudge'));
     }
   });
 });

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -51,9 +51,6 @@ define([
     },
 
     'sign up, verify same browser': function () {
-
-      var self = this;
-
       return this.remote
         .get(require.toUrl(PAGE_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
@@ -64,12 +61,9 @@ define([
         .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
-
-        .then(function () {
-          return testIsBrowserNotifiedOfLogin(self, email);
-        })
-
         .end()
+
+        .then(testIsBrowserNotifiedOfLogin(email))
 
         // verify the user
         .then(openVerificationLinkInNewTab(email, 0))
@@ -159,8 +153,6 @@ define([
 
 
     'signup, verify different browser - from original tab\'s P.O.V.': function () {
-      var self = this;
-
       return this.remote
         .get(require.toUrl(PAGE_URL))
         .setFindTimeout(intern.config.pageLoadTimeout)
@@ -171,12 +163,9 @@ define([
         .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
+                .end()
 
-        .then(function () {
-          return testIsBrowserNotifiedOfLogin(self, email);
-        })
-
-        .end()
+        .then(testIsBrowserNotifiedOfLogin(email))
 
         .then(function () {
           return FunctionalHelpers.openVerificationLinkDifferentBrowser(client, email);
@@ -200,11 +189,9 @@ define([
         .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
-
-        .then(function () {
-          return testIsBrowserNotifiedOfLogin(self, email);
-        })
         .end()
+
+        .then(testIsBrowserNotifiedOfLogin(email))
 
         // clear local/sessionStorage to synthesize continuing in
         // a separate browser.
@@ -232,7 +219,6 @@ define([
     },
 
     'choose option to customize sync': function () {
-      var self = this;
       return this.remote
         .get(require.toUrl(PAGE_URL))
         .execute(listenForFxaCommands)
@@ -248,9 +234,7 @@ define([
         .end()
         .then(fillOutSignUp(email, PASSWORD, { customizeSync: true }))
 
-        .then(function () {
-          return testIsBrowserNotifiedOfLogin(self, email);
-        })
+        .then(testIsBrowserNotifiedOfLogin(email))
 
         // Being pushed to the confirmation screen is success.
         .findById('fxa-confirm-header')


### PR DESCRIPTION
Context is removed for `testIsBrowserNotifiedOfLogin` and `testIsBrowserNotifiedOfMessage`

In the call to testIsBrowserNotifiedOfLogin, change `checkLogin` to
`expectLogin` for clarity

@mozilla/fxa-devs - r?