### PR TITLE
refactor(client): Extract a PulseGraphicsMixin.

### DIFF
--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -14,6 +14,7 @@ define(function (require, exports, module) {
   const ExperimentMixin = require('views/mixins/experiment-mixin');
   const OpenConfirmationEmailMixin = require('views/mixins/open-webmail-mixin');
   const p = require('lib/promise');
+  const PulseGraphicMixin = require('views/mixins/pulse-graphic-mixin');
   const ResendMixin = require('views/mixins/resend-mixin');
   const ResumeTokenMixin = require('views/mixins/resume-token-mixin');
   const ServiceMixin = require('views/mixins/service-mixin');
@@ -88,9 +89,6 @@ define(function (require, exports, module) {
     },
 
     afterRender () {
-      var graphic = this.$el.find('.graphic');
-      graphic.addClass('pulse');
-
       this.transformLinks();
       return proto.afterRender.call(this);
     },
@@ -187,6 +185,7 @@ define(function (require, exports, module) {
     BackMixin,
     ExperimentMixin,
     OpenConfirmationEmailMixin,
+    PulseGraphicMixin,
     ResendMixin,
     ResumeTokenMixin,
     ServiceMixin,

--- a/app/scripts/views/mixins/pulse-graphic-mixin.js
+++ b/app/scripts/views/mixins/pulse-graphic-mixin.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A mixin to pulse the primary graphic on the view.
+ */
+define((require, exports, module) => {
+  'use strict';
+
+  return {
+    afterRender () {
+      this.$('.graphic').addClass('pulse');
+    }
+  };
+});

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -15,6 +15,7 @@ define(function (require, exports, module) {
   const ExperimentMixin = require('views/mixins/experiment-mixin');
   const FormView = require('views/form');
   const MarketingMixin = require('views/mixins/marketing-mixin');
+  const PulseGraphicMixin = require('views/mixins/pulse-graphic-mixin');
   const ServiceMixin = require('views/mixins/service-mixin');
   const Template = require('stache!templates/ready');
   const VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
@@ -53,7 +54,6 @@ define(function (require, exports, module) {
 
   /*eslint-enable camelcase*/
 
-  const proto = FormView.prototype;
   const View = FormView.extend({
     template: Template,
     className: 'ready',
@@ -116,13 +116,6 @@ define(function (require, exports, module) {
       return !! (this.isSignUp() &&
                  redirectUri &&
                  verificationRedirect === Constants.VERIFICATION_REDIRECT_ALWAYS);
-    },
-
-    afterRender () {
-      var graphic = this.$el.find('.graphic');
-      graphic.addClass('pulse');
-
-      return proto.afterRender.call(this);
     }
   });
 
@@ -130,6 +123,7 @@ define(function (require, exports, module) {
     View,
     ExperimentMixin,
     MarketingMixin({ marketingId: Constants.MARKETING_ID_SPRING_2015 }),
+    PulseGraphicMixin,
     ServiceMixin,
     VerificationReasonMixin
   );

--- a/app/tests/spec/views/mixins/pulse-graphic-mixin.js
+++ b/app/tests/spec/views/mixins/pulse-graphic-mixin.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define((require, exports, module) => {
+  'use strict';
+
+  const { assert } = require('chai');
+  const BaseView = require('views/base');
+  const Cocktail = require('cocktail');
+  const PulseGraphicMixin = require('views/mixins/pulse-graphic-mixin');
+
+  const View = BaseView.extend({
+    template: () => '<div class="graphic"></div>'
+  });
+
+  Cocktail.mixin(
+    View,
+    PulseGraphicMixin
+  );
+
+  describe('views/mixins/pulse-graphic-mixin', () => {
+    let view;
+
+    beforeEach(() => {
+      view = new View({});
+      return view.render();
+    });
+
+    afterEach(() => {
+      view.remove();
+      view.destroy();
+    });
+
+    it('adds the `pulse` class to `.graphic`', () => {
+      assert.isTrue(view.$('.graphic').hasClass('pulse'));
+    });
+  });
+});

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -140,6 +140,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/password-prompt-mixin',
     '../tests/spec/views/mixins/password-reset-mixin',
     '../tests/spec/views/mixins/password-strength-mixin',
+    '../tests/spec/views/mixins/pulse-graphic-mixin',
     '../tests/spec/views/mixins/resend-mixin',
     '../tests/spec/views/mixins/resume-token-mixin',
     '../tests/spec/views/mixins/service-mixin',


### PR DESCRIPTION
## What is this?
A tiny mixin to pulse the main graphic whenever a view is displayed.

## Why?
With Send SMS, logic to pulse the main graphic was duplicated in 3 locations.
That seemed silly.

Not attached to an issue, but will be used by the [send-sms PR](https://github.com/mozilla/fxa-content-server/pull/4625).

@philbooth or @vbudhram - r?