### PR TITLE
fix(broker): Fix the POST /metrics validation error w/ FxSync broker.

### DIFF
--- a/app/scripts/models/auth_brokers/fx-sync.js
+++ b/app/scripts/models/auth_brokers/fx-sync.js
@@ -12,14 +12,13 @@ define(function (require, exports, module) {
   'use strict';
 
   const BaseAuthenticationBroker = require('models/auth_brokers/base');
-  const { FX_SYNC_CONTEXT } = require('lib/constants');
 
   const proto = BaseAuthenticationBroker.prototype;
 
   module.exports = BaseAuthenticationBroker.extend({
     defaultBehaviors: proto.defaultBehaviors,
 
-    type: FX_SYNC_CONTEXT
+    type: 'fx-sync'
   });
 });
 

--- a/app/tests/spec/models/auth_brokers/index.js
+++ b/app/tests/spec/models/auth_brokers/index.js
@@ -5,11 +5,13 @@
 define((require, exports, module) => {
   'use strict';
 
-  const chai = require('chai');
+  const { assert } = require('chai');
   const constants = require('lib/constants');
   const index = require('models/auth_brokers/index');
 
-  const assert = chai.assert;
+  // Unfortunately, until we have shared validation on both
+  // server and client, this regexp is copied from /server/lib/validate.js
+  const VALID_TYPE = /^[0-9a-z-]+$/;
 
   describe('models/auth_brokers/index', () => {
     it('interface is correct', () => {
@@ -23,51 +25,61 @@ define((require, exports, module) => {
     it('get returns correct broker for fx-sync context', () => {
       const authBroker = index.get(constants.FX_SYNC_CONTEXT);
       assert.equal(authBroker, require('models/auth_brokers/fx-sync'));
+      assert.ok(VALID_TYPE.test(authBroker.prototype.type));
     });
 
     it('get returns correct broker for desktop-v1 context', () => {
       const authBroker = index.get(constants.FX_DESKTOP_V1_CONTEXT);
       assert.equal(authBroker, require('models/auth_brokers/fx-desktop-v1'));
+      assert.ok(VALID_TYPE.test(authBroker.prototype.type));
     });
 
     it('get returns correct broker for desktop-v2 context', () => {
       const authBroker = index.get(constants.FX_DESKTOP_V2_CONTEXT);
       assert.equal(authBroker, require('models/auth_brokers/fx-desktop-v2'));
+      assert.ok(VALID_TYPE.test(authBroker.prototype.type));
     });
 
     it('get returns correct broker for desktop-v3 context', () => {
       const authBroker = index.get(constants.FX_DESKTOP_V3_CONTEXT);
       assert.equal(authBroker, require('models/auth_brokers/fx-desktop-v3'));
+      assert.ok(VALID_TYPE.test(authBroker.prototype.type));
     });
 
     it('get returns correct broker for fennec-v1 context', () => {
       const authBroker = index.get(constants.FX_FENNEC_V1_CONTEXT);
       assert.equal(authBroker, require('models/auth_brokers/fx-fennec-v1'));
+      assert.ok(VALID_TYPE.test(authBroker.prototype.type));
     });
 
     it('get returns correct broker for firstrun-v1 context', () => {
       const authBroker = index.get(constants.FX_FIRSTRUN_V1_CONTEXT);
       assert.equal(authBroker, require('models/auth_brokers/fx-firstrun-v1'));
+      assert.ok(VALID_TYPE.test(authBroker.prototype.type));
     });
 
     it('get returns correct broker for firstrun-v2 context', () => {
       const authBroker = index.get(constants.FX_FIRSTRUN_V2_CONTEXT);
       assert.equal(authBroker, require('models/auth_brokers/fx-firstrun-v2'));
+      assert.ok(VALID_TYPE.test(authBroker.prototype.type));
     });
 
     it('get returns correct broker for ios-v1 context', () => {
       const authBroker = index.get(constants.FX_IOS_V1_CONTEXT);
       assert.equal(authBroker, require('models/auth_brokers/fx-ios-v1'));
+      assert.ok(VALID_TYPE.test(authBroker.prototype.type));
     });
 
     it('get returns correct broker for oauth context', () => {
       const authBroker = index.get(constants.OAUTH_CONTEXT);
       assert.equal(authBroker, require('models/auth_brokers/oauth-redirect'));
+      assert.ok(VALID_TYPE.test(authBroker.prototype.type));
     });
 
     it('get returns correct broker for web context', () => {
       const authBroker = index.get(constants.CONTENT_SERVER_CONTEXT);
       assert.equal(authBroker, require('models/auth_brokers/web'));
+      assert.ok(VALID_TYPE.test(authBroker.prototype.type));
     });
 
     it('get falls back to the web auth broker', () => {


### PR DESCRIPTION
Server validation allows `-`, not `_`. This updates the FxSync
broker's type to be consistent with others and use `-` instead of `_`.

fixes #5066

@philbooth - r?