### PR TITLE
fix(change_password): Made error message field specific.

### DIFF
--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -57,8 +57,9 @@ define(function (require, exports, module) {
         })
         .fail((err) => {
           if (AuthErrors.is(err, 'INCORRECT_PASSWORD')) {
-            this.showValidationError(this.$('#old_password'), err);
-            return;
+            return this.showValidationError(this.$('#old_password'), err);
+          } else if (AuthErrors.is(err, 'PASSWORDS_MUST_BE_DIFFERENT')) {
+            return this.showValidationError(this.$('#new_password'), err);
           }
           throw err;
         });

--- a/app/tests/spec/views/settings/change_password.js
+++ b/app/tests/spec/views/settings/change_password.js
@@ -211,6 +211,25 @@ define(function (require, exports, module) {
             assert.isTrue(view.showValidationError.called);
           });
         });
+
+        describe('error', function () {
+
+          beforeEach(function () {
+            $('#old_password').val('password');
+            $('#new_password').val('password');
+
+            sinon.stub(user, 'changeAccountPassword', function () {
+              return p.reject(AuthErrors.toError('PASSWORDS_MUST_BE_DIFFERENT'));
+            });
+
+            sinon.stub(view, 'showValidationError', function () { });
+            return view.submit();
+          });
+
+          it('display an error message', function () {
+            assert.isTrue(view.showValidationError.called);
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Fixes #4768 
The method followed is a bit different than the approach mentioned in the issue
The fail handler already existed to handle error requests, so I made the changes directly over there.
