### PR TITLE
fix(settings): Fix the display name flicker.

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -1033,6 +1033,17 @@ define(function (require, exports, module) {
       }
 
       return this._fxaClient.smsStatus(sessionToken);
+    },
+
+    /**
+     * Update the `displayName` for the account.
+     *
+     * @param {String} displayName
+     * @returns {Promise} resolves when name has been saved
+     */
+    updateDisplayName (displayName) {
+      this.set('displayName', displayName);
+      return this.postDisplayName(displayName);
     }
   }, {
     ALLOWED_KEYS: ALLOWED_KEYS,

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -154,7 +154,7 @@ define(function (require, exports, module) {
     updateProfileImage (profileImage, account) {
       account.setProfileImage(profileImage);
       return this.user.setAccount(account)
-        .then(_.bind(this._notifyProfileUpdate, this, account.get('uid')));
+        .then(() => this._notifyProfileUpdate(account.get('uid')));
     },
 
     deleteDisplayedAccountProfileImage (account) {
@@ -179,11 +179,17 @@ define(function (require, exports, module) {
         });
     },
 
-    updateDisplayName (displayName) {
-      var account = this.getSignedInAccount();
-      account.set('displayName', displayName);
-      return this.user.setAccount(account)
-        .then(_.bind(this._notifyProfileUpdate, this, account.get('uid')));
+    /**
+     * Update `displayName` for `account`
+     *
+     * @param {Object} account
+     * @param {String} displayName
+     * @returns {Promise}
+     */
+    updateDisplayName (account, displayName) {
+      return account.updateDisplayName(displayName)
+        .then(() => this.user.setAccount(account))
+        .then(() => this._notifyProfileUpdate(account.get('uid')));
     },
 
     _notifyProfileUpdate (uid) {

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -2263,5 +2263,17 @@ define(function (require, exports, module) {
         });
       });
     });
+
+    describe('updateDisplayName', () => {
+      it('sets the displayName, saves to the backend', () => {
+        sinon.stub(account, 'postDisplayName', () => p());
+
+        return account.updateDisplayName('new name')
+          .then(() => {
+            assert.equal(account.get('displayName'), 'new name');
+            assert.isTrue(account.postDisplayName.calledOnce);
+          });
+      });
+    });
   });
 });

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -9,7 +9,7 @@ define(function (require, exports, module) {
   const AuthErrors = require('lib/auth-errors');
   const AvatarMixin = require('views/mixins/avatar-mixin');
   const BaseView = require('views/base');
-  const Chai = require('chai');
+  const { assert } = require('chai');
   const Cocktail = require('cocktail');
   const Metrics = require('lib/metrics');
   const Notifier = require('lib/channels/notifier');
@@ -23,11 +23,11 @@ define(function (require, exports, module) {
   const TestHelpers = require('../../../lib/helpers');
   const User = require('models/user');
 
-  var assert = Chai.assert;
-
-  var SettingsView = BaseView.extend({});
-
-  Cocktail.mixin(SettingsView, AvatarMixin);
+  const SettingsView = BaseView.extend({});
+  Cocktail.mixin(
+    SettingsView,
+    AvatarMixin
+  );
 
   describe('views/mixins/avatar-mixin', function () {
     var UID = '123';
@@ -238,10 +238,11 @@ define(function (require, exports, module) {
 
     describe('updateDisplayName', function () {
       it('stores the name', function () {
-        return view.updateDisplayName('joe')
+        sinon.stub(account, 'updateDisplayName', () => p());
+        return view.updateDisplayName(account, 'joe')
           .then(function () {
-            assert.equal(account.get('displayName'), 'joe');
-            assert.isTrue(view.getSignedInAccount.called);
+            assert.isTrue(account.updateDisplayName.calledOnce);
+            assert.isTrue(account.updateDisplayName.calledWith('joe'));
             assert.isTrue(user.setAccount.calledWith(account));
             assert.isTrue(notifier.trigger.calledWith(Notifier.PROFILE_CHANGE, { uid: UID }));
           });


### PR DESCRIPTION
To minimize flicker after updating the displayName,
fetchProfile is not called in beforeRender. The latency
in the XHR request made it so the user submit the name,
the panel closed, and the button would only update a
second or two later. Instead, call fetchProfile from `initialize`,
then re-do the initial render once the profile is fetched.
When the user updates the displayName, `onProfileUpdate`
will be called immediately, causing an immediate re-render.

follow on for PR #4823 
