### PR TITLE
fix(preferences): add specific error msg for rate-limiting error

### DIFF
--- a/app/scripts/lib/marketing-email-errors.js
+++ b/app/scripts/lib/marketing-email-errors.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
     },
     USAGE_ERROR: {
       errno: 5,
-      message: UNEXPECTED_ERROR
+      message: t('Please try again later')
     },
     EMAIL_PROVIDER_AUTH_FAILURE: {
       errno: 6,

--- a/app/tests/spec/views/settings/communication_preferences.js
+++ b/app/tests/spec/views/settings/communication_preferences.js
@@ -219,9 +219,21 @@ define(function (require, exports, module) {
           });
       });
 
-      it('errors are displayed', function () {
+      it('shows `Please try again later` for 429 (rate-limited) error', function () {
         sinon.stub(emailPrefsModel, 'optOut', function () {
           return p.reject(MarketingEmailErrors.toError('USAGE_ERROR'));
+        });
+
+        return view.setOptInStatus(NEWSLETTER_ID, false)
+          .then(function () {
+            assert.isTrue(view.isErrorVisible());
+            assert.equal($('.error').text(), 'Please try again later');
+          });
+      });
+
+      it('other errors are displayed', function () {
+        sinon.stub(emailPrefsModel, 'optOut', function () {
+          return p.reject(MarketingEmailErrors.toError('UNEXPECTED_ERROR'));
         });
 
         return view.setOptInStatus(NEWSLETTER_ID, false)


### PR DESCRIPTION
fixes [#238](https://github.com/mozilla/fxa-bugzilla-mirror/issues/238) in bugzilla-mirror

Add new error message that tells users who click subscribe and unsubscribe too many times to try again later.

Test at http://127.0.0.1:3030/tests/index.html?grep=views%2Fsettings%2Fcommunication_preferences%20setOptInStatus%20shows%20%60Please%20try%20again%20later%60%20for%20429%20(rate-limited)%20error