### PR TITLE
fix(test): Fix the `on second attempt canonical form is used` test.

### DIFF
--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -78,13 +78,18 @@ define([
 
         .then(testElementExists('#fxa-settings-header'))
 
-        // synthesize signin pre-#4470 with incorrect email case
-        .then(denormalizeStoredEmail(email))
-
         // reset prefill and context
         .then(clearSessionStorage())
 
         .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
+        // synthesize signin pre-#4470 with incorrect email case.
+        // to avoid a timing issue where the de-normalized email was
+        // being overwritten in localStorage when denormalization was
+        // done on the settings page, wait for the signin page to load,
+        // denormalize, then refresh. See #4711
+        .then(denormalizeStoredEmail(email))
+        .refresh()
+        .then(testElementExists('#fxa-signin-header'))
 
         // email is not yet denormalized :(
         .then(testElementValueEquals('.email', email.toUpperCase()))


### PR DESCRIPTION
### What is the problem?
The problem seems to be the denormalized email is being overwritten
in localStorage at some point during the settings page load. The
settings page performs a lot of XHR requests, any of which could
introduce sufficient latency to cause problems.

### How does this fix it?
Denormalize the email on the signin page, which makes fewer requests.
Once the email is denormalized on the signin page, refresh the page.

fixes #4711