### PR TITLE
refactor(settings): Simplify settings header rendering.

### DIFF
--- a/app/scripts/templates/partial/settings-header.mustache
+++ b/app/scripts/templates/partial/settings-header.mustache
@@ -1,0 +1,8 @@
+{{#displayName}}
+  <h1 class="card-header">{{displayName}}</h1>
+  <h2 class="card-subheader">{{email}}</h2>
+{{/displayName}}
+{{^displayName}}
+  <h1 class="card-header">{{email}}</h1>
+  <h2 class="card-subheader"></h2>
+{{/displayName}}

--- a/app/scripts/templates/settings.mustache
+++ b/app/scripts/templates/settings.mustache
@@ -2,7 +2,7 @@
   <header id="fxa-settings-header">
     <h1 id="fxa-manage-account">{{#t}}Firefox Accounts{{/t}}</h1>
     {{#showSignOut}}
-    <button id="signout" class="settings-button secondary">{{#t}}Sign out{{/t}}</button>
+      <button id="signout" class="settings-button secondary">{{#t}}Sign out{{/t}}</button>
     {{/showSignOut}}
   </header>
 
@@ -14,16 +14,7 @@
 <div class="avatar-wrapper avatar-settings-view"></div>
 <div id="fxa-settings-content" class="card">
   <header id="fxa-settings-profile-header">
-
-    {{#displayName}}
-      <h1 class="card-header">{{displayName}}</h1>
-      <h2 class="card-subheader">{{userEmail}}</h2>
-    {{/displayName}}
-    {{^displayName}}
-      <h1 class="card-header">{{userEmail}}</h1>
-      <h2 class="card-subheader"></h2>
-    {{/displayName}}
-
+    {{{ unsafeHeaderHTML }}}
   </header>
   <div id="sub-panels"></div>
 </div>


### PR DESCRIPTION
### What was the problem?
The settings header format was duplicated in both the template
and in code. In addition, updating the settings header was
done imperatively, manually after leaving a child view.
This just felt a bit complex and gross. Not very MVC.

### How does this fix that?
Extract the settings header HTML into a template. Render the
template on view render and on account change:email or
change:displayName.

@mozilla/fxa-devs - r?