### PR TITLE
fix(change_password): Change password field specific error, fixes #4768

### DIFF
--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -44,6 +44,14 @@ define(function (require, exports, module) {
           newPassword,
           this.relier
         )
+        .fail((err) => {
+          if (AuthErrors.is(err, 'PASSWORDS_MUST_BE_DIFFERENT')) {
+            this.showValidationError(this.$('#new_password'), err);
+            return;
+          }
+
+          throw err;
+        })
         .then(() => {
           this.logViewEvent('success');
           return this.invokeBrokerMethod('afterChangePassword', account);

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const AuthErrors = require('lib/auth-errors');
   const BackMixin = require('views/mixins/back-mixin');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -45,6 +45,10 @@ define(function (require, exports, module) {
           newPassword,
           this.relier
         )
+        .then(() => {
+          this.logViewEvent('success');
+          return this.invokeBrokerMethod('afterChangePassword', account);
+        })
         .fail((err) => {
           if (AuthErrors.is(err, 'PASSWORDS_MUST_BE_DIFFERENT')) {
             this.showValidationError(this.$('#new_password'), err);
@@ -52,10 +56,6 @@ define(function (require, exports, module) {
           }
 
           throw err;
-        })
-        .then(() => {
-          this.logViewEvent('success');
-          return this.invokeBrokerMethod('afterChangePassword', account);
         })
         .then(() => {
           this.displaySuccess(t('Password changed successfully'));

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -49,6 +49,12 @@ define(function (require, exports, module) {
           this.logViewEvent('success');
           return this.invokeBrokerMethod('afterChangePassword', account);
         })
+        .then(() => {
+          this.displaySuccess(t('Password changed successfully'));
+          this.navigate('settings');
+
+          return this.render();
+        })
         .fail((err) => {
           if (AuthErrors.is(err, 'PASSWORDS_MUST_BE_DIFFERENT')) {
             this.showValidationError(this.$('#new_password'), err);
@@ -56,12 +62,6 @@ define(function (require, exports, module) {
           }
 
           throw err;
-        })
-        .then(() => {
-          this.displaySuccess(t('Password changed successfully'));
-          this.navigate('settings');
-
-          return this.render();
         });
     }
 


### PR DESCRIPTION
I've gone through a few commits of trying to fix the ["Your new password must be different" issue](https://github.com/mozilla/fxa-content-server/issues/4768), and am having trouble having the ValidationError pop up. Currently, if you enter the same password as your old password, the change will be made successfully. Commenting out the return statement in the error handler seems to trigger both the original error message and the new validation error.

![image](https://cloud.githubusercontent.com/assets/7684791/23730030/18858f94-041a-11e7-9315-0e0cc82ee481.png)
![image](https://cloud.githubusercontent.com/assets/7684791/23730036/239ee650-041a-11e7-8de2-52faa7b53da8.png)