### PR TITLE
feat(sms): Add a configurable successMessage to `resend-mixin`

### DIFF
--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -169,7 +169,7 @@ define(function (require, exports, module) {
     PasswordMixin,
     PasswordResetMixin,
     PasswordStrengthMixin,
-    ResendMixin,
+    ResendMixin(),
     ServiceMixin
   );
 

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -14,7 +14,7 @@ define(function (require, exports, module) {
   const PasswordMixin = require('views/mixins/password-mixin');
   const PasswordResetMixin = require('views/mixins/password-reset-mixin');
   const PasswordStrengthMixin = require('views/mixins/password-strength-mixin');
-  const ResendMixin = require('views/mixins/resend-mixin');
+  const ResendMixin = require('views/mixins/resend-mixin')();
   const ServiceMixin = require('views/mixins/service-mixin');
   const Template = require('stache!templates/complete_reset_password');
   const { t } = require('views/base');
@@ -169,7 +169,7 @@ define(function (require, exports, module) {
     PasswordMixin,
     PasswordResetMixin,
     PasswordStrengthMixin,
-    ResendMixin(),
+    ResendMixin,
     ServiceMixin
   );
 

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -313,7 +313,7 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     CompleteSignUpView,
     ExperimentMixin,
-    ResendMixin,
+    ResendMixin(),
     ResumeTokenMixin,
     VerificationReasonMixin
   );

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -24,7 +24,7 @@ define(function (require, exports, module) {
   const ExperimentMixin = require('views/mixins/experiment-mixin');
   const MarketingEmailErrors = require('lib/marketing-email-errors');
   const p = require('lib/promise');
-  const ResendMixin = require('views/mixins/resend-mixin');
+  const ResendMixin = require('views/mixins/resend-mixin')();
   const ResumeTokenMixin = require('views/mixins/resume-token-mixin');
   const t = BaseView.t;
   const VerificationInfo = require('models/verification/sign-up');
@@ -313,7 +313,7 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     CompleteSignUpView,
     ExperimentMixin,
-    ResendMixin(),
+    ResendMixin,
     ResumeTokenMixin,
     VerificationReasonMixin
   );

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
     ExperimentMixin,
     OpenConfirmationEmailMixin,
     PulseGraphicMixin,
-    ResendMixin,
+    ResendMixin(),
     ResumeTokenMixin,
     ServiceMixin,
     VerificationReasonMixin

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -15,7 +15,7 @@ define(function (require, exports, module) {
   const OpenConfirmationEmailMixin = require('views/mixins/open-webmail-mixin');
   const p = require('lib/promise');
   const PulseGraphicMixin = require('views/mixins/pulse-graphic-mixin');
-  const ResendMixin = require('views/mixins/resend-mixin');
+  const ResendMixin = require('views/mixins/resend-mixin')();
   const ResumeTokenMixin = require('views/mixins/resume-token-mixin');
   const ServiceMixin = require('views/mixins/service-mixin');
   const Template = require('stache!templates/confirm');
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
     ExperimentMixin,
     OpenConfirmationEmailMixin,
     PulseGraphicMixin,
-    ResendMixin(),
+    ResendMixin,
     ResumeTokenMixin,
     ServiceMixin,
     VerificationReasonMixin

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -273,7 +273,7 @@ define(function (require, exports, module) {
     View,
     PasswordResetMixin,
     OpenResetPasswordEmailMixin,
-    ResendMixin,
+    ResendMixin(),
     ServiceMixin
   );
 

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
   const p = require('lib/promise');
   const PasswordResetMixin = require('views/mixins/password-reset-mixin');
   const OpenResetPasswordEmailMixin = require('views/mixins/open-webmail-mixin');
-  const ResendMixin = require('views/mixins/resend-mixin');
+  const ResendMixin = require('views/mixins/resend-mixin')();
   const ServiceMixin = require('views/mixins/service-mixin');
   const Session = require('lib/session');
   const Template = require('stache!templates/confirm_reset_password');
@@ -273,7 +273,7 @@ define(function (require, exports, module) {
     View,
     PasswordResetMixin,
     OpenResetPasswordEmailMixin,
-    ResendMixin(),
+    ResendMixin,
     ServiceMixin
   );
 

--- a/app/scripts/views/mixins/resend-mixin.js
+++ b/app/scripts/views/mixins/resend-mixin.js
@@ -2,19 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Helper functions to allow a view to resend an email.
-//
-// Binds a click event to the #resend DOM element which causes
-// an email to be resent.
-//
-// Consumers must expose a `resend` function which returns a promise
-// and actually sends the email.
-//
-// When #resend is clicked, a <viewname>.resend event is logged.
+/**
+ * Helper functions to allow a view to resend, e.g., an email or SMS.
+ *
+ * Binds a click event to the #resend DOM element which causes
+ * the message to be resent.
+ *
+ * Consumers must expose a `resend` function which returns a promise
+ * and actually resends the message.
+ *
+ * When #resend is clicked, a <viewname>.resend event is logged.
+ *
+ * @module ResendMixin
+ */
 
 define(function (require, exports, module) {
   'use strict';
 
+  const _ = require('underscore');
   const Duration = require('duration');
   const EmailResend = require('models/email-resend');
   const p = require('lib/promise');
@@ -22,50 +27,68 @@ define(function (require, exports, module) {
 
   const SHOW_RESEND_IN_MS = new Duration('5m').milliseconds();
 
-  module.exports = {
-    initialize () {
-      this._emailResend = new EmailResend();
-      this.listenTo(this._emailResend, 'maxTriesReached', this._onMaxTriesReached);
-    },
+  /**
+   * Creates the mixin to be used by views.
+   *
+   * @param {Object} [options={}] options
+   *   @param {String} successMessage success message to display when complete.
+   *     Defaults to `Email resent`. If falsey, no message is displayed.
+   * @return {Function} the mixin to be consumed by views.
+   */
+  module.exports = function (options = {}) {
+    const { successMessage } = _.defaults(options, {
+      successMessage: t('Email resent')
+    });
 
-    events: {
-      'click #resend': preventDefaultThen('_resend')
-    },
+    return {
+      initialize () {
+        this._emailResend = new EmailResend();
+        this.listenTo(this._emailResend, 'maxTriesReached', this._onMaxTriesReached);
+      },
 
-    _resend () {
-      return p().then(() => {
-        this.logViewEvent('resend');
-        this._updateSuccessMessage();
+      events: {
+        'click #resend': preventDefaultThen('_resend')
+      },
 
-        // The button is hidden after the fourth click for 5 minutes, then
-        // start the process again.
-        this._emailResend.incrementRequestCount();
-        if (this._emailResend.shouldResend()) {
-          return this.resend()
-            .then(() => this.displaySuccess(t('Email resent')))
-            .fail((err) => this.displayError(err));
+      _resend () {
+        return p().then(() => {
+          this.logViewEvent('resend');
+          this._updateSuccessMessage();
+
+          // The button is hidden after the fourth click for 5 minutes, then
+          // start the process again.
+          this._emailResend.incrementRequestCount();
+          if (this._emailResend.shouldResend()) {
+            return this.resend()
+              .then(() => {
+                if (successMessage) {
+                  this.displaySuccess(successMessage);
+                }
+              })
+              .fail((err) => this.displayError(err));
+          }
+        });
+      },
+
+      _updateSuccessMessage () {
+        // if a success message is already being displayed, shake it.
+        var successEl = this.$('.success:visible');
+        if (successEl) {
+          successEl.one('animationend', () => {
+            successEl.removeClass('shake');
+          }).addClass('shake');
         }
-      });
-    },
+      },
 
-    _updateSuccessMessage () {
-      // if a success message is already being displayed, shake it.
-      var successEl = this.$('.success:visible');
-      if (successEl) {
-        successEl.one('animationend', () => {
-          successEl.removeClass('shake');
-        }).addClass('shake');
+      _onMaxTriesReached () {
+        // Hide the button after too many attempts. Redisplay button after a delay.
+        this.logViewEvent('too_many_attempts');
+        this.$('#resend').hide();
+        this.setTimeout(() => {
+          this._emailResend.reset();
+          this.$('#resend').show();
+        }, SHOW_RESEND_IN_MS);
       }
-    },
-
-    _onMaxTriesReached () {
-      // Hide the button after too many attempts. Redisplay button after a delay.
-      this.logViewEvent('too_many_attempts');
-      this.$('#resend').hide();
-      this.setTimeout(() => {
-        this._emailResend.reset();
-        this.$('#resend').show();
-      }, SHOW_RESEND_IN_MS);
-    }
+    };
   };
 });

--- a/app/scripts/views/sign_in_unblock.js
+++ b/app/scripts/views/sign_in_unblock.js
@@ -13,7 +13,7 @@ define(function (require, exports, module) {
   const Cocktail = require('cocktail');
   const Constants = require('lib/constants');
   const FormView = require('views/form');
-  const ResendMixin = require('views/mixins/resend-mixin');
+  const ResendMixin = require('views/mixins/resend-mixin')();
   const ResumeTokenMixin = require('views/mixins/resume-token-mixin');
   const SignInMixin = require('views/mixins/signin-mixin');
   const Template = require('stache!templates/sign_in_unblock');
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     View,
-    ResendMixin(),
+    ResendMixin,
     ResumeTokenMixin,
     SignInMixin
   );

--- a/app/scripts/views/sign_in_unblock.js
+++ b/app/scripts/views/sign_in_unblock.js
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     View,
-    ResendMixin,
+    ResendMixin(),
     ResumeTokenMixin,
     SignInMixin
   );

--- a/app/tests/spec/views/mixins/resend-mixin.js
+++ b/app/tests/spec/views/mixins/resend-mixin.js
@@ -6,7 +6,8 @@ define(function (require, exports, module) {
   'use strict';
 
   const $ = require('jquery');
-  const assert = require('chai').assert;
+  const { assert } = require('chai');
+  const AuthErrors = require('lib/auth-errors');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
   const p = require('lib/promise');
@@ -15,84 +16,115 @@ define(function (require, exports, module) {
   const TestTemplate = require('stache!templates/confirm');
 
   const View = BaseView.extend({
-    template: TestTemplate,
-
-    resendError: null,
-    resend () {
-      if (this.resendError) {
-        return p.reject(this.resendError);
-      }
-
-      return p();
-    }
+    resend: () => p(),
+    template: TestTemplate
   });
-
-  Cocktail.mixin(
-    View,
-    ResendMixin
-  );
 
   describe('views/mixins/resend-mixin', () => {
     let view;
 
-    beforeEach(() => {
-      view = new View();
+    describe('Default successMessage', () => {
+      const DefaultSuccessMessageView = View.extend({});
+      Cocktail.mixin(
+        DefaultSuccessMessageView,
+        ResendMixin()
+      );
 
-      return view.render()
-        .then(() => {
-          $('#container').html(view.el);
-        });
+      beforeEach(() => {
+        view = new DefaultSuccessMessageView();
+
+        return view.render()
+          .then(() => {
+            $('#container').html(view.el);
+          });
+      });
+
+      afterEach(() => {
+        view.destroy(true);
+        view = null;
+      });
+
+      it('hooks up to `click` on #resend', () => {
+        sinon.spy(view, '_resend');
+
+        view.$('section').click();
+        assert.equal(view._resend.callCount, 0);
+
+        view.$('#resend').click();
+        assert.equal(view._resend.callCount, 1);
+      });
+
+      it('debounces resend calls - submit on first four attempts', () => {
+        sinon.spy(view, 'logViewEvent');
+        sinon.spy(view, 'displaySuccess');
+        sinon.spy(view, 'resend');
+
+        return view._resend()
+          .then(() => {
+            assert.equal(view.logViewEvent.callCount, 1);
+            assert.isTrue(view.logViewEvent.calledWith('resend'));
+            assert.isFalse(view.logViewEvent.calledWith('too_many_attempts'));
+            assert.equal(view.resend.callCount, 1);
+            assert.equal(view.displaySuccess.callCount, 1);
+            assert.isTrue(view.displaySuccess.calledWith('Email resent'));
+            assert.lengthOf(view.$('#resend:visible'), 1);
+
+            return view._resend();
+          }).then(() => {
+            assert.equal(view.logViewEvent.callCount, 2);
+            assert.isFalse(view.logViewEvent.calledWith('too_many_attempts'));
+            assert.equal(view.resend.callCount, 2);
+            assert.equal(view.displaySuccess.callCount, 2);
+            assert.lengthOf(view.$('#resend:visible'), 1);
+
+            return view._resend();
+          }).then(() => {
+            assert.equal(view.logViewEvent.callCount, 3);
+            assert.isFalse(view.logViewEvent.calledWith('too_many_attempts'));
+            assert.equal(view.resend.callCount, 3);
+            assert.equal(view.displaySuccess.callCount, 3);
+            assert.lengthOf(view.$('#resend:visible'), 1);
+
+            return view._resend();
+          }).then(() => {
+            assert.equal(view.logViewEvent.callCount, 5);
+            assert.isTrue(view.logViewEvent.calledWith('too_many_attempts'));
+            assert.equal(view.resend.callCount, 4);
+            assert.equal(view.displaySuccess.callCount, 4);
+            assert.lengthOf(view.$('#resend:visible'), 0);
+          });
+      });
+
+      it('_resend displays returned errors', () => {
+        const err = AuthErrors.toError('UNEXPECTED_ERROR');
+        sinon.stub(view, 'resend', () => p.reject(err));
+        sinon.spy(view, 'displayError');
+
+        return view._resend()
+          .then(() => {
+            assert.isTrue(view.displayError.calledOnce);
+            assert.isTrue(view.displayError.calledWith(err));
+          });
+      });
     });
 
-    it('hooks up to `click` on #resend', () => {
-      sinon.spy(view, '_resend');
+    describe('successMessage: false View', () => {
+      const NoSuccessMessageView = View.extend({});
+      Cocktail.mixin(
+        NoSuccessMessageView,
+        ResendMixin({ successMessage: false })
+      );
 
-      view.$('section').click();
-      assert.equal(view._resend.callCount, 0);
+      it('does not display a success message', () => {
+        view = new NoSuccessMessageView();
+        sinon.spy(view, 'displaySuccess');
 
-      view.$('#resend').click();
-      assert.equal(view._resend.callCount, 1);
-    });
-
-    it('debounces resend calls - submit on first four attempts', () => {
-      sinon.spy(view, 'logViewEvent');
-      sinon.spy(view, 'displaySuccess');
-      sinon.spy(view, 'resend');
-
-      return view._resend()
-        .then(() => {
-          assert.equal(view.logViewEvent.callCount, 1);
-          assert.isTrue(view.logViewEvent.calledWith('resend'));
-          assert.isFalse(view.logViewEvent.calledWith('too_many_attempts'));
-          assert.equal(view.resend.callCount, 1);
-          assert.equal(view.displaySuccess.callCount, 1);
-          assert.isTrue(view.displaySuccess.calledWith('Email resent'));
-          assert.lengthOf(view.$('#resend:visible'), 1);
-
-          return view._resend();
-        }).then(() => {
-          assert.equal(view.logViewEvent.callCount, 2);
-          assert.isFalse(view.logViewEvent.calledWith('too_many_attempts'));
-          assert.equal(view.resend.callCount, 2);
-          assert.equal(view.displaySuccess.callCount, 2);
-          assert.lengthOf(view.$('#resend:visible'), 1);
-
-          return view._resend();
-        }).then(() => {
-          assert.equal(view.logViewEvent.callCount, 3);
-          assert.isFalse(view.logViewEvent.calledWith('too_many_attempts'));
-          assert.equal(view.resend.callCount, 3);
-          assert.equal(view.displaySuccess.callCount, 3);
-          assert.lengthOf(view.$('#resend:visible'), 1);
-
-          return view._resend();
-        }).then(() => {
-          assert.equal(view.logViewEvent.callCount, 5);
-          assert.isTrue(view.logViewEvent.calledWith('too_many_attempts'));
-          assert.equal(view.resend.callCount, 4);
-          assert.equal(view.displaySuccess.callCount, 4);
-          assert.lengthOf(view.$('#resend:visible'), 0);
-        });
+        return view.render()
+          .then(view._resend())
+          .then(() => {
+            assert.isFalse(view.displaySuccess.called);
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
### What is the problem?
The resend mixin assumes the user is resending an email and displays
`Email resent` after the `resend` completes. This doesn't work
when sending an SMS where the successMessage contains the user's
phone number and must be created at run time.

### How does this fix it?
The ResendMixin is now configurable to allow an override to the
default success message. The mixin exports a function that must
be invoked to get the actual mixin.

### How do I override the success message?
```js
// Display an alternative success message
Cocktail.mixin(
  View,
  ResendMixin({
    successMessage: t('A different success message')
  }
);

// Display no success message
Cocktail.mixin(
  View,
  ResendMixin({
    successMessage: false
  }
)
```

### Does this depend on anything?

Yes, #4762. I found that bug while fixing this.

This is easiest to review with the `?w=1` query parameter.

@mozilla/fxa-devs - r?

