### PR TITLE
fix(metrics): Fix the "refreshes_metrics" test.

### DIFF
--- a/app/scripts/lib/storage-metrics.js
+++ b/app/scripts/lib/storage-metrics.js
@@ -17,19 +17,11 @@ define(function (require, exports, module) {
 
   var storage = Storage.factory('localStorage');
 
-  function StorageMetrics() {
-    // do nothing
+  function StorageMetrics(options) {
+    Metrics.call(this, options);
   }
 
-  const notifier = {
-    off () {},
-    on () {},
-    trigger () {},
-    triggerAll () {},
-    triggerRemote () {}
-  };
-
-  _.extend(StorageMetrics.prototype, new Metrics({ notifier }), {
+  _.extend(StorageMetrics.prototype, Metrics.prototype, {
     _send (data) {
       var metrics = storage.get('metrics_all');
 
@@ -50,5 +42,4 @@ define(function (require, exports, module) {
   });
 
   module.exports = StorageMetrics;
-
 });

--- a/tests/intern_functional_circle.js
+++ b/tests/intern_functional_circle.js
@@ -33,6 +33,7 @@ define([
     'tests/functional/delete_account',
     'tests/functional/reset_password',
     'tests/functional/sync_reset_password',
+    'tests/functional/refreshes_metrics',
     'tests/functional/robots_txt',
     'tests/functional/settings',
     'tests/functional/settings_common',


### PR DESCRIPTION
### What is the problem?
The `_send` function on Metrics.prototype was always being called instead of
the variant on StorageMetrics.prototype.

This happened because `Metrics.initialize` was called during the setup of StorageMetrics' 
prototype chain. `Metrics.initialize` creates `this._flush` by binding `this.flush`
to the current context, which is a Metrics instance at this time. When `this._flush` 
was called, the context was the original Metrics object. `this._flush` would call 
`this._send` on the original object too, because of the context.

### How does this fix it?
Instead of calling `new Metrics()` to set up the prototype chain, copy
over the functions from Metrics' prototype to StorageMetrics' prototype,
then from the StorageMetrics constructor, call the Metrics constructor. It
sets up the prototype chain correctly, and allows functions to bind correctly.

### Why remove the Notifier mock?
App-start passes StorageMetrics a notifier instance, which is then passed
to the Metrics constructor, no need for a mock.

fixes #4844

@vladikoff, @philbooth - r?