### PR TITLE
feat(sms): Use Able to decide if user should see /sms

### DIFF
--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -6,10 +6,8 @@ define(function (require, exports, module) {
   'use strict';
 
   const _ = require('underscore');
+  const BaseExperiment = require('lib/experiments/base');
   const ConnectAnotherDeviceExperiment = require('lib/experiments/connect-another-device');
-  // For now, the send SMS experiment only needs to log "enrolled", so
-  // no special experiment is created.
-  const SendSMSExperiment = require('lib/experiments/base');
   const Url = require('lib/url');
 
   const FORCE_EXPERIMENT_PARAM = 'forceExperiment';
@@ -18,7 +16,9 @@ define(function (require, exports, module) {
 
   const ALL_EXPERIMENTS = {
     'connectAnotherDevice': ConnectAnotherDeviceExperiment,
-    'sendSms': SendSMSExperiment
+    // For now, the send SMS experiment only needs to log "enrolled", so
+    // no special experiment is created.
+    'sendSms': BaseExperiment
   };
 
   function ExperimentInterface (options) {

--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -7,6 +7,9 @@ define(function (require, exports, module) {
 
   const _ = require('underscore');
   const ConnectAnotherDeviceExperiment = require('lib/experiments/connect-another-device');
+  // For now, the send SMS experiment only needs to log "enrolled", so
+  // no special experiment is created.
+  const SendSMSExperiment = require('lib/experiments/base');
   const Url = require('lib/url');
 
   const FORCE_EXPERIMENT_PARAM = 'forceExperiment';
@@ -14,7 +17,8 @@ define(function (require, exports, module) {
   const UA_OVERRIDE = 'FxATester';
 
   const ALL_EXPERIMENTS = {
-    'connectAnotherDevice': ConnectAnotherDeviceExperiment
+    'connectAnotherDevice': ConnectAnotherDeviceExperiment,
+    'sendSms': SendSMSExperiment
   };
 
   function ExperimentInterface (options) {

--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
     _allExperiments: ALL_EXPERIMENTS,
 
     /**
-     * Destory all active experiments.
+     * Destroy all active experiments.
      */
     destroy () {
       for (let expName in this._activeExperiments) {


### PR DESCRIPTION
### What is the problem?
To test /sms, the user has to create a session and then visit /sms manually.

### How does this fix it?
Use Able to decide whether to show the user the /sms screen post-verification.

### Does this depend on anything?
* [x] https://github.com/mozilla/fxa-content-experiments/pull/55 which provides
the Able based logic.
* [x] #4809 


### What about gating on the user's country?
That's coming next.

fixes #4789