### PR TITLE
refactor(channels): Place all web channel command declarations in one location.

### DIFF
--- a/app/scripts/lib/channels/notifier.js
+++ b/app/scripts/lib/channels/notifier.js
@@ -12,13 +12,14 @@ define(function (require, exports, module) {
   const _ = require('underscore');
   const Backbone = require('backbone');
   const Vat = require('lib/vat');
+  const WebChannel = require('lib/channels/web');
 
   // Commands that have the 'internal:' namespace should only be
   // handled by the content server. Other commands may be handled
   // both externally and internally to the content server.
   var COMMANDS = {
     CHANGE_PASSWORD: {
-      name: 'fxaccounts:change_password',
+      name: WebChannel.CHANGE_PASSWORD,
       schema: {
         email: Vat.email().required(),
         keyFetchToken: Vat.keyFetchToken().optional(),
@@ -33,13 +34,13 @@ define(function (require, exports, module) {
       schema: null
     },
     DELETE: {
-      name: 'fxaccounts:delete',
+      name: WebChannel.DELETE,
       schema: {
         uid: Vat.uid().required()
       }
     },
     PROFILE_CHANGE: {
-      name: 'profile:change',
+      name: WebChannel.PROFILE_CHANGE,
       schema: {
         uid: Vat.uid().required()
       }
@@ -60,7 +61,7 @@ define(function (require, exports, module) {
       }
     },
     SIGNED_OUT: {
-      name: 'fxaccounts:logout',
+      name: WebChannel.LOGOUT,
       schema: {
         uid: Vat.uid().optional()
       }

--- a/app/scripts/models/auth_brokers/fx-sync-web-channel.js
+++ b/app/scripts/models/auth_brokers/fx-sync-web-channel.js
@@ -24,16 +24,13 @@ define(function (require, exports, module) {
       sendChangePasswordNotice: false
     }),
 
-    commands: {
-      CAN_LINK_ACCOUNT: 'fxaccounts:can_link_account',
-      CHANGE_PASSWORD: null,
-      DELETE_ACCOUNT: 'fxaccounts:delete_account',
-      LOADED: 'fxaccounts:loaded',
-      LOGIN: 'fxaccounts:login'
-      /*
-      SYNC_PREFERENCES: 'fxaccounts:sync_preferences' // Removed in issue #4250
-      */
-    },
+    commands: _.pick(WebChannel,
+      'CAN_LINK_ACCOUNT',
+      'CHANGE_PASSWORD',
+      'DELETE_ACCOUNT',
+      'LOADED',
+      'LOGIN'
+    ),
 
     createChannel () {
       var channel = new WebChannel(Constants.ACCOUNT_UPDATES_WEBCHANNEL_ID);

--- a/app/tests/spec/lib/channels/web.js
+++ b/app/tests/spec/lib/channels/web.js
@@ -35,6 +35,32 @@ define(function (require, exports, module) {
       }, 'WebChannel must have an id');
     });
 
+    it('exports the expected commands on the static interface', () => {
+      assert.ok(WebChannel.CAN_LINK_ACCOUNT);
+      assert.ok(WebChannel.CHANGE_PASSWORD);
+      assert.ok(WebChannel.DELETE);
+      assert.ok(WebChannel.LOADED);
+      assert.ok(WebChannel.LOGIN);
+      assert.ok(WebChannel.LOGOUT);
+      assert.ok(WebChannel.PROFILE_CHANGE);
+    });
+
+    it('exports the expected commands on an instance', () => {
+      channel = new WebChannel('MyChannel');
+      channel.initialize({
+        window: windowMock
+      });
+
+      assert.lengthOf(Object.keys(channel.COMMANDS), 8);
+      assert.ok(channel.COMMANDS.CAN_LINK_ACCOUNT);
+      assert.ok(channel.COMMANDS.CHANGE_PASSWORD);
+      assert.ok(channel.COMMANDS.DELETE);
+      assert.ok(channel.COMMANDS.LOADED);
+      assert.ok(channel.COMMANDS.LOGIN);
+      assert.ok(channel.COMMANDS.LOGOUT);
+      assert.ok(channel.COMMANDS.PROFILE_CHANGE);
+    });
+
     describe('send', function () {
       it('sends a message', function () {
         channel = new WebChannel('MyChannel');


### PR DESCRIPTION
The web channel command declarations were sprinkled throughout several modules.
This centralizes the location to lib/channels/web.js

This does not fix #3432, but takes the first step - centralizing where
the commands are declared.

issue #3432

This is an extraction from #4695 