### PR TITLE
refactor(test): Remove `context` from `noSuchBrowserNotification` and `testIsBrowserNotified`

### DIFF
--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -35,7 +35,7 @@ define([
 
   var testIsBrowserNotifiedOfAvatarChange = thenify(function () {
     return this.parent
-      .then(testIsBrowserNotified(this.parent, 'profile:change'));
+      .then(testIsBrowserNotified('profile:change'));
   });
 
   function signUp(context, email) {

--- a/tests/functional/fx_fennec_v1_force_auth.js
+++ b/tests/functional/fx_fennec_v1_force_auth.js
@@ -44,11 +44,11 @@ define([
       .then(fillOutForceAuth(PASSWORD))
 
       .then(testElementExists(successSelector))
-      .then(testIsBrowserNotified(this.parent, 'fxaccounts:can_link_account'))
+      .then(testIsBrowserNotified('fxaccounts:can_link_account'))
       .then(() => {
         if (! options.blocked) {
           return this.parent
-            .then(testIsBrowserNotified(this.parent, 'fxaccounts:login'));
+            .then(testIsBrowserNotified('fxaccounts:login'));
         }
       });
   });
@@ -93,7 +93,7 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
-        .then(testIsBrowserNotified(this.parent, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-sign-in-complete-header'));
     }

--- a/tests/functional/fx_fennec_v1_settings.js
+++ b/tests/functional/fx_fennec_v1_settings.js
@@ -47,8 +47,8 @@ define([
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // User must confirm their Sync signin
         .then(testElementExists('#fxa-confirm-signin-header'))
@@ -71,7 +71,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:change_password'));
+        .then(testIsBrowserNotified('fxaccounts:change_password'));
     },
 
     'sign in, change the password by browsing directly to settings': function () {
@@ -79,10 +79,10 @@ define([
         .then(openPage(SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
-        .then(noSuchBrowserNotification(this, 'fxaccounts:change_password'))
+        .then(noSuchBrowserNotification('fxaccounts:change_password'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:change_password'));
+        .then(testIsBrowserNotified('fxaccounts:change_password'));
     },
 
     'sign in, delete the account': function () {
@@ -93,7 +93,7 @@ define([
         .then(fillOutDeleteAccount(FIRST_PASSWORD))
         // Fx desktop requires fxaccounts:delete, Fennec requires
         // fxaccounts:delete_account
-        .then(testIsBrowserNotified(this, 'fxaccounts:delete_account'))
+        .then(testIsBrowserNotified('fxaccounts:delete_account'))
 
         .then(testElementExists('#fxa-signup-header'));
     },

--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -38,11 +38,11 @@ define([
       .then(openPage(PAGE_URL, '#fxa-signin-header'))
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(email, PASSWORD))
-      .then(testIsBrowserNotified(this.parent, 'fxaccounts:can_link_account'))
+      .then(testIsBrowserNotified('fxaccounts:can_link_account'))
       .then(() => {
         if (! options.blocked) {
           return this.parent
-            .then(testIsBrowserNotified(this.parent, 'fxaccounts:login'));
+            .then(testIsBrowserNotified('fxaccounts:login'));
         }
       });
   });
@@ -82,8 +82,8 @@ define([
         .then(setupTest({ preVerified: false }))
 
         .then(testElementExists('#fxa-confirm-header'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // email 0 - initial sign up email
         // email 1 - sign in w/ unverified address email
@@ -106,7 +106,7 @@ define([
         .then(testElementTextInclude('.verification-email-message', email))
         .then(fillOutSignInUnblock(email, 0))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(testElementExists('#fxa-sign-in-complete-header'));
     }
   });

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -4,24 +4,28 @@
 
 define([
   'intern',
-  'intern/chai!assert',
   'intern!object',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, assert, registerSuite, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_fennec_v1&service=sync';
 
   var email;
   var PASSWORD = '12345678';
 
+  var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noSuchElement = FunctionalHelpers.noSuchElement;
+  var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
 
   registerSuite({
     name: 'Fx Fennec Sync v1 sign_up',
@@ -43,69 +47,35 @@ define([
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
-
         .then(noSuchElement('#customize-sync'))
-
         .then(fillOutSignUp(email, PASSWORD))
 
-        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         // the login message is only sent after the confirm screen is shown.
-        .then(FunctionalHelpers.noSuchBrowserNotification(self, 'fxaccounts:login'))
-
+        .then(noSuchBrowserNotification('fxaccounts:login'))
         // user should be transitioned to the choose what to Sync page
-        .findByCssSelector('#fxa-choose-what-to-sync-header')
-        .end()
-
+        .then(testElementExists('#fxa-choose-what-to-sync-header'))
         // uncheck the passwords and history engines
-        .findByCssSelector('div.two-col-block:nth-child(2) > div:nth-child(1) > label:nth-child(1)')
-          .click()
-        .end()
-
-        .findByCssSelector('div.two-col-block:nth-child(2) > div:nth-child(2) > label:nth-child(1)')
-          .click()
-        .end()
-
-        .findByCssSelector('button[type=submit]')
-          .click()
-        .end()
+        .then(click('div.two-col-block:nth-child(2) > div:nth-child(1) > label:nth-child(1)'))
+        .then(click('div.two-col-block:nth-child(2) > div:nth-child(2) > label:nth-child(1)'))
+        .then(click('button[type=submit]'))
 
         // user should be transitioned to the "go confirm your address" page
-        .findByCssSelector('#fxa-confirm-header')
-        .end()
+        .then(testElementExists('#fxa-confirm-header'))
 
         // the login message is only sent after the sync preferences screen
         // has been cleared.
-        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:login', function (data) {
-          assert.isTrue(data.customizeSync);
-          assert.deepEqual(data.declinedSyncEngines, ['passwords', 'history']);
-          assert.equal(data.email, email);
-          assert.ok(data.keyFetchToken);
-          assert.ok(data.sessionToken);
-          assert.ok(data.uid);
-          assert.ok(data.unwrapBKey);
-          assert.isFalse(data.verified);
-          assert.isTrue(data.verifiedCanLinkAccount);
-        }))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // verify the user
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')
 
-        .findByCssSelector('#fxa-sign-up-complete-header')
-        .end()
-
-        .findByCssSelector('.account-ready-service')
-          .getVisibleText()
-          .then(function (text) {
-            assert.ok(text.indexOf('Firefox Sync') > -1);
-          })
-        .end()
+        .then(testElementExists('#fxa-sign-up-complete-header'))
+        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
 
         .then(closeCurrentWindow())
-
-        .findByCssSelector('#fxa-sign-up-complete-header')
-        .end()
-
+        .then(testElementExists('#fxa-sign-up-complete-header'))
         // A post-verification email should be sent, this is Sync.
         .then(testEmailExpected(email, 1));
 

--- a/tests/functional/fx_firstrun_v1_settings.js
+++ b/tests/functional/fx_firstrun_v1_settings.js
@@ -44,8 +44,8 @@ define([
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
         .then(openVerificationLinkDifferentBrowser(email))
@@ -65,7 +65,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:change_password'));
+        .then(testIsBrowserNotified('fxaccounts:change_password'));
     },
 
     'sign in, change the password by browsing directly to settings': function () {
@@ -75,7 +75,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:change_password'));
+        .then(testIsBrowserNotified('fxaccounts:change_password'));
     }
   });
 });

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -42,7 +42,7 @@ define([
       // delay for the webchannel message
       .sleep(500)
       .then(fillOutSignIn(email, PASSWORD))
-      .then(testIsBrowserNotified(this.parent, 'fxaccounts:can_link_account'));
+      .then(testIsBrowserNotified('fxaccounts:can_link_account'));
   });
 
   registerSuite({
@@ -61,7 +61,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
         .then(testElementExists('#fxa-confirm-signin-header'))
 
@@ -71,21 +71,21 @@ define([
           .then(closeCurrentWindow())
 
         .then(testElementExists('#fxa-sign-in-complete-header'))
-        .then(noSuchBrowserNotification(this, 'fxaccounts:login'));
+        .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
     'verified, verify different browser - from original tab\'s P.O.V.': function () {
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
         .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openVerificationLinkDifferentBrowser(email))
 
         .then(testElementExists('#fxa-sign-in-complete-header'))
-        .then(noSuchBrowserNotification(this, 'fxaccounts:login'));
+        .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
     'unverified': function () {
@@ -93,7 +93,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: false }))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
 
         .then(testElementExists('#fxa-confirm-header'))
@@ -107,14 +107,14 @@ define([
           .then(closeCurrentWindow())
 
         .then(testElementExists('#fxa-sign-up-complete-header'))
-        .then(noSuchBrowserNotification(this, 'fxaccounts:login'));
+        .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
     'signin, cancel merge warning': function () {
       return this.remote
         .then(setupTest({ canLinkAccountResponse: false, preVerified: true }))
 
-        .then(noSuchBrowserNotification(this, 'fxaccounts:login'))
+        .then(noSuchBrowserNotification('fxaccounts:login'))
 
         // user should not transition to the next screen
         .then(noPageTransition('#fxa-signin-header'));
@@ -130,7 +130,7 @@ define([
         .then(testElementTextInclude('.verification-email-message', email))
         .then(fillOutSignInUnblock(email, 0))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // Only users that go through signin confirmation see
         // `/signin_complete`, and users that go through signin unblock see

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -23,6 +23,7 @@ define([
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
 
   registerSuite({
     name: 'Firstrun Sync v1 sign_up',
@@ -47,8 +48,8 @@ define([
         .findByCssSelector('#fxa-confirm-header')
         .end()
 
-        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
-        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
 
         // verify the user
@@ -86,7 +87,7 @@ define([
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: false } ))
         .then(fillOutSignUp(email, PASSWORD))
 
-        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
         // user should not transition to the next screen
         .then(noSuchElement('#fxa-confirm-header'));

--- a/tests/functional/fx_firstrun_v2_settings.js
+++ b/tests/functional/fx_firstrun_v2_settings.js
@@ -44,8 +44,8 @@ define([
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
         .then(openVerificationLinkDifferentBrowser(email))
@@ -65,7 +65,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:change_password'));
+        .then(testIsBrowserNotified('fxaccounts:change_password'));
     },
 
     'sign in, change the password by browsing directly to settings': function () {
@@ -75,7 +75,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:change_password'));
+        .then(testIsBrowserNotified('fxaccounts:change_password'));
     }
   });
 });

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -21,6 +21,7 @@ define([
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
 
   registerSuite({
     name: 'Firstrun Sync v2 sign_up',
@@ -45,7 +46,7 @@ define([
 
         .then(fillOutSignUp(email, PASSWORD))
 
-        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
         .findByCssSelector('#fxa-choose-what-to-sync-header')
         .end()
@@ -69,10 +70,7 @@ define([
 
         // the login message is only sent after the sync preferences screen
         // has been cleared.
-        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:login', function (data) {
-          assert.isTrue(data.customizeSync);
-          assert.deepEqual(data.declinedSyncEngines, ['addons', 'passwords']);
-        }))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // user should be transitioned to the "go confirm your address" page
         .findByCssSelector('#fxa-confirm-header')

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -965,9 +965,15 @@ define([
     };
   }
 
-  function testIsBrowserNotified(context, command, cb) {
+  /**
+   * Test to ensure the browser has received a web channel notification.
+   *
+   * @param {string} command to ensure was received
+   * @returns {promise} rejects if message has not been received.
+   */
+  function testIsBrowserNotified(command) {
     return function () {
-      return getRemote(context)
+      return this.parent
         // Allow 5 seconds for the event to come through.
         .setExecuteAsyncTimeout(5000)
         .executeAsync(function (command, done) {
@@ -1000,9 +1006,16 @@ define([
     };
   }
 
-  function noSuchBrowserNotification(context, command) {
+  /**
+   * Test to ensure the browser has not received a web channel notification.
+   *
+   * @param   {string} command command that should not be received.
+   * @returns {promise} rejects if command has been received
+   */
+  function noSuchBrowserNotification(command) {
     return function () {
-      return testIsBrowserNotified(context, command)()
+      return this.parent
+        .then(testIsBrowserNotified(command))
         .then(function () {
           var unexpectedNotificationError = new Error('UnexpectedBrowserNotification');
           unexpectedNotificationError.command = command;

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -104,7 +104,7 @@ define([
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(testElementExists('#fxa-confirm-signin-header'))
         .then(openVerificationLinkDifferentBrowser(email))
 
@@ -147,7 +147,7 @@ define([
         .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .execute(function () {
           var accounts = JSON.parse(localStorage.getItem('__fxa_storage.accounts'));
@@ -212,7 +212,7 @@ define([
         .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openPage(PAGE_SIGNIN + '?email=' + email2, '#fxa-signin-header'))
@@ -238,7 +238,7 @@ define([
         .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(testElementExists('#fxa-confirm-signin-header'))
 
         // ensure signin page is visible otherwise credentials might

--- a/tests/functional/sync_v2_force_auth.js
+++ b/tests/functional/sync_v2_force_auth.js
@@ -46,17 +46,17 @@ define([
       .then(clearBrowserState())
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openForceAuth(forceAuthOptions))
-      .then(noSuchBrowserNotification(this.parent, 'fxaccounts:logout'))
-      .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
+      .then(noSuchBrowserNotification('fxaccounts:logout'))
+      .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutForceAuth(PASSWORD))
 
       .then(testElementExists(successSelector))
-      .then(testIsBrowserNotified(this.parent, 'fxaccounts:can_link_account'))
+      .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
       .then(() => {
         if (! options.blocked) {
           return this.parent
-            .then(testIsBrowserNotified(this.parent, 'fxaccounts:login'));
+            .then(testIsBrowserNotified('fxaccounts:login'));
         }
       });
   });
@@ -94,15 +94,15 @@ define([
       return this.remote
         .then(setupTest({ forceAboutAccounts: true, preVerified: false }))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'));
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
     'verified - web flow, verify, from original tab\'s P.O.V.': function () {
       return this.remote
         .then(setupTest({ preVerified: true }))
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(openVerificationLinkDifferentBrowser(email))
         .then(testElementExists('#fxa-sign-in-complete-header'));
@@ -111,8 +111,8 @@ define([
     'unverified - web flow, verify, from original tab\'s P.O.V.': function () {
       return this.remote
         .then(setupTest({ preVerified: false }))
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(openVerificationLinkDifferentBrowser(email, 1))
         .then(testElementExists('#fxa-sign-up-complete-header'));
@@ -126,7 +126,7 @@ define([
         .then(fillOutSignInUnblock(email, 0))
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'));
+        .then(testIsBrowserNotified('fxaccounts:login'));
     }
   });
 });

--- a/tests/functional/sync_v2_reset_password.js
+++ b/tests/functional/sync_v2_reset_password.js
@@ -66,12 +66,12 @@ define([
         // two problems: 1) initiating tab is closed, 2) The initiating
         // tab when running in E10s does not have all the necessary data
         // because localStorage is not shared.
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(closeCurrentWindow())
 
         .then(testSuccessWasShown())
-        .then(noSuchBrowserNotification(this, 'fxaccounts:login'));
+        .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
     'reset password with a restmail address, get the open webmail button': function () {

--- a/tests/functional/sync_v2_settings.js
+++ b/tests/functional/sync_v2_settings.js
@@ -44,8 +44,8 @@ define([
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
         .then(openVerificationLinkDifferentBrowser(email))
@@ -65,7 +65,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:change_password'));
+        .then(testIsBrowserNotified('fxaccounts:change_password'));
     },
 
     'sign in, change the password by browsing directly to settings': function () {
@@ -75,7 +75,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:change_password'));
+        .then(testIsBrowserNotified('fxaccounts:change_password'));
     }
   });
 });

--- a/tests/functional/sync_v2_sign_in.js
+++ b/tests/functional/sync_v2_sign_in.js
@@ -45,12 +45,12 @@ define([
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(signInEmail, PASSWORD))
 
-      .then(testIsBrowserNotified(this.parent, 'fxaccounts:can_link_account'))
+      .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
       .then(() => {
         if (! options.blocked) {
           return this.parent
-            .then(testIsBrowserNotified(this.parent, 'fxaccounts:login'));
+            .then(testIsBrowserNotified('fxaccounts:login'));
         }
       })
 
@@ -99,7 +99,7 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'));
@@ -123,7 +123,7 @@ define([
         // the canonicalized email. Ugly UX, but at least the user can proceed.
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignInUnblock(signUpEmail, 0))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'));

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -19,11 +19,13 @@ define([
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noPageTransition = FunctionalHelpers.noPageTransition;
+  var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testAttributeExists = FunctionalHelpers.testAttributeExists;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
+  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
 
   registerSuite({
     name: 'Firefox Desktop Sync v2 sign_up',
@@ -45,9 +47,8 @@ define([
         .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 
-        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:can_link_account'))
-
-        .then(FunctionalHelpers.noSuchBrowserNotification(self, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(noSuchBrowserNotification('fxaccounts:login'))
 
         // user should be transitioned to the choose what to Sync page
         .findByCssSelector('#fxa-choose-what-to-sync-header')
@@ -76,17 +77,7 @@ define([
 
         // the login message is only sent after the sync preferences screen
         // has been cleared.
-        .then(FunctionalHelpers.testIsBrowserNotified(self, 'fxaccounts:login', function (data) {
-          assert.isTrue(data.customizeSync);
-          assert.deepEqual(data.declinedSyncEngines, ['addons', 'passwords']);
-          assert.equal(data.email, email);
-          assert.ok(data.keyFetchToken);
-          assert.ok(data.sessionToken);
-          assert.ok(data.uid);
-          assert.ok(data.unwrapBKey);
-          assert.isFalse(data.verified);
-          assert.isTrue(data.verifiedCanLinkAccount);
-        }))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         // verify the user
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')

--- a/tests/functional/sync_v3_force_auth.js
+++ b/tests/functional/sync_v3_force_auth.js
@@ -51,8 +51,8 @@ define([
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
 
@@ -82,8 +82,8 @@ define([
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
 
@@ -108,12 +108,12 @@ define([
             uid: TestHelpers.createUID()
           }
         }))
-        .then(noSuchBrowserNotification(this, 'fxaccounts:logout'))
+        .then(noSuchBrowserNotification('fxaccounts:logout'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
         // user is able to sign in, browser notified of new uid
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
 
@@ -155,8 +155,8 @@ define([
         // screen is overridden because the user is signing up outside
         // of about:accounts.
         .then(testElementExists('#fxa-confirm-header'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'));
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
     'with an unregistered email, registered uid': function () {
@@ -221,16 +221,16 @@ define([
             uid: TestHelpers.createUID()
           }
         }))
-        .then(noSuchBrowserNotification(this, 'fxaccounts:logout'))
+        .then(noSuchBrowserNotification('fxaccounts:logout'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
         // user is able to sign in, browser notified of new uid
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
         .then(fillOutSignInUnblock(email, 0))
 
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'));
     }

--- a/tests/functional/sync_v3_settings.js
+++ b/tests/functional/sync_v3_settings.js
@@ -47,8 +47,8 @@ define([
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
         .then(openVerificationLinkDifferentBrowser(email))
@@ -68,7 +68,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:change_password'));
+        .then(testIsBrowserNotified('fxaccounts:change_password'));
     },
 
     'sign in, change the password by browsing directly to settings': function () {
@@ -76,10 +76,10 @@ define([
         .then(openPage(SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
-        .then(noSuchBrowserNotification(this, 'fxaccounts:change_password'))
+        .then(noSuchBrowserNotification('fxaccounts:change_password'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:change_password'));
+        .then(testIsBrowserNotified('fxaccounts:change_password'));
     },
 
     'sign in, delete the account': function () {
@@ -88,7 +88,7 @@ define([
         .then(visibleByQSA('#delete-account .settings-unit-details'))
 
         .then(fillOutDeleteAccount(FIRST_PASSWORD))
-        .then(testIsBrowserNotified(this, 'fxaccounts:delete'))
+        .then(testIsBrowserNotified('fxaccounts:delete'))
 
         .then(testElementExists('#fxa-signup-header'));
     },

--- a/tests/functional/sync_v3_sign_in.js
+++ b/tests/functional/sync_v3_sign_in.js
@@ -49,12 +49,12 @@ define([
       .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(signInEmail, PASSWORD))
 
-      .then(testIsBrowserNotified(this.parent, 'fxaccounts:can_link_account'))
+      .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
       .then(() => {
         if (! options.blocked) {
           return this.parent
-            .then(testIsBrowserNotified(this.parent, 'fxaccounts:login'));
+            .then(testIsBrowserNotified('fxaccounts:login'));
         }
       })
 
@@ -149,7 +149,7 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'));
@@ -173,7 +173,7 @@ define([
         // the canonicalized email. Ugly UX, but at least the user can proceed.
         .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignInUnblock(signUpEmail, 0))
-        .then(testIsBrowserNotified(this, 'fxaccounts:login'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'));


### PR DESCRIPTION
`testIsBrowserNotified` has not used its `cb` argument for a long time,
so I removed it and any callbacks declared in the tests.

Modernize fx_fennec_v1_signup.js and sync_v3_sign_up.js

@mozilla/fxa-devs - r?