### PR TITLE
fix(test): Fix Firefox Desktop Sync v2 sign_in

### DIFF
--- a/tests/functional/sync_v2_sign_in.js
+++ b/tests/functional/sync_v2_sign_in.js
@@ -44,17 +44,14 @@ define([
       .then(openPage(PAGE_URL, '#fxa-signin-header'))
       .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
       .then(fillOutSignIn(signInEmail, PASSWORD))
-
+      .then(testElementExists(successSelector))
       .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-
       .then(() => {
         if (! options.blocked) {
           return this.parent
             .then(testIsBrowserNotified('fxaccounts:login'));
         }
-      })
-
-      .then(testElementExists(successSelector));
+      });
   });
 
   registerSuite({


### PR DESCRIPTION
We were checking for browser notifications before the
screen transitioned.

fixes #4898

@mozilla/fxa-devs - r?