### PR TITLE
fix(sms): Fix the SMS experiment bucketing logic.

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -1026,13 +1026,13 @@ define(function (require, exports, module) {
      *   * {Boolean} ok - true if user can send an SMS
      *   * {String} country - user's country
      */
-    smsStatus() {
+    smsStatus (options) {
       const sessionToken = this.get('sessionToken');
       if (! sessionToken) {
         return p({ ok: false });
       }
 
-      return this._fxaClient.smsStatus(sessionToken);
+      return this._fxaClient.smsStatus(sessionToken, options);
     }
   }, {
     ALLOWED_KEYS: ALLOWED_KEYS,

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -202,6 +202,19 @@ define(function (require, exports, module) {
       return accountUid === signedInAccountUid;
     },
 
+    /**
+     * Check if another account is signed in. Not the inverse
+     * of `isSignedInAccount` because if either account is default,
+     * this will return `false`.
+     *
+     * @param {Object} account
+     * @returns {Boolean}
+     */
+    isAnotherAccountSignedIn (account) {
+      return ! this.getSignedInAccount().isDefault() &&
+             ! this.isSignedInAccount(account);
+    },
+
     setSignedInAccountByUid (uid) {
       if (this._accounts()[uid]) {
         this._setSignedInAccountUid(uid);

--- a/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Helpers for the "Connect Another Device" screens. Users who
+ * are eligible for CAD can go to either /sms or /connect_another_device.
+ * This module exposes functions to query whether the user is eligible
+ * for CAD, and if so, to navigate to the appropriate screen.
+ *
+ * Should be called like:
+ * if (this.isEligibleForConnectAnotherDevice(account)) {
+ *   return this.navigateToConnectAnotherDeviceScreen(account);
+ * } else {
+ *   return this.navigateToAnotherScreen();
+ * }
+ *
+ * This mixin unfortunately requires a bunch of other mixins:
+ *  - ExperimentMixin,
+ *  - UserAgentMixin,
+ *  - VerificationReasonMixin
+ */
+
+define((require, exports, module) => {
+  'use strict';
+
+  const p = require('lib/promise');
+
+  return {
+    /**
+     * Is `account` eligible for connect another device?
+     *
+     * @param {Object} account - account to check
+     * @returns {Boolean}
+     */
+    isEligibleForConnectAnotherDevice (account) {
+      // Only show to users who are signing up, until we have better text for
+      // users who are signing in.
+      return this.isSignUp() &&
+             // If a user is already signed in to Sync which is different to the
+             // user that just verified, show them the old "Account verified!" screen.
+             ! this.user.isAnotherAccountSignedIn(account);
+    },
+
+    /**
+     * Navigate to the appropriate CAD screen for `account`.
+     *
+     * @param {Object} account
+     * @returns {Promise}
+     */
+    navigateToConnectAnotherDeviceScreen (account) {
+      // users have to be eligible for CAD to be part of SMS too.
+      // Users selected to be part of the SMS experiment who are
+      // in the control group will go to the existing CAD screen.
+      if (! this.isEligibleForConnectAnotherDevice(account)) {
+        // this shouldn't happen IRL.
+        return p.reject(new Error('chooseConnectAnotherDeviceScreen can only be called if user is eligible to connect another device'));
+      }
+
+      return this._isEligibleForSms(account)
+        .then(({ ok, country }) => {
+          if (ok) {
+            // User is eligible for SMS experiment, now bucket
+            // users into treatment and control groups.
+            const group = this.getExperimentGroup('sendSms', { account });
+            this.createExperiment('sendSms', group);
+
+            if (group === 'treatment') {
+              this.navigate('sms', { account, country });
+            } else { // there are only two groups, by default, this is the control
+              this.navigate('connect_another_device', { account });
+            }
+          } else {
+            this.navigate('connect_another_device', { account });
+          }
+        });
+    },
+
+    /**
+     * Is `account` eligible for SMS?
+     *
+     * @param {Object} account
+     * @returns {Promise} resolves to an object with two fields:
+     *   @returns {String} country - country user is in, only valid if user is eligible for SMS
+     *   @returns {Boolean} ok - whether the user is eligible for SMS.
+     * @private
+     */
+    _isEligibleForSms (account) {
+      return p(
+        this._areSmsRequirementsMet(account) &&
+        this._smsCountry(account)
+      )
+      .then((country) => {
+        return {
+          country,
+          ok: !! country
+        };
+      });
+    },
+
+    /**
+     * Check if the requirements are met to send an SMS.
+     *
+     * @param {Object} account
+     * @returns {Boolean}
+     * @private
+     */
+    _areSmsRequirementsMet (account) {
+      return this.isSignUp() &&
+        // If already on a mobile device, doesn't make sense to send an SMS.
+        ! this.getUserAgent().isAndroid() &&
+        ! this.getUserAgent().isIos() &&
+        // If a user is already signed in to Sync which is different to the
+        // user that just verified, show them the old "Account verified!" screen.
+        ! this.user.isAnotherAccountSignedIn(account) &&
+        // Does able say we are eligible for the experiment?
+        this.isInExperiment('sendSms', { account });
+    },
+
+    /**
+     * Check if `account` to send an SMS, and if so, which
+     * country the SMS should be sent to.
+     *
+     * @param {Object} account - account to check
+     * @returns {Promise} If user can send an SMS, resolves to
+     *   the country to send the SMS to.
+     * @private
+     */
+    _smsCountry (account) {
+      // The auth server can gate whether users can send an SMS based
+      // on the user's country and whether the SMS provider account
+      // has sufficient funds.
+      return account.smsStatus(this.relier.pick('country'))
+        .then((resp = {}) => {
+          // If the auth-server says the user is good to send an SMS,
+          // check with Able to ensure SMS is enabled for the country
+          // returned in the response. The auth-server may report
+          // that SMS is enabled for Romania, though it's only enabled
+          // for testing and not for the public at large. Able is used
+          // for this because it's the logic most likey to change.
+
+          // If geo-lookup is disabled, no country is returned, assume US
+          const country = resp.country || 'US';
+          if (resp.ok && this.isInExperiment('sendSmsEnabledForCountry', { country })) {
+            return country;
+          }
+        });
+    }
+  };
+});

--- a/app/scripts/views/mixins/experiment-mixin.js
+++ b/app/scripts/views/mixins/experiment-mixin.js
@@ -30,12 +30,29 @@ define(function (require, exports, module) {
         this.experiments.destroy();
         this.experiments = null;
       }
+    },
+
+    /**
+     * Create an experiment and add it to the list of active experiments.
+     * Only creates an experiment with `experimentName` once.
+     * This is useful to create an experiment that is not created
+     * at startup.
+     *
+     * @param {String} experimentName - name of experiment to create.
+     * @param {String} groupType - which group the user is in.
+     * @returns {Object} experiment object, if created.
+     */
+    createExperiment (...args) {
+      // force the flow model to be initialized so that
+      // the experiment is logged.
+      this.notifier.trigger('flow.initialize');
+
+      return this.experiments.createExperiment(...args);
     }
   };
 
   // Create some delegate methods.
   [
-    'createExperiment',
     'getExperimentGroup',
     'isInExperiment',
     'isInExperimentGroup'

--- a/app/scripts/views/mixins/experiment-mixin.js
+++ b/app/scripts/views/mixins/experiment-mixin.js
@@ -30,27 +30,18 @@ define(function (require, exports, module) {
         this.experiments.destroy();
         this.experiments = null;
       }
-    },
-
-    /**
-     * Is the user in an experiment?
-     *
-     * @param {String} experimentName
-     * @return {Boolean}
-     */
-    isInExperiment (...args) {
-      return this.experiments.isInExperiment(...args);
-    },
-
-    /**
-     * Is the user in an experiment group?
-     *
-     * @param {String} experimentName
-     * @param {String} groupName
-     * @return {Boolean}
-     */
-    isInExperimentGroup (...args) {
-      return this.experiments.isInExperimentGroup(...args);
     }
   };
+
+  // Create some delegate methods.
+  [
+    'createExperiment',
+    'getExperimentGroup',
+    'isInExperiment',
+    'isInExperimentGroup'
+  ].forEach((methodName) => {
+    module.exports[methodName] = function (...args) {
+      return this.experiments[methodName](...args);
+    };
+  });
 });

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -2251,14 +2251,14 @@ define(function (require, exports, module) {
           account.set('sessionToken', 'sessionToken');
 
           const smsStatusOptions = { country: 'GB' };
-          return account.smsStatus()
+          return account.smsStatus(smsStatusOptions)
             .then((response) => {
               assert.equal(response.country, 'GB');
               assert.isTrue(response.ok);
 
               assert.isTrue(fxaClient.smsStatus.calledOnce);
               assert.isTrue(
-                fxaClient.smsStatus.calledWith('sessionToken'), smsStatusOptions);
+                fxaClient.smsStatus.calledWith('sessionToken', smsStatusOptions));
             });
         });
       });

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -1372,21 +1372,21 @@ define(function (require, exports, module) {
         account = user.initAccount({ email: 'testuser@testuser.com', uid: createUid() });
       });
 
