### PR TITLE
refactor(client): Extract a "sync-auth-mixin" from connect_another_device.js

### DIFF
--- a/app/scripts/views/mixins/sync-auth-mixin.js
+++ b/app/scripts/views/mixins/sync-auth-mixin.js
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Determine whether the user can sign in to Sync in the
+ * current tab, and if so, which URL should be used to do so.
+ */
+
+define((require, exports, module) => {
+  'use strict';
+
+  const _ = require('underscore');
+  const Constants = require('lib/constants');
+  const Url = require('lib/url');
+
+  module.exports = {
+    /**
+     * Does the browser support WebChannels?
+     *
+     * @returns {Boolean}
+     * @private
+     */
+    _hasWebChannelSupport () {
+      const uap = this.getUserAgent();
+      const browserVersion = uap.browser.version;
+
+      // WebChannels were introduced in Fx Desktop 40 and Fennec 43.
+      return ((uap.isFirefoxDesktop() && browserVersion >= 40) ||
+              (uap.isFirefoxAndroid() && browserVersion >= 43));
+    },
+
+    /**
+     * Check whether the current environment supports sign in for Sync.
+     *
+     * @returns {Boolean}
+     */
+    isSyncAuthSupported () {
+      return !! this._hasWebChannelSupport();
+    },
+
+    /**
+     * Return the context that can be used to sign up/in
+     * to Sync. Assumes the context is only used if the user
+     * can actually sign in to Sync.
+     *
+     * @returns {String}
+     */
+    _getSyncContext () {
+      const uap = this.getUserAgent();
+      if (uap.isFirefoxAndroid()) {
+        return Constants.FX_FENNEC_V1_CONTEXT;
+      } else if (uap.isFirefoxDesktop()) {
+        // desktop_v3 is safe for all desktop versions that can
+        // use WebChannels. The only difference between v2 and v3
+        // was the Sync Preferences button, which has since
+        // been disabled.
+        return Constants.FX_DESKTOP_V3_CONTEXT;
+      }
+    },
+
+    /**
+     * Get an escaped Sync URL for `pathname`.
+     *
+     * @param {String} pathname target pathname
+     * @param {String} entrypoint entrypoint for metrics
+     * @param {Object} [extraQueryParams={}] Extra query parameters
+     * @returns {String}
+     */
+    getEscapedSyncUrl (pathname, entrypoint, extraQueryParams = {}) {
+      const origin = this.window.location.origin;
+      const relier = this.relier;
+
+      const params = _.extend({
+        context: this._getSyncContext(),
+        entrypoint: entrypoint,
+        service: Constants.SYNC_SERVICE,
+        /* eslint-disable camelcase */
+        utm_campaign: relier.get('utmCampaign'),
+        utm_content: relier.get('utmContent'),
+        utm_medium: relier.get('utmMedium'),
+        utm_source: relier.get('utmSource'),
+        utm_term: relier.get('utmTerm')
+        /* eslint-enable camelcase */
+      }, extraQueryParams);
+      // Url.objToSearchString escapes each of the
+      // query parameters.
+      const escapedSearchString = Url.objToSearchString(params);
+
+      return `${origin}/${pathname}${escapedSearchString}`;
+    }
+  };
+});

