### PR TITLE
fix(client): Use a 5 sec timeout to send `login` in Fx for iOS.

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -111,7 +111,7 @@ define(function (require, exports, module) {
     ],
 
     // Login delay for iOS broker
-    IOS_V1_LOGIN_MESSAGE_DELAY_MS: 10000,
+    IOS_V1_LOGIN_MESSAGE_DELAY_MS: 5000,
 
     BLOCKED_SIGNIN_SUPPORT_URL: 'https://support.mozilla.org/kb/accounts-blocked',
     UNBLOCK_CODE_LENGTH: 8,


### PR DESCRIPTION
This is only a stopgap to see if we can increase the # of users
that successfully sign in on Fx for iOS w/o changing any browser code.

issue #4377 

@rfk - r?