### PR TITLE
refactor(test): Remove `context` from `openSignInInNewTab`

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -602,8 +602,17 @@ define([
     };
   }
 
-  function openSignInInNewTab(context, windowName) {
-    return getRemote(context).execute(openWindow, [ SIGNIN_URL, windowName ]);
+  /**
+   * Open the signin page in a new tab.
+   *
+   * @param   {string} windowName name of tab
+   * @returns {promise} resolves when complete
+   */
+  function openSignInInNewTab(windowName) {
+    return function () {
+      return this.parent
+        .execute(openWindow, [ SIGNIN_URL, windowName ]);
+    };
   }
 
   function openSignUpInNewTab(context, windowName) {

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -22,7 +22,7 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var openPage = FunctionalHelpers.openPage;
-  var openSignInInNewTab = thenify(FunctionalHelpers.openSignInInNewTab);
+  var openSignInInNewTab = FunctionalHelpers.openSignInInNewTab;
   var openSignUpInNewTab = thenify(FunctionalHelpers.openSignUpInNewTab);
   var testAttributeMatches = FunctionalHelpers.testAttributeMatches;
   var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
@@ -150,7 +150,7 @@ define([
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(openPage(PAGE_URL, '#fxa-signin-header'))
-        .then(openSignInInNewTab(this, windowName))
+        .then(openSignInInNewTab(windowName))
         .switchToWindow(windowName)
 
         .then(testElementExists('#fxa-signin-header'))


### PR DESCRIPTION
I'm opening a few at once to get this slow drop over with.

@mozilla/fxa-devs - r?
