### PR TITLE
refactor(metrics): Log the `loaded` event from the metrics module.

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -137,6 +137,19 @@ define(function (require, exports, module) {
     this.initialize(options);
   }
 
+  /**
+   * Log an event once. Use in the `notifications` hash to
+   * log an event whenever a notification is triggered.
+   *
+   * @param  {String} eventName name of event to log
+   * @return {Function} function that does logging.
+   */
+  function logEventOnce(eventName) {
+    return function () {
+      this.logEventOnce(eventName);
+    };
+  }
+
   _.extend(Metrics.prototype, Backbone.Events, {
     ALLOWED_FIELDS: ALLOWED_FIELDS,
 
@@ -162,7 +175,13 @@ define(function (require, exports, module) {
     notifications: {
       /* eslint-disable sorting/sort-object-props */
       'flow.initialize': '_initializeFlowModel',
-      'flow.event': '_logFlowEvent'
+      'flow.event': '_logFlowEvent',
+      /*
+       * `loaded` is used to determine how long until the
+       * first screen is rendered and the user can interact
+       * with FxA. Similar to window.onload, but FxA specific.
+       */
+      'view-shown': logEventOnce('loaded')
       /* eslint-enable sorting/sort-object-props */
     },
 

--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -277,11 +277,6 @@ define(function (require, exports, module) {
       // is attached and the promise is not returned.
       this.broker.afterLoaded();
 
-      // `loaded` is used to determine how long until the
-      // first screen is rendered and the user can interact
-      // with FxA. Similar to window.onload, but FxA specific.
-      this.metrics.logEvent('loaded');
-
       // back is enabled after the first view is rendered or
       // if the user re-starts the app.
       this.storage.set('canGoBack', true);

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
     });
 
     it('calls notifier.on correctly', () => {
-      assert.equal(notifier.on.callCount, 2);
+      assert.equal(notifier.on.callCount, 3);
 
       let args = notifier.on.args[0];
       assert.lengthOf(args, 2);
@@ -87,6 +87,11 @@ define(function (require, exports, module) {
       assert.lengthOf(args, 2);
       assert.equal(args[0], 'flow.event');
       assert.notEqual(args[1], notifier.on.args[0][1]);
+
+      args = notifier.on.args[2];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'view-shown');
+      assert.isFunction(args[1]);
     });
 
     it('observable flow state is correct', () => {
@@ -268,6 +273,9 @@ define(function (require, exports, module) {
           metrics.logEvent('foo');
           notifier.trigger('flow.event', { event: 'bar', once: true });
           metrics.logEvent('baz');
+          notifier.trigger('view-shown');
+          // trigger `view-shown` twice, ensure it's only logged once.
+          notifier.trigger('view-shown');
         });
 
         describe('has sendBeacon', function () {
@@ -306,10 +314,11 @@ define(function (require, exports, module) {
               assert.isNumber(data.duration);
               assert.equal(data.entrypoint, 'none');
               assert.isArray(data.events);
-              assert.lengthOf(data.events, 3);
+              assert.lengthOf(data.events, 4);
               assert.equal(data.events[0].type, 'foo');
               assert.equal(data.events[1].type, 'flow.bar');
               assert.equal(data.events[2].type, 'baz');
+              assert.equal(data.events[3].type, 'loaded');
               assert.equal(data.flowId, FLOW_ID);
               assert.equal(data.flowBeginTime, FLOW_BEGIN_TIME);
               assert.equal(data.isSampledUser, false);
@@ -430,11 +439,12 @@ define(function (require, exports, module) {
               var data = JSON.parse(settings.data);
               assert.lengthOf(Object.keys(data), 25);
               assert.isArray(data.events);
-              assert.lengthOf(data.events, 4);
+              assert.lengthOf(data.events, 5);
               assert.equal(data.events[0].type, 'foo');
               assert.equal(data.events[1].type, 'flow.bar');
               assert.equal(data.events[2].type, 'baz');
-              assert.equal(data.events[3].type, 'qux');
+              assert.equal(data.events[3].type, 'loaded');
+              assert.equal(data.events[4].type, 'qux');
             });
 
             it('resolves to true', function () {
@@ -506,11 +516,12 @@ define(function (require, exports, module) {
 
             var data = metrics._send.getCall(0).args[0];
             assert.lengthOf(Object.keys(data), 25);
-            assert.lengthOf(data.events, 4);
+            assert.lengthOf(data.events, 5);
             assert.equal(data.events[0].type, 'foo');
             assert.equal(data.events[1].type, 'flow.bar');
             assert.equal(data.events[2].type, 'baz');
-            assert.equal(data.events[3].type, 'wibble');
+            assert.equal(data.events[3].type, 'loaded');
+            assert.equal(data.events[4].type, 'wibble');
           });
         });
 
@@ -530,11 +541,12 @@ define(function (require, exports, module) {
 
             var data = metrics._send.getCall(0).args[0];
             assert.lengthOf(Object.keys(data), 25);
-            assert.lengthOf(data.events, 4);
+            assert.lengthOf(data.events, 5);
             assert.equal(data.events[0].type, 'foo');
             assert.equal(data.events[1].type, 'flow.bar');
             assert.equal(data.events[2].type, 'baz');
-            assert.equal(data.events[3].type, 'blee');
+            assert.equal(data.events[3].type, 'loaded');
+            assert.equal(data.events[4].type, 'blee');
           });
         });
 

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -6,10 +6,10 @@ define(function (require, exports, module) {
   'use strict';
 
   const Account = require('models/account');
+  const { assert } = require('chai');
   const AuthErrors = require('lib/auth-errors');
   const Backbone = require('backbone');
   const BaseView = require('views/base');
-  const chai = require('chai');
   const Constants = require('lib/constants');
   const DisplayNameView = require('views/settings/display_name');
   const Metrics = require('lib/metrics');
@@ -20,11 +20,8 @@ define(function (require, exports, module) {
   const Router = require('lib/router');
   const SettingsView = require('views/settings');
   const sinon = require('sinon');
-  const TestHelpers = require('../../lib/helpers');
   const User = require('models/user');
   const WindowMock = require('../../mocks/window');
-
-  var assert = chai.assert;
 
   describe('lib/router', function () {
     var broker;
@@ -314,12 +311,6 @@ define(function (require, exports, module) {
         assert.isTrue(broker.afterLoaded.called);
       });
 
-      it('logs a `loaded` event', function () {
-        router._afterFirstViewHasRendered();
-
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'loaded'));
-      });
-
       it('sets `canGoBack`', function () {
         router._afterFirstViewHasRendered();
 
@@ -460,5 +451,3 @@ define(function (require, exports, module) {
     });
   });
 });
-
-


### PR DESCRIPTION
### What is the problem?
`loaded` used to be logged by the router after the first `view-shown` notification.
This was done because the router had a reference to the notifier, now that the
NotifierMixin can be used by models and libs, logging via the router seems a bit
too complex.

### How does this fix it?
Now that the metrics module has a reference to the notifier, have metrics listen
for a `view-shown` message and log a `loaded` event.

@mozilla/fxa-devs - r?