### PR TITLE
fix(test): Fix 'get the open restmail button' functional test.

### DIFF
--- a/tests/functional/confirm.js
+++ b/tests/functional/confirm.js
@@ -22,6 +22,7 @@ define([
   var noSuchElement = FunctionalHelpers.noSuchElement;
   var openPage = FunctionalHelpers.openPage;
   var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  var switchToWindow = FunctionalHelpers.switchToWindow;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
@@ -78,10 +79,7 @@ define([
         .then(testElementExists('#fxa-confirm-header'))
         .then(click('[data-webmail-type="restmail"]'))
 
-        .getAllWindowHandles()
-          .then(function (handles) {
-            return this.parent.switchToWindow(handles[1]);
-          })
+        .then(switchToWindow(1))
 
           // wait until url is correct
         .then(FunctionalHelpers.pollUntil(function (email) {

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -579,6 +579,29 @@ define([
     return this.parent.execute(openWindow, [ url, name ]);
   });
 
+  /**
+   * Switch to a new window/tab
+   *
+   * @param {Number} which - tab index to switch to
+   * @returns {Promise}
+   */
+  const switchToWindow = thenify(function (which) {
+    return this.parent
+      .getAllWindowHandles()
+      .then(function (handles) {
+        if (handles[which]) {
+          return this.parent.switchToWindow(handles[which]);
+        } else {
+          // give a little time to open the browser tab, otherwise
+          // geckodriver sometimes attempts to switch to the tab
+          // before it's open. See #4740
+          return this.parent
+            .sleep(1000)
+            .then(switchToWindow(which));
+        }
+      });
+  });
+
   function openWindow (url, name) {
     var newWindow = window.open(url, name || 'newwindow');
 
@@ -1617,6 +1640,7 @@ define([
     pollUntil: pollUntil,
     pollUntilGoneByQSA: pollUntilGoneByQSA,
     respondToWebChannelMessage: respondToWebChannelMessage,
+    switchToWindow: switchToWindow,
     takeScreenshot: takeScreenshot,
     testAreEventsLogged: testAreEventsLogged,
     testAttribute: testAttribute,


### PR DESCRIPTION
### What was the problem?
geckodriver sometimes attempts to switch to the tab before it's open.

### How does this fix it?
If the tab is not available, wait 1 second and try again.

fixes #4740

@mozilla/fxa-devs - r?