### PR TITLE
refactor(test): Remove the oauth `keys` tests.

### DIFF
--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -28,7 +28,6 @@ define(function (require, exports, module) {
   var SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA = {
     access_type: Vat.accessType().renameTo('accessType'),
     client_id: Vat.clientId().required().renameTo('clientId'),
-    keys: Vat.boolean(),
     prompt: Vat.prompt(),
     redirectTo: Vat.url(),
     redirect_uri: Vat.url().renameTo('redirectUri'),
@@ -41,7 +40,6 @@ define(function (require, exports, module) {
     access_type: Vat.accessType().renameTo('accessType'),
     action: Vat.string().min(1),
     client_id: Vat.clientId().required().renameTo('clientId'),
-    keys: Vat.boolean(),
     prompt: Vat.prompt(),
     redirect_uri: Vat.url().renameTo('redirectUri'),
     // scopes are optional when verifying, user could be verifying in a 2nd browser
@@ -57,8 +55,6 @@ define(function (require, exports, module) {
       accessType: null,
       clientId: null,
       context: Constants.OAUTH_CONTEXT,
-      // whether to fetch and derive relier-specific keys
-      keys: false,
       // permissions are individual scopes
       permissions: null,
       // whether the permissions prompt will be shown to trusted reliers
@@ -131,18 +127,6 @@ define(function (require, exports, module) {
 
     isOAuth () {
       return true;
-    },
-
-    /**
-     * OAuth reliers can opt in to fetch relier-specific keys.
-     *
-     * @returns {Boolean}
-     */
-    wantsKeys () {
-      if (this.get('keys')) {
-        return true;
-      }
-      return Relier.prototype.wantsKeys.call(this);
     },
 
     _isVerificationFlow () {

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -100,9 +100,6 @@ define(function (require, exports, module) {
             // the redirect_uri returned by the oauth server
             assert.notEqual(relier.get('redirectUri'), REDIRECT_URI);
             assert.equal(relier.get('redirectUri'), SERVER_REDIRECT_URI);
-
-            // Encryption keys are not fetched by default.
-            assert.equal(relier.get('keys'), false);
           });
       });
 
@@ -237,15 +234,6 @@ define(function (require, exports, module) {
               });
             });
           });
-        });
-
-        describe('keys', function () {
-          var invalidValues = ['', ' ', 'not-boolean'];
-          testInvalidQueryParams('keys', invalidValues);
-
-          var validValues = [undefined, 'true', 'false'];
-          var expectedValues = [false, true, false];
-          testValidQueryParams('keys', validValues, 'keys', expectedValues);
         });
 
         describe('prompt', function () {
@@ -442,14 +430,6 @@ define(function (require, exports, module) {
           utmSource: ITEM,
           utmTerm: ITEM
         });
-      });
-    });
-
-    describe('wantsKeys', function () {
-      it('returns `true` only when keys are explicitly asked for', function () {
-        assert.isFalse(relier.wantsKeys());
-        relier.set('keys', true);
-        assert.isTrue(relier.wantsKeys());
       });
     });
 

--- a/docs/query-params.md
+++ b/docs/query-params.md
@@ -24,20 +24,6 @@ When signing up a user.
 #### Options
 * `amo`
 
-### `keys`
-Set to true to receive derived kA and kB keys that can be used to encrypt data.
-
-#### Options
-* `true`
-* `false` (default)
-
-#### When to specify
-When authenticating a user for OAuth.
-
-* /oauth/signin
-* /oauth/signup
-* /oauth/force_auth
-
 ### `prompt`
 Specifies whether the content server prompts for permissions consent. Only applicable for `trusted` reliers.
 Untrusted reliers always show the prompt.

--- a/tests/functional/oauth_query_param_validation.js
+++ b/tests/functional/oauth_query_param_validation.js
@@ -155,65 +155,6 @@ define([
         .then(testErrorInclude('unknown client'));
     },
 
-    'missing keys': function () {
-      return this.remote
-        .then(openSignUpExpect200({
-          client_id: TRUSTED_CLIENT_ID,
-          scope: TRUSTED_SCOPE
-        }));
-    },
-
-    'empty keys': function () {
-      return this.remote
-        .then(openSignUpExpect400({
-          client_id: TRUSTED_CLIENT_ID,
-          keys: '',
-          scope: TRUSTED_SCOPE
-        }))
-        .then(testErrorInclude('invalid'))
-        .then(testErrorInclude('keys'));
-    },
-
-    'space keys': function () {
-      return this.remote
-        .then(openSignUpExpect400({
-          client_id: TRUSTED_CLIENT_ID,
-          keys: ' ',
-          scope: TRUSTED_SCOPE
-        }))
-        .then(testErrorInclude('invalid'))
-        .then(testErrorInclude('keys'));
-    },
-
-    'invalid keys': function () {
-      return this.remote
-        .then(openSignUpExpect400({
-          client_id: TRUSTED_CLIENT_ID,
-          keys: 'asdf',
-          scope: TRUSTED_SCOPE
-        }))
-        .then(testErrorInclude('invalid'))
-        .then(testErrorInclude('keys'));
-    },
-
-    'valid keys (true)': function () {
-      return this.remote
-        .then(openSignUpExpect200({
-          client_id: TRUSTED_CLIENT_ID,
-          keys: 'true',
-          scope: TRUSTED_SCOPE
-        }));
-    },
-
-    'valid keys (false)': function () {
-      return this.remote
-        .then(openSignUpExpect200({
-          client_id: TRUSTED_CLIENT_ID,
-          keys: 'false',
-          scope: TRUSTED_SCOPE
-        }));
-    },
-
     'empty prompt': function () {
       return this.remote
         .then(openSignUpExpect400({


### PR DESCRIPTION
`keys` support was removed a while ago, yet the tests remain. This removes
the leftovers from the tests, as well as from the relier.

fixes #5001 

@mozilla/fxa-devs - r?