### PR TITLE
refactor(client): auth brokers listens for `view-shown` to call afterLoaded.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -446,10 +446,10 @@ define(function (require, exports, module) {
     initializeRouter () {
       if (! this._router) {
         this._router = new Router({
-          broker: this._authenticationBroker,
           createView: this.createView.bind(this),
           metrics: this._metrics,
           notifier: this._notifier,
+          relier: this._relier,
           user: this._user,
           window: this._window
         });

--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -117,12 +117,10 @@ define(function (require, exports, module) {
       'verify_email(/)': createViewHandler(CompleteSignUpView, { type: VerificationReasons.SIGN_UP })
     },
 
-    initialize (options) {
-      options = options || {};
-
-      this.broker = options.broker;
+    initialize (options = {}) {
       this.metrics = options.metrics;
       this.notifier = options.notifier;
+      this.relier = options.relier;
       this.user = options.user;
       this.window = options.window || window;
 
@@ -197,7 +195,7 @@ define(function (require, exports, module) {
      */
     redirectToBestOAuthChoice () {
       // Attempt to get email address from relier
-      var email = this.broker.relier.get('email');
+      var email = this.relier.get('email');
 
       return p().then(() => {
         if (email) {
@@ -277,11 +275,6 @@ define(function (require, exports, module) {
     },
 
     _afterFirstViewHasRendered () {
-      // afterLoaded lets the relier know when the first screen has been
-      // loaded. It does not expect a response, so no error handler
-      // is attached and the promise is not returned.
-      this.broker.afterLoaded();
-
       // back is enabled after the first view is rendered or
       // if the user re-starts the app.
       this.storage.set('canGoBack', true);

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -14,6 +14,7 @@ define(function (require, exports, module) {
   const Backbone = require('backbone');
   const Cocktail = require('cocktail');
   const Environment = require('lib/environment');
+  const NotifierMixin = require('lib/channels/notifier-mixin');
   const NullBehavior = require('views/behaviors/null');
   const p = require('lib/promise');
   const SameBrowserVerificationModel = require('models/verification/same-browser');
@@ -27,15 +28,17 @@ define(function (require, exports, module) {
   var BaseAuthenticationBroker = Backbone.Model.extend({
     type: 'base',
 
-    initialize (options) {
-      options = options || {};
-
+    initialize (options = {}) {
       this.relier = options.relier;
       this.window = options.window || window;
       this.environment = new Environment(this.window);
 
       this._behaviors = new Backbone.Model(this.defaultBehaviors);
       this._capabilities = new Backbone.Model(this.defaultCapabilities);
+    },
+
+    notifications: {
+      'once!view-shown': 'afterLoaded'
     },
 
     /**
@@ -104,7 +107,6 @@ define(function (require, exports, module) {
     afterLoaded () {
       return p();
     },
-
 
     /**
      * Called before sign in. Can be used to prevent sign in.
@@ -403,6 +405,7 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     BaseAuthenticationBroker,
+    NotifierMixin,
     SearchParamMixin
   );
 

--- a/app/scripts/models/auth_brokers/fx-firstrun-v2.js
+++ b/app/scripts/models/auth_brokers/fx-firstrun-v2.js
@@ -15,7 +15,6 @@ define(function (require, exports, module) {
   const _ = require('underscore');
   const Constants = require('lib/constants');
   const FxFirstrunV1AuthenticationBroker = require('./fx-firstrun-v1');
-  const NotifierMixin = require('lib/channels/notifier-mixin');
 
   var proto = FxFirstrunV1AuthenticationBroker.prototype;
 
@@ -29,19 +28,13 @@ define(function (require, exports, module) {
       }
     }),
 
-    initialize (options = {}) {
-      proto.initialize.call(this, options);
-
-      NotifierMixin.initialize.call(this, options);
-    },
-
-    notifications: {
+    notifications: _.extend({}, proto.notifications, {
       'form.disabled': '_sendFormDisabled',
       'form.enabled': '_sendFormEnabled',
       'form.engaged': '_sendFormEngaged',
       'show-child-view': '_onShowChildView',
       'show-view': '_onShowView'
-    },
+    }),
 
     _iframeCommands: _.extend({}, proto._iframeCommands, {
       FORM_DISABLED: 'form_disabled',

--- a/app/tests/spec/lib/channels/notifier-mixin.js
+++ b/app/tests/spec/lib/channels/notifier-mixin.js
@@ -7,46 +7,51 @@ define(function (require, exports, module) {
 
   const { assert } = require('chai');
   const BaseView = require('views/base');
-  const Cocktail = require('cocktail');
   const Notifier = require('lib/channels/notifier');
   const NotifierMixin = require('lib/channels/notifier-mixin');
   const sinon = require('sinon');
 
-  describe('lib/channels/notifier-mixin', function () {
-    var data = { uid: 'foo' };
-    var functionHandlerSpy;
-    var notifier;
-    var view;
+  describe('lib/channels/notifier-mixin', () => {
+    let data = { uid: 'foo' };
+    let functionHandlerSpy;
+    let notifier;
+    let view;
 
-    beforeEach(function () {
+    beforeEach(() => {
       functionHandlerSpy = sinon.spy();
 
-      var ConsumingView = BaseView.extend({
+      const ConsumingView = BaseView.extend({
         notificationHandler () {
+          // intentionally empty, a spy is added later.
+        },
+
+        callOnceHandler () {
           // intentionally empty, a spy is added later.
         },
 
         notifications: {
           'function-handler': functionHandlerSpy,
+          'once!call-once': 'callOnceHandler',
           'string-handler': 'notificationHandler'
         }
       });
 
-      Cocktail.mixin(ConsumingView, NotifierMixin);
+      // BaseView mixes in NotifierMixin already, no need
+      // to re-add it.
 
       notifier = new Notifier();
       view = new ConsumingView({
-        notifier: notifier
+        notifier
       });
     });
 
-    afterEach(function () {
+    afterEach(() => {
       view.destroy();
       view = null;
     });
 
-    it('exports correct interface', function () {
-      var expectedFunctions = [
+    it('exports correct interface', () => {
+      let expectedFunctions = [
         'initialize',
       ];
       assert.lengthOf(Object.keys(NotifierMixin), expectedFunctions.length);
@@ -55,73 +60,136 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('auto-binding of notifier', function () {
-      describe('with a string for the handler', function () {
-        beforeEach(function () {
+    describe('auto-binding of notifier', () => {
+      describe('with a string for the handler', () => {
+        beforeEach(() => {
           sinon.spy(view, 'notificationHandler');
           notifier.trigger('string-handler');
         });
 
-        it('calls the correct handler, even if handler is a spy', function () {
-          assert.isTrue(view.notificationHandler.called);
+        it('calls the correct handler, even if handler is a spy', () => {
+          assert.isTrue(view.notificationHandler.calledOnce);
         });
       });
 
-      describe('with a function for the handler', function () {
-        beforeEach(function () {
+      describe('with a function for the handler', () => {
+        beforeEach(() => {
           notifier.trigger('function-handler');
         });
 
-        it('calls the correct handler', function () {
-          assert.isTrue(functionHandlerSpy.called);
+        it('calls the correct handler', () => {
+          assert.isTrue(functionHandlerSpy.calledOnce);
+        });
+      });
+
+      describe('with a handler that should be invoked once', () => {
+        beforeEach(() => {
+          sinon.spy(view, 'callOnceHandler');
+
+          notifier.trigger('call-once');
+          notifier.trigger('call-once');
+          notifier.trigger('call-once');
+        });
+
+        it('invokes the handler only once', () => {
+          assert.isTrue(view.callOnceHandler.calledOnce);
         });
       });
     });
 
-    describe('notifier.on', function () {
-      var callback = function () {};
+    describe('notifier.on', () => {
+      let callback;
 
-      beforeEach(function () {
+      beforeEach(() => {
+        callback = sinon.spy();
         sinon.spy(notifier, 'on');
 
         view.notifier.on('message', callback);
+        notifier.trigger('message');
       });
 
-      it('registers a message with the notifier', function () {
+      it('registers a message with the notifier', () => {
         assert.isTrue(notifier.on.calledWith('message', callback));
+        assert.isTrue(callback.calledOnce);
       });
     });
 
-    describe('notifcations.off', function () {
-      describe('with an event name and callback', function () {
-        beforeEach(function () {
+    describe('notifier.once', () => {
+      let callback;
+
+      beforeEach(() => {
+        callback = sinon.spy();
+        sinon.spy(notifier, 'once');
+
+        view.notifier.once('handle-once', callback);
+        notifier.trigger('handle-once');
+        notifier.trigger('handle-once');
+        notifier.trigger('handle-once');
+      });
+
+      it('registers a message with the notifier', () => {
+        assert.isTrue(notifier.once.calledWith('handle-once'));
+        // A second argument is passed, but it's opaque to us.
+        assert.isFunction(notifier.once.args[0][1]);
+        assert.isTrue(callback.calledOnce);
+      });
+    });
+
+    describe('notifcations.off', () => {
+      describe('with an event name attached using `on` and a callback', () => {
+        let callback;
+
+        beforeEach(() => {
           sinon.spy(notifier, 'off');
 
-          var callback = function () {};
+          callback = sinon.spy();
 
           view.notifier.on('message', callback);
           view.notifier.off('message', callback);
+          view.notifier.trigger('message');
         });
 
-        it('unregisters a message with the notifier', function () {
+        it('unregisters a message with the notifier', () => {
           assert.isTrue(notifier.off.calledWith('message'));
           // A second argument is passed, but it's opaque to us.
-          assert.ok(notifier.off.args[0][1]);
+          assert.isFunction(notifier.off.args[0][1]);
+          assert.isFalse(callback.called);
         });
       });
 
-      describe('without an event name and callback', function () {
-        beforeEach(function () {
+      describe('with an event attached using `once` and a callback', () => {
+        let callback;
+
+        beforeEach(() => {
           sinon.spy(notifier, 'off');
 
-          var callback1 = function () {};
-          var callback2 = function () {};
+          callback = sinon.spy();
+
+          view.notifier.once('message', callback);
+          view.notifier.off('message', callback);
+          view.notifier.trigger('message');
+        });
+
+        it('unregisters a message with the notifier', () => {
+          assert.isTrue(notifier.off.calledWith('message'));
+          // A second argument is passed, but it's opaque to us.
+          assert.isFunction(notifier.off.args[0][1]);
+          assert.isFalse(callback.called);
+        });
+      });
+
+      describe('without an event name and callback', () => {
+        beforeEach(() => {
+          sinon.spy(notifier, 'off');
+
+          let callback1 = () => {};
+          let callback2 = () => {};
 
           view.notifier.on('message1', callback1);
           view.notifier.on('message2', callback2);
         });
 
-        it('unregisters all of the view\'s handlers from the notifier', function () {
+        it('unregisters all of the view\'s handlers from the notifier', () => {
           view.notifier.off();
 
           assert.isTrue(notifier.off.calledWith('message1'));
@@ -135,35 +203,35 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('notifier.trigger', function () {
-      beforeEach(function () {
+    describe('notifier.trigger', () => {
+      beforeEach(() => {
         sinon.spy(notifier, 'trigger');
         view.notifier.trigger('fxaccounts:logout', data);
       });
 
-      it('delegates to notifier.trigger', function () {
+      it('delegates to notifier.trigger', () => {
         assert.isTrue(notifier.trigger.calledWith('fxaccounts:logout', data, view));
       });
     });
 
-    describe('notifier.triggerAll', function () {
-      beforeEach(function () {
+    describe('notifier.triggerAll', () => {
+      beforeEach(() => {
         sinon.spy(notifier, 'triggerAll');
         view.notifier.triggerAll('fxaccounts:logout', data);
       });
 
-      it('delegates to notifier.triggerAll', function () {
+      it('delegates to notifier.triggerAll', () => {
         assert.isTrue(notifier.triggerAll.calledWith('fxaccounts:logout', data, view));
       });
     });
 
-    describe('notifier.triggerRemote', function () {
-      beforeEach(function () {
+    describe('notifier.triggerRemote', () => {
+      beforeEach(() => {
         sinon.spy(notifier, 'triggerRemote');
         view.notifier.triggerRemote('fxaccounts:logout', data);
       });
 
-      it('delegates to notifier.triggerRemote', function () {
+      it('delegates to notifier.triggerRemote', () => {
         assert.isTrue(notifier.triggerRemote.calledWith('fxaccounts:logout', data));
       });
     });

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -14,7 +14,6 @@ define(function (require, exports, module) {
   const DisplayNameView = require('views/settings/display_name');
   const Metrics = require('lib/metrics');
   const Notifier = require('lib/channels/notifier');
-  const NullBroker = require('models/auth_brokers/base');
   const p = require('lib/promise');
   const Relier = require('models/reliers/relier');
   const Router = require('lib/router');
@@ -24,7 +23,6 @@ define(function (require, exports, module) {
   const WindowMock = require('../../mocks/window');
 
   describe('lib/router', function () {
-    var broker;
     var metrics;
     var navigateOptions;
     var navigateUrl;
@@ -46,14 +44,10 @@ define(function (require, exports, module) {
         window: windowMock
       });
 
-      broker = new NullBroker({
-        relier: relier
-      });
-
       router = new Router({
-        broker: broker,
         metrics: metrics,
         notifier: notifier,
+        relier: relier,
         user: user,
         window: windowMock
       });
@@ -303,14 +297,6 @@ define(function (require, exports, module) {
     });
 
     describe('_afterFirstViewHasRendered', function () {
-      it('notifies the broker', function () {
-        sinon.spy(broker, 'afterLoaded');
-
-        router._afterFirstViewHasRendered();
-
-        assert.isTrue(broker.afterLoaded.called);
-      });
-
       it('sets `canGoBack`', function () {
         router._afterFirstViewHasRendered();
 
@@ -375,9 +361,9 @@ define(function (require, exports, module) {
       it('is `true` if sessionStorage.canGoBack is set', function () {
         windowMock.sessionStorage.setItem('canGoBack', true);
         router = new Router({
-          broker: broker,
           metrics: metrics,
           notifier: notifier,
+          relier: relier,
           user: user,
           window: windowMock
         });


### PR DESCRIPTION
### What is the problem?
The router listened for a `view-shown` notification and invoked the broker's afterLoaded
method. The router shouldn't be reponsible for doing this, the broker should!

### How does this fix it?
Auth-brokers listen for a `view-shown` message and invoke its own `afterLoaded` method.

### Why all the changes to the NotifierMixin?
The mixin did not have a `once` method, and there was no way to encode the notion of
`once` inside of the `notifications` hash. This PR provides both of those
concepts. Additionally, the `off` method of the mixin was needlessly complex trying
to keep track of currently bound listeners. Instead, `off` no longer removes items
from the array of messages and only removes them all when an object is destroyed.

### Why does the router take a relier now instead of a broker?
After the call to `afterLoaded` was removed, the only thing
the broker was used for was to get a reference to the relier.
Might as well just pass in a relier.

### What does `once` look like in the notifications hash?

```js
notifications: {
  'once!event-name': '_handlerToBeRunOnce'
}
```

@philbooth - since you are my inspiration for leaning more on the notifier, mind an r?