### PR TITLE
feat(test): Make it easier to load screenshots in the browser.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -64,7 +64,7 @@ define([
     return this.parent.takeScreenshot()
       .then(function (buffer) {
         console.error('Capturing base64 screenshot:');
-        console.error(buffer.toString('base64'));
+        console.error('data:image/jpeg;base64,' + buffer.toString('base64'));
       });
   });
 


### PR DESCRIPTION
Add the `data:image/jpeg;base64` prefix to screenshots so that
the screenshot can be copied directly from logs into the browser
URL bar.

@mozilla/fxa-devs - r?