### PR TITLE
fix(circle): if branch master, tag is latest

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,13 +52,14 @@ deployment:
           | tee config/version.json version.json
       - docker build -f Dockerfile-build -t fxa-content-server:build .
       - docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
-      - >
-          if [ $CIRCLE_BRANCH -eq "master" ]; then
+      - |
+          if [ $CIRCLE_BRANCH = "master" ]; then
             CIRCLE_BRANCH=latest
           fi
-      - "echo ${DOCKERHUB_REPO}:${CIRCLE_BRANCH}"
-      - "docker tag fxa-content-server:build ${DOCKERHUB_REPO}:${CIRCLE_BRANCH}"
-      - "docker push ${DOCKERHUB_REPO}:${CIRCLE_BRANCH}"
+
+          echo ${DOCKERHUB_REPO}:${CIRCLE_BRANCH}
+          docker tag fxa-content-server:build ${DOCKERHUB_REPO}:${CIRCLE_BRANCH}
+          docker push ${DOCKERHUB_REPO}:${CIRCLE_BRANCH}
 
   hub_releases:
     # push all tags


### PR DESCRIPTION
r? - @vladikoff, @jbuck 

So, the `master` branch is being pushed with a docker tag of `master`. You did put in code to switch from `master` to `latest`, but: https://circleci.com/docs/1.0/environment-variables/#custom - `The only gotcha is that each command runs in its own shell, so just adding an export FOO=bar command won’t work`.

Hence this PR. This, of course, does mean we lose individual timing sections for the tag and the push, but the tag phase is only a couple of seconds, so...

Difficult to see this actually run on the actual `master` branch until it's merged, but this run on a `dockerpush-fix-circle-push-branch-master-is-latest` branch, that changes the tag name to `dockerpush-fix-circle-push-branch-master-is-latest-for-realz` shows the logic working: https://circleci.com/gh/mozilla/fxa-content-server/6832, https://hub.docker.com/r/mozilla/fxa-content-server/tags/

Will also need to do the same in https://github.com/mozilla/fxa-auth-server/blob/master/circle.yml#L31-L37, if this fix seems like the right fix.