### PR TITLE
refactor(notifier-mixin): Simplify the notifier-mixin using built in object event methods

### DIFF
--- a/app/tests/spec/lib/channels/notifier-mixin.js
+++ b/app/tests/spec/lib/channels/notifier-mixin.js
@@ -179,26 +179,25 @@ define(function (require, exports, module) {
       });
 
       describe('without an event name and callback', () => {
-        beforeEach(() => {
-          sinon.spy(notifier, 'off');
+        let callback1;
+        let callback2;
 
-          let callback1 = () => {};
-          let callback2 = () => {};
+        beforeEach(() => {
+          callback1 = sinon.spy();
+          callback2 = sinon.spy();
 
           view.notifier.on('message1', callback1);
           view.notifier.on('message2', callback2);
+
+          view.notifier.off();
+
+          notifier.trigger('message1');
+          notifier.trigger('message2');
         });
 
         it('unregisters all of the view\'s handlers from the notifier', () => {
-          view.notifier.off();
-
-          assert.isTrue(notifier.off.calledWith('message1'));
-          // A second argument is passed, but it's opaque to us.
-          assert.ok(notifier.off.args[0][1]);
-
-          assert.isTrue(notifier.off.calledWith('message2'));
-          // A second argument is passed, but it's opaque to us.
-          assert.ok(notifier.off.args[1][1]);
+          assert.isFalse(callback1.called);
+          assert.isFalse(callback2.called);
         });
       });
     });
@@ -233,6 +232,29 @@ define(function (require, exports, module) {
 
       it('delegates to notifier.triggerRemote', () => {
         assert.isTrue(notifier.triggerRemote.calledWith('fxaccounts:logout', data));
+      });
+    });
+
+    describe('destroy', () => {
+      let callback1;
+      let callback2;
+
+      beforeEach(() => {
+        callback1 = sinon.spy();
+        callback2 = sinon.spy();
+
+        view.notifier.on('message1', callback1);
+        view.notifier.on('message2', callback2);
+
+        view.destroy();
+
+        notifier.trigger('message1');
+        notifier.trigger('message2');
+      });
+
+      it('unregisters all of the view\'s handlers from the notifier', () => {
+        assert.isFalse(callback1.called);
+        assert.isFalse(callback2.called);
       });
     });
   });

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -75,23 +75,12 @@ define(function (require, exports, module) {
       metrics = null;
     });
 
