### PR TITLE
feat(experiments): Re-add `additionalInfo` parameter for experiment functions.

### DIFF
--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -84,12 +84,13 @@ define(function (require, exports, module) {
      * Is the user in an experiment?
      *
      * @param {String} experimentName
+     * @param {Object} [additionalInfo] additional info to pass to Able.
      * @return {Boolean}
      */
-    isInExperiment (experimentName) {
+    isInExperiment (experimentName, additionalInfo) {
       // If able returns any truthy value, consider the
       // user in the experiment.
-      return !! this._getExperimentGroup(experimentName);
+      return !! this._getExperimentGroup(experimentName, additionalInfo);
     },
 
     /**
@@ -97,10 +98,11 @@ define(function (require, exports, module) {
      *
      * @param {String} experimentName
      * @param {String} groupName
+     * @param {Object} [additionalInfo] additional info to pass to Able.
      * @return {Boolean}
      */
-    isInExperimentGroup (experimentName, groupName) {
-      return this._getExperimentGroup(experimentName) === groupName;
+    isInExperimentGroup (experimentName, groupName, additionalInfo) {
+      return this._getExperimentGroup(experimentName, additionalInfo) === groupName;
     },
 
     /**
@@ -157,16 +159,17 @@ define(function (require, exports, module) {
      * Get the experiment group for `experimentName` the user is in.
      *
      * @param {String} experimentName
+     * @param {Object} [additionalInfo] additional info to pass to Able.
      * @returns {String}
      * @private
      */
-    _getExperimentGroup (experimentName) {
+    _getExperimentGroup (experimentName, additionalInfo = {}) {
       // can't be in an experiment group if not initialized.
       if (! this.initialized) {
         return false;
       }
 
-      return this.able.choose(experimentName, {
+      return this.able.choose(experimentName, _.extend({
         // yes, this is a hack because experiments do not have a reference
         // to able internally. This allows experiments to reference other
         // experiments
@@ -176,7 +179,7 @@ define(function (require, exports, module) {
         forceExperimentGroup: this.forceExperimentGroup,
         isMetricsEnabledValue: this.metrics.isCollectionEnabled(),
         uniqueUserId: this.user.get('uniqueUserId')
-      });
+      }, additionalInfo));
     }
   });
 

--- a/app/scripts/views/mixins/experiment-mixin.js
+++ b/app/scripts/views/mixins/experiment-mixin.js
@@ -38,8 +38,8 @@ define(function (require, exports, module) {
      * @param {String} experimentName
      * @return {Boolean}
      */
-    isInExperiment (experimentName) {
-      return this.experiments.isInExperiment(experimentName);
+    isInExperiment (...args) {
+      return this.experiments.isInExperiment(...args);
     },
 
     /**
@@ -49,8 +49,8 @@ define(function (require, exports, module) {
      * @param {String} groupName
      * @return {Boolean}
      */
-    isInExperimentGroup (experimentName, groupName) {
-      return this.experiments.isInExperimentGroup(experimentName, groupName);
+    isInExperimentGroup (...args) {
+      return this.experiments.isInExperimentGroup(...args);
     }
   };
 });

--- a/app/tests/spec/lib/experiment.js
+++ b/app/tests/spec/lib/experiment.js
@@ -74,11 +74,13 @@ define(function (require, exports, module) {
 
     describe('isInExperiment', () => {
       it('checks experiment opt in', () => {
-        sinon.stub(expInt, '_getExperimentGroup', (experimentName) => {
-          return experimentName === 'mockExperiment';
+        sinon.stub(expInt, '_getExperimentGroup', (experimentName, additionalData = {}) => {
+          return !! (experimentName === 'mockExperiment' &&
+                     additionalData.isEligible);
         });
 
-        assert.isTrue(expInt.isInExperiment('mockExperiment'));
+        assert.isTrue(expInt.isInExperiment('mockExperiment', { isEligible: true }));
+        assert.isFalse(expInt.isInExperiment('mockExperiment'));
         assert.isFalse(expInt.isInExperiment('otherExperiment'));
         assert.isFalse(expInt.isInExperiment());
       });
@@ -86,14 +88,16 @@ define(function (require, exports, module) {
 
     describe('isInExperimentGroup', () => {
       it('is true when opted in', () => {
-        sinon.stub(expInt, '_getExperimentGroup', (experimentName) => {
-          return experimentName === 'mockExperiment' ? 'treatment' : false;
+        sinon.stub(expInt, '_getExperimentGroup', (experimentName, additionalData = {}) => {
+          const isInExperimentGroup = !! (experimentName === 'mockExperiment' && additionalData.isEligible);
+          return isInExperimentGroup ? 'treatment' : false;
         });
         expInt._activeExperiments = {
           'mockExperiment': mockExperiment
         };
 
-        assert.isTrue(expInt.isInExperimentGroup('mockExperiment', 'treatment'));
+        assert.isTrue(expInt.isInExperimentGroup('mockExperiment', 'treatment', { isEligible: true }));
+        assert.isFalse(expInt.isInExperimentGroup('mockExperiment', 'treatment'));
         assert.isFalse(expInt.isInExperimentGroup('otherExperiment', 'control'));
         assert.isFalse(expInt.isInExperimentGroup());
       });

--- a/app/tests/spec/views/mixins/experiment-mixin.js
+++ b/app/tests/spec/views/mixins/experiment-mixin.js
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
           experiments: experimentsMock
         });
 
-        assert.isTrue(experimentsMock.chooseExperiments.called);
+        assert.isTrue(experimentsMock.chooseExperiments.calledOnce);
       });
     });
 
@@ -86,23 +86,28 @@ define(function (require, exports, module) {
 
     describe('isInExperiment', () => {
       it('returns `true` if user is in experiment, `false` if not', () => {
-        sinon.stub(view.experiments, 'isInExperiment', (experimentName) => {
-          return experimentName === 'realExperiment';
+        sinon.stub(view.experiments, 'isInExperiment', (experimentName, additionalData = {}) => {
+          return !! (experimentName === 'realExperiment' && additionalData.isEligible);
         });
 
-        assert.isTrue(view.isInExperiment('realExperiment'));
+        assert.isTrue(view.isInExperiment('realExperiment', { isEligible: true }));
+        assert.isFalse(view.isInExperiment('realExperiment', { isEligible: false }));
+        assert.isFalse(view.isInExperiment('realExperiment'));
         assert.isFalse(view.isInExperiment('fakeExperiment'));
       });
     });
 
     describe('isInExperimentGroup', () => {
       it('returns `true` if user is in experiment group, `false` otw', () => {
-        sinon.stub(view.experiments, 'isInExperimentGroup', (experimentName, groupName) => {
-          return experimentName === 'realExperiment' &&
-                 groupName === 'treatment';
+        sinon.stub(view.experiments, 'isInExperimentGroup', (experimentName, groupName, additionalData = {}) => {
+          return !! (experimentName === 'realExperiment' &&
+                     groupName === 'treatment' &&
+                     additionalData.isEligible);
         });
 
-        assert.isTrue(view.isInExperimentGroup('realExperiment', 'treatment'));
+        assert.isTrue(view.isInExperimentGroup('realExperiment', 'treatment', { isEligible: true }));
+        assert.isFalse(view.isInExperimentGroup('realExperiment', 'treatment', { isEligible: false }));
+        assert.isFalse(view.isInExperimentGroup('realExperiment', 'treatment'));
         assert.isFalse(view.isInExperimentGroup('realExperiment', 'control'));
       });
     });


### PR DESCRIPTION
I removed the `additionalInfo` args from the ExperimentInterface function
args recently because they weren't being used by anything. That was
pre-mature, I now need to pass in extra data for the send SMS work.

Extracted from https://github.com/mozilla/fxa-content-server/pull/4872

@vladikoff or @vbudhram - r?