### PR TITLE
fix(CWTS): Ensure `destroy` calls the parent.

### DIFF
--- a/app/scripts/views/choose_what_to_sync.js
+++ b/app/scripts/views/choose_what_to_sync.js
@@ -14,7 +14,8 @@ define(function (require, exports, module) {
 
   const SCREEN_CLASS = 'screen-choose-what-to-sync';
 
-  var View = FormView.extend({
+  const proto = FormView.prototype;
+  const View = FormView.extend({
     template: Template,
     className: 'choose-what-to-sync',
 
@@ -46,8 +47,9 @@ define(function (require, exports, module) {
       $('body').addClass(SCREEN_CLASS);
     },
 
-    destroy () {
+    destroy (...args) {
       $('body').removeClass(SCREEN_CLASS);
+      return proto.destroy.call(this, ...args);
     },
 
     context () {
@@ -121,6 +123,8 @@ define(function (require, exports, module) {
         });
       }
     }
+  }, {
+    SCREEN_CLASS
   });
 
   Cocktail.mixin(


### PR DESCRIPTION
### What is the problem?
`destroy` didn't call it's parent method, and the parent
method does important teardown/housekeeping and needs
to be called.

### How does this fix it?
Ensure `destroy` calls the parent.

I noticed this while working on an experiment infra simplification.

@philbooth - r?