### PR TITLE
refactor(client): move flow model resposibilities out of the views

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -110,15 +110,15 @@ define(function (require, exports, module) {
         // both the metrics and router depend on the language
         // fetched from config.
         .then(_.bind(this.initializeRelier, this))
-        // metrics depends on the relier.
-        .then(_.bind(this.initializeMetrics, this))
-        // iframe channel depends on the relier and metrics
+        // iframe channel depends on the relier.
         .then(_.bind(this.initializeIframeChannel, this))
         // fxaClient depends on the relier and
         // inter tab communication.
         .then(_.bind(this.initializeFxaClient, this))
         // depends on iframeChannel and interTabChannel
         .then(_.bind(this.initializeNotifier, this))
+        // metrics depends on relier and notifier
+        .then(_.bind(this.initializeMetrics, this))
         // assertionLibrary depends on fxaClient
         .then(_.bind(this.initializeAssertionLibrary, this))
         // profileClient depends on fxaClient and assertionLibrary
@@ -195,8 +195,10 @@ define(function (require, exports, module) {
         isSampledUser: isSampledUser,
         lang: this._config.lang,
         migration: relier.get('migration'),
+        notifier: this._notifier,
         screenHeight: screenInfo.screenHeight,
         screenWidth: screenInfo.screenWidth,
+        sentryMetrics: this._sentryMetrics,
         service: relier.get('service'),
         uniqueUserId: this._getUniqueUserId(),
         utmCampaign: relier.get('utmCampaign'),
@@ -214,7 +216,6 @@ define(function (require, exports, module) {
         const iframeChannel = new IframeChannel();
 
         iframeChannel.initialize({
-          metrics: this._metrics,
           origin: parentOrigin,
           window: this._window
         });

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -23,6 +23,7 @@ define(function (require, exports, module) {
   const Backbone = require('backbone');
   const Duration = require('duration');
   const Environment = require('lib/environment');
+  const Flow = require('models/flow');
   const p = require('lib/promise');
   const speedTrap = require('speedTrap');
   const Strings = require('lib/strings');
@@ -129,6 +130,8 @@ define(function (require, exports, module) {
     this._utmSource = options.utmSource || NOT_REPORTED_VALUE;
     this._utmTerm = options.utmTerm || NOT_REPORTED_VALUE;
     this._xhr = options.xhr || xhr;
+
+    this._initializeFlowEvents(options);
   }
 
   _.extend(Metrics.prototype, Backbone.Events, {
@@ -151,6 +154,46 @@ define(function (require, exports, module) {
       $(this._window).off('unload', this._flush);
       $(this._window).off('blur', this._flush);
       this._clearInactivityFlushTimeout();
+    },
+
+    _initializeFlowEvents (options) {
+      const notifier = options.notifier;
+
+      if (notifier) {
+        notifier.on('flow.initialize', () => this._initializeFlowModel(options.sentryMetrics));
+        notifier.on('flow.event', data => this._handleFlowEvent(data));
+      }
+    },
+
+    _initializeFlowModel (sentryMetrics) {
+      if (this._flowModel) {
+        return;
+      }
+
+      const flowModel = new Flow({
+        sentryMetrics,
+        window: this._window
+      });
+
+      if (flowModel.has('flowId')) {
+        this._flowModel = flowModel;
+      }
+    },
+
+    _handleFlowEvent (data) {
+      if (! this._flowModel) {
+        // If there is no flow model, we're not in a recognised flow
+        // and we should not emit the event.
+        return;
+      }
+
+      const eventName = marshallFlowEvent(data.event, data.view);
+
+      if (data.once) {
+        this.logEventOnce(eventName);
+      } else {
+        this.logEvent(eventName);
+      }
     },
 
     /**
@@ -240,16 +283,17 @@ define(function (require, exports, module) {
      * @returns {Object}
      */
     getAllData () {
-      var loadData = this._speedTrap.getLoad();
-      var unloadData = this._speedTrap.getUnload();
+      const loadData = this._speedTrap.getLoad();
+      const unloadData = this._speedTrap.getUnload();
+      const flowData = this.getFlowEventMetadata();
 
-      var allData = _.extend({}, loadData, unloadData, {
+      const allData = _.extend({}, loadData, unloadData, {
         broker: this._brokerType,
         context: this._context,
         entrypoint: this._entrypoint,
         experiments: flattenHashIntoArrayOfObjects(this._activeExperiments),
-        flowBeginTime: this._flowBeginTime,
-        flowId: this._flowId,
+        flowBeginTime: flowData.flowBeginTime,
+        flowId: flowData.flowId,
         flushTime: Date.now(),
         isSampledUser: this._isSampledUser,
         lang: this._lang,
@@ -503,23 +547,6 @@ define(function (require, exports, module) {
       return this._isSampledUser;
     },
 
-    logFlowBegin (flowId, flowBeginTime) {
-      // Don't emit a new flow.begin event unless flowId has changed.
-      if (flowId !== this._flowId) {
-        this._flowId = flowId;
-        this._flowBeginTime = flowBeginTime;
-        this.logFlowEvent('begin');
-      }
-    },
-
-    logFlowEvent (eventName, viewName) {
-      this.logEvent(marshallFlowEvent(eventName, viewName));
-    },
-
-    logFlowEventOnce (eventName, viewName) {
-      this.logEventOnce(marshallFlowEvent(eventName, viewName));
-    },
-
     getFlowEventMetadata () {
       const metadata = (this._flowModel && this._flowModel.attributes) || {};
       return {
@@ -528,8 +555,8 @@ define(function (require, exports, module) {
       };
     },
 
-    setFlowModel (flowModel) {
-      this._flowModel = flowModel;
+    getFlowModel (flowModel) {
+      return this._flowModel;
     },
 
     /**

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -713,9 +713,13 @@ define(function (require, exports, module) {
      *
      * @param {String} eventName
      * @param {String} viewName
+     * @param {Object} data
      */
-    logFlowEvent (eventName, viewName) {
-      this.metrics.logFlowEvent(eventName, viewName);
+    logFlowEvent (eventName, viewName, data) {
+      this.notifier.trigger('flow.event', _.assign({}, data, {
+        event: eventName,
+        view: viewName
+      }));
     },
 
     /**
@@ -725,7 +729,7 @@ define(function (require, exports, module) {
      * @param {String} viewName
      */
     logFlowEventOnce (eventName, viewName) {
-      this.metrics.logFlowEventOnce(eventName, viewName);
+      this.logFlowEvent(eventName, viewName, { once: true });
     },
 
     hideError () {

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -36,7 +36,6 @@ define(function (require, exports, module) {
       // ephemeral properties like unwrapBKey and keyFetchToken
       // that need to be sent to the browser.
       this._account = this.user.initAccount(this.model.get('account'));
-      this.flow = this.model.get('flow');
     },
 
     getAccount () {

--- a/app/scripts/views/mixins/flow-begin-mixin.js
+++ b/app/scripts/views/mixins/flow-begin-mixin.js
@@ -10,10 +10,7 @@ define(function (require, exports, module) {
 
   module.exports = {
     afterRender () {
-      const flowId = this.flow.get('flowId');
-      const flowBegin = this.flow.get('flowBegin');
-
-      this.metrics.logFlowBegin(flowId, flowBegin);
+      this.logFlowEventOnce('begin');
     }
   };
 });

--- a/app/scripts/views/mixins/flow-events-mixin.js
+++ b/app/scripts/views/mixins/flow-events-mixin.js
@@ -8,16 +8,11 @@ define(function (require, exports, module) {
   'use strict';
 
   const $ = require('jquery');
-  const Flow = require('models/flow');
   const KEYS = require('lib/key-codes');
 
   module.exports = {
     afterRender () {
-      this.flow = new Flow({
-        sentryMetrics: this.sentryMetrics,
-        window: this.window
-      });
-      this.metrics.setFlowModel(this.flow);
+      this.notifier.trigger('flow.initialize');
     },
 
     events: {

--- a/app/scripts/views/mixins/resume-token-mixin.js
+++ b/app/scripts/views/mixins/resume-token-mixin.js
@@ -20,10 +20,14 @@ define(function (require, exports, module) {
      */
     getResumeToken (account) {
       var accountInfo = account.pickResumeTokenInfo();
-      // flow is only available in views that mix in the flow-events-mixin
-      var flowInfo = this.flow && this.flow.pickResumeTokenInfo();
       var relierInfo = this.relier.pickResumeTokenInfo();
       var userInfo = this.user.pickResumeTokenInfo();
+
+      let flowInfo;
+      const flowModel = this.metrics.getFlowModel();
+      if (flowModel) {
+        flowInfo = flowModel.pickResumeTokenInfo();
+      }
 
       var resumeTokenInfo = _.extend(
         {},

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -105,16 +105,10 @@ define(function (require, exports, module) {
 
         if (verificationReason === VerificationReasons.SIGN_IN &&
             verificationMethod === VerificationMethods.EMAIL) {
-          return this.navigate('confirm_signin', {
-            account: account,
-            flow: this.flow
-          });
-        } else {
-          return this.navigate('confirm', {
-            account: account,
-            flow: this.flow
-          });
+          return this.navigate('confirm_signin', { account });
         }
+
+        return this.navigate('confirm', { account });
       }
 
       // If the account's uid changed, update the relier model or else

--- a/app/scripts/views/mixins/signup-mixin.js
+++ b/app/scripts/views/mixins/signup-mixin.js
@@ -83,10 +83,7 @@ define(function (require, exports, module) {
 
       return this.invokeBrokerMethod('afterSignUp', account)
         .then(() => {
-          this.navigate('confirm', {
-            account: account,
-            flow: this.flow
-          });
+          this.navigate('confirm', { account });
         });
     },
 

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -14,20 +14,27 @@ define(function (require, exports, module) {
   const Constants = require('lib/constants');
   const Environment = require('lib/environment');
   const Metrics = require('lib/metrics');
+  const Notifier = require('lib/channels/notifier');
   const p = require('lib/promise');
   const sinon = require('sinon');
   const TestHelpers = require('../../lib/helpers');
   const WindowMock = require('../../mocks/window');
 
+  const FLOW_ID = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const FLOW_BEGIN_TIME = 1484923219448;
   const MARKETING_CAMPAIGN = 'campaign1';
   const MARKETING_CAMPAIGN_URL = 'https://accounts.firefox.com';
 
   describe('lib/metrics', function () {
-    var metrics;
-    var windowMock;
+    let metrics;
+    let notifier;
+    let windowMock;
 
     function createMetrics(options) {
       options = options || {};
+
+      notifier = new Notifier();
+      sinon.spy(notifier, 'on');
 
       metrics = new Metrics(_.defaults(options, {
         brokerType: 'fx-desktop-v1',
@@ -39,6 +46,7 @@ define(function (require, exports, module) {
         isSampledUser: true,
         lang: 'db_LB',
         migration: 'sync1.5',
+        notifier,
         screenHeight: 1200,
         screenWidth: 1600,
         service: 'sync',
@@ -56,6 +64,8 @@ define(function (require, exports, module) {
     beforeEach(function () {
       windowMock = new WindowMock();
       windowMock.document.referrer = 'https://marketplace.firefox.com';
+      $(windowMock.document.body).attr('data-flow-id', FLOW_ID);
+      $(windowMock.document.body).attr('data-flow-begin', FLOW_BEGIN_TIME);
 
       createMetrics();
       metrics.init();
@@ -64,6 +74,85 @@ define(function (require, exports, module) {
     afterEach(function () {
       metrics.destroy();
       metrics = null;
+    });
+
+    it('calls notifier.on correctly', () => {
+      assert.equal(notifier.on.callCount, 2);
+
+      let args = notifier.on.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'flow.initialize');
+      assert.isFunction(args[1]);
+
+      args = notifier.on.args[1];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'flow.event');
+      assert.notEqual(args[1], notifier.on.args[0][1]);
+    });
+
+    it('observable flow state is correct', () => {
+      assert.isUndefined(metrics.getFlowModel());
+      assert.deepEqual(metrics.getFlowEventMetadata(), {
+        flowBeginTime: undefined,
+        flowId: undefined
+      });
+    });
+
+    describe('trigger flow.initialize event', () => {
+      beforeEach(() => {
+        notifier.trigger('flow.initialize');
+      });
+
+      it('observable flow state is correct', () => {
+        assert.equal(metrics.getFlowModel().get('flowId'), FLOW_ID);
+        assert.equal(metrics.getFlowModel().get('flowBegin'), FLOW_BEGIN_TIME);
+        assert.deepEqual(metrics.getFlowEventMetadata(), {
+          flowBeginTime: FLOW_BEGIN_TIME,
+          flowId: FLOW_ID
+        });
+      });
+
+      it('flow events are triggered correctly', () => {
+        notifier.trigger('flow.event', { event: 'foo', view: 'signin' });
+        notifier.trigger('flow.event', { event: 'foo', view: 'signin' });
+        notifier.trigger('flow.event', { event: 'bar', view: 'oauth.signin' });
+        notifier.trigger('flow.event', { event: 'baz' });
+
+        const events = metrics.getFilteredData().events;
+        assert.equal(events.length, 4);
+        assert.equal(events[0].type, 'flow.signin.foo');
+        assert.equal(events[1].type, 'flow.signin.foo');
+        assert.equal(events[2].type, 'flow.signin.bar');
+        assert.equal(events[3].type, 'flow.baz');
+      });
+
+      it('flow events are triggered correctly with once=true', () => {
+        notifier.trigger('flow.event', { event: 'foo', once: true, view: 'signin' });
+        notifier.trigger('flow.event', { event: 'foo', once: true, view: 'signin' });
+        notifier.trigger('flow.event', { event: 'foo', once: true, view: 'signup' });
+
+        const events = metrics.getFilteredData().events;
+        assert.equal(events.length, 2);
+        assert.equal(events[0].type, 'flow.signin.foo');
+        assert.equal(events[1].type, 'flow.signup.foo');
+      });
+
+      describe('trigger flow.initialize event with fresh data', () => {
+        beforeEach(() => {
+          $(windowMock.document.body).attr('data-flow-id', 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef');
+          $(windowMock.document.body).attr('data-flow-begin', 1484930216699);
+          notifier.trigger('flow.initialize');
+        });
+
+        it('observable flow state is correct', () => {
+          assert.equal(metrics.getFlowModel().get('flowId'), FLOW_ID);
+          assert.equal(metrics.getFlowModel().get('flowBegin'), FLOW_BEGIN_TIME);
+          assert.deepEqual(metrics.getFlowEventMetadata(), {
+            flowBeginTime: FLOW_BEGIN_TIME,
+            flowId: FLOW_ID
+          });
+        });
+      });
     });
 
     describe('getFilteredData', function () {
@@ -164,6 +253,7 @@ define(function (require, exports, module) {
         metrics = new Metrics({
           environment: environment,
           inactivityFlushMs: 100,
+          notifier,
           window: windowMock,
           xhr: xhr
         });
@@ -177,9 +267,10 @@ define(function (require, exports, module) {
 
       describe('log events', function () {
         beforeEach(function () {
+          notifier.trigger('flow.initialize');
           metrics.logEvent('foo');
-          metrics.logFlowBegin('bar', 'baz');
-          metrics.logEvent('qux');
+          notifier.trigger('flow.event', { event: 'bar', once: true });
+          metrics.logEvent('baz');
         });
 
         describe('has sendBeacon', function () {
@@ -220,10 +311,10 @@ define(function (require, exports, module) {
               assert.isArray(data.events);
               assert.lengthOf(data.events, 3);
               assert.equal(data.events[0].type, 'foo');
-              assert.equal(data.events[1].type, 'flow.begin');
-              assert.equal(data.events[2].type, 'qux');
-              assert.equal(data.flowId, 'bar');
-              assert.equal(data.flowBeginTime, 'baz');
+              assert.equal(data.events[1].type, 'flow.bar');
+              assert.equal(data.events[2].type, 'baz');
+              assert.equal(data.flowId, FLOW_ID);
+              assert.equal(data.flowBeginTime, FLOW_BEGIN_TIME);
               assert.equal(data.isSampledUser, false);
               assert.equal(data.lang, 'unknown');
               assert.isArray(data.marketing);
@@ -253,10 +344,10 @@ define(function (require, exports, module) {
               assert.equal(metrics.getFilteredData().events.length, 0);
             });
 
-            describe('log a second flow.begin event with same flowId', function () {
+            describe('log a duplicate flow event', function () {
               beforeEach(function () {
-                metrics.logFlowBegin('bar', 'blee');
-                metrics.logEvent('wibble');
+                notifier.trigger('flow.event', { event: 'bar', once: true });
+                metrics.logEvent('baz');
                 return metrics.flush();
               });
 
@@ -265,9 +356,9 @@ define(function (require, exports, module) {
                 var data = JSON.parse(windowMock.navigator.sendBeacon.args[1][1]);
                 assert.isArray(data.events);
                 assert.lengthOf(data.events, 1);
-                assert.equal(data.events[0].type, 'wibble');
-                assert.equal(data.flowId, 'bar');
-                assert.equal(data.flowBeginTime, 'baz');
+                assert.equal(data.events[0].type, 'baz');
+                assert.equal(data.flowId, FLOW_ID);
+                assert.equal(data.flowBeginTime, FLOW_BEGIN_TIME);
               });
             });
           });
@@ -317,7 +408,7 @@ define(function (require, exports, module) {
               sandbox.stub(xhr, 'ajax', function () {
                 return p(true);
               });
-              metrics.logEvent('baz');
+              metrics.logEvent('qux');
               return metrics.flush(true).then(function (r) {
                 result = r;
               });
@@ -344,9 +435,9 @@ define(function (require, exports, module) {
               assert.isArray(data.events);
               assert.lengthOf(data.events, 4);
               assert.equal(data.events[0].type, 'foo');
-              assert.equal(data.events[1].type, 'flow.begin');
-              assert.equal(data.events[2].type, 'qux');
-              assert.equal(data.events[3].type, 'baz');
+              assert.equal(data.events[1].type, 'flow.bar');
+              assert.equal(data.events[2].type, 'baz');
+              assert.equal(data.events[3].type, 'qux');
             });
 
             it('resolves to true', function () {
@@ -420,8 +511,8 @@ define(function (require, exports, module) {
             assert.lengthOf(Object.keys(data), 25);
             assert.lengthOf(data.events, 4);
             assert.equal(data.events[0].type, 'foo');
-            assert.equal(data.events[1].type, 'flow.begin');
-            assert.equal(data.events[2].type, 'qux');
+            assert.equal(data.events[1].type, 'flow.bar');
+            assert.equal(data.events[2].type, 'baz');
             assert.equal(data.events[3].type, 'wibble');
           });
         });
@@ -444,8 +535,8 @@ define(function (require, exports, module) {
             assert.lengthOf(Object.keys(data), 25);
             assert.lengthOf(data.events, 4);
             assert.equal(data.events[0].type, 'foo');
-            assert.equal(data.events[1].type, 'flow.begin');
-            assert.equal(data.events[2].type, 'qux');
+            assert.equal(data.events[1].type, 'flow.bar');
+            assert.equal(data.events[2].type, 'baz');
             assert.equal(data.events[3].type, 'blee');
           });
         });
@@ -647,53 +738,6 @@ define(function (require, exports, module) {
         metrics.logExperiment(experiment, group);
         assert.equal(Object.keys(metrics._activeExperiments).length, 1);
         assert.isDefined(metrics._activeExperiments['mailcheck']);
-      });
-    });
-
-    it('metrics.logFlowEvent', () => {
-      metrics.logFlowEvent('foo', 'signin');
-      metrics.logFlowEvent('foo', 'signin');
-      metrics.logFlowEvent('bar', 'oauth.signin');
-      metrics.logFlowEvent('baz');
-
-      const events = metrics.getFilteredData().events;
-      assert.equal(events.length, 4);
-      assert.equal(events[0].type, 'flow.signin.foo');
-      assert.equal(events[1].type, 'flow.signin.foo');
-      assert.equal(events[2].type, 'flow.signin.bar');
-      assert.equal(events[3].type, 'flow.baz');
-    });
-
-    it('metrics.logFlowEventOnce', () => {
-      metrics.logFlowEventOnce('foo', 'signin');
-      metrics.logFlowEventOnce('foo', 'signin');
-      metrics.logFlowEventOnce('foo', 'signup');
-
-      const events = metrics.getFilteredData().events;
-      assert.equal(events.length, 2);
-      assert.equal(events[0].type, 'flow.signin.foo');
-      assert.equal(events[1].type, 'flow.signup.foo');
-    });
-
-    it('getFlowEventMetadata', () => {
-      const result = metrics.getFlowEventMetadata();
-      assert.deepEqual(result, {
-        flowBeginTime: undefined,
-        flowId: undefined
-      });
-      assert.deepEqual(Object.keys(result), ['flowBeginTime','flowId']);
-    });
-
-    it('setFlowModel', () => {
-      metrics.setFlowModel({
-        attributes: {
-          flowBegin: 'foo',
-          flowId: 'bar'
-        }
-      });
-      assert.deepEqual(metrics.getFlowEventMetadata(), {
-        flowBeginTime: 'foo',
-        flowId: 'bar'
       });
     });
 

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -70,8 +70,13 @@ define(function (require, exports, module) {
 
       broker = new BaseBroker();
       model = new Backbone.Model();
-      metrics = new Metrics();
       notifier = new Notifier();
+      metrics = new Metrics({
+        notifier,
+        sentryMetrics: {
+          captureException () {}
+        }
+      });
       relier = new Relier();
       user = new User();
       windowMock = new WindowMock();
@@ -87,6 +92,10 @@ define(function (require, exports, module) {
         viewName: viewName,
         window: windowMock
       });
+
+      $(windowMock.document.body).attr('data-flow-id', '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
+      $(windowMock.document.body).attr('data-flow-begin', Date.now());
+      notifier.trigger('flow.initialize');
 
       return view.render();
     });

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -220,22 +220,15 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('afterRender', function () {
-      var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
-
-      beforeEach(function () {
-        $('body').data('flowId', FLOW_ID);
-        $('body').data('flowBegin', -1);
-        sinon.spy(metrics, 'setFlowModel');
+    describe('afterRender', () => {
+      beforeEach(() => {
+        sinon.spy(notifier, 'trigger');
         return view.afterRender();
       });
 
-      it('called metrics.setFlowModel correctly', function () {
-        assert.equal(metrics.setFlowModel.callCount, 1);
-        var args = metrics.setFlowModel.args[0];
-        assert.lengthOf(args, 1);
-        assert.equal(args[0].get('flowId'), FLOW_ID);
-        assert.equal(args[0].get('flowBegin'), -1);
+      it('called notifier.trigger correctly', () => {
+        assert.equal(notifier.trigger.callCount, 1);
+        assert.equal(notifier.trigger.args[0][0], 'flow.initialize');
       });
     });
 

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -27,7 +27,6 @@ define(function (require, exports, module) {
   describe('views/confirm', function () {
     var account;
     var broker;
-    var flow;
     var metrics;
     var model;
     var notifier;
@@ -37,9 +36,6 @@ define(function (require, exports, module) {
     var windowMock;
 
     beforeEach(function () {
-      flow = {
-        pickResumeTokenInfo () {}
-      };
       metrics = new Metrics();
       model = new Backbone.Model();
       notifier = new Notifier();
@@ -65,7 +61,6 @@ define(function (require, exports, module) {
 
       model.set({
         account: account,
-        flow: flow,
         type: SIGNUP_REASON
       });
 
@@ -96,10 +91,6 @@ define(function (require, exports, module) {
       view.destroy();
 
       view = metrics = null;
-    });
-
-    it('sets this.flow correctly', function () {
-      assert.equal(view.flow, flow);
     });
 
     describe('render', function () {

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -43,9 +43,14 @@ define(function (require, exports, module) {
       broker = new Broker();
       email = TestHelpers.createEmail();
       formPrefill = new FormPrefill();
-      metrics = new Metrics();
       model = new Backbone.Model();
       notifier = new Notifier();
+      metrics = new Metrics({
+        notifier,
+        sentryMetrics: {
+          captureException () {}
+        }
+      });
       translator = new Translator({forceEnglish: true});
       relier = new Relier();
       user = new User({
@@ -81,6 +86,10 @@ define(function (require, exports, module) {
 
       sinon.spy(view, 'navigate');
       sinon.spy(view, 'fatalError');
+
+      $(windowMock.document.body).attr('data-flow-id', '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
+      $(windowMock.document.body).attr('data-flow-begin', Date.now());
+      notifier.trigger('flow.initialize');
     }
 
     beforeEach(function () {

--- a/app/tests/spec/views/mixins/flow-begin-mixin.js
+++ b/app/tests/spec/views/mixins/flow-begin-mixin.js
@@ -18,22 +18,15 @@ define((require, exports, module) => {
 
     describe('afterRender', () => {
       beforeEach(() => {
-        flowBeginMixin.metrics = {
-          logFlowBegin: sinon.spy()
-        };
-        flowBeginMixin.flow = {
-          get: sinon.spy(property => `mock ${property}`)
-        };
-        flowBeginMixin.viewName = 'wibble';
+        flowBeginMixin.logFlowEventOnce = sinon.spy();
         flowBeginMixin.afterRender();
       });
 
-      it('called metrics.logFlowBegin correctly', () => {
-        assert.strictEqual(flowBeginMixin.metrics.logFlowBegin.callCount, 1);
-        const args = flowBeginMixin.metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 2);
-        assert.strictEqual(args[0], 'mock flowId');
-        assert.strictEqual(args[1], 'mock flowBegin');
+      it('called metrics.logFlowEventOnce correctly', () => {
+        assert.strictEqual(flowBeginMixin.logFlowEventOnce.callCount, 1);
+        const args = flowBeginMixin.logFlowEventOnce.args[0];
+        assert.lengthOf(args, 1);
+        assert.strictEqual(args[0], 'begin');
       });
     });
   });

--- a/app/tests/spec/views/mixins/flow-events-mixin.js
+++ b/app/tests/spec/views/mixins/flow-events-mixin.js
@@ -5,19 +5,26 @@
 define((require, exports, module) => {
   'use strict';
 
-  const $ = require('jquery');
   const { assert } = require('chai');
   const flowEventsMixin = require('views/mixins/flow-events-mixin');
   const sinon = require('sinon');
 
-  const FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
-
   describe('views/mixins/flow-events-mixin', () => {
+    let isFormEnabled;
+
+    beforeEach(() => {
+      flowEventsMixin.isFormEnabled = () => isFormEnabled;
+      flowEventsMixin.logFlowEvent = sinon.spy();
+      flowEventsMixin.logFlowEventOnce = sinon.spy();
+      flowEventsMixin.notifier = {
+        trigger: sinon.spy()
+      };
+      flowEventsMixin.viewName = 'bar';
+    });
+
     it('exports correct interface', () => {
-      assert.lengthOf(Object.keys(flowEventsMixin), 6);
       assert.isFunction(flowEventsMixin.afterRender);
       assert.lengthOf(flowEventsMixin.afterRender, 0);
-      assert.notOk(flowEventsMixin.flow);
       assert.deepEqual(flowEventsMixin.events, {
         'click a': '_clickFlowEventsLink',
         'click input': '_engageFlowEventsForm',
@@ -31,203 +38,174 @@ define((require, exports, module) => {
       assert.isFunction(flowEventsMixin._submitFlowEventsForm);
     });
 
-    describe('mix in', () => {
-      let isFormEnabled;
-
+    describe('afterRender', () => {
       beforeEach(() => {
-        flowEventsMixin.metrics = {
-          logFlowBegin: sinon.spy(),
-          setFlowModel: sinon.spy()
-        };
-        flowEventsMixin.isFormEnabled = () => isFormEnabled;
-        flowEventsMixin.logEvent = sinon.spy();
-        flowEventsMixin.logEventOnce = sinon.spy();
-        flowEventsMixin.logFlowEvent = sinon.spy();
-        flowEventsMixin.logFlowEventOnce = sinon.spy();
-        $('body').data('flowId', FLOW_ID);
-        $('body').data('flowBegin', 42);
-        flowEventsMixin.viewName = 'bar';
+        flowEventsMixin.afterRender();
       });
 
-      describe('afterRender', () => {
-        beforeEach(() => {
-          flowEventsMixin.afterRender();
-        });
+      it('calls notifier.trigger correctly', () => {
+        assert.equal(flowEventsMixin.notifier.trigger.callCount, 1);
+        const args = flowEventsMixin.notifier.trigger.args[0];
+        assert.lengthOf(args, 1);
+        assert.equal(args[0], 'flow.initialize');
+      });
+    });
 
-        it('correctly created a Flow model instance', () => {
-          assert.ok(flowEventsMixin.flow);
-          assert.strictEqual(flowEventsMixin.flow.get('flowId'), FLOW_ID);
-          assert.strictEqual(flowEventsMixin.flow.get('flowBegin'), 42);
-        });
-
-        it('called metrics.setFlowModel correctly', () => {
-          assert.strictEqual(flowEventsMixin.metrics.setFlowModel.callCount, 1);
-          const args = flowEventsMixin.metrics.setFlowModel.args[0];
-          assert.lengthOf(args, 1);
-          assert.equal(args[0], flowEventsMixin.flow);
-        });
-
-        it('did not call metrics.logFlowBegin', () => {
-          assert.strictEqual(flowEventsMixin.metrics.logFlowBegin.callCount, 0);
+    describe('_clickFlowEventsLink with target id', () => {
+      beforeEach(() => {
+        flowEventsMixin._clickFlowEventsLink({
+          target: {
+            getAttribute () {
+              return 'baz';
+            },
+            nodeType: 1
+          }
         });
       });
 
-      describe('_clickFlowEventsLink with target id', () => {
-        beforeEach(() => {
-          flowEventsMixin._clickFlowEventsLink({
-            target: {
-              getAttribute () {
-                return 'baz';
-              },
-              nodeType: 1
-            }
-          });
-        });
+      it('emits flow events correctly', () => {
+        assert.equal(flowEventsMixin.logFlowEvent.callCount, 1);
+        assert.equal(flowEventsMixin.logFlowEvent.args[0].length, 2);
+        assert.equal(flowEventsMixin.logFlowEvent.args[0][0], 'baz');
+        assert.equal(flowEventsMixin.logFlowEvent.args[0][1], 'bar');
 
-        it('emits flow events correctly', () => {
-          assert.equal(flowEventsMixin.logFlowEvent.callCount, 1);
-          assert.equal(flowEventsMixin.logFlowEvent.args[0].length, 2);
-          assert.equal(flowEventsMixin.logFlowEvent.args[0][0], 'baz');
-          assert.equal(flowEventsMixin.logFlowEvent.args[0][1], 'bar');
+        assert.strictEqual(flowEventsMixin.logFlowEventOnce.callCount, 0);
+      });
+    });
 
-          assert.strictEqual(flowEventsMixin.logFlowEventOnce.callCount, 0);
+    describe('_clickFlowEventsLink without target id', () => {
+      beforeEach(() => {
+        flowEventsMixin._clickFlowEventsLink({
+          target: {
+            getAttribute () {},
+            nodeType: 1
+          }
         });
       });
 
-      describe('_clickFlowEventsLink without target id', () => {
-        beforeEach(() => {
-          flowEventsMixin._clickFlowEventsLink({
-            target: {
-              getAttribute () {},
-              nodeType: 1
-            }
-          });
-        });
+      it('emits flow events correctly', () => {
+        assert.equal(flowEventsMixin.logFlowEvent.callCount, 0);
+        assert.strictEqual(flowEventsMixin.logFlowEventOnce.callCount, 0);
+      });
+    });
 
-        it('emits flow events correctly', () => {
-          assert.equal(flowEventsMixin.logFlowEvent.callCount, 0);
-          assert.strictEqual(flowEventsMixin.logFlowEventOnce.callCount, 0);
+    describe('_engageFlowEventsForm', () => {
+      beforeEach(() => {
+        flowEventsMixin._engageFlowEventsForm();
+      });
+
+      it('emits flow event correctly', () => {
+        assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
+
+        assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 1);
+        assert.equal(flowEventsMixin.logFlowEventOnce.args[0].length, 2);
+        assert.equal(flowEventsMixin.logFlowEventOnce.args[0][0], 'engage');
+        assert.equal(flowEventsMixin.logFlowEventOnce.args[0][1], 'bar');
+      });
+    });
+
+    describe('_keyupFlowEventsInput with TAB key', () => {
+      beforeEach(() => {
+        flowEventsMixin._keyupFlowEventsInput({
+          which: 9
         });
       });
 
-      describe('_engageFlowEventsForm', () => {
-        beforeEach(() => {
-          flowEventsMixin._engageFlowEventsForm();
-        });
+      it('emits flow event correctly', () => {
+        assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
 
-        it('emits flow event correctly', () => {
-          assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
+        assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 1);
+        assert.equal(flowEventsMixin.logFlowEventOnce.args[0].length, 2);
+        assert.equal(flowEventsMixin.logFlowEventOnce.args[0][0], 'engage');
+        assert.equal(flowEventsMixin.logFlowEventOnce.args[0][1], 'bar');
+      });
+    });
 
-          assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 1);
-          assert.equal(flowEventsMixin.logFlowEventOnce.args[0].length, 2);
-          assert.equal(flowEventsMixin.logFlowEventOnce.args[0][0], 'engage');
-          assert.equal(flowEventsMixin.logFlowEventOnce.args[0][1], 'bar');
+    describe('_keyupFlowEventsInput with META+TAB keys', () => {
+      beforeEach(() => {
+        flowEventsMixin._keyupFlowEventsInput({
+          metaKey: true,
+          which: 9
         });
       });
 
-      describe('_keyupFlowEventsInput with TAB key', () => {
-        beforeEach(() => {
-          flowEventsMixin._keyupFlowEventsInput({
-            which: 9
-          });
-        });
+      it('does not emit flow event', () => {
+        assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
+        assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 0);
+      });
+    });
 
-        it('emits flow event correctly', () => {
-          assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
-
-          assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 1);
-          assert.equal(flowEventsMixin.logFlowEventOnce.args[0].length, 2);
-          assert.equal(flowEventsMixin.logFlowEventOnce.args[0][0], 'engage');
-          assert.equal(flowEventsMixin.logFlowEventOnce.args[0][1], 'bar');
+    describe('_keyupFlowEventsInput with CTRL+TAB keys', () => {
+      beforeEach(() => {
+        flowEventsMixin._keyupFlowEventsInput({
+          ctrlKey: true,
+          which: 9
         });
       });
 
-      describe('_keyupFlowEventsInput with META+TAB keys', () => {
-        beforeEach(() => {
-          flowEventsMixin._keyupFlowEventsInput({
-            metaKey: true,
-            which: 9
-          });
-        });
+      it('does not emit flow event', () => {
+        assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
+        assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 0);
+      });
+    });
 
-        it('does not emit flow event', () => {
-          assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
-          assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 0);
+    describe('_keyupFlowEventsInput with ALT+TAB keys', () => {
+      beforeEach(() => {
+        flowEventsMixin._keyupFlowEventsInput({
+          altKey: true,
+          which: 9
         });
       });
 
-      describe('_keyupFlowEventsInput with CTRL+TAB keys', () => {
-        beforeEach(() => {
-          flowEventsMixin._keyupFlowEventsInput({
-            ctrlKey: true,
-            which: 9
-          });
-        });
+      it('does not emit flow event', () => {
+        assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
+        assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 0);
+      });
+    });
 
-        it('does not emit flow event', () => {
-          assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
-          assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 0);
+    describe('_keyupFlowEventsInput with SHIFT+TAB keys', () => {
+      beforeEach(() => {
+        flowEventsMixin._keyupFlowEventsInput({
+          shiftKey: true,
+          which: 9
         });
       });
 
-      describe('_keyupFlowEventsInput with ALT+TAB keys', () => {
-        beforeEach(() => {
-          flowEventsMixin._keyupFlowEventsInput({
-            altKey: true,
-            which: 9
-          });
-        });
+      it('emits flow event correctly', () => {
+        assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
 
-        it('does not emit flow event', () => {
-          assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
-          assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 0);
-        });
+        assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 1);
+        assert.equal(flowEventsMixin.logFlowEventOnce.args[0].length, 2);
+        assert.equal(flowEventsMixin.logFlowEventOnce.args[0][0], 'engage');
+        assert.equal(flowEventsMixin.logFlowEventOnce.args[0][1], 'bar');
+      });
+    });
+
+    describe('_submitFlowEventsForm with form enabled', () => {
+      beforeEach(() => {
+        isFormEnabled = true;
+        flowEventsMixin._submitFlowEventsForm();
       });
 
-      describe('_keyupFlowEventsInput with SHIFT+TAB keys', () => {
-        beforeEach(() => {
-          flowEventsMixin._keyupFlowEventsInput({
-            shiftKey: true,
-            which: 9
-          });
-        });
+      it('emits flow events correctly', () => {
+        assert.strictEqual(flowEventsMixin.logFlowEventOnce.callCount, 0);
 
-        it('emits flow event correctly', () => {
-          assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
+        assert.equal(flowEventsMixin.logFlowEvent.callCount, 1);
+        assert.equal(flowEventsMixin.logFlowEvent.args[0].length, 2);
+        assert.equal(flowEventsMixin.logFlowEvent.args[0][0], 'submit');
+        assert.equal(flowEventsMixin.logFlowEvent.args[0][1], 'bar');
+      });
+    });
 
-          assert.equal(flowEventsMixin.logFlowEventOnce.callCount, 1);
-          assert.equal(flowEventsMixin.logFlowEventOnce.args[0].length, 2);
-          assert.equal(flowEventsMixin.logFlowEventOnce.args[0][0], 'engage');
-          assert.equal(flowEventsMixin.logFlowEventOnce.args[0][1], 'bar');
-        });
+    describe('_submitFlowEventsForm with form disabled', () => {
+      beforeEach(() => {
+        isFormEnabled = false;
+        flowEventsMixin._submitFlowEventsForm();
       });
 
-      describe('_submitFlowEventsForm with form enabled', () => {
-        beforeEach(() => {
-          isFormEnabled = true;
-          flowEventsMixin._submitFlowEventsForm();
-        });
-
-        it('emits flow events correctly', () => {
-          assert.strictEqual(flowEventsMixin.logFlowEventOnce.callCount, 0);
-
-          assert.equal(flowEventsMixin.logFlowEvent.callCount, 1);
-          assert.equal(flowEventsMixin.logFlowEvent.args[0].length, 2);
-          assert.equal(flowEventsMixin.logFlowEvent.args[0][0], 'submit');
-          assert.equal(flowEventsMixin.logFlowEvent.args[0][1], 'bar');
-        });
-      });
-
-      describe('_submitFlowEventsForm with form disabled', () => {
-        beforeEach(() => {
-          isFormEnabled = false;
-          flowEventsMixin._submitFlowEventsForm();
-        });
-
-        it('emits flow events correctly', () => {
-          assert.strictEqual(flowEventsMixin.logFlowEventOnce.callCount, 0);
-          assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
-        });
+      it('emits flow events correctly', () => {
+        assert.strictEqual(flowEventsMixin.logFlowEventOnce.callCount, 0);
+        assert.strictEqual(flowEventsMixin.logFlowEvent.callCount, 0);
       });
     });
   });

--- a/app/tests/spec/views/mixins/resume-token-mixin.js
+++ b/app/tests/spec/views/mixins/resume-token-mixin.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
     template: TestTemplate,
 
     initialize (options = {}) {
-      this.flow = options.flow;
+      this.metrics = options.metrics;
       this.relier = options.relier;
       this.user = options.user;
     }
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
   describe('views/mixins/resume-token-mixin', function () {
     let account;
     let flow;
+    let metrics;
     let relier;
     let user;
     let view;
@@ -44,6 +45,12 @@ define(function (require, exports, module) {
         pickResumeTokenInfo: sinon.spy()
       };
 
+      metrics = {
+        getFlowModel () {
+          return flow;
+        }
+      };
+
       relier = {
         pickResumeTokenInfo: sinon.spy()
       };
@@ -53,7 +60,7 @@ define(function (require, exports, module) {
       };
 
       view = new TestView({
-        flow,
+        metrics,
         relier,
         user
       });

--- a/app/tests/spec/views/mixins/signin-mixin.js
+++ b/app/tests/spec/views/mixins/signin-mixin.js
@@ -32,7 +32,6 @@ define(function (require, exports, module) {
     describe('signIn', function () {
       let account;
       let broker;
-      let flow;
       let model;
       let relier;
       let user;
@@ -44,7 +43,6 @@ define(function (require, exports, module) {
           verified: true
         });
         broker = new AuthBroker();
-        flow = {};
         model = new Backbone.Model();
         user = new User();
         sinon.stub(user, 'signInAccount', (account) => p(account));
@@ -60,7 +58,6 @@ define(function (require, exports, module) {
           broker: broker,
           currentPage: 'force_auth',
           displayError: sinon.spy(),
-          flow: flow,
           getStringifiedResumeToken: sinon.spy(() => RESUME_TOKEN),
           invokeBrokerMethod: sinon.spy(function () {
             return p();
@@ -209,8 +206,7 @@ define(function (require, exports, module) {
           var args = view.navigate.args[0];
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'confirm');
-          assert.strictEqual(args[1].account, account);
-          assert.strictEqual(args[1].flow, flow);
+          assert.deepEqual(args[1], { account });
         });
 
         it('calls logFlowEvent correctly', () => {
@@ -245,8 +241,7 @@ define(function (require, exports, module) {
           var args = view.navigate.args[0];
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'confirm_signin');
-          assert.strictEqual(args[1].account, account);
-          assert.strictEqual(args[1].flow, flow);
+          assert.deepEqual(args[1], { account });
         });
 
         it('calls logFlowEvent correctly', () => {

--- a/app/tests/spec/views/mixins/signup-mixin.js
+++ b/app/tests/spec/views/mixins/signup-mixin.js
@@ -24,7 +24,6 @@ define(function (require, exports, module) {
     describe('signUp', function () {
       let account;
       let broker;
-      let flow;
       let relier;
       let user;
       let view;
@@ -35,7 +34,6 @@ define(function (require, exports, module) {
         });
 
         broker = new Broker();
-        flow = {};
         relier = new Relier();
         user = {
           signUpAccount: sinon.spy((account) => p(account))
@@ -46,7 +44,6 @@ define(function (require, exports, module) {
             clear: sinon.spy()
           },
           broker,
-          flow,
           getStringifiedResumeToken: sinon.spy(() => 'resume token'),
           invokeBrokerMethod: sinon.spy(function () {
             return p();
@@ -231,9 +228,8 @@ define(function (require, exports, module) {
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'confirm');
           assert.isObject(args[1]);
-          assert.lengthOf(Object.keys(args[1]), 2);
-          assert.equal(args[1].account, account);
-          assert.equal(args[1].flow, flow);
+          assert.lengthOf(Object.keys(args[1]), 1);
+          assert.deepEqual(args[1], { account });
         });
       });
 

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -109,22 +109,15 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('afterRender', function () {
-      var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
-
-      beforeEach(function () {
-        $('body').data('flowId', FLOW_ID);
-        $('body').data('flowBegin', -1);
-        sinon.spy(metrics, 'setFlowModel');
+    describe('afterRender', () => {
+      beforeEach(() => {
+        sinon.spy(notifier, 'trigger');
         return view.afterRender();
       });
 
-      it('called metrics.setFlowModel correctly', function () {
-        assert.equal(metrics.setFlowModel.callCount, 1);
-        var args = metrics.setFlowModel.args[0];
-        assert.lengthOf(args, 1);
-        assert.equal(args[0].get('flowId'), FLOW_ID);
-        assert.equal(args[0].get('flowBegin'), -1);
+      it('called notifier.trigger correctly', () => {
+        assert.equal(notifier.trigger.callCount, 1);
+        assert.equal(notifier.trigger.args[0][0], 'flow.initialize');
       });
     });
 
@@ -242,59 +235,65 @@ define(function (require, exports, module) {
     });
   });
 
-  describe('views/reset_password with email specified in relier', function () {
-    var broker;
-    var formPrefill;
-    var relier;
-    var view;
+  describe('views/reset_password with email specified in relier', () => {
+    let broker;
+    let formPrefill;
+    let notifier;
+    let relier;
+    let view;
 
-    beforeEach(function () {
+    beforeEach(() => {
       relier = new Relier();
       relier.set('email', 'testuser@testuser.com');
       broker = new Broker({
-        relier: relier
+        relier
       });
       formPrefill = new FormPrefill();
+      notifier = new Notifier();
 
       view = new View({
-        broker: broker,
-        formPrefill: formPrefill,
-        relier: relier
+        broker,
+        formPrefill,
+        notifier,
+        relier
       });
 
       return view.render();
     });
 
-    afterEach(function () {
+    afterEach(() => {
       view.destroy();
       view = null;
       $('#container').empty();
     });
 
-    it('does not pre-fills email address', function () {
+    it('does not pre-fills email address', () => {
       assert.equal(view.$('.email').val(), '');
     });
   });
 
-  describe('views/reset_password with model.forceEmail', function () {
-    var broker;
-    var email = 'testuser@testuser.com';
-    var formPrefill;
-    var model;
-    var relier;
-    var view;
+  describe('views/reset_password with model.forceEmail', () => {
+    let broker;
+    let email = 'testuser@testuser.com';
+    let formPrefill;
+    let model;
+    let notifier;
+    let relier;
+    let view;
 
-    beforeEach(function () {
-      broker = new Broker({ relier: relier });
+    beforeEach(() => {
+      broker = new Broker({ relier });
       formPrefill = new FormPrefill();
       model = new Backbone.Model({ forceEmail: email });
-      relier = new Relier({ email: email });
+      notifier = new Notifier();
+      relier = new Relier({ email });
 
       view = new View({
-        broker: broker,
-        formPrefill: formPrefill,
-        model: model,
-        relier: relier
+        broker,
+        formPrefill,
+        model,
+        notifier,
+        relier
       });
 
       sinon.spy(view, '_resetPassword');
@@ -302,29 +301,29 @@ define(function (require, exports, module) {
       return view.render();
     });
 
-    afterEach(function () {
+    afterEach(() => {
       view.destroy();
       view = null;
       $('#container').empty();
     });
 
-    it('shows a readonly email', function () {
-      var $emailInputEl = view.$('[type=email]');
+    it('shows a readonly email', () => {
+      const $emailInputEl = view.$('[type=email]');
       assert.equal($emailInputEl.val(), email);
       assert.isTrue($emailInputEl.hasClass('hidden'));
 
       assert.equal(view.$('.prefillEmail').text(), email);
     });
 
-    it('has a link back to /force_auth', function () {
+    it('has a link back to /force_auth', () => {
       assert.ok(view.$('a[href="/force_auth"]').length);
     });
 
-    it('does not submit the email address automatically', function () {
+    it('does not submit the email address automatically', () => {
       assert.isFalse(view._resetPassword.called);
     });
 
-    it('removes the back button - the user probably browsed here directly', function () {
+    it('removes the back button - the user probably browsed here directly', () => {
       assert.equal(view.$('#back').length, 0);
     });
   });

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -84,9 +84,14 @@ define(function (require, exports, module) {
       email = TestHelpers.createEmail();
       formPrefill = new FormPrefill();
       fxaClient = new FxaClient();
-      metrics = new Metrics();
       model = new Backbone.Model();
       notifier = new Notifier();
+      metrics = new Metrics({
+        notifier,
+        sentryMetrics: {
+          captureException () {}
+        }
+      });
       relier = new Relier();
       translator = new Translator({forceEnglish: true});
 
@@ -99,6 +104,9 @@ define(function (require, exports, module) {
       });
 
       createView();
+
+      $('body').attr('data-flow-id', 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103');
+      $('body').attr('data-flow-begin', '42');
 
       return view.render()
         .then(function () {
@@ -375,34 +383,6 @@ define(function (require, exports, module) {
           .then(function () {
             assert.isTrue(view.getPasswordStrengthChecker.called);
           });
-      });
-    });
-
-    describe('afterRender', function () {
-      var FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
-
-      beforeEach(function () {
-        $('body').data('flowId', FLOW_ID);
-        $('body').data('flowBegin', 3);
-        sinon.spy(metrics, 'setFlowModel');
-        sinon.spy(metrics, 'logFlowBegin');
-        return view.afterRender();
-      });
-
-      it('called metrics.setFlowModel correctly', function () {
-        assert.equal(metrics.setFlowModel.callCount, 1);
-        var args = metrics.setFlowModel.args[0];
-        assert.lengthOf(args, 1);
-        assert.equal(args[0].get('flowId'), FLOW_ID);
-        assert.equal(args[0].get('flowBegin'), 3);
-      });
-
-      it('called metrics.logFlowBegin correctly', function () {
-        assert.equal(metrics.logFlowBegin.callCount, 1);
-        var args = metrics.logFlowBegin.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], FLOW_ID);
-        assert.equal(args[1], 3);
       });
     });
 
@@ -1370,7 +1350,15 @@ define(function (require, exports, module) {
 
     describe('flow events', () => {
       beforeEach(() => {
-        view.afterVisible();
+        sinon.spy(notifier, 'trigger');
+        return view.afterRender();
+      });
+
+      it('called notifier.trigger correctly', () => {
+        assert.equal(notifier.trigger.callCount, 2);
+        assert.equal(notifier.trigger.args[0][0], 'flow.initialize');
+        assert.equal(notifier.trigger.args[1][0], 'flow.event');
+        assert.deepEqual(notifier.trigger.args[1][1], { event: 'begin', once: true, view: undefined });
       });
 
       it('logs the begin event', () => {


### PR DESCRIPTION
This is the refactoring part of #4654, opened as a separate PR because I kind of like how it separated the responsibility for managing the flow model away from the views. It is minus the `flow.clear` part of that PR, which is no longer needed because of #4676 (if that gets merged).

Instead of the views holding a reference to the flow model and passing it as view data in calls to navigate, flow model access is now gated via the metrics object using events. This eliminates the need to pass the flow model around and makes the view code cleaner (imho).

Not sure how the rest of you feel about it though, so I leave it here for your assessment.

@mozilla/fxa-devs r?
