### PR TITLE
fix(avatar): Use the EXPORT_LENGTH when checking for gravatars.

### DIFF
--- a/app/scripts/views/settings/avatar_gravatar.js
+++ b/app/scripts/views/settings/avatar_gravatar.js
@@ -6,7 +6,6 @@ define(function (require, exports, module) {
   'use strict';
 
   const $ = require('jquery');
-  const _ = require('underscore');
   const AuthErrors = require('lib/auth-errors');
   const AvatarMixin = require('views/mixins/avatar-mixin');
   const Cocktail = require('cocktail');
@@ -24,7 +23,6 @@ define(function (require, exports, module) {
   }
 
   var EXPORT_LENGTH = Constants.PROFILE_IMAGE_EXPORT_SIZE;
-  var DISPLAY_LENGTH = Constants.PROFILE_IMAGE_DISPLAY_SIZE;
   var GRAVATAR_URL = 'https://secure.gravatar.com/avatar/';
 
   const proto = FormView.prototype;
@@ -49,7 +47,7 @@ define(function (require, exports, module) {
 
     _showGravatar: showProgressIndicator(function () {
       return ImageLoader.load(this.gravatarUrl())
-        .then(_.bind(this._found, this), _.bind(this._notFound, this));
+        .then(() => this._found(), () => this._notFound());
     }, '.avatar-wrapper', '_gravatarProgressIndicator'),
 
     _found () {
@@ -67,9 +65,9 @@ define(function (require, exports, module) {
       var hashedEmail = this.hashedEmail();
       if (this.broker.isAutomatedBrowser()) {
         // Don't return a 404 so we can test the success flow
-        return GRAVATAR_URL + hashedEmail + '?s=' + DISPLAY_LENGTH;
+        return `${GRAVATAR_URL}${hashedEmail}?s=${EXPORT_LENGTH}`;
       }
-      return GRAVATAR_URL + hashedEmail + '?s=' + DISPLAY_LENGTH + '&d=404';
+      return `${GRAVATAR_URL}${hashedEmail}?s=${EXPORT_LENGTH}&d=404`;
     },
 
     hashedEmail () {


### PR DESCRIPTION
Most users that attempt to use gravatar see the "No gravatar found" error.
While @ryanfeeley and I were testing, we noticed with some images, some
resolutions would return a 503 http response while others would return a 200.

When checking for the existence of a gravatar, we requested a different size
to the size that is placed into the avatar holders. If a user has a gravatar
that doesn't work correctly at 240, but does at 600, we won't let them
set a gravatar, even though we use 600 everywhere aside from the check.

This changes the initial check to look for a 600px avatar.

issue #4931 

@mozilla/fxa-devs - r?