### PR TITLE
fix(sms): Update SMS legal text to cover more countries.

### DIFF
--- a/app/scripts/templates/sms_send.mustache
+++ b/app/scripts/templates/sms_send.mustache
@@ -17,7 +17,7 @@
     </section>
     <div class="marketing-area"></div>
     <div class="sms-disclaimer">
-      {{#unsafeTranslate}}SMS service available to U.S. phone numbers only. SMS &amp; data rates may apply. The intended recipient of the email or SMS must have consented. <a %(escapedLearnMoreAttributes)s>Learn more</a>{{/unsafeTranslate}}
+      {{#unsafeTranslate}}SMS service only available in certain countries. SMS &amp; data rates may apply. The intended recipient of the email or SMS must have consented. <a %(escapedLearnMoreAttributes)s>Learn more</a>{{/unsafeTranslate}}
     </div>
     <div class="links">
       <a href="/sms/why" data-flow-event="link.why" class="left">{{#t}}Why is this required?{{/t}}</a>


### PR DESCRIPTION
SMS legal text is made more generic to cover any country
for which the feature is enabled.

fixes #4945

@mozilla/fxa-devs - r?