### PR TITLE
refactor(routes): Extract routes into their own route modules.

### DIFF
--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -2,12 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var babel = require('babel-middleware');
 var logger = require('mozlog')('server.routes');
-var path = require('path');
-
-var VERSION_PREFIX = '/v1';
-var VERSION_PREFIX_REGEXP = new RegExp('^' + VERSION_PREFIX);
 
 /**
  * Each route has 3 attributes: method, path and process.
@@ -20,10 +15,13 @@ function isValidRoute(route) {
 }
 
 module.exports = function (config, i18n) {
-
-  var STATIC_RESOURCE_URL = config.get('static_resource_url');
+  var redirectVersionedToUnversioned = require('./routes/redirect-versioned-to-unversioned');
 
   var routes = [
+    redirectVersionedToUnversioned('complete_reset_password'),
+    redirectVersionedToUnversioned('reset_password'),
+    redirectVersionedToUnversioned('verify_email'),
+    require('./routes/get-frontend')(),
     require('./routes/get-terms-privacy')(i18n),
     require('./routes/get-index')(config),
     require('./routes/get-ver.json'),
@@ -35,7 +33,8 @@ module.exports = function (config, i18n) {
     require('./routes/get-version.json'),
     require('./routes/post-metrics')(),
     require('./routes/post-metrics-errors')(),
-    require('./routes/redirect-complete-to-verified')()
+    require('./routes/redirect-complete-to-verified')(),
+    require('./routes/get-500')(config)
   ];
 
   if (config.get('csp.enabled')) {
@@ -51,150 +50,32 @@ module.exports = function (config, i18n) {
     }));
   }
 
-  function addVersionPrefix(unversionedUrl) {
-    return VERSION_PREFIX + unversionedUrl;
-  }
+  if (config.get('env') === 'development') {
+    routes.push(require('./routes/get-502')(config));
+    routes.push(require('./routes/get-503')(config));
+    // Add a route in dev mode to test 500 errors
+    routes.push(require('./routes/get-boom')());
+    // front end mocha tests
+    routes.push(require('./routes/get-test-index')(config));
+    routes.push(require('./routes/get-test-style-guide')(config));
 
-  function removeVersionPrefix(versionedUrl) {
-    return versionedUrl.replace(VERSION_PREFIX_REGEXP, '');
+    // Babel is *only* available in development
+    if (config.get('babel.enabled')) {
+      // Compile ES2015 scripts to ES5 before serving to the client.
+      // This is done for two reasons:
+      // 1. The blanket code coverage tool does not understand ES6, only ES5.
+      // 2. It'll give us a better approximation of the code that'll eventually
+      //    be run on prod.
+      routes.push(require('./routes/get-babelified-source')(config));
+    }
   }
 
   return function (app) {
-    // handle password reset links
-    app.get(addVersionPrefix('/complete_reset_password'), function (req, res) {
-      res.redirect(removeVersionPrefix(req.originalUrl));
-    });
-
-    // handle email verification links
-    app.get(addVersionPrefix('/verify_email'), function (req, res) {
-      res.redirect(removeVersionPrefix(req.originalUrl));
-    });
-
-    // handle reset password from notification emails
-    app.get(addVersionPrefix('/reset_password'), function (req, res) {
-      res.redirect(removeVersionPrefix(req.originalUrl));
-    });
-
-    if (config.get('env') === 'development') {
-      // Babel is *only* available in development
-      if (config.get('babel.enabled')) {
-        // Compile ES2015 scripts to ES5 before serving to the client.
-        // This is done for two reasons:
-        // 1. The blanket code coverage tool does not understand ES6, only ES5.
-        // 2. It'll give us a better approximation of the code that'll eventually
-        //    be run on prod.
-        app.get('/scripts/*\.(js|map)', babel({
-          babelOptions: {
-            presets: ['babel-preset-es2015-nostrict'],
-            sourceMaps: true
-          },
-          cachePath: path.join(__dirname, '..', '..', '.es5cache'),
-          consoleErrors: true,
-          exclude: ['scripts/{head|vendor}/**'],
-          srcPath: path.join(__dirname, '..', '..', 'app')
-        }));
-      }
-
-      // front end mocha tests
-      app.get('/tests/index.html', function (req, res) {
-        var checkCoverage = 'coverage' in req.query &&
-                                req.query.coverage !== 'false';
-        var coverNever = JSON.stringify(config.get('tests.coverage.excludeFiles'));
-
-        return res.render('mocha', {
-          check_coverage: checkCoverage, //eslint-disable-line camelcase
-          cover_never: coverNever //eslint-disable-line camelcase
-        });
-      });
-
-      app.get('/tests/style-guide.html', function (req, res) {
-        return res.render('style-guide');
-      });
-    }
-
-    // an array is used instead of a regexp simply because the regexp
-    // became too long. One route is created for each item.
-    var FRONTEND_ROUTES = [
-      '/',
-      '/cannot_create_account',
-      '/choose_what_to_sync',
-      '/clear',
-      '/complete_reset_password',
-      '/complete_signin',
-      '/confirm',
-      '/confirm_reset_password',
-      '/confirm_signin',
-      '/connect_another_device',
-      '/connect_another_device/why',
-      '/cookies_disabled',
-      '/force_auth',
-      '/legal',
-      '/oauth',
-      '/oauth/force_auth',
-      '/oauth/signin',
-      '/oauth/signup',
-      '/report_signin',
-      '/reset_password',
-      '/reset_password_confirmed',
-      '/reset_password_verified',
-      '/settings',
-      '/settings/avatar/camera',
-      '/settings/avatar/change',
-      '/settings/avatar/crop',
-      '/settings/avatar/gravatar',
-      '/settings/avatar/gravatar_permissions',
-      '/settings/change_password',
-      '/settings/clients',
-      '/settings/clients/disconnect',
-      '/settings/communication_preferences',
-      '/settings/delete_account',
-      '/settings/display_name',
-      '/signin',
-      '/signin_confirmed',
-      '/signin_permissions',
-      '/signin_reported',
-      '/signin_unblock',
-      '/signin_verified',
-      '/signup',
-      '/signup_confirmed',
-      '/signup_permissions',
-      '/signup_verified',
-      '/verify_email'
-    ];
-
-    FRONTEND_ROUTES.forEach(function (route) {
-      app.get(route, function (req, res, next) {
-        // setting the url to / will use the correct
-        // index.html for either dev or prod mode.
-        req.url = '/';
-        next();
-      });
-    });
-
     routes.forEach(function (route) {
       if (! isValidRoute(route)) {
         return logger.error('route definition invalid: ', route);
       }
       app[route.method](route.path, route.process);
-    });
-
-    if (config.get('env') === 'development') {
-      app.get('/503.html', function (req, res) {
-        return res.render('503', { staticResourceUrl: STATIC_RESOURCE_URL });
-      });
-
-      app.get('/502.html', function (req, res) {
-        return res.render('502', { staticResourceUrl: STATIC_RESOURCE_URL });
-      });
-
-      // Add a route in dev mode to test 500 errors
-      app.get('/boom', function (req, res, next) {
-        next(new Error('Uh oh!'));
-      });
-    }
-
-    app.get('/500.html', function (req, res) {
-      return res.render('500', { staticResourceUrl: STATIC_RESOURCE_URL });
     });
   };
 };

--- a/server/lib/routes/get-500.js
+++ b/server/lib/routes/get-500.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (config) {
+  var STATIC_RESOURCE_URL = config.get('static_resource_url');
+
+  return {
+    method: 'get',
+    path: '/500.html',
+    process: (req, res, next) => {
+      res.render('500', { staticResourceUrl: STATIC_RESOURCE_URL });
+    }
+  };
+};

--- a/server/lib/routes/get-502.js
+++ b/server/lib/routes/get-502.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (config) {
+  var STATIC_RESOURCE_URL = config.get('static_resource_url');
+
+  return {
+    method: 'get',
+    path: '/502.html',
+    process: (req, res, next) => {
+      res.render('502', { staticResourceUrl: STATIC_RESOURCE_URL });
+    }
+  };
+};

--- a/server/lib/routes/get-503.js
+++ b/server/lib/routes/get-503.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (config) {
+  var STATIC_RESOURCE_URL = config.get('static_resource_url');
+
+  return {
+    method: 'get',
+    path: '/503.html',
+    process: (req, res, next) => {
+      res.render('503', { staticResourceUrl: STATIC_RESOURCE_URL });
+    }
+  };
+};

--- a/server/lib/routes/get-babelified-source.js
+++ b/server/lib/routes/get-babelified-source.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ var babel = require('babel-middleware');
+ var path = require('path');
+
+ module.exports = function (config) {
+   return {
+     method: 'get',
+     path: '/scripts/*\.(js|map)',
+     process: babel({
+       babelOptions: {
+         presets: ['babel-preset-es2015-nostrict'],
+         sourceMaps: true
+       },
+       cachePath: path.join(__dirname, '..', '..', '..', '.es5cache'),
+       consoleErrors: true,
+       exclude: ['scripts/{head|vendor}/**'],
+       srcPath: path.join(__dirname, '..', '..', '..', 'app')
+     })
+   };
+ };

--- a/server/lib/routes/get-boom.js
+++ b/server/lib/routes/get-boom.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ // Route to test 500 errors
+module.exports = function () {
+  return {
+    method: 'get',
+    path: '/boom',
+    process: (req, res, next) => {
+      next(new Error('Uh oh!'));
+    }
+  };
+};

--- a/server/lib/routes/get-frontend.js
+++ b/server/lib/routes/get-frontend.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function () {
+  // The array is converted into a RegExp
+  var FRONTEND_ROUTES = [
+    'cannot_create_account',
+    'choose_what_to_sync',
+    'clear',
+    'complete_reset_password',
+    'complete_signin',
+    'confirm',
+    'confirm_reset_password',
+    'confirm_signin',
+    'connect_another_device',
+    'connect_another_device/why',
+    'cookies_disabled',
+    'force_auth',
+    'legal',
+    'oauth',
+    'oauth/force_auth',
+    'oauth/signin',
+    'oauth/signup',
+    'report_signin',
+    'reset_password',
+    'reset_password_confirmed',
+    'reset_password_verified',
+    'settings',
+    'settings/avatar/camera',
+    'settings/avatar/change',
+    'settings/avatar/crop',
+    'settings/avatar/gravatar',
+    'settings/avatar/gravatar_permissions',
+    'settings/change_password',
+    'settings/clients',
+    'settings/clients/disconnect',
+    'settings/communication_preferences',
+    'settings/delete_account',
+    'settings/display_name',
+    'signin',
+    'signin_confirmed',
+    'signin_permissions',
+    'signin_reported',
+    'signin_unblock',
+    'signin_verified',
+    'signup',
+    'signup_confirmed',
+    'signup_permissions',
+    'signup_verified',
+    'verify_email'
+  ].join('|'); // prepare for use in a RegExp
+
+  return {
+    method: 'get',
+    path: new RegExp('^/(' + FRONTEND_ROUTES + ')/?$'),
+    process: function (req, res, next) {
+      // setting the url to / will use the correct
+      // index.html for either dev or prod mode.
+      req.url = '/';
+      next();
+    }
+  };
+};

--- a/server/lib/routes/get-test-index.js
+++ b/server/lib/routes/get-test-index.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (config) {
+  return {
+    method: 'get',
+    path: '/tests/index.html',
+    process: (req, res, next) => {
+      var checkCoverage = 'coverage' in req.query &&
+                              req.query.coverage !== 'false';
+      var coverNever = JSON.stringify(config.get('tests.coverage.excludeFiles'));
+
+      return res.render('mocha', {
+        check_coverage: checkCoverage, //eslint-disable-line camelcase
+        cover_never: coverNever //eslint-disable-line camelcase
+      });
+    }
+  };
+};

--- a/server/lib/routes/get-test-style-guide.js
+++ b/server/lib/routes/get-test-style-guide.js
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = function (config) {
+  return {
+    method: 'get',
+    path: '/tests/style-guide.html',
+    process: (req, res, next) => {
+      return res.render('style-guide');
+    }
+  };
+};

--- a/server/lib/routes/redirect-versioned-to-unversioned.js
+++ b/server/lib/routes/redirect-versioned-to-unversioned.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Redirects a versioned route to an unversioned route.
+ */
+module.exports = function (path) {
+  var VERSION_PREFIX = '/v1';
+  var VERSION_PREFIX_REGEXP = new RegExp('^' + VERSION_PREFIX);
+
+  function removeVersionPrefix(versionedUrl) {
+    return versionedUrl.replace(VERSION_PREFIX_REGEXP, '');
+  }
+
+  return {
+    method: 'get',
+    path: VERSION_PREFIX + '/' + path,
+    process: (req, res, next) => {
+      res.redirect(removeVersionPrefix(req.originalUrl));
+    }
+  };
+};


### PR DESCRIPTION
I always found server/lib/routes.js a bit complicated, all kinds of conditional logic mixed in with logic to serve routes. This extracts each route or class of routes into its own module in server/lib/routes.

This is to simplify some of the other work I'm doing.

@mozilla/fxa-devs - r?