### PR TITLE
fix(sign_in): Making incorrect error message field specific.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -56,7 +56,7 @@ define(function (require, exports, module) {
     },
     INCORRECT_PASSWORD: {
       errno: 103,
-      message: t('Incorrect password. To double-check what you\'ve entered, press and hold down the Show button.')
+      message: t('Incorrect password')
     },
     UNVERIFIED_ACCOUNT: {
       errno: 104,

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -153,6 +153,8 @@ define(function (require, exports, module) {
         return;
       } else if (AuthErrors.is(err, 'ACCOUNT_RESET')) {
         return this.notifyOfResetAccount(account);
+      } else if (AuthErrors.is(err, 'INCORRECT_PASSWORD')) {
+        return this.showValidationError(this.$('#password'), err);
       }
       // re-throw error, it will be handled at a lower level.
       throw err;

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -115,7 +115,8 @@ define([
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(fillOutSignIn(email, '  ' + PASSWORD))
         // success is seeing the error message.
-        .then(visibleByQSA('.tooltip'));
+        .then(visibleByQSA('.tooltip'))
+        .then(testElementTextInclude('.tooltip', 'password'));
     },
 
     'visiting the pp links saves information for return': function () {

--- a/tests/functional/sign_in.js
+++ b/tests/functional/sign_in.js
@@ -78,7 +78,7 @@ define([
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(fillOutSignIn(email, 'incorrect password'))
         // success is seeing the error message.
-        .then(visibleByQSA('.error'))
+        .then(visibleByQSA('.tooltip'))
         // If user clicks on "forgot your password?",
         // begin the reset password flow.
         .then(click('a[href="/reset_password"]'))
@@ -115,8 +115,7 @@ define([
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(fillOutSignIn(email, '  ' + PASSWORD))
         // success is seeing the error message.
-        .then(visibleByQSA('.error'))
-        .then(testElementTextInclude('.error', 'password'));
+        .then(visibleByQSA('.tooltip'));
     },
 
     'visiting the pp links saves information for return': function () {


### PR DESCRIPTION
Ref. #4806 #4652 

Changed the [sign_in.js](https://github.com/mozilla/fxa-content-server/blob/master/app/scripts/views/sign_in.js) file to make the "Incorrect password" message field specific. As mentioned in #4652.

Current : 

![screenshot from 2017-03-13 21-33-49](https://cloud.githubusercontent.com/assets/17474532/23863263/49def674-0835-11e7-9ac8-c44588ccf571.png)


Proposed : 

![screenshot from 2017-03-13 21-32-55](https://cloud.githubusercontent.com/assets/17474532/23863290/5d897172-0835-11e7-9e69-dfe82e61505c.png)

