### PR TITLE
fix(test): Fix the failing OAuth functional tests. (#4630) r=@vbudhram

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -694,10 +694,15 @@ define([
         return this.parent
           .then(openPage(endpoint, expectedHeader))
           .then(function () {
-            if (Object.keys(queryParams).length > 1) {
-              return this.parent
-                .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader));
+            var numQueryParams = Object.keys(queryParams).length;
+            if (! numQueryParams || (numQueryParams === 1 && queryParams.email)) {
+              // email will already have been added, if passed in. email is
+              // not passed in for some functional tests to ensure query parameter
+              // validation is working properly.
+              return;
             }
+            return this.parent
+              .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader));
           });
       }
 
@@ -710,7 +715,7 @@ define([
         .then(testElementExists(expectedHeader))
 
         .then(function () {
-          if (Object.keys(queryParams).length > 1) {
+          if (Object.keys(queryParams).length) {
             return this.parent
               .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader));
           }


### PR DESCRIPTION
* fix(test): Fix the failing OAuth functional tests.

The functional tests specified extra query parameters. The query parameter
processing in `openFxaFromRp` only appended the query parameters if more
than 1 query parameter was specified. DOH

fixes #4612 

@jrgm, @jbuck - this is #4630 backported to train-78