### PR TITLE
feat(test): Throw an error if emails do not contain the expected header.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -448,6 +448,27 @@ define([
   });
 
   /**
+   * Get an email
+   *
+   * @param {string} user - username or email address
+   * @param {number} index - email index.
+   * @param {object} [options]
+   *   @param {number} [options.maxAttempts] - number of email fetch attempts
+   *   to make. Defaults to 10.
+   * @returns {promise} resolves with the email if email is found.
+   */
+  const getEmail = thenify(function (user, index, options) {
+    if (/@/.test(user)) {
+      user = TestHelpers.emailToUser(user);
+    }
+
+    // restmail takes a length, not an index. Add 1.
+    return this.parent
+      .then(() => restmail(EMAIL_SERVER_ROOT + '/mail/' + user, index + 1, options)())
+      .then((emails) => emails[index]);
+  });
+
+  /**
    * Get the email headers
    *
    * @param {string} user - username or email address
@@ -458,16 +479,9 @@ define([
    * @returns {promise} resolves with the email headers if email is found.
    */
   const getEmailHeaders = thenify(function(user, index, options) {
-    if (/@/.test(user)) {
-      user = TestHelpers.emailToUser(user);
-    }
-
-    // restmail takes a length, not an index. Add 1.
     return this.parent
-      .then(() => restmail(EMAIL_SERVER_ROOT + '/mail/' + user, index + 1, options)())
-      .then(function (emails) {
-        return emails[index].headers;
-      });
+      .then(getEmail(user, index, options))
+      .then((email) => email.headers);
   });
 
   /**
@@ -485,7 +499,11 @@ define([
     return this.parent
       .then(getEmailHeaders(user, index))
       .then(function (headers) {
-        return require.toUrl(headers['x-link']);
+        const link = headers['x-link'];
+        if (! link) {
+          throw new Error('Email does not contain verification link: ' + headers['x-template-name']);
+        }
+        return require.toUrl(link);
       });
   });
 
@@ -505,13 +523,18 @@ define([
     return this.parent
       .then(getEmailHeaders(user, index))
       .then(function (headers) {
+        const unblockCode = headers['x-unblock-code'];
+        if (! unblockCode) {
+          throw new Error('Email does not contain unblock code: ' + headers['x-template-name']);
+        }
         return {
           reportSignInLink: require.toUrl(headers['x-report-signin-link']),
           uid: headers['x-uid'],
-          unblockCode: headers['x-unblock-code']
+          unblockCode: unblockCode
         };
       });
   });
+
 
   /**
    * Test to ensure an expected email arrives
@@ -691,6 +714,9 @@ define([
       .then(function (headers) {
         var uid = headers['x-uid'];
         var code = headers['x-verify-code'];
+        if (! code) {
+          throw new Error('Email does not contain verify code: ' + headers['x-template-name']);
+        }
 
         return client.verifyCode(uid, code);
       });
@@ -718,7 +744,9 @@ define([
         var search = Url.parse(link).query;
         var queryParams = Querystring.parse(search);
         var token = queryParams.token;
-
+        if (! code) {
+          throw new Error('Email does not contain reset password code: ' + headers['x-template-name']);
+        }
         return client.passwordForgotVerifyCode(code, token);
       })
       .then(function (result) {
@@ -1712,6 +1740,7 @@ define([
     fillOutSignInUnblock: fillOutSignInUnblock,
     fillOutSignUp: fillOutSignUp,
     focus: focus,
+    getEmail: getEmail,
     getEmailHeaders: getEmailHeaders,
     getFxaClient: getFxaClient,
     getQueryParamValue: getQueryParamValue,


### PR DESCRIPTION
I'm never certain whether signup verification emails are being sent before
the emails we expect. This PR has the tests throw an error if the expected
email headers are not present, and should help us debug intermittent errors.

issue #4925