### PR TITLE
fix(firstrun): Show the `continue to Firefox Sync` subheader in the firstrun page

### DIFF
--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -124,12 +124,6 @@ header {
       }
     }
 
-    .service {
-      .chromeless & {
-        display: none;
-      }
-    }
-
     .email {
       color: $faint-text-color;
       // allow long email addresses to be

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -8,36 +8,38 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var config = intern.config;
-  var PAGE_URL = config.fxaContentRoot + 'signin?context=iframe&service=sync';
+  const config = intern.config;
+  const PAGE_URL = config.fxaContentRoot + 'signin?context=iframe&service=sync';
 
   var email;
-  var PASSWORD = '12345678';
+  const PASSWORD = '12345678';
 
-  var thenify = FunctionalHelpers.thenify;
+  const thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserNotifications = FunctionalHelpers.clearBrowserNotifications;
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-  var noPageTransition = FunctionalHelpers.noPageTransition;
-  var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
-  var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
-  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  const clearBrowserNotifications = FunctionalHelpers.clearBrowserNotifications;
+  const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  const createUser = FunctionalHelpers.createUser;
+  const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
+  const fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
+  const noPageTransition = FunctionalHelpers.noPageTransition;
+  const noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
+  const openPage = FunctionalHelpers.openPage;
+  const openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
+  const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
+  const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  const testElementExists = FunctionalHelpers.testElementExists;
+  const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
+  const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  const visibleByQSA = FunctionalHelpers.visibleByQSA;
 
-  var setupTest = thenify(function (options) {
+  const setupTest = thenify(function (options) {
     options = options || {};
 
     return this.parent
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(options.pageUrl || PAGE_URL, '.email'))
+      .then(visibleByQSA('#fxa-signin-header .service'))
       .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: options.canLinkAccountResponse !== false }))
       // delay for the webchannel message
       .sleep(500)

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -8,22 +8,23 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var config = intern.config;
-  var PAGE_URL = config.fxaContentRoot + 'signup?context=iframe&service=sync';
+  const config = intern.config;
+  const PAGE_URL = config.fxaContentRoot + 'signup?context=iframe&service=sync';
 
   var email;
-  var PASSWORD = '12345678';
+  const PASSWORD = '12345678';
 
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testEmailExpected = FunctionalHelpers.testEmailExpected;
-  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
+  const noSuchElement = FunctionalHelpers.noSuchElement;
+  const openPage = FunctionalHelpers.openPage;
+  const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
+  const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  const testElementExists = FunctionalHelpers.testElementExists;
+  const testEmailExpected = FunctionalHelpers.testEmailExpected;
+  const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  const visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   registerSuite({
     name: 'Firstrun Sync v1 sign_up',
@@ -40,6 +41,7 @@ define([
     'sign up, verify same browser in a different tab': function () {
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))
+        .then(visibleByQSA('#fxa-signup-header .service'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -26,6 +26,7 @@ define([
   const SELECTOR_SEND_SMS_HEADER = '#fxa-send-sms-header';
   const SELECTOR_SEND_SMS_PHONE_NUMBER = 'input[type="tel"]';
   const SELECTOR_SIGN_UP_HEADER = '#fxa-signup-header';
+  const SELECTOR_SIGN_UP_SUB_HEADER = '#fxa-signup-header .service';
   const SELECTOR_SIGN_UP_COMPLETE_HEADER = '#fxa-sign-up-complete-header';
 
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
@@ -42,10 +43,12 @@ define([
   const testEmailExpected = FunctionalHelpers.testEmailExpected;
   const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
   const thenify = FunctionalHelpers.thenify;
+  const visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   const setupTest = thenify(function () {
     return this.parent
       .then(openPage(PAGE_URL, SELECTOR_SIGN_UP_HEADER))
+      .then(visibleByQSA(SELECTOR_SIGN_UP_SUB_HEADER))
       .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
 
       .then(fillOutSignUp(email, PASSWORD))


### PR DESCRIPTION
@ryanfeeley - this re-adds the "to continue to Firefox Sync" on both the signup and signin pages, is that OK?

fixes #5063