### PR TITLE
fix(sms): Fix visiting /sms w/o ?service=sync query parameter.

### DIFF
--- a/app/scripts/views/sms_send.js
+++ b/app/scripts/views/sms_send.js
@@ -58,7 +58,13 @@ define(function (require, exports, module) {
       // number in the success message on /sms/sent, and
       // clicks "Mistyped number?"
       let phoneNumber = this._formPrefill.get('phoneNumber');
-      const country = this._getCountry();
+      let country = this._getCountry();
+      if (! CountryTelephoneInfo[country]) {
+        // this shouldn't be possible because only the Sync relier imports
+        // a country, and it'll only import a list of allowed countries,
+        // but defense in depth.
+        country = 'US';
+      }
       const prefix = CountryTelephoneInfo[country].prefix;
       if (! phoneNumber && prefix !== CountryTelephoneInfo.US.prefix) {
         phoneNumber = prefix;
@@ -98,7 +104,7 @@ define(function (require, exports, module) {
       // Once the feature is opened up to more countries, we'll get the country
       // first from the relier (query params), and then data returned from
       // the auth-server's /sms/status endpoint
-      return this.relier.get('country');
+      return this.relier.get('country') || 'US';
     },
 
     /**

--- a/app/tests/spec/views/sms_send.js
+++ b/app/tests/spec/views/sms_send.js
@@ -67,6 +67,29 @@
              assert.equal(view.$('input[type=tel]').data('country'), 'GB');
            });
        });
+
+       it('with relier set country that is not supported, it renders correctly for the US/CA, renders marketing', () => {
+         formPrefill.unset('phoneNumber');
+         relier.set('country', 'KZ');
+
+         return view.render()
+           .then(() => {
+             assert.equal(view.$('input[type=tel]').__val(), '');
+             assert.equal(view.$('input[type=tel]').data('country'), 'US');
+             assert.lengthOf(view.$('.marketing-link'), 2);
+           });
+       });
+
+       it('with no relier set country, it renders correctly for the US/CA', () => {
+         formPrefill.unset('phoneNumber');
+         relier.unset('country');
+         return view.render()
+           .then(() => {
+             assert.equal(view.$('input[type=tel]').__val(), '');
+             assert.equal(view.$('input[type=tel]').data('country'), 'US');
+             assert.lengthOf(view.$('.marketing-link'), 2);
+           });
+       });
      });
 
      describe('submit', () => {


### PR DESCRIPTION
What is the problem?
I assumed a `service=sync` query parameter would always be specified when
loading the /sms page. The SyncRelier specifies the default country
to use if none is specified on the URL. w/o service=sync, the BaseRelier
was used, which does not specify a default country. We tried to get
the phone number info for the country `undefined`. This blew up.

How does this fix it?
Two fixes:
* If the relier does not specify a country, assume US.
* If the relier specifies an invalid country, use US anyways.

Is this the proper fix?
The proper fix would be to block the /sms page to all users
unless `?service=sync` is specified, but that looked like
a bigger fix. This is targeted, and something I'm comfortable
issuing a point release for.