### PR TITLE
fix(test): Fix NoSuchBrowserNotification flakiness.

### DIFF
--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -113,9 +113,9 @@ define([
         .then(testElementExists('img[src*="https://secure.gravatar.com"]'))
         .then(click('.modal-panel #submit-btn'))
 
-        .then(testIsBrowserNotifiedOfAvatarChange())
         //success is returning to the settings page
         .then(testElementExists('#fxa-settings-header'))
+        .then(testIsBrowserNotifiedOfAvatarChange())
         // check for an image with the gravatar url
         .then(testElementExists('img[src*="https://secure.gravatar.com"]'))
 
@@ -186,8 +186,8 @@ define([
 
         .then(click('.modal-panel #submit-btn'))
 
-        .then(testIsBrowserNotifiedOfAvatarChange())
         .then(testElementExists('#fxa-settings-header'))
+        .then(testIsBrowserNotifiedOfAvatarChange())
         //success is seeing the image loaded
         .then(FunctionalHelpers.imageLoadedByQSA('.change-avatar > img'));
     },
@@ -222,8 +222,8 @@ define([
         .then(click('.rotate'))
         .then(click('.modal-panel #submit-btn'))
 
-        .then(testIsBrowserNotifiedOfAvatarChange())
         .then(testElementExists('#fxa-settings-header'))
+        .then(testIsBrowserNotifiedOfAvatarChange())
         //success is seeing the image loaded
         .then(FunctionalHelpers.imageLoadedByQSA('.change-avatar > img'));
 

--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -45,9 +45,9 @@ define([
         .then(openPage(PAGE_SIGNIN_URL, '#fxa-signin-header'))
         .execute(listenForFxaCommands)
         .then(fillOutSignIn(email, PASSWORD))
+        .then(testElementExists('#fxa-confirm-signin-header'))
         .then(testIsBrowserNotified('can_link_account'))
         .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }))
-        .then(testElementExists('#fxa-confirm-signin-header'))
         .then(restmail(EMAIL_SERVER_ROOT + '/mail/' + user))
         .then((emails) => {
           code = emails[0].headers['x-verify-code'];

--- a/tests/functional/fx_fennec_v1_force_auth.js
+++ b/tests/functional/fx_fennec_v1_force_auth.js
@@ -93,9 +93,9 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
-        .then(testIsBrowserNotified('fxaccounts:login'))
 
-        .then(testElementExists('#fxa-sign-in-complete-header'));
+        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     }
   });
 });

--- a/tests/functional/fx_fennec_v1_settings.js
+++ b/tests/functional/fx_fennec_v1_settings.js
@@ -45,11 +45,12 @@ define([
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // User must confirm their Sync signin
         .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
+
         .then(openVerificationLinkInDifferentBrowser(email))
         .then(testElementExists('#fxa-sign-in-complete-header'))
 

--- a/tests/functional/fx_fennec_v1_sign_up.js
+++ b/tests/functional/fx_fennec_v1_sign_up.js
@@ -47,11 +47,12 @@ define([
         .then(noSuchElement('#customize-sync'))
         .then(fillOutSignUp(email, PASSWORD))
 
+        // user should be transitioned to the choose what to Sync page
+        .then(testElementExists('#fxa-choose-what-to-sync-header'))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         // the login message is only sent after the confirm screen is shown.
         .then(noSuchBrowserNotification('fxaccounts:login'))
-        // user should be transitioned to the choose what to Sync page
-        .then(testElementExists('#fxa-choose-what-to-sync-header'))
+
         // uncheck the passwords and history engines
         .then(click('div.two-col-block:nth-child(2) > div:nth-child(1) > label:nth-child(1)'))
         .then(click('div.two-col-block:nth-child(2) > div:nth-child(2) > label:nth-child(1)'))

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -61,9 +61,10 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
+        .then(testElementExists('#fxa-confirm-signin-header'))
+
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
-        .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')
@@ -78,9 +79,9 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
+        .then(testElementExists('#fxa-confirm-signin-header'))
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
-        .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openVerificationLinkInDifferentBrowser(email))
 
@@ -93,10 +94,9 @@ define([
       return this.remote
         .then(setupTest({ preVerified: false }))
 
+        .then(testElementExists('#fxa-confirm-header'))
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
-
-        .then(testElementExists('#fxa-confirm-header'))
 
         // email 0 - initial sign up email
         // email 1 - sign in w/ unverified address email
@@ -130,12 +130,11 @@ define([
         .then(testElementTextInclude('.verification-email-message', email))
         .then(fillOutSignInUnblock(email, 0))
 
-        .then(testIsBrowserNotified('fxaccounts:login'))
-
         // Only users that go through signin confirmation see
         // `/signin_complete`, and users that go through signin unblock see
         // the default `settings` page.
-        .then(testElementExists('#fxa-settings-header'));
+        .then(testElementExists('#fxa-settings-header'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     }
   });
 });

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -72,10 +72,9 @@ define([
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: false } ))
         .then(fillOutSignUp(email, PASSWORD))
 
-        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-
         // user should not transition to the next screen
-        .then(noSuchElement('#fxa-confirm-header'));
+        .then(noSuchElement('#fxa-confirm-header'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'));
     }
   });
 });

--- a/tests/functional/fx_firstrun_v2_settings.js
+++ b/tests/functional/fx_firstrun_v2_settings.js
@@ -42,10 +42,11 @@ define([
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
+
+        .then(testElementExists('#fxa-confirm-signin-header'))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))
 
-        .then(testElementExists('#fxa-confirm-signin-header'))
         .then(openVerificationLinkInDifferentBrowser(email))
 
         // wait until account data is in localstorage before redirecting

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -53,8 +53,8 @@ define([
 
       .then(fillOutSignUp(email, PASSWORD))
 
-      .then(testIsBrowserNotified('fxaccounts:can_link_account'))
       .then(testElementExists(SELECTOR_CHOOSE_WHAT_TO_SYNC_HEADER))
+      .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
       // uncheck the passwords and history engines
       .then(click(SELECTOR_CHOOSE_WHAT_TO_SYNC_HISTORY_ENTRY))

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -56,14 +56,14 @@ define([
       }))
       .execute(listenForFxaCommands)
       .then(fillOutSignIn(email, PASSWORD))
+      .then(testElementExists(successSelector))
       .then(testIsBrowserNotified('can_link_account'))
       .then(() => {
         if (! options.blocked) {
           return this.parent
             .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }));
         }
-      })
-      .then(testElementExists(successSelector));
+      });
   });
 
   registerSuite({
@@ -158,9 +158,9 @@ define([
         .then(testElementTextInclude('.verification-email-message', email))
         .then(fillOutSignInUnblock(email, 0))
 
-        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }))
         // about:accounts will take over post-unblock, no transition
-        .then(noPageTransition('#fxa-signin-unblock-header'));
+        .then(noPageTransition('#fxa-signin-unblock-header'))
+        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }));
     }
   });
 });

