### PR TITLE
fix(notifications): Allow a notification handler to be spied upon.

### DIFF
--- a/app/scripts/lib/channels/notifier-mixin.js
+++ b/app/scripts/lib/channels/notifier-mixin.js
@@ -62,13 +62,17 @@ define(function (require, exports, module) {
         return false;
       }
 
-      for (var notificationName in notifications) {
-        var method = notifications[notificationName];
-        if (_.isString(method)) {
-          method = consumer[method];
-        }
-
-        if (_.isFunction(method)) {
+      for (let notificationName in notifications) {
+        let method = notifications[notificationName];
+        if (_.isString(method) && _.isFunction(consumer[method])) {
+          this.on(notificationName, (...args) => {
+            // The level of indirection is used to allow for
+            // late-binding when using sinon spies & stubs.
+            // Without indirection, the original function is
+            // always called.
+            consumer[method](...args);
+          });
+        } else if (_.isFunction(method)) {
           this.on(notificationName, method.bind(consumer));
         }
       }
@@ -158,4 +162,3 @@ define(function (require, exports, module) {
 
   module.exports = NotifierMixin;
 });
-

--- a/app/tests/spec/lib/channels/notifier-mixin.js
+++ b/app/tests/spec/lib/channels/notifier-mixin.js
@@ -5,14 +5,12 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const { assert } = require('chai');
   const BaseView = require('views/base');
-  const chai = require('chai');
   const Cocktail = require('cocktail');
   const Notifier = require('lib/channels/notifier');
   const NotifierMixin = require('lib/channels/notifier-mixin');
   const sinon = require('sinon');
-
-  var assert = chai.assert;
 
   describe('lib/channels/notifier-mixin', function () {
     var data = { uid: 'foo' };
@@ -24,7 +22,9 @@ define(function (require, exports, module) {
       functionHandlerSpy = sinon.spy();
 
       var ConsumingView = BaseView.extend({
-        notificationHandler: sinon.spy(),
+        notificationHandler () {
+          // intentionally empty, a spy is added later.
+        },
 
         notifications: {
           'function-handler': functionHandlerSpy,
@@ -58,10 +58,11 @@ define(function (require, exports, module) {
     describe('auto-binding of notifier', function () {
       describe('with a string for the handler', function () {
         beforeEach(function () {
+          sinon.spy(view, 'notificationHandler');
           notifier.trigger('string-handler');
         });
 
-        it('calls the correct handler', function () {
+        it('calls the correct handler, even if handler is a spy', function () {
           assert.isTrue(view.notificationHandler.called);
         });
       });
@@ -168,4 +169,3 @@ define(function (require, exports, module) {
     });
   });
 });
-


### PR DESCRIPTION
## What's the problem?

While adding handlers for items in `notifications`, if the handler
was declared using a string, the actual handler method reference was
immediately created. This made it impossible to spy upon a method
declared this way.

### What's the fix?

Do "late-binding" where the handler method is looked up
when the notification is triggered. This allows sinon to set up a spy
and then have the spy called whenever the notification is triggered.

fixes #4731

@philbooth - you've been doing a lot with notifications lately, mind an r on this?