### PR TITLE
feat(CAD): `install_from.fx_desktop` A/B metric, use consistent names.

### DIFF
--- a/app/scripts/lib/experiments/connect-another-device.js
+++ b/app/scripts/lib/experiments/connect-another-device.js
@@ -20,21 +20,20 @@ define(function (require, exports, module) {
 
   module.exports = BaseExperiment.extend({
     notifications: {
-      'connectAnotherDevice.install_from.fennec': createSaveStateDelegate('install_from.fennec'),
+      'connectAnotherDevice.install_from.fx_android': createSaveStateDelegate('install_from.fx_android'),
+      'connectAnotherDevice.install_from.fx_desktop': createSaveStateDelegate('install_from.fx_desktop'),
       'connectAnotherDevice.install_from.other': createSaveStateDelegate('install_from.other'),
-      'connectAnotherDevice.install_from.other_android':
-        createSaveStateDelegate('install_from.other_android'),
-      'connectAnotherDevice.install_from.other_ios':
-        createSaveStateDelegate('install_from.other_ios'),
+      'connectAnotherDevice.install_from.other_android': createSaveStateDelegate('install_from.other_android'),
+      'connectAnotherDevice.install_from.other_ios': createSaveStateDelegate('install_from.other_ios'),
       'connectAnotherDevice.other_user_signed_in': createSaveStateDelegate('other_user_signed_in'),
       'connectAnotherDevice.signedin.false': createSaveStateDelegate('signedin.false'),
       'connectAnotherDevice.signedin.true': createSaveStateDelegate('signedin.true'),
       'connectAnotherDevice.signin.clicked': createSaveStateDelegate('signin.clicked'),
       'connectAnotherDevice.signin.eligible': createSaveStateDelegate('signin.eligible'),
       'connectAnotherDevice.signin.ineligible': createSaveStateDelegate('signin.ineligible'),
-      'connectAnotherDevice.signin_from.desktop': createSaveStateDelegate('signin_from.desktop'),
-      'connectAnotherDevice.signin_from.fennec': createSaveStateDelegate('signin_from.fennec'),
-      'connectAnotherDevice.signin_from.fxios': createSaveStateDelegate('signin_from.fxios'),
+      'connectAnotherDevice.signin_from.fx_android': createSaveStateDelegate('signin_from.fx_android'),
+      'connectAnotherDevice.signin_from.fx_desktop': createSaveStateDelegate('signin_from.fx_desktop'),
+      'connectAnotherDevice.signin_from.fx_ios': createSaveStateDelegate('signin_from.fx_ios'),
       'marketing.clicked': '_onMarketingClick',
       'marketing.impression': '_onMarketingImpression'
     },

--- a/app/scripts/templates/connect_another_device.mustache
+++ b/app/scripts/templates/connect_another_device.mustache
@@ -21,18 +21,6 @@
       </form>
     {{/canSignIn}}
     {{^canSignIn}}
-      {{#isFirefoxIos}}
-        <!-- user verifies in Fx for iOS, assume they are not signed in -->
-        <p id="signin-fxios">
-          {{#t}}Open settings and select Sign in to Firefox to complete set-up{{/t}}
-        </p>
-      {{/isFirefoxIos}}
-      {{#isOtherIos}}
-        <!-- Safari or Chrome for iOS, encourage installation of Fx -->
-        <p id="install-mobile-firefox-ios">
-          {{#t}}Sign in to Firefox for iOS to complete set-up{{/t}}
-        </p>
-      {{/isOtherIos}}
       {{#isFirefoxAndroid}}
         <!-- User verified in Fx for Android - they are using an old Fennec
         or are already signed in. Ignore old browsers, assume already signed in.
@@ -41,12 +29,29 @@
           {{#t}}Sign in to Firefox on another device to complete set-up{{/t}}
         </p>
       {{/isFirefoxAndroid}}
+      {{#isFirefoxDesktop}}
+        <p id="install-mobile-firefox-desktop">
+          {{#t}}Sign in to Firefox on another device to complete set-up{{/t}}
+        </p>
+      {{/isFirefoxDesktop}}
+      {{#isFirefoxIos}}
+        <!-- user verifies in Fx for iOS, assume they are not signed in -->
+        <p id="signin-fxios">
+          {{#t}}Open settings and select Sign in to Firefox to complete set-up{{/t}}
+        </p>
+      {{/isFirefoxIos}}
       {{#isOtherAndroid}}
         <!-- Another android browser, encourage Fx for Android installation -->
         <p id="install-mobile-firefox-android">
           {{#t}}Sign in to Firefox for Android to complete set-up{{/t}}
         </p>
       {{/isOtherAndroid}}
+      {{#isOtherIos}}
+        <!-- Safari or Chrome for iOS, encourage installation of Fx -->
+        <p id="install-mobile-firefox-ios">
+          {{#t}}Sign in to Firefox for iOS to complete set-up{{/t}}
+        </p>
+      {{/isOtherIos}}
       {{#isOther}}
         <!-- probably some desktop browser -->
         <p id="install-mobile-firefox-other">

--- a/app/tests/spec/lib/experiments/connect-another-device.js
+++ b/app/tests/spec/lib/experiments/connect-another-device.js
@@ -44,27 +44,20 @@ define(function (require, exports, module) {
       });
     }
 
-    testNotificationSavesState(
-      'connectAnotherDevice.install_from.fennec', null, 'install_from.fennec');
-    testNotificationSavesState(
-      'connectAnotherDevice.install_from.other', null, 'install_from.other');
-    testNotificationSavesState(
-      'connectAnotherDevice.install_from.other_android', null, 'install_from.other_android');
-    testNotificationSavesState(
-      'connectAnotherDevice.install_from.other_ios', null, 'install_from.other_ios');
-    testNotificationSavesState(
-      'connectAnotherDevice.other_user_signed_in', null, 'other_user_signed_in');
+    testNotificationSavesState('connectAnotherDevice.install_from.fx_android', null, 'install_from.fx_android');
+    testNotificationSavesState('connectAnotherDevice.install_from.fx_desktop', null, 'install_from.fx_desktop');
+    testNotificationSavesState('connectAnotherDevice.install_from.other', null, 'install_from.other');
+    testNotificationSavesState('connectAnotherDevice.install_from.other_android', null, 'install_from.other_android');
+    testNotificationSavesState('connectAnotherDevice.install_from.other_ios', null, 'install_from.other_ios');
+    testNotificationSavesState('connectAnotherDevice.other_user_signed_in', null, 'other_user_signed_in');
     testNotificationSavesState('connectAnotherDevice.signedin.false', null, 'signedin.false');
     testNotificationSavesState('connectAnotherDevice.signedin.true', null, 'signedin.true');
     testNotificationSavesState('connectAnotherDevice.signin.clicked', null, 'signin.clicked');
     testNotificationSavesState('connectAnotherDevice.signin.eligible', null, 'signin.eligible');
     testNotificationSavesState('connectAnotherDevice.signin.ineligible', null, 'signin.ineligible');
-    testNotificationSavesState(
-      'connectAnotherDevice.signin_from.desktop', null, 'signin_from.desktop');
-    testNotificationSavesState(
-      'connectAnotherDevice.signin_from.fennec', null, 'signin_from.fennec');
-    testNotificationSavesState(
-      'connectAnotherDevice.signin_from.fxios', null, 'signin_from.fxios');
+    testNotificationSavesState('connectAnotherDevice.signin_from.fx_android', null, 'signin_from.fx_android');
+    testNotificationSavesState('connectAnotherDevice.signin_from.fx_desktop', null, 'signin_from.fx_desktop');
+    testNotificationSavesState('connectAnotherDevice.signin_from.fx_ios', null, 'signin_from.fx_ios');
     testNotificationSavesState('marketing.clicked', { type: 'ios' }, 'marketing.click.ios');
     testNotificationSavesState('marketing.impression', { type: 'ios' }, 'marketing.impression.ios');
   });

--- a/app/tests/spec/views/connect_another_device.js
+++ b/app/tests/spec/views/connect_another_device.js
@@ -53,8 +53,12 @@ define(function (require, exports, module) {
       });
     });
 
+    function testIsNotified(expectedMessage) {
+      assert.isTrue(notifier.trigger.calledWith(expectedMessage));
+    }
+
     describe('render', () => {
-      describe('with a desktop user that is signed in', () => {
+      describe('with a Fx desktop user that is signed in', () => {
         beforeEach(() => {
           sinon.stub(user, 'isSignedInAccount', () => true);
 
@@ -63,9 +67,9 @@ define(function (require, exports, module) {
 
         it('shows the marketing area, logs appropriately', () => {
           assert.lengthOf(view.$('.marketing-area'), 1);
-          notifier.trigger.calledWith('connectAnotherDevice.signedin.true');
-          notifier.trigger.calledWith('connectAnotherDevice.signin.ineligible');
-          notifier.trigger.calledWith('connectAnotherDevice.install_from.other');
+          testIsNotified('connectAnotherDevice.signedin.true');
+          testIsNotified('connectAnotherDevice.signin.ineligible');
+          testIsNotified('connectAnotherDevice.install_from.fx_desktop');
         });
       });
 
@@ -89,13 +93,13 @@ define(function (require, exports, module) {
 
         it('shows the marketing area, logs appropriately', () => {
           assert.lengthOf(view.$('.marketing-area'), 1);
-          notifier.trigger.calledWith('connectAnotherDevice.signedin.true');
-          notifier.trigger.calledWith('connectAnotherDevice.signin.ineligible');
-          notifier.trigger.calledWith('connectAnotherDevice.install_from.fennec');
+          testIsNotified('connectAnotherDevice.signedin.true');
+          testIsNotified('connectAnotherDevice.signin.ineligible');
+          testIsNotified('connectAnotherDevice.install_from.fx_android');
         });
       });
 
-      describe('with a desktop user that can sign in', () => {
+      describe('with a Fx desktop user that can sign in', () => {
         beforeEach(() => {
           sinon.stub(view, '_getUap', () => {
             return {
@@ -117,9 +121,9 @@ define(function (require, exports, module) {
 
         it('shows a sign in button with the appropriate link, logs appropriately', () => {
           assert.lengthOf(view.$('#signin'), 1);
-          notifier.trigger.calledWith('connectAnotherDevice.signedin.false');
-          notifier.trigger.calledWith('connectAnotherDevice.signin.eligible');
-          notifier.trigger.calledWith('connectAnotherDevice.signin_from.desktop');
+          testIsNotified('connectAnotherDevice.signedin.false');
+          testIsNotified('connectAnotherDevice.signin.eligible');
+          testIsNotified('connectAnotherDevice.signin_from.fx_desktop');
         });
       });
 
@@ -145,9 +149,9 @@ define(function (require, exports, module) {
 
         it('shows a sign in button with the appropriate link, logs appropriately', () => {
           assert.lengthOf(view.$('#signin'), 1);
-          notifier.trigger.calledWith('connectAnotherDevice.signedin.false');
-          notifier.trigger.calledWith('connectAnotherDevice.signin.eligible');
-          notifier.trigger.calledWith('connectAnotherDevice.signin_from.fennec');
+          testIsNotified('connectAnotherDevice.signedin.false');
+          testIsNotified('connectAnotherDevice.signin.eligible');
+          testIsNotified('connectAnotherDevice.signin_from.fx_android');
         });
       });
 
@@ -173,7 +177,7 @@ define(function (require, exports, module) {
             .then(() => {
               assert.lengthOf(view.$('#signin-fxios'), 1);
               assert.lengthOf(view.$('.marketing-area'), 0);
-              notifier.trigger.calledWith('connectAnotherDevice.signin_from.fxios');
+              testIsNotified('connectAnotherDevice.signin_from.fx_ios');
             });
         });
 
@@ -193,7 +197,7 @@ define(function (require, exports, module) {
             .then(() => {
               assert.lengthOf(view.$('#install-mobile-firefox-ios'), 1);
               assert.lengthOf(view.$('.marketing-area'), 1);
-              notifier.trigger.calledWith('connectAnotherDevice.install_from.other_ios');
+              testIsNotified('connectAnotherDevice.install_from.other_ios');
             });
         });
 
@@ -213,7 +217,27 @@ define(function (require, exports, module) {
             .then(() => {
               assert.lengthOf(view.$('#install-mobile-firefox-android'), 1);
               assert.lengthOf(view.$('.marketing-area'), 1);
-              notifier.trigger.calledWith('connectAnotherDevice.install_from.other_android');
+              testIsNotified('connectAnotherDevice.install_from.other_android');
+            });
+        });
+
+        it('shows FxDesktop text, marketing area to Fx Desktop users', () => {
+          sinon.stub(view, '_getUap', () => {
+            return {
+              isAndroid: () => false,
+              isFirefox: () => true,
+              isFirefoxAndroid: () => false,
+              isFirefoxDesktop: () => true,
+              isFirefoxIos: () => false,
+              isIos: () => false
+            };
+          });
+
+          return view.render()
+            .then(() => {
+              assert.lengthOf(view.$('#install-mobile-firefox-desktop'), 1);
+              assert.lengthOf(view.$('.marketing-area'), 1);
+              testIsNotified('connectAnotherDevice.install_from.fx_desktop');
             });
         });
 
@@ -233,7 +257,7 @@ define(function (require, exports, module) {
             .then(() => {
               assert.lengthOf(view.$('#install-mobile-firefox-other'), 1);
               assert.lengthOf(view.$('.marketing-area'), 1);
-              notifier.trigger.calledWith('connectAnotherDevice.install_from.other');
+              testIsNotified('connectAnotherDevice.install_from.other');
             });
         });
       });
@@ -457,7 +481,7 @@ define(function (require, exports, module) {
       it('notifies of click', () => {
         view._onSignInClick();
 
-        assert.isTrue(notifier.trigger.calledWith('connectAnotherDevice.signin.clicked'));
+        testIsNotified('connectAnotherDevice.signin.clicked');
       });
     });
   });

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -372,29 +372,33 @@ No page specific events
 ## Experiment Metrics
 ### connectAnotherDevice
 
-* experiment.control.connectAnotherDevice.enrolled
-* experiment.control.connectAnotherDevice.marketing.click.android
-* experiment.control.connectAnotherDevice.marketing.click.ios
-* experiment.control.connectAnotherDevice.marketing.impression.android
-* experiment.control.connectAnotherDevice.marketing.impression.ios
-* experiment.treatment.connectAnotherDevice.enrolled
-* experiment.treatment.connectAnotherDevice.install_from.fennec
-* experiment.treatment.connectAnotherDevice.install_from.other
-* experiment.treatment.connectAnotherDevice.install_from.other_android
-* experiment.treatment.connectAnotherDevice.install_from.other_ios
-* experiment.treatment.connectAnotherDevice.marketing.click.android
-* experiment.treatment.connectAnotherDevice.marketing.click.ios
-* experiment.treatment.connectAnotherDevice.marketing.impression.android
-* experiment.treatment.connectAnotherDevice.marketing.impression.ios
-* experiment.treatment.connectAnotherDevice.other_user_signed_in
-* experiment.treatment.connectAnotherDevice.signedin.true
-* experiment.treatment.connectAnotherDevice.signedin.false
-* experiment.treatment.connectAnotherDevice.signin.clicked
-* experiment.treatment.connectAnotherDevice.signin.eligible
-* experiment.treatment.connectAnotherDevice.signin.ineligible
-* experiment.treatment.connectAnotherDevice.signin_from.desktop
-* experiment.treatment.connectAnotherDevice.signin_from.fennec
-* experiment.treatment.connectAnotherDevice.signin_from.fxios
+#### Control group metric
+* experiment.control.connectAnotherDevice.enrolled - user is enrolled in connectAnotherDevice experiment in the `control` group.
+* experiment.control.connectAnotherDevice.marketing.click.android - User has clicked on the Install Fx Android link
+* experiment.control.connectAnotherDevice.marketing.click.ios - User has clicked on the Install Fx iOS link
+* experiment.control.connectAnotherDevice.marketing.impression.android - User was displayed the Install Fx Android link
+* experiment.control.connectAnotherDevice.marketing.impression.ios - User was displayed the Install Fx iOS link
+
+#### Treatment group events
+* experiment.treatment.connectAnotherDevice.enrolled - user is enrolled in connectAnotherDevice experiment in the `treatment` group
+* experiment.treatment.connectAnotherDevice.install_from.fx_android - Fx Android user encouraged to install Fx on more devices
+* experiment.treatment.connectAnotherDevice.install_from.fx_desktop - Fx Desktop user encouraged to install Fx on their devices
+* experiment.treatment.connectAnotherDevice.install_from.other_android - Non-Fx Android user encouraged to install Fx Android
+* experiment.treatment.connectAnotherDevice.install_from.other_ios - Non-Fx iOS user encouraged to install Fx iOS
+* experiment.treatment.connectAnotherDevice.install_from.other - User on non-Fx, non-Android, non-iOS device is encouraged to install Fx on their devices
+* experiment.treatment.connectAnotherDevice.marketing.click.android - User has clicked on the Install Fx for Android link
+* experiment.treatment.connectAnotherDevice.marketing.click.ios - User has clicked on the Install Fx for iOS link
+* experiment.treatment.connectAnotherDevice.marketing.impression.android - User was displayed the Install Fx for Android
+* experiment.treatment.connectAnotherDevice.marketing.impression.ios - User was displayed the Install Fx for iOS link
+* experiment.treatment.connectAnotherDevice.other_user_signed_in - Another user is signed in, so user cannot connect another device
+* experiment.treatment.connectAnotherDevice.signedin.true - User is signed in.
+* experiment.treatment.connectAnotherDevice.signedin.false - User is not signed in.
+* experiment.treatment.connectAnotherDevice.signin.clicked - User who can sign in clicked the "Sign in" button.
+* experiment.treatment.connectAnotherDevice.signin.eligible - User verified in a 2nd, disconnected, Firefox and can sign in.
+* experiment.treatment.connectAnotherDevice.signin.ineligible - User is not eligible to see the "Sign in" button.
+* experiment.treatment.connectAnotherDevice.signin_from.fx_android - User who is eligible to sign in is on Fx Android.
+* experiment.treatment.connectAnotherDevice.signin_from.fx_desktop - User who is eligible to sign in is on Fx Desktop.
+* experiment.treatment.connectAnotherDevice.signin_from.fx_ios - User who is eligible to sign in is on Fx iOS.
 
 ### mailcheck
 

--- a/tests/functional/connect_another_device.js
+++ b/tests/functional/connect_another_device.js
@@ -38,6 +38,7 @@ define([
   var SELECTOR_CONFIRM_SIGNIN_HEADER = '#fxa-confirm-signin-header';
   var SELECTOR_CONTINUE_BUTTON = 'form div a';
   var SELECTOR_INSTALL_TEXT_ANDROID = '#install-mobile-firefox-android';
+  var SELECTOR_INSTALL_TEXT_FX_DESKTOP = '#install-mobile-firefox-desktop';
   var SELECTOR_INSTALL_TEXT_IOS = '#install-mobile-firefox-ios';
   var SELECTOR_INSTALL_TEXT_OTHER = '#install-mobile-firefox-other';
   var SELECTOR_INSTALL_TEXT_FROM_ANDROID = '#connect-other-firefox-from-android';
@@ -110,7 +111,7 @@ define([
         .then(testElementExists(SELECTOR_PAGE_LOADED))
         .then(testElementExists(SELECTOR_SUCCESS_SAME_BROWSER))
         .then(noSuchElement(SELECTOR_CONTINUE_BUTTON))
-        .then(testElementExists(SELECTOR_INSTALL_TEXT_OTHER))
+        .then(testElementExists(SELECTOR_INSTALL_TEXT_FX_DESKTOP))
         .then(testHrefEquals(SELECTOR_MARKETING_LINK_IOS, ADJUST_LINK_IOS))
         .then(testHrefEquals(SELECTOR_MARKETING_LINK_ANDROID, ADJUST_LINK_ANDROID));
     },


### PR DESCRIPTION
`install_from.fx_desktop` used to be a part of `install_from.other`,
which was not ideal in DataDog. This means the semantics of
`install_from.other` have changed slightly, and will drop significantly
once this feature is sent to production.

I also took the opportunity to unify the reported event nomenclature.
Since these metrics are only used as part of the A/B test, I didn't
feel too bad about it.

Updated names:

* `install_from.fennec` => `install_from.fx_android`
* `signin_from.desktop` => `signin_from.fx_desktop`
* `signin_from.fennec` => `signin_from.fx_android`
* `signin_from.fxios` => `signin_from.fx_ios`

fixes #4692

@mozilla/fxa-devs - r?

@ryanfeeley - I added the new metric as `install_from.fx_desktop`. I have also renamed some of the other metrics, see above. These changes don't affect the actual A/B test that's going on, which is "which app store buttons have a higher click through rate?" Those names stayed the same.