### PR TITLE
fix(iOS): Send the `login` message within the `visibilitychange`

### DIFF
--- a/app/scripts/lib/user-agent.js
+++ b/app/scripts/lib/user-agent.js
@@ -73,6 +73,21 @@ define(function (require, exports, module) {
        */
       isFirefoxDesktop () {
         return this.isFirefox() && ! this.isFirefoxIos() && ! this.isFirefoxAndroid();
+      },
+
+      /**
+       * Parse uap.browser.version into an object with
+       * `major`, `minor`, and `patch`
+       *
+       * @returns {Object}
+       */
+      parseVersion () {
+        const browserVersion = this.browser.version.split('.');
+        return {
+          major: parseInt(browserVersion[0] || 0, 10),
+          minor: parseInt(browserVersion[1] || 0, 10),
+          patch: parseInt(browserVersion[2] || 0, 10)
+        };
       }
     });
 

--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -15,22 +15,43 @@ define(function (require, exports, module) {
   const Constants = require('lib/constants');
   const FxDesktopV1AuthenticationBroker = require('models/auth_brokers/fx-desktop-v1');
   const p = require('lib/promise');
+  const UserAgent = require('lib/user-agent');
 
   const proto = FxDesktopV1AuthenticationBroker.prototype;
 
   const FxiOSV1AuthenticationBroker = FxDesktopV1AuthenticationBroker.extend({
-    defaults: {
-      loginMessageDelayMS: Constants.IOS_V1_LOGIN_MESSAGE_DELAY_MS
-    },
-
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       chooseWhatToSyncCheckbox: false,
-      convertExternalLinksToText: true
+      convertExternalLinksToText: true,
+      immediateUnverifiedLogin: false
     }),
+
+    initialize (options = {}) {
+      proto.initialize.call(this, options);
+
+      this.setCapability(
+        'immediateUnverifiedLogin',
+        this._supportsImmediateUnverifiedLogin());
+    },
+
+
+    /**
+     * Check if the browser supports immediate login
+     * for unverified accounts.
+     *
+     * @returns {Boolean}
+     * @private
+     */
+    _supportsImmediateUnverifiedLogin () {
+      const userAgent = new UserAgent(this.window.navigator.userAgent);
+      const version = userAgent.parseVersion();
+      return version.major > 6 ||
+            (version.major === 6 && version.minor >= 1);
+    },
 
     /**
      * Notify the relier of login. This contains a bit of a hack.
-     * Fx for iOS takes over the UI as soon as it receives a `login`
+     * Fx for iOS < 6.1 takes over the UI as soon as it receives a `login`
      * message. For verified accounts, this is fine because the user
      * is signed in and Sync starts immediately. For unverified accounts,
      * this causes problems because users don't have enough time to
@@ -45,7 +66,8 @@ define(function (require, exports, module) {
      *
      * If the account is verified, send the `login` message right away.
      *
-     * This will all go away in fx_ios_v2 and
+     * This problem goes away w/ Fx for iOS 6.1.
+     *
      * https://bugzilla.mozilla.org/show_bug.cgi?id=1335491
      *
      * @param {Object} account
@@ -53,10 +75,13 @@ define(function (require, exports, module) {
      * @private
      */
     _notifyRelierOfLogin (account) {
-      if (account.get('verified')) {
-        // For verified accounts, send the `login` message right away -
+      if (account.get('verified') ||
+          this.getCapability('immediateUnverifiedLogin')) {
+        // For verified accounts, always send the `login` message right away -
         // no screen transition occurs in this case so it's safe to let
         // the browser take over the UI.
+        // If the browser supports `immediateUnverifiedLogin`,
+        // also send right away. We know it'll do the right thing.
         return proto._notifyRelierOfLogin.call(this, account);
       }
 
@@ -66,7 +91,7 @@ define(function (require, exports, module) {
       const win = this.window;
       const $win = $(win);
 
-      const timeout = win.setTimeout(resolve, this.get('loginMessageDelayMS'));
+      const timeout = win.setTimeout(resolve, Constants.IOS_V1_LOGIN_MESSAGE_DELAY_MS);
       $win.on('blur', resolve);
 
       return deferred.promise

--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -11,31 +11,72 @@ define(function (require, exports, module) {
   'use strict';
 
   const _ = require('underscore');
+  const $ = require('jquery');
   const Constants = require('lib/constants');
-  const p = require('lib/promise');
-
   const FxDesktopV1AuthenticationBroker = require('models/auth_brokers/fx-desktop-v1');
+  const p = require('lib/promise');
 
   const proto = FxDesktopV1AuthenticationBroker.prototype;
 
   const FxiOSV1AuthenticationBroker = FxDesktopV1AuthenticationBroker.extend({
+    defaults: {
+      loginMessageDelayMS: Constants.IOS_V1_LOGIN_MESSAGE_DELAY_MS
+    },
+
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       chooseWhatToSyncCheckbox: false,
       convertExternalLinksToText: true
     }),
 
+    /**
+     * Notify the relier of login. This contains a bit of a hack.
+     * Fx for iOS takes over the UI as soon as it receives a `login`
+     * message. For verified accounts, this is fine because the user
+     * is signed in and Sync starts immediately. For unverified accounts,
+     * this causes problems because users don't have enough time to
+     * see the "Go verify your account" screen and often drop off.
+     *
+     * To give unverified users a bit of time to see the "go verify
+     * your account" screen, a slight delay is introduced before
+     * sending the `login` message. If the user blurs the Fx for iOS
+     * window during this delay, for example if the user goes to check
+     * their email, then the `login` message is sent immediately so
+     * the browser can update its UI.
+     *
+     * If the account is verified, send the `login` message right away.
+     *
+     * This will all go away in fx_ios_v2 and
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=1335491
+     *
+     * @param {Object} account
+     * @returns {Promise}
+     * @private
+     */
     _notifyRelierOfLogin (account) {
-      /**
-       * As a workaround for sign-in/sign-up confirmation view disappearing
-       * on iOS, delay the login message sent via the channel by LOGIN_MESSAGE_DELAY_MS.
-       * This will give the user an indication that they need to verify
-       * their email address.
-       */
-      const loginMessageDelayMS = this.get('loginMessageDelayMS') || Constants.IOS_V1_LOGIN_MESSAGE_DELAY_MS;
-      return p().delay(loginMessageDelayMS).then(() => {
+      if (account.get('verified')) {
+        // For verified accounts, send the `login` message right away -
+        // no screen transition occurs in this case so it's safe to let
+        // the browser take over the UI.
         return proto._notifyRelierOfLogin.call(this, account);
-      });
-    },
+      }
+
+      const deferred = p.defer();
+      const resolve = () => deferred.resolve();
+
+      const win = this.window;
+      const $win = $(win);
+
+      const timeout = win.setTimeout(resolve, this.get('loginMessageDelayMS'));
+      $win.on('blur', resolve);
+
+      return deferred.promise
+        .then(() => proto._notifyRelierOfLogin.call(this, account))
+        .then((response) => {
+          win.clearTimeout(timeout);
+          $win.off('blur', resolve);
+          return response;
+        });
+    }
   });
 
   module.exports = FxiOSV1AuthenticationBroker;

--- a/app/tests/spec/lib/user-agent.js
+++ b/app/tests/spec/lib/user-agent.js
@@ -303,6 +303,42 @@ define(function (require, exports, module) {
           assert.isFalse(uap.isMobileSafari());
         });
       });
+
+      describe('parseVersion', () => {
+        it('returns expected major, minor, patch', () => {
+          const toTest = {
+            'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19': {
+              major: 18,
+              minor: 0,
+              patch: 1025
+            },
+
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:10.0) Gecko/20100101 Firefox/10.0': {
+              major: 10,
+              minor: 0,
+              patch: 0
+            },
+
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/6.1 Mobile/12F69 Safari/600.1.4': {
+              major: 6,
+              minor: 1,
+              patch: 0
+            }
+
+          };
+
+          for (let userAgentString in toTest) {
+            testParseVersion(userAgentString);
+          }
+
+          function testParseVersion(userAgentString) {
+            let uap = new UserAgent(userAgentString);
+            let version = uap.parseVersion();
+            let expected = toTest[userAgentString];
+            assert.deepEqual(version, expected);
+          }
+        });
+      });
     });
   });
 });