--- a/tests/functional/oauth_sync_sign_in.js
+++ b/tests/functional/oauth_sync_sign_in.js
@@ -62,6 +62,7 @@ define([
         .execute(listenForFxaCommands)
 
         .then(fillOutSignIn(email, PASSWORD))
+        .then(testElementExists('#fxa-confirm-signin-header'))
         .then(testIsBrowserNotifiedOfLogin(email))
 
         // Sync sign ins must be verified.

--- a/tests/functional/sign_in_cached.js
+++ b/tests/functional/sign_in_cached.js
@@ -107,8 +107,8 @@ define([
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
 
-        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(openVerificationLinkInDifferentBrowser(email))
 
         .then(openPage(PAGE_SIGNIN, '#fxa-signin-header'))
@@ -150,6 +150,7 @@ define([
         .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
+        .then(testElementExists('#fxa-confirm-signin-header'))
         .then(testIsBrowserNotified('fxaccounts:login'))
 
         .execute(function () {
@@ -215,8 +216,8 @@ define([
         .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(openPage(PAGE_SIGNIN + '?email=' + email2, '#fxa-signin-header'))
         /*.then(testElementValueEquals('input.email.prefilled', email2))*/
@@ -241,8 +242,8 @@ define([
         .then(openPage(PAGE_SIGNIN_DESKTOP, '#fxa-signin-header'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // ensure signin page is visible otherwise credentials might
         // not be cleared by clicking .use-different

--- a/tests/functional/sync_force_auth.js
+++ b/tests/functional/sync_force_auth.js
@@ -44,15 +44,14 @@ define([
       }}))
       .execute(listenForFxaCommands)
       .then(fillOutForceAuth(PASSWORD))
+      .then(testElementExists(successSelector))
       .then(testIsBrowserNotified('can_link_account'))
       .then(() => {
         if (! options.blocked) {
           return this.parent
             .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }));
         }
-      })
-
-      .then(testElementExists(successSelector));
+      });
   });
 
   registerSuite({
@@ -97,10 +96,10 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
-        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }))
 
         // about:accounts will take over post-verification, no transition
-        .then(noPageTransition('#fxa-signin-unblock-header'));
+        .then(noPageTransition('#fxa-signin-unblock-header'))
+        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }));
     }
   });
 });

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -48,14 +48,14 @@ define([
       .then(openPage(options.pageUrl || PAGE_URL, '#fxa-signin-header'))
       .execute(listenForFxaCommands)
       .then(fillOutSignIn(email, PASSWORD))
+      .then(testElementExists(successSelector))
       .then(testIsBrowserNotified('can_link_account'))
       .then(() => {
         if (! options.blocked) {
           return this.parent
             .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }));
         }
-      })
-      .then(testElementExists(successSelector));
+      });
   });
 
   registerSuite({
@@ -139,10 +139,10 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
-        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }))
 
         // about:accounts will take over post-verification, no transition
