### PR TITLE
fix(client): Fix status message on /connect_another_device

### DIFF
--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -175,8 +175,22 @@ define(function (require, exports, module) {
       return this._cachedSignedInAccount;
     },
 
+    /**
+     * Check if the current account is the signed in account
+     *
+     * @param {Object} account
+     * @returns {Boolean}
+     */
     isSignedInAccount (account) {
-      return account.get('uid') === this.getSignedInAccount().get('uid');
+      const accountUid = account.get('uid');
+      const signedInAccountUid = this.getSignedInAccount().get('uid');
+
+      // both accounts must have a UID to be able to compare.
+      if (! signedInAccountUid || ! accountUid) {
+        return false;
+      }
+
+      return accountUid === signedInAccountUid;
     },
 
     setSignedInAccountByUid (uid) {

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -6,8 +6,8 @@ define(function (require, exports, module) {
   'use strict';
 
   const Account = require('models/account');
+  const { assert } = require('chai');
   const AuthErrors = require('lib/auth-errors');
-  const chai = require('chai');
   const Constants = require('lib/constants');
   const Device = require('models/device');
   const AttachedClients = require('models/attached-clients');
@@ -21,12 +21,10 @@ define(function (require, exports, module) {
   const sinon = require('sinon');
   const User = require('models/user');
 
-  var assert = chai.assert;
-
-  var CODE = 'verification code';
-  var EMAIL = 'a@a.com';
-  var SESSION_TOKEN = 'session token';
-  var UUID = '12345678-1234-1234-1234-1234567890ab';
+  const CODE = 'verification code';
+  const EMAIL = 'a@a.com';
+  const SESSION_TOKEN = 'session token';
+  const UUID = '12345678-1234-1234-1234-1234567890ab';
 
   describe('models/user', function () {
     var fxaClientMock;
@@ -1182,6 +1180,51 @@ define(function (require, exports, module) {
         user.logNumStoredAccounts();
         assert.equal(metrics.logNumStoredAccounts.callCount, 2);
         assert.isTrue(metrics.logNumStoredAccounts.calledWith(1));
+      });
+    });
+
+    describe('isSignedInAccount', () => {
+      let account;
+
+      beforeEach(() => {
+        account = user.initAccount({ email: 'testuser@testuser.com', uid: 'uid' });
+      });
+
+      describe('no signed in user', () => {
+        it('returns false', () => {
+          user.clearSignedInAccount();
+          assert.isFalse(user.isSignedInAccount(account));
+        });
+      });
+
+      describe('no signed in user, pass in a `default` account', () => {
+        it('returns false', () => {
+          user.clearSignedInAccount();
+          assert.isFalse(user.isSignedInAccount(user.initAccount({})));
+        });
+      });
+
+      describe('different signed in user', () => {
+        it('returns false', () => {
+          let signedInAccount = user.initAccount({
+            email: 'testuser2@testuser.com',
+            uid: 'uid2'
+          });
+
+          return user.setSignedInAccount(signedInAccount)
+            .then(() => {
+              assert.isFalse(user.isSignedInAccount(account));
+            });
+        });
+      });
+
+      describe('is the signed in user', () => {
+        it('returns true', () => {
+          return user.setSignedInAccount(account)
+            .then(() => {
+              assert.isTrue(user.isSignedInAccount(account));
+            });
+        });
       });
     });
   });

--- a/app/tests/spec/views/connect_another_device.js
+++ b/app/tests/spec/views/connect_another_device.js
@@ -11,7 +11,6 @@ define(function (require, exports, module) {
   const Backbone = require('backbone');
   const Constants = require('lib/constants');
   const Notifier = require('lib/channels/notifier');
-  const p = require('lib/promise');
   const Relier = require('models/reliers/relier');
   const sinon = require('sinon');
   const Url = require('lib/url');
@@ -57,7 +56,7 @@ define(function (require, exports, module) {
     describe('render', () => {
       describe('with a desktop user that is signed in', () => {
         beforeEach(() => {
-          sinon.stub(account, 'isSignedIn', () => p(true));
+          sinon.stub(user, 'isSignedInAccount', () => true);
 
           return view.render();
         });
@@ -83,7 +82,7 @@ define(function (require, exports, module) {
             };
           });
 
-          sinon.stub(account, 'isSignedIn', () => p(true));
+          sinon.stub(user, 'isSignedInAccount', () => true);
 
           return view.render();
         });
@@ -110,7 +109,7 @@ define(function (require, exports, module) {
           });
 
           account.set('email', 'testuser@testuser.com');
-          sinon.stub(account, 'isSignedIn', () => p(false));
+          sinon.stub(user, 'isSignedInAccount', () => false);
           sinon.stub(view, '_canSignIn', () => true);
 
           return view.render();
@@ -138,7 +137,7 @@ define(function (require, exports, module) {
           });
 
           account.set('email', 'testuser@testuser.com');
-          sinon.stub(account, 'isSignedIn', () => p(false));
+          sinon.stub(user, 'isSignedInAccount', () => false);
           sinon.stub(view, '_canSignIn', () => true);
 
           return view.render();
@@ -154,7 +153,7 @@ define(function (require, exports, module) {
 
       describe('with a user that cannot sign in', () => {
         beforeEach(() => {
-          sinon.stub(account, 'isSignedIn', () => p(false));
+          sinon.stub(user, 'isSignedInAccount', () => false);
           sinon.stub(view, '_canSignIn', () => false);
         });
 

--- a/tests/functional/connect_another_device.js
+++ b/tests/functional/connect_another_device.js
@@ -69,6 +69,7 @@ define([
   var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   var testElementExists = FunctionalHelpers.testElementExists;
+  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   var testHrefEquals = FunctionalHelpers.testHrefEquals;
   var testUrlInclude = FunctionalHelpers.testUrlInclude;
@@ -314,6 +315,7 @@ define([
           }
         }))
         .then(testElementExists(SELECTOR_SUCCESS_DIFFERENT_BROWSER))
+        .then(testElementTextInclude(SELECTOR_SUCCESS_DIFFERENT_BROWSER, 'email verified'))
 
         // ask "why must I do this?"
         .then(click(SELECTOR_WHY_CONNECT_ANOTHER_DEVICE))
@@ -324,7 +326,12 @@ define([
         .then(noSuchElement(SELECTOR_CONTINUE_BUTTON))
         .then(testElementExists(SELECTOR_INSTALL_TEXT_ANDROID))
         .then(noSuchElement(SELECTOR_MARKETING_LINK_IOS))
-        .then(testHrefEquals(SELECTOR_MARKETING_LINK_ANDROID, ADJUST_LINK_ANDROID));
+        .then(testHrefEquals(SELECTOR_MARKETING_LINK_ANDROID, ADJUST_LINK_ANDROID))
+
+        .refresh()
+
+        .then(testElementExists(SELECTOR_SUCCESS_DIFFERENT_BROWSER))
+        .then(testElementTextInclude(SELECTOR_SUCCESS_DIFFERENT_BROWSER, 'email verified'));
     },
 
     'sign up Fx Desktop, verify in Chrome Desktop': function () {


### PR DESCRIPTION
Users who verify on a non-Firefox browser see a "Email verified" success message. If the user re-loaded the page, they'd see "This device is connected." This wasn't right.

The problem was with the user model's isSignedInAccount function, it didn't check to ensure both the "signed in account" and the "account to check" had UID's before comparing them. If both UIDs were undefined, the function returned true.

fixes #4634

@mozilla/fxa-devs - r?