--- a/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -44,22 +44,26 @@ define(function (require, exports, module) {
 
     describe('capabilities', () => {
       describe('does not support immediateUnverifiedLogin', () => {
-        it('has the expected default capabilities', () => {
+        it('has the expected capabilities and behaviors', () => {
           assert.isTrue(broker.hasCapability('signup'));
           assert.isTrue(broker.hasCapability('handleSignedInNotification'));
           assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
           assert.isFalse(broker.hasCapability('immediateUnverifiedLogin'));
+
+          assert.equal(broker.getBehavior('beforeSignUpConfirmationPoll').type, 'halt');
         });
       });
 
       describe('supports immediateUnverifiedLogin', () => {
-        it('has the expected default capabilities', () => {
+        it('has the expected capabilities and behaviors', () => {
           initializeBroker(IMMEDIATE_UNVERIFIED_LOGIN_UA_STRING);
 
           assert.isTrue(broker.hasCapability('signup'));
           assert.isTrue(broker.hasCapability('handleSignedInNotification'));
           assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
           assert.isTrue(broker.hasCapability('immediateUnverifiedLogin'));
+
+          assert.equal(broker.getBehavior('beforeSignUpConfirmationPoll').type, 'null');
         });
       });
     });

--- a/tests/functional/fx_ios_v1_sign_up.js
+++ b/tests/functional/fx_ios_v1_sign_up.js
@@ -15,10 +15,12 @@ define([
   var email;
   var PASSWORD = '12345678';
 
+  var thenify = FunctionalHelpers.thenify;
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  var noPageTransition = FunctionalHelpers.noPageTransition;
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
@@ -26,6 +28,36 @@ define([
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testEmailExpected = FunctionalHelpers.testEmailExpected;
   var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+
+  /*eslint-disable max-len*/
+  var UA_STRINGS = {
+    'ios_firefox_6_0': 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/6.0 Mobile/12F69 Safari/600.1.4',
+    'ios_firefox_6_1': 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/6.1 Mobile/12F69 Safari/600.1.4',
+  };
+  /*eslint-enable max-len*/
+
+  const setupTest = thenify(function (userAgent) {
+    return this.parent
+      .then(openPage(PAGE_URL, '#fxa-signup-header', {
+        query: {
+          forceUA: userAgent
+        }
+      }))
+      .execute(listenForFxaCommands)
+      .then(noSuchElement('#customize-sync'))
+      .then(fillOutSignUp(email, PASSWORD))
+
+      .then(testElementExists('#fxa-confirm-header'))
+      .then(testIsBrowserNotifiedOfLogin(email))
+
+      // verify the user
+      .then(openVerificationLinkInNewTab(email, 0))
+      .switchToWindow('newwindow')
+
+      .then(testElementExists('#fxa-sign-up-complete-header'))
+      .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
+      .then(closeCurrentWindow());
+  });
 
   registerSuite({
     name: 'FxiOS v1 sign_up',
@@ -40,25 +72,24 @@ define([
         .then(clearBrowserState());
     },
 
-    'sign up, verify same browser': function () {
+    'Fx iOS <= 6.0 sign up, verify same browser': function () {
       return this.remote
-        .then(openPage(PAGE_URL, '#fxa-signup-header'))
-        .execute(listenForFxaCommands)
-        .then(noSuchElement('#customize-sync'))
-        .then(fillOutSignUp(email, PASSWORD))
+        .then(setupTest(UA_STRINGS['ios_firefox_6_0']))
 
-        .then(testElementExists('#fxa-confirm-header'))
-        .then(testIsBrowserNotifiedOfLogin(email))
+        // no screen transition, no polling even, in Fx <= 6.0
+        .then(noPageTransition('#fxa-confirm-header'))
 
-        // verify the user
-        .then(openVerificationLinkInNewTab(email, 0))
-        .switchToWindow('newwindow')
+        // A post-verification email should be sent, this is Sync.
+        .then(testEmailExpected(email, 1));
+    },
 
+    'Fx iOS >= 6.1 sign up, verify same browser': function () {
+      return this.remote
+        .then(setupTest(UA_STRINGS['ios_firefox_6_1']))
+
+        // In Fx for iOS >= 6.1, user should redirect to the signup-complete
+        // page after verification.
         .then(testElementExists('#fxa-sign-up-complete-header'))
-        .then(testElementTextInclude('.account-ready-service', 'Firefox Sync'))
-        .then(closeCurrentWindow())
-
-        .then(testElementExists('#fxa-confirm-header'))
 
         // A post-verification email should be sent, this is Sync.
         .then(testEmailExpected(email, 1));


### PR DESCRIPTION
For verified accounts, the `login` message is sent immediately.

For unverified accounts, the `login` message is sent after the
first of 1) a 5 second timeout, or 2) a `blur` DOM event.

The `blur` DOM event is to handle the case where a user receives
their verification email and opens the email client before the timeout
has occurred.

For Fx for iOS >= 6.1, always send the `login` message immediately.

fixes #4377