### PR TITLE
fix(test): Fix the "delete oauth sessions" test.

### DIFF
--- a/tests/functional/oauth_settings_clients.js
+++ b/tests/functional/oauth_settings_clients.js
@@ -84,12 +84,12 @@ define([
         // second app should show up using 'refresh'
         .then(click('.clients-refresh'))
 
-        .then(testElementExists('li.client-oAuthApp:nth-child(2)'))
+        .then(testElementExists('li.client-oAuthApp[data-name^="321"]'))
 
         // delete should work
-        .then(click('li.client-oAuthApp:nth-child(2) .client-disconnect'))
-        .then(click('li.client-oAuthApp:nth-child(1) .client-disconnect'))
-        .then(pollUntilGoneByQSA('.client-disconnect'));
+        .then(click('li.client-oAuthApp[data-name^="123"] .client-disconnect'))
+        .then(click('li.client-oAuthApp[data-name^="321"] .client-disconnect'))
+        .then(pollUntilGoneByQSA('li.client-oAuthApp'));
     }
 
   });


### PR DESCRIPTION
With the introduction of web sessions in the UI, the OAuth session
selectors were no longer valid. This fixes that.

fixes #4968

Are web sessions enabled in stage and prod for these tests to pass there?

@vladikoff - r?

