### PR TITLE
feat(sms): Allow sending SMS messages to Romania.

### DIFF
--- a/app/scripts/lib/country-telephone-info.js
+++ b/app/scripts/lib/country-telephone-info.js
@@ -72,7 +72,8 @@
        },
        // +407xxxxxxxx, allow leading 0 for sloppiness.
        pattern: /^(?:\+40)?0?7\d{8,8}$/,
-       prefix: '+40'
+       // The country code is +40, all mobile phones have a 7 prefix.
+       prefix: '+407'
 
      },
      US: {

--- a/app/scripts/lib/country-telephone-info.js
+++ b/app/scripts/lib/country-telephone-info.js
@@ -48,13 +48,32 @@
          return num.slice(0, 3) + ' ' + num.slice(3, 7) + ' ' + num.slice(7, 14);
        },
        normalize (num) {
-         if (/\+44/.test(num)) {
+         if (/^\+44/.test(num)) {
            return num;
          }
          return `+44${num}`;
        },
        pattern: /^(?:\+44)?\d{10,10}$/,
        prefix: '+44'
+     },
+     RO: {
+       format(num) {
+         // +40 7xx xxxxxx
+         return num.slice(0, 3) + ' ' + num.slice(3, 6) + ' ' + num.slice(6, 12);
+       },
+       normalize(num) {
+         // allow +40 country code prefix
+         // as well as an extra 0 before the 7 prefix.
+         const prefix = /^(\+40)?0?/;
+         if (prefix.test(num)) {
+           num = num.replace(prefix, '');
+         }
+         return `+40${num}`;
+       },
+       // +407xxxxxxxx, allow leading 0 for sloppiness.
+       pattern: /^(?:\+40)?0?7\d{8,8}$/,
+       prefix: '+40'
+
      },
      US: {
        format (num) {
@@ -74,4 +93,7 @@
        prefix: '+1'
      }
    };
+
+   // alias CA (Canada) to use the same info as the US.
+   module.exports.CA = module.exports.US;
  });

--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -13,25 +13,26 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const AuthErrors = require('lib/auth-errors');
   const _ = require('underscore');
+  const AuthErrors = require('lib/auth-errors');
+  const AllowedCountries = Object.keys(require('lib/country-telephone-info'));
   const Relier = require('models/reliers/relier');
   const Vat = require('lib/vat');
 
-  function t(str) {
-    return str;
-  }
+  const t = (msg) => msg;
 
   /*eslint-disable camelcase*/
-  var QUERY_PARAMETER_SCHEMA = {
+  const QUERY_PARAMETER_SCHEMA = {
     // context is not available when verifying.
     context: Vat.string().min(1),
+    country: Vat.string().valid(...AllowedCountries),
     customizeSync: Vat.boolean()
   };
   /*eslint-enable camelcase*/
 
-  var SyncRelier = Relier.extend({
+  module.exports = Relier.extend({
     defaults: _.extend({}, Relier.prototype.defaults, {
+      country: 'US',
       customizeSync: false
     }),
 
@@ -74,6 +75,4 @@ define(function (require, exports, module) {
       return !! this.get('customizeSync');
     }
   });
-
-  module.exports = SyncRelier;
 });

--- a/app/tests/spec/lib/country-telephone-info.js
+++ b/app/tests/spec/lib/country-telephone-info.js
@@ -37,6 +37,37 @@
        });
      });
 
