### PR TITLE
fix(cad): Always show app store buttons for /connect_another_device, /sms

### DIFF
--- a/app/scripts/views/connect_another_device.js
+++ b/app/scripts/views/connect_another_device.js
@@ -12,10 +12,10 @@ define(function (require, exports, module) {
   'use strict';
 
   const Cocktail = require('cocktail');
-  const Constants = require('lib/constants');
   const ExperimentMixin = require('views/mixins/experiment-mixin');
   const FlowEventsMixin = require('views/mixins/flow-events-mixin');
   const FormView = require('views/form');
+  const { MARKETING_ID_AUTUMN_2016, SYNC_SERVICE } = require('lib/constants');
   const MarketingMixin = require('views/mixins/marketing-mixin');
   const MarketingSnippet = require('views/marketing_snippet');
   const SyncAuthMixin = require('views/mixins/sync-auth-mixin');
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
 
     afterRender () {
       const options = {
-        marketingId: Constants.MARKETING_ID_AUTUMN_2016
+        marketingId: MARKETING_ID_AUTUMN_2016
       };
 
       // If the user signed up and verified in Firefox for Android,
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
 
     getAccount () {
       if (! this.model.get('account')) {
-        this.model.set('account', this.user.initAccount({}));
+        this.model.set('account', this.user.getSignedInAccount());
       }
 
       return this.model.get('account');
@@ -195,7 +195,11 @@ define(function (require, exports, module) {
     FlowEventsMixin,
     MarketingMixin({
       // The marketing area is manually created to which badges are displayed.
-      autocreate: false
+      autocreate: false,
+      // This screen is only shown to Sync users. The service is always Sync,
+      // even if not specified on the URL. This makes manual testing slightly
+      // easier where sometimes ?service=sync is forgotten. See #4948.
+      service: SYNC_SERVICE
     }),
     SyncAuthMixin,
     UserAgentMixin

--- a/app/scripts/views/sms_send.js
+++ b/app/scripts/views/sms_send.js
@@ -15,7 +15,7 @@ define(function (require, exports, module) {
   const { FIREFOX_MOBILE_INSTALL } = require('lib/sms-message-ids');
   const FlowEventsMixin = require('views/mixins/flow-events-mixin');
   const FormView = require('views/form');
-  const { MARKETING_ID_AUTUMN_2016 } = require('lib/constants');
+  const { MARKETING_ID_AUTUMN_2016, SYNC_SERVICE } = require('lib/constants');
   const MarketingMixin = require('views/mixins/marketing-mixin');
   const PulseGraphicMixin = require('views/mixins/pulse-graphic-mixin');
   const SmsErrors = require('lib/sms-errors');
@@ -174,7 +174,13 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     FlowEventsMixin,
-    MarketingMixin({ marketingId: MARKETING_ID_AUTUMN_2016 }),
+    MarketingMixin({
+      marketingId: MARKETING_ID_AUTUMN_2016,
+      // This screen is only shown to Sync users. The service is always Sync,
+      // even if not specified on the URL. This makes manual testing slightly
+      // easier where sometimes ?service=sync is forgotten. See #4948.
+      service: SYNC_SERVICE
+    }),
     PulseGraphicMixin
   );
 

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -14,6 +14,17 @@
    CountryTelephoneInfo, serverConfig) {
    const config = intern.config;
 
+   const ADJUST_LINK_ANDROID =
+    'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +
+    'creative=button-autumn-2016-connect-another-device&adgroup=android';
+
+   const ADJUST_LINK_IOS =
+    'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +
+    'creative=button-autumn-2016-connect-another-device&adgroup=ios&' +
+    'fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&' +
+    'ct=adjust_tracker&mt=8';
+
+
    const SEND_SMS_URL = config.fxaContentRoot + 'sms?service=sync&country=US';
    const SEND_SMS_NO_QUERY_URL = config.fxaContentRoot + 'sms';
 
@@ -23,6 +34,8 @@
    const SELECTOR_LEARN_MORE = 'a#learn-more';
    const SELECTOR_LEARN_MORE_HEADER = '#websites-notice';
    const SELECTOR_MARKETING_LINK = '.marketing-link';
+   const SELECTOR_MARKETING_LINK_ANDROID = '.marketing-link-android';
+   const SELECTOR_MARKETING_LINK_IOS = '.marketing-link-ios';
    const SELECTOR_SEND_SMS_HEADER = '#fxa-send-sms-header';
    const SELECTOR_SEND_SMS_PHONE_NUMBER = 'input[type="tel"]';
    const SELECTOR_SEND_SMS_SUBMIT = 'button[type="submit"]';
@@ -48,6 +61,7 @@
    const testElementExists = FunctionalHelpers.testElementExists;
    const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
    const testElementValueEquals = FunctionalHelpers.testElementValueEquals;
+   const testHrefEquals = FunctionalHelpers.testHrefEquals;
    const type = FunctionalHelpers.type;
 
    const suite = {
@@ -67,7 +81,9 @@
        return this.remote
          .then(openPage(SEND_SMS_NO_QUERY_URL, SELECTOR_SEND_SMS_HEADER))
          .then(testElementValueEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, ''))
-         .then(testAttributeEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, 'data-country', 'US'));
+         .then(testAttributeEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, 'data-country', 'US'))
+         .then(testHrefEquals(SELECTOR_MARKETING_LINK_IOS, ADJUST_LINK_IOS))
+         .then(testHrefEquals(SELECTOR_MARKETING_LINK_ANDROID, ADJUST_LINK_ANDROID));
      },
 
      'with no service, unsupported country': function () {


### PR DESCRIPTION
The marketing material was only shown if ?service=sync was specified on
the URL. This caused confusion whenever loading the two screens during
manual testing. Since these screens are only shown for the Sync flow,
always show them.

fixes #4948

@mozilla/fxa-devs - r?