### PR TITLE
Add csp to html 404 page

### DIFF
--- a/server/bin/fxa-content-server.js
+++ b/server/bin/fxa-content-server.js
@@ -148,6 +148,11 @@ function makeApp() {
   // it's a four-oh-four not found.
   app.use(fourOhFour);
 
+  // add CSP header if the route changed the content-type to html
+  if (config.get('csp.enabled')) {
+    app.use(csp({ rules: cspRulesBlocking }));
+  }
+
   // The error handler must be before any other error middleware
   app.use(raven.ravenModule.middleware.express.errorHandler(raven.ravenMiddleware));
 

--- a/server/lib/404.js
+++ b/server/lib/404.js
@@ -8,6 +8,7 @@ module.exports = function (req, res, next) {
   res.status(404);
 
   if (req.accepts('html')) {
+    res.setHeader('content-type', 'text/html; charset=utf-8');
     return res.render('404');
   }
 

--- a/server/lib/csp.js
+++ b/server/lib/csp.js
@@ -11,7 +11,7 @@
 const helmet = require('helmet');
 const utils = require('./utils');
 
-function isCspRequired(req) {
+function isCspRequired(req, res) {
   if (req.method !== 'GET') {
     return false;
   }
@@ -23,6 +23,9 @@ function isCspRequired(req) {
   }
 
   // Only HTML files need CSP headers.
+  if (res && res.getHeader && res.getHeader('content-type')) {
+    return utils.isHTMLPage(path) || /html/i.test(res.getHeader('content-type'));
+  }
   return utils.isHTMLPage(path);
 }
 
@@ -30,7 +33,7 @@ module.exports = function (config) {
   const cspMiddleware = helmet.contentSecurityPolicy(config.rules);
 
   return function (req, res, next) {
-    if (! isCspRequired(req)) {
+    if (! isCspRequired(req, res)) {
       return next();
     }
 

--- a/tests/server/csp.js
+++ b/tests/server/csp.js
@@ -24,6 +24,7 @@ define([
     assert.isFalse(csp.isCspRequired({ method: 'GET', path: '/fonts/clearsans.woff' }));
 
     assert.isTrue(csp.isCspRequired({ method: 'GET', path: '/404.html' }));
+    assert.isTrue(csp.isCspRequired({ method: 'GET', path: '/notfound.css' }, { getHeader: () => 'text/html' }));
     assert.isTrue(csp.isCspRequired({ method: 'GET', path: '/' }));
     assert.isTrue(csp.isCspRequired({ method: 'GET', path: '/confirm' }));
   };


### PR DESCRIPTION
refs: [get FxA passing the webappsec baseline](https://github.com/mozilla-services/foxsec/issues/177) (should be the last application level content-server change)

Note: the 404 page doesn't include any JS and could be served with a much more locked down header, but I figured it'd to keep things simpler to use the default CSP config.

Functional Tests:

- [x] 404 page includes CSP header for non-html path

```
» curl -IX GET http://localhost:3030/sitemap.xml
HTTP/1.1 404 Not Found
X-XSS-Protection: 1; mode=block
Strict-Transport-Security: max-age=15552000; includeSubDomains
X-Content-Type-Options: nosniff
Content-Type: text/html; charset=utf-8
Content-Security-Policy: connect-src 'self' http://127.0.0.1:9000 http://127.0.0.1:9010 http://127.0.0.1:1111 http://127.0.0.1:1114; d
efault-src 'self'; font-src 'self'; img-src 'self' data: https://secure.gravatar.com http://127.0.0.1:1112; media-src blob:; object-sr
c 'none'; report-uri /_/csp-violation; script-src 'self'; style-src 'self' 'sha256-9n6ek6ecEYlqel7uDyKLy6fdGNo3vw/uScXSq9ooQlk='
X-Content-Security-Policy: connect-src 'self' http://127.0.0.1:9000 http://127.0.0.1:9010 http://127.0.0.1:1111 http://127.0.0.1:1114;
 default-src 'self'; font-src 'self'; img-src 'self' data: https://secure.gravatar.com http://127.0.0.1:1112; media-src blob:; object-
src 'none'; report-uri /_/csp-violation; script-src 'self'; style-src 'self' 'sha256-9n6ek6ecEYlqel7uDyKLy6fdGNo3vw/uScXSq9ooQlk='
X-WebKit-CSP: connect-src 'self' http://127.0.0.1:9000 http://127.0.0.1:9010 http://127.0.0.1:1111 http://127.0.0.1:1114; default-src
'self'; font-src 'self'; img-src 'self' data: https://secure.gravatar.com http://127.0.0.1:1112; media-src blob:; object-src 'none'; r
eport-uri /_/csp-violation; script-src 'self'; style-src 'self' 'sha256-9n6ek6ecEYlqel7uDyKLy6fdGNo3vw/uScXSq9ooQlk='
Content-Length: 24
Date: Thu, 16 Feb 2017 21:01:26 GMT
Connection: keep-alive
```

- [x] non-html 404 page does not include CSP header

```
» curl -H 'Accept: application/json' -IX GET http://localhost:3030/sitemap.xml
HTTP/1.1 404 Not Found
X-XSS-Protection: 1; mode=block
Strict-Transport-Security: max-age=15552000; includeSubDomains
X-Content-Type-Options: nosniff
Content-Type: application/json; charset=utf-8
Content-Length: 21
ETag: W/"15-Lvrg4Gz9w+rMdDVG/1lddA"
Date: Thu, 16 Feb 2017 21:02:40 GMT
Connection: keep-alive
```

- [x] other page returns CSP as usual

```
» curl -IX GET http://localhost:3030/
HTTP/1.1 200 OK
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
Strict-Transport-Security: max-age=15552000; includeSubDomains
X-Content-Type-Options: nosniff
Content-Security-Policy: connect-src 'self' http://127.0.0.1:9000 http://127.0.0.1:9010 http://127.0.0.1:1111 http://127.0.0.1:1114; d
efault-src 'self'; font-src 'self'; img-src 'self' data: https://secure.gravatar.com http://127.0.0.1:1112; media-src blob:; object-sr
c 'none'; report-uri /_/csp-violation; script-src 'self'; style-src 'self' 'sha256-9n6ek6ecEYlqel7uDyKLy6fdGNo3vw/uScXSq9ooQlk='
X-Content-Security-Policy: connect-src 'self' http://127.0.0.1:9000 http://127.0.0.1:9010 http://127.0.0.1:1111 http://127.0.0.1:1114;
 default-src 'self'; font-src 'self'; img-src 'self' data: https://secure.gravatar.com http://127.0.0.1:1112; media-src blob:; object-
src 'none'; report-uri /_/csp-violation; script-src 'self'; style-src 'self' 'sha256-9n6ek6ecEYlqel7uDyKLy6fdGNo3vw/uScXSq9ooQlk='
X-WebKit-CSP: connect-src 'self' http://127.0.0.1:9000 http://127.0.0.1:9010 http://127.0.0.1:1111 http://127.0.0.1:1114; default-src
'self'; font-src 'self'; img-src 'self' data: https://secure.gravatar.com http://127.0.0.1:1112; media-src blob:; object-src 'none'; r
eport-uri /_/csp-violation; script-src 'self'; style-src 'self' 'sha256-9n6ek6ecEYlqel7uDyKLy6fdGNo3vw/uScXSq9ooQlk='
X-Robots-Tag: noindex,nofollow
Content-Type: text/html; charset=utf-8
Content-Length: 3472
ETag: W/"d90-Dh4DnXs0aQ8hhLURkG5X/Q"
Date: Thu, 16 Feb 2017 21:03:56 GMT
Connection: keep-alive
```
