### PR TITLE
refactor(test): `thenify` not needed for `getVerificationLink`

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -300,15 +300,24 @@ define([
     };
   }
 
+  /**
+   * Get an email verification link
+   *
+   * @param   {string} user username or email
+   * @param   {number} index email index
+   * @returns {promise} resolves with verification link
+   */
   function getVerificationLink(user, index) {
     if (/@/.test(user)) {
       user = TestHelpers.emailToUser(user);
     }
 
-    return getEmailHeaders(user, index)
-      .then(function (headers) {
-        return require.toUrl(headers['x-link']);
-      });
+    return function () {
+      return getEmailHeaders(user, index)
+        .then(function (headers) {
+          return require.toUrl(headers['x-link']);
+        });
+    };
   }
 
   /**
@@ -456,9 +465,7 @@ define([
       var user = TestHelpers.emailToUser(email);
 
       return this.parent
-        .then(function () {
-          return getVerificationLink(user, index);
-        })
+        .then(getVerificationLink(user, index))
         .then(function (verificationLink) {
           return this.parent
             .execute(openWindow, [ verificationLink, windowName ]);
@@ -473,9 +480,7 @@ define([
 
     return function () {
       return this.parent
-        .then(function () {
-          return getVerificationLink(user, index);
-        })
+        .then(getVerificationLink(user, index))
         .then(function (verificationLink) {
           const parsedVerificationLink = Url.parse(verificationLink, true);
           for (var paramName in options.query) {

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -16,9 +16,6 @@ define([
   var PASSWORD = 'password';
 
   var email;
-  var user;
-
-  var thenify = FunctionalHelpers.thenify;
 
   var click = FunctionalHelpers.click;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
@@ -26,13 +23,12 @@ define([
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openFxaFromTrustedRp = FunctionalHelpers.openFxaFromRp;
   var openFxaFromUntrustedRp = FunctionalHelpers.openFxaFromUntrustedRp;
-  var openPage = FunctionalHelpers.openPage;
   var openSettingsInNewTab = FunctionalHelpers.openSettingsInNewTab;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
+  var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testUrlEquals = FunctionalHelpers.testUrlEquals;
@@ -44,7 +40,6 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      user = TestHelpers.emailToUser(email);
 
       return this.remote
         .then(FunctionalHelpers.clearBrowserState({
@@ -107,12 +102,9 @@ define([
         // get the second email, the first was sent on client.signUp w/
         // preVerified: false above. The second email has the `service` and
         // `resume` parameters.
-        .then(getVerificationLink(user, 1))
-        .then(function (verifyUrl) {
-          // user verifies in the same tab, so they are logged in to the RP.
-          return this.parent
-            .then(openPage(verifyUrl, '#loggedin'));
-        });
+        .then(openVerificationLinkInSameTab(email, 1))
+        // user verifies in the same tab, so they are logged in to the RP.
+        .then(testElementExists('#loggedin'));
     },
 
     'signup, verify same browser': function () {
@@ -323,7 +315,6 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      user = TestHelpers.emailToUser(email);
 
       return this.remote
         .then(FunctionalHelpers.clearBrowserState({

--- a/tests/functional/oauth_settings_clients.js
+++ b/tests/functional/oauth_settings_clients.js
@@ -16,14 +16,13 @@ define([
   var PASSWORD = 'password';
   var UNTRUSTED_OAUTH_WINDOW = 'untrusted';
 
-  var thenify = FunctionalHelpers.thenify;
   var click = FunctionalHelpers.click;
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var testElementExists = FunctionalHelpers.testElementExists;
   var openFxaFromRp = FunctionalHelpers.openFxaFromRp;
   var openPage = FunctionalHelpers.openPage;
+  var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var pollUntilGoneByQSA = FunctionalHelpers.pollUntilGoneByQSA;
   var type = FunctionalHelpers.type;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
@@ -51,17 +50,11 @@ define([
         .then(openFxaFromRp('signup'))
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists('#fxa-confirm-header'))
-        .then(getVerificationLink(email, 0))
-        .then(function (verificationLink) {
-          return this.parent
-            .then(openPage(verificationLink, '#loggedin'));
-        })
+        .then(openVerificationLinkInSameTab(email, 0))
+        .then(testElementExists('#loggedin'))
 
         // lists the first client
-        .then(function () {
-          return this.parent
-            .then(openPage(APPS_SETTINGS_URL, '.client-disconnect'));
-        })
+        .then(openPage(APPS_SETTINGS_URL, '.client-disconnect'))
 
         // sign in into another app
         .execute(function (UNTRUSTED_OAUTH_APP, UNTRUSTED_OAUTH_WINDOW) {

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -15,7 +15,6 @@ define([
   var SIGNIN_ROOT = config.fxaContentRoot + 'oauth/signin';
 
   var PASSWORD = 'password';
-  var user;
   var email;
 
   var thenify = FunctionalHelpers.thenify;
@@ -27,6 +26,7 @@ define([
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var openFxaFromRp = FunctionalHelpers.openFxaFromRp;
   var openPage = FunctionalHelpers.openPage;
+  var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testUrlPathnameEquals = FunctionalHelpers.testUrlPathnameEquals;
   var type = FunctionalHelpers.type;
@@ -34,8 +34,7 @@ define([
 
   var testAtOAuthApp = thenify(function () {
     return this.parent
-      .findByCssSelector('#loggedin')
-      .end()
+      .then(testElementExists('#loggedin'))
 
       .getCurrentUrl()
       .then(function (url) {
@@ -49,7 +48,6 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      user = TestHelpers.emailToUser(email);
 
       return this.remote
         .then(FunctionalHelpers.clearBrowserState({
@@ -115,17 +113,12 @@ define([
 
         .then(testElementExists('#fxa-confirm-header'))
 
-        .then(function () {
-          // get the second email, the first was sent on client.signUp w/
-          // preVerified: false above. The second email has the `service` and
-          // `resume` parameters.
-          return FunctionalHelpers.getVerificationLink(user, 1);
-        })
-        .then(function (verifyUrl) {
-          return this.parent
-            // user verifies in the same tab, so they are logged in to the RP.
-            .then(openPage(verifyUrl, '#loggedin'));
-        });
+        // get the second email, the first was sent on client.signUp w/
+        // preVerified: false above. The second email has the `service` and
+        // `resume` parameters.
+        .then(openVerificationLinkInSameTab(email, 1))
+        // user verifies in the same tab, so they are logged in to the RP.
+        .then(testElementExists('#loggedin'));
 
     },
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -5,10 +5,9 @@
 define([
   'intern',
   'intern!object',
-  'require',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (intern, registerSuite, require, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
   var fxaProduction = intern.config.fxaProduction;
   var PAGE_URL = config.fxaContentRoot + 'signup';
@@ -397,12 +396,7 @@ define([
         .then(testElementExists('#fxa-signup-header'))
 
         .switchToWindow('')
-        .then(function () {
-          return FunctionalHelpers.getVerificationLink(email, 0);
-        })
-        .then(function (verificationLink) {
-          return this.parent.get(require.toUrl(verificationLink));
-        })
+        .then(openVerificationLinkInSameTab(email, 0))
         .switchToWindow(windowName)
         .then(testElementExists('#fxa-settings-header'))
         .then(closeCurrentWindow())

--- a/tests/functional/sync_reset_password.js
+++ b/tests/functional/sync_reset_password.js
@@ -5,19 +5,16 @@
 define([
   'intern',
   'intern!object',
-  'require',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'tests/functional/lib/fx-desktop'
-], function (intern, registerSuite, require,
-        TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
   var config = intern.config;
 
   var PAGE_URL = config.fxaContentRoot + 'reset_password?context=fx_desktop_v1&service=sync';
   var PASSWORD = 'password';
 
   var email;
-  var user;
 
   var thenify = FunctionalHelpers.thenify;
 
@@ -27,12 +24,12 @@ define([
   var createUser = FunctionalHelpers.createUser;
   var fillOutCompleteResetPassword = FunctionalHelpers.fillOutCompleteResetPassword;
   var fillOutResetPassword = FunctionalHelpers.fillOutResetPassword;
-  var getVerificationLink = thenify(FunctionalHelpers.getVerificationLink);
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var openExternalSite = FunctionalHelpers.openExternalSite;
   var openPage = FunctionalHelpers.openPage;
   var openPasswordResetLinkDifferentBrowser = thenify(FunctionalHelpers.openPasswordResetLinkDifferentBrowser);
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
+  var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
@@ -47,7 +44,6 @@ define([
       this.timeout = 90000;
 
       email = TestHelpers.createEmail('sync{id}');
-      user = TestHelpers.emailToUser(email);
 
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
@@ -97,7 +93,6 @@ define([
     },
 
     'reset password, verify same browser by replacing the original tab': function () {
-      var self = this;
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-reset-password-header'))
         .execute(listenForFxaCommands)
@@ -105,11 +100,7 @@ define([
 
         .then(testElementExists('#fxa-confirm-reset-password-header'))
 
-        .then(getVerificationLink(email, 0))
-        .then(function (verificationLink) {
-          return self.remote.get(require.toUrl(verificationLink));
-        })
-
+        .then(openVerificationLinkInSameTab(email, 0))
         .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
         .then(testElementExists('#fxa-reset-password-complete-header'));
     },
@@ -140,8 +131,6 @@ define([
 
     'reset password, verify different browser - from new browser\'s P.O.V.': function () {
 
-      var self = this;
-
       // verify account
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-reset-password-header'))
@@ -152,10 +141,7 @@ define([
         // clear all browser state, simulate opening in a new
         // browser
         .then(clearBrowserState())
-        .then(getVerificationLink(user, 0))
-        .then(function (url) {
-          return self.remote.get(require.toUrl(url));
-        })
+        .then(openVerificationLinkInSameTab(email, 0))
         .then(testElementExists('#fxa-complete-reset-password-header'))
         .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 


### PR DESCRIPTION
Replaced a lot of direct calls to `getVerificationLink` => `openPage`
with calls to `openVerificationLinkInSameTab`.

Modernized several modules while digging in:
* complete_sign_up
* oauth_sign_up