### PR TITLE
fix(tests): on-headers is required for server tests

### DIFF
--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -88,6 +88,7 @@ node ./tests/teamcity/install-npm-deps.js \
   mozlog                          \
   node-statsd                     \
   node-uap                        \
+  on-headers                      \
   proxyquire                      \
   raven                           \
   sinon                           \


### PR DESCRIPTION
r? - @vladikoff 

New dependency to run server tests.