### PR TITLE
feat(tests): Reload mocha tests whenever source/js changes.

### DIFF
--- a/grunttasks/watch.js
+++ b/grunttasks/watch.js
@@ -5,6 +5,16 @@
 module.exports = function (grunt) {
   grunt.config('watch', {
     grunt: { files: ['Gruntfile.js'] },
+    livereload: {
+      files: [
+        '<%= yeoman.app %>/**/*.js',
+        '!<%= yeoman.app %>/bower_components/**',
+        '!<%= yeoman.app %>/scripts/vendor/**'
+      ],
+      options: {
+        livereload: true
+      }
+    },
     sass: {
       files: '<%= yeoman.app %>/styles/**/*.scss',
       tasks: ['sass', 'autoprefixer']

--- a/server/templates/pages/src/mocha.html
+++ b/server/templates/pages/src/mocha.html
@@ -12,6 +12,7 @@
         <div id="mocha"></div>
         <div id="container"></div>
 
+        <script src="//localhost:35729/livereload.js"></script>
         <!--
              For blanket to work correctly with mocha and requirejs,
              mocha and blanket must both be included manually, outside

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -285,9 +285,10 @@ define([
 
       var promise = makeRequest(url, requestOptions)
         .then(function (res) {
-          if (/support.mozilla.org/.test(url)) {
+          if (/support.mozilla.org/.test(url) || /localhost:35729/.test(url)) {
             // Do not check support.mozilla.org URLs. Issue #4712
             // In February 2017 SUMO links started returning 404s to non-browser redirect requests
+            // Also skip the livereload link in the mocha tests
             return;
           }
           assert.equal(res.statusCode, 200);


### PR DESCRIPTION
### What is the problem?
To run the unit tests while developing, the dev has to leave
their editor, go to the browser tab with the unit tests open,
and refresh the page. That's a big context shift.

### How does this fix it?
Add the `grunt watch:livereload` task which forces the mocha
tests to reload any time a test or source file changes.

### What's the process to use livereload?
1. Start the livereload server using `grunt watch:livereload`
2. In a browser tab, visit http://127.0.0.1:3030

If the livereload server is killed & restarted, the browser tab must be 
refreshed for reload to occur again.

### Do the tests still run w/o the grunt task running?
Yes, but they will not automatically reload whenever
source files change.

@mozilla/fxa-devs - r?