-    it('calls notifier.on correctly', () => {
-      assert.equal(notifier.on.callCount, 3);
+    it('has the expected notifications', () => {
+      assert.lengthOf(Object.keys(metrics.notifications), 3);
 
-      let args = notifier.on.args[0];
-      assert.lengthOf(args, 2);
-      assert.equal(args[0], 'flow.initialize');
-      assert.isFunction(args[1]);
-
-      args = notifier.on.args[1];
-      assert.lengthOf(args, 2);
-      assert.equal(args[0], 'flow.event');
-      assert.notEqual(args[1], notifier.on.args[0][1]);
-
-      args = notifier.on.args[2];
-      assert.lengthOf(args, 2);
-      assert.equal(args[0], 'view-shown');
-      assert.isFunction(args[1]);
+      assert.isTrue('flow.initialize' in metrics.notifications);
+      assert.isTrue('flow.event' in metrics.notifications);
+      assert.isTrue('view-shown' in metrics.notifications);
     });
 
     it('observable flow state is correct', () => {

--- a/app/tests/spec/views/mixins/signed-in-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-in-notification-mixin.js
@@ -5,33 +5,31 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const { assert } = require('chai');
   const Backbone = require('backbone');
   const BaseView = require('views/base');
-  const chai = require('chai');
   const Cocktail = require('cocktail');
   const Notifier = require('lib/channels/notifier');
   const p = require('lib/promise');
   const SignedInNotificationMixin = require('views/mixins/signed-in-notification-mixin');
   const sinon = require('sinon');
 
-  var assert = chai.assert;
-
-  var View = BaseView.extend({});
+  const View = BaseView.extend({});
   Cocktail.mixin(View, SignedInNotificationMixin);
 
-  describe('views/mixins/signed-in-notification-mixin', function () {
-    it('exports correct interface', function () {
+  describe('views/mixins/signed-in-notification-mixin', () => {
+    it('exports correct interface', () => {
       assert.lengthOf(Object.keys(SignedInNotificationMixin), 2);
       assert.isObject(SignedInNotificationMixin.notifications);
       assert.isFunction(SignedInNotificationMixin._navigateToSignedInView);
     });
 
-    describe('new View', function () {
-      var model;
-      var notifier;
-      var view;
+    describe('new View', () => {
+      let model;
+      let notifier;
+      let view;
 
-      before(function () {
+      before(() => {
         model = new Backbone.Model();
         notifier = new Notifier();
         notifier.on = sinon.spy();
@@ -41,27 +39,25 @@ define(function (require, exports, module) {
         });
       });
 
-      after(function () {
+      after(() => {
         view.destroy();
+        view = null;
       });
 
-      it('calls notifier.on correctly', function () {
-        assert.equal(notifier.on.callCount, 1);
-        var args = notifier.on.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], notifier.COMMANDS.SIGNED_IN);
-        assert.isFunction(args[1]);
+      it('has the expected notifications', () => {
+        assert.lengthOf(Object.keys(view.notifications), 1);
+        assert.isTrue(notifier.COMMANDS.SIGNED_IN in view.notifications);
       });
 
-      describe('navigateToSignedInView', function () {
-        before(function () {
+      describe('navigateToSignedInView', () => {
+        before(() => {
           view.broker = {
-            hasCapability: sinon.spy(function () {
+            hasCapability: sinon.spy(() => {
               return true;
             })
           };
           view.user = {
-            setSignedInAccountByUid: sinon.spy(function () {
+            setSignedInAccountByUid: sinon.spy(() => {
               return p();
             })
           };
@@ -72,43 +68,43 @@ define(function (require, exports, module) {
           });
         });
 
-        it('calls broker.hasCapability correctly', function () {
+        it('calls broker.hasCapability correctly', () => {
           assert.equal(view.broker.hasCapability.callCount, 1);
           assert.isTrue(view.broker.hasCapability.alwaysCalledOn(view.broker));
-          var args = view.broker.hasCapability.args[0];
+          const args = view.broker.hasCapability.args[0];
           assert.lengthOf(args, 1);
           assert.equal(args[0], 'handleSignedInNotification');
         });
 
-        it('calls user.setSignedInAccountByUid correctly', function () {
+        it('calls user.setSignedInAccountByUid correctly', () => {
           assert.equal(view.user.setSignedInAccountByUid.callCount, 1);
           assert.isTrue(view.user.setSignedInAccountByUid.alwaysCalledOn(view.user));
           assert.isTrue(view.user.setSignedInAccountByUid.calledWith('uid'));
         });
 
-        it('calls navigate correctly', function () {
+        it('calls navigate correctly', () => {
           assert.equal(view.navigate.callCount, 1);
           assert.isTrue(view.navigate.alwaysCalledOn(view));
           assert.isTrue(view.navigate.calledAfter(view.user.setSignedInAccountByUid));
-          var args = view.navigate.args[0];
+          const args = view.navigate.args[0];
           assert.lengthOf(args, 1);
           assert.equal(args[0], 'settings');
         });
 
-        it('does not call notifier.triggerAll', function () {
+        it('does not call notifier.triggerAll', () => {
           assert.equal(notifier.triggerAll.callCount, 0);
         });
       });
 
-      describe('navigateToSignedInView without handleSignedInNotification capability', function () {
-        before(function () {
+      describe('navigateToSignedInView without handleSignedInNotification capability', () => {
+        before(() => {
           view.broker = {
-            hasCapability: sinon.spy(function () {
+            hasCapability: sinon.spy(() => {
               return false;
             })
           };
           view.user = {
-            setSignedInAccountByUid: sinon.spy(function () {
+            setSignedInAccountByUid: sinon.spy(() => {
               return p();
             })
           };
@@ -118,87 +114,71 @@ define(function (require, exports, module) {
           });
         });
 
-        it('calls broker.hasCapability', function () {
+        it('calls broker.hasCapability', () => {
           assert.equal(view.broker.hasCapability.callCount, 1);
         });
 
-        it('does not call user.setSignedInAccountByUid', function () {
+        it('does not call user.setSignedInAccountByUid', () => {
           assert.isFalse(view.user.setSignedInAccountByUid.called);
         });
 
-        it('does not call navigate', function () {
+        it('does not call navigate', () => {
           assert.equal(view.navigate.callCount, 0);
         });
       });
 
-      describe('navigateToSignedInView with OAuth redirect URL', function () {
+      describe('navigateToSignedInView with OAuth redirect URL', () => {
 
-        beforeEach(function () {
+        beforeEach(() => {
           view.broker = {
-            hasCapability: sinon.spy(function () {
+            hasCapability: sinon.spy(() => {
               return true;
             })
           };
           view.user = {
-            setSignedInAccountByUid: sinon.spy(function () {
+            setSignedInAccountByUid: sinon.spy(() => {
               return p();
             })
           };
           view.navigate = sinon.spy();
         });
 
-        describe('without model.redirectTo', function () {
-          beforeEach(function () {
+        describe('without model.redirectTo', () => {
+          beforeEach(() => {
             return notifier.on.args[0][1]({
               uid: 'uid'
             });
           });
 
-          it('calls broker.hasCapability', function () {
+          it('calls broker.hasCapability', () => {
             assert.equal(view.broker.hasCapability.callCount, 1);
           });
 
-          it('calls user.setSignedInAccountByUid correctly', function () {
+          it('calls user.setSignedInAccountByUid correctly', () => {
             assert.equal(view.user.setSignedInAccountByUid.callCount, 1);
             assert.isTrue(view.user.setSignedInAccountByUid.calledWith('uid'));
           });
 
-          it('calls navigate correctly', function () {
+          it('calls navigate correctly', () => {
             assert.equal(view.navigate.callCount, 1);
             assert.equal(view.navigate.args[0][0], 'settings');
           });
         });
 
-        describe('with model.redirectTo', function () {
-          beforeEach(function () {
+        describe('with model.redirectTo', () => {
+          beforeEach(() => {
             model.set('redirectTo', 'foo');
             return notifier.on.args[0][1]({
               uid: 'uid'
             });
           });
 
-          it('calls navigate correctly', function () {
+          it('calls navigate correctly', () => {
             assert.equal(view.navigate.callCount, 1);
             assert.equal(view.navigate.args[0][0], 'foo');
           });
         });
       });
-
-      describe('destroy', function () {
-        beforeEach(function () {
-          notifier.off = sinon.spy();
-          view.destroy();
-        });
-
-        it('calls notifier.off correctly', function () {
-          assert.equal(notifier.off.callCount, 1);
-          var args = notifier.off.args[0];
-          assert.lengthOf(args, 2);
-          assert.equal(args[0], notifier.COMMANDS.SIGNED_IN);
-          assert.equal(args[1], notifier.on.args[0][1]);
-        });
-      });
     });
   });
 });
-

--- a/app/tests/spec/views/mixins/signed-out-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-out-notification-mixin.js
@@ -51,12 +51,9 @@ define((require, exports, module) => {
         view.destroy();
       });
 
-      it('calls notifier.on correctly', () => {
-        assert.equal(notifier.on.callCount, 1);
-        var args = notifier.on.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], Notifier.SIGNED_OUT);
-        assert.isFunction(args[1]);
+      it('has the expected notifications', () => {
+        assert.lengthOf(Object.keys(view.notifications), 1);
+        assert.isTrue(Notifier.SIGNED_OUT in view.notifications);
       });
 
       describe('clearSessionAndNavigateToSignIn', () => {


### PR DESCRIPTION
### What is the problem?
The notifier-mixin duplicated logic already provided by Backbone.

### How so?
The notifier-mixin kept track of all events that were attached so that those events
could be removed whenever the consumer object was destroyed. Backbone does the same
with the `object.listenTo*` methods.

### How does this fix the problem?
Ditch the internal housekeeping and let Backbone take care of it.

### Does this change where the mixin can be used?
The consuming object has to be Backbone.Events capable.

### Why did the tests change to no longer test for `notifier.on` calls?
That's an internal detail that tests shouldn't really know about. If we
trust the notifier-mixin works, then we should trust that `notifications`
will be handled correctly. Test to ensure there are handlers for the
expected messages, and test to ensure those message handlers are invoked
when the message is triggered.


@philbooth - you have the most context into the recent work here, I noticed the duplication after you reviewed the last PR, mind an r?