### PR TITLE
fix(signup): decrease checkbox line height for email opt-in

### DIFF
--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -98,6 +98,10 @@ ul.links {
     margin: 20px 0 10px 0;
   }
 
+  .fxa-checkbox {
+    line-height: 18px;
+  }
+
 }
 
 .choose-what-to-sync-row,


### PR DESCRIPTION
Fixes #4707 

Decreases the line height on the checkbox to opt-in for newsletter emails on the initial account sign up page from 24px (for most `.fxa-checkbox`es) to 18px.

Screenshot of proposed changes:

![](https://puu.sh/uAt3y/1fbe53ceae.png)