### PR TITLE
fix(events): Allow a DOM event handler to be spied upon.

### DIFF
--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -27,22 +27,24 @@ define(function (require, exports, module) {
   const VerificationMethods = require('lib/verification-methods');
   const WindowMock = require('../../mocks/window');
 
-  var requiresFocus = TestHelpers.requiresFocus;
-  var wrapAssertion = TestHelpers.wrapAssertion;
+  const { requiresFocus, wrapAssertion } = TestHelpers;
 
   describe('views/base', function () {
-    var broker;
-    var metrics;
-    var model;
-    var notifier;
-    var relier;
-    var translator;
-    var user;
-    var view;
-    var viewName = 'view';
-    var windowMock;
+    let broker;
+    let metrics;
+    let model;
+    let notifier;
+    let relier;
+    let translator;
+    let user;
+    let view;
+    let viewName = 'view';
+    let windowMock;
 
-    var View = BaseView.extend({
+    const View = BaseView.extend({
+      events: {
+        'click #required': '_onRequiredClick'
+      },
       layoutClassName: 'layout',
       template: Template,
       context: function () {
@@ -50,6 +52,10 @@ define(function (require, exports, module) {
           error: this.model.get('templateWrittenError'),
           success: this.model.get('templateWrittenSuccess')
         };
+      },
+
+      _onRequiredClick () {
+        // intentionally left empty, a spy is attached.
       }
     });
 
@@ -1071,6 +1077,15 @@ define(function (require, exports, module) {
         const filteredSearchParams = view.getSearchParams('another');
         assert.notProperty(filteredSearchParams, 'search');
         assert.equal(filteredSearchParams.another, '2');
+      });
+    });
+
+    describe('events handling', () => {
+      it('calls spys on DOM event handlers', () => {
+        sinon.spy(view, '_onRequiredClick');
+
+        view.$('#required').click();
+        assert.isTrue(view._onRequiredClick.calledOnce);
       });
     });
   });


### PR DESCRIPTION
### What's the problem?

While adding DOM event handlers in `events`, if the handler
was declared using a string, Backbone immediately binds the
DOM event to the existing method named by the declaration.
This made it impossible to spy upon a method declared this way.

### How does this fix it?

The fix is to do "late-binding" where the handler method is looked up
when the DOM event is triggered. This allows sinon to set up a spy
and then have the spy called whenever the notification is triggered.

fixes #4736

@mozilla/fxa-devs - r?