### PR TITLE
fix(version): use use cwd and env var to get version

### DIFF
--- a/server/lib/version.js
+++ b/server/lib/version.js
@@ -20,7 +20,6 @@
 
 'use strict';
 const cp = require('child_process');
-const util = require('util');
 const path = require('path');
 const Promise = require('bluebird');
 const logger = require('mozlog')('server.version');
@@ -45,8 +44,7 @@ function getCommitHash () {
 
   return new Promise(function (resolve) {
     const gitDir = path.resolve(__dirname, '..', '..', '.git');
-    const cmd = util.format('git --git-dir=%s rev-parse HEAD', gitDir);
-    cp.exec(cmd, function (err, stdout) {
+    cp.exec('git rev-parse HEAD', { cwd: gitDir }, function (err, stdout) {
       if (err) {
         // ignore the error
         resolve(UNKNOWN);
@@ -71,8 +69,8 @@ function getSourceRepo () {
   return new Promise(function (resolve) {
     const gitDir = path.resolve(__dirname, '..', '..', '.git');
     const configPath = path.join(gitDir, 'config');
-    const cmd = util.format('git config --file %s --get remote.origin.url', configPath);
-    cp.exec(cmd, function (err, stdout) {
+    const cmd = 'git config --get remote.origin.url';
+    cp.exec(cmd, { env: { GIT_CONFIG: configPath } }, function (err, stdout) {
       if (err) {
         // ignore the error
         return resolve(UNKNOWN);


### PR DESCRIPTION
refs: bug 1320217

Fix commend execution in the unlikely event the application is run from a location with a malicious or malformed directory name per rfk's suggestions in the bug mentioned above.

Functionals Tests:

- [x] on master in a malicious directory, returns a corrupted version:

```
fxa-local-dev/fxa-content-server - [master] » pwd
/Users/gguthe/; echo hi ||/fxa-local-dev/fxa-content-server
fxa-local-dev/fxa-content-server - [master] » npm start

> fxa-content-server@1.82.0 start /Users/gguthe/; echo hi ||/fxa-local-dev/fxa-content-server
> node scripts/check-local-config && grunt server

Running "server" task
...
fxa-content-server.server.main.INFO: Firefox Account Content server listening on port 3030
fxa-content-server.server.main.INFO: Firefox Account HTTP redirect server listening on port 3080
fxa-content-server.server.version.INFO: source set to: hi
fxa-content-server.server.version.INFO: version set to: 1.82.0
fxa-content-server.server.version.INFO: commit hash set to: usage: git [--version] [--help] [-C <path>] [-c name=value]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p | --paginate | --no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           <command> [<args>]

These are common Git commands used in various situations:

start a working area (see also: git help tutorial)
   clone      Clone a repository into a new directory
   init       Create an empty Git repository or reinitialize an existing one

work on the current change (see also: git help everyday)
   add        Add file contents to the index
   mv         Move or rename a file, a directory, or a symlink
   reset      Reset current HEAD to the specified state
   rm         Remove files from the working tree and from the index

examine the history and state (see also: git help revisions)
   bisect     Use binary search to find the commit that introduced a bug
   grep       Print lines matching a pattern
   log        Show commit logs
   show       Show various types of objects
   status     Show the working tree status

grow, mark and tweak your common history
   branch     List, create, or delete branches
   checkout   Switch branches or restore working tree files
   commit     Record changes to the repository
   diff       Show changes between commits, commit and working tree, etc
   merge      Join two or more development histories together
   rebase     Reapply commits on top of another base tip
   tag        Create, list, delete or verify a tag object signed with GPG

collaborate (see also: git help workflows)
   fetch      Download objects and refs from another repository
   pull       Fetch from and integrate with another repository or a local branch
   push       Update remote refs along with associated objects

'git help -a' and 'git help -g' list available subcommands and some
concept guides. See 'git help <command>' or 'git help <concept>'
to read about a specific subcommand or concept.
hi
fxa-content-server.server.version.INFO: fxa-content-server-l10n commit hash set to: a96f5973b200c43adb17603c581a350fb22832ef
fxa-content-server.server.version.INFO: tos-pp (legal-docs) commit hash set to: be7e12625f
```

- [x] on master in a non-malicious directory, returns the expected version:

```
fxa-local-dev/fxa-content-server - [master] » pwd
/Users/gguthe/fxa-local-dev/fxa-content-server
fxa-local-dev/fxa-content-server - [master] » npm start

> fxa-content-server@1.82.0 start /Users/gguthe/; echo hi ||/fxa-local-dev/fxa-content-server
> node scripts/check-local-config && grunt server

Running "server" task
...
fxa-content-server.server.main.INFO: page_template_directory: /Users/gguthe/fxa-local-dev/fxa-content-server/server/templates/pages/src
fxa-content-server.server.main.INFO: Firefox Account Content server listening on port 3030
fxa-content-server.server.main.INFO: Firefox Account HTTP redirect server listening on port 3080
fxa-content-server.server.version.INFO: source set to: https://github.com/mozilla/fxa-content-server.git
fxa-content-server.server.version.INFO: version set to: 1.82.0
fxa-content-server.server.version.INFO: commit hash set to: 5935bf9f3a1b858482998b41545e480d72ed6cc9
fxa-content-server.server.version.INFO: fxa-content-server-l10n commit hash set to: a96f5973b200c43adb17603c581a350fb22832ef
fxa-content-server.server.version.INFO: tos-pp (legal-docs) commit hash set to: be7e12625f
```

- [x] on this branch, in a malicious directory returns the expected version:

```
fxa-local-dev/fxa-content-server - [fix-version-use-use-cwd-and-env-var-to-get-version] » pwd
/Users/gguthe/; echo hi ||/fxa-local-dev/fxa-content-server
fxa-local-dev/fxa-content-server - [fix-version-use-use-cwd-and-env-var-to-get-version] » npm start

> fxa-content-server@1.82.0 start /Users/gguthe/; echo hi ||/fxa-local-dev/fxa-content-server
> node scripts/check-local-config && grunt server

Running "server" task
...
fxa-content-server.server.main.INFO: Firefox Account Content server listening on port 3030
fxa-content-server.server.main.INFO: Firefox Account HTTP redirect server listening on port 3080
fxa-content-server.server.version.INFO: source set to: https://github.com/mozilla/fxa-content-server.git
fxa-content-server.server.version.INFO: version set to: 1.82.0
fxa-content-server.server.version.INFO: commit hash set to: 928733743d9e6013ec5ff3cc2c0d7561a2918350
fxa-content-server.server.version.INFO: fxa-content-server-l10n commit hash set to: a96f5973b200c43adb17603c581a350fb22832ef
fxa-content-server.server.version.INFO: tos-pp (legal-docs) commit hash set to: be7e12625f
```

r? @seanmonstar 