### PR TITLE
FOR DISCUSSION ONLY, DON'T MERGE

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -110,15 +110,15 @@ define(function (require, exports, module) {
         // both the metrics and router depend on the language
         // fetched from config.
         .then(_.bind(this.initializeRelier, this))
-        // metrics depends on the relier.
-        .then(_.bind(this.initializeMetrics, this))
-        // iframe channel depends on the relier and metrics
+        // iframe channel depends on the relier.
         .then(_.bind(this.initializeIframeChannel, this))
         // fxaClient depends on the relier and
         // inter tab communication.
         .then(_.bind(this.initializeFxaClient, this))
         // depends on iframeChannel and interTabChannel
         .then(_.bind(this.initializeNotifier, this))
+        // metrics depends on relier and notifier
+        .then(_.bind(this.initializeMetrics, this))
         // assertionLibrary depends on fxaClient
         .then(_.bind(this.initializeAssertionLibrary, this))
         // profileClient depends on fxaClient and assertionLibrary
@@ -195,6 +195,7 @@ define(function (require, exports, module) {
         isSampledUser: isSampledUser,
         lang: this._config.lang,
         migration: relier.get('migration'),
+        notifier: this._notifier,
         screenHeight: screenInfo.screenHeight,
         screenWidth: screenInfo.screenWidth,
         service: relier.get('service'),
@@ -214,7 +215,6 @@ define(function (require, exports, module) {
         const iframeChannel = new IframeChannel();
 
         iframeChannel.initialize({
-          metrics: this._metrics,
           origin: parentOrigin,
           window: this._window
         });

--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -198,6 +198,7 @@ define(function (require, exports, module) {
         notifier: this._notifier,
         screenHeight: screenInfo.screenHeight,
         screenWidth: screenInfo.screenWidth,
+        sentryMetrics: this._sentryMetrics,
         service: relier.get('service'),
         uniqueUserId: this._getUniqueUserId(),
         utmCampaign: relier.get('utmCampaign'),

--- a/app/scripts/models/flow.js
+++ b/app/scripts/models/flow.js
@@ -50,17 +50,25 @@ define(function (require, exports, module) {
       flowId: null
     },
 
-    populateFromDataAttribute (attribute) {
-      var data = $(this.window.document.body).data(attribute);
+    populateFromDataAttribute (property) {
+      const $body = $(this.window.document.body);
+      const attribute = `data-${hyphenate(property)}`;
+      let data = $body.attr(attribute);
+
       if (! data) {
-        this.logError(AuthErrors.toMissingDataAttributeError(attribute));
+        this.logError(AuthErrors.toMissingDataAttributeError(property));
       } else {
         try {
-          data = this.resumeTokenSchema[attribute].validate(data);
-          this.set(attribute, data);
+          data = this.resumeTokenSchema[property].validate(data);
+          this.set(property, data);
         } catch (err) {
-          this.logError(AuthErrors.toInvalidDataAttributeError(attribute));
+          this.logError(AuthErrors.toInvalidDataAttributeError(property));
         }
+
+        // If a user signs out then signs in again, it is a separate flow.
+        // Remove the attributes from the DOM to ensure they're not re-used
+        // if that happens.
+        $body.removeAttr(attribute);
       }
     },
 
@@ -86,4 +94,8 @@ define(function (require, exports, module) {
   );
 
   module.exports = Model;
+
+  function hyphenate (string) {
+    return string.replace(/[A-Z]/g, uppercase => `-${uppercase.toLowerCase()}`);
+  }
 });

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -418,6 +418,7 @@ define(function (require, exports, module) {
           // See issue #616
           if (this.isSignedInAccount(account)) {
             this.clearSignedInAccount();
+            this._notifier.trigger('flow.clear');
           }
         });
     },

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -713,9 +713,13 @@ define(function (require, exports, module) {
      *
      * @param {String} eventName
      * @param {String} viewName
+     * @param {Object} data
      */
-    logFlowEvent (eventName, viewName) {
-      this.metrics.logFlowEvent(eventName, viewName);
+    logFlowEvent (eventName, viewName, data) {
+      this.notifier.trigger('flow.event', _.assign({}, data, {
+        event: eventName,
+        view: viewName
+      }));
     },
 
     /**
@@ -725,7 +729,7 @@ define(function (require, exports, module) {
      * @param {String} viewName
      */
     logFlowEventOnce (eventName, viewName) {
-      this.metrics.logFlowEventOnce(eventName, viewName);
+      this.logFlowEvent(eventName, viewName, { once: true });
     },
 
     hideError () {

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -36,7 +36,6 @@ define(function (require, exports, module) {
       // ephemeral properties like unwrapBKey and keyFetchToken
       // that need to be sent to the browser.
       this._account = this.user.initAccount(this.model.get('account'));
-      this.flow = this.model.get('flow');
     },
 
     getAccount () {

--- a/app/scripts/views/mixins/flow-begin-mixin.js
+++ b/app/scripts/views/mixins/flow-begin-mixin.js
@@ -10,7 +10,7 @@ define(function (require, exports, module) {
 
   module.exports = {
     afterRender () {
-      this.metrics.logFlowEventOnce('begin');
+      this.logFlowEventOnce('begin');
     }
   };
 });

--- a/app/scripts/views/mixins/flow-begin-mixin.js
+++ b/app/scripts/views/mixins/flow-begin-mixin.js
@@ -10,10 +10,7 @@ define(function (require, exports, module) {
 
   module.exports = {
     afterRender () {
-      const flowId = this.flow.get('flowId');
-      const flowBegin = this.flow.get('flowBegin');
-
-      this.metrics.logFlowBegin(flowId, flowBegin);
+      this.metrics.logFlowEventOnce('begin');
     }
   };
 });

--- a/app/scripts/views/mixins/flow-events-mixin.js
+++ b/app/scripts/views/mixins/flow-events-mixin.js
@@ -8,23 +8,11 @@ define(function (require, exports, module) {
   'use strict';
 
   const $ = require('jquery');
-  const Flow = require('models/flow');
   const KEYS = require('lib/key-codes');
 
   module.exports = {
     afterRender () {
-      if (this.metrics.hasFlowModel()) {
-        return;
-      }
-
-      const flow = new Flow({
-        sentryMetrics: this.sentryMetrics,
-        window: this.window
-      });
-
-      if (flow.has('flowId')) {
-        this.metrics.setFlowModel(flow);
-      }
+      this.notifier.trigger('flow.initialize');
     },
 
     events: {

--- a/app/scripts/views/mixins/flow-events-mixin.js
+++ b/app/scripts/views/mixins/flow-events-mixin.js
@@ -13,11 +13,18 @@ define(function (require, exports, module) {
 
   module.exports = {
     afterRender () {
-      this.flow = new Flow({
+      if (this.metrics.hasFlowModel()) {
+        return;
+      }
+
+      const flow = new Flow({
         sentryMetrics: this.sentryMetrics,
         window: this.window
       });
-      this.metrics.setFlowModel(this.flow);
+
+      if (flow.has('flowId')) {
+        this.metrics.setFlowModel(flow);
+      }
     },
 
     events: {

--- a/app/scripts/views/mixins/resume-token-mixin.js
+++ b/app/scripts/views/mixins/resume-token-mixin.js
@@ -20,10 +20,14 @@ define(function (require, exports, module) {
      */
     getResumeToken (account) {
       var accountInfo = account.pickResumeTokenInfo();
-      // flow is only available in views that mix in the flow-events-mixin
-      var flowInfo = this.flow && this.flow.pickResumeTokenInfo();
       var relierInfo = this.relier.pickResumeTokenInfo();
       var userInfo = this.user.pickResumeTokenInfo();
+
+      let flowInfo;
+      const flowModel = this.metrics.getFlowModel();
+      if (flowModel) {
+        flowInfo = flowModel.pickResumeTokenInfo();
+      }
 
       var resumeTokenInfo = _.extend(
         {},

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -105,16 +105,10 @@ define(function (require, exports, module) {
 
         if (verificationReason === VerificationReasons.SIGN_IN &&
             verificationMethod === VerificationMethods.EMAIL) {
-          return this.navigate('confirm_signin', {
-            account: account,
-            flow: this.flow
-          });
-        } else {
-          return this.navigate('confirm', {
-            account: account,
-            flow: this.flow
-          });
+          return this.navigate('confirm_signin', { account });
         }
+
+        return this.navigate('confirm', { account });
       }
 
       // If the account's uid changed, update the relier model or else

--- a/app/scripts/views/mixins/signup-mixin.js
+++ b/app/scripts/views/mixins/signup-mixin.js
@@ -83,10 +83,7 @@ define(function (require, exports, module) {
 
       return this.invokeBrokerMethod('afterSignUp', account)
         .then(() => {
-          this.navigate('confirm', {
-            account: account,
-            flow: this.flow
-          });
+          this.navigate('confirm', { account });
         });
     },
 

--- a/app/tests/spec/models/flow.js
+++ b/app/tests/spec/models/flow.js
@@ -54,13 +54,17 @@ define(function (require, exports, module) {
     });
 
     it('fetches from body data attributes, if available', function () {
-      $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
-      $(windowMock.document.body).attr('data-flow-begin', '42');
+      const $body = $(windowMock.document.body);
+      $body.attr('data-flow-id', BODY_FLOW_ID);
+      $body.attr('data-flow-begin', '42');
 
       createFlow();
 
       assert.equal(flow.get('flowId'), BODY_FLOW_ID);
       assert.equal(flow.get('flowBegin'), 42);
+
+      assert.isUndefined($body.attr('data-flow-id'));
+      assert.isUndefined($body.attr('data-flow-begin'));
     });
 
     it('gives preference to values from the `resume` search parameter', function () {

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -82,6 +82,29 @@ define(function (require, exports, module) {
         assert.equal(account.get('email'), email);
         assert.deepEqual(account.pick('email'), { email: email });
       });
+
+      it('signOutAccount behaves correctly', () => {
+        sinon.stub(account, 'signOut', () => p());
+        sinon.spy(user, 'clearSignedInAccount');
+        sinon.spy(notifier, 'trigger');
+
+        assert.equal(account.signOut.callCount, 0);
+        assert.equal(user.clearSignedInAccount.callCount, 0);
+        assert.equal(notifier.trigger.callCount, 0);
+
+        return user.signOutAccount(account)
+          .then(() => {
+            assert.equal(account.signOut.callCount, 1);
+            assert.lengthOf(account.signOut.args[0], 0);
+
+            assert.equal(user.clearSignedInAccount.callCount, 1);
+            assert.lengthOf(user.clearSignedInAccount.args[0], 0);
+
+            assert.equal(notifier.trigger.callCount, 1);
+            assert.lengthOf(notifier.trigger.args[0], 1);
+            assert.equal(notifier.trigger.args[0][0], 'flow.clear');
+          });
+      });
     });
 
     it('isSyncAccount', function () {

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -76,6 +76,8 @@ define(function (require, exports, module) {
       user = new User();
       windowMock = new WindowMock();
 
+      metrics.setFlowModel({});
+
       view = new View({
         broker: broker,
         metrics: metrics,

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -224,8 +224,8 @@ define(function (require, exports, module) {
       var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
 
       beforeEach(function () {
-        $('body').data('flowId', FLOW_ID);
-        $('body').data('flowBegin', -1);
+        $('body').attr('data-flow-id', FLOW_ID);
+        $('body').attr('data-flow-begin', '42');
         sinon.spy(metrics, 'setFlowModel');
         return view.afterRender();
       });
@@ -235,7 +235,7 @@ define(function (require, exports, module) {
         var args = metrics.setFlowModel.args[0];
         assert.lengthOf(args, 1);
         assert.equal(args[0].get('flowId'), FLOW_ID);
-        assert.equal(args[0].get('flowBegin'), -1);
+        assert.equal(args[0].get('flowBegin'), 42);
       });
     });
 

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -27,7 +27,6 @@ define(function (require, exports, module) {
   describe('views/confirm', function () {
     var account;
     var broker;
-    var flow;
     var metrics;
     var model;
     var notifier;
@@ -37,9 +36,6 @@ define(function (require, exports, module) {
     var windowMock;
 
     beforeEach(function () {
-      flow = {
-        pickResumeTokenInfo () {}
-      };
       metrics = new Metrics();
       model = new Backbone.Model();
       notifier = new Notifier();
@@ -65,7 +61,6 @@ define(function (require, exports, module) {
 
       model.set({
         account: account,
-        flow: flow,
         type: SIGNUP_REASON
       });
 
@@ -96,10 +91,6 @@ define(function (require, exports, module) {
       view.destroy();
 
       view = metrics = null;
-    });
-
-    it('sets this.flow correctly', function () {
-      assert.equal(view.flow, flow);
     });
 
     describe('render', function () {

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -52,6 +52,7 @@ define(function (require, exports, module) {
         metrics,
         notifier
       });
+      metrics.setFlowModel({});
       user.getSignedInAccount().set('uid', 'foo');
 
       isEmailRegistered = isUidRegistered = false;

--- a/app/tests/spec/views/mixins/flow-begin-mixin.js
+++ b/app/tests/spec/views/mixins/flow-begin-mixin.js
@@ -19,7 +19,7 @@ define((require, exports, module) => {
     describe('afterRender', () => {
       beforeEach(() => {
         flowBeginMixin.metrics = {
-          logFlowBegin: sinon.spy()
+          logFlowEventOnce: sinon.spy()
         };
         flowBeginMixin.flow = {
           get: sinon.spy(property => `mock ${property}`)
@@ -28,12 +28,11 @@ define((require, exports, module) => {
         flowBeginMixin.afterRender();
       });
 
-      it('called metrics.logFlowBegin correctly', () => {
-        assert.strictEqual(flowBeginMixin.metrics.logFlowBegin.callCount, 1);
-        const args = flowBeginMixin.metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 2);
-        assert.strictEqual(args[0], 'mock flowId');
-        assert.strictEqual(args[1], 'mock flowBegin');
+      it('called metrics.logFlowEventOnce correctly', () => {
+        assert.strictEqual(flowBeginMixin.metrics.logFlowEventOnce.callCount, 1);
+        const args = flowBeginMixin.metrics.logFlowEventOnce.args[0];
+        assert.lengthOf(args, 1);
+        assert.strictEqual(args[0], 'begin');
       });
     });
   });

--- a/app/tests/spec/views/mixins/resume-token-mixin.js
+++ b/app/tests/spec/views/mixins/resume-token-mixin.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
     template: TestTemplate,
 
     initialize (options = {}) {
-      this.flow = options.flow;
+      this.metrics = options.metrics;
       this.relier = options.relier;
       this.user = options.user;
     }
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
   describe('views/mixins/resume-token-mixin', function () {
     let account;
     let flow;
+    let metrics;
     let relier;
     let user;
     let view;
@@ -44,6 +45,12 @@ define(function (require, exports, module) {
         pickResumeTokenInfo: sinon.spy()
       };
 
+      metrics = {
+        getFlowModel () {
+          return flow;
+        }
+      };
+
       relier = {
         pickResumeTokenInfo: sinon.spy()
       };
@@ -53,7 +60,7 @@ define(function (require, exports, module) {
       };
 
       view = new TestView({
-        flow,
+        metrics,
         relier,
         user
       });

--- a/app/tests/spec/views/mixins/signin-mixin.js
+++ b/app/tests/spec/views/mixins/signin-mixin.js
@@ -32,7 +32,6 @@ define(function (require, exports, module) {
     describe('signIn', function () {
       let account;
       let broker;
-      let flow;
       let model;
       let relier;
       let user;
@@ -44,7 +43,6 @@ define(function (require, exports, module) {
           verified: true
         });
         broker = new AuthBroker();
-        flow = {};
         model = new Backbone.Model();
         user = new User();
         sinon.stub(user, 'signInAccount', (account) => p(account));
@@ -60,7 +58,6 @@ define(function (require, exports, module) {
           broker: broker,
           currentPage: 'force_auth',
           displayError: sinon.spy(),
-          flow: flow,
           getStringifiedResumeToken: sinon.spy(() => RESUME_TOKEN),
           invokeBrokerMethod: sinon.spy(function () {
             return p();
@@ -203,8 +200,7 @@ define(function (require, exports, module) {
           var args = view.navigate.args[0];
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'confirm');
-          assert.strictEqual(args[1].account, account);
-          assert.strictEqual(args[1].flow, flow);
+          assert.deepEqual(args[1], { account });
         });
 
         it('calls logFlowEvent correctly', () => {
@@ -239,8 +235,7 @@ define(function (require, exports, module) {
           var args = view.navigate.args[0];
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'confirm_signin');
-          assert.strictEqual(args[1].account, account);
-          assert.strictEqual(args[1].flow, flow);
+          assert.deepEqual(args[1], { account });
         });
 
         it('calls logFlowEvent correctly', () => {

--- a/app/tests/spec/views/mixins/signup-mixin.js
+++ b/app/tests/spec/views/mixins/signup-mixin.js
@@ -24,7 +24,6 @@ define(function (require, exports, module) {
     describe('signUp', function () {
       let account;
       let broker;
-      let flow;
       let relier;
       let user;
       let view;
@@ -35,7 +34,6 @@ define(function (require, exports, module) {
         });
 
         broker = new Broker();
-        flow = {};
         relier = new Relier();
         user = {
           signUpAccount: sinon.spy((account) => p(account))
@@ -46,7 +44,6 @@ define(function (require, exports, module) {
             clear: sinon.spy()
           },
           broker,
-          flow,
           getStringifiedResumeToken: sinon.spy(() => 'resume token'),
           invokeBrokerMethod: sinon.spy(function () {
             return p();
@@ -231,9 +228,8 @@ define(function (require, exports, module) {
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'confirm');
           assert.isObject(args[1]);
-          assert.lengthOf(Object.keys(args[1]), 2);
-          assert.equal(args[1].account, account);
-          assert.equal(args[1].flow, flow);
+          assert.lengthOf(Object.keys(args[1]), 1);
+          assert.deepEqual(args[1], { account });
         });
       });
 

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -113,8 +113,8 @@ define(function (require, exports, module) {
       var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
 
       beforeEach(function () {
-        $('body').data('flowId', FLOW_ID);
-        $('body').data('flowBegin', -1);
+        $('body').attr('data-flow-id', FLOW_ID);
+        $('body').attr('data-flow-begin', '42');
         sinon.spy(metrics, 'setFlowModel');
         return view.afterRender();
       });
@@ -124,7 +124,7 @@ define(function (require, exports, module) {
         var args = metrics.setFlowModel.args[0];
         assert.lengthOf(args, 1);
         assert.equal(args[0].get('flowId'), FLOW_ID);
-        assert.equal(args[0].get('flowBegin'), -1);
+        assert.equal(args[0].get('flowBegin'), 42);
       });
     });
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -748,10 +748,10 @@ define(function (require, exports, module) {
       var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
 
       beforeEach(function () {
-        $('body').data('flowId', FLOW_ID);
-        $('body').data('flowBegin', -1);
+        $('body').attr('data-flow-id', FLOW_ID);
+        $('body').attr('data-flow-begin', '42');
         sinon.spy(metrics, 'setFlowModel');
-        sinon.spy(metrics, 'logFlowBegin');
+        sinon.spy(metrics, 'logFlowEventOnce');
         return view.afterRender();
       });
 
@@ -760,21 +760,22 @@ define(function (require, exports, module) {
         var args = metrics.setFlowModel.args[0];
         assert.lengthOf(args, 1);
         assert.equal(args[0].get('flowId'), FLOW_ID);
-        assert.equal(args[0].get('flowBegin'), -1);
+        assert.equal(args[0].get('flowBegin'), 42);
       });
 
-      it('called metrics.logFlowBegin correctly', function () {
-        assert.equal(metrics.logFlowBegin.callCount, 1);
-        var args = metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], FLOW_ID);
-        assert.equal(args[1], -1);
+      it('called metrics.logFlowEventOnce correctly', function () {
+        assert.equal(metrics.logFlowEventOnce.callCount, 1);
+        var args = metrics.logFlowEventOnce.args[0];
+        assert.lengthOf(args, 1);
+        assert.equal(args[0], 'begin');
       });
     });
 
     describe('flow events', () => {
       beforeEach(() => {
-        view.afterVisible();
+        $('body').attr('data-flow-id', 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103');
+        $('body').attr('data-flow-begin', '42');
+        return view.afterRender();
       });
 
       it('logs the begin event', () => {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -381,10 +381,10 @@ define(function (require, exports, module) {
       var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
 
       beforeEach(function () {
-        $('body').data('flowId', FLOW_ID);
-        $('body').data('flowBegin', 3);
+        $('body').attr('data-flow-id', FLOW_ID);
+        $('body').attr('data-flow-begin', 3);
         sinon.spy(metrics, 'setFlowModel');
-        sinon.spy(metrics, 'logFlowBegin');
+        sinon.spy(metrics, 'logFlowEventOnce');
         return view.afterRender();
       });
 
@@ -396,12 +396,11 @@ define(function (require, exports, module) {
         assert.equal(args[0].get('flowBegin'), 3);
       });
 
-      it('called metrics.logFlowBegin correctly', function () {
-        assert.equal(metrics.logFlowBegin.callCount, 1);
-        var args = metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], FLOW_ID);
-        assert.equal(args[1], 3);
+      it('called metrics.logFlowEventOnce correctly', function () {
+        assert.equal(metrics.logFlowEventOnce.callCount, 1);
+        var args = metrics.logFlowEventOnce.args[0];
+        assert.lengthOf(args, 1);
+        assert.equal(args[0], 'begin');
       });
     });
 
@@ -1371,7 +1370,9 @@ define(function (require, exports, module) {
 
     describe('flow events', () => {
       beforeEach(() => {
-        view.afterVisible();
+        $('body').attr('data-flow-id', 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103');
+        $('body').attr('data-flow-begin', 3);
+        return view.afterRender();
       });
 
       it('logs the begin event', () => {

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -177,6 +177,14 @@ define([
         .then(closeCurrentWindow())
 
         .then(testElementExists('#fxa-settings-header'));
+    },
+
+    'data-flow-begin attribute is set': function () {
+      // TODO: test the attribute is gone after sign out
+      // TODO: test the data-flow-id attribute
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signin-header'))
+        .then(testAttributeMatches('body', 'data-flow-begin', /^[1-9][0-9]{12,}$/));
     }
   });
 

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -177,12 +177,6 @@ define([
         .then(closeCurrentWindow())
 
         .then(testElementExists('#fxa-settings-header'));
-    },
-
-    'data-flow-begin attribute is set': function () {
-      return this.remote
-        .then(openPage(PAGE_URL, '#fxa-signin-header'))
-        .then(testAttributeMatches('body', 'data-flow-begin', /^[1-9][0-9]{12,}$/));
     }
   });
 

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -427,6 +427,14 @@ define([
         .then(testSuccessWasShown());
     },
 
+    'data-flow-begin attribute is set': function () {
+      // TODO: test the attribute is gone after sign out
+      // TODO: test the data-flow-id attribute
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-signup-header'))
+        .then(testAttributeMatches('body', 'data-flow-begin', /^[1-9][0-9]{12,}$/));
+    },
+
     'integrity attribute is set on scripts and css': function () {
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -427,12 +427,6 @@ define([
         .then(testSuccessWasShown());
     },
 
-    'data-flow-begin attribute is set': function () {
-      return this.remote
-        .then(openPage(PAGE_URL, '#fxa-signup-header'))
-        .then(testAttributeMatches('body', 'data-flow-begin', /^[1-9][0-9]{12,}$/));
-    },
-
     'integrity attribute is set on scripts and css': function () {
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))


### PR DESCRIPTION
@shane-tomlinson, this branch represents what I'm planning to propose to sort out the lifetime of the flow model (see #3705). I'm updating the tests at the moment but would appreciate an early shout from you if you think I'm doing it wrong here.

The main thing I've done is move most of the flow model interaction out of the views and into `lib/metrics.js`. All the views do now is emit events, which are handled by the metrics object. There is a `flow.initialize` event that replaces the model instantiation from `flow-events-mixin`. There is a `flow.event` event that is used by the base view to emit flow events. And there is a `flow.clear` event emitted from `models/user::signOutAccount`, which takes care of invalidating the flow model and removing the `data-` attributes from the DOM.

If you think this sounds like the division of responsibility is all wrong, shout now!