### PR TITLE
fix(tests): Bail out after the first test failure to speed test runs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start-production": "grunt build && CONFIG_FILES=server/config/local.json,server/config/production.json grunt serverproc:dist",
     "start-remote": "node scripts/check-local-config && CONFIG_FILES=server/config/local.json,server/config/content.json grunt server",
     "test": "intern-runner config=tests/intern",
-    "test-circle": "intern-runner config=tests/intern_functional_circle fxaAuthRoot=https://fxa-ci.dev.lcip.org/auth fxaEmailRoot=http://restmail.net fxaOauthApp=https://oauth-fxa-ci.dev.lcip.org fxaUntrustedOauthApp=https://321done-fxa-ci.dev.lcip.org fxaProduction=true",
+    "test-circle": "intern-runner config=tests/intern_functional_circle fxaAuthRoot=https://fxa-ci.dev.lcip.org/auth fxaEmailRoot=http://restmail.net fxaOauthApp=https://oauth-fxa-ci.dev.lcip.org fxaUntrustedOauthApp=https://321done-fxa-ci.dev.lcip.org fxaProduction=true bailAfterFirstFailure=true",
     "test-functional": "intern-runner config=tests/intern_functional",
     "test-functional-oauth": "intern-runner config=tests/intern_functional_oauth",
     "test-latest": "intern-runner config=tests/intern_functional_full fxaAuthRoot=https://latest.dev.lcip.org/auth/v1 fxaContentRoot=https://latest.dev.lcip.org/ fxaEmailRoot=http://restmail.net fxaOauthApp=https://123done-latest.dev.lcip.org/ fxaUntrustedOauthApp=https://321done-latest.dev.lcip.org/ fxaProduction=true fxaToken=https://token.dev.lcip.org/1.0/sync/1.5",

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -32,6 +32,10 @@ function (intern, topic, firefoxProfile) {
   var fxaToken = args.fxaToken || 'http://';
   var asyncTimeout = parseInt(args.asyncTimeout || 5000, 10);
 
+  // On Circle, we bail after the first failure.
+  // args.bailAfterFirstFailure comes in as a string.
+  var bailAfterFirstFailure = args.bailAfterFirstFailure === 'true';
+
   if (topic) {
     topic.subscribe('/suite/start', function (suite) {
       console.log('Running: ' + suite.name);
@@ -40,7 +44,9 @@ function (intern, topic, firefoxProfile) {
 
   var config = {
     asyncTimeout: asyncTimeout,
+    bail: bailAfterFirstFailure,
     capabilities: {},
+    defaultTimeout: 45000, // 30 seconds just isn't long enough for some tests.
     environments: [{
       browserName: 'firefox',
       marionette: true


### PR DESCRIPTION
Circle and travis keep running, even after there's a test failure.

This is an experiment.

Also bump timeout to 45 seconds.