### PR TITLE
Modified the link for Firefox users on sign up page

### DIFF
--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -24,7 +24,9 @@ define(function (require, exports, module) {
   const SignedInNotificationMixin = require('views/mixins/signed-in-notification-mixin');
   const SignInMixin = require('views/mixins/signin-mixin');
   const SignUpMixin = require('views/mixins/signup-mixin');
+  const SyncAuthMixin = require('views/mixins/sync-auth-mixin');
   const Template = require('stache!templates/sign_up');
+  const UserAgentMixin = require('views/mixins/user-agent-mixin');
 
   var t = BaseView.t;
 
@@ -163,7 +165,6 @@ define(function (require, exports, module) {
         chooseWhatToSyncCheckbox: this.broker.hasCapability('chooseWhatToSyncCheckbox'),
         email: prefillEmail,
         error: this.error,
-        escapedSyncSuggestionUrl: encodeURI('https://mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started'), // eslint-disable-line max-len
         forceEmail: forceEmail,
         isAmoMigration: this.isAmoMigration(),
         isCustomizeSyncChecked: relier.isCustomizeSyncChecked(),
@@ -177,6 +178,14 @@ define(function (require, exports, module) {
         shouldFocusPassword: autofocusEl === 'password',
         showSyncSuggestion: this.isSyncSuggestionEnabled()
       };
+      if (this.isSyncAuthSupported()) {
+        context.escapedSyncSuggestionUrl = this.getEscapedSyncUrl('signup', View.ENTRYPOINT);
+      } else {
+        context.escapedSyncSuggestionUrl = encodeURI(
+                'https://mozilla.org/firefox/sync?' +
+                'utm_source=fx-website&utm_medium=fx-accounts&' +
+                'utm_campaign=fx-signup&utm_content=fx-sync-get-started');
+      }
 
       return context;
     },
@@ -387,6 +396,8 @@ define(function (require, exports, module) {
         lang: this.navigator.language
       });
     }
+  }, {
+    ENTRYPOINT: 'fxa:signup'
   });
 
   Cocktail.mixin(
@@ -404,7 +415,9 @@ define(function (require, exports, module) {
     ServiceMixin,
     SignInMixin,
     SignUpMixin,
-    SignedInNotificationMixin
+    SignedInNotificationMixin,
+    SyncAuthMixin,
+    UserAgentMixin
   );
 
   module.exports = View;

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -261,12 +261,60 @@ define(function (require, exports, module) {
 
             const $getStartedEl = $suggestSyncEl.find('a');
             assert.equal($getStartedEl.attr('rel'), 'noopener noreferrer');
+
+            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signup.sync-suggest.visible'), 'enrolled');
+          });
+      });
+
+      it('does not have sync auth supported', function () {
+        createView();
+        relier.set('service', null);
+        sinon.stub(view, 'isSyncAuthSupported', () => false);
+        return view.render()
+          .then(function () {
+            const $getStartedEl = view.$('#suggest-sync').find('a');
             assert.equal($getStartedEl.attr('href'),
               'https://mozilla.org/firefox/sync?' +
               'utm_source=fx-website&utm_medium=fx-accounts&' +
               'utm_campaign=fx-signup&utm_content=fx-sync-get-started');
+          });
+      });
 
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signup.sync-suggest.visible'), 'enrolled');
+      it('has sync auth supported on Firefox for Desktop', function () {
+        createView();
+        relier.set('service', null);
+        sinon.stub(view, 'isSyncAuthSupported', () => true);
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            isFirefoxAndroid: () => false,
+            isFirefoxDesktop: () => true,
+          };
+        });
+        return view.render()
+          .then(function () {
+            const $getStartedEl = view.$('#suggest-sync').find('a');
+            assert.equal($getStartedEl.attr('href'),
+              view.window.location.origin +
+              '/signup?context=fx_desktop_v3&entrypoint=fxa%3Asignup&service=sync');
+          });
+      });
+
+      it('has sync auth supported on Firefox for Android', function () {
+        createView();
+        relier.set('service', null);
+        sinon.stub(view, 'isSyncAuthSupported', () => true);
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            isFirefoxAndroid: () => true,
+            isFirefoxDesktop: () => false,
+          };
+        });
+        return view.render()
+          .then(function () {
+            const $getStartedEl = view.$('#suggest-sync').find('a');
+            assert.equal($getStartedEl.attr('href'),
+              view.window.location.origin +
+              '/signup?context=fx_fennec_v1&entrypoint=fxa%3Asignup&service=sync');
           });
       });
 


### PR DESCRIPTION
Modified the introduction link to point [here]( https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=uitour) for firefox users as mentioned in issue #4605.

I have used the following code to determine if the user is in firefox or not
```js
var isFirefox = typeof InstallTrigger !== 'undefined';
```
Please let me know if this is the right method to locate the browser.