### PR TITLE
fix(sms): US area codes must start with 2-9.

### DIFF
--- a/app/scripts/lib/country-telephone-info.js
+++ b/app/scripts/lib/country-telephone-info.js
@@ -70,7 +70,7 @@
          }
          return `+1${num}`;
        },
-       pattern: /^(?:\+?1)?\d{10,10}$/, // allow for a +1 or 1 prefix before the area code
+       pattern: /^(\+?1)?[2-9]\d{9,9}$/, // allow for a +1 or 1 prefix before the area code, area codes are all 2-9
        prefix: '+1'
      }
    };

--- a/app/tests/spec/lib/country-telephone-info.js
+++ b/app/tests/spec/lib/country-telephone-info.js
@@ -55,13 +55,18 @@
 
        describe('pattern', () => {
          it('validates correctly', () => {
-           assert.ok(pattern.test('1234567890'));
-           assert.ok(pattern.test('+11234567890')); // full country code prefix
-           assert.ok(pattern.test('11234567890')); // country code prefix w/o +
+           assert.ok(pattern.test('2134567890'));
+           assert.ok(pattern.test('+12134567890')); // full country code prefix
+           assert.ok(pattern.test('12134567890')); // country code prefix w/o +
            assert.ok(pattern.test('15234567890'));
-           assert.isFalse(pattern.test('+331234567890'));
-           assert.isFalse(pattern.test('+1123456789'));
-           assert.isFalse(pattern.test('123456789'));
+           assert.isFalse(pattern.test('+332134567890'));
+           assert.isFalse(pattern.test('+1213456789'));
+           assert.isFalse(pattern.test('213456789'));
+           assert.isFalse(pattern.test('1213456789'));
+           assert.isFalse(pattern.test('1123456789')); // can't start an area code with 1
+           assert.isFalse(pattern.test('11234567890')); // can't start an area code with 1
+           assert.isFalse(pattern.test('121345678901')); // too long, has country prefix
+           assert.isFalse(pattern.test('21345678901')); // too long, no country prefix
          });
        });
      });

--- a/app/tests/spec/views/elements/tel-input.js
+++ b/app/tests/spec/views/elements/tel-input.js
@@ -74,15 +74,15 @@ define(function (require, exports, module) {
         });
 
         it('does not throw if valid', () => {
-          assert.isUndefined(validate($requiredTelEl, '1234567890'));
-          assert.isUndefined(validate($requiredTelEl, '11234567890'));
-          assert.isUndefined(validate($requiredTelEl, '(123)4567890'));
-          assert.isUndefined(validate($requiredTelEl, '(123)456-7890'));
-          assert.isUndefined(validate($requiredTelEl, '(123) 456-7890'));
-          assert.isUndefined(validate($requiredTelEl, '1(123) 456-7890'));
-          assert.isUndefined(validate($requiredTelEl, '1 (123) 456-7890'));
-          assert.isUndefined(validate($requiredTelEl, '+1(123) 456-7890'));
-          assert.isUndefined(validate($requiredTelEl, '+1 (123) 456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '2134567890'));
+          assert.isUndefined(validate($requiredTelEl, '12134567890'));
+          assert.isUndefined(validate($requiredTelEl, '(213)4567890'));
+          assert.isUndefined(validate($requiredTelEl, '(213)456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '(213) 456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '1(213) 456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '1 (213) 456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '+1(213) 456-7890'));
+          assert.isUndefined(validate($requiredTelEl, '+1 (213) 456-7890'));
         });
       });
 

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -103,26 +103,26 @@
 
      'invalid phone number (too short)': function () {
        return this.remote
-        .then(openPage(SEND_SMS_URL, SELECTOR_SEND_SMS_HEADER))
-        .then(type(SELECTOR_SEND_SMS_PHONE_NUMBER, '1234567'))
-        .then(click(SELECTOR_SEND_SMS_SUBMIT))
-        .then(testElementExists(SELECTOR_SEND_SMS_TOOLTIP))
-        .then(testElementTextInclude(SELECTOR_SEND_SMS_TOOLTIP, 'invalid'));
+         .then(openPage(SEND_SMS_URL, SELECTOR_SEND_SMS_HEADER))
+         .then(type(SELECTOR_SEND_SMS_PHONE_NUMBER, '2134567'))
+         .then(click(SELECTOR_SEND_SMS_SUBMIT))
+         .then(testElementExists(SELECTOR_SEND_SMS_TOOLTIP))
+         .then(testElementTextInclude(SELECTOR_SEND_SMS_TOOLTIP, 'invalid'));
+     },
+
+     'invalid phone number (too long)': function () {
+       return this.remote
+         .then(openPage(SEND_SMS_URL, SELECTOR_SEND_SMS_HEADER))
+         .then(type(SELECTOR_SEND_SMS_PHONE_NUMBER, '21345678901'))
+         .then(click(SELECTOR_SEND_SMS_SUBMIT))
+         .then(testElementExists(SELECTOR_SEND_SMS_TOOLTIP))
+         .then(testElementTextInclude(SELECTOR_SEND_SMS_TOOLTIP, 'invalid'));
      },
 
      'invalid phone number (contains letters)': function () {
        return this.remote
         .then(openPage(SEND_SMS_URL, SELECTOR_SEND_SMS_HEADER))
-        .then(type(SELECTOR_SEND_SMS_PHONE_NUMBER, '1234567a890'))
-        .then(click(SELECTOR_SEND_SMS_SUBMIT))
-        .then(testElementExists(SELECTOR_SEND_SMS_TOOLTIP))
-        .then(testElementTextInclude(SELECTOR_SEND_SMS_TOOLTIP, 'invalid'));
-     },
-
-     'invalid phone number (fails hapi validation)': function () {
-       return this.remote
-        .then(openPage(SEND_SMS_URL, SELECTOR_SEND_SMS_HEADER))
-        .then(type(SELECTOR_SEND_SMS_PHONE_NUMBER, '1234567890'))
+        .then(type(SELECTOR_SEND_SMS_PHONE_NUMBER, '2134567a890'))
         .then(click(SELECTOR_SEND_SMS_SUBMIT))
         .then(testElementExists(SELECTOR_SEND_SMS_TOOLTIP))
         .then(testElementTextInclude(SELECTOR_SEND_SMS_TOOLTIP, 'invalid'));


### PR DESCRIPTION
This fixes a problem where 1 123 456 789 was considered a valid phone number.

fixes #4833 

@vbudhram, @vladikoff - r?