### PR TITLE
fix(CWTS): Fix styles for the trustedUI

### DIFF
--- a/app/styles/modules/_branding.scss
+++ b/app/styles/modules/_branding.scss
@@ -101,8 +101,11 @@
 
   .success-email-created {
     margin: -35px 0 40px 0;
-  }
 
+    @include respond-to('trustedUI') {
+      margin-top: -5px;
+    }
+  }
 }
 
 .sms-row {

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -153,11 +153,6 @@ ul.links {
   .links + .extra-links {
     margin: 5px auto;
   }
-
-  .extra-links +
-  .button-row {
-    margin: 0;
-  }
 }
 
 .small-label,


### PR DESCRIPTION
* Ensure the success message is displayed.
* Add a little space above the "back" button.

fixes #4749 

@ryanfeeley - r?

<img width="270" alt="screen shot 2017-03-07 at 12 24 14" src="https://cloud.githubusercontent.com/assets/848085/23656474/c6f78724-0331-11e7-9c3f-9a34d89cc49b.png">
