### PR TITLE
fix(metrics): Allow entrypoints with the fxa: prefix

### DIFF
--- a/app/scripts/views/connect_another_device.js
+++ b/app/scripts/views/connect_another_device.js
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
       return this.getEscapedSyncUrl('signin', View.ENTRYPOINT, { email: email });
     }
   }, {
-    ENTRYPOINT: 'connect_another_device'
+    ENTRYPOINT: 'fxa:connect_another_device'
   });
 
   Cocktail.mixin(

--- a/docs/client-metrics.md
+++ b/docs/client-metrics.md
@@ -34,7 +34,11 @@ The known values of `entrypoint` are:
 * tabs-sidebar: the synced-tabs sidebar
 * accounts-page: the iframe at https://www.mozilla.org/firefox/accounts/
 * firstrun: the iframe on the Firefox first-run page
+* firstrun_v2: the iframe on the Firefox first-run page, version 2
+* fxa:connect_another_device: user clicked "sign in" button from /connect_another_device page
 * fxa:signin-complete: TODO: we need to track down what's sending this value
+* fxa:signup: user clicked the "Looking for Sync" text from the signup page
+* fxa:signup-complete: TODO: we need to track down what's sending this value
 
 ### events
 The event stream, see [Event Stream](#event_stream)

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -13,7 +13,7 @@ module.exports = {
     BROKER: /^[0-9a-z-]+$/,
     CLIENT_ID: /^[0-9a-f]{16}/,
     CONTEXT: /^[0-9a-z_-]+$/,
-    ENTRYPOINT: /^[\w.-]+$/,
+    ENTRYPOINT: /^[\w.:-]+$/,
     EVENT_TYPE: /^[\w\s.:-]+$/, // the space is to allow for error contexts that contain spaces, e.g., `error.unknown context.auth.108`
     EXPERIMENT: /^[\w.-]+$/,
     MIGRATION: /^(sync11|amo|none)$/,

--- a/tests/functional/connect_another_device.js
+++ b/tests/functional/connect_another_device.js
@@ -21,7 +21,7 @@ define([
     'fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&' +
     'ct=adjust_tracker&mt=8';
 
-  var CONNECT_ANOTHER_DEVICE_ENTRYPOINT = 'entrypoint=connect_another_device';
+  var CONNECT_ANOTHER_DEVICE_ENTRYPOINT = 'entrypoint=' + encodeURIComponent('fxa:connect_another_device');
   var SELECTOR_CONFIRM_SIGNIN_HEADER = '#fxa-confirm-signin-header';
   var SELECTOR_CONTINUE_BUTTON = 'form div a';
   var SELECTOR_INSTALL_TEXT_ANDROID = '#install-mobile-firefox-android';

--- a/tests/server/metrics.js
+++ b/tests/server/metrics.js
@@ -31,6 +31,9 @@ define([
   };
 
   suite['#post /metrics - returns 200 with valid data'] = {
+    'valid entrypoint (fxa:connect_another_device)': testValidMetricsField('entrypoint', 'fxa:connect_another_device'),
+    'valid entrypoint (fxa:signup)': testValidMetricsField('entrypoint', 'fxa:signup'),
+    'valid entrypoint (fxa:signup-complete)': testValidMetricsField('entrypoint', 'fxa:signup-complete'),
     'valid error-type (error.unknown context.auth.108)':
         testValidMetricsEvent('type', 'error.unknown context.auth.108'),
     'valid error-type (signin-permissions.checkbox.change.profile:display_name.unchecked)':


### PR DESCRIPTION
Also convert the `connect_another_device` entrypoint to `fxa:connect_another_device`

fixes #4887

@philbooth - r?

@philbooth - will an entrypoint that contains a `:` be accepted within the flow events infrastructure?