### PR TITLE
fix(sms): Clarify the "Why is this required" SMS text.

### DIFF
--- a/app/scripts/templates/why_connect_another_device.mustache
+++ b/app/scripts/templates/why_connect_another_device.mustache
@@ -4,7 +4,7 @@
   </header>
 
   <p>
-    {{#t}}Sync lets you share the bookmarks, history and passwords you save to Firefox on one device with Firefox on other devices. Sign in to Firefox on your phone or tablet and everything you've saved to Firefox for desktop will appear.{{/t}}
+    {{#t}}Sync lets you securely find your bookmarks, passwords and more from any of your devices running Firefox.{{/t}}
   </p>
   <p>
     {{#t}}Sync isn't designed as a permanent backup – it's just sharing what is saved locally. If you reset your password and your data isn't stored on at least one other device, you could lose all the information associated with the old password. That's why you'll want to install Firefox and use Sync on more than one device.{{/t}}


### PR DESCRIPTION
Combine and simplify the first two sentences.

issue #4944

@ryanfeeley and @davismtl - is this what you had in mind? The title is still the same, but I replaced the first two sentences within the text with the suggested text.

<img width="421" alt="screen shot 2017-05-04 at 12 16 00" src="https://cloud.githubusercontent.com/assets/848085/25701302/b6e328d8-30c3-11e7-9b7e-510b45ed2212.png">
