### PR TITLE
feat(client): Sync state with the browser!

### DIFF
--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -36,6 +36,11 @@ define(function (require, exports, module) {
 
       this._behaviors = new Backbone.Model(this.defaultBehaviors);
       this._capabilities = new Backbone.Model(this.defaultCapabilities);
+
+      this._notificationChannel = options.notificationChannel;
+      if (this._notificationChannel) {
+        this.setCapability('fxaStatus', this._notificationChannel.isFxaStatusSupported());
+      }
     },
 
     notifications: {
@@ -89,14 +94,41 @@ define(function (require, exports, module) {
     },
 
     /**
-     * initialize the broker with any necessary data.
+     * Initialize the broker with any necessary data.
+     *
      * @returns {Promise}
      */
     fetch () {
       return p().then(() => {
         this._isForceAuth = this._isForceAuthUrl();
         this.importSearchParamsUsingSchema(QUERY_PARAMETER_SCHEMA, AuthErrors);
+
+        if (this.hasCapability('fxaStatus')) {
+          return this._fetchFxaStatus();
+        }
       });
+    },
+
+    /**
+     * Request FXA_STATUS info from the UA.
+     *
+     * @returns {Promise} resolves when complete.
+     */
+    _fetchFxaStatus () {
+      const TEST_REQUEST_DELAY_MS = this.isAutomatedBrowser() ? 200 : 0;
+
+      const channel = this._notificationChannel;
+      return p().delay(TEST_REQUEST_DELAY_MS)
+        // OAuth reliers will have `service` set to the client_id, Sync to `sync`
+        .then(() => channel.request(channel.COMMANDS.FXA_STATUS, this.relier.pick('service')))
+        .then((response = {}) => {
+          // The browser will respond with a signedInUser in the following cases:
+          // - non-PB mode, service=*
+          // - PB mode, service=sync
+          this.set('browserSignedInAccount', response.signedInUser);
+          // In the future, additional data will be returned
+          // in the response, handle it here.
+        });
     },
 
     /**
@@ -337,6 +369,10 @@ define(function (require, exports, module) {
        * should the *_complete pages show the marketing snippet?
        */
       emailVerificationMarketingSnippet: true,
+      /**
+       * Should the UA be queried for FxA data?
+       */
+      fxaStatus: false,
       /**
        * Should the view handle signed-in notifications from other tabs?
        */

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -119,7 +119,6 @@ define(function (require, exports, module) {
 
       const channel = this._notificationChannel;
       return p().delay(TEST_REQUEST_DELAY_MS)
-        // OAuth reliers will have `service` set to the client_id, Sync to `sync`
         .then(() => channel.request(channel.COMMANDS.FXA_STATUS, this.relier.pick('service')))
         .then((response = {}) => {
           // The browser will respond with a signedInUser in the following cases:

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -733,6 +733,80 @@ define(function (require, exports, module) {
      */
     rejectAccountUnblockCode(account, unblockCode) {
       return account.rejectUnblockCode(unblockCode);
+    },
+
+    /**
+     * Initialize the signed in account from the browser, if needed.
+     *
+     * If service=sync, always use the browser's state of the world.
+     * If trying to sign in to an OAuth relier, prefer any users that are
+     * stored in localStorage and only use the browser's state if no
+     * user is stored.
+     *
+     * @param {Object} channel channel used to request data from browser.
+     * @param {String} [service=''] service being signed into.
+     * @returns {Promise} resolves with Account if loaded from browser.
+     *   Resolves to `undefined` if not.
+     */
+    setSignedInAccountFromBrowser (channel, service = '') {
+      if (! this.shouldSetSignedInAccountFromBrowser(channel, service)) {
+        return p();
+      }
+
+      // OAuth reliers will have `service` set to the client_id, Sync to `sync`
+      return channel.request(channel.COMMANDS.FXA_STATUS, { service })
+        .then((browserUserData) => this._setSignedInAccountFromFxaStatusResponse(browserUserData));
+    },
+
+    /**
+     * Should the model be initialized using browser data?
+     *
+     * @param {Object} channel channel used to request data from browser.
+     * @param {Object} [service=''] service being signed into.
+     * @returns {Boolean}
+     */
+    shouldSetSignedInAccountFromBrowser (channel, service = '') {
+      // If service=sync, always use the browser's state of the world.
+      // If trying to sign in to an OAuth relier, prefer any users that are
+      // stored in localStorage and only use the browser's state if no
+      // user is stored.
+      return channel.isFxaStatusSupported() && (
+        service === Constants.SYNC_SERVICE ||
+        this.getSignedInAccount().isDefault()
+      );
+    },
+
+    /**
+     * Set signed in account data from browser response.
+     *
+     * @param {Object} [response={}]
+     * @returns {Promise}
+     */
+    _setSignedInAccountFromFxaStatusResponse (response = {}) {
+      return p().then(() => {
+        // The browser will respond with a signedInUser in the following cases:
+        // - non-PB mode, service=*
+        // - PB mode, service=sync
+        const accountData = response.signedInUser;
+        if (accountData) {
+          const account = this.initAccount({
+            email: accountData.email,
+            sessionToken: accountData.sessionToken,
+            sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
+            uid: accountData.uid,
+            verified: accountData.verified
+          });
+
+          // If service=sync, account information is stored in memory only.
+          // All other services store account information in localStorage.
+          return this.setSignedInAccount(account);
+        }
+
+        // If no account data is returned from the browser,
+        // don't clear or store anything. No need to. Sync users
+        // will have no accounts stored in memory, and OAuth users
+        // can only arrive here if no accounts are stored in localStorage.
+      });
     }
   });
 

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -746,7 +746,7 @@ define(function (require, exports, module) {
       // If trying to sign in to an OAuth relier, prefer any users that are
       // stored in localStorage and only use the browser's state if no
       // user is stored.
-      return !! (service === Constants.SYNC_SERVICE || this.getSignedInAccount().isDefault());
+      return service === Constants.SYNC_SERVICE || this.getSignedInAccount().isDefault();
     },
 
     /**

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -1454,5 +1454,157 @@ define(function (require, exports, module) {
         });
       });
     });
+
+    describe('setSignedInAccountFromBrowser', () => {
+      describe('browser does not support fxa_status query', () => {
+        it('should not request user data from the browser', () => {
+          sinon.stub(user, 'shouldSetSignedInAccountFromBrowser', () => false);
+          sinon.spy(user, 'setSignedInAccount');
+          const channel = {
+            request: sinon.spy()
+          };
+
+          return user.setSignedInAccountFromBrowser(channel, Constants.SYNC_SERVICE)
+            .then(() => {
+              assert.isFalse(channel.request.called);
+              assert.isFalse(user.setSignedInAccount.called);
+            });
+        });
+      });
+
+      describe('browser supports fxa_status query', () => {
+        const browserUserData = {
+          signedInUser: {
+            email: 'testuser@testuser.com',
+            sessionToken: 'sessionToken',
+            uid: 'uid',
+            verified: true
+          }
+        };
+
+        it('should request user data from the browser, save data', () => {
+          sinon.stub(user, 'shouldSetSignedInAccountFromBrowser', () => true);
+          sinon.stub(user, '_setSignedInAccountFromFxaStatusResponse', () => {});
+
+          const channel = {
+            COMMANDS: {
+              FXA_STATUS: 'fxaccounts:fxa_status'
+            },
+            request: sinon.spy(() => p(browserUserData))
+          };
+
+          return user.setSignedInAccountFromBrowser(channel, Constants.SYNC_SERVICE)
+            .then(() => {
+              assert.isTrue(channel.request.calledOnce);
+              assert.isTrue(channel.request.calledWith('fxaccounts:fxa_status'));
+
+              assert.isTrue(user._setSignedInAccountFromFxaStatusResponse.calledOnce);
+              assert.isTrue(user._setSignedInAccountFromFxaStatusResponse.calledWith(browserUserData));
+            });
+        });
+      });
+
+      describe('shouldSetSignedInAccountFromBrowser', () => {
+        let channel;
+
+        describe('channel supports fxa status request', () => {
+          beforeEach(() => {
+            channel = {
+              isFxaStatusSupported: () => true
+            };
+          });
+
+          describe('service is sync', () => {
+            it('returns true', () => {
+              assert.isTrue(user.shouldSetSignedInAccountFromBrowser(channel, Constants.SYNC_SERVICE));
+            });
+          });
+
+          describe('default account', () => {
+            it('returns true', () => {
+              sinon.stub(user, 'getSignedInAccount', () => {
+                return {
+                  isDefault: () => true
+                };
+              });
+              assert.isTrue(user.shouldSetSignedInAccountFromBrowser(channel, 'fake_client_id'));
+            });
+          });
+
+          describe('neither sync nor default account', () => {
+            it('returns false', () => {
+              sinon.stub(user, 'getSignedInAccount', () => {
+                return {
+                  isDefault: () => false
+                };
+              });
+              assert.isFalse(user.shouldSetSignedInAccountFromBrowser(channel, 'fake_client_id'));
+            });
+          });
+        });
+
+        describe('channel does not support fxa status request', () => {
+          it('returns false', () => {
+            channel = {
+              isFxaStatusSupported: () => false
+            };
+
+            assert.isFalse(user.shouldSetSignedInAccountFromBrowser(channel, Constants.SYNC_SERVICE));
+          });
+        });
+      });
+
+      describe('_setSignedInAccountFromFxaStatusResponse', () => {
+        beforeEach(() => {
+          sinon.spy(user, 'setSignedInAccount');
+        });
+
+        describe('response does not have `signedInUser`', () => {
+          it('does not attempt to save an account', () => {
+            return user._setSignedInAccountFromFxaStatusResponse({})
+              .then(() => {
+                assert.isFalse(user.setSignedInAccount.called);
+              });
+          });
+        });
+
+        describe('response has `signedInUser`', () => {
+          it('sets the signed in user', () => {
+            const browserResponse = {
+              signedInUser: {
+                email: 'testuser@testuser.com',
+                sessionToken: 'sessionToken',
+                uid: 'uid',
+                verified: true
+              }
+            };
+
+
+            return user._setSignedInAccountFromFxaStatusResponse(browserResponse)
+              .then(() => {
+                assert.isTrue(user.setSignedInAccount.calledOnce);
+
+                const signedInAccount = user.getSignedInAccount();
+                assert.deepEqual(
+                  signedInAccount.pick(
+                    'email',
+                    'sessionToken',
+                    'sessionTokenContext',
+                    'uid',
+                    'verified'
+                  ),
+                  {
+                    email: 'testuser@testuser.com',
+                    sessionToken: 'sessionToken',
+                    sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC,
+                    uid: 'uid',
+                    verified: true
+                  }
+                );
+              });
+          });
+        });
+      });
+    });
   });
 });

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -23,6 +23,7 @@ define([
   './functional/sync_v3_sign_in',
   './functional/sync_v3_settings',
   './functional/sync_v3_force_auth',
+  './functional/fx_desktop_handshake',
   './functional/fx_firstrun_v1_sign_up',
   './functional/fx_firstrun_v1_sign_in',
   './functional/fx_firstrun_v1_settings',

--- a/tests/functional/fx_desktop_handshake.js
+++ b/tests/functional/fx_desktop_handshake.js
@@ -1,0 +1,321 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers',
+  'tests/functional/lib/selectors',
+  'tests/functional/lib/ua-strings'
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors, uaStrings) {
+  'use strict';
+
+  const config = intern.config;
+
+  const userAgent = uaStrings['desktop_firefox_55'];
+
+  const FORCE_AUTH_PAGE_URL = `${config.fxaContentRoot}force_auth?automatedBrowser=true&forceUA=${encodeURIComponent(userAgent)}`;
+  const SYNC_FORCE_AUTH_PAGE_URL = `${FORCE_AUTH_PAGE_URL}&service=sync`;
+
+  const SIGNIN_PAGE_URL = `${config.fxaContentRoot}signin?automatedBrowser=true&forceUA=${encodeURIComponent(userAgent)}`;
+  const SYNC_SIGNIN_PAGE_URL = `${SIGNIN_PAGE_URL}&service=sync`;
+
+  const SIGNUP_PAGE_URL = `${config.fxaContentRoot}signup?automatedBrowser=true&forceUA=${encodeURIComponent(userAgent)}`;
+  const SYNC_SIGNUP_PAGE_URL = `${SIGNUP_PAGE_URL}&service=sync`;
+
+  const SETTINGS_PAGE_URL = `${config.fxaContentRoot}settings?automatedBrowser=true&forceUA=${encodeURIComponent(userAgent)}`;
+  const SYNC_SETTINGS_PAGE_URL = `${SETTINGS_PAGE_URL}&service=sync`;
+
+  var browserSignedInEmail;
+  let browserSignedInAccount;
+
+  let otherEmail;
+  let otherAccount;
+
+  const PASSWORD = '12345678';
+
+  const click = FunctionalHelpers.click;
+  const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const createUser = FunctionalHelpers.createUser;
+  const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
+  const openPage = FunctionalHelpers.openPage;
+  const noSuchElement = FunctionalHelpers.noSuchElement;
+  const testElementExists = FunctionalHelpers.testElementExists;
+  const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
+  const testElementValueEquals = FunctionalHelpers.testElementValueEquals;
+  const thenify = FunctionalHelpers.thenify;
+
+  const ensureUsers = thenify(function () {
+    return this.parent
+      .then(() => {
+        if (! browserSignedInAccount) {
+          browserSignedInEmail = TestHelpers.createEmail();
+          return this.parent
+            .then(createUser(browserSignedInEmail, PASSWORD, { preVerified: true }))
+            .then((_browserSignedInAccount) => {
+              browserSignedInAccount = _browserSignedInAccount;
+            });
+        }
+      })
+      .then(() => {
+        if (! otherAccount) {
+          otherEmail = TestHelpers.createEmail();
+          return this.parent
+            .then(createUser(otherEmail, PASSWORD, { preVerified: true }))
+            .then((_otherAccount) => {
+              otherAccount = _otherAccount;
+            });
+        }
+      });
+  });
+
+  registerSuite({
+    name: 'Firefox desktop user info handshake',
+
+    beforeEach: function () {
+      return this.remote.then(clearBrowserState())
+        .then(ensureUsers());
+    },
+
+    afterEach: function () {
+      return this.remote.then(clearBrowserState());
+    },
+
+    'Sync signup page - user signed into browser': function () {
+      return this.remote
+        .then(openPage(SYNC_SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        // browserSignedInEmail not prefilled on signup page
+        .then(testElementValueEquals(selectors.SIGNUP.EMAIL, ''))
+        .then(click(selectors.SIGNUP.LINK_SIGN_IN))
+
+
+        .then(testElementExists(selectors.SIGNIN.HEADER))
+        .then(testElementValueEquals(selectors.SIGNIN.EMAIL, browserSignedInEmail));
+    },
+
+    'Non-Sync signup page - user signed into browser': function () {
+      return this.remote
+        .then(openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        // browserSignedInEmail not prefilled on signup page
+        .then(testElementValueEquals(selectors.SIGNUP.EMAIL, ''))
+        .then(click(selectors.SIGNUP.LINK_SIGN_IN))
+
+        .then(testElementExists(selectors.SIGNIN.HEADER))
+        .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, browserSignedInEmail))
+        .then(noSuchElement(selectors.SIGNIN.PASSWORD));
+    },
+
+    'Sync signin page - user signed into browser': function () {
+      return this.remote
+        .then(openPage(SYNC_SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        .then(testElementValueEquals(selectors.SIGNIN.EMAIL, browserSignedInEmail));
+    },
+
+    'Non-Sync signin page - user signed into browser, no user signed in locally': function () {
+      return this.remote
+        .then(openPage(SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, browserSignedInEmail))
+        // User can sign in with cached credentials, no password needed.
+        .then(noSuchElement(selectors.SIGNIN.PASSWORD));
+    },
+
+    'Non-Sync signin page - user signed into browser, user signed in locally': function () {
+      return this.remote
+        // First, sign in the user to populate localStorage
+        .then(openPage(SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }))
+        .then(fillOutSignIn(otherEmail, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+
+        // Then, sign in the user again, synthesizing the user having signed
+        // into Sync after the initial sign in.
+        .then(openPage(SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        // browsers version of the world is ignored for non-Sync signins if another
+        // user has already signed in.
+        .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, otherEmail))
+        // normal email element is in the DOM to help password managers.
+        .then(testElementValueEquals(selectors.SIGNIN.EMAIL, otherEmail))
+        .then(testElementExists(selectors.SIGNIN.PASSWORD));
+    },
+
+    'Sync signin page - no user signed into browser': function () {
+      return this.remote
+        .then(openPage(SYNC_SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }))
+        .then(testElementValueEquals(selectors.SIGNIN.EMAIL, ''));
+    },
+
+    'Sync signin page - no user signed into browser, user signed in locally': function () {
+      return this.remote
+        // First, sign in the user to populate localStorage
+        .then(openPage(SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }))
+        .then(fillOutSignIn(otherEmail, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+
+        .then(openPage(SYNC_SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }))
+
+        // unfortunately, this is one hole in our implementation. localStorage
+        // is totally ignored for Sync.
+        .then(testElementValueEquals(selectors.SIGNIN.EMAIL, ''));
+    },
+
+    'Non-Sync signin page - no user signed into browser': function () {
+      return this.remote
+        .then(openPage(SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }))
+        .then(testElementValueEquals(selectors.SIGNIN.EMAIL, ''));
+    },
+
+    'Sync force_auth page - user signed into browser is different to requested user': function () {
+      return this.remote
+        .then(openPage(`${SYNC_FORCE_AUTH_PAGE_URL}&email=${encodeURIComponent(otherEmail)}`, selectors.FORCE_AUTH.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        .then(testElementValueEquals(selectors.FORCE_AUTH.EMAIL, otherEmail));
+    },
+
+    'Non-Sync force_auth page - user signed into browser is different to requested user': function () {
+      return this.remote
+        .then(openPage(`${FORCE_AUTH_PAGE_URL}&email=${encodeURIComponent(otherEmail)}`, selectors.FORCE_AUTH.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        .then(testElementValueEquals(selectors.FORCE_AUTH.EMAIL, otherEmail));
+    },
+
+    'Sync settings page - user signed into browser': function () {
+      return this.remote
+        .then(openPage(SYNC_SETTINGS_PAGE_URL, selectors.SETTINGS.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        .then(testElementTextEquals(selectors.SETTINGS.PROFILE_HEADER, browserSignedInEmail));
+    },
+
+    'Non-Sync settings page - user signed into browser': function () {
+      return this.remote
+        .then(openPage(SETTINGS_PAGE_URL, selectors.SETTINGS.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        .then(testElementTextEquals(selectors.SETTINGS.PROFILE_HEADER, browserSignedInEmail));
+    },
+
+    'Sync settings page - no user signed into browser': function () {
+      return this.remote
+        .then(openPage(SYNC_SETTINGS_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }));
+    },
+
+    'Non-Sync settings page - no user signed into browser, no user signed in locally': function () {
+      return this.remote
+        .then(openPage(SETTINGS_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }));
+    },
+
+    'Non-Sync settings page - no user signed into browser, user signed in locally': function () {
+      return this.remote
+        .then(openPage(SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }))
+        .then(fillOutSignIn(otherEmail, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+
+        .then(openPage(SETTINGS_PAGE_URL, selectors.SETTINGS.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }))
+
+        .then(testElementTextEquals(selectors.SETTINGS.PROFILE_HEADER, otherEmail));
+    }
+  });
+});

--- a/tests/functional/fx_desktop_handshake.js
+++ b/tests/functional/fx_desktop_handshake.js
@@ -56,6 +56,8 @@ define([
             .then(createUser(browserSignedInEmail, PASSWORD, { preVerified: true }))
             .then((_browserSignedInAccount) => {
               browserSignedInAccount = _browserSignedInAccount;
+              browserSignedInAccount.email = browserSignedInEmail;
+              browserSignedInAccount.verified = true;
             });
         }
       })
@@ -66,6 +68,8 @@ define([
             .then(createUser(otherEmail, PASSWORD, { preVerified: true }))
             .then((_otherAccount) => {
               otherAccount = _otherAccount;
+              otherAccount.email = otherEmail;
+              otherAccount.verified = true;
             });
         }
       });

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -700,6 +700,54 @@ define([
       });
   });
 
+  /**
+   * Respond to a web channel message.
+   *
+   * @param   {string} expectedCommand command to respond to
+   * @param   {object} response response
+   * @returns {promise} resolves when complete
+   */
+  const respondToWebChannelMessage = thenify(function (expectedCommand, response) {
+    var attachedId = Math.floor(Math.random() * 10000);
+    return this.parent
+      .execute(function (expectedCommand, response, attachedId) {
+        function startListening() {
+          try {
+            addEventListener('WebChannelMessageToChrome', function listener(e) {
+              var command = e.detail.message.command;
+              var messageId = e.detail.message.messageId;
+
+              console.log('responding to', command, response);
+              if (command === expectedCommand) {
+                removeEventListener('WebChannelMessageToChrome', listener);
+                var event = new CustomEvent('WebChannelMessageToContent', {
+                  detail: {
+                    id: 'account_updates',
+                    message: {
+                      command: command,
+                      data: response,
+                      messageId: messageId
+                    }
+                  }
+                });
+
+                dispatchEvent(event);
+              }
+            });
+            $('body').append('<div>').addClass('attached' + attachedId);
+          } catch (e) {
+            // problem adding the listener, window may not be
+            // ready, try again.
+            setTimeout(startListening, 0);
+          }
+        }
+
+        startListening();
+      }, [ expectedCommand, response, attachedId ])
+      // once the event is attached it adds a div with an attachedId.
+      .then(testElementExists('.attached' + attachedId));
+  });
+
   function openWindow (url, name) {
     var newWindow = window.open(url, name || 'newwindow');
 
@@ -854,6 +902,15 @@ define([
     return this.parent
       .get(require.toUrl(url))
       .setFindTimeout(config.pageLoadTimeout)
+
+      .then(function () {
+        const webChannelResponses = options.webChannelResponses;
+        if (webChannelResponses) {
+          return Object.keys(webChannelResponses).reduce((parent, webChannelMessage) => {
+            return parent.then(respondToWebChannelMessage(webChannelMessage, webChannelResponses[webChannelMessage]));
+          }, this.parent);
+        }
+      })
 
       // Wait until the `readySelector` element is found to return.
       .then(testElementExists(readySelector))
@@ -1170,53 +1227,6 @@ define([
   var mousedown = mouseevent('mousedown');
   var mouseout = mouseevent('mouseout');
   var mouseup = mouseevent('mouseup');
-
-  /**
-   * Respond to a web channel message.
-   *
-   * @param   {string} expectedCommand command to respond to
-   * @param   {object} response response
-   * @returns {promise} resolves when complete
-   */
-  const respondToWebChannelMessage = thenify(function (expectedCommand, response) {
-    var attachedId = Math.floor(Math.random() * 10000);
-    return this.parent
-      .execute(function (expectedCommand, response, attachedId) {
-        function startListening() {
-          try {
-            addEventListener('WebChannelMessageToChrome', function listener(e) {
-              var command = e.detail.message.command;
-              var messageId = e.detail.message.messageId;
-
-              if (command === expectedCommand) {
-                removeEventListener('WebChannelMessageToChrome', listener);
-                var event = new CustomEvent('WebChannelMessageToContent', {
-                  detail: {
-                    id: 'account_updates',
-                    message: {
-                      command: command,
-                      data: response,
-                      messageId: messageId
-                    }
-                  }
-                });
-
-                dispatchEvent(event);
-              }
-            });
-            $('body').append('<div>').addClass('attached' + attachedId);
-          } catch (e) {
-            // problem adding the listener, window may not be
-            // ready, try again.
-            setTimeout(startListening, 0);
-          }
-        }
-
-        startListening();
-      }, [ expectedCommand, response, attachedId ])
-      // once the event is attached it adds a div with an attachedId.
-      .then(testElementExists('.attached' + attachedId));
-  });
 
   const clearBrowserNotifications = thenify(function () {
     return this.parent

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -717,7 +717,6 @@ define([
               var command = e.detail.message.command;
               var messageId = e.detail.message.messageId;
 
-              console.log('responding to', command, response);
               if (command === expectedCommand) {
                 removeEventListener('WebChannelMessageToChrome', listener);
                 var event = new CustomEvent('WebChannelMessageToContent', {

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Define selectors on a per-screen basis.
+ */
+define([], function () {
+  /*eslint-disable max-len*/
+  return {
+    FORCE_AUTH: {
+      EMAIL: 'input[type=email]',
+      HEADER: '#fxa-force-auth-header'
+    },
+    SETTINGS: {
+      HEADER: '#fxa-settings-header',
+      PROFILE_HEADER: '#fxa-settings-profile-header .card-header',
+      PROFILE_SUB_HEADER: '#fxa-settings-profile-header .card-subheader'
+    },
+    SIGNIN: {
+      EMAIL: 'input[type=email]',
+      EMAIL_NOT_EDITABLE: '.prefillEmail',
+      HEADER: '#fxa-signin-header',
+      PASSWORD: 'input[type=password]'
+    },
+    SIGNUP: {
+      EMAIL: 'input[type=email]',
+      HEADER: '#fxa-signup-header',
+      LINK_SIGN_IN: 'a#have-account'
+    }
+  };
+  /*eslint-enable max-len*/
+});

--- a/tests/functional/lib/ua-strings.js
+++ b/tests/functional/lib/ua-strings.js
@@ -9,6 +9,7 @@ define([], function () {
     'android_firefox': 'Mozilla/5.0 (Android 4.4; Mobile; rv:43.0) Gecko/41.0 Firefox/43.0',
     'desktop_chrome': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.59 Safari/537.36',
     'desktop_firefox': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:50.0) Gecko/20100101 Firefox/50.0',
+    'desktop_firefox_55': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0',
     'ios_firefox': 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
     'ios_firefox_6_0': 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/6.0 Mobile/12F69 Safari/600.1.4',
     'ios_firefox_6_1': 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/6.1 Mobile/12F69 Safari/600.1.4',

--- a/tests/intern_functional_circle.js
+++ b/tests/intern_functional_circle.js
@@ -21,6 +21,7 @@ define([
     'tests/functional/cookies_disabled',
     'tests/functional/delete_account',
     'tests/functional/force_auth',
+    'tests/functional/fx_desktop_handshake',
     'tests/functional/fx_fennec_v1_force_auth',
     'tests/functional/fx_fennec_v1_sign_in',
     'tests/functional/fx_fennec_v1_sign_up',


### PR DESCRIPTION
Very early stage yet, putting this up so we don't forget about it. Goes along with https://bugzilla.mozilla.org/attachment.cgi?id=8832820

Perform a handshake with the browser to use the browser as the canonical
source of truth when it comes to signed in accounts.

issue #4252
https://bugzilla.mozilla.org/show_bug.cgi?id=1308038