### PR TITLE
feat(experiments): Push all knowledge of mutually exclusive tests to able.

### DIFF
--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -75,7 +75,18 @@ define(function (require, exports, module) {
      * @return {Boolean}
      */
     isInExperiment (experimentName) {
-      return !! this._activeExperiments[experimentName];
+      // If able returns any truthy value, consider the
+      // user in the experiment.
+      return !! this.able.choose(experimentName, {
+        // yes, this is a hack because experiments do not have a reference
+        // to able internally. This allows experiemnts to reference other
+        // experiments
+        able: this.able,
+        forceExperiment: this.forceExperiment,
+        forceExperimentGroup: this.forceExperimentGroup,
+        isMetricsEnabledValue: this.metrics.isCollectionEnabled(),
+        uniqueUserId: this.user.get('uniqueUserId')
+      });
     },
 
     /**
@@ -86,7 +97,7 @@ define(function (require, exports, module) {
      * @return {Boolean}
      */
     isInExperimentGroup (experimentName, groupName) {
-      if (this.isInExperiment(experimentName)) {
+      if (this.isInExperiment(experimentName) && this._activeExperiments[experimentName]) {
         return this._activeExperiments[experimentName].isInGroup(groupName);
       }
 
@@ -104,34 +115,10 @@ define(function (require, exports, module) {
       }
 
       for (let experimentName in this._allExperiments) {
-        const isInExperiment = !! this.choose(experimentName);
-
-          // If able returns any truthy value, consider the
-          // user in the experiment.
-        if (isInExperiment) {
+        if (this.isInExperiment(experimentName)) {
           this.createExperiment(experimentName);
         }
       }
-    },
-
-    /**
-     * Query able for a choice.
-     *
-     * @param {String} experimentName - name of experiment to query.
-     * @returns {String|Boolean} - the result of able's choice. Returns `false`
-     *  if user is not part of experiment.
-     */
-    choose (experimentName) {
-      return this.able.choose(experimentName, {
-        // yes, this is a hack because experiments do not have a reference
-        // to able internally. This allows experiemnts to reference other
-        // experiments
-        able: this.able,
-        forceExperiment: this.forceExperiment,
-        forceExperimentGroup: this.forceExperimentGroup,
-        isMetricsEnabledValue: this.metrics.isCollectionEnabled(),
-        uniqueUserId: this.user.get('uniqueUserId')
-      });
     },
 
     /**

--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -36,13 +36,6 @@ define(function (require, exports, module) {
     this.forceExperiment = Url.searchParam(FORCE_EXPERIMENT_PARAM, search);
     this.forceExperimentGroup = Url.searchParam(FORCE_EXPERIMENT_GROUP_PARAM, search);
 
-    const agent = this.window.navigator.userAgent;
-    // if this is running in functional test mode then we do not want any unpredictable experiments
-    if (agent.indexOf(UA_OVERRIDE) >= 0 && ! this.forceExperiment) {
-      this.initialized = false;
-      return;
-    }
-
     // reset the active experiments so that each instance
     // of the interface creates its own copy of the list.
     this._activeExperiments = {};
@@ -53,6 +46,13 @@ define(function (require, exports, module) {
     this.notifier = options.notifier;
     this.translator = options.translator;
     this.user = options.user;
+
+    const agent = this.window.navigator.userAgent;
+    // if this is running in functional test mode then we do not want any unpredictable experiments
+    if (agent.indexOf(UA_OVERRIDE) >= 0 && ! this.forceExperiment) {
+      this.initialized = false;
+      return;
+    }
 
     this.initialized = true;
   }
@@ -79,7 +79,7 @@ define(function (require, exports, module) {
       // user in the experiment.
       return !! this.able.choose(experimentName, {
         // yes, this is a hack because experiments do not have a reference
-        // to able internally. This allows experiemnts to reference other
+        // to able internally. This allows experiments to reference other
         // experiments
         able: this.able,
         forceExperiment: this.forceExperiment,
@@ -130,7 +130,7 @@ define(function (require, exports, module) {
       const ExperimentConstructor = this._allExperiments[experimentName];
       if (_.isFunction(ExperimentConstructor)) {
         const experiment = new ExperimentConstructor();
-        const initResult = experiment.initialize(experimentName , {
+        const initResult = experiment.initialize(experimentName, {
           able: this.able,
           account: this.account,
           metrics: this.metrics,

--- a/app/scripts/lib/experiments/base.js
+++ b/app/scripts/lib/experiments/base.js
@@ -71,6 +71,7 @@ define(function (require, exports, module) {
       this.window = options.window;
 
       var abData = {
+        able: this.able,
         // the window parameter will override any ab testing features
         forceExperimentGroup: Url.searchParam(FORCE_GROUP_TYPE, this.window.location.search),
         isMetricsEnabledValue: this.metrics.isCollectionEnabled(),

--- a/app/tests/spec/lib/experiment.js
+++ b/app/tests/spec/lib/experiment.js
@@ -6,25 +6,24 @@ define(function (require, exports, module) {
   'use strict';
 
   const Able = require('lib/able');
-  const chai = require('chai');
+  const { assert } = require('chai');
   const ExperimentInterface = require('lib/experiment');
   const Metrics = require('lib/metrics');
   const Notifier = require('lib/channels/notifier');
-  const Session = require('lib/session');
   const sinon = require('sinon');
   const User = require('models/user');
   const WindowMock = require('../../mocks/window');
 
-  var assert = chai.assert;
-  var expInt;
-  var expOptions;
-  var notifier;
-  var windowMock;
-  var able;
-  var metrics;
-  var user;
-  var UUID = 'a mock uuid';
-  var mockExperiment = {
+  let able;
+  let expInt;
+  let expOptions;
+  let metrics;
+  let notifier;
+  let user;
+  let windowMock;
+
+  const UUID = 'a mock uuid';
+  const mockExperiment = {
     initialize () {
       return true;
     },
@@ -52,10 +51,6 @@ define(function (require, exports, module) {
         window: windowMock
       };
       expInt = new ExperimentInterface(expOptions);
-    });
-
-    afterEach(function () {
-      Session.testClear();
     });
 
     describe('constructor', function () {
@@ -103,30 +98,85 @@ define(function (require, exports, module) {
     });
 
     describe('chooseExperiments', function () {
-      it('does not choose when not init', function () {
-        sinon.spy(expInt.able, 'choose');
-        expInt.initialized = false;
-        expInt.chooseExperiments();
-        assert.isFalse(expInt.able.choose.called);
-      });
-
-      it('choose experiments', function () {
+      beforeEach(() => {
+        sinon.spy(expInt, 'createExperiment');
         expInt._allExperiments = {
-          // Cannot use object shorthand because it's converts
-          mock: function () {
+          experiment1: function () {
+            return mockExperiment;
+          },
+          experiment2: function () {
+            return mockExperiment;
+          },
+          experiment3: function () {
             return mockExperiment;
           }
         };
-        sinon.stub(expInt.able, 'choose', function () {
-          return 'mock';
+      });
+
+      it('does not choose when not initialized', function () {
+        sinon.spy(expInt, 'choose');
+        expInt.initialized = false;
+        expInt.chooseExperiments();
+        assert.isFalse(expInt.choose.called);
+      });
+
+      describe('user is not part of any experiment', () => {
+        it('does not create the experiment', () => {
+          sinon.stub(expInt, 'choose', () => false);
+
+          expInt.chooseExperiments();
+
+          assert.isTrue(expInt.choose.calledWith('experiment1'));
+          assert.isFalse(expInt.createExperiment.calledWith('experiment1'));
+          assert.isFalse(expInt.isInExperiment('experiment1'));
+
+          assert.isTrue(expInt.choose.calledWith('experiment2'));
+          assert.isFalse(expInt.createExperiment.calledWith('experiment2'));
+          assert.isFalse(expInt.isInExperiment('experiment2'));
+
+          assert.isTrue(expInt.choose.calledWith('experiment3'));
+          assert.isFalse(expInt.createExperiment.calledWith('experiment3'));
+          assert.isFalse(expInt.isInExperiment('experiment3'));
+        });
+      });
+
+      describe('user is part of at least one experiment', () => {
+        it('creates the experiment', () => {
+          sinon.stub(expInt, 'choose', (choiceName) => {
+            if (choiceName === 'experiment1') {
+              return true;
+            } else if (choiceName === 'experiment3') {
+              return true;
+            }
+            return false;
+          });
+
+          expInt.chooseExperiments();
+
+          assert.isTrue(expInt.isInExperiment('experiment1'));
+          assert.isFalse(expInt.isInExperiment('experiment2'));
+          assert.isTrue(expInt.isInExperiment('experiment3'));
+        });
+      });
+
+      it('accepts window parameter override', function () {
+        windowMock.location.search = '?forceExperiment=mailcheck&forceExperimentGroup=treatment';
+
+        sinon.stub(able, 'choose', () => true);
+
+        expInt = new ExperimentInterface({
+          able: able,
+          metrics: metrics,
+          notifier: notifier,
+          user: user,
+          window: windowMock
         });
 
-        assert.isUndefined(expInt._activeExperiments.mock);
         expInt.chooseExperiments();
-        assert.isTrue(expInt.able.choose.called);
-        assert.isNotNull(expInt._activeExperiments.mock);
+        const mailcheckArgs = able.choose.args[0];
+        assert.equal(mailcheckArgs[1].forceExperiment, 'mailcheck');
+        assert.equal(mailcheckArgs[1].forceExperimentGroup, 'treatment');
       });
     });
-
   });
 });

--- a/app/tests/spec/lib/experiment.js
+++ b/app/tests/spec/lib/experiment.js
@@ -75,9 +75,9 @@ define(function (require, exports, module) {
 
     describe('isInExperiment', function () {
       it('checks experiment opt in', function () {
-        expInt._activeExperiments = {
-          'mockExperiment': mockExperiment
-        };
+        sinon.stub(expInt, 'isInExperiment', (experimentName) => {
+          return experimentName === 'mockExperiment';
+        });
 
         assert.isTrue(expInt.isInExperiment('mockExperiment'));
         assert.isFalse(expInt.isInExperiment('otherExperiment'));
@@ -87,6 +87,9 @@ define(function (require, exports, module) {
 
     describe('isInExperimentGroup', function () {
       it('is true when opted in', function () {
+        sinon.stub(expInt, 'isInExperiment', (experimentName) => {
+          return experimentName === 'mockExperiment';
+        });
         expInt._activeExperiments = {
           'mockExperiment': mockExperiment
         };
@@ -114,27 +117,27 @@ define(function (require, exports, module) {
       });
 
       it('does not choose when not initialized', function () {
-        sinon.spy(expInt, 'choose');
+        sinon.spy(expInt, 'isInExperiment');
         expInt.initialized = false;
         expInt.chooseExperiments();
-        assert.isFalse(expInt.choose.called);
+        assert.isFalse(expInt.isInExperiment.called);
       });
 
       describe('user is not part of any experiment', () => {
         it('does not create the experiment', () => {
-          sinon.stub(expInt, 'choose', () => false);
+          sinon.stub(expInt, 'isInExperiment', () => false);
 
           expInt.chooseExperiments();
 
-          assert.isTrue(expInt.choose.calledWith('experiment1'));
+          assert.isTrue(expInt.isInExperiment.calledWith('experiment1'));
           assert.isFalse(expInt.createExperiment.calledWith('experiment1'));
           assert.isFalse(expInt.isInExperiment('experiment1'));
 
-          assert.isTrue(expInt.choose.calledWith('experiment2'));
+          assert.isTrue(expInt.isInExperiment.calledWith('experiment2'));
           assert.isFalse(expInt.createExperiment.calledWith('experiment2'));
           assert.isFalse(expInt.isInExperiment('experiment2'));
 
-          assert.isTrue(expInt.choose.calledWith('experiment3'));
+          assert.isTrue(expInt.isInExperiment.calledWith('experiment3'));
           assert.isFalse(expInt.createExperiment.calledWith('experiment3'));
           assert.isFalse(expInt.isInExperiment('experiment3'));
         });
@@ -142,7 +145,7 @@ define(function (require, exports, module) {
 
       describe('user is part of at least one experiment', () => {
         it('creates the experiment', () => {
-          sinon.stub(expInt, 'choose', (choiceName) => {
+          sinon.stub(expInt, 'isInExperiment', (choiceName) => {
             if (choiceName === 'experiment1') {
               return true;
             } else if (choiceName === 'experiment3') {

--- a/app/tests/spec/views/mixins/experiment-mixin.js
+++ b/app/tests/spec/views/mixins/experiment-mixin.js
@@ -12,6 +12,7 @@ define(function (require, exports, module) {
   const Metrics = require('lib/metrics');
   const Mixin = require('views/mixins/experiment-mixin');
   const Notifier = require('lib/channels/notifier');
+  const sinon = require('sinon');
   const TestTemplate = require('stache!templates/test_template');
   const User = require('models/user');
   const WindowMock = require('../../../mocks/window');
@@ -70,25 +71,21 @@ define(function (require, exports, module) {
     });
 
     describe('isInExperiment', function () {
-      it('returns if user is in experiment', function () {
-        view.experiments._activeExperiments = {
-          'realExperiment': mockExperiment
-        };
+      it('returns `true` if user is in experiment, `false` if not', function () {
+        sinon.stub(view.experiments, 'isInExperiment', (experimentName) => {
+          return experimentName === 'realExperiment';
+        });
 
         assert.isTrue(view.isInExperiment('realExperiment'));
-      });
-
-      it('returns if user is not in experiment', function () {
-        view.experiments._activeExperiments = {
-          'realExperiment': mockExperiment
-        };
-
         assert.isFalse(view.isInExperiment('fakeExperiment'));
       });
     });
 
     describe('isInExperimentGroup', function () {
       it('returns if user is in experiment group', function () {
+        sinon.stub(view.experiments, 'isInExperiment', (experimentName) => {
+          return experimentName === 'realExperiment';
+        });
         view.experiments._activeExperiments = {
           'realExperiment': mockExperiment
         };

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -6,6 +6,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const _ = require('underscore');
   const $ = require('jquery');
   const Able = require('lib/able');
   const Account = require('models/account');
@@ -1220,21 +1221,13 @@ define(function (require, exports, module) {
         }, 50);
       });
 
-      it('accepts window parameter override', function (done) {
+      it('accepts window parameter override', function () {
         var windowMock = new WindowMock();
-        windowMock.location.search = '?forceVerificationExperiment=mailcheck&forceExperimentGroup=treatment';
+        windowMock.location.search = '?forceExperiment=mailcheck&forceExperimentGroup=treatment';
         windowMock.navigator.userAgent = 'mocha';
-        var mockAble = new Able();
-        sinon.stub(mockAble, 'choose', function (name, data) {
-          if (name === 'chooseAbExperiment') {
-            return 'mailcheck';
-          }
-          assert.equal(name, 'mailcheck');
-          assert.equal(data.forceExperimentGroup, 'treatment');
-          done();
 
-          return 'treatment';
-        });
+        var mockAble = new Able();
+        sinon.stub(mockAble, 'choose', () => true);
 
         view.experiments = new ExperimentInterface({
           able: mockAble,
@@ -1243,9 +1236,15 @@ define(function (require, exports, module) {
           user: user,
           window: windowMock
         });
+
         view.experiments.chooseExperiments();
-        view.$('.email').val('testuser@gnail.com');
-        view.onEmailBlur();
+        // find the first call to mailcheck, then check its arguments
+        const mailcheckArgs = _.find(mockAble.choose.args, (args, index) => {
+          return args[0] === 'mailcheck';
+        });
+        assert.equal(mailcheckArgs[0], 'mailcheck');
+        assert.equal(mailcheckArgs[1].forceExperiment, 'mailcheck');
+        assert.equal(mailcheckArgs[1].forceExperimentGroup, 'treatment');
       });
 
       it('measures how successful our mailcheck suggestion is', function () {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -1252,11 +1252,11 @@ define(function (require, exports, module) {
         windowMock.navigator.userAgent = 'mocha';
         var mockAble = new Able();
         sinon.stub(mockAble, 'choose', function (name) {
-          if (name === 'chooseAbExperiment') {
-            return 'mailcheck';
+          if (name === 'mailcheck') {
+            return 'treatment';
           }
 
-          return 'treatment';
+          return false;
         });
         view.experiments = new ExperimentInterface({
           able: mockAble,


### PR DESCRIPTION
Knowledge of whether a test was to be run as a "mutually exclusive" test
was spread across both able and the content server, making the content
server code more complex than it needed to be. It would be cleaner
to isolate that knowledge and have the front-end know nothing about
mutual exclusivity.

This commit does that.

Pass in a reference to able experiments so that experiments can query
able itself to see whether it's the active test.

Goes along with https://github.com/mozilla/fxa-content-experiments/pull/53