-        .then(noPageTransition('#fxa-signin-unblock-header'));
+        .then(noPageTransition('#fxa-signin-unblock-header'))
+        .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }));
     }
   });
 });

--- a/tests/functional/sync_v2_settings.js
+++ b/tests/functional/sync_v2_settings.js
@@ -42,10 +42,10 @@ define([
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(openVerificationLinkInDifferentBrowser(email))
 
         // wait until account data is in localstorage before redirecting

--- a/tests/functional/sync_v2_sign_in.js
+++ b/tests/functional/sync_v2_sign_in.js
@@ -99,10 +99,10 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
-        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // about:accounts will take over post-verification, no transition
-        .then(noPageTransition('#fxa-signin-unblock-header'));
+        .then(noPageTransition('#fxa-signin-unblock-header'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
     'verified, blocked, incorrect email case': function () {
@@ -123,10 +123,10 @@ define([
         // the canonicalized email. Ugly UX, but at least the user can proceed.
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignInUnblock(signUpEmail, 0))
-        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // about:accounts will take over post-verification, no transition
-        .then(noPageTransition('#fxa-signin-unblock-header'));
+        .then(noPageTransition('#fxa-signin-unblock-header'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     }
   });
 });

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -46,11 +46,11 @@ define([
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 
-        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-        .then(noSuchBrowserNotification('fxaccounts:login'))
-
         // user should be transitioned to the choose what to Sync page
         .then(testElementExists('#fxa-choose-what-to-sync-header'))
+
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(noSuchBrowserNotification('fxaccounts:login'))
 
         // test that autofocus attribute has been applied to submit button
         .then(testAttributeExists('#submit-btn', 'autofocus'))

--- a/tests/functional/sync_v3_force_auth.js
+++ b/tests/functional/sync_v3_force_auth.js
@@ -51,10 +51,9 @@ define([
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
 
+        .then(testElementExists('#fxa-confirm-signin-header'))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))
-
-        .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')
@@ -82,10 +81,10 @@ define([
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
 
+        .then(testElementExists('#fxa-confirm-signin-header'))
+
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))
-
-        .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')
@@ -111,11 +110,11 @@ define([
         .then(noSuchBrowserNotification('fxaccounts:logout'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
-        // user is able to sign in, browser notified of new uid
+
+        .then(testElementExists('#fxa-confirm-signin-header'))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))
 
-        .then(testElementExists('#fxa-confirm-signin-header'))
 
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')
@@ -224,15 +223,14 @@ define([
         .then(noSuchBrowserNotification('fxaccounts:logout'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutForceAuth(PASSWORD))
-        // user is able to sign in, browser notified of new uid
-        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
         .then(testElementExists('#fxa-signin-unblock-header'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(fillOutSignInUnblock(email, 0))
 
-        .then(testIsBrowserNotified('fxaccounts:login'))
         // about:accounts will take over post-verification, no transition
-        .then(noPageTransition('#fxa-signin-unblock-header'));
+        .then(noPageTransition('#fxa-signin-unblock-header'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     }
   });
 });

--- a/tests/functional/sync_v3_settings.js
+++ b/tests/functional/sync_v3_settings.js
@@ -45,10 +45,10 @@ define([
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(openVerificationLinkInDifferentBrowser(email))
 
         // wait until account data is in localstorage before redirecting

--- a/tests/functional/sync_v3_sign_in.js
+++ b/tests/functional/sync_v3_sign_in.js
@@ -48,17 +48,14 @@ define([
       .then(openPage(PAGE_URL, '#fxa-signin-header'))
       .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(signInEmail, PASSWORD))
-
+      .then(testElementExists(successSelector))
       .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-
       .then(() => {
         if (! options.blocked) {
           return this.parent
             .then(testIsBrowserNotified('fxaccounts:login'));
         }
-      })
-
-      .then(testElementExists(successSelector));
+      });
   });
 
   registerSuite({
@@ -149,10 +146,10 @@ define([
         .then(setupTest({ blocked: true, preVerified: true }))
 
         .then(fillOutSignInUnblock(email, 0))
-        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // about:accounts will take over post-verification, no transition
-        .then(noPageTransition('#fxa-signin-unblock-header'));
+        .then(noPageTransition('#fxa-signin-unblock-header'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
     'verified, blocked, incorrect email case': function () {
@@ -173,10 +170,10 @@ define([
         // the canonicalized email. Ugly UX, but at least the user can proceed.
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignInUnblock(signUpEmail, 0))
-        .then(testIsBrowserNotified('fxaccounts:login'))
 
         // about:accounts will take over post-verification, no transition
-        .then(noPageTransition('#fxa-signin-unblock-header'));
+        .then(noPageTransition('#fxa-signin-unblock-header'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     }
   });
 });

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -47,11 +47,12 @@ define([
         .then(noSuchElement('#suggest-sync'))
         .then(fillOutSignUp(email, PASSWORD))
 
+        // user should be transitioned to the choose what to Sync page
+        .then(testElementExists('#fxa-choose-what-to-sync-header'))
+
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(noSuchBrowserNotification('fxaccounts:login'))
 
-        // user should be transitioned to the choose what to Sync page
-        .then(testElementExists('#fxa-choose-what-to-sync-header'))
         .then(click('button[type=submit]'))
 
         // user should be transitioned to the "go confirm your address" page


### PR DESCRIPTION
Tests would often fail with a NoSuchNotification message.
If notifications were checked for before the screen
transitions, it's possible the XHR request was still
outstanding and the web channel message wasn't yet sent.

Wait for the page to transition, then check.

fixes #4882