### PR TITLE
refactor(client): Automate link transforming for OAuth integrations.

### DIFF
--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -88,11 +88,6 @@ define(function (require, exports, module) {
       }
     },
 
-    afterRender () {
-      this.transformLinks();
-      return proto.afterRender.call(this);
-    },
-
     afterVisible () {
       // the view is always rendered, but the confirmation poll may be
       // prevented by the broker. An example is Firefox Desktop where the

--- a/app/scripts/views/mixins/service-mixin.js
+++ b/app/scripts/views/mixins/service-mixin.js
@@ -12,6 +12,10 @@ define(function (require, exports, module) {
   const $ = require('jquery');
 
   module.exports = {
+    afterRender () {
+      this.transformLinks();
+    },
+
     transformLinks () {
       // need to add /oauth to urls, but also maintain the existing query params
       const $linkEls = this.$('a[href^="/signin"],a[href^="/signup"],a[href^="/reset_password"]');

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -48,14 +48,6 @@ define(function (require, exports, module) {
       return FormView.prototype.beforeRender.call(this);
     },
 
-    afterRender () {
-      if (this.relier.isOAuth()) {
-        this.transformLinks();
-      }
-
-      FormView.prototype.afterRender.call(this);
-    },
-
     beforeDestroy () {
       this._formPrefill.set('email', this.getElementValue('.email'));
     },

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -111,11 +111,6 @@ define(function (require, exports, module) {
       'click .use-logged-in': 'useLoggedInAccount'
     },
 
-    afterRender () {
-      this.transformLinks();
-      return FormView.prototype.afterRender.call(this);
-    },
-
     afterVisible () {
       FormView.prototype.afterVisible.call(this);
       return this.displayAccountProfileImage(this.getAccount(), { spinner: true });

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -100,11 +100,7 @@ define(function (require, exports, module) {
           String(this._isEmailOptInEnabled()));
 
       return this._createCoppaView()
-        .then(() => {
-          this.transformLinks();
-
-          return FormView.prototype.afterRender.call(this);
-        });
+        .then(() => FormView.prototype.afterRender.call(this));
     },
 
     afterVisible () {

--- a/app/tests/spec/views/mixins/service-mixin.js
+++ b/app/tests/spec/views/mixins/service-mixin.js
@@ -5,35 +5,42 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const { assert } = require('chai');
   const BaseView = require('views/base');
-  const Chai = require('chai');
   const Cocktail = require('cocktail');
   const NullBroker = require('models/auth_brokers/base');
   const OAuthRelier = require('models/reliers/oauth');
   const ServiceMixin = require('views/mixins/service-mixin');
   const Session = require('lib/session');
   const sinon = require('sinon');
-  const TestTemplate = require('stache!templates/test_template');
   const WindowMock = require('../../../mocks/window');
-
-  var assert = Chai.assert;
 
   var OAuthView = BaseView.extend({
     className: 'oauth',
-    template: TestTemplate
+    template () {
+      return '' +
+        '<div>' +
+          '<div class="error"></div>' +
+          '<div class="success"></div>' +
+          '<a href="/signin" id="signin">signin</a>' +
+          '<a href="/signup" id="signup">signup</a>' +
+          '<a href="/reset_password" id="reset_password">reset password</a>' +
+        '</div>';
+    }
   });
+
   Cocktail.mixin(
     OAuthView,
     ServiceMixin
   );
 
-  describe('views/mixins/service-mixin', function () {
+  describe('views/mixins/service-mixin', () => {
     var view;
     var windowMock;
     var relier;
     var broker;
 
-    beforeEach(function () {
+    beforeEach(() => {
       windowMock = new WindowMock();
       relier = new OAuthRelier();
 
@@ -48,40 +55,69 @@ define(function (require, exports, module) {
         window: windowMock
       });
 
-      return view.render();
     });
 
-    describe('unsafeDisplayError', function () {
-      describe('with a broker that munges links', function () {
-        beforeEach(function () {
-          sinon.stub(broker, 'transformLink', function (link) {
-            return '/oauth' + link;
-          });
+    describe('render', () => {
+      describe('broker modifies links', () => {
+        beforeEach(() => {
+          sinon.stub(broker, 'transformLink', (link) => `/oauth${link}`);
+          return view.render();
         });
 
-        it('converts /signin links to /oauth/signin', function () {
+        it('replaces links', () => {
+          assert.equal(view.$('#signin').attr('href'), '/oauth/signin');
+          assert.equal(view.$('#signup').attr('href'), '/oauth/signup');
+          assert.equal(view.$('#reset_password').attr('href'), '/oauth/reset_password');
+        });
+      });
+
+      describe('broker does not modify links', () => {
+        beforeEach(() => {
+          return view.render();
+        });
+
+        it('does not modify links', () => {
+          assert.equal(view.$('#signin').attr('href'), '/signin');
+          assert.equal(view.$('#signup').attr('href'), '/signup');
+          assert.equal(view.$('#reset_password').attr('href'), '/reset_password');
+        });
+      });
+    });
+
+    describe('unsafeDisplayError', () => {
+      describe('broker modifies links', () => {
+        beforeEach(() => {
+          sinon.stub(broker, 'transformLink', (link) => `/oauth${link}`);
+          return view.render();
+        });
+
+        it('converts /signin links to /oauth/signin', () => {
           view.unsafeDisplayError('<a href="/signin" id="replaceMe">error</a>');
           assert.equal(view.$('#replaceMe').attr('href'), '/oauth/signin');
         });
 
-        it('keeps attributes during the transformation', function () {
+        it('keeps attributes during the transformation', () => {
           view.unsafeDisplayError('<a href="/signin?client_id=foo&state=bar" id="replaceMe">error</a>');
           assert.equal(view.$('#replaceMe').attr('href'), '/oauth/signin?client_id=foo&state=bar');
         });
 
-        it('converts /signup links to /oauth/signup', function () {
+        it('converts /signup links to /oauth/signup', () => {
           view.unsafeDisplayError('<a href="/signup" id="replaceMe">error</a>');
           assert.equal(view.$('#replaceMe').attr('href'), '/oauth/signup');
         });
       });
 
-      describe('with a broker that does not munge links', function () {
-        it('leaves /signin alone', function () {
+      describe('broker does not modify links', () => {
+        beforeEach(() => {
+          return view.render();
+        });
+
+        it('leaves /signin alone', () => {
           view.unsafeDisplayError('<a href="/signin" id="replaceMe">error</a>');
           assert.equal(view.$('#replaceMe').attr('href'), '/signin');
         });
 
-        it('leaves /signup alone', function () {
+        it('leaves /signup alone', () => {
           view.unsafeDisplayError('<a href="/signup" id="replaceMe">error</a>');
           assert.equal(view.$('#replaceMe').attr('href'), '/signup');
         });


### PR DESCRIPTION
service-mixin calls `transformLinks` in afterRender instead of
calling `transformLinks` imperatively in each view.

Not attached to any issue.

@mozilla/fxa-devs - r?