+     describe('RO', () => {
+       let { format, normalize, pattern } = CountryTelephoneInfo.RO;
+
+       it('formats correctly', () => {
+         assert.equal(format('+40712345678'), '+40 712 345678');
+       });
+
+       describe('normalize', () => {
+         it('normalizes a number accepted by pattern correctly', () => {
+           assert.equal(normalize('712345678'), '+40712345678'); // no country code prefix
+           assert.equal(normalize('0712345678'), '+40712345678'); // no country code prefix, extra 0 before the 7
+           assert.equal(normalize('+40712345678'), '+40712345678'); // full country code prefix
+           assert.equal(normalize('+400712345678'), '+40712345678'); // full country code prefix, extra 0 before the 7
+         });
+       });
+
+       describe('pattern', () => {
+         it('validates correctly', () => {
+           assert.isFalse(pattern.test('71234567')); // too short
+           assert.isFalse(pattern.test('7123456789')); // too long
+           assert.isFalse(pattern.test('812345678')); // invalid prefix (must be 7)
+
+           assert.ok(pattern.test('712345678'));
+           assert.ok(pattern.test('0712345678')); // allow leading 0
+           assert.ok(pattern.test('+40712345678')); // full country code prefix
+           assert.ok(pattern.test('+400712345678')); // full country code prefix with 0 before 7
+           assert.isFalse(pattern.test('+45712345678')); // incorrect country code prefix
+         });
+       });
+     });
+
      describe('US', () => {
        let { format, normalize, pattern } = CountryTelephoneInfo.US;
 

--- a/app/tests/spec/models/reliers/sync.js
+++ b/app/tests/spec/models/reliers/sync.js
@@ -13,10 +13,11 @@ define(function (require, exports, module) {
   const WindowMock = require('../../../mocks/window');
 
   const CONTEXT = 'fx_desktop_v1';
+  const COUNTRY = 'RO';
   const SYNC_MIGRATION = 'sync11';
   const SYNC_SERVICE = 'sync';
 
-  describe('models/reliers/sync', function () {
+  describe('models/reliers/sync', () => {
     let err;
     let relier;
     let translator;
@@ -29,7 +30,7 @@ define(function (require, exports, module) {
         });
     }
 
-    beforeEach(function () {
+    beforeEach(() => {
       translator = new Translator('en-US', ['en-US']);
       windowMock = new WindowMock();
 
@@ -41,39 +42,41 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('fetch', function () {
-      it('populates model from the search parameters', function () {
+    describe('fetch', () => {
+      it('populates model from the search parameters', () => {
         windowMock.location.search = TestHelpers.toSearchString({
           context: CONTEXT,
+          country: COUNTRY,
           customizeSync: 'true',
           migration: SYNC_MIGRATION,
           service: SYNC_SERVICE
         });
 
         return relier.fetch()
-          .then(function () {
+          .then(() => {
             assert.equal(relier.get('context'), CONTEXT);
+            assert.equal(relier.get('country'), COUNTRY);
             assert.equal(relier.get('migration'), SYNC_MIGRATION);
             assert.equal(relier.get('service'), SYNC_SERVICE);
             assert.isTrue(relier.get('customizeSync'));
           });
       });
 
-      describe('context query parameter', function () {
-        describe('missing', function () {
-          beforeEach(function () {
+      describe('context query parameter', () => {
+        describe('missing', () => {
+          beforeEach(() => {
             windowMock.location.search = TestHelpers.toSearchString({});
 
             return relier.fetch();
           });
 
-          it('falls back to passed in `context', function () {
+          it('falls back to passed in `context', () => {
             assert.equal(relier.get('context'), CONTEXT);
           });
         });
 
-        describe('emtpy', function () {
-          beforeEach(function () {
+        describe('emtpy', () => {
+          beforeEach(() => {
             windowMock.location.search = TestHelpers.toSearchString({
               context: ''
             });
@@ -81,14 +84,14 @@ define(function (require, exports, module) {
             return fetchExpectError();
           });
 
-          it('errors correctly', function () {
+          it('errors correctly', () => {
             assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
             assert.equal(err.param, 'context');
           });
         });
 
-        describe('whitespace', function () {
-          beforeEach(function () {
+        describe('whitespace', () => {
+          beforeEach(() => {
             windowMock.location.search = TestHelpers.toSearchString({
               context: ' '
             });
@@ -96,16 +99,75 @@ define(function (require, exports, module) {
             return fetchExpectError();
           });
 
-          it('errors correctly', function () {
+          it('errors correctly', () => {
             assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
             assert.equal(err.param, 'context');
           });
         });
       });
 
-      describe('customizeSync query parameter', function () {
-        describe('missing', function () {
-          beforeEach(function () {
+      describe('country query parameter', () => {
+        describe('missing', () => {
+          beforeEach(() => {
+            windowMock.location.search = TestHelpers.toSearchString({});
+
+            return relier.fetch();
+          });
+
+          it('falls back to default country', () => {
+            assert.equal(relier.get('country'), 'US');
+          });
+        });
+
+        describe('emtpy', () => {
+          beforeEach(() => {
+            windowMock.location.search = TestHelpers.toSearchString({
+              country: ''
+            });
+
+            return fetchExpectError();
+          });
+
+          it('errors correctly', () => {
+            assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
+            assert.equal(err.param, 'country');
+          });
+        });
+
+        describe('invalid', () => {
+          beforeEach(() => {
+            windowMock.location.search = TestHelpers.toSearchString({
+              country: 'AR'
+            });
+
+            return fetchExpectError();
+          });
+
+          it('errors correctly', () => {
+            assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
+            assert.equal(err.param, 'country');
+          });
+        });
+
+        describe('whitespace', () => {
+          beforeEach(() => {
+            windowMock.location.search = TestHelpers.toSearchString({
+              country: ' '
+            });
+
+            return fetchExpectError();
+          });
+
+          it('errors correctly', () => {
+            assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
+            assert.equal(err.param, 'country');
+          });
+        });
+      });
+
+      describe('customizeSync query parameter', () => {
+        describe('missing', () => {
+          beforeEach(() => {
             windowMock.location.search = TestHelpers.toSearchString({
               context: CONTEXT
             });
@@ -113,13 +175,13 @@ define(function (require, exports, module) {
             return relier.fetch();
           });
 
-          it('succeeds', function () {
+          it('succeeds', () => {
             assert.isFalse(relier.get('customizeSync'));
           });
         });
 
-        describe('emtpy', function () {
-          beforeEach(function () {
+        describe('emtpy', () => {
+          beforeEach(() => {
             windowMock.location.search = TestHelpers.toSearchString({
               context: CONTEXT,
               customizeSync: ''
@@ -128,14 +190,14 @@ define(function (require, exports, module) {
             return fetchExpectError();
           });
 
-          it('errors correctly', function () {
+          it('errors correctly', () => {
             assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
             assert.equal(err.param, 'customizeSync');
           });
         });
 
-        describe('whitespace', function () {
-          beforeEach(function () {
+        describe('whitespace', () => {
+          beforeEach(() => {
             windowMock.location.search = TestHelpers.toSearchString({
               context: CONTEXT,
               customizeSync: ' '
@@ -144,14 +206,14 @@ define(function (require, exports, module) {
             return fetchExpectError();
           });
 
-          it('errors correctly', function () {
+          it('errors correctly', () => {
             assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
             assert.equal(err.param, 'customizeSync');
           });
         });
 
-        describe('not a boolean', function () {
-          beforeEach(function () {
+        describe('not a boolean', () => {
+          beforeEach(() => {
             windowMock.location.search = TestHelpers.toSearchString({
               context: CONTEXT,
               customizeSync: 'not a boolean'
@@ -160,60 +222,60 @@ define(function (require, exports, module) {
             return fetchExpectError();
           });
 
-          it('errors correctly', function () {
+          it('errors correctly', () => {
             assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
             assert.equal(err.param, 'customizeSync');
           });
         });
       });
 
-      it('translates `service` to `serviceName`', function () {
+      it('translates `service` to `serviceName`', () => {
         windowMock.location.search = TestHelpers.toSearchString({
           context: CONTEXT,
           service: SYNC_SERVICE
         });
 
         return relier.fetch()
-          .then(function () {
+          .then(() => {
             assert.equal(relier.get('serviceName'), 'Firefox Sync');
           });
       });
     });
 
-    describe('isSync', function () {
-      it('returns `true`', function () {
+    describe('isSync', () => {
+      it('returns `true`', () => {
         assert.isTrue(relier.isSync());
       });
     });
 
-    describe('isCustomizeSyncChecked', function () {
-      it('returns true if `customizeSync=true`', function () {
+    describe('isCustomizeSyncChecked', () => {
+      it('returns true if `customizeSync=true`', () => {
         windowMock.location.search = TestHelpers.toSearchString({
           context: CONTEXT,
           customizeSync: 'true'
         });
 
         return relier.fetch()
-          .then(function () {
+          .then(() => {
             assert.isTrue(relier.isCustomizeSyncChecked());
           });
       });
 
-      it('returns false if `customizeSync=false`', function () {
+      it('returns false if `customizeSync=false`', () => {
         windowMock.location.search = TestHelpers.toSearchString({
           context: CONTEXT,
           customizeSync: 'false'
         });
 
         return relier.fetch()
-          .then(function () {
+          .then(() => {
             assert.isFalse(relier.isCustomizeSyncChecked());
           });
       });
     });
 
-    describe('wantsKeys', function () {
-      it('always returns true', function () {
+    describe('wantsKeys', () => {
+      it('always returns true', () => {
         assert.isTrue(relier.wantsKeys());
       });
     });

--- a/docs/query-params.md
+++ b/docs/query-params.md
@@ -117,6 +117,15 @@ When the relier supports being linked to its `redirect_uri` without extra OAuth 
 * /signup
 * /force_auth
 
+### `country`
+Force a country to be used when testing the SMS feature.
+
+#### Options
+* `CA`
+* `GB`
+* `RO`
+* `US`
+
 ### `customizeSync`
 Set the default value of the "Customize which values to sync" checkbox.
 

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -14,7 +14,7 @@
    CountryTelephoneInfo, serverConfig) {
    const config = intern.config;
 
-   const SEND_SMS_URL = config.fxaContentRoot + 'sms?service=sync';
+   const SEND_SMS_URL = config.fxaContentRoot + 'sms?service=sync&country=US';
 
    const LEARN_MORE_WINDOW_HANDLE = '_learn-more';
 
@@ -60,6 +60,46 @@
        return this.remote
          .then(fillOutSignUp(email, PASSWORD))
          .then(testElementExists(SELECTOR_CONFIRM_SIGNUP));
+     },
+
+     'with `country=CA`': function () {
+       return this.remote
+         .then(openPage(SEND_SMS_URL, SELECTOR_SEND_SMS_HEADER, {
+           query: {
+             country: 'CA'
+           }
+         }))
+         .then(testElementValueEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, ''));
+     },
+
+     'with `country=RO`': function () {
+       return this.remote
+         .then(openPage(SEND_SMS_URL, SELECTOR_SEND_SMS_HEADER, {
+           query: {
+             country: 'RO'
+           }
+         }))
+         .then(testElementValueEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, '+40'));
+     },
+
+     'with `country=GB`': function () {
+       return this.remote
+         .then(openPage(SEND_SMS_URL, SELECTOR_SEND_SMS_HEADER, {
+           query: {
+             country: 'GB'
+           }
+         }))
+         .then(testElementValueEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, '+44'));
+     },
+
+     'with `country=US`': function () {
+       return this.remote
+         .then(openPage(SEND_SMS_URL, SELECTOR_SEND_SMS_HEADER, {
+           query: {
+             country: 'US'
+           }
+         }))
+         .then(testElementValueEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, ''));
      },
 
      'learn more': function () {

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -79,7 +79,7 @@
              country: 'RO'
            }
          }))
-         .then(testElementValueEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, '+40'));
+         .then(testElementValueEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, '+407'));
      },
 
      'with `country=GB`': function () {


### PR DESCRIPTION
Allow sending SMS messages to Romania. Instead of using a click handler on
the .success element, allow testers to open /verify_email with a `?country=<xx>`
query parameter where country is one of `CA`, `GB`, `RO`, `US`.

fixes #4829 

@philbooth, @vladikoff, @vbudhram - r?