--- a/app/tests/spec/views/mixins/sync-auth-mixin.js
+++ b/app/tests/spec/views/mixins/sync-auth-mixin.js
@@ -1,0 +1,228 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const { assert } = require('chai');
+  const BaseView = require('views/base');
+  const Cocktail = require('cocktail');
+  const Constants = require('lib/constants');
+  const Relier = require('models/reliers/base');
+  const sinon = require('sinon');
+  const SyncAuthMixin = require('views/mixins/sync-auth-mixin');
+  const Url = require('lib/url');
+  const UserAgentMixin = require('views/mixins/user-agent-mixin');
+  const WindowMock = require('../../../mocks/window');
+
+  const SyncView = BaseView.extend({});
+
+  Cocktail.mixin(
+    SyncView,
+    SyncAuthMixin,
+    UserAgentMixin
+  );
+
+  describe('views/mixins/sync-auth-mixin', function () {
+    let relier;
+    let view;
+    let windowMock;
+
+    beforeEach(() => {
+      relier = new Relier();
+      windowMock = new WindowMock();
+
+      view = new SyncView({
+        relier,
+        window: windowMock
+      });
+    });
+
+    describe('_getSyncContext', () => {
+      it('returns fx_fennec_v1 for fennec', () => {
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            isFirefoxAndroid: () => true,
+            isFirefoxDesktop: () => false,
+          };
+        });
+
+        assert.equal(view._getSyncContext(), Constants.FX_FENNEC_V1_CONTEXT);
+      });
+
+      it('returns fx_desktop_v3 for desktop users', () => {
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            isFirefoxAndroid: () => false,
+            isFirefoxDesktop: () => true
+          };
+        });
+        assert.equal(view._getSyncContext(), Constants.FX_DESKTOP_V3_CONTEXT);
+      });
+    });
+
+    describe('getEscapedSyncUrl', () => {
+      const CONTEXT = 'fx_desktop_v3';
+      const EMAIL = 'testuser@testuser.com';
+      const ENTRYPOINT = 'fxa:signup';
+      const ORIGIN = 'https://accounts.firefox.com';
+      const PATHNAME = 'signin';
+
+      beforeEach(() => {
+        windowMock.location.origin = ORIGIN;
+        relier.set({
+          utmCampaign: 'campaign',
+          utmContent: 'content',
+          utmMedium: 'medium',
+          utmSource: 'source',
+          utmTerm: 'term'
+        });
+      });
+
+      it('returns the expected URL', () => {
+        const escapedSyncUrl
+          = view.getEscapedSyncUrl(PATHNAME, ENTRYPOINT, { email: EMAIL });
+
+        const search = escapedSyncUrl.split('?')[1];
+        const params = Url.searchParams(search);
+
+        assert.deepEqual(params, {
+          context: CONTEXT,
+          email: EMAIL,
+          entrypoint: ENTRYPOINT,
+          service: Constants.SYNC_SERVICE,
+          /* eslint-disable camelcase */
+          utm_campaign: 'campaign',
+          utm_content: 'content',
+          utm_medium: 'medium',
+          utm_source: 'source',
+          utm_term: 'term'
+          /* eslint-enable camelcase */
+        });
+
+        const origin = Url.getOrigin(escapedSyncUrl);
+        assert.equal(origin, ORIGIN);
+      });
+    });
+
+    describe('isSyncAuthSupported', () => {
+      let areWebChannelsSupported;
+
+      beforeEach(() => {
+        sinon.stub(view, '_hasWebChannelSupport', () => areWebChannelsSupported);
+      });
+
+      it('returns true if web channels are supported', () => {
+        areWebChannelsSupported = true;
+        assert.isTrue(view.isSyncAuthSupported());
+        areWebChannelsSupported = false;
+        assert.isFalse(view.isSyncAuthSupported());
+      });
+    });
+
+    describe('_hasWebChannelSupport', () => {
+      it('returns `false` if not Firefox', () => {
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            browser: {
+              version: 52
+            },
+            isFirefox: () => false,
+            isFirefoxAndroid: () => false,
+            isFirefoxDesktop: () => false,
+            isFirefoxIos: () => false,
+            isIos: () => false,
+          };
+        });
+
+        assert.isFalse(view._hasWebChannelSupport());
+      });
+
+      it('returns `false` if Fx Desktop < 40', () => {
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            browser: {
+              version: 39
+            },
+            isFirefox: () => true,
+            isFirefoxAndroid: () => false,
+            isFirefoxDesktop: () => true,
+            isFirefoxIos: () => false,
+            isIos: () => false,
+          };
+        });
+
+        assert.isFalse(view._hasWebChannelSupport());
+      });
+
+      it('returns `false` if Fx Desktop < 43', () => {
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            browser: {
+              version: 42
+            },
+            isFirefox: () => true,
+            isFirefoxAndroid: () => true,
+            isFirefoxDesktop: () => false,
+            isFirefoxIos: () => false,
+            isIos: () => false,
+          };
+        });
+
+        assert.isFalse(view._hasWebChannelSupport());
+      });
+
+      it('returns `false` if Fx for iOS', () => {
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            browser: {
+              version: 6
+            },
+            isFirefox: () => true,
+            isFirefoxAndroid: () => false,
+            isFirefoxDesktop: () => false,
+            isFirefoxIos: () => true,
+            isIos: () => true,
+          };
+        });
+
+        assert.isFalse(view._hasWebChannelSupport());
+      });
+
+      it('returns true if Fx Desktop >= 40', () => {
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            browser: {
+              version: 40
+            },
+            isFirefox: () => true,
+            isFirefoxAndroid: () => false,
+            isFirefoxDesktop: () => true,
+            isFirefoxIos: () => false,
+            isIos: () => false,
+          };
+        });
+
+        assert.isTrue(view._hasWebChannelSupport());
+      });
+
+      it('returns true if Fennec >= 43', () => {
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            browser: {
+              version: 43
+            },
+            isFirefox: () => true,
+            isFirefoxAndroid: () => true,
+            isFirefoxDesktop: () => false,
+            isFirefoxIos: () => false,
+            isIos: () => false,
+          };
+        });
+
+        assert.isTrue(view._hasWebChannelSupport());
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/mixins/sync-auth-mixin.js
+++ b/app/tests/spec/views/mixins/sync-auth-mixin.js
@@ -81,8 +81,9 @@ define(function (require, exports, module) {
       });
 
       it('returns the expected URL', () => {
-        const escapedSyncUrl
-          = view.getEscapedSyncUrl(PATHNAME, ENTRYPOINT, { email: EMAIL });
+        const escapedSyncUrl = view.getEscapedSyncUrl(PATHNAME, ENTRYPOINT, {
+          email: EMAIL
+        });
 
         const search = escapedSyncUrl.split('?')[1];
         const params = Url.searchParams(search);

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -151,6 +151,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/signed-out-notification-mixin',
     '../tests/spec/views/mixins/signin-mixin',
     '../tests/spec/views/mixins/signup-mixin',
+    '../tests/spec/views/mixins/sync-auth-mixin',
     '../tests/spec/views/mixins/timer-mixin',
     '../tests/spec/views/mixins/user-agent-mixin',
     '../tests/spec/views/mixins/verification-reason-mixin',


### PR DESCRIPTION
Extracts the logic that is used to determine whether the user can
sign in to Sync from the current tab, and if so, which URL they
should be redirected to to do so.

This logic is currently used by CAD, but will also be used
by @vershwal in her PR to allow users on the /signup page
to reload the app to sign in to Sync.

issue #4605

@vbudhram - r?
cc @vershwal - if this merges, this should make your work in https://github.com/mozilla/fxa-content-server/pull/4798 a bit simpler.