### PR TITLE
refactor(test): No more `thenify` for `openVerificationLinkDifferentBrowser`

### DIFF
--- a/tests/functional/fx_fennec_v1_force_auth.js
+++ b/tests/functional/fx_fennec_v1_force_auth.js
@@ -15,7 +15,7 @@ define([
   var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
   var openForceAuth = FunctionalHelpers.openForceAuth;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -76,7 +76,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         .then(testElementExists('#fxa-sign-in-complete-header'));
     },

--- a/tests/functional/fx_fennec_v1_settings.js
+++ b/tests/functional/fx_fennec_v1_settings.js
@@ -8,8 +8,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var thenify = FunctionalHelpers.thenify;
-
   var click = FunctionalHelpers.click;
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
@@ -19,7 +17,7 @@ define([
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
@@ -52,7 +50,7 @@ define([
 
         // User must confirm their Sync signin
         .then(testElementExists('#fxa-confirm-signin-header'))
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
         .then(testElementExists('#fxa-sign-in-complete-header'))
 
         // wait until account data is in localstorage before redirecting

--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -22,7 +22,7 @@ define([
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -72,7 +72,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         .then(testElementExists('#fxa-sign-in-complete-header'));
     },

--- a/tests/functional/fx_firstrun_v1_settings.js
+++ b/tests/functional/fx_firstrun_v1_settings.js
@@ -8,15 +8,13 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var thenify = FunctionalHelpers.thenify;
-
   var click = FunctionalHelpers.click;
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = FunctionalHelpers.fillOutChangePassword;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
@@ -48,7 +46,7 @@ define([
         .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // wait until account data is in localstorage before redirecting
         .then(FunctionalHelpers.pollUntil(function () {

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -25,7 +25,7 @@ define([
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -82,7 +82,7 @@ define([
         .then(clearBrowserNotifications())
         .then(testElementExists('#fxa-confirm-signin-header'))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         .then(testElementExists('#fxa-sign-in-complete-header'))
         .then(noSuchBrowserNotification('fxaccounts:login'));

--- a/tests/functional/fx_firstrun_v2_settings.js
+++ b/tests/functional/fx_firstrun_v2_settings.js
@@ -8,15 +8,13 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var thenify = FunctionalHelpers.thenify;
-
   var click = FunctionalHelpers.click;
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = FunctionalHelpers.fillOutChangePassword;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
@@ -48,7 +46,7 @@ define([
         .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // wait until account data is in localstorage before redirecting
         .then(FunctionalHelpers.pollUntil(function () {

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -26,7 +26,7 @@ define([
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
@@ -83,7 +83,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -541,22 +541,26 @@ define([
     startListening();
   }
 
-  function openVerificationLinkDifferentBrowser(client, email, emailNumber) {
-    if (typeof client === 'string') {
-      emailNumber = email;
-      email = client;
-      client = getFxaClient();
-    }
+  /**
+   * Synthesize opening the verification link in a different browser.
+   *
+   * @param   {string} email - email to verify
+   * @param   {number} [emailNumber] - email number with the verification link. Defaults to `0`.
+   * @returns {promise} resolves when complete
+   */
+  function openVerificationLinkInDifferentBrowser(email, emailNumber) {
+    return function () {
+      var  client = getFxaClient();
+      var user = TestHelpers.emailToUser(email);
 
-    var user = TestHelpers.emailToUser(email);
+      return getEmailHeaders(user, emailNumber || 0)
+        .then(function (headers) {
+          var uid = headers['x-uid'];
+          var code = headers['x-verify-code'];
 
-    return getEmailHeaders(user, emailNumber || 0)
-      .then(function (headers) {
-        var uid = headers['x-uid'];
-        var code = headers['x-verify-code'];
-
-        return client.verifyCode(uid, code);
-      });
+          return client.verifyCode(uid, code);
+        });
+    };
   }
 
   function openPasswordResetLinkDifferentBrowser(client, email, password) {
@@ -1725,7 +1729,7 @@ define([
     openSignInInNewTab: openSignInInNewTab,
     openSignUpInNewTab: openSignUpInNewTab,
     openTab: openTab,
-    openVerificationLinkDifferentBrowser: openVerificationLinkDifferentBrowser,
+    openVerificationLinkInDifferentBrowser: openVerificationLinkInDifferentBrowser,
     openVerificationLinkInNewTab: openVerificationLinkInNewTab,
     openVerificationLinkInSameTab: openVerificationLinkInSameTab,
     pollUntil: pollUntil,

--- a/tests/functional/oauth_sign_up.js
+++ b/tests/functional/oauth_sign_up.js
@@ -17,7 +17,6 @@ define([
   var PASSWORD = 'password';
   var email;
   var bouncedEmail;
-  var fxaClient;
 
   var click = FunctionalHelpers.click;
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
@@ -28,6 +27,7 @@ define([
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   var openFxaFromRp = FunctionalHelpers.openFxaFromRp;
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -52,9 +52,6 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail();
       bouncedEmail = TestHelpers.createEmail();
-      fxaClient = new FxaClient(AUTH_SERVER_ROOT, {
-        xhr: nodeXMLHttpRequest.XMLHttpRequest
-      });
 
       // clear localStorage to avoid polluting other tests.
       // Without the clear, /signup tests fail because of the info stored
@@ -157,9 +154,7 @@ define([
         .findByCssSelector('#fxa-confirm-header')
         .end()
 
-        .then(function () {
-          return FunctionalHelpers.openVerificationLinkDifferentBrowser(fxaClient, email);
-        })
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // original tab redirects back to 123done
         .findByCssSelector('#loggedin')

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -26,8 +26,6 @@ define([
   var email;
   var email2;
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var clearSessionStorage = FunctionalHelpers.clearSessionStorage;
   var click = FunctionalHelpers.click;
@@ -36,7 +34,7 @@ define([
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextEquals = FunctionalHelpers.testElementTextEquals;
@@ -106,7 +104,7 @@ define([
 
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(testElementExists('#fxa-confirm-signin-header'))
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -15,8 +15,6 @@ define([
   var email;
   var PASSWORD = '12345678';
 
-  var thenify = FunctionalHelpers.thenify;
-
   var click = FunctionalHelpers.click;
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
@@ -27,7 +25,7 @@ define([
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var openPage = FunctionalHelpers.openPage;
   var openSignUpInNewTab = FunctionalHelpers.openSignUpInNewTab;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var testAttributeMatches = FunctionalHelpers.testAttributeMatches;
@@ -167,7 +165,7 @@ define([
         .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // The original tab should transition to the settings page w/ success
         // message.
@@ -371,7 +369,7 @@ define([
         .then(fillOutSignUp(email, PASSWORD))
         .then(testAtConfirmScreen(email))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // The original tab should transition to the settings page w/ success
         // message.

--- a/tests/functional/sync_force_auth.js
+++ b/tests/functional/sync_force_auth.js
@@ -18,7 +18,7 @@ define([
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var openForceAuth = FunctionalHelpers.openForceAuth;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
@@ -79,7 +79,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));

--- a/tests/functional/sync_settings.js
+++ b/tests/functional/sync_settings.js
@@ -21,7 +21,7 @@ define([
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
   var testIsBrowserNotifiedOfMessage = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
@@ -48,7 +48,7 @@ define([
       .then(function () {
         if (shouldVerifySignin) {
           return this.parent
-            .then(openVerificationLinkDifferentBrowser(email))
+            .then(openVerificationLinkInDifferentBrowser(email))
 
             .then(openPage(SETTINGS_URL, '#fxa-settings-header'))
             .execute(listenForFxaCommands);

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -29,7 +29,7 @@ define([
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
@@ -84,7 +84,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -16,15 +16,13 @@ define([
   var email;
   var PASSWORD = '12345678';
 
-  var thenify = FunctionalHelpers.thenify;
-
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var testAttributeEquals = FunctionalHelpers.testAttributeEquals;
@@ -118,7 +116,7 @@ define([
         .then(testElementExists('#fxa-confirm-header'))
         .then(testIsBrowserNotifiedOfLogin(email))
 
-        .then(openVerificationLinkDifferentBrowser(email, 0))
+        .then(openVerificationLinkInDifferentBrowser(email, 0))
 
         // The original tab should not transition
         .then(noPageTransition('#fxa-confirm-header', 5000));

--- a/tests/functional/sync_v2_force_auth.js
+++ b/tests/functional/sync_v2_force_auth.js
@@ -20,7 +20,7 @@ define([
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var openForceAuth = FunctionalHelpers.openForceAuth;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -85,7 +85,7 @@ define([
       return this.remote
         .then(setupTest({ forceAboutAccounts: true, preVerified: true }))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));
     },
@@ -104,7 +104,7 @@ define([
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
         .then(testElementExists('#fxa-sign-in-complete-header'));
     },
 
@@ -114,7 +114,7 @@ define([
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))
 
-        .then(openVerificationLinkDifferentBrowser(email, 1))
+        .then(openVerificationLinkInDifferentBrowser(email, 1))
         .then(testElementExists('#fxa-sign-up-complete-header'));
     },
 

--- a/tests/functional/sync_v2_settings.js
+++ b/tests/functional/sync_v2_settings.js
@@ -8,15 +8,13 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var thenify = FunctionalHelpers.thenify;
-
   var click = FunctionalHelpers.click;
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
   var fillOutChangePassword = FunctionalHelpers.fillOutChangePassword;
   var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
@@ -48,7 +46,7 @@ define([
         .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // wait until account data is in localstorage before redirecting
         .then(FunctionalHelpers.pollUntil(function () {

--- a/tests/functional/sync_v2_sign_in.js
+++ b/tests/functional/sync_v2_sign_in.js
@@ -23,7 +23,7 @@ define([
   var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -81,7 +81,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));

--- a/tests/functional/sync_v3_settings.js
+++ b/tests/functional/sync_v3_settings.js
@@ -8,8 +8,6 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var thenify = FunctionalHelpers.thenify;
-
   var click = FunctionalHelpers.click;
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var createUser = FunctionalHelpers.createUser;
@@ -19,7 +17,7 @@ define([
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
@@ -51,7 +49,7 @@ define([
         .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // wait until account data is in localstorage before redirecting
         .then(FunctionalHelpers.pollUntil(function () {

--- a/tests/functional/sync_v3_sign_in.js
+++ b/tests/functional/sync_v3_sign_in.js
@@ -25,7 +25,7 @@ define([
   var noEmailExpected = FunctionalHelpers.noEmailExpected;
   var noPageTransition = FunctionalHelpers.noPageTransition;
   var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkDifferentBrowser = thenify(FunctionalHelpers.openVerificationLinkDifferentBrowser);
+  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
@@ -105,7 +105,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(openVerificationLinkDifferentBrowser(email))
+        .then(openVerificationLinkInDifferentBrowser(email))
 
         // about:accounts will take over post-verification, no transition
         .then(noPageTransition('#fxa-confirm-signin-header'));


### PR DESCRIPTION
Renamed `openVerificationLinkDifferentBrowser` to
`openVerificationLinkInDifferentBrowser` to go along with the other
`openVerificationLinkIn*` functions.


IT'S THE LAST ONE! @mozilla/fxa-devs - r?