### PR TITLE
refactor(test): remove `context` from `openSignUpInNewTab`

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -615,8 +615,17 @@ define([
     };
   }
 
-  function openSignUpInNewTab(context, windowName) {
-    return getRemote(context).execute(openWindow, [ SIGNUP_URL, windowName ]);
+  /**
+   * Open the signup page in a new tab.
+   *
+   * @param   {string} windowName name of tab
+   * @returns {promise} resolves when complete
+   */
+  function openSignUpInNewTab(windowName) {
+    return function () {
+      return this.parent
+        .execute(openWindow, [ SIGNUP_URL, windowName ]);
+    };
   }
 
   /**

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -14,8 +14,6 @@ define([
   var PASSWORD = 'password';
   var email;
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
@@ -23,7 +21,7 @@ define([
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var openPage = FunctionalHelpers.openPage;
   var openSignInInNewTab = FunctionalHelpers.openSignInInNewTab;
-  var openSignUpInNewTab = thenify(FunctionalHelpers.openSignUpInNewTab);
+  var openSignUpInNewTab = FunctionalHelpers.openSignUpInNewTab;
   var testAttributeMatches = FunctionalHelpers.testAttributeMatches;
   var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -166,7 +164,7 @@ define([
       var windowName = 'sign-in inter-tab functional test';
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(openSignUpInNewTab(this, windowName))
+        .then(openSignUpInNewTab(windowName))
         .switchToWindow(windowName)
 
         .then(testElementExists('#fxa-signup-header'))

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -27,6 +27,7 @@ define([
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var openPage = FunctionalHelpers.openPage;
+  var openSignUpInNewTab = FunctionalHelpers.openSignUpInNewTab;
   var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
@@ -390,9 +391,7 @@ define([
       return this.remote
         .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
-        .then(function () {
-          return FunctionalHelpers.openSignUpInNewTab(this.parent, windowName);
-        })
+        .then(openSignUpInNewTab(windowName))
         .switchToWindow(windowName)
 
         .then(testElementExists('#fxa-signup-header'))


### PR DESCRIPTION
I'm opening a few at once to get this slow drop over with.

@mozilla/fxa-devs - r?