### PR TITLE
Removed period on newsletter label on registration

### DIFF
--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -60,7 +60,7 @@
 
       {{#isEmailOptInVisible}}
       <div class="input-row marketing-email-optin-row">
-          <label class="fxa-checkbox"><input id="marketing-email-optin" type="checkbox" class="marketing-email-optin"><span>{{#t}}Receive the monthly Firefox newsletter.{{/t}}</span></label>
+          <label class="fxa-checkbox"><input id="marketing-email-optin" type="checkbox" class="marketing-email-optin"><span>{{#t}}Receive the monthly Firefox newsletter{{/t}}</span></label>
       </div>
       {{/isEmailOptInVisible}}
 


### PR DESCRIPTION
Removed period on newsletter label on registration as requested by Michelle. May save us a line break in some languages too.