### PR TITLE
fix(sms): Allow parens in the phone number

### DIFF
--- a/app/scripts/views/elements/tel-input.js
+++ b/app/scripts/views/elements/tel-input.js
@@ -22,7 +22,7 @@ define(function (require, exports, module) {
       return this.__val(val);
     }
 
-    return this.__val().replace(/[.,-\s]/g, '');
+    return this.__val().replace(/[.,()\s-]/g, '');
   };
 
   element.validate = function () {

--- a/app/tests/spec/views/elements/tel-input.js
+++ b/app/tests/spec/views/elements/tel-input.js
@@ -40,8 +40,8 @@ define(function (require, exports, module) {
     });
 
     describe('val', () => {
-      it('strips periods, commas, -, spaces', () => {
-        $requiredTelEl.val('  123,456.78-90');
+      it('strips periods, commas, -, spaces, ()', () => {
+        $requiredTelEl.val('  (123),456.78-90');
         assert.equal($requiredTelEl.val(), '1234567890');
       });
     });
@@ -75,7 +75,14 @@ define(function (require, exports, module) {
 
         it('does not throw if valid', () => {
           assert.isUndefined(validate($requiredTelEl, '1234567890'));
-          assert.isUndefined(validate($requiredTelEl, '+11234567890'));
+          assert.isUndefined(validate($requiredTelEl, '11234567890'));
+          assert.isUndefined(validate($requiredTelEl, '(123)4567890'));
+          assert.isUndefined(validate($requiredTelEl, '(123)456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '(123) 456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '1(123) 456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '1 (123) 456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '+1(123) 456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '+1 (123) 456-7890'));
         });
       });
 


### PR DESCRIPTION
### What is the problem?
Parenthesis are not allowed in a phone number. Lots of people surround
a US area code with ().

### How does this fix it?
Allow any combination of ( and ).

fixes #4764

@mozilla/fxa-devs - r?