-      describe('no signed in user', () => {
+      describe('no account signed in', () => {
         it('returns false', () => {
           user.clearSignedInAccount();
           assert.isFalse(user.isSignedInAccount(account));
         });
       });
 
-      describe('no signed in user, pass in a `default` account', () => {
+      describe('no account signed in, pass in a `default` account', () => {
         it('returns false', () => {
           user.clearSignedInAccount();
           assert.isFalse(user.isSignedInAccount(user.initAccount({})));
         });
       });
 
-      describe('different signed in user', () => {
+      describe('different account signed in', () => {
         it('returns false', () => {
           const signedInAccount = user.initAccount({
             email: 'testuser2@testuser.com',
@@ -1400,11 +1400,56 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('is the signed in user', () => {
+      describe('same account signed in', () => {
         it('returns true', () => {
           return user.setSignedInAccount(account)
             .then(() => {
               assert.isTrue(user.isSignedInAccount(account));
+            });
+        });
+      });
+    });
+
+    describe('isAnotherAccountSignedIn', () => {
+      let account;
+
+      beforeEach(() => {
+        account = user.initAccount({ email: 'testuser@testuser.com', uid: 'uid' });
+      });
+
+      describe('no account signed in', () => {
+        it('returns false', () => {
+          user.clearSignedInAccount();
+          assert.isFalse(user.isAnotherAccountSignedIn(account));
+        });
+      });
+
+      describe('no account signed in, pass in a `default` account', () => {
+        it('returns false', () => {
+          user.clearSignedInAccount();
+          assert.isFalse(user.isAnotherAccountSignedIn(user.initAccount({})));
+        });
+      });
+
+      describe('different account signed in', () => {
+        it('returns true', () => {
+          const signedInAccount = user.initAccount({
+            email: 'testuser2@testuser.com',
+            uid: 'uid2'
+          });
+
+          return user.setSignedInAccount(signedInAccount)
+            .then(() => {
+              assert.isTrue(user.isAnotherAccountSignedIn(account));
+            });
+        });
+      });
+
+      describe('same account signed in', () => {
+        it('returns false', () => {
+          return user.setSignedInAccount(account)
+            .then(() => {
+              assert.isFalse(user.isAnotherAccountSignedIn(account));
             });
         });
       });

--- a/app/tests/spec/views/mixins/connect-another-device-mixin.js
+++ b/app/tests/spec/views/mixins/connect-another-device-mixin.js
@@ -1,0 +1,405 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const { assert } = require('chai');
+  const BaseView = require('views/base');
+  const ConnectAnotherDeviceMixin = require('views/mixins/connect-another-device-mixin');
+  const Constants = require('lib/constants');
+  const ExperimentMixin = require('views/mixins/experiment-mixin');
+  const Cocktail = require('cocktail');
+  const p = require('lib/promise');
+  const Relier = require('models/reliers/relier');
+  const sinon = require('sinon');
+  const Template = require('stache!templates/test_template');
+  const User = require('models/user');
+  const UserAgentMixin = require('views/mixins/user-agent-mixin');
+  const { createRandomHexString } = require('../../../lib/helpers');
+  const VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
+
+  const VALID_UID = createRandomHexString(Constants.UID_LENGTH);
+
+  var View = BaseView.extend({
+    template: Template
+  });
+
+  Cocktail.mixin(
+    View,
+    ConnectAnotherDeviceMixin,
+    ExperimentMixin,
+    UserAgentMixin,
+    VerificationReasonMixin
+  );
+
+
+  describe('views/mixins/connect-another-device-mixin', () => {
+    let account;
+    let relier;
+    let user;
+    let view;
+
+    beforeEach(() => {
+      relier = new Relier();
+      user = new User();
+
+      view = new View({
+        relier,
+        user
+      });
+    });
+
+    describe('isEligibleForConnectAnotherDevice', () => {
+      beforeEach(() => {
+        account = user.initAccount({
+          email: 'a@a.com',
+          sessionToken: 'foo',
+          uid: VALID_UID
+        });
+      });
+
+      describe('user is completing sign-in', () => {
+        beforeEach(() => {
+          sinon.stub(user, 'getSignedInAccount', () => {
+            return {
+              isDefault: () => true
+            };
+          });
+          sinon.stub(view, 'isSignUp', () => false);
+        });
+
+        it('returns `false`', () => {
+          assert.isFalse(view.isEligibleForConnectAnotherDevice(account));
+        });
+      });
+
+      describe('no user signed in', () => {
+        beforeEach(() => {
+          sinon.stub(user, 'getSignedInAccount', () => {
+            return {
+              isDefault: () => true
+            };
+          });
+        });
+
+        it('returns `true`', () => {
+          assert.isTrue(view.isEligibleForConnectAnotherDevice(account));
+        });
+      });
+
+      describe('different user signed in', () => {
+        beforeEach(() => {
+          sinon.stub(user, 'getSignedInAccount', () => {
+            return {
+              isDefault: () => false
+            };
+          });
+          sinon.stub(user, 'isSignedInAccount', () => false);
+        });
+
+        it('returns `false`', () => {
+          assert.isFalse(view.isEligibleForConnectAnotherDevice(account));
+        });
+      });
+
+      describe('same user signed in', () => {
+        beforeEach(() => {
+          sinon.stub(user, 'getSignedInAccount', () => {
+            return {
+              isDefault: () => false
+            };
+          });
+          sinon.stub(user, 'isSignedInAccount', () => true);
+        });
+
+        it('returns `true`', () => {
+          assert.isTrue(view.isEligibleForConnectAnotherDevice(account));
+        });
+      });
+    });
+
+    describe('_isEligibleForSms', () => {
+      beforeEach(() => {
+        account = user.initAccount({
+          email: 'a@a.com',
+          sessionToken: 'foo',
+          uid: VALID_UID
+        });
+
+        relier.set('country', 'US');
+      });
+
+      describe('pre-reqs are not met', () => {
+        beforeEach(() => {
+          sinon.stub(view, '_areSmsRequirementsMet', () => false);
+          sinon.spy(account, 'smsStatus');
+        });
+
+        it('resolves to object with `ok: false`', () => {
+          return view._isEligibleForSms(account)
+            .then((resp) => {
+              assert.isFalse(resp.ok);
+              assert.isTrue(view._areSmsRequirementsMet.calledOnce);
+              assert.isTrue(view._areSmsRequirementsMet.calledWith(account));
+              assert.isFalse(account.smsStatus.called);
+            });
+        });
+      });
+
+      describe('pre-reqs are met, auth-server blocks, Able says OK', () => {
+        beforeEach(() => {
+          sinon.stub(view, '_areSmsRequirementsMet', () => true);
+          sinon.spy(view, 'isInExperiment');
+          sinon.stub(account, 'smsStatus', () => p({ country: 'US', ok: false }));
+        });
+
+        it('resolves to object with `ok: true, country: US`', () => {
+          return view._isEligibleForSms(account)
+            .then((resp) => {
+              assert.isFalse(resp.ok);
+              assert.isTrue(view._areSmsRequirementsMet.calledOnce);
+              assert.isTrue(view._areSmsRequirementsMet.calledWith(account));
+              assert.isTrue(account.smsStatus.calledOnce);
+              assert.isTrue(account.smsStatus.calledWith({ country: 'US' }));
+              assert.isFalse(view.isInExperiment.called);
+            });
+        });
+      });
+
+      describe('pre-reqs are met, auth-server says OK, Able blocks', () => {
+        beforeEach(() => {
+          sinon.stub(view, '_areSmsRequirementsMet', () => true);
+          sinon.stub(view, 'isInExperiment', () => false);
+          sinon.stub(account, 'smsStatus', () => p({ country: 'US', ok: true }));
+        });
+
+        it('resolves to object with `ok: true, country: US`', () => {
+          return view._isEligibleForSms(account)
+            .then((resp) => {
+              assert.isFalse(resp.ok);
+
+              assert.isTrue(view._areSmsRequirementsMet.calledOnce);
+              assert.isTrue(view._areSmsRequirementsMet.calledWith(account));
+              assert.isTrue(account.smsStatus.calledOnce);
+              assert.isTrue(account.smsStatus.calledWith({ country: 'US' }));
+              assert.isTrue(view.isInExperiment.calledOnce);
+              assert.isTrue(view.isInExperiment.calledWith('sendSmsEnabledForCountry'));
+            });
+        });
+      });
+
+      describe('pre-reqs are met, auth-server says OK, Able says OK', () => {
+        beforeEach(() => {
+          sinon.stub(view, '_areSmsRequirementsMet', () => true);
+          sinon.stub(view, 'isInExperiment', (experimentName) => experimentName === 'sendSmsEnabledForCountry');
+          sinon.stub(account, 'smsStatus', () => p({ country: 'US', ok: true }));
+        });
+
+        it('resolves to object with `ok: true, country: US`', () => {
+          return view._isEligibleForSms(account)
+            .then((resp) => {
+              assert.equal(resp.country, 'US');
+              assert.isTrue(resp.ok);
+
+              assert.isTrue(view._areSmsRequirementsMet.calledOnce);
+              assert.isTrue(view._areSmsRequirementsMet.calledWith(account));
+              assert.isTrue(account.smsStatus.calledOnce);
+              assert.isTrue(account.smsStatus.calledWith({ country: 'US' }));
+              assert.isTrue(view.isInExperiment.calledOnce);
+              assert.isTrue(view.isInExperiment.calledWith('sendSmsEnabledForCountry'));
+            });
+        });
+      });
+    });
+
+    describe('_areSmsRequirementsMet', () => {
+      describe('user is signing in', () => {
+        beforeEach(() => {
+          sinon.stub(view, 'isSignUp', () => false);
+          sinon.stub(view, 'isInExperiment', () => true);
+          sinon.stub(view, 'getUserAgent', () => {
+            return {
+              isAndroid: () => false,
+              isIos: () => false
+            };
+          });
+          sinon.stub(user, 'isAnotherAccountSignedIn', () => false);
+        });
+
+        it('returns `false', () => {
+          assert.isFalse(view._areSmsRequirementsMet(account));
+        });
+      });
+
+      describe('user is on Android', () => {
+        beforeEach(() => {
+          sinon.stub(view, 'isSignUp', () => true);
+          sinon.stub(view, 'isInExperiment', () => true);
+          sinon.stub(view, 'getUserAgent', () => {
+            return {
+              isAndroid: () => true,
+              isIos: () => false
+            };
+          });
+          sinon.stub(user, 'isAnotherAccountSignedIn', () => false);
+        });
+
+        it('returns `false', () => {
+          assert.isFalse(view._areSmsRequirementsMet(account));
+        });
+      });
+
+      describe('user is on iOS', () => {
+        beforeEach(() => {
+          sinon.stub(view, 'isSignUp', () => true);
+          sinon.stub(view, 'isInExperiment', () => true);
+          sinon.stub(view, 'getUserAgent', () => {
+            return {
+              isAndroid: () => false,
+              isIos: () => true
+            };
+          });
+          sinon.stub(user, 'isAnotherAccountSignedIn', () => false);
+        });
+
+        it('returns `false', () => {
+          assert.isFalse(view._areSmsRequirementsMet(account));
+        });
+      });
+
+      describe('another user is signed in', () => {
+        beforeEach(() => {
+          sinon.stub(view, 'isSignUp', () => true);
+          sinon.stub(view, 'isInExperiment', () => true);
+          sinon.stub(view, 'getUserAgent', () => {
+            return {
+              isAndroid: () => false,
+              isIos: () => false
+            };
+          });
+          sinon.stub(user, 'isAnotherAccountSignedIn', () => true);
+        });
+
+        it('returns `false', () => {
+          assert.isFalse(view._areSmsRequirementsMet(account));
+        });
+      });
+
+      describe('user is not part of treatment group', () => {
+        beforeEach(() => {
+          sinon.stub(view, 'isSignUp', () => true);
+          sinon.stub(view, 'isInExperiment', () => false);
+          sinon.stub(view, 'getUserAgent', () => {
+            return {
+              isAndroid: () => false,
+              isIos: () => false
+            };
+          });
+          sinon.stub(user, 'isAnotherAccountSignedIn', () => false);
+        });
+
+        it('returns `false', () => {
+          assert.isFalse(view._areSmsRequirementsMet(account));
+        });
+      });
+
+      describe('user is eligible',() => {
+        beforeEach(() => {
+          sinon.stub(view, 'isSignUp', () => true);
+          sinon.stub(view, 'isInExperiment', () => true);
+          sinon.stub(view, 'getUserAgent', () => {
+            return {
+              isAndroid: () => false,
+              isIos: () => false
+            };
+          });
+          sinon.stub(user, 'isAnotherAccountSignedIn', () => false);
+        });
+
+        it('returns `true', () => {
+          assert.isTrue(view._areSmsRequirementsMet(account));
+        });
+      });
+    });
+
+    describe('navigateToConnectAnotherDeviceScreen', () => {
+      let account;
+
+      beforeEach(() => {
+        account = user.initAccount({
+          email: 'a@a.com',
+          sessionToken: 'foo',
+          uid: VALID_UID
+        });
+      });
+
+      describe('not eligible for CAD', () => {
+        it('rejects with an error', () => {
+          sinon.stub(view, 'isEligibleForConnectAnotherDevice', () => false);
+          return view.navigateToConnectAnotherDeviceScreen(account)
+            .then(assert.fail, (err) => {
+              assert.ok(err);
+            });
+        });
+      });
+
+      describe('eligible for CAD', () => {
+        beforeEach(() => {
+          sinon.stub(view, 'isEligibleForConnectAnotherDevice', () => true);
+          sinon.stub(view, 'navigate', () => {});
+          sinon.stub(view, 'createExperiment', () => {});
+        });
+
+        describe('not eligible for SMS', () => {
+          it('redirects to /connect_another_device', () => {
+            sinon.stub(view, '_isEligibleForSms', () => p({ ok: false }));
+
+            return view.navigateToConnectAnotherDeviceScreen(account)
+              .then(() => {
+                assert.isFalse(view.createExperiment.called);
+
+                assert.isTrue(view.navigate.calledOnce);
+                assert.isTrue(view.navigate.calledWith('connect_another_device', { account }));
+              });
+          });
+        });
+
+        describe('eligible for SMS', () => {
+          beforeEach(() => {
+            sinon.stub(view, '_isEligibleForSms', () => p({ country: 'GB', ok: true }));
+          });
+
+          describe('in treatment group', () => {
+            it('creates the experiment, redirects to /sms', () => {
+              sinon.stub(view, 'getExperimentGroup', () => 'treatment');
+              return view.navigateToConnectAnotherDeviceScreen(account)
+                .then(() => {
+                  assert.isTrue(view.createExperiment.calledOnce);
+                  assert.isTrue(view.createExperiment.calledWith('sendSms', 'treatment'));
+
+                  assert.isTrue(view.navigate.calledOnce);
+                  assert.isTrue(view.navigate.calledWith('sms', { account, country: 'GB' }));
+                });
+            });
+          });
+
+          describe('in control group', () => {
+            it('creates the experiment, redirects to /connect_another_device', () => {
+              sinon.stub(view, 'getExperimentGroup', () => 'control');
+              return view.navigateToConnectAnotherDeviceScreen(account)
+                .then(() => {
+                  assert.isTrue(view.createExperiment.calledOnce);
+                  assert.isTrue(view.createExperiment.calledWith('sendSms', 'control'));
+
+                  assert.isTrue(view.navigate.calledOnce);
+                  assert.isTrue(view.navigate.calledWith('connect_another_device', { account }));
+                });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/mixins/experiment-mixin.js
+++ b/app/tests/spec/views/mixins/experiment-mixin.js
@@ -5,16 +5,12 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const Able = require('lib/able');
   const { assert } = require('chai');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
-  const Metrics = require('lib/metrics');
   const Mixin = require('views/mixins/experiment-mixin');
-  const Notifier = require('lib/channels/notifier');
   const sinon = require('sinon');
   const TestTemplate = require('stache!templates/test_template');
-  const User = require('models/user');
   const WindowMock = require('../../../mocks/window');
 
   const View = BaseView.extend({
@@ -27,25 +23,13 @@ define(function (require, exports, module) {
   );
 
   describe('views/mixins/experiment-mixin', () => {
-    let able;
-    let metrics;
-    let notifier;
-    let user;
     let view;
     let windowMock;
 
     beforeEach(() => {
-      able = new Able();
-      notifier = new Notifier();
-      metrics = new Metrics({ notifier });
-      user = new User();
       windowMock = new WindowMock();
 
       view = new View({
-        able: able,
-        metrics: metrics,
-        notifier: notifier,
-        user: user,
         window: windowMock
       });
     });
@@ -84,32 +68,11 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('isInExperiment', () => {
-      it('returns `true` if user is in experiment, `false` if not', () => {
-        sinon.stub(view.experiments, 'isInExperiment', (experimentName, additionalData = {}) => {
-          return !! (experimentName === 'realExperiment' && additionalData.isEligible);
-        });
-
-        assert.isTrue(view.isInExperiment('realExperiment', { isEligible: true }));
-        assert.isFalse(view.isInExperiment('realExperiment', { isEligible: false }));
-        assert.isFalse(view.isInExperiment('realExperiment'));
-        assert.isFalse(view.isInExperiment('fakeExperiment'));
-      });
-    });
-
-    describe('isInExperimentGroup', () => {
-      it('returns `true` if user is in experiment group, `false` otw', () => {
-        sinon.stub(view.experiments, 'isInExperimentGroup', (experimentName, groupName, additionalData = {}) => {
-          return !! (experimentName === 'realExperiment' &&
-                     groupName === 'treatment' &&
-                     additionalData.isEligible);
-        });
-
-        assert.isTrue(view.isInExperimentGroup('realExperiment', 'treatment', { isEligible: true }));
-        assert.isFalse(view.isInExperimentGroup('realExperiment', 'treatment', { isEligible: false }));
-        assert.isFalse(view.isInExperimentGroup('realExperiment', 'treatment'));
-        assert.isFalse(view.isInExperimentGroup('realExperiment', 'control'));
-      });
+    it('contains delegate functions', () => {
+      assert.isFunction(view.createExperiment);
+      assert.isFunction(view.getExperimentGroup);
+      assert.isFunction(view.isInExperiment);
+      assert.isFunction(view.isInExperimentGroup);
     });
   });
 });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -127,6 +127,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/avatar-mixin',
     '../tests/spec/views/mixins/back-mixin',
     '../tests/spec/views/mixins/checkbox-mixin',
+    '../tests/spec/views/mixins/connect-another-device-mixin',
     '../tests/spec/views/mixins/experiment-mixin',
     '../tests/spec/views/mixins/external-links-mixin',
     '../tests/spec/views/mixins/floating-placeholder-mixin',


### PR DESCRIPTION
Users in the SMS "control" group must be in CAD, we are comparing
SMS against the CAD screens, not the general population.

This PR makes that happen. The SMS/CAD selection logic is extracted
into its own mixin so that it can be independently tested and
used on the "signup" page too.

issue #4944