### PR TITLE
fix(auth_errors): User received an error message saying no message

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -147,7 +147,7 @@ define(function (require, exports, module) {
     },
     USER_CANCELED_LOGIN: {
       errno: 1001,
-      message: t('no message')
+      message: t('Login attempt cancelled')
     },
     SESSION_EXPIRED: {
       errno: 1002,


### PR DESCRIPTION
Fixes #4701
User received an error message saying "no message", changed it to "Login attempt cancelled".
