### PR TITLE
fix(test): Fix timing problems in functional tests.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -364,21 +364,26 @@ define([
     var timeout = options.timeout || 10000;
 
     return pollUntil(function (selector, options) {
-      var $matchingEl = $(selector);
+      var matchingEls = document.querySelectorAll(selector);
 
-      if ($matchingEl.length === 0) {
+      if (matchingEls.length === 0) {
         return null;
       }
 
-      if ($matchingEl.length > 1) {
+      if (matchingEls.length > 1) {
         throw new Error('Multiple elements matched. Make a more precise selector - ' + selector);
       }
 
-      if (! $matchingEl.is(':visible')) {
+      var matchingEl = matchingEls[0];
+
+      // Check if the element is visible. This is from jQuery source - see
+      // https://github.com/jquery/jquery/blob/e1b1b2d7fe5aff907a9accf59910bc3b7e4d1dec/src/css/hiddenVisibleSelectors.js#L12
+      if (! (matchingEl.offsetWidth || matchingEl.offsetHeight || matchingEl.getClientRects().length)) {
         return null;
       }
 
-      if ($matchingEl.is(':animated')) {
+      // use jQuery if available to check for jQuery animations.
+      if (typeof $ !== 'undefined' && $(selector).is(':animated')) {
         // If the element is animating, try again after a delay. Clicks
         // do not always register if the element is in the midst of
         // an animation.

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -113,8 +113,8 @@ define([
     text = String(text);
 
     return this.parent
+      .then(click(selector))
       .findByCssSelector(selector)
-        .click()
 
         .then(function () {
           if (clearValue) {
@@ -361,7 +361,7 @@ define([
    */
   function visibleByQSA(selector, options) {
     options = options || {};
-    var timeout = options.timeout || 10000;
+    var timeout = options.timeout || config.pageLoadTimeout;
 
     return pollUntil(function (selector, options) {
       var matchingEls = document.querySelectorAll(selector);


### PR DESCRIPTION
* In `type`, use the `click` helper which ensures an element is visible first.
* In `visibleByQSA`, use config.pageLoadTimeout for the timeout, which is what
  we use elsewhere when searching for elements.

This is trying to address the `ElementNotVisible` problem in https://tc-test.dev.lcip.org/viewLog.html?buildId=9374&tab=buildResultsDiv&buildTypeId=FxaLatest_FunctionalTests#testNameId6508327029632508806.

@mozilla/fxa-devs - r?