### PR TITLE
fix(test): Bump the timeout to 90 seconds for oauth permissions tests.

### DIFF
--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -11,6 +11,8 @@ define([
 ], function (intern, registerSuite, assert, TestHelpers, FunctionalHelpers) {
   var config = intern.config;
 
+  var TIMEOUT = 90 * 1000;
+
   var TRUSTED_OAUTH_APP = config.fxaOauthApp;
   var UNTRUSTED_OAUTH_APP = config.fxaUntrustedOauthApp;
   var PASSWORD = 'password';
@@ -39,6 +41,7 @@ define([
     name: 'oauth permissions for untrusted reliers',
 
     beforeEach: function () {
+      this.timeout = TIMEOUT;
       email = TestHelpers.createEmail();
 
       return this.remote


### PR DESCRIPTION
Some of these tests take close to 45 seconds locally, when run against
remote servers this could be significantly longer.

fixes #4923