### PR TITLE
refactor(experiments): Simplify the experiment architecture

### DIFF
--- a/app/scripts/views/mixins/experiment-mixin.js
+++ b/app/scripts/views/mixins/experiment-mixin.js
@@ -9,7 +9,7 @@ define(function (require, exports, module) {
 
   module.exports = {
     initialize (options = {}) {
-      this.experiments = new ExperimentInterface({
+      this.experiments = options.experiments || new ExperimentInterface({
         able: options.able,
         account: this._account,
         metrics: this.metrics,
@@ -20,6 +20,16 @@ define(function (require, exports, module) {
       });
 
       this.experiments.chooseExperiments();
+    },
+
+    /**
+     * Destroy the attached experiments instance.
+     */
+    destroy () {
+      if (this.experiments) {
+        this.experiments.destroy();
+        this.experiments = null;
+      }
     },
 
     /**

--- a/app/tests/spec/lib/experiments/connect-another-device.js
+++ b/app/tests/spec/lib/experiments/connect-another-device.js
@@ -18,21 +18,19 @@ define(function (require, exports, module) {
       notifier = new Notifier();
       experiment = new Experiment();
       experiment.initialize('connectAnotherDevice', {
-        able: {
-          choose: sinon.spy(() => 'choice')
-        },
+        groupType: 'treatment',
         metrics: {
-          isCollectionEnabled: () => true,
-          logEvent: sinon.spy()
+          logEvent () {},
+          logExperiment () {}
         },
-        notifier,
-        user: {
-          get: () => 'uuid'
-        },
-        window
+        notifier
       });
 
       sinon.stub(experiment, 'saveState', () => {});
+    });
+
+    afterEach(() => {
+      experiment.destroy();
     });
 
     function testNotificationSavesState(notification, data, expectedState) {


### PR DESCRIPTION
### What is the problem?
While trying to hook up the Send SMS experiment, I noticed a couple of
problems with the experiment architecture.

First, setting up an experiment required a lot of dependencies, the same
list of dependencies as the ExperimentInterface. Experiments also called
able to get the groupType, duplicating work by the ExperimentInterface.

Second, multiple views create the same set of experiments, each view hooks
up listeners on the notifier, but the experiments are never torn down
when the view is destroyed. This didn't cause any problems because
the experiment code only logs an event if the same event has not been
logged previously, but the lack of housekeeping leaves objects in memory
that don't need to be there which made my OCD go haywire.

Third, base.js had its own "notifications" handling method, which was
duplicated from the NotifierMixin. The NotifierMixin's version was updated,
this version wasn't.

### How does this fix it?
First, Separate concerns better. ExperimentInterface is the only entity to invoke
able.choose, it now gets the experiment's groupType and passes it to the
concrete experiment implementation. ExperimentInterace no longer logs, those
responsibilities are pushed to the Experiment. An Experiment/concrete
implementation is responsible for saving state and logging. No more able.
Far fewer dependencies.

Second, cleanup after ourselves! View.destroy calls experiment.destroy, which
destroys each experiment, which causes all the notification handlers to be
removed.

Third, replace the notifications handling logic and just use the NotifierMixin.

@vladikoff - this updates a code you have the best knowledge of, mind an r?