### PR TITLE
fix(test): Fix sync v2 password reset test.

### DIFF
--- a/tests/functional/sync_v2_reset_password.js
+++ b/tests/functional/sync_v2_reset_password.js
@@ -25,6 +25,7 @@ define([
   var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
   var openPage = FunctionalHelpers.openPage;
   var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
+  var switchToWindow = FunctionalHelpers.switchToWindow;
   var testElementExists = FunctionalHelpers.testElementExists;
   var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
   var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
@@ -85,12 +86,8 @@ define([
         .then(testElementExists('#fxa-confirm-reset-password-header'))
         .then(click('[data-webmail-type="restmail"]'))
 
-        .getAllWindowHandles()
-          .then(function (handles) {
-            return this.parent.switchToWindow(handles[1]);
-          })
-
-          // wait until url is correct
+        .then(switchToWindow(1))
+        // wait until url is correct
         .then(FunctionalHelpers.pollUntil(function (email) {
           return window.location.pathname.endsWith(email);
         }, [email], 10000))


### PR DESCRIPTION
The test was trying to go to window handle 1 before it was available.

Use the helper function that ensures a window exists before calling
switchToWindow.

fixes #4894

@philbooth or @vladikoff - r?