### PR TITLE
chore(validation): Update to VAT 0.0.9

### DIFF
--- a/app/scripts/models/flow.js
+++ b/app/scripts/models/flow.js
@@ -55,11 +55,11 @@ define(function (require, exports, module) {
       if (! data) {
         this.logError(AuthErrors.toMissingDataAttributeError(attribute));
       } else {
-        try {
-          data = this.resumeTokenSchema[attribute].validate(data);
-          this.set(attribute, data);
-        } catch (err) {
+        const result = this.resumeTokenSchema[attribute].validate(data);
+        if (result.error) {
           this.logError(AuthErrors.toInvalidDataAttributeError(attribute));
+        } else {
+          this.set(attribute, data);
         }
       }
     },

--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "ua-parser-js": "https://github.com/vladikoff/ua-parser-js.git#643d1698aef5bed095e1264ae258902bf346175c",
     "underscore": "1.8.3",
     "webrtc-adapter": "0.2.5",
-    "vat": "0.0.5",
+    "vat": "0.0.9",
     "Duration.js": "duration.js#3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update to the newest version of VAT which unifies the `validate` function
return values.

The flow model validation was updated because validating a single item
now has the same response as validating a complex schema.

Not attached to an issue.

@mozilla/fxa-devs - r?