### PR TITLE
fix(connect-another-device): Disable CAD for signin.

### DIFF
--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -189,6 +189,12 @@ define(function (require, exports, module) {
      * @returns {Boolean}
      */
     _isEligibleToConnectAnotherDevice (verifiedAccount) {
+      // Only show to users who are signing up, until we have better text for
+      // users who are signing in.
+      if (this.isSignIn()) {
+        return false;
+      }
+
       const user = this.user;
       const isInExperimentGroup = this.isInExperimentGroup('connectAnotherDevice', 'treatment');
       const isAnotherUserSignedIn =

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -507,6 +507,22 @@ define(function (require, exports, module) {
           sinon.stub(view, 'isInExperimentGroup', () => true);
         });
 
+        describe('user is completing sign-in', () => {
+          beforeEach(() => {
+            sinon.stub(user, 'getSignedInAccount', () => {
+              return {
+                isDefault: () => true
+              };
+            });
+            sinon.stub(view, 'isSignIn', () => true);
+          });
+
+          it('returns `false`', () => {
+            assert.isFalse(view._isEligibleToConnectAnotherDevice(account));
+          });
+        });
+
+
         describe('no user signed in', () => {
           beforeEach(() => {
             sinon.stub(user, 'getSignedInAccount', () => {

--- a/tests/functional/connect_another_device.js
+++ b/tests/functional/connect_another_device.js
@@ -46,6 +46,7 @@ define([
   var SELECTOR_PAGE_LOADED = '.graphic-connect-another-device';
   var SELECTOR_SIGNIN_FXIOS = '#signin-fxios';
   var SELECTOR_SIGNIN_HEADER = '#fxa-signin-header';
+  var SELECTOR_SIGNIN_COMPLETE_HEADER = '#fxa-sign-in-complete-header';
   var SELECTOR_SIGNUP_COMPLETE_HEADER = '#fxa-sign-up-complete-header';
   var SELECTOR_SUCCESS_DIFFERENT_BROWSER = '.success-not-authenticated';
   var SELECTOR_SUCCESS_SAME_BROWSER = '.success-authenticated';
@@ -170,9 +171,8 @@ define([
             forceExperimentGroup: EXPERIMENT_GROUP
           }
         }))
-        // Works for signin confirmation!
-        .then(testElementExists(SELECTOR_INSTALL_TEXT_OTHER))
-        .then(testElementExists(SELECTOR_SUCCESS_SAME_BROWSER));
+        // Does not work for sign in, even if forced.
+        .then(testElementExists(SELECTOR_SIGNIN_COMPLETE_HEADER));
     },
 
     'sign up Fx Desktop, verify different Fx Desktop with another user already signed in': function () {
@@ -197,8 +197,8 @@ define([
             forceExperimentGroup: EXPERIMENT_GROUP
           }
         }))
-        // Works for signin confirmation!
-        .then(testElementExists(SELECTOR_INSTALL_TEXT_OTHER))
+        // Does not work for sign in, even if forced.
+        .then(testElementExists(SELECTOR_SIGNIN_COMPLETE_HEADER))
 
         // NOW - go back and open the verification link for the sign up user in a
         // browser where another user is already signed in.
@@ -406,7 +406,7 @@ define([
         .then(testHrefEquals(SELECTOR_MARKETING_LINK_IOS, ADJUST_LINK_IOS));
     },
 
-    'signup in Fennec, verify same browser': function () {
+    'sign up in Fennec, verify same browser': function () {
       // should have both links to mobile apps
       return this.remote
         .then(openPage(SIGNUP_FENNEC_URL, '#fxa-signup-header', {


### PR DESCRIPTION
The UX is not ideal if we keep telling users they
must connect another device. @ryanfeeley is working
on a better experience. Disable CAD on signin until
that's ready.

fixes #4665 

@vladikoff - r?