### PR TITLE
fix(test): Fix the rp listen in apps, can be deleted test.

### DIFF
--- a/tests/functional/oauth_settings_clients.js
+++ b/tests/functional/oauth_settings_clients.js
@@ -87,8 +87,8 @@ define([
         .then(testElementExists('li.client-oAuthApp:nth-child(2)'))
 
         // delete should work
-        .then(click('li.client-oAuthApp:nth-child(1) .client-disconnect'))
         .then(click('li.client-oAuthApp:nth-child(2) .client-disconnect'))
+        .then(click('li.client-oAuthApp:nth-child(1) .client-disconnect'))
         .then(pollUntilGoneByQSA('.client-disconnect'));
     }
 


### PR DESCRIPTION
A lot of StaleElementReference errors showed up on TeamCity when trying
to reference `:nth-child(2)` after deleting the first item. This can
happen when the first item is deleted, removed from the list, and the 2nd
item becomes the first.

Reverse the order of deletions.

fixes #4878

@vladikoff - r?