### PR TITLE
fix(sms): Fix autofocus cursor position on input[type=tel]

### DIFF
--- a/app/scripts/templates/test_template.mustache
+++ b/app/scripts/templates/test_template.mustache
@@ -34,6 +34,9 @@
     <div class="input-row">
       <input type="email" id="email" />
     </div>
+    <div class="input-row">
+      <input type="tel" id="phone" />
+    </div>
     <div class="input-row password-row">
       <input type="password" class="password" id="password" pattern=".{8,}" required />
       <input type="password" id="old_password" placeholder="Old password" required pattern=".{8,}" />

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -856,7 +856,7 @@ define(function (require, exports, module) {
      * @param {Number} selectionStart - defaults to after the last character.
      * @param {Number} selectionEnd - defaults to selectionStart.
      */
-    placeCursorAt (which, selectionStart = $(which).val().length, selectionEnd = selectionStart) {
+    placeCursorAt (which, selectionStart = $(which).__val().length, selectionEnd = selectionStart) {
       const el = $(which).get(0);
 
       try {

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -726,6 +726,23 @@ define(function (require, exports, module) {
         focusEl = $focusEl.get(0);
       });
 
+      it('places the cursor at the end if no position given', () => {
+        view.placeCursorAt('#focusMe');
+
+        assert.equal(focusEl.selectionStart, elText.length);
+        assert.equal(focusEl.selectionEnd, elText.length);
+      });
+
+      it('works correctly with a formatted input[type=tel]', () => {
+        const TELEPHONE_NUMBER = '123-456-7890';
+        $focusEl = view.$('input[type=tel]').val(TELEPHONE_NUMBER);
+        focusEl = $focusEl.get(0);
+
+        view.placeCursorAt('input[type=tel]');
+        assert.equal(focusEl.selectionStart, TELEPHONE_NUMBER.length);
+        assert.equal(focusEl.selectionEnd, TELEPHONE_NUMBER.length);
+      });
+
       it('places the cursor at the specified position if only start given', () => {
         view.placeCursorAt('#focusMe', elText.length);
 


### PR DESCRIPTION
### What is the problem?
When calling view.focus on a telephone input that contained
a formatted phone number, e.g., 123-456-7890, the cursor was
placed between the 8 and 9. This is because `$().val()` on
an `input[type=tel]` returns the value without whitespace
and punctuation.

### How does this fix it?
Instead of calling `$().val()`, call `$().__val()` which
returns the uncleaned version of the input.

### Dependency alert!
Depends on https://github.com/mozilla/fxa-content-server/pull/4759 and should be reviewed afterwards.

Not attached to an issue.

@mozilla/fxa-devs - r?