### PR TITLE
fix(sign_up): make error for AGE-REQUIRED field specific on sign up screen

### DIFF
--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -305,7 +305,8 @@ define(function (require, exports, module) {
           this.notifier.trigger('signup.tooyoung');
           return this._cannotCreateAccount();
         } else {
-          throw AuthErrors.toError('AGE_REQUIRED');
+          this.showValidationError(this.$('#age'), AuthErrors.toError('AGE_REQUIRED'));
+          return;
         }
       } else if (AuthErrors.is(err, 'ACCOUNT_RESET')) {
         return this.notifyOfResetAccount(account);


### PR DESCRIPTION
A similar tidy-up to (#4768)
<img src='https://cloud.githubusercontent.com/assets/7684791/23780020/f7dfbcf8-04f8-11e7-9778-42dc44ca7af0.png' width='150' style='vertical-align: top'><img src='https://cloud.githubusercontent.com/assets/7684791/23780849/214a9306-04fe-11e7-9d79-1da23b8e78e9.png' width='148'>

On the sign up screen, makes the AGE_REQUIRED error a field specific error.