### PR TITLE
feat(sms): SMS feature gated by the auth-server.

### DIFF
--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
      * @param {String} groupName
      * @return {Boolean}
      */
-    isInExperimentGroup(experimentName, groupName) {
+    isInExperimentGroup (experimentName, groupName) {
       return this._getExperimentGroup(experimentName) === groupName;
     },
 
@@ -162,7 +162,7 @@ define(function (require, exports, module) {
      * @returns {String}
      * @private
      */
-    _getExperimentGroup(experimentName) {
+    _getExperimentGroup (experimentName) {
       // can't be in an experiment group if not initialized.
       if (! this.initialized) {
         return false;

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -649,6 +649,20 @@ define(function (require, exports, module) {
 
           throw err;
         });
+    }),
+
+    /**
+     * Check whether SMS is enabled for the user
+     *
+     * @param {String} sessionToken
+     * @returns {Promise} resolves to `true` if SMS is enabled,
+     *  `false` otw.
+     */
+    smsStatus: withClient((client, sessionToken) => {
+      return client.smsStatus(sessionToken)
+        .then((resp) => {
+          return !! (resp && resp.ok);
+        });
     })
   };
 

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -1006,6 +1006,18 @@ define(function (require, exports, module) {
           metricsContext: this._metrics.getFlowEventMetadata()
         }
       );
+    },
+
+    /**
+     * Check whether SMS is enabled for the current account.
+     *
+     * @returns {Promise} resolves to `true` if SMS is enabled,
+     *  `false` otw.
+     */
+    smsStatus() {
+      return this._fxaClient.smsStatus(
+        this.get('sessionToken')
+      );
     }
   }, {
     ALLOWED_KEYS: ALLOWED_KEYS,

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -236,7 +236,12 @@ define(function (require, exports, module) {
 
         // If a user is already signed in to Sync which is different to the
         // user that just verified, show them the old "Account verified!" screen.
-        return isInExperimentGroup && ! isAnotherUserSignedIn;
+        return isInExperimentGroup &&
+               ! isAnotherUserSignedIn &&
+               // The auth server can gate whether users can send an SMS based
+               // on the user's country and whether the SMS provider account
+               // has sufficient funds.
+               verifiedAccount.smsStatus();
       });
     },
 
@@ -247,7 +252,7 @@ define(function (require, exports, module) {
      * @returns {Boolean} `true` if another user is signed in, `false` otw.
      * @private
      */
-    _isAnotherUserSignedIn(account) {
+    _isAnotherUserSignedIn (account) {
       const user = this.user;
       return (! user.getSignedInAccount().isDefault() &&
               ! user.isSignedInAccount(account));

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -1380,5 +1380,17 @@ define(function (require, exports, module) {
         });
       });
     });
+
+    describe('smsStatus', () => {
+      it('delegates to the fxa-js-client', () => {
+        sinon.stub(realClient, 'smsStatus', () => p());
+
+        return client.smsStatus('sessionToken')
+          .then(() => {
+            assert.isTrue(realClient.smsStatus.calledOnce);
+            assert.isTrue(realClient.smsStatus.calledWith('sessionToken'));
+          });
+      });
+    });
   });
 });

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -2150,5 +2150,45 @@ define(function (require, exports, module) {
         });
       });
     });
