### PR TITLE
fix(sms): Fix users who verify in a 2nd browser.

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -1023,9 +1023,12 @@ define(function (require, exports, module) {
      *  `false` otw.
      */
     smsStatus() {
-      return this._fxaClient.smsStatus(
-        this.get('sessionToken')
-      );
+      const sessionToken = this.get('sessionToken');
+      if (! sessionToken) {
+        return p(false);
+      }
+
+      return this._fxaClient.smsStatus(sessionToken);
     }
   }, {
     ALLOWED_KEYS: ALLOWED_KEYS,

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -2221,15 +2221,33 @@ define(function (require, exports, module) {
 
     describe('smsStatus', () => {
       beforeEach(() => {
-        sinon.stub(fxaClient, 'smsStatus', () => p());
-
-        account.set('sessionToken', 'sessionToken');
-        return account.smsStatus();
+        sinon.stub(fxaClient, 'smsStatus', () => p(true));
       });
 
-      it('delegates to the fxa-client', () => {
-        assert.isTrue(fxaClient.smsStatus.calledOnce);
-        assert.isTrue(fxaClient.smsStatus.calledWith('sessionToken'));
+      describe('sessionToken not available', () => {
+        it('does not delegate to fxa-client, resolves with `false`', () => {
+          account.unset('sessionToken');
+
+          return account.smsStatus()
+            .then((response) => {
+              assert.isFalse(response);
+              assert.isFalse(fxaClient.smsStatus.called);
+            });
+        });
+      });
+
+      describe('sessionToken available', () => {
+        it('delegates to the fxa-client, returns response', () => {
+          account.set('sessionToken', 'sessionToken');
+
+          return account.smsStatus()
+            .then((response) => {
+              assert.isTrue(response);
+
+              assert.isTrue(fxaClient.smsStatus.calledOnce);
+              assert.isTrue(fxaClient.smsStatus.calledWith('sessionToken'));
+            });
+        });
       });
     });
   });

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -105,18 +105,6 @@ define([
         .then(clearBrowserState());
     },
 
-    'sign up, verify different browser': function () {
-      return this.remote
-        .then(setupTest())
-        // clear browser state to synthesize opening in a different browser
-        .then(clearBrowserState())
-
-        // verify the user in a different browser, they should see the
-        // "connect another device" screen.
-        .then(openVerificationLinkInSameTab(email, 0))
-        .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER));
-    },
-
     'sign up, verify same browser': function () {
       return this.remote
         .then(setupTest())
@@ -136,6 +124,22 @@ define([
         .then(testElementExists(SELECTOR_SIGN_UP_COMPLETE_HEADER))
         // A post-verification email should be sent, this is Sync.
         .then(testEmailExpected(email, 1));
+    },
+
+    'sign up, verify different browser, force SMS': function () {
+      return this.remote
+        .then(setupTest())
+        // clear browser state to synthesize opening in a different browser
+        .then(clearBrowserState({ force: true }))
+        // verify the user in a different browser, they should see the
+        // "connect another device" screen.
+        .then(openVerificationLinkInSameTab(email, 0, {
+          query: {
+            forceExperiment: 'sendSms',
+            forceExperimentGroup: 'treatment'
+          }
+        }))
+        .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER));
     },
 
     'sign up, verify same browser, force SMS': function () {

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -39,6 +39,7 @@ define([
   const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   const openPage = FunctionalHelpers.openPage;
   const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
+  const openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
   const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   const testElementExists = FunctionalHelpers.testElementExists;
   const testEmailExpected = FunctionalHelpers.testEmailExpected;
@@ -102,6 +103,18 @@ define([
     afterEach: function () {
       return this.remote
         .then(clearBrowserState());
+    },
+
+    'sign up, verify different browser': function () {
+      return this.remote
+        .then(setupTest())
+        // clear browser state to synthesize opening in a different browser
+        .then(clearBrowserState())
+
+        // verify the user in a different browser, they should see the
+        // "connect another device" screen.
+        .then(openVerificationLinkInSameTab(email, 0))
+        .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER));
     },
 
     'sign up, verify same browser': function () {


### PR DESCRIPTION
Users who verified in a 2nd browser saw a "Missing sessionToken" error.
These users will not have a sessionToken, which is required to call
/sms/status. The fxa-js-client threw an error which was displayed
to the user.

This fixes the problem by only calling the fxa-js-client if
the account has a sessionToken. If the account does not have
a sessionToken, account.smsStatus resolves to `false`.

fixes #4873

@vladikoff, @vbudhram, @philbooth, @jrgm - r?

This will need to be added to train-83 or else users who verify on a 2nd device are going to have a terrible experience. Agggh... 