### PR TITLE
fix(reset-password): Fix the reset password flow w/ e10s enabled!

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -420,7 +420,8 @@ define(function (require, exports, module) {
       // to read and create Accounts for unfiltered data.
       // upgradeFromSession writes the new format, so this is safe.
       return user.upgradeFromUnfilteredAccountData()
-        .then(user.upgradeFromSession.bind(user, Session, this._fxaClient));
+        .then(() => user.upgradeFromSession(Session, this._fxaClient))
+        .then(() => user.removeAccountsWithInvalidUid());
     },
 
     createView (Constructor, options = {}) {

--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -360,6 +360,13 @@ define(function (require, exports, module) {
     PHONE_NUMBER_REQUIRED: {
       errno: 1049,
       message: t('Phone number required')
+    },
+    ACCOUNT_HAS_NO_UID: {
+      errno: 1050,
+      // not user facing, only used for logging. Logged whenever
+      // an attempt is made to write an account w/o a uid
+      // to localStorage.
+      message: 'Account has no uid'
     }
   };
   /*eslint-enable sorting/sort-object-props*/

--- a/app/scripts/lib/channels/notifier.js
+++ b/app/scripts/lib/channels/notifier.js
@@ -44,6 +44,8 @@ define(function (require, exports, module) {
       name: 'internal:signed_in',
       schema: {
         keyFetchToken: '?String',
+        sessionToken: 'String',
+        sessionTokenContext: 'String',
         uid: 'String',
         unwrapBKey: '?String'
       }

--- a/app/scripts/lib/channels/notifier.js
+++ b/app/scripts/lib/channels/notifier.js
@@ -43,6 +43,11 @@ define(function (require, exports, module) {
     SIGNED_IN: {
       name: 'internal:signed_in',
       schema: {
+        // A bug in e10s causes localStorage in about:accounts and content tabs to be isolated from
+        // each other. Writes to localStorage from /complete_reset_password are not able to be read
+        // from within about:accounts. Because of this, all account data needed to sign in must
+        // be passed between windows. See https://github.com/mozilla/fxa-content-server/issues/4763
+        // and https://bugzilla.mozilla.org/show_bug.cgi?id=666724
         keyFetchToken: '?String',
         sessionToken: 'String',
         sessionTokenContext: 'String',

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -106,13 +106,22 @@ define(function (require, exports, module) {
       return this._getAccount(this._storage.get('currentAccountUid'));
     },
 
-    // persists account data
+    /**
+     * Persists account data to localStorage.
+     * The account will only be written if it has a uid.
+     *
+     * @param {Object} accountData
+     */
     _persistAccount (accountData) {
-      var account = this.initAccount(accountData);
+      const account = this.initAccount(accountData);
+      const accounts = this._accounts();
+      const uid = account.get('uid');
+      if (! uid) {
+        this._metrics.logError(AuthErrors.toError('ACCOUNT_HAS_NO_UID'));
+        return;
+      }
 
-      var accounts = this._accounts();
-      accounts[account.get('uid')] = account.toPersistentJSON();
-
+      accounts[uid] = account.toPersistentJSON();
       this._storage.set('accounts', accounts);
     },
 
@@ -297,6 +306,7 @@ define(function (require, exports, module) {
     // Hydrate the account then persist it
     setAccount (accountData) {
       var account = this.initAccount(accountData);
+
       return account.fetch()
         .then(() => {
           this._persistAccount(account);
@@ -354,7 +364,7 @@ define(function (require, exports, module) {
 
     // Before a13f05f2 (18 Dec 2014), all kinds of extra
     // data was written to the Account. This extra data hung
-    // arround even if the user signed in again. After d4321990
+    // around even if the user signed in again. After d4321990
     // (12 Jan 2016), only allowed fields are allowed to be
     // set on an account, unexpected fields cause an error.
     // Update any accounts with unexpected data.
@@ -379,6 +389,27 @@ define(function (require, exports, module) {
       return (Session.email && Session.sessionToken &&
         (! Session.cachedCredentials ||
         Session.cachedCredentials.email !== Session.email));
+    },
+
+    /**
+     * Remove accounts with empty or `undefined` uids.
+     * See #4769. w/ e10s enabled, post account reset,
+     * a phantom account with a uid of `undefined` was
+     * being written to localStorage. These accounts
+     * are garbage, get rid of them.
+     *
+     * @returns {Promise}
+     */
+    removeAccountsWithInvalidUid () {
+      return p().then(() => {
+        const accounts = this._accounts();
+        for (const uid in accounts) {
+          if (! uid || uid === 'undefined') {
+            delete accounts[uid];
+            this._storage.set('accounts', accounts);
+          }
+        }
+      });
     },
 
     /**
@@ -519,10 +550,12 @@ define(function (require, exports, module) {
      * @param {Object} account
      */
     _notifyOfAccountSignIn (account) {
-      // Other tabs only need to know the account `uid` to load any
-      // necessary info from localStorage
-      this._notifier.triggerRemote(
-        this._notifier.COMMANDS.SIGNED_IN, account.pick('uid', 'unwrapBKey', 'keyFetchToken'));
+      const notifier = this._notifier;
+      const signedInCommand = notifier.COMMANDS.SIGNED_IN;
+      notifier.triggerRemote(
+        signedInCommand,
+        account.pick(Object.keys(notifier.SCHEMATA[signedInCommand]))
+      );
     },
 
     /**

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -117,7 +117,7 @@ define(function (require, exports, module) {
       const accounts = this._accounts();
       const uid = account.get('uid');
       if (! uid) {
-        this._metrics.logError(AuthErrors.toError('ACCOUNT_HAS_NO_UID'));
+        this._metrics.logError(AuthErrors.toError('ACCOUNT_HAS_NO_UID', 'persistAccount'));
         return;
       }
 
@@ -392,10 +392,10 @@ define(function (require, exports, module) {
     },
 
     /**
-     * Remove accounts with empty or `undefined` uids.
+     * Remove accounts with invalid uids.
      * See #4769. w/ e10s enabled, post account reset,
-     * a phantom account with a uid of `undefined` was
-     * being written to localStorage. These accounts
+     * a phantom account with a uid of the string `undefined`
+     * was being written to localStorage. These accounts
      * are garbage, get rid of them.
      *
      * @returns {Promise}
@@ -404,6 +404,8 @@ define(function (require, exports, module) {
       return p().then(() => {
         const accounts = this._accounts();
         for (const uid in accounts) {
+          // the string `undefined` is correct here. That's the
+          // uid being stored in localStorage.
           if (! uid || uid === 'undefined') {
             delete accounts[uid];
             this._storage.set('accounts', accounts);

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -5,6 +5,8 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const _ = require('underscore');
+  const Account = require('models/account');
   const AuthErrors = require('lib/auth-errors');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
@@ -139,21 +141,20 @@ define(function (require, exports, module) {
     },
 
     _finishPasswordResetSameBrowser (sessionInfo) {
-      // Only the account UID, unwrapBKey and keyFetchToken are passed
-      // from the verification tab. Load other from localStorage
-      var account = this.user.getAccountByUid(sessionInfo.uid);
+      const account = this.user.getAccountByUid(sessionInfo.uid);
 
+      // A bug in e10s causes localStorage in about:accounts and content tabs to be isolated from
+      // each other. Writes to localStorage from /complete_reset_password are not able to be read
+      // from within about:accounts. Because of this, all account data needed to sign in must
+      // be passed between windows. See https://github.com/mozilla/fxa-content-server/issues/4763
+      // and https://bugzilla.mozilla.org/show_bug.cgi?id=666724
+      //
       // keyFetchToken and unwrapBKey are sent from the verification tab,
       // this tab has no idea what they are. The keyFetchToken and
       // unwrapBKey are used to generate encryption keys for Hello
       // that must be sent from this tab, otherwise Hello gets
       // confused on where it should update it's UI.
-      if (sessionInfo.keyFetchToken && sessionInfo.unwrapBKey) {
-        account.set({
-          keyFetchToken: sessionInfo.keyFetchToken,
-          unwrapBKey: sessionInfo.unwrapBKey
-        });
-      }
+      account.set(_.pick(sessionInfo, Account.ALLOWED_KEYS));
 
       if (account.isDefault()) {
         return p.reject(AuthErrors.toError('UNEXPECTED_ERROR'));

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -148,12 +148,6 @@ define(function (require, exports, module) {
       // from within about:accounts. Because of this, all account data needed to sign in must
       // be passed between windows. See https://github.com/mozilla/fxa-content-server/issues/4763
       // and https://bugzilla.mozilla.org/show_bug.cgi?id=666724
-      //
-      // keyFetchToken and unwrapBKey are sent from the verification tab,
-      // this tab has no idea what they are. The keyFetchToken and
-      // unwrapBKey are used to generate encryption keys for Hello
-      // that must be sent from this tab, otherwise Hello gets
-      // confused on where it should update it's UI.
       account.set(_.pick(sessionInfo, Account.ALLOWED_KEYS));
 
       if (account.isDefault()) {

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -886,16 +886,15 @@ define(function (require, exports, module) {
 
         sinon.spy(userMock, 'upgradeFromUnfilteredAccountData');
         sinon.spy(userMock, 'upgradeFromSession');
+        sinon.spy(userMock, 'removeAccountsWithInvalidUid');
 
         return appStart.upgradeStorageFormats();
       });
 
-      it('upgrades unfiltered account data', function () {
-        assert.isTrue(userMock.upgradeFromUnfilteredAccountData.called);
-      });
-
-      it('upgrades from Session data', function () {
-        assert.isTrue(userMock.upgradeFromSession.called);
+      it('upgrades and fixes account data', function () {
+        assert.isTrue(userMock.upgradeFromUnfilteredAccountData.calledOnce);
+        assert.isTrue(userMock.upgradeFromSession.calledOnce);
+        assert.isTrue(userMock.removeAccountsWithInvalidUid.calledOnce);
       });
     });
 

--- a/app/tests/spec/lib/channels/notifier.js
+++ b/app/tests/spec/lib/channels/notifier.js
@@ -5,13 +5,11 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const { assert } = require('chai');
   const Backbone = require('backbone');
-  const chai = require('chai');
   const Notifier = require('lib/channels/notifier');
   const NullChannel = require('lib/channels/null');
   const sinon = require('sinon');
-
-  var assert = chai.assert;
 
   describe('lib/channels/notifier', function () {
     var NOTIFICATION = Notifier.COMPLETE_RESET_PASSWORD_TAB_OPEN;
@@ -228,4 +226,3 @@ define(function (require, exports, module) {
     });
   });
 });
-

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -41,9 +41,6 @@ define(function (require, exports, module) {
       assert.lengthOf(args, 2);
       assert.equal(args[0], notifier.COMMANDS.SIGNED_IN);
 
-      // unwrapBKey and keyFetchToken are used in password reset
-      // to enable the original tab to send encryption keys
-      // to Firefox Hello.
       assert.deepEqual(
         args[1], account.pick('keyFetchToken', 'sessionToken', 'sessionTokenContext', 'uid', 'unwrapBKey'));
     }
@@ -304,7 +301,9 @@ define(function (require, exports, module) {
 
           assert.isFalse(storage.set.called);
           assert.isTrue(metrics.logError.calledOnce);
-          assert.isTrue(AuthErrors.is(metrics.logError.args[0][0], 'ACCOUNT_HAS_NO_UID'));
+          const err = metrics.logError.args[0][0];
+          assert.isTrue(AuthErrors.is(err, 'ACCOUNT_HAS_NO_UID'));
+          assert.equal(err.context, 'persistAccount');
         });
       });
     });

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -394,17 +394,14 @@ define(function (require, exports, module) {
       });
 
       describe('with an unknown account uid', function () {
-        var err;
-
-        beforeEach(function () {
-          return view._finishPasswordResetSameBrowser({ uid: 'unknown uid' })
-            .then(assert.fail, function (_err) {
-              err = _err;
-            });
+        beforeEach(() => {
+          return view._finishPasswordResetSameBrowser({ uid: 'unknown uid' });
         });
 
-        it('throws', function () {
-          assert.isTrue(AuthErrors.is(err, 'UNEXPECTED_ERROR'));
+        it('sets the account, notifies the broker', function () {
+          assert.isTrue(user.setSignedInAccount.calledOnce);
+          assert.equal(user.setSignedInAccount.args[0][0].get('uid'), 'unknown uid');
+          assert.isTrue(broker.afterResetPasswordConfirmationPoll.calledOnce);
         });
       });
 

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -115,6 +115,7 @@ The event stream is a log of events and the time they occurred while the user is
 * error.&lt;unexpected_origin&gt;.auth.1027 - a postMessage message was received from an unexpected origin.
 * error.&lt;image_url&gt;.profile.997 - a profile image could not load.
 * error.&lt;screen_name&gt;.&lt;service&gt;.998 - System unavailable.
+* error.no context.auth.1050 - an attempt is being made to write an account with no uid to localStorage.
 * loaded - logged after the first screen is rendered.
 * &lt;screen_name&gt;.submit - A submit event has occurred and all of the form's input elements are valid.
 * &lt;screen_name&gt;.refresh - The aforementioned screen was refreshed.

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -115,7 +115,7 @@ The event stream is a log of events and the time they occurred while the user is
 * error.&lt;unexpected_origin&gt;.auth.1027 - a postMessage message was received from an unexpected origin.
 * error.&lt;image_url&gt;.profile.997 - a profile image could not load.
 * error.&lt;screen_name&gt;.&lt;service&gt;.998 - System unavailable.
-* error.no context.auth.1050 - an attempt is being made to write an account with no uid to localStorage.
+* error.persistAccount.auth.1050 - an attempt is being made to write an account with no uid to localStorage.
 * loaded - logged after the first screen is rendered.
 * &lt;screen_name&gt;.submit - A submit event has occurred and all of the form's input elements are valid.
 * &lt;screen_name&gt;.refresh - The aforementioned screen was refreshed.


### PR DESCRIPTION
### What is the problem?
Fx w/ e10s enabled isolates localStorage in about:accounts from
localStorage in normal web content. If a user created a new profile
and did the reset password flow, completed the reset password flow
in the same browser, and then clicked "Manage account", the
user would have to sign in again because of this localStorage isolation.
The last localStorage write in about:accounts blew away the user's
account information, and in fact added a junk account with a uid
of `undefined`.

### How does this fix it?
Pass all the data needed to retain the user's session from
the confirm_reset_account tab to the about:accounts tab. The
passed data will be written to localStorage from the about:accounts
tab. Whenever the user clicks Manage Account, the data will
be in localStorage, as expected.

### What is `user.removeAccountsWithInvalidUid`?
A bunch of users report having > 1 stored account, it may
be most of these are users who have reset their password
and have one of these junk accounts. Remove them.

fixes #4748 
fixes #4763
fixes #4769

@vladikoff, @vbudhram or @philbooth - r?