### PR TITLE
fix(client): Only the first call to `back` is processed.

### DIFF
--- a/app/scripts/views/mixins/back-mixin.js
+++ b/app/scripts/views/mixins/back-mixin.js
@@ -14,11 +14,9 @@ define(function (require, exports, module) {
   const BaseView = require('views/base');
   const KeyCodes = require('lib/key-codes');
 
-  var BackMixin = {
+  module.exports = {
     _canGoBack: false,
-    initialize (options) {
-      options = options || {};
-
+    initialize (options = {}) {
       this._canGoBack = options.canGoBack;
     },
 
@@ -52,11 +50,14 @@ define(function (require, exports, module) {
      * @param {Object} [nextViewData] - data to send to the next(last) view.
      */
     back (nextViewData) {
-      this.logViewEvent('back');
+      if (this.canGoBack()) {
+        this._canGoBack = false;
+        this.logViewEvent('back');
 
-      this.notifier.trigger('navigate-back', {
-        nextViewData: nextViewData
-      });
+        this.notifier.trigger('navigate-back', {
+          nextViewData
+        });
+      }
     },
 
     /**
@@ -81,6 +82,4 @@ define(function (require, exports, module) {
       return !! this._canGoBack;
     }
   };
-
-  module.exports = BackMixin;
 });

--- a/app/tests/spec/views/mixins/back-mixin.js
+++ b/app/tests/spec/views/mixins/back-mixin.js
@@ -5,21 +5,23 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const { assert } = require('chai');
   const BackMixin = require('views/mixins/back-mixin');
   const BaseView = require('views/base');
-  const Chai = require('chai');
   const Cocktail = require('cocktail');
   const KeyCodes = require('lib/key-codes');
   const Notifier = require('lib/channels/notifier');
   const sinon = require('sinon');
   const TestTemplate = require('stache!templates/test_template');
 
-  var assert = Chai.assert;
-
-  var View = BaseView.extend({
+  const View = BaseView.extend({
     template: TestTemplate
   });
-  Cocktail.mixin(View, BackMixin);
+
+  Cocktail.mixin(
+    View,
+    BackMixin
+  );
 
   describe('views/mixins/back-mixin', function () {
     var notifier;
@@ -29,6 +31,7 @@ define(function (require, exports, module) {
       notifier = new Notifier();
 
       view = new View({
+        canGoBack: true,
         notifier: notifier,
         screenName: 'back-screen'
       });
@@ -37,11 +40,14 @@ define(function (require, exports, module) {
     });
 
     describe('back', function () {
-      it('triggers the `navigate-back` message on the notifier', function () {
+      it('triggers `navigate-back` message on the notifier once', function () {
         sinon.spy(notifier, 'trigger');
 
         view.back({ nextViewField: 'value' });
+        // The second invocation should be ignored.
+        view.back();
 
+        assert.isTrue(notifier.trigger.calledOnce);
         assert.isTrue(
           notifier.trigger.calledWith('navigate-back', {
             nextViewData: {


### PR DESCRIPTION
### What's the problem?

`back` triggers a `navigate-back` message, which tells the router
to go back in history. Multiple `navigate-back` messages could be
triggered from a single view, causing the page to go back multiple
places in history. This isn't what is wanted.

### How does this fix it?

The fix is to only process the first `back` invocation.

fixes #4733

@mozilla/fxa-devs - r?