### PR TITLE
fix(navigation): Fixes for ESC key pressing in settings view

### DIFF
--- a/app/scripts/templates/settings/clients.mustache
+++ b/app/scripts/templates/settings/clients.mustache
@@ -52,7 +52,7 @@
 
       <div class="button-row">
         <button type="submit" class="settings-button primary clients-refresh">{{#t}}Refresh{{/t}}</button>
-        <button class="settings-button secondary cancel" autofocus>{{#t}}Done{{/t}}</button>
+        <button class="settings-button secondary cancel">{{#t}}Done{{/t}}</button>
       </div>
     </form>
   </div>

--- a/app/scripts/templates/settings/clients.mustache
+++ b/app/scripts/templates/settings/clients.mustache
@@ -52,7 +52,7 @@
 
       <div class="button-row">
         <button type="submit" class="settings-button primary clients-refresh">{{#t}}Refresh{{/t}}</button>
-        <button class="settings-button secondary cancel">{{#t}}Done{{/t}}</button>
+        <button class="settings-button secondary cancel" autofocus>{{#t}}Done{{/t}}</button>
       </div>
     </form>
   </div>

--- a/app/scripts/views/app.js
+++ b/app/scripts/views/app.js
@@ -36,12 +36,14 @@ define(function (require, exports, module) {
     },
 
     onKeyUp (event) {
-      // Application level listener for keyboard events. This is
+      // Global listener for keyboard events. This is
       // useful for cases where the view has lost focus
       // but you still want to perform an action on that view.
 
       // Handle user pressing `ESC`
       if (event.which === KeyCodes.ESCAPE) {
+
+        // Pressing ESC when any modal is visible should close the modal.
         if ($.modal.isActive()) {
           $.modal.close();
         } else if (event.currentTarget.className.indexOf('settings') >= 0) {

--- a/app/scripts/views/app.js
+++ b/app/scripts/views/app.js
@@ -13,6 +13,7 @@ define(function (require, exports, module) {
   const Backbone = require('backbone');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
+  const KeyCodes = require('lib/key-codes');
   const LoadingMixin = require('views/mixins/loading-mixin');
   const p = require('lib/promise');
 
@@ -30,7 +31,27 @@ define(function (require, exports, module) {
     },
 
     events: {
-      'click a[href^="/"]': 'onAnchorClick'
+      'click a[href^="/"]': 'onAnchorClick',
+      'keyup': 'onKeyUp'
+    },
+
+    onKeyUp (event) {
+      // Application level listener for keyboard events. This is
+      // useful for cases where the view has lost focus
+      // but you still want to perform an action on that view.
+
+      // Handle user pressing `ESC`
+      if (event.which === KeyCodes.ESCAPE) {
+        if ($.modal.isActive()) {
+          $.modal.close();
+        } else if (event.currentTarget.className.indexOf('settings') >= 0) {
+
+          // If event came from any settings view, close all panels and
+          // goto base settings view.
+          $('.settings-unit').removeClass('open');
+          this.navigate('settings');
+        }
+      }
     },
 
     onAnchorClick (event) {

--- a/app/scripts/views/mixins/modal-panel-mixin.js
+++ b/app/scripts/views/mixins/modal-panel-mixin.js
@@ -23,6 +23,7 @@ define(function (require, exports, module) {
     openPanel () {
       this.$el.modal({
         clickClose: false, // we take care of closing on the background ourselves.
+        escapeClose: false, // we take care of closing on the escape key ourselves.
         opacity: 0.75,
         showClose: false,
         zIndex: 999
@@ -64,6 +65,7 @@ define(function (require, exports, module) {
 
     onAfterClose () {
       this.destroy(true);
+      this.trigger('modal-cancel');
       $('.blocker').off('click', this._boundBlockerClick);
     },
 

--- a/app/scripts/views/mixins/modal-settings-panel-mixin.js
+++ b/app/scripts/views/mixins/modal-settings-panel-mixin.js
@@ -29,14 +29,18 @@ define(function (require, exports, module) {
       this.navigate('settings/avatar/change');
     },
 
+    _returnToClients () {
+      this.navigate('settings/clients');
+    },
+
     _returnToSettings () {
       this.navigate('settings');
     },
 
     onModalCancel () {
-      // A view could have already navigated. If so, do not
-      // attempt to navigate a second time.
-      if (! this._hasNavigated) {
+      if (this.currentPage === 'settings/clients/disconnect') {
+        this._returnToClients();
+      } else {
         this._returnToSettings();
       }
     },

--- a/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/app/scripts/views/mixins/settings-panel-mixin.js
@@ -28,13 +28,6 @@ define(function (require, exports, module) {
       this.$('[autofocus]')
         .attr('data-autofocus-on-panel-open', true)
         .removeAttr('autofocus');
-
-
-      // The client view is a special case because the model is rendered
-      // after being added. Manually set the focus.
-      if (this.viewName === 'settings.clients') {
-        this.focus(this.$('[data-autofocus-on-panel-open]'));
-      }
     },
 
     _triggerPanel (event) {

--- a/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/app/scripts/views/mixins/settings-panel-mixin.js
@@ -10,7 +10,6 @@ define(function (require, exports, module) {
 
   const $ = require('jquery');
   const BaseView = require('views/base');
-  const KeyCodes = require('lib/key-codes');
 
   module.exports = {
     initialize (options) {
@@ -19,8 +18,7 @@ define(function (require, exports, module) {
 
     events: {
       'click .cancel': BaseView.preventDefaultThen('_closePanelReturnToSettings'),
-      'click .settings-unit-toggle': BaseView.preventDefaultThen('_triggerPanel'),
-      'keyup .settings-unit': 'onKeyUp'
+      'click .settings-unit-toggle': BaseView.preventDefaultThen('_triggerPanel')
     },
 
     afterRender () {
@@ -30,11 +28,12 @@ define(function (require, exports, module) {
       this.$('[autofocus]')
         .attr('data-autofocus-on-panel-open', true)
         .removeAttr('autofocus');
-    },
 
-    onKeyUp (event) {
-      if (event.which === KeyCodes.ESCAPE) {
-        this.hidePanel();
+
+      // The client view is a special case because the model is rendered
+      // after being added. Manually set the focus.
+      if (this.viewName === 'settings.clients') {
+        this.focus(this.$('[data-autofocus-on-panel-open]'));
       }
     },
 
@@ -46,6 +45,8 @@ define(function (require, exports, module) {
     },
 
     openPanel () {
+      this.closeAllPanels();
+
       this.$('.settings-unit').addClass('open');
       this.focus(this.$('[data-autofocus-on-panel-open]'));
     },
@@ -89,6 +90,10 @@ define(function (require, exports, module) {
 
     closePanel () {
       this.$('.settings-unit').removeClass('open');
+    },
+
+    closeAllPanels () {
+      $('.settings-unit').removeClass('open');
     },
 
     displaySuccess (msg) {

--- a/app/tests/spec/views/app.js
+++ b/app/tests/spec/views/app.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
   const Backbone = require('backbone');
   const chai = require('chai');
   const Environment = require('lib/environment');
+  const KeyCodes = require('lib/key-codes');
   const Notifier = require('lib/channels/notifier');
   const p = require('lib/promise');
   const sinon = require('sinon');
@@ -445,6 +446,20 @@ define(function (require, exports, module) {
 
       it('sets the title', function () {
         assert.isTrue(view.setTitle.calledWith('the title, the second title'));
+      });
+    });
+
+    describe('onKeyUp', function () {
+
+      before(function () {
+        createDeps();
+        sinon.spy(view, 'navigate');
+      });
+
+      it('press escape from settings view', function () {
+        view.onKeyUp({ currentTarget: {className: 'settings'}, which: KeyCodes.ESCAPE });
+        assert.isTrue(view.navigate.calledOnce);
+        assert.isTrue(view.navigate.calledWith('settings'));
       });
     });
   });

--- a/app/tests/spec/views/mixins/modal-settings-panel-mixin.js
+++ b/app/tests/spec/views/mixins/modal-settings-panel-mixin.js
@@ -71,19 +71,18 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('`navigate` has already been called', () => {
-        it('does not navigate to settings', () => {
-          view.navigate('signin');
-
+      describe('cancel from clients disconnect modal navigates to /settings/clients', () => {
+        it('navigates to /settings/clients', () => {
+          view.currentPage = 'settings/clients/disconnect';
           view.trigger('modal-cancel');
-
           assert.isTrue(view.navigate.calledOnce);
-          assert.isTrue(view.navigate.calledWith('signin'));
+          assert.isTrue(view.navigate.calledWith('settings/clients'));
         });
       });
 
-      describe('`navigate` has not been called', () => {
-        it('navigates to settings', () => {
+      describe('cancel from other modal navigates to /settings', () => {
+        it('does not navigate to settings', () => {
+          view.currentPage = 'settings/avatar/change';
           view.trigger('modal-cancel');
           assert.isTrue(view.navigate.calledOnce);
           assert.isTrue(view.navigate.calledWith('settings'));

--- a/app/tests/spec/views/mixins/settings-panel-mixin.js
+++ b/app/tests/spec/views/mixins/settings-panel-mixin.js
@@ -10,7 +10,6 @@ define(function (require, exports, module) {
   const Cocktail = require('cocktail');
   const FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
   const FormView = require('views/form');
-  const KeyCodes = require('lib/key-codes');
   const Metrics = require('lib/metrics');
   const SettingsPanelMixin = require('views/mixins/settings-panel-mixin');
   const sinon = require('sinon');
@@ -79,18 +78,6 @@ define(function (require, exports, module) {
         assert.isTrue(view.closePanel.called);
         assert.isTrue(view.clearInput.called);
         assert.isTrue(view.navigate.calledWith('settings'));
-      });
-
-      it('calls hidePanel when esc key is pressed', function () {
-        sinon.stub(view, 'hidePanel', function () {});
-        view.onKeyUp({ which: KeyCodes.ESCAPE });
-        assert.isTrue(view.hidePanel.called);
-      });
-
-      it('does not call hidePanel when other keys are pressed', function () {
-        sinon.spy(view, 'hidePanel');
-        view.onKeyUp({ which: KeyCodes.ENTER });
-        assert.isFalse(view.hidePanel.called);
       });
     });
 


### PR DESCRIPTION
This PR attempts to tackle some of the current issues when using the escape key in our settings view. It doesn't do a complete refactor of our settings navigation, just minor updates to make it more user friendly.

Updates
* Moves keyboard event checks to the `app.js` view.
* Fixes issue where open a panel, then lose focus of that panel, you could not close panel by pressing ESC, now you can.
* Fixes issue where opening a modal and dismissing via ESC would not let you reopen modal.
* Can only have one open panel at a time now.

Fixes https://github.com/mozilla/fxa-content-server/issues/4569,  https://github.com/mozilla/fxa-content-server/issues/4169

@vladikoff @shane-tomlinson Thoughts on approach?