+
+    describe('sendSms', () => {
+      const flowEventMetaData = {
+        startTime: Date.now()
+      };
+
+      beforeEach(() => {
+        sinon.stub(fxaClient, 'sendSms', () => p());
+        sinon.stub(metrics, 'getFlowEventMetadata', () => flowEventMetaData);
+
+        account.set('sessionToken', 'sessionToken');
+        return account.sendSms('1234567890', 1);
+      });
+
+      it('delegates to the fxa-client', () => {
+        assert.isTrue(fxaClient.sendSms.calledOnce);
+        assert.isTrue(fxaClient.sendSms.calledWith(
+          'sessionToken',
+          '1234567890',
+          1,
+          {
+            metricsContext: flowEventMetaData
+          }
+        ));
+      });
+    });
+
+    describe('smsStatus', () => {
+      beforeEach(() => {
+        sinon.stub(fxaClient, 'smsStatus', () => p());
+
+        account.set('sessionToken', 'sessionToken');
+        return account.smsStatus();
+      });
+
+      it('delegates to the fxa-client', () => {
+        assert.isTrue(fxaClient.smsStatus.calledOnce);
+        assert.isTrue(fxaClient.smsStatus.calledWith('sessionToken'));
+      });
+    });
   });
 });

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -615,10 +615,11 @@ define(function (require, exports, module) {
         describe('user is completing sign-in', () => {
           beforeEach(() => {
             sinon.stub(view, 'isSignIn', () => true);
+            sinon.stub(account, 'smsStatus', () => true);
           });
 
           it('resolves to `false`', () => {
-            return view._isEligibleToSendSms()
+            return view._isEligibleToSendSms(account)
               .then((isEligible) => {
                 assert.isFalse(isEligible);
               });
@@ -633,10 +634,11 @@ define(function (require, exports, module) {
                 isDefault: () => true
               };
             });
+            sinon.stub(account, 'smsStatus', () => true);
           });
 
           it('resolves to `true`', () => {
-            return view._isEligibleToSendSms()
+            return view._isEligibleToSendSms(account)
               .then((isEligible) => {
                 assert.isTrue(isEligible);
               });
@@ -651,10 +653,11 @@ define(function (require, exports, module) {
               };
             });
             sinon.stub(user, 'isSignedInAccount', () => false);
+            sinon.stub(account, 'smsStatus', () => true);
           });
 
           it('resolves to `false`', () => {
-            return view._isEligibleToSendSms()
+            return view._isEligibleToSendSms(account)
               .then((isEligible) => {
                 assert.isFalse(isEligible);
               });
@@ -669,10 +672,11 @@ define(function (require, exports, module) {
               };
             });
             sinon.stub(user, 'isSignedInAccount', () => true);
+            sinon.stub(account, 'smsStatus', () => true);
           });
 
           it('resolves to `true`', () => {
-            return view._isEligibleToSendSms()
+            return view._isEligibleToSendSms(account)
               .then((isEligible) => {
                 assert.isTrue(isEligible);
               });
@@ -683,10 +687,25 @@ define(function (require, exports, module) {
       describe('user is not part of treatment group', () => {
         beforeEach(() => {
           sinon.stub(view, 'isInExperimentGroup', () => false);
+          sinon.stub(account, 'smsStatus', () => true);
         });
 
         it('resolves to `false`', () => {
-          return view._isEligibleToSendSms()
+          return view._isEligibleToSendSms(account)
+            .then((isEligible) => {
+              assert.isFalse(isEligible);
+            });
+        });
+      });
+
+      describe('auth-server blocks user from sending SMS', () => {
+        beforeEach(() => {
+          sinon.stub(view, 'isInExperimentGroup', () => true);
+          sinon.stub(account, 'smsStatus', () => false);
+        });
+
+        it('resolves to `false`', () => {
+          return view._isEligibleToSendSms(account)
             .then((isEligible) => {
               assert.isFalse(isEligible);
             });

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "cocktail": "0.5.9",
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
     "fxa-checkbox": "mozilla/fxa-checkbox#7f856afffd394a144f718e28e6fb79092d6ccddd",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.53",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.54",
     "fxa-password-strength-checker": "https://github.com/mozilla/fxa-password-strength-checker.git#d73b3ade374607e2749ee375301b0a168008b16f",
     "html5shiv": "3.7.2",
     "JavaScript-MD5": "1.1.0",


### PR DESCRIPTION
The /sms/status endpoint of the auth-server can prevent a user from
seeing the SMS feature if the user is in a country that is not supported
or if the SMS provider account has insufficient funds.

fixes #4789

@philbooth, @vbudhram, @vladikoff - r?

When I run this against the current auth-server, I see the error in https://irccloud.mozilla.com/pastebin/tJdwzFw4/