### PR TITLE
refactor(sms): Remove the "Maybe later" link.

### DIFF
--- a/app/scripts/templates/sms_send.mustache
+++ b/app/scripts/templates/sms_send.mustache
@@ -20,8 +20,7 @@
       {{#unsafeTranslate}}SMS service only available in certain countries. SMS &amp; data rates may apply. The intended recipient of the email or SMS must have consented. <a %(escapedLearnMoreAttributes)s>Learn more</a>{{/unsafeTranslate}}
     </div>
     <div class="links">
-      <a href="/sms/why" data-flow-event="link.why" class="left">{{#t}}Why is this required?{{/t}}</a>
-      <a id="maybe-later" href="/connect_another_device" data-flow-event="link.maybe_later" class="right">{{#t}}Maybe later{{/t}}</a>
+      <a href="/sms/why" data-flow-event="link.why">{{#t}}Why is this required?{{/t}}</a>
     </div>
     <aside class="child-view"></aside>
 </div>

--- a/app/tests/spec/views/sms_send.js
+++ b/app/tests/spec/views/sms_send.js
@@ -267,12 +267,6 @@
          assert.isTrue(view.logFlowEvent.calledWith('link.why'));
        });
 
-       it('logs a click on `maybe later`', () => {
-         view.$('a#maybe-later').click();
-         assert.isTrue(view.logFlowEvent.calledOnce);
-         assert.isTrue(view.logFlowEvent.calledWith('link.maybe_later'));
-       });
-
        it('logs a click in the phone number field', () => {
          view.$('input[type=tel]').val('1234').click();
          assert.isTrue(view.logFlowEventOnce.calledOnce);

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -18,13 +18,11 @@
    const SEND_SMS_NO_QUERY_URL = config.fxaContentRoot + 'sms';
 
    const SELECTOR_CONFIRM_SIGNUP = '#fxa-confirm-header';
-   const SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER = '#fxa-connect-another-device-header';
    const SELECTOR_400_HEADER = '#fxa-400-header';
    const SELECTOR_400_ERROR = '.error';
    const SELECTOR_LEARN_MORE = 'a#learn-more';
    const SELECTOR_LEARN_MORE_HEADER = '#websites-notice';
    const SELECTOR_MARKETING_LINK = '.marketing-link';
-   const SELECTOR_SEND_SMS_MAYBE_LATER = 'a[href="/connect_another_device"]';
    const SELECTOR_SEND_SMS_HEADER = '#fxa-send-sms-header';
    const SELECTOR_SEND_SMS_PHONE_NUMBER = 'input[type="tel"]';
    const SELECTOR_SEND_SMS_SUBMIT = 'button[type="submit"]';
@@ -160,14 +158,6 @@
         .then(click(SELECTOR_WHY_IS_THIS_REQUIRED_CLOSE))
 
         .then(testElementExists(SELECTOR_SEND_SMS_HEADER));
-     },
-
-     'maybe later': function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, SELECTOR_SEND_SMS_HEADER))
-         .then(click(SELECTOR_SEND_SMS_MAYBE_LATER))
-
-         .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER));
      },
 
      'empty phone number': function () {


### PR DESCRIPTION
@ryanfeeley and @davismtl both agree that "Maybe later"
should be removed from the /sms screen. Doing so will
probably boost the number of users who send an SMS,
and most /connect_another_device screens show the
user the same app store links as showed on the /sms page.

fixes #5044 

@mozilla/fxa-devs - r?