### PR TITLE
fix(test): Close all windows but the first after a test run

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -234,6 +234,27 @@ define([
       .then(testElementExists('#loggedout'));
   });
 
+  /**
+   * Close all windows but the first. Used to cleanup after
+   * failing functional tests where the test fails when checking
+   * the 2nd window.
+   *
+   * @returns {Promise}
+   */
+  const closeAllButFirstWindow = thenify(function () {
+    return this.parent
+      .getAllWindowHandles()
+      .then(function (handles) {
+        if (handles.length > 1) {
+          return this.parent
+            .switchToWindow(handles[1])
+            .closeCurrentWindow()
+            .switchToWindow('')
+            .then(closeAllButFirstWindow());
+        }
+      });
+  });
+
   const clearBrowserState = thenify(function (options) {
     options = options || {};
     if (! ('contentServer' in options)) {
@@ -266,7 +287,8 @@ define([
           return this.parent
             .then(clear123DoneState( { untrusted: true }));
         }
-      });
+      })
+      .then(closeAllButFirstWindow());
   });
 
   const clearSessionStorage = thenify(function () {


### PR DESCRIPTION
If a test opens a new tab and checks for an element in the new
tab, but fails, then the 2nd tab is never closed. This causes
cascading failures down the line.

In `clearBrowserState`, close all windows but the first.

fixes #4896

@mozilla/fxa-devs - r?