### PR TITLE
feat(metrics): emit a flow event for active experiments

### DIFF
--- a/app/scripts/lib/experiments/base.js
+++ b/app/scripts/lib/experiments/base.js
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
     notifications: {},
 
     /**
-     * The A/B testing group type, see https://en.wikipedia.org/wiki/A/B_testing for details.
+     * The A/B testing group type, usually either `'control'` or `'treatment'`.
      */
     _groupType: null,
 

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -521,6 +521,11 @@ define(function (require, exports, module) {
      * @param {String} group - the experiment group (treatment or control)
      */
     logExperiment (choice, group) {
+      this._logFlowEvent({
+        event: `experiment.${choice}.${group}`,
+        once: true
+      });
+
       if (! choice || ! group) {
         return;
       }

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -739,14 +739,25 @@ define(function (require, exports, module) {
       it('logs the experiment name and group', function () {
         var experiment = 'mailcheck';
         var group = 'group';
+        sinon.spy(metrics, 'logEvent');
+        sinon.spy(metrics, 'logEventOnce');
+        notifier.trigger('flow.initialize');
 
         metrics.logExperiment();
         assert.equal(Object.keys(metrics._activeExperiments).length, 0);
+        assert.equal(metrics.logEventOnce.callCount, 1);
+        assert.equal(metrics.logEventOnce.args[0][0], 'flow.experiment.undefined.undefined');
+
         metrics.logExperiment(experiment);
         assert.equal(Object.keys(metrics._activeExperiments).length, 0);
+        assert.equal(metrics.logEventOnce.callCount, 2);
+        assert.equal(metrics.logEventOnce.args[1][0], 'flow.experiment.mailcheck.undefined');
+
         metrics.logExperiment(experiment, group);
         assert.equal(Object.keys(metrics._activeExperiments).length, 1);
         assert.isDefined(metrics._activeExperiments['mailcheck']);
+        assert.equal(metrics.logEventOnce.callCount, 3);
+        assert.equal(metrics.logEventOnce.args[2][0], 'flow.experiment.mailcheck.group');
       });
     });
 


### PR DESCRIPTION
Fixes #4290.

There is some additional monkeying around we can do in the import scripts, to make the experiment data available as metadata rather than a standalone event. But that can happen in a separate issue.

@mozilla/fxa-devs r?