### PR TITLE
fix(test): Change `after` to `afterEach`.

### DIFF
--- a/tests/functional/upgrade_storage_formats.js
+++ b/tests/functional/upgrade_storage_formats.js
@@ -26,7 +26,7 @@ define([
       return this.remote.then(clearBrowserState());
     },
 
-    after: function () {
+    afterEach: function () {
       return this.remote.then(clearBrowserState());
     },
 


### PR DESCRIPTION
`after` is run after *all* tests are run, not after the suite.

This was found because of some issues @divyabiyani had today while running the functional tests.