### PR TITLE
refactor(metrics): Remove `viewToId` and helpers.testIsViewLogged

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -485,7 +485,9 @@ define(function (require, exports, module) {
      * @param {String} viewName
      */
     logView (viewName) {
-      this.logEvent(this.viewToId(viewName));
+      // `screen.` is a legacy artifact from when each View was a screen.
+      // The identifier is kept to avoid updating all metrics queries.
+      this.logEvent(`screen.${viewName}`);
     },
 
     /**
@@ -495,25 +497,9 @@ define(function (require, exports, module) {
      * @param {String} eventName
      */
     logViewEvent (viewName, eventName) {
-      var event = Strings.interpolate('%(viewName)s.%(eventName)s', {
-        eventName: eventName,
-        viewName: viewName,
-      });
-
-      this.logEvent(event);
+      this.logEvent(`${viewName}.${eventName}`);
     },
 
-    /**
-     * Convert a viewName to an identifier used in metrics.
-     *
-     * @param {String} viewName
-     * @return {String} identifier
-     */
-    viewToId (viewName) {
-      // `screen.` is a legacy artifact from when each View was a screen.
-      // The idenifier is kept to avoid updating all metrics queries.
-      return 'screen.' + viewName;
-    },
     /**
      * Log when an experiment is shown to the user
      *

--- a/app/tests/lib/helpers.js
+++ b/app/tests/lib/helpers.js
@@ -133,11 +133,6 @@ define(function (require, exports, module) {
     return isEventLogged(metrics, eventName);
   }
 
-  function isViewLogged(metrics, viewName) {
-    var eventName = metrics.viewToId(viewName);
-    return isEventLogged(metrics, eventName);
-  }
-
   function toSearchString(obj) {
     var searchString = '?';
     var pairs = [];
@@ -174,7 +169,6 @@ define(function (require, exports, module) {
     indexOfEvent: indexOfEvent,
     isErrorLogged: isErrorLogged,
     isEventLogged: isEventLogged,
-    isViewLogged: isViewLogged,
     removeFxaClientSpy: removeFxaClientSpy,
     requiresFocus: requiresFocus,
     stubbedProfileClient: stubbedProfileClient,

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -678,7 +678,8 @@ define(function (require, exports, module) {
     describe('logView', function () {
       it('logs the screen', function () {
         metrics.logView('signup');
-        assert.isTrue(TestHelpers.isViewLogged(metrics, 'signup'));
+
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen.signup'));
       });
     });
 


### PR DESCRIPTION
They were only used in one place and didn't provide much value.

Done while working on #5026

@mozilla/fxa-devs - r?