### PR TITLE
Disable web sessions by default

### DIFF
--- a/app/scripts/templates/settings/clients.mustache
+++ b/app/scripts/templates/settings/clients.mustache
@@ -30,6 +30,7 @@
               </li>
             {{/isDevice}}
 
+            {{#areWebSessionsVisible}}
             {{#isWebSession}}
                 <li class="client {{type}} client-webSession" data-name="{{name}}" id="{{id}}">
                     <div class="client-name" title="{{title}}">{{title}}</div>
@@ -42,6 +43,7 @@
                     <button class="settings-button warning client-disconnect" data-id="{{id}}" data-type="{{clientType}}">{{#t}}Disconnect{{/t}}</button>
                 </li>
             {{/isWebSession}}
+            {{/areWebSessionsVisible}}
 
             {{#isOAuthApp}}
                 <li class="client {{type}} client-oAuthApp" data-name="{{name}}" id="{{id}}">

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -104,12 +104,8 @@ define(function (require, exports, module) {
         // if forced via query param
         return true;
       }
-
-      const userAgent = this.getUserAgent();
-      const version = userAgent.parseVersion();
-      return userAgent.isFirefox() && this._able.choose('sessionsListVisible', {
-        firefoxVersion: version.major
-      });
+      // currently disabled by default for all users, pending some fixes.
+      return false;
     },
 
     /**

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -79,6 +79,7 @@ define(function (require, exports, module) {
       const clients = this._attachedClients.toJSON();
 
       return {
+        areWebSessionsVisible: this._areWebSessionsVisible(),
         clients: this._formatAccessTimeAndScope(clients),
         devicesSupportUrl: DEVICES_SUPPORT_URL,
         isPanelOpen: this.isPanelOpen(),
@@ -91,6 +92,24 @@ define(function (require, exports, module) {
     events: {
       'click .client-disconnect': preventDefaultThen('_onDisconnectClient'),
       'click [data-get-app]': '_onGetApp'
+    },
+
+    /**
+     * Determine if the clients list should show Web Sessions
+     * @returns {Boolean}
+     * @private
+     */
+    _areWebSessionsVisible () {
+      if (this.getSearchParam('sessionsListVisible')) {
+        // if forced via query param
+        return true;
+      }
+
+      const userAgent = this.getUserAgent();
+      const version = userAgent.parseVersion();
+      return userAgent.isFirefox() && this._able.choose('sessionsListVisible', {
+        firefoxVersion: version.major
+      });
     },
 
     /**

--- a/app/tests/spec/views/settings/clients.js
+++ b/app/tests/spec/views/settings/clients.js
@@ -408,20 +408,6 @@ define(function (require, exports, module) {
 
     });
 
-    describe('_areWebSessionsVisible', function () {
-      it('calls able with the first version', function () {
-        windowMock.navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:52.0) Gecko/20100101 Firefox/52.0';
-        return initView()
-          .then(() => {
-            view._able.choose.reset();
-            view._areWebSessionsVisible();
-            assert.isTrue(view._able.choose.calledWith('sessionsListVisible', {
-              firefoxVersion: 52
-            }));
-          });
-      });
-    });
-
     describe('_onGetApp', function () {
       it('logs get event', function () {
         attachedClients = new AttachedClients([

--- a/app/tests/spec/views/settings/clients.js
+++ b/app/tests/spec/views/settings/clients.js
@@ -408,6 +408,20 @@ define(function (require, exports, module) {
 
     });
 
+    describe('_areWebSessionsVisible', function () {
+      it('calls able with the first version', function () {
+        windowMock.navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:52.0) Gecko/20100101 Firefox/52.0';
+        return initView()
+          .then(() => {
+            view._able.choose.reset();
+            view._areWebSessionsVisible();
+            assert.isTrue(view._able.choose.calledWith('sessionsListVisible', {
+              firefoxVersion: 52
+            }));
+          });
+      });
+    });
+
     describe('_onGetApp', function () {
       it('logs get event', function () {
         attachedClients = new AttachedClients([

--- a/tests/functional/settings_clients.js
+++ b/tests/functional/settings_clients.js
@@ -54,7 +54,7 @@ define([
 
     'sessions are listed in clients view': function () {
       return this.remote
-        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(SIGNIN_URL + '?sessionsListVisible=1', '#fxa-signin-header'))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
 
         .then(testElementExists('#fxa-settings-header'))


### PR DESCRIPTION
Connects to #4987; this targets the train-85 branch for point-release and will need to be merged to master.

This reverts #4964 to restore the feature-flag on web sessions, then trims down the logic so that they're disabled by default.  You can still opt-in via query parameter to help debug issues like https://github.com/mozilla/fxa-content-server/issues/4987#issuecomment-297115457.

@vladikoff r? for a v1.85.3 point-release?