### PR TITLE
feat(sms): SMS country based updates.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -655,14 +655,14 @@ define(function (require, exports, module) {
      * Check whether SMS is enabled for the user
      *
      * @param {String} sessionToken
-     * @returns {Promise} resolves to `true` if SMS is enabled,
-     *  `false` otw.
+     * @param {Object} [options={}] options
+     *   @param {String} [options.country] country code to force for testing.
+     * @returns {Promise} resolves to an object with:
+     *   * {Boolean} ok - true if user can send an SMS
+     *   * {String} country - user's country
      */
-    smsStatus: withClient((client, sessionToken) => {
-      return client.smsStatus(sessionToken)
-        .then((resp) => {
-          return !! (resp && resp.ok);
-        });
+    smsStatus: withClient((client, sessionToken, options) => {
+      return client.smsStatus(sessionToken, options);
     })
   };
 

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -1020,13 +1020,16 @@ define(function (require, exports, module) {
     /**
      * Check whether SMS is enabled for the current account.
      *
-     * @returns {Promise} resolves to `true` if SMS is enabled,
-     *  `false` otw.
+     * @param {Object} [options={}] options
+     *   @param {Boolean} [options.country]  country code to force for testing.
+     * @returns {Promise} resolves to an object with:
+     *   * {Boolean} ok - true if user can send an SMS
+     *   * {String} country - user's country
      */
     smsStatus() {
       const sessionToken = this.get('sessionToken');
       if (! sessionToken) {
-        return p(false);
+        return p({ ok: false });
       }
 
       return this._fxaClient.smsStatus(sessionToken);

--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -32,7 +32,6 @@ define(function (require, exports, module) {
 
   module.exports = Relier.extend({
     defaults: _.extend({}, Relier.prototype.defaults, {
-      country: 'US',
       customizeSync: false
     }),
 

--- a/app/scripts/views/sms_send.js
+++ b/app/scripts/views/sms_send.js
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
      * @private
      */
     _getCountry () {
-      // relier takes precedence over the model so to allow query parameters
+      // relier takes precedence over the model to allow query parameters
       // to override the auth-server's view of the world. This allows
       // testers and functional tests to force a country even if geo-lookup
       // is enabled on the auth server.

--- a/app/scripts/views/sms_send.js
+++ b/app/scripts/views/sms_send.js
@@ -101,10 +101,11 @@ define(function (require, exports, module) {
      * @private
      */
     _getCountry () {
-      // Once the feature is opened up to more countries, we'll get the country
-      // first from the relier (query params), and then data returned from
-      // the auth-server's /sms/status endpoint
-      return this.relier.get('country') || 'US';
+      // relier takes precedence over the model so to allow query parameters
+      // to override the auth-server's view of the world. This allows
+      // testers and functional tests to force a country even if geo-lookup
+      // is enabled on the auth server.
+      return this.relier.get('country') || this.model.get('country') || 'US';
     },
 
     /**

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -1381,12 +1381,20 @@ define(function (require, exports, module) {
 
     describe('smsStatus', () => {
       it('delegates to the fxa-js-client', () => {
-        sinon.stub(realClient, 'smsStatus', () => p());
+        sinon.stub(realClient, 'smsStatus', () => p({
+          country: 'GB',
+          ok: true
+        }));
 
-        return client.smsStatus('sessionToken')
-          .then(() => {
+        const smsStatusOptions = { country: 'GB '};
+        return client.smsStatus('sessionToken', smsStatusOptions)
+          .then((resp) => {
+            assert.equal(resp.country, 'GB');
+            assert.isTrue(resp.ok);
+
             assert.isTrue(realClient.smsStatus.calledOnce);
-            assert.isTrue(realClient.smsStatus.calledWith('sessionToken'));
+            assert.isTrue(
+              realClient.smsStatus.calledWith('sessionToken', smsStatusOptions));
           });
       });
     });

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -2227,7 +2227,10 @@ define(function (require, exports, module) {
 
     describe('smsStatus', () => {
       beforeEach(() => {
-        sinon.stub(fxaClient, 'smsStatus', () => p(true));
+        sinon.stub(fxaClient, 'smsStatus', () => p({
+          country: 'GB',
+          ok: true
+        }));
       });
 
       describe('sessionToken not available', () => {
@@ -2236,7 +2239,8 @@ define(function (require, exports, module) {
 
           return account.smsStatus()
             .then((response) => {
-              assert.isFalse(response);
+              assert.isFalse(response.ok);
+
               assert.isFalse(fxaClient.smsStatus.called);
             });
         });
@@ -2246,12 +2250,15 @@ define(function (require, exports, module) {
         it('delegates to the fxa-client, returns response', () => {
           account.set('sessionToken', 'sessionToken');
 
+          const smsStatusOptions = { country: 'GB' };
           return account.smsStatus()
             .then((response) => {
-              assert.isTrue(response);
+              assert.equal(response.country, 'GB');
+              assert.isTrue(response.ok);
 
               assert.isTrue(fxaClient.smsStatus.calledOnce);
-              assert.isTrue(fxaClient.smsStatus.calledWith('sessionToken'));
+              assert.isTrue(
+                fxaClient.smsStatus.calledWith('sessionToken'), smsStatusOptions);
             });
         });
       });

--- a/app/tests/spec/models/reliers/sync.js
+++ b/app/tests/spec/models/reliers/sync.js
@@ -114,8 +114,8 @@ define(function (require, exports, module) {
             return relier.fetch();
           });
 
-          it('falls back to default country', () => {
-            assert.equal(relier.get('country'), 'US');
+          it('does not set a country, it\'ll be retrieved via a call to /sms/status', () => {
+            assert.isFalse(relier.has('country'));
           });
         });
 

--- a/app/tests/spec/views/sms_send.js
+++ b/app/tests/spec/views/sms_send.js
@@ -44,7 +44,7 @@
        formPrefill = new Backbone.Model({});
        model = new Backbone.Model({ account });
        notifier = new Notifier();
-       relier = new Relier({ country: 'US', service: 'sync' });
+       relier = new Relier({ service: 'sync' });
 
        createView();
 
@@ -58,9 +58,21 @@
          assert.lengthOf(view.$('.marketing-link'), 2);
        });
 
+       it('with model set country, it renders correctly for country, renders marketing', () => {
+         formPrefill.unset('phoneNumber');
+         model.set('country', 'RO');
+
+         return view.render()
+           .then(() => {
+             assert.equal(view.$('input[type=tel]').__val(), '+407');
+             assert.equal(view.$('input[type=tel]').data('country'), 'RO');
+           });
+       });
+
        it('with relier set country, it renders correctly for country, renders marketing', () => {
          formPrefill.unset('phoneNumber');
          relier.set('country', 'GB');
+
          return view.render()
            .then(() => {
              assert.equal(view.$('input[type=tel]').__val(), '+44');

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "cocktail": "0.5.9",
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
     "fxa-checkbox": "mozilla/fxa-checkbox#7f856afffd394a144f718e28e6fb79092d6ccddd",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.54",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.55",
     "html5shiv": "3.7.2",
     "JavaScript-MD5": "1.1.0",
     "jquery": "3.1.0",

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -14,6 +14,8 @@ define([
   var email;
   const PASSWORD = '12345678';
 
+  const SELECTOR_400_HEADER = '#fxa-400-header';
+  const SELECTOR_400_ERROR = '.error';
   const SELECTOR_CHOOSE_WHAT_TO_SYNC_HEADER = '#fxa-choose-what-to-sync-header';
   const SELECTOR_CHOOSE_WHAT_TO_SYNC_HISTORY_ENTRY = 'div.two-col-block:nth-child(2) > div:nth-child(1) > label:nth-child(1)';
   const SELECTOR_CHOOSE_WHAT_TO_SYNC_PASSWORD_ENTRY = 'div.two-col-block:nth-child(1) > div:nth-child(3) > label:nth-child(1)';
@@ -21,6 +23,7 @@ define([
   const SELECTOR_CONFIRM_HEADER = '#fxa-confirm-header';
   const SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER = '#fxa-connect-another-device-header';
   const SELECTOR_SEND_SMS_HEADER = '#fxa-send-sms-header';
+  const SELECTOR_SEND_SMS_PHONE_NUMBER = 'input[type="tel"]';
   const SELECTOR_SIGN_UP_HEADER = '#fxa-signup-header';
   const SELECTOR_SIGN_UP_COMPLETE_HEADER = '#fxa-sign-up-complete-header';
 
@@ -41,7 +44,9 @@ define([
   const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   const openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  const testAttributeEquals = FunctionalHelpers.testAttributeEquals;
   const testElementExists = FunctionalHelpers.testElementExists;
+  const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   const testEmailExpected = FunctionalHelpers.testEmailExpected;
   const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
   const thenify = FunctionalHelpers.thenify;
@@ -71,10 +76,14 @@ define([
   const verifyMobileTest = thenify(function (uaString) {
     return this.parent
       .then(setupTest())
+      // These all synthesize the user verifying on a mobile device
+      // instead of on the same device. Clear browser state.
+      .then(clearBrowserState())
 
       // verify the user
       .then(openVerificationLinkInNewTab(email, 0, {
         query: {
+          country: 'US',
           forceExperiment: 'sendSms',
           forceExperimentGroup: 'treatment',
           forceUA: uaString
@@ -142,13 +151,14 @@ define([
         .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER));
     },
 
-    'sign up, verify same browser, force SMS': function () {
+    'sign up, verify same browser, force SMS, force supported country': function () {
       return this.remote
         .then(setupTest())
 
         // verify the user
         .then(openVerificationLinkInNewTab(email, 0, {
           query: {
+            country: 'CA',
             forceExperiment: 'sendSms',
             forceExperimentGroup: 'treatment'
           }
@@ -157,10 +167,35 @@ define([
 
         // user should be redirected to "Send SMS" screen.
         .then(testElementExists(SELECTOR_SEND_SMS_HEADER))
+        .then(testAttributeEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, 'data-country', 'CA'))
 
         // switch back to the original window, it should transition.
         .then(closeCurrentWindow())
         .then(testElementExists(SELECTOR_SIGN_UP_COMPLETE_HEADER));
+    },
+
+    'sign up, verify same browser, force SMS, force unsupported country': function () {
+      return this.remote
+        .then(setupTest())
+
+        // verify the user
+        .then(openVerificationLinkInNewTab(email, 0, {
+          query: {
+            country: 'ZZ',
+            forceExperiment: 'sendSms',
+            forceExperimentGroup: 'treatment'
+          }
+        }))
+        .switchToWindow('newwindow')
+
+        // user should be redirected to the 400 page, `country` is invalid
+        .then(testElementExists(SELECTOR_400_HEADER))
+        .then(testElementTextInclude(SELECTOR_400_ERROR, 'country'))
+
+        // switch back to the original window, it should not transition,
+        // the invalid country prevents the verification code from being sent.
+        .then(closeCurrentWindow())
+        .then(testElementExists(SELECTOR_CONFIRM_HEADER));
     },
 
     'sign up, verify Chrome on Android, force SMS sends to connect_another_device': function () {


### PR DESCRIPTION
* Pass the user's country to the /sms form so that
  the form's validation is set up correctly.
* Add additional gating logic for Romania, if
  the auth server says the user can send an SMS,
  only allow users with softvision.(com|ro)
  addresses to see the SMS form. This allow
  softvision to test w/o exposing the feature
  to everyone else from the country.

fixes #4861 