### PR TITLE
refactor(user-agent): Extract a user-agent-mixin to share amongst the views.

### DIFF
--- a/app/scripts/views/connect_another_device.js
+++ b/app/scripts/views/connect_another_device.js
@@ -20,7 +20,7 @@ define(function (require, exports, module) {
   const MarketingSnippet = require('views/marketing_snippet');
   const Template = require('stache!templates/connect_another_device');
   const Url = require('lib/url');
-  const UserAgent = require('lib/user-agent');
+  const UserAgentMixin = require('views/mixins/user-agent-mixin');
 
   const proto = FormView.prototype;
   const View = FormView.extend({
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
 
       // If the user signed up and verified in Firefox for Android,
       // show marketing material for both mobile OSs.
-      if (this._isSignedIn() && this._getUap().isFirefoxAndroid()) {
+      if (this._isSignedIn() && this.getUserAgent().isFirefoxAndroid()) {
         options.which = MarketingSnippet.WHICH.BOTH;
       }
 
@@ -130,7 +130,7 @@ define(function (require, exports, module) {
       const signInContext = this._getSignInContext();
       const escapedSignInUrl = this._getEscapedSignInUrl(signInContext, email);
 
-      const uap = this._getUap();
+      const uap = this.getUserAgent();
       const isAndroid = uap.isAndroid();
       const isFirefoxAndroid = uap.isFirefoxAndroid();
       const isFirefoxDesktop = uap.isFirefoxDesktop();
@@ -152,33 +152,6 @@ define(function (require, exports, module) {
         isOtherIos,
         isSignedIn
       };
-    },
-
-    /**
-     * Get the user-agent string. For functional testing
-     * purposes, first attempts to fetch a UA string from the
-     * `forceUA` query parameter, if that is not found, use
-     * the browser's.
-     *
-     * @returns {String}
-     * @private
-     */
-    _getUserAgentString () {
-      return this.getSearchParam('forceUA') || this.window.navigator.userAgent;
-    },
-
-    /**
-     * Get a user-agent parser instance.
-     *
-     * @returns {Object}
-     * @private
-     */
-    _getUap () {
-      if (! this._uap) {
-        const userAgent = this._getUserAgentString();
-        this._uap = new UserAgent(userAgent);
-      }
-      return this._uap;
     },
 
     /**
@@ -210,7 +183,7 @@ define(function (require, exports, module) {
      * @private
      */
     _hasWebChannelSupport () {
-      const uap = this._getUap();
+      const uap = this.getUserAgent();
       const browserVersion = uap.browser.version;
 
       // WebChannels were introduced in Fx Desktop 40 and Fennec 43.
@@ -227,7 +200,7 @@ define(function (require, exports, module) {
      * @private
      */
     _getSignInContext() {
-      const uap = this._getUap();
+      const uap = this.getUserAgent();
       if (uap.isFirefoxAndroid()) {
         return Constants.FX_FENNEC_V1_CONTEXT;
       } else if (uap.isFirefoxDesktop()) {
@@ -282,7 +255,8 @@ define(function (require, exports, module) {
     MarketingMixin({
       // The marketing area is manually created to which badges are displayed.
       autocreate: false
-    })
+    }),
+    UserAgentMixin
   );
 
   module.exports = View;

--- a/app/scripts/views/marketing_snippet.js
+++ b/app/scripts/views/marketing_snippet.js
@@ -22,7 +22,7 @@ define(function (require, exports, module) {
   const Constants = require('lib/constants');
   const Strings = require('lib/strings');
   const Template = require('stache!templates/marketing_snippet');
-  const UserAgent = require('lib/user-agent');
+  const UserAgentMixin = require('views/mixins/user-agent-mixin');
   const VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
 
   const APP_STORE_BUTTON = 'apple_app_store_button';
@@ -119,18 +119,6 @@ define(function (require, exports, module) {
       });
     },
 
-    _getUserAgentString () {
-      return this.getSearchParam('forceUA') || this.window.navigator.userAgent;
-    },
-
-    _getUap () {
-      if (! this._uap) {
-        const userAgent = this._getUserAgentString();
-        this._uap = new UserAgent(userAgent);
-      }
-      return this._uap;
-    },
-
     _shouldShowSignUpMarketing () {
       const hasBrokerSupport = this.broker.hasCapability('emailVerificationMarketingSnippet');
       const isFirefoxMobile = this._isFirefoxMobile();
@@ -143,17 +131,17 @@ define(function (require, exports, module) {
     },
 
     _isFirefoxMobile () {
-      const uap = this._getUap();
+      const uap = this.getUserAgent();
       return uap.isFirefoxIos() || uap.isFirefoxAndroid();
     },
 
     _isIos () {
       // if _which is set, ignore the userAgent
-      return (! this._which && this._getUap().isIos()) || this._which === View.WHICH.IOS;
+      return (! this._which && this.getUserAgent().isIos()) || this._which === View.WHICH.IOS;
     },
 
     _isAndroid () {
-      return (! this._which && this._getUap().isAndroid()) || this._which === View.WHICH.ANDROID;
+      return (! this._which && this.getUserAgent().isAndroid()) || this._which === View.WHICH.ANDROID;
     },
 
     _isOther () {
@@ -234,6 +222,7 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     View,
+    UserAgentMixin,
     VerificationReasonMixin
   );
 

--- a/app/scripts/views/mixins/user-agent-mixin.js
+++ b/app/scripts/views/mixins/user-agent-mixin.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+define((require, exports, module) => {
+  'use strict';
+
+  const UserAgent = require('lib/user-agent');
+
+  module.exports = {
+    /**
+     * Get the user-agent string. For functional testing
+     * purposes, first attempts to fetch a UA string from the
+     * `forceUA` query parameter, if that is not found, use
+     * the browser's.
+     *
+     * @returns {String}
+     */
+    getUserAgentString () {
+      return this.getSearchParam('forceUA') || this.window.navigator.userAgent;
+    },
+
+    /**
+     * Get a UserAgent instance.
+     *
+     * @returns {Object}
+     */
+    getUserAgent () {
+      if (! this._uap) {
+        const userAgent = this.getUserAgentString();
+        this._uap = new UserAgent(userAgent);
+      }
+      return this._uap;
+    }
+  };
+});

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -17,7 +17,7 @@ define(function (require, exports, module) {
   const Strings = require('lib/strings');
   const { t } = require('views/base');
   const Template = require('stache!templates/settings/clients');
-  const UserAgent = require('lib/user-agent');
+  const UserAgentMixin = require('views/mixins/user-agent-mixin');
 
   const DEVICE_REMOVED_ANIMATION_MS = 150;
   const UTM_PARAMS = '?utm_source=accounts.firefox.com&utm_medium=referral&utm_campaign=fxa-devices';
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
         return true;
       }
 
-      const userAgent = new UserAgent(this.getSearchParam('forceUA') || this.window.navigator.userAgent);
+      const userAgent = this.getUserAgent();
       const version = userAgent.parseVersion();
       return userAgent.isFirefox() && this._able.choose('sessionsListVisible', {
         firefoxVersion: version.major
@@ -215,7 +215,8 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     SettingsPanelMixin,
-    SignedOutNotificationMixin
+    SignedOutNotificationMixin,
+    UserAgentMixin
   );
 
   module.exports = View;

--- a/app/tests/spec/views/connect_another_device.js
+++ b/app/tests/spec/views/connect_another_device.js
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
 
       describe('with a fennec user that is signed in', () => {
         beforeEach(() => {
-          sinon.stub(view, '_getUap', () => {
+          sinon.stub(view, 'getUserAgent', () => {
             return {
               isAndroid: () => true,
               isFirefox: () => true,
@@ -114,7 +114,7 @@ define(function (require, exports, module) {
 
       describe('with a Fx desktop user that can sign in', () => {
         beforeEach(() => {
-          sinon.stub(view, '_getUap', () => {
+          sinon.stub(view, 'getUserAgent', () => {
             return {
               isAndroid: () => false,
               isFirefox: () => true,
@@ -145,7 +145,7 @@ define(function (require, exports, module) {
 
       describe('with a fennec user that can sign in', () => {
         beforeEach(() => {
-          sinon.stub(view, '_getUap', () => {
+          sinon.stub(view, 'getUserAgent', () => {
             return {
               isAndroid: () => true,
               isFirefox: () => true,
@@ -181,7 +181,7 @@ define(function (require, exports, module) {
         });
 
         it('shows FxiOS help text, no marketing area to users on FxiOS', () => {
-          sinon.stub(view, '_getUap', () => {
+          sinon.stub(view, 'getUserAgent', () => {
             return {
               isAndroid: () => false,
               isFirefox: () => true,
@@ -203,7 +203,7 @@ define(function (require, exports, module) {
         });
 
         it('shows iOS text, marketing area to users on iOS', () => {
-          sinon.stub(view, '_getUap', () => {
+          sinon.stub(view, 'getUserAgent', () => {
             return {
               isAndroid: () => false,
               isFirefox: () => false,
@@ -225,7 +225,7 @@ define(function (require, exports, module) {
         });
 
         it('shows Android text, marketing area to users on Android', () => {
-          sinon.stub(view, '_getUap', () => {
+          sinon.stub(view, 'getUserAgent', () => {
             return {
               isAndroid: () => true,
               isFirefox: () => false,
@@ -247,7 +247,7 @@ define(function (require, exports, module) {
         });
 
         it('shows FxDesktop text, marketing area to Fx Desktop users', () => {
-          sinon.stub(view, '_getUap', () => {
+          sinon.stub(view, 'getUserAgent', () => {
             return {
               isAndroid: () => false,
               isFirefox: () => true,
@@ -269,7 +269,7 @@ define(function (require, exports, module) {
         });
 
         it('shows Other text, marketing area to everyone else', () => {
-          sinon.stub(view, '_getUap', () => {
+          sinon.stub(view, 'getUserAgent', () => {
             return {
               isAndroid: () => false,
               isFirefox: () => false,
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
 
     describe('_hasWebChannelSupport', () => {
       it('returns `false` if not Firefox', () => {
-        sinon.stub(view, '_getUap', () => {
+        sinon.stub(view, 'getUserAgent', () => {
           return {
             browser: {
               version: 52
@@ -346,7 +346,7 @@ define(function (require, exports, module) {
       });
 
       it('returns `false` if Fx Desktop < 40', () => {
-        sinon.stub(view, '_getUap', () => {
+        sinon.stub(view, 'getUserAgent', () => {
           return {
             browser: {
               version: 39
@@ -363,7 +363,7 @@ define(function (require, exports, module) {
       });
 
       it('returns `false` if Fx Desktop < 43', () => {
-        sinon.stub(view, '_getUap', () => {
+        sinon.stub(view, 'getUserAgent', () => {
           return {
             browser: {
               version: 42
@@ -380,7 +380,7 @@ define(function (require, exports, module) {
       });
 
       it('returns `false` if Fx for iOS', () => {
-        sinon.stub(view, '_getUap', () => {
+        sinon.stub(view, 'getUserAgent', () => {
           return {
             browser: {
               version: 6
@@ -397,7 +397,7 @@ define(function (require, exports, module) {
       });
 
       it('returns true if Fx Desktop >= 40', () => {
-        sinon.stub(view, '_getUap', () => {
+        sinon.stub(view, 'getUserAgent', () => {
           return {
             browser: {
               version: 40
@@ -414,7 +414,7 @@ define(function (require, exports, module) {
       });
 
       it('returns true if Fennec >= 43', () => {
-        sinon.stub(view, '_getUap', () => {
+        sinon.stub(view, 'getUserAgent', () => {
           return {
             browser: {
               version: 43
@@ -433,7 +433,7 @@ define(function (require, exports, module) {
 
     describe('_getSignInContext', () => {
       it('returns fx_fennec_v1 for fennec', () => {
-        sinon.stub(view, '_getUap', () => {
+        sinon.stub(view, 'getUserAgent', () => {
           return {
             isFirefoxAndroid: () => true,
             isFirefoxDesktop: () => false,
@@ -444,7 +444,7 @@ define(function (require, exports, module) {
       });
 
       it('returns fx_desktop_v3 for desktop users', () => {
-        sinon.stub(view, '_getUap', () => {
+        sinon.stub(view, 'getUserAgent', () => {
           return {
             isFirefoxAndroid: () => false,
             isFirefoxDesktop: () => true
@@ -508,7 +508,7 @@ define(function (require, exports, module) {
 
     describe('clicks', () => {
       beforeEach(() => {
-        sinon.stub(view, '_getUap', () => {
+        sinon.stub(view, 'getUserAgent', () => {
           return {
             isAndroid: () => false,
             isFirefox: () => true,

--- a/app/tests/spec/views/mixins/user-agent-mixin.js
+++ b/app/tests/spec/views/mixins/user-agent-mixin.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const { assert } = require('chai');
+  const BaseView = require('views/base');
+  const Cocktail = require('cocktail');
+  const sinon = require('sinon');
+  const UserAgentMixin = require('views/mixins/user-agent-mixin');
+  const WindowMock = require('../../../mocks/window');
+
+  const View = BaseView.extend({});
+
+  const FORCED_USER_AGENT_STRING = 'forced user agent string';
+  const NAVIGATOR_USER_AGENT_STRING = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
+
+  Cocktail.mixin(
+    View,
+    UserAgentMixin
+  );
+
+  describe('views/mixins/user-agent-mixin', function () {
+    let view;
+    let windowMock;
+
+    beforeEach(function () {
+      windowMock = new WindowMock();
+      windowMock.navigator.userAgent = NAVIGATOR_USER_AGENT_STRING;
+
+      view = new View({
+        window: windowMock
+      });
+    });
+
+    describe('getUserAgentString', () => {
+      it('fetches from forceUA query parameter, if exists', () => {
+        sinon.stub(view, 'getSearchParam', (param) => {
+          if (param === 'forceUA') {
+            return FORCED_USER_AGENT_STRING;
+          }
+        });
+
+        assert.equal(view.getUserAgentString(), FORCED_USER_AGENT_STRING);
+      });
+
+      it('falls back to navigator.userAgent if forceUA query parameter does not exist', () => {
+        sinon.stub(view, 'getSearchParam', (param) => {});
+
+        assert.equal(view.getUserAgentString(), NAVIGATOR_USER_AGENT_STRING);
+      });
+    });
+
+    describe('getUserAgent', () => {
+      it('returns a UserAgent instance', () => {
+        sinon.stub(view, 'getSearchParam', (param) => {});
+
+        const uap = view.getUserAgent();
+
+        assert.isTrue(uap.isFirefox());
+      });
+    });
+  });
+});
+

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -152,6 +152,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/signin-mixin',
     '../tests/spec/views/mixins/signup-mixin',
     '../tests/spec/views/mixins/timer-mixin',
+    '../tests/spec/views/mixins/user-agent-mixin',
     '../tests/spec/views/mixins/verification-reason-mixin',
     '../tests/spec/views/oauth_index',
     '../tests/spec/views/oauth_sign_in',


### PR DESCRIPTION
Logic to create the UserAgent instance was duplicated in 3 places and
a 4th would have been added to fix #4855.

This extracts the common code into a mixin so that creating a UserAgent instance
is done the same way everywhere.

issue #4855

@mozilla/fxa-devs - r?