### PR TITLE
fix(test): Fix "verify different browser, verification_redirect=always" test.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1641,6 +1641,25 @@ define([
     };
   }
 
+  /**
+   * Wait for the given `url`
+   *
+   * @param {string} url - url to wait for
+   * @returns {promise} resolves when true
+   */
+
+  const waitForUrl = thenify(function (url) {
+    return this.parent
+      .getCurrentUrl()
+      .then(function (currentUrl) {
+        if (currentUrl !== url) {
+          return this.parent
+            .sleep(500)
+            .then(waitForUrl(url));
+        }
+      });
+  });
+
   return {
     clearBrowserNotifications: clearBrowserNotifications,
     clearBrowserState: clearBrowserState,
@@ -1716,6 +1735,7 @@ define([
     testUrlPathnameEquals: testUrlPathnameEquals,
     thenify: thenify,
     type: type,
-    visibleByQSA: visibleByQSA
+    visibleByQSA: visibleByQSA,
+    waitForUrl: waitForUrl
   };
 });

--- a/tests/functional/oauth_sign_up_verification_redirect.js
+++ b/tests/functional/oauth_sign_up_verification_redirect.js
@@ -3,13 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
+  'intern',
   'intern!object',
   'intern/chai!assert',
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
-], function (registerSuite, assert, TestHelpers, FunctionalHelpers) {
+], function (intern, registerSuite, assert, TestHelpers, FunctionalHelpers) {
   var PASSWORD = 'password';
   var email;
+
+  const OAUTH_APP = intern.config.fxaOauthApp;
 
   var clearBrowserState = FunctionalHelpers.clearBrowserState;
   var click = FunctionalHelpers.click;
@@ -21,6 +24,7 @@ define([
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   var openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   var testElementExists = FunctionalHelpers.testElementExists;
+  var waitForUrl = FunctionalHelpers.waitForUrl;
 
   registerSuite({
     name: 'oauth sign up verification_redirect',
@@ -136,6 +140,7 @@ define([
         .then(click('#proceed'))
 
         // Note: success is 123done giving a bad request because this is a different browser
+        .then(waitForUrl(`${OAUTH_APP}api/oauth`))
         .findByCssSelector('body')
         .getVisibleText()
         .then(function (text) {


### PR DESCRIPTION
### What is the problem?
We often see a StaleElementReference error when getting the body text.
This can happen whenever `findByCssSelector('body')` is called when FxA
is present and `getVisibleText` is called when 123done loads.

### How does this fix it?
Look at the URL, if the URL is the OAuth app, then try to get the body.

issue #4847

6/6 when run locally against latest!

@vladikoff, @jrgm - r?