### PR TITLE
fix(test): Avoid rate limiting in a `confirm` functional test.

### DIFF
--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -44,7 +44,7 @@ define([
     },
 
     'sign up, wait for confirmation screen, click resend': function () {
-      var email = 'test_signin' + Math.random() + '@mailinator.com';
+      var email = 'test_signin' + Math.random() + '@restmail.dev.lcip.org';
 
       return this.remote
         .then(openPage(SIGNUP_URL, '#fxa-signup-header'))


### PR DESCRIPTION
Replace `mailinator.com` with `restmail.dev.lcip.org`. mailinator addresses
are rate limited, restmail.dev.lcip.org is a mozilla controlled server and
isn't rate limited.

fixes #4537

@vladikoff - r?

I see the [change to the customs-server](https://github.com/mozilla/fxa-customs-server/blob/262c210974818860e0f6f53dbb37145eca118245/lib/config/config.js#L177) has already been made.