### PR TITLE
fix(test): Fix the broken `refreshes_metrics` functional test.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1154,33 +1154,35 @@ define([
    * @returns {promise} rejects if all events are not logged
    */
   function testAreEventsLogged(eventsNames) {
-    return this.parent
-      .then(fetchAllMetrics())
-      .then(function (metrics) {
-        var events = metrics.reduce(function (evts, metrics) {
-          var evtsNames = metrics.events.map(function (evt) {
-            return evt.type;
-          });
-          return evts.concat(evtsNames);
-        }, []);
-
-        return this.parent
-          .execute(function (eventsNames, events) {
-            var toFindAll = eventsNames.slice().reverse();
-            var toFind = toFindAll.pop();
-
-            events.forEach(function (event) {
-              if (event === toFind) {
-                toFind = toFindAll.pop();
-              }
+    return function () {
+      return this.parent
+        .then(fetchAllMetrics())
+        .then(function (metrics) {
+          var events = metrics.reduce(function (evts, metrics) {
+            var evtsNames = metrics.events.map(function (evt) {
+              return evt.type;
             });
+            return evts.concat(evtsNames);
+          }, []);
 
-            return toFindAll.length === 0;
-          }, [ eventsNames, events ]);
-      })
-      .then(function (found) {
-        assert.ok(found, 'found the events we were looking for');
-      });
+          return this.parent
+            .execute(function (eventsNames, events) {
+              var toFindAll = eventsNames.slice().reverse();
+              var toFind = toFindAll.pop();
+
+              events.forEach(function (event) {
+                if (event === toFind) {
+                  toFind = toFindAll.pop();
+                }
+              });
+
+              return toFindAll.length === 0;
+            }, [ eventsNames, events ]);
+        })
+        .then(function (found) {
+          assert.ok(found, 'found the events we were looking for');
+        });
+    };
   }
 
   /**

--- a/tests/functional/refreshes_metrics.js
+++ b/tests/functional/refreshes_metrics.js
@@ -8,8 +8,8 @@ define([
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, FunctionalHelpers) {
   var AUTOMATED = '?automatedBrowser=true';
-  var url = intern.config.fxaContentRoot + 'signup' + AUTOMATED;
-  var signin = intern.config.fxaContentRoot + 'signin' + AUTOMATED;
+  var SIGNUP_URL = intern.config.fxaContentRoot + 'signup' + AUTOMATED;
+  var SIGNIN_URL = intern.config.fxaContentRoot + 'signin' + AUTOMATED;
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var openPage = FunctionalHelpers.openPage;
@@ -26,12 +26,12 @@ define([
 
     'refreshing the signup screen': function () {
       return this.remote
-        .get(openPage(url, '#fxa-signup-header'))
+        .then(openPage(SIGNUP_URL, '#fxa-signup-header'))
 
         .refresh()
         .then(testElementExists('#fxa-signup-header'))
         // Unload the page to flush the metrics
-        .then(openPage(signin, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(testAreEventsLogged(['screen.signup', 'screen.signup', 'signup.refresh']));
     }
   });


### PR DESCRIPTION
No associated bug.

There were two problems:

* Calling `.get` instead of `.then` when opening the page.
* `testAreEventsLogged` was not set up to be callable within a `then`


@philbooth, @vladikoff or @vbudhram - r?