### PR TITLE
fix(test): Fix the JavaScript error in the functional tests.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -65,10 +65,10 @@ define([
    */
   const click = thenify(function (selector) {
     return this.parent
-      // Ensure the element is visible and not animating before attempting to click.
-      // Sometimes clicks do not register if the element is in the middle of an animation.
-      .then(visibleByQSA(selector))
       .findByCssSelector(selector)
+        // Ensure the element is visible and not animating before attempting to click.
+        // Sometimes clicks do not register if the element is in the middle of an animation.
+        .then(visibleByQSA(selector))
         .click()
       .end();
   });


### PR DESCRIPTION
Ensure the element to click is present in the DOM
before attaching a script to check its visibility.

This avoids a problem where `click` could be called
on an element before a page transition has occurred.

fixes #4929