### PR TITLE
refactor(client): ConfirmResetPassword extends BaseView, not ConfirmView.

### DIFF
--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -8,7 +8,6 @@ define(function (require, exports, module) {
   const AuthErrors = require('lib/auth-errors');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
-  const ConfirmView = require('views/confirm');
   const Notifier = require('lib/channels/notifier');
   const p = require('lib/promise');
   const PasswordResetMixin = require('views/mixins/password-reset-mixin');
@@ -17,17 +16,17 @@ define(function (require, exports, module) {
   const ServiceMixin = require('views/mixins/service-mixin');
   const Session = require('lib/session');
   const Template = require('stache!templates/confirm_reset_password');
+  const { VERIFICATION_POLL_IN_MS } = require('lib/constants');
 
-  var t = BaseView.t;
+  const t = BaseView.t;
 
-  var View = ConfirmView.extend({
+  const View = BaseView.extend({
     template: Template,
     className: 'confirm-reset-password',
 
-    initialize (options) {
-      options = options || {};
-      this._verificationPollMS = options.verificationPollMS ||
-              this.VERIFICATION_POLL_IN_MS;
+    initialize (options = {}) {
+      this._verificationPollMS =
+        options.verificationPollMS || VERIFICATION_POLL_IN_MS;
     },
 
     context () {


### PR DESCRIPTION
### What is the problem?
Both ConfirmView and ConfirmResetPasswordView consume a bunch of mixins.
Both consume the ResendMixin. With #4761, this is problematic because
the "resend" button is hidden after two clicks instead of 4 because
both views are considered to have a "_resend" function even though
they are the same function on two prototypes. The two _resend
invocations cause the model to increment at twice the speed.

ConfirmResetPasswordView only used VERIFICATION_POLL_IN_MS from
ConfirmView. Everything else is overridden.

### How does this fix it?
Extend ConfirmResetPasswordView from BaseView instead. Let it have
its own mixins that do not collide. Import Constants.VERIFICATION_POLL_IN_MS.

### No tests changed?!?!
Yeah, who the view extends is an implementation detail, everything else
is the same.

Blocks #4761

@mozilla/fxa-devs - r?
