### PR TITLE
fix(test): Fix the failing OAuth functional tests.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -708,11 +708,15 @@ define([
         return this.parent
           .then(openPage(endpoint, expectedHeader))
           .then(function () {
-            // > 1 because email must always be specified
-            if (Object.keys(queryParams).length > 1) {
-              return this.parent
-                .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader));
+            var numQueryParams = Object.keys(queryParams).length;
+            if (! numQueryParams || (numQueryParams === 1 && queryParams.email)) {
+              // email will already have been added, if passed in. email is
+              // not passed in for some functional tests to ensure query parameter
+              // validation is working properly.
+              return;
             }
+            return this.parent
+              .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader));
           });
       }
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -708,6 +708,7 @@ define([
         return this.parent
           .then(openPage(endpoint, expectedHeader))
           .then(function () {
+            // > 1 because email must always be specified
             if (Object.keys(queryParams).length > 1) {
               return this.parent
                 .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader));
@@ -724,7 +725,7 @@ define([
         .then(testElementExists(expectedHeader))
 
         .then(function () {
-          if (Object.keys(queryParams).length > 1) {
+          if (Object.keys(queryParams).length) {
             return this.parent
               .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader));
           }


### PR DESCRIPTION
The functional tests specified extra query parameters. The query parameter
processing in `openFxaFromRp` only appended the query parameters if more
than 1 query parameter was specified. DOH

fixes #4612 

@vladikoff, @philbooth or @vbudhram - r?