### PR TITLE
refactor(test): Remove `context` from `respondToWebChannelMessage`

### DIFF
--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -68,7 +68,7 @@ define([
 
       return this.remote
         .then(openPage(SIGNUP_URL, '#fxa-signup-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
 
         .then(fillOutSignUp(email, PASSWORD))
 

--- a/tests/functional/connect_another_device.js
+++ b/tests/functional/connect_another_device.js
@@ -91,7 +91,7 @@ define([
         .then(openPage(SIGNUP_DESKTOP_URL, '#fxa-signup-header', {
           forceUA: UA_STRINGS['desktop_firefox']
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
         .then(click('button[type=submit]'))
@@ -118,7 +118,7 @@ define([
         .then(openPage(SIGNUP_DESKTOP_URL, '#fxa-signup-header', {
           forceUA: UA_STRINGS['desktop_firefox']
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         // this tests needs to sign up so that we can check if the email gets prefilled
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
@@ -159,7 +159,7 @@ define([
         .then(openPage(SIGNIN_DESKTOP_URL, '#fxa-signin-header', {
           forceUA: UA_STRINGS['desktop_firefox']
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testElementExists(SELECTOR_CONFIRM_SIGNIN_HEADER))
         .then(openVerificationLinkInSameTab(email, 0, {
@@ -186,7 +186,7 @@ define([
         .then(openPage(SIGNIN_DESKTOP_URL, '#fxa-signin-header', {
           forceUA: UA_STRINGS['desktop_firefox']
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(signInEmail, PASSWORD))
         .then(testElementExists(SELECTOR_CONFIRM_SIGNIN_HEADER))
         .then(openVerificationLinkInSameTab(signInEmail, 0, {
@@ -216,7 +216,7 @@ define([
         .then(openPage(SIGNUP_DESKTOP_URL, '#fxa-signup-header', {
           forceUA: UA_STRINGS['desktop_firefox']
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         // this tests needs to sign up so that we can check if the email gets prefilled
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
@@ -258,7 +258,7 @@ define([
         .then(openPage(SIGNUP_DESKTOP_URL, '#fxa-signup-header', {
           forceUA: UA_STRINGS['desktop_firefox']
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
         .then(click('button[type=submit]'))
@@ -295,7 +295,7 @@ define([
         .then(openPage(SIGNUP_DESKTOP_URL, '#fxa-signup-header', {
           forceUA: UA_STRINGS['desktop_firefox']
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
         .then(click('button[type=submit]'))
@@ -332,7 +332,7 @@ define([
         .then(openPage(SIGNUP_DESKTOP_URL, '#fxa-signup-header', {
           forceUA: UA_STRINGS['desktop_firefox']
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
         .then(click('button[type=submit]'))
@@ -367,7 +367,7 @@ define([
         .then(openPage(SIGNUP_DESKTOP_URL, '#fxa-signup-header', {
           forceUA: UA_STRINGS['desktop_firefox']
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
         .then(click('button[type=submit]'))
@@ -406,7 +406,7 @@ define([
             forceUA: UA_STRINGS['android_firefox']
           }
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
         .then(click('button[type=submit]'))

--- a/tests/functional/fx_fennec_v1_force_auth.js
+++ b/tests/functional/fx_fennec_v1_force_auth.js
@@ -40,7 +40,7 @@ define([
         email: email,
         service: 'sync'
       }}))
-      .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
+      .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutForceAuth(PASSWORD))
 
       .then(testElementExists(successSelector))

--- a/tests/functional/fx_fennec_v1_settings.js
+++ b/tests/functional/fx_fennec_v1_settings.js
@@ -45,7 +45,7 @@ define([
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))

--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -36,7 +36,7 @@ define([
       .then(clearBrowserState())
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(PAGE_URL, '#fxa-signin-header'))
-      .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
+      .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(email, PASSWORD))
       .then(testIsBrowserNotified('fxaccounts:can_link_account'))
       .then(() => {

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -42,11 +42,9 @@ define([
     },
 
     'sign up, verify same browser': function () {
-      var self = this;
-
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))
-        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(noSuchElement('#customize-sync'))
         .then(fillOutSignUp(email, PASSWORD))
 

--- a/tests/functional/fx_firstrun_v1_settings.js
+++ b/tests/functional/fx_firstrun_v1_settings.js
@@ -42,7 +42,7 @@ define([
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -38,7 +38,7 @@ define([
     return this.parent
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(options.pageUrl || PAGE_URL, '.email'))
-      .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: options.canLinkAccountResponse !== false }))
+      .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: options.canLinkAccountResponse !== false }))
       // delay for the webchannel message
       .sleep(500)
       .then(fillOutSignIn(email, PASSWORD))

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -38,11 +38,9 @@ define([
     },
 
     'sign up, verify same browser in a different tab': function () {
-      var self = this;
-
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))
-        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 
         .findByCssSelector('#fxa-confirm-header')
@@ -81,10 +79,9 @@ define([
     },
 
     'sign up, cancel merge warning': function () {
-      var self = this;
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))
-        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: false } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: false } ))
         .then(fillOutSignUp(email, PASSWORD))
 
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))

--- a/tests/functional/fx_firstrun_v2_settings.js
+++ b/tests/functional/fx_firstrun_v2_settings.js
@@ -42,7 +42,7 @@ define([
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -38,11 +38,9 @@ define([
     },
 
     'sign up, verify same browser': function () {
-      var self = this;
-
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))
-        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
 
         .then(fillOutSignUp(email, PASSWORD))
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -914,10 +914,17 @@ define([
   var mouseout = mouseevent('mouseout');
   var mouseup = mouseevent('mouseup');
 
-  function respondToWebChannelMessage(context, expectedCommand, response) {
+  /**
+   * Respond to a web channel message.
+   *
+   * @param   {string} expectedCommand command to respond to
+   * @param   {object} response response
+   * @returns {promise} resolves when complete
+   */
+  function respondToWebChannelMessage(expectedCommand, response) {
     var attachedId = Math.floor(Math.random() * 10000);
     return function () {
-      return getRemote(context)
+      return this.parent
         .execute(function (expectedCommand, response, attachedId) {
           function startListening() {
             try {

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -101,7 +101,7 @@ define([
     'sign in first in sync context, on second attempt credentials will be cached': function () {
       return this.remote
         .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
 
         .then(testIsBrowserNotified('fxaccounts:login'))
@@ -145,7 +145,7 @@ define([
     'sign in with cached credentials but with an expired session': function () {
       return this.remote
         .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testIsBrowserNotified('fxaccounts:login'))
 
@@ -173,7 +173,7 @@ define([
       var email = TestHelpers.createEmail();
       return this.remote
         .then(openPage(PAGE_SIGNUP_DESKTOP, '#fxa-signup-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
@@ -210,7 +210,7 @@ define([
     'sign in on desktop then sign in with prefill does not show picker': function () {
       return this.remote
         .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(testElementExists('#fxa-confirm-signin-header'))
@@ -236,7 +236,7 @@ define([
     'sign in with desktop context then no context, desktop credentials should not persist': function () {
       return this.remote
         .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(testElementExists('#fxa-confirm-signin-header'))

--- a/tests/functional/sync_v2_force_auth.js
+++ b/tests/functional/sync_v2_force_auth.js
@@ -47,7 +47,7 @@ define([
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openForceAuth(forceAuthOptions))
       .then(noSuchBrowserNotification('fxaccounts:logout'))
-      .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+      .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutForceAuth(PASSWORD))
 
       .then(testElementExists(successSelector))

--- a/tests/functional/sync_v2_settings.js
+++ b/tests/functional/sync_v2_settings.js
@@ -42,7 +42,7 @@ define([
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))

--- a/tests/functional/sync_v2_sign_in.js
+++ b/tests/functional/sync_v2_sign_in.js
@@ -42,7 +42,7 @@ define([
       .then(clearBrowserState({ force: true }))
       .then(createUser(signUpEmail, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(PAGE_URL, '#fxa-signin-header'))
-      .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
+      .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(signInEmail, PASSWORD))
 
       .then(testIsBrowserNotified('fxaccounts:can_link_account'))
@@ -121,7 +121,7 @@ define([
         // If a different user was signed in to the browser, two "merge" dialogs
         // are presented, the first for the non-canonicalized email, the 2nd for
         // the canonicalized email. Ugly UX, but at least the user can proceed.
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignInUnblock(signUpEmail, 0))
         .then(testIsBrowserNotified('fxaccounts:login'))
 

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -40,11 +40,9 @@ define([
     },
 
     'signup, verify same browser': function () {
-      var self = this;
-
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))
-        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))

--- a/tests/functional/sync_v3_force_auth.js
+++ b/tests/functional/sync_v3_force_auth.js
@@ -48,7 +48,7 @@ define([
             }
           }).call(this);
         })
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
 
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
@@ -79,7 +79,7 @@ define([
             }
           }).call(this);
         })
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
 
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
@@ -109,7 +109,7 @@ define([
           }
         }))
         .then(noSuchBrowserNotification('fxaccounts:logout'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
         // user is able to sign in, browser notified of new uid
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
@@ -140,7 +140,7 @@ define([
             service: 'sync'
           }
         }))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(visibleByQSA('.error'))
         .then(testElementTextInclude('.error', 'recreate'))
         // ensure the email is filled in, and not editible.
@@ -222,7 +222,7 @@ define([
           }
         }))
         .then(noSuchBrowserNotification('fxaccounts:logout'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
         // user is able to sign in, browser notified of new uid
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))

--- a/tests/functional/sync_v3_settings.js
+++ b/tests/functional/sync_v3_settings.js
@@ -45,7 +45,7 @@ define([
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))

--- a/tests/functional/sync_v3_sign_in.js
+++ b/tests/functional/sync_v3_sign_in.js
@@ -46,7 +46,7 @@ define([
       .then(clearBrowserState({ force: true }))
       .then(createUser(signUpEmail, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(PAGE_URL, '#fxa-signin-header'))
-      .then(respondToWebChannelMessage(this.parent, 'fxaccounts:can_link_account', { ok: true } ))
+      .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(signInEmail, PASSWORD))
 
       .then(testIsBrowserNotified('fxaccounts:can_link_account'))
@@ -171,7 +171,7 @@ define([
         // If a different user was signed in to the browser, two "merge" dialogs
         // are presented, the first for the non-canonicalized email, the 2nd for
         // the canonicalized email. Ugly UX, but at least the user can proceed.
-        .then(respondToWebChannelMessage(this, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignInUnblock(signUpEmail, 0))
         .then(testIsBrowserNotified('fxaccounts:login'))
 

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -42,11 +42,9 @@ define([
     },
 
     'sign up, verify same browser': function () {
-      var self = this;
-
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))
-        .then(respondToWebChannelMessage(self, 'fxaccounts:can_link_account', { ok: true } ))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(noSuchElement('#suggest-sync'))
         .then(fillOutSignUp(email, PASSWORD))
 


### PR DESCRIPTION
I'm opening a few at once to get this slow drop over with.

@mozilla/fxa-devs - r?