### PR TITLE
refactor(CAD): WhyConnectAnotherDeviceView uses the BackMixin

### DIFF
--- a/app/scripts/templates/why_connect_another_device.mustache
+++ b/app/scripts/templates/why_connect_another_device.mustache
@@ -10,6 +10,6 @@
     {{#t}}Sync isn't designed as a permanent backup – it's just sharing what is saved locally. If you reset your password and your data isn't stored on at least one other device, you could lose all the information associated with the old password. That's why you'll want to install Firefox and use Sync on more than one device.{{/t}}
   </p>
   <div class="button-row">
-    <button id="submit-btn" type="submit">{{#t}}Got it{{/t}}</button>
+    <button id="back" type="submit">{{#t}}Got it{{/t}}</button>
   </div>
 </aside>

--- a/app/scripts/views/mixins/modal-panel-mixin.js
+++ b/app/scripts/views/mixins/modal-panel-mixin.js
@@ -17,6 +17,11 @@ define(function (require, exports, module) {
   module.exports = {
     isModal: true,
 
+    notifications: {
+      'navigate': 'closePanel',
+      'navigate-back': 'closePanel'
+    },
+
     /**
      * Open the panel.
      */
@@ -67,14 +72,6 @@ define(function (require, exports, module) {
       this.destroy(true);
       this.trigger('modal-cancel');
       $('.blocker').off('click', this._boundBlockerClick);
-    },
-
-    /**
-     * Wrap the navigate function to close the panel. If the next view
-     * is also a modal, a new modal will immediately be created.
-     */
-    navigate () {
-      this.closePanel();
     },
 
     /**

--- a/app/scripts/views/why_connect_another_device.js
+++ b/app/scripts/views/why_connect_another_device.js
@@ -9,6 +9,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const BackMixin = require('views/mixins/back-mixin');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
   const ModalPanelMixin = require('views/mixins/modal-panel-mixin');
@@ -17,25 +18,18 @@ define(function (require, exports, module) {
   const View = BaseView.extend({
     template: Template,
 
-    events: {
-      'click button[type=submit]': '_returnToConnectAnotherDevice'
-    },
-
     initialize () {
-      this.on('modal-cancel', () => this._returnToConnectAnotherDevice());
+      this.once('modal-cancel', () => this.back());
     },
 
     afterRender () {
       this.openPanel();
-    },
-
-    _returnToConnectAnotherDevice () {
-      this.navigate('connect_another_device');
     }
   });
 
   Cocktail.mixin(
     View,
+    BackMixin,
     ModalPanelMixin
   );
 

--- a/app/tests/spec/views/mixins/modal-panel-mixin.js
+++ b/app/tests/spec/views/mixins/modal-panel-mixin.js
@@ -6,11 +6,11 @@ define(function (require, exports, module) {
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
   const ModalPanelMixin = require('views/mixins/modal-panel-mixin');
+  const Notifier = require('lib/channels/notifier');
   const sinon = require('sinon');
   const TestTemplate = require('stache!templates/test_template');
 
   const ModalPanelView = BaseView.extend({
-    navigate: () => {},
     template: TestTemplate
   });
 
@@ -20,10 +20,14 @@ define(function (require, exports, module) {
   );
 
   describe('views/mixins/modal-panel-mixin', function () {
+    let notifier;
     let view;
 
     beforeEach(function () {
-      view = new ModalPanelView();
+      notifier = new Notifier();
+      view = new ModalPanelView({
+        notifier
+      });
 
       return view.render();
     });
@@ -78,11 +82,18 @@ define(function (require, exports, module) {
       });
     });
 
-    it('navigate forces the panel closed', () => {
-      sinon.spy(view, 'closePanel');
-      view.navigate('settings');
+    describe('notifications', () => {
+      function testNotificationClosesPanel(notification) {
+        it(`${notification} closes the panel`, () => {
+          sinon.spy(view, 'closePanel');
+          notifier.trigger(notification);
 
-      assert.isTrue(view.closePanel.calledOnce);
+          assert.isTrue(view.closePanel.calledOnce);
+        });
+      }
+
+      testNotificationClosesPanel('navigate');
+      testNotificationClosesPanel('navigate-back');
     });
   });
 });

--- a/app/tests/spec/views/mixins/modal-settings-panel-mixin.js
+++ b/app/tests/spec/views/mixins/modal-settings-panel-mixin.js
@@ -9,6 +9,7 @@ define(function (require, exports, module) {
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
   const ModalSettingsPanelMixin = require('views/mixins/modal-settings-panel-mixin');
+  const Notifier = require('lib/channels/notifier');
   const sinon = require('sinon');
   const TestTemplate = require('stache!templates/test_template');
 
@@ -22,10 +23,14 @@ define(function (require, exports, module) {
   );
 
   describe('views/mixins/modal-settings-panel-mixin', function () {
+    let notifier;
     let view;
 
     beforeEach(function () {
+      notifier = new Notifier();
+
       view = new ModalSettingsPanelView({
+        notifier,
         parentView: {
           displaySuccess: sinon.spy()
         },

--- a/app/tests/spec/views/why_connect_another_device.js
+++ b/app/tests/spec/views/why_connect_another_device.js
@@ -5,15 +5,23 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const { assert } = require('chai');
+  const Notifier = require('lib/channels/notifier');
   const sinon = require('sinon');
   const View = require('views/why_connect_another_device');
 
   describe('views/why_connect_another_device', () => {
+    let notifier;
     let view;
 
     beforeEach(() => {
-      view = new View({});
+      notifier = new Notifier();
+
+      view = new View({
+        canGoBack: true,
+        notifier
+      });
     });
 
     afterEach(() => {
@@ -29,23 +37,25 @@ define(function (require, exports, module) {
         });
     });
 
-    describe('click handlers', () => {
+    describe('going back', () => {
       beforeEach(() => {
-        sinon.stub(view, 'navigate', () => {});
+        sinon.spy(view, 'back');
 
-        return view.render();
+        return view.render().then(() => {
+          $('#container').html(view.el);
+        });
       });
 
-      it('a click on the button returns to `connect_another_device`', () => {
-        view.$el.find('button[type=submit]').click();
-        assert.isTrue(view.navigate.calledOnce);
-        assert.isTrue(view.navigate.calledWith('connect_another_device'));
+      it('a click on the button navigates `back`', () => {
+        view.$el.find('button[type="submit"]').click();
+        assert.isTrue(view.back.called);
       });
 
-      it('a click on the background returns to `connect_another_device`', () => {
+      it('`modal-cancel` event navigates `back`', () => {
         view.trigger('modal-cancel');
-        assert.isTrue(view.navigate.calledOnce);
-        assert.isTrue(view.navigate.calledWith('connect_another_device'));
+        // the 2nd notification should be ignored.
+        view.trigger('modal-cancel');
+        assert.isTrue(view.back.calledOnce);
       });
     });
   });


### PR DESCRIPTION
### What's the problem?
A click on the "Got it" button sends the user back to
the previous screen. Up to this point, the previous
screen was always "connect_another_device" and that
was hard coded.

With the "send SMS" feature, this screen will also
be displayed under the "sms/why" path. A way is needed
to go back to either "connect_another_device" OR "sms".

### How does this fix it?
Use the "BackMixin" to go back to the previous screen. Calling "back" will
enable the view to be used for either "connect_another_device/why" or "sms/why".

### Why did the modal-panel-mixin change?
I initially added a `back` override in the mixin to close the panel and realized
both `navigate` and `back` trigger messages on the notifier. Instead of adding
more override methods, I thought it'd be cleaner to listen for the notifications.


### Dependencies! (merge after these)
* [x] https://github.com/mozilla/fxa-content-server/pull/4734
* [x] https://github.com/mozilla/fxa-content-server/pull/4737

@mozilla/fxa-devs - r?

fixes #4735