### PR TITLE
fix(tests): add a direct unit test of signOutAccount

### DIFF
--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -626,9 +626,7 @@ define(function (require, exports, module) {
             return p();
           });
 
-          sinon.stub(user, 'setSignedInAccount', function () {
-            return p(account);
-          });
+          sinon.spy(user, 'setSignedInAccount');
 
           sinon.spy(notifier, 'triggerRemote');
 
@@ -656,6 +654,20 @@ define(function (require, exports, module) {
 
         it('did not call account.retrySignUp', function () {
           assert.strictEqual(account.retrySignUp.callCount, 0);
+        });
+
+        it('signOutAccount behaves correctly', () => {
+          sinon.stub(account, 'signOut', () => p());
+          sinon.spy(user, 'clearSignedInAccount');
+
+          return user.signOutAccount(account)
+            .then(() => {
+              assert.equal(account.signOut.callCount, 1);
+              assert.lengthOf(account.signOut.args[0], 0);
+
+              assert.equal(user.clearSignedInAccount.callCount, 1);
+              assert.lengthOf(user.clearSignedInAccount.args[0], 0);
+            });
         });
       });
 


### PR DESCRIPTION
I'm pulling some stuff out of the closed #4654 to open as separate PRs in their own right. In this case, I noticed that there is no direct unit test for `models/user::signOutAccount`.

It's only a tiddler but I added one here, do we want to keep it or throw it back?

@mozilla/fxa-devs r?