### PR TITLE
feat(CAD): Add CAD to the signup tab in firstrun

### DIFF
--- a/app/scripts/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/scripts/models/auth_brokers/fx-firstrun-v1.js
@@ -27,6 +27,7 @@ define(function (require, exports, module) {
     },
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
+      cadAfterSignUpConfirmationPoll: true,
       chooseWhatToSyncCheckbox: true,
       chooseWhatToSyncWebV1: false,
       openWebmailButtonVisible: true

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -682,9 +682,7 @@ define(function (require, exports, module) {
         err = new Error(err);
       }
 
-      if (! err.context) {
-        err.context = this.getViewName();
-      }
+      err.viewName = this.getViewName();
 
       return err;
     },
@@ -733,7 +731,7 @@ define(function (require, exports, module) {
     logFlowEvent (eventName, viewName, data) {
       this.notifier.trigger('flow.event', _.assign({}, data, {
         event: eventName,
-        view: viewName
+        viewName
       }));
     },
 

--- a/app/scripts/views/behaviors/connect-another-device.js
+++ b/app/scripts/views/behaviors/connect-another-device.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A behavior that sends eligible users to the appropriate
+ * connect-another-device screen. If ineligible, fallback
+ * to `defaultBehavior`.
+ *
+ * Requires the view to mixin the ConnectAnotherDeviceMixin
+ */
+
+define((require, exports, module) => {
+  'use strict';
+
+  /**
+   * Create a ConnectAnotherDevice behavior.
+   *
+   * @param {Object} defaultBehavior - behavior to invoke if ineligible
+   *   for ConnectAnotherDevice
+   * @returns {Function} behavior
+   */
+  module.exports = function (defaultBehavior) {
+    const behavior = function (view, account) {
+      if (view.isEligibleForConnectAnotherDevice(account)) {
+        return view.navigateToConnectAnotherDeviceScreen(account);
+      }
+
+      return view.invokeBehavior(defaultBehavior, account);
+    };
+
+    behavior.type = 'connect-another-device';
+
+    return behavior;
+  };
+});

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -10,6 +10,7 @@ define(function (require, exports, module) {
   const BackMixin = require('views/mixins/back-mixin');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
+  const ConnectAnotherDeviceMixin = require('views/mixins/connect-another-device-mixin');
   const Constants = require('lib/constants');
   const ExperimentMixin = require('views/mixins/experiment-mixin');
   const OpenConfirmationEmailMixin = require('views/mixins/open-webmail-mixin');
@@ -19,6 +20,7 @@ define(function (require, exports, module) {
   const ResumeTokenMixin = require('views/mixins/resume-token-mixin');
   const ServiceMixin = require('views/mixins/service-mixin');
   const Template = require('stache!templates/confirm');
+  const UserAgentMixin = require('views/mixins/user-agent-mixin');
   const VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
 
   const proto = BaseView.prototype;
@@ -160,12 +162,14 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     BackMixin,
+    ConnectAnotherDeviceMixin,
     ExperimentMixin,
     OpenConfirmationEmailMixin,
     PulseGraphicMixin,
     ResendMixin,
     ResumeTokenMixin,
     ServiceMixin,
+    UserAgentMixin,
     VerificationReasonMixin
   );
 

--- a/app/scripts/views/marketing_snippet.js
+++ b/app/scripts/views/marketing_snippet.js
@@ -117,6 +117,10 @@ define(function (require, exports, module) {
       this.$('.marketing-link').each((index, element) => {
         this._logMarketingImpression(element);
       });
+
+      // Add the marketingId as a class so that different styles
+      // can be applied to different snippets.
+      this.$el.addClass(this._marketingId);
     },
 
     _shouldShowSignUpMarketing () {

--- a/app/scripts/views/mixins/modal-panel-mixin.js
+++ b/app/scripts/views/mixins/modal-panel-mixin.js
@@ -13,6 +13,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const $ = require('jquery');
+  const Environment = require('lib/environment');
 
   module.exports = {
     isModal: true,
@@ -35,6 +36,13 @@ define(function (require, exports, module) {
       });
 
       this.$el.on($.modal.AFTER_CLOSE, () => this.onAfterClose());
+
+      if (this._needsToSetBodyMinHeight()) {
+        // ensure the body is at least as tall as the modal. This is used
+        // when inside the firstrun iframe and the "why connect another device"
+        // content is larger than the body on the /connect_another_device page.
+        this._setBodyMinHeight();
+      }
 
       this._boundBlockerClick = this.onBlockerClick.bind(this);
       $('.blocker').on('click', this._boundBlockerClick);
@@ -80,6 +88,41 @@ define(function (require, exports, module) {
      */
     destroy () {
       this.closePanel();
+      if (this._needsToSetBodyMinHeight() && this.model.has('origMinHeight')) {
+        $('body').css('min-height', this.model.get('origMinHeight'));
+        this.model.unset('origMinHeight');
+      }
+    },
+
+    /**
+     * Check whether the `body` element needs it's `min-height` set
+     * so that the body expands to be at least as tall as the modal.
+     *
+     * @returns {Boolean}
+     * @private
+     */
+    _needsToSetBodyMinHeight() {
+      const environment = new Environment(this.window);
+      return environment.isFramed();
+    },
+
+    /**
+     * Ensure the body is at least as tall as the modal. This is used
+     * when inside the firstrun iframe and the "why connect another device"
+     * content is larger than the body on the /connect_another_device page.
+     *
+     * @private
+     */
+    _setBodyMinHeight () {
+      const RADIX = 10;
+      const bodyMinHeightCssValue = $('body').css('min-height');
+      const bodyMinHeight = parseInt(bodyMinHeightCssValue || 0, RADIX);
+      const modalHeight = $('.modal').outerHeight();
+
+      if (modalHeight > bodyMinHeight) {
+        this.model.set('origMinHeight', bodyMinHeightCssValue);
+        $('body').css('min-height', `${modalHeight}px`);
+      }
     }
   };
 });

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -78,7 +78,7 @@ $link-color: $button-background-color;
 $marketing-border-color: $color-grey-spinner;
 $message-text-color: $color-white;
 $mobile-html-background-color: $color-white;
-$modal-border-color: $color-black;
+
 $secondary-button-background-color: $color-grey-lightest;
 $secondary-button-border-color: lighten($color-grey, 5);
 
@@ -88,6 +88,10 @@ $show-password-label-color: $color-grey-faint-text;
 
 $success-background-color: #5fad47;
 $text-color: $color-grey-text;
+
+//Modal colors
+$modal-border-color: $color-black;
+$modal-background-color-iframe: $color-white;
 
 //Settings Specific Colors
 $settings-header-border-bottom: #b4bdc3;

--- a/app/styles/modules/_marketing.scss
+++ b/app/styles/modules/_marketing.scss
@@ -15,17 +15,19 @@
   }
 
   .chromeless.iframe & {
-    @include respond-to('reasonableUI') {
-      // This is a hack. The width of the firstrun iframe is 400px.
-      // The max-width of the main-content area is 360px, leaving 20px
-      // on either side. A 20px bottom-padding exists on the body.
-      // This leaves a 20px white area around the marketing snippet.
+    &.spring-2015-android-ios-sync {
+      @include respond-to('reasonableUI') {
+        // This is a hack. The width of the firstrun iframe is 400px.
+        // The max-width of the main-content area is 360px, leaving 20px
+        // on either side. A 20px bottom-padding exists on the body.
+        // This leaves a 20px white area around the marketing snippet.
 
-      // For the firstrun flow only, pull the marketing box
-      // out to the sides to get rid of the padding.
-      bottom: -20px;
-      margin: 0 -20px;
-      position: relative;
+        // For the firstrun flow only, pull the marketing box
+        // out to the sides to get rid of the padding.
+        bottom: -20px;
+        margin: 0 -20px;
+        position: relative;
+      }
     }
   }
 

--- a/app/styles/modules/_modal.scss
+++ b/app/styles/modules/_modal.scss
@@ -1,6 +1,18 @@
+.blocker {
+  .iframe & {
+    background-color: $modal-background-color-iframe;
+    padding: 0;
+  }
+}
+
 .modal {
   border-radius: $big-border-radius;
   box-shadow: 0 1px 5px $modal-border-color;
+
+  .iframe & {
+    border-radius: 0;
+    box-shadow: none;
+  }
 
 
   @include respond-to('big') {

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -7,17 +7,63 @@ define((require, exports, module) => {
 
   const { assert } = require('chai');
   const FxSyncAuthenticationBroker = require('models/auth_brokers/fx-sync');
+  const Metrics = require('lib/metrics');
+  const sinon = require('sinon');
   const WindowMock = require('../../../mocks/window');
 
   describe('models/auth_brokers/fx-sync', () => {
+    let account;
+    let broker;
+    let metrics;
     let windowMock;
 
     beforeEach(() => {
+      account = {};
+      metrics = new Metrics();
       windowMock = new WindowMock();
+
+      broker = new FxSyncAuthenticationBroker({
+        metrics,
+        window: windowMock
+      });
     });
 
-    it('can be created', () => {
-      assert.ok(new FxSyncAuthenticationBroker({ window: windowMock }));
+    afterEach(() => {
+      account = null;
+      broker = null;
+      metrics.destroy();
+      metrics = null;
+      windowMock = null;
+    });
+
+    describe('afterSignUpConfirmationPoll', () => {
+      describe('broker has `cadAfterSignUpConfirmationPoll` capability', () => {
+        it('sets the metrics viewName prefix, resolves to a `ConnectAnotherDeviceBehavior`', () => {
+          broker.setCapability('cadAfterSignUpConfirmationPoll', true);
+          sinon.spy(metrics, 'setViewNamePrefix');
+
+          return broker.afterSignUpConfirmationPoll(account)
+            .then((behavior) => {
+              assert.equal(behavior.type, 'connect-another-device');
+
+              assert.isTrue(metrics.setViewNamePrefix.calledOnce);
+              assert.isTrue(metrics.setViewNamePrefix.calledWith('signup'));
+            });
+        });
+      });
+
+      describe('broker does not have `cadAfterSignUpConfirmationPoll` capability', () => {
+        it('resolves to the default behavior', () => {
+          sinon.spy(metrics, 'setViewNamePrefix');
+
+          return broker.afterSignUpConfirmationPoll(account)
+            .then((behavior) => {
+              assert.equal(behavior.type, broker.getBehavior('afterSignUpConfirmationPoll').type);
+
+              assert.isFalse(metrics.setViewNamePrefix.called);
+            });
+        });
+      });
     });
   });
 });

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -532,6 +532,7 @@ define(function (require, exports, module) {
         view.displayError(error);
         assert.isTrue(view.logError.called);
         assert.isTrue(error.logged);
+        assert.equal(error.viewName, 'view');
       });
 
       it('does not log an already logged error', function () {
@@ -988,72 +989,30 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('invokeBrokerMethod', () => {
-      it('invokes the broker method, passing along any extra parameters, invokes the behavior', function () {
-        const behavior = sinon.spy();
-        sinon.stub(broker, 'afterSignIn', () => behavior);
-        sinon.stub(view, 'invokeBehavior', () => {});
+    describe('invokeBrokerMethod', function () {
+      it('invokes the broker method, passing along any extra parameters, invokes the value returned from the broker if a function', function () {
+        var behavior = sinon.spy();
 
-        const extraData = { key: 'value' };
+        sinon.stub(broker, 'afterSignIn', function () {
+          return behavior;
+        });
+
+        var extraData = { key: 'value' };
         return view.invokeBrokerMethod('afterSignIn', extraData)
           .then(function () {
-            assert.isTrue(broker.afterSignIn.calledOnce);
             assert.isTrue(broker.afterSignIn.calledWith(extraData));
-
-            assert.isTrue(view.invokeBehavior.calledOnce);
-            assert.isTrue(view.invokeBehavior.calledWith(behavior, extraData));
+            assert.isTrue(behavior.calledWith(view));
           });
       });
 
-      it('correctly handles rejected broker promises', () => {
-        const error = new Error('propagated error');
-        const behavior = p.reject(error);
-        sinon.stub(broker, 'afterSignIn', () => behavior);
-        sinon.spy(view, 'invokeBehavior');
-
-        return view.invokeBrokerMethod('afterSignIn')
-          .then(assert.fail, (caughtError) => {
-            assert.isTrue(broker.afterSignIn.calledOnce);
-
-            assert.isFalse(view.invokeBehavior.called);
-          });
-      });
-
-      it('correctly handles broker returning an object', function () {
-        const behavior = {};
-        sinon.stub(broker, 'afterSignIn', () => behavior);
-        sinon.stub(view, 'invokeBehavior', () => {});
+      it('does not explode if the value returned from the broker is not a function', function () {
+        sinon.stub(broker, 'afterSignIn', function () {
+          return {};
+        });
 
         return view.invokeBrokerMethod('afterSignIn')
           .then(function () {
-            assert.isTrue(broker.afterSignIn.calledOnce);
-
-            assert.isTrue(view.invokeBehavior.calledOnce);
-            assert.isTrue(view.invokeBehavior.calledWith(behavior));
-          });
-      });
-    });
-
-    describe('invokeBehavior', () => {
-      it('correctly handles a function', () => {
-        const behavior = sinon.spy(() => behavior);
-        const extraData = {};
-
-        return view.invokeBehavior(behavior, extraData)
-          .then((value) => {
-            assert.strictEqual(value, behavior);
-
-            assert.isTrue(behavior.calledOnce);
-            assert.isTrue(behavior.calledWith(view, extraData));
-          });
-      });
-
-      it('correctly handles an object', () => {
-        const behavior = {};
-
-        return view.invokeBehavior(behavior)
-          .then((value) => {
-            assert.strictEqual(value, behavior);
+            assert.isTrue(broker.afterSignIn.called);
           });
       });
     });

--- a/app/tests/spec/views/behaviors/connect-another-device.js
+++ b/app/tests/spec/views/behaviors/connect-another-device.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define((require, exports, module) => {
+  'use strict';
+
+  const { assert } = require('chai');
+  const ConnectAnotherDeviceBehavior = require('views/behaviors/connect-another-device');
+  const NullBehavior = require('views/behaviors/null');
+  const sinon = require('sinon');
+
+  describe('views/behaviors/connect-another-device', () => {
+    let account;
+    let cadBehavior;
+    let defaultBehavior;
+
+    before(() => {
+      account = {};
+      defaultBehavior = new NullBehavior();
+      cadBehavior = new ConnectAnotherDeviceBehavior(defaultBehavior);
+    });
+
+    describe('eligible for CAD', () => {
+      it('delegates to `view.navigateToConnectAnotherDeviceScreen`', () => {
+        const view = {
+          invokeBehavior: sinon.spy(),
+          isEligibleForConnectAnotherDevice: sinon.spy(() => true),
+          navigateToConnectAnotherDeviceScreen: sinon.spy()
+        };
+
+        cadBehavior(view, account);
+
+        assert.isTrue(view.isEligibleForConnectAnotherDevice.calledOnce);
+        assert.isTrue(view.isEligibleForConnectAnotherDevice.calledWith(account));
+
+        assert.isTrue(view.navigateToConnectAnotherDeviceScreen.calledOnce);
+        assert.isTrue(view.navigateToConnectAnotherDeviceScreen.calledWith(account));
+
+        assert.isFalse(view.invokeBehavior.called);
+      });
+    });
+
+    describe('ineligible for CAD', () => {
+      it('invokes the defaultBehavior', () => {
+        const view = {
+          invokeBehavior: sinon.spy(),
+          isEligibleForConnectAnotherDevice: sinon.spy(() => false),
+          navigateToConnectAnotherDeviceScreen: sinon.spy()
+        };
+
+        cadBehavior(view, account);
+
+        assert.isTrue(view.isEligibleForConnectAnotherDevice.calledOnce);
+        assert.isTrue(view.isEligibleForConnectAnotherDevice.calledWith(account));
+
+        assert.isFalse(view.navigateToConnectAnotherDeviceScreen.called);
+
+        assert.isTrue(view.invokeBehavior.calledOnce);
+        assert.isTrue(view.invokeBehavior.calledWith(defaultBehavior, account));
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/marketing_snippet.js
+++ b/app/tests/spec/views/marketing_snippet.js
@@ -51,9 +51,14 @@ define(function (require, exports, module) {
     });
 
     afterEach(function () {
+      metrics.destroy();
+      metrics = null;
+
       view.remove();
       view.destroy();
-      view = windowMock = null;
+      view = null;
+
+      windowMock = null;
     });
 
     testMarketingCampaign(Constants.MARKETING_ID_SPRING_2015);
@@ -90,6 +95,7 @@ define(function (require, exports, module) {
           .then(() => {
             assert.lengthOf(view.$('.marketing-link-ios'), 1);
             assert.lengthOf(view.$('.marketing-link-android'), 1);
+            assert.isTrue(view.$el.hasClass(marketingId));
           });
         });
 
@@ -104,6 +110,7 @@ define(function (require, exports, module) {
           .then(() => {
             assertLinkHasExpectedAttributes(view, marketingId, 'ios');
             assert.lengthOf(view.$('.marketing-link-android'), 0);
+            assert.isTrue(view.$el.hasClass(marketingId));
           });
         });
 
@@ -116,6 +123,7 @@ define(function (require, exports, module) {
           .then(() => {
             assert.lengthOf(view.$('.marketing-link-ios'), 0);
             assertLinkHasExpectedAttributes(view, marketingId, 'android');
+            assert.isTrue(view.$el.hasClass(marketingId));
           });
         });
 

--- a/app/tests/spec/views/mixins/modal-panel-mixin.js
+++ b/app/tests/spec/views/mixins/modal-panel-mixin.js
@@ -19,11 +19,11 @@ define(function (require, exports, module) {
     ModalPanelMixin
   );
 
-  describe('views/mixins/modal-panel-mixin', function () {
+  describe('views/mixins/modal-panel-mixin', () => {
     let notifier;
     let view;
 
-    beforeEach(function () {
+    beforeEach(() => {
       notifier = new Notifier();
       view = new ModalPanelView({
         notifier
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
       return view.render();
     });
 
-    afterEach(function () {
+    afterEach(() => {
       view.remove();
       view.destroy();
 
@@ -40,12 +40,32 @@ define(function (require, exports, module) {
     });
 
 
-    it('open and close', function () {
-      view.openPanel();
-      assert.isTrue($.modal.isActive());
+    describe('open and close', () => {
+      it('does the right thing when body min-height needed', () => {
+        sinon.stub(view, '_needsToSetBodyMinHeight', () => true);
 
-      view.closePanel();
-      assert.isFalse($.modal.isActive());
+        assert.equal($('body').css('min-height'), '0px');
+        view.openPanel();
+        assert.isTrue($.modal.isActive());
+        assert.ok(parseInt($('body').css('min-height'), 10) > 0);
+
+        view.closePanel();
+        assert.isFalse($.modal.isActive());
+        assert.equal($('body').css('min-height'), '0px');
+      });
+
+      it('does the right thing when body min-height not needed', () => {
+        sinon.stub(view, '_needsToSetBodyMinHeight', () => false);
+
+        assert.equal($('body').css('min-height'), '0px');
+        view.openPanel();
+        assert.isTrue($.modal.isActive());
+        assert.equal($('body').css('min-height'), '0px');
+
+        view.closePanel();
+        assert.isFalse($.modal.isActive());
+        assert.equal($('body').css('min-height'), '0px');
+      });
     });
 
     it('closePanel destroys the view', () => {

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -762,7 +762,7 @@ define(function (require, exports, module) {
         assert.equal(notifier.trigger.callCount, 2);
         assert.equal(notifier.trigger.args[0][0], 'flow.initialize');
         assert.equal(notifier.trigger.args[1][0], 'flow.event');
-        assert.deepEqual(notifier.trigger.args[1][1], { event: 'begin', once: true, view: undefined });
+        assert.deepEqual(notifier.trigger.args[1][1], { event: 'begin', once: true, viewName: undefined });
       });
 
       it('logs the begin event', () => {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -1299,7 +1299,7 @@ define(function (require, exports, module) {
         assert.equal(notifier.trigger.callCount, 2);
         assert.equal(notifier.trigger.args[0][0], 'flow.initialize');
         assert.equal(notifier.trigger.args[1][0], 'flow.event');
-        assert.deepEqual(notifier.trigger.args[1][1], { event: 'begin', once: true, view: undefined });
+        assert.deepEqual(notifier.trigger.args[1][1], { event: 'begin', once: true, viewName: undefined });
       });
 
       it('logs the begin event', () => {

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -107,6 +107,7 @@ function (Translator, Session) {
     '../tests/spec/models/web-session',
     '../tests/spec/views/app',
     '../tests/spec/views/base',
+    '../tests/spec/views/behaviors/connect-another-device',
     '../tests/spec/views/behaviors/halt',
     '../tests/spec/views/behaviors/navigate',
     '../tests/spec/views/behaviors/null',

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -14,6 +14,16 @@ define([
   var email;
   const PASSWORD = '12345678';
 
+  const SELECTOR_CONFIRM_SIGNIN_HEADER = '#fxa-confirm-signin-header';
+  const SELECTOR_CONFIRM_SIGNUP_HEADER = '#fxa-confirm-header';
+  const SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER = '#fxa-connect-another-device-header';
+  const SELECTOR_SETTINGS_HEADER = '#fxa-settings-header';
+  const SELECTOR_SIGNIN_HEADER = '#fxa-signin-header';
+  const SELECTOR_SIGNIN_SUB_HEADER = '#fxa-signin-header .service';
+  const SELECTOR_SIGNIN_UNBLOCK_HEADER = '#fxa-signin-unblock-header';
+  const SELECTOR_SIGNIN_COMPLETE_HEADER = '#fxa-sign-in-complete-header';
+  const SELECTOR_VERIFICATION_EMAIL = '.verification-email-message';
+
   const thenify = FunctionalHelpers.thenify;
 
   const clearBrowserNotifications = FunctionalHelpers.clearBrowserNotifications;
@@ -39,7 +49,7 @@ define([
     return this.parent
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(options.pageUrl || PAGE_URL, '.email'))
-      .then(visibleByQSA('#fxa-signin-header .service'))
+      .then(visibleByQSA(SELECTOR_SIGNIN_SUB_HEADER))
       .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: options.canLinkAccountResponse !== false }))
       // delay for the webchannel message
       .sleep(500)
@@ -63,17 +73,17 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testElementExists(SELECTOR_CONFIRM_SIGNIN_HEADER))
 
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
 
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')
-          .then(testElementExists('#fxa-sign-in-complete-header'))
+          .then(testElementExists(SELECTOR_SIGNIN_COMPLETE_HEADER))
           .then(closeCurrentWindow())
 
-        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(testElementExists(SELECTOR_SIGNIN_COMPLETE_HEADER))
         .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
@@ -81,13 +91,13 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testElementExists(SELECTOR_CONFIRM_SIGNIN_HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
 
         .then(openVerificationLinkInDifferentBrowser(email))
 
-        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(testElementExists(SELECTOR_SIGNIN_COMPLETE_HEADER))
         .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
@@ -96,7 +106,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: false }))
 
-        .then(testElementExists('#fxa-confirm-header'))
+        .then(testElementExists(SELECTOR_CONFIRM_SIGNUP_HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
 
@@ -105,10 +115,12 @@ define([
         // email 2 - "You have verified your Firefox Account"
         .then(openVerificationLinkInNewTab(email, 1))
         .switchToWindow('newwindow')
-          .then(testElementExists('#fxa-connect-another-device-header'))
+          .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER))
           .then(closeCurrentWindow())
 
-        .then(testElementExists('#fxa-sign-up-complete-header'))
+        // Since this is really a signup flow, the original tab
+        // redirects to CAD too.
+        .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER))
         .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
@@ -119,7 +131,7 @@ define([
         .then(noSuchBrowserNotification('fxaccounts:login'))
 
         // user should not transition to the next screen
-        .then(noPageTransition('#fxa-signin-header'));
+        .then(noPageTransition(SELECTOR_SIGNIN_HEADER));
     },
 
     'blocked, valid code entered': function () {
@@ -128,14 +140,14 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(testElementExists('#fxa-signin-unblock-header'))
-        .then(testElementTextInclude('.verification-email-message', email))
+        .then(testElementExists(SELECTOR_SIGNIN_UNBLOCK_HEADER))
+        .then(testElementTextInclude(SELECTOR_VERIFICATION_EMAIL, email))
         .then(fillOutSignInUnblock(email, 0))
 
         // Only users that go through signin confirmation see
         // `/signin_complete`, and users that go through signin unblock see
         // the default `settings` page.
-        .then(testElementExists('#fxa-settings-header'))
+        .then(testElementExists(SELECTOR_SETTINGS_HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'));
     }
   });

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -14,6 +14,11 @@ define([
   var email;
   const PASSWORD = '12345678';
 
+  const SELECTOR_CONFIRM_HEADER = '#fxa-confirm-header';
+  const SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER = '#fxa-connect-another-device-header';
+  const SELECTOR_SIGN_UP_HEADER = '#fxa-signup-header';
+  const SELECTOR_SIGN_UP_SUB_HEADER = '#fxa-signup-header .service';
+
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
   const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
@@ -40,12 +45,12 @@ define([
 
     'sign up, verify same browser in a different tab': function () {
       return this.remote
-        .then(openPage(PAGE_URL, '#fxa-signup-header'))
-        .then(visibleByQSA('#fxa-signup-header .service'))
+        .then(openPage(PAGE_URL, SELECTOR_SIGN_UP_HEADER))
+        .then(visibleByQSA(SELECTOR_SIGN_UP_SUB_HEADER))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 
-        .then(testElementExists('#fxa-confirm-header'))
+        .then(testElementExists(SELECTOR_CONFIRM_HEADER))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))
 
@@ -54,15 +59,12 @@ define([
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')
 
-        // user should be redirected to "Success!" screen.
-        // In real life, the original browser window would show
-        // a "welcome to sync!" screen that has a manage button
-        // on it, and this screen should show the FxA success screen.
-        .then(testElementExists('#fxa-connect-another-device-header'))
+        // user should see the CAD screen in both signup and verification tabs.
+        .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER))
         // switch back to the original window, it should transition.
         .then(closeCurrentWindow())
 
-        .then(testElementExists('#fxa-sign-up-complete-header'))
+        .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER))
 
         // A post-verification email should be sent, this is Sync.
         .then(testEmailExpected(email, 1));
@@ -70,12 +72,12 @@ define([
 
     'sign up, cancel merge warning': function () {
       return this.remote
-        .then(openPage(PAGE_URL, '#fxa-signup-header'))
+        .then(openPage(PAGE_URL, SELECTOR_SIGN_UP_HEADER))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: false } ))
         .then(fillOutSignUp(email, PASSWORD))
 
         // user should not transition to the next screen
-        .then(noSuchElement('#fxa-confirm-header'))
+        .then(noSuchElement(SELECTOR_CONFIRM_HEADER))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'));
     }
   });


### PR DESCRIPTION
Builds on https://github.com/mozilla/fxa-content-server/pull/4995

Not even close to ready for review.

TODO:
* [x] Sizing of app store buttons. (with existing firstrun iframe size, no need to resize the buttons)
* [x] Resize window for modal, or stop using modals if in the iframe.
* [x] What do we do for "Maybe later" on the /sms page? User should already be signed in, so sending them to "/signin" doesn't make sense. Sending them to `/connect_another_device` seems equally strange, we just prompt the user to install Fx for mobile, which the /sms screen does. (decided to remove)
* [x] Update lots of functional tests.
* [x] In metrics, figure out how to differentiate between users who perform an action from the signup and verification tabs.

fixes #4944 