### PR TITLE
fix(devices): Add the 1800 ms artificial delay when clicking `Refresh`

### DIFF
--- a/app/scripts/views/decorators/progress_indicator.js
+++ b/app/scripts/views/decorators/progress_indicator.js
@@ -28,7 +28,8 @@ define(function (require, exports, module) {
   function showProgressIndicator(handler, el = 'button[type=submit]', delayHandlerByMills = 0) {
     return function (...args) {
       const target = this.$(el);
-      const minProgressIndicatorMs = parseInt(target.data('minProgressIndicatorMs') || 0, 10);
+      const RADIX = 10;
+      const minProgressIndicatorMs = parseInt(target.data('minProgressIndicatorMs') || 0, RADIX);
 
       const progressIndicator = getProgressIndicator(this, target);
       progressIndicator.start(target);

--- a/app/scripts/views/decorators/progress_indicator.js
+++ b/app/scripts/views/decorators/progress_indicator.js
@@ -25,26 +25,32 @@ define(function (require, exports, module) {
     return deferred.promise;
   }
 
-  function showProgressIndicator(handler, _el, delayMills) {
-    var el = _el || 'button[type=submit]';
-    const delayHandlerByMills = delayMills || 0;
+  function showProgressIndicator(handler, el = 'button[type=submit]', delayHandlerByMills = 0) {
+    return function (...args) {
+      const target = this.$(el);
+      const minProgressIndicatorMs = parseInt(target.data('minProgressIndicatorMs') || 0, 10);
 
-    return function () {
-      var args = arguments;
-      var target = this.$(el);
-
-      var progressIndicator = getProgressIndicator(this, target);
+      const progressIndicator = getProgressIndicator(this, target);
       progressIndicator.start(target);
 
+      const startTime = Date.now();
       return delay(progressIndicator, delayHandlerByMills)
         .then(() => this.invokeHandler(handler, args))
-        .then(function (value) {
-          // Stop the progress indicator unless the flow halts.
-          if (! (value && value.halt)) {
-            progressIndicator.done();
-          }
-          return value;
-        }, function (err) {
+        .then((value) => {
+          // calculate the artificial delay time, if one is set.
+          // If the handler took longer than the artificial delay,
+          // or if no artificial delay is set, the extra delay is 0.
+          const diff = Date.now() - startTime;
+          const extraDelayTimeMS = Math.max(minProgressIndicatorMs - diff, 0);
+          return delay(progressIndicator, extraDelayTimeMS)
+            .then(() => {
+              // Stop the progress indicator unless the flow halts.
+              if (! (value && value.halt)) {
+                progressIndicator.done();
+              }
+              return value;
+            });
+        }, (err) => {
           progressIndicator.done();
           throw err;
         });

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -229,7 +229,8 @@ define(function (require, exports, module) {
 
           // all good, do the beforeSubmit, submit, and afterSubmit chain.
           this.logViewEvent('submit');
-          return this._submitForm();
+          return this._submitForm()
+            .then(() => this.afterSubmit());
         });
     }),
 
@@ -246,8 +247,7 @@ define(function (require, exports, module) {
           // display error and surface for testing.
           this.displayError(err);
           throw err;
-        })
-        .then(_.bind(this.afterSubmit, this));
+        });
     })),
 
     /**

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -19,7 +19,9 @@ define(function (require, exports, module) {
   const Template = require('stache!templates/settings/clients');
   const UserAgentMixin = require('views/mixins/user-agent-mixin');
 
+  const MIN_REFRESH_INDICATOR_MS = 1800;
   const DEVICE_REMOVED_ANIMATION_MS = 150;
+
   const UTM_PARAMS = '?utm_source=accounts.firefox.com&utm_medium=referral&utm_campaign=fxa-devices';
   const DEVICES_SUPPORT_URL = 'https://support.mozilla.org/kb/fxa-managing-devices' + UTM_PARAMS;
   const FIREFOX_ANDROID_DOWNLOAD_LINK = Strings.interpolate(Constants.DOWNLOAD_LINK_TEMPLATE_ANDROID, {
@@ -31,7 +33,8 @@ define(function (require, exports, module) {
     creative: 'button'
   });
 
-  var View = FormView.extend({
+  const proto = FormView.prototype;
+  const View = FormView.extend({
     template: Template,
     className: 'clients',
     viewName: 'settings.clients',
@@ -46,7 +49,6 @@ define(function (require, exports, module) {
         });
       }
 
-      this.listenTo(this._attachedClients, 'add', this._onItemAdded);
       this.listenTo(this._attachedClients, 'remove', this._onItemRemoved);
     },
 
@@ -98,8 +100,10 @@ define(function (require, exports, module) {
 
     events: {
       'click .client-disconnect': preventDefaultThen('_onDisconnectClient'),
+      'click .clients-refresh': 'startRefresh',
       'click [data-get-app]': '_onGetApp'
     },
+
 
     /**
      * Determine if the clients list should show Web Sessions
@@ -132,10 +136,6 @@ define(function (require, exports, module) {
       return ! _.some(clients, function (client) {
         return client.type === 'mobile' || client.type === 'tablet';
       });
-    },
-
-    _onItemAdded () {
-      this.render();
     },
 
     _onItemRemoved (item) {
@@ -178,7 +178,7 @@ define(function (require, exports, module) {
     openPanel () {
       this.logViewEvent('open');
       // manually submit using an element to trigger the progress indicator mixin
-      this.$el.find('.clients-refresh').trigger('submit');
+      return this.validateAndSubmit();
     },
 
     _fetchAttachedClients () {
@@ -202,17 +202,33 @@ define(function (require, exports, module) {
       });
     },
 
+    startRefresh () {
+      // only add the artificial delay once the user clicks refresh. This
+      // allows the initial load/render to occur as fast as the server
+      // can respond.
+      this.$('.clients-refresh').data('minProgressIndicatorMs', MIN_REFRESH_INDICATOR_MS);
+      this.logViewEvent('refresh');
+      // the actual refresh is done by `submit`.
+    },
+
     submit () {
       if (this.isPanelOpen()) {
-        this.logViewEvent('refresh');
         // only refresh devices if panel is visible
-        // if panel is hidden there is no point of fetching devices
-        return this._fetchAttachedClients().then(() => {
-          this.render();
-        });
+        // if panel is hidden there is no point of fetching devices.
+        // The re-render is done in afterSubmit to ensure
+        // the minimum artifical delay time is honored before
+        // re-rendering.
+        return this._fetchAttachedClients();
       }
-    }
+    },
 
+    afterSubmit () {
+      // afterSubmit is called after the artificial delay has
+      // expired in the progress indicator decorator. re-render
+      // once the progress indicator has gone away.
+      return proto.afterSubmit.call(this)
+        .then(() => this.render());
+    }
   });
 
   Cocktail.mixin(

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -19,7 +19,7 @@ define(function (require, exports, module) {
   const Template = require('stache!templates/settings/clients');
   const UserAgentMixin = require('views/mixins/user-agent-mixin');
 
-  const MIN_REFRESH_INDICATOR_MS = 1800;
+  const MIN_REFRESH_INDICATOR_MS = 1600;
   const DEVICE_REMOVED_ANIMATION_MS = 150;
 
   const UTM_PARAMS = '?utm_source=accounts.firefox.com&utm_medium=referral&utm_campaign=fxa-devices';
@@ -103,7 +103,6 @@ define(function (require, exports, module) {
       'click .clients-refresh': 'startRefresh',
       'click [data-get-app]': '_onGetApp'
     },
-
 
     /**
      * Determine if the clients list should show Web Sessions

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -19,7 +19,6 @@ define(function (require, exports, module) {
   const Template = require('stache!templates/settings/clients');
   const UserAgentMixin = require('views/mixins/user-agent-mixin');
 
-  const MIN_REFRESH_INDICATOR_MS = 1600;
   const DEVICE_REMOVED_ANIMATION_MS = 150;
 
   const UTM_PARAMS = '?utm_source=accounts.firefox.com&utm_medium=referral&utm_campaign=fxa-devices';
@@ -205,7 +204,7 @@ define(function (require, exports, module) {
       // only add the artificial delay once the user clicks refresh. This
       // allows the initial load/render to occur as fast as the server
       // can respond.
-      this.$('.clients-refresh').data('minProgressIndicatorMs', MIN_REFRESH_INDICATOR_MS);
+      this.$('.clients-refresh').data('minProgressIndicatorMs', View.MIN_REFRESH_INDICATOR_MS);
       this.logViewEvent('refresh');
       // the actual refresh is done by `submit`.
     },
@@ -228,6 +227,8 @@ define(function (require, exports, module) {
       return proto.afterSubmit.call(this)
         .then(() => this.render());
     }
+  }, {
+    MIN_REFRESH_INDICATOR_MS: 1600
   });
 
   Cocktail.mixin(

--- a/app/tests/spec/views/settings/clients.js
+++ b/app/tests/spec/views/settings/clients.js
@@ -406,7 +406,7 @@ define(function (require, exports, module) {
 
         view.startRefresh();
 
-        assert.equal(view.$('.clients-refresh').data('minProgressIndicatorMs'), 1800);
+        assert.equal(view.$('.clients-refresh').data('minProgressIndicatorMs'), View.MIN_REFRESH_INDICATOR_MS);
         assert.isTrue(view.logViewEvent.calledOnce);
         assert.isTrue(view.logViewEvent.calledWith('refresh'));
       });

--- a/app/tests/spec/views/settings/clients.js
+++ b/app/tests/spec/views/settings/clients.js
@@ -22,20 +22,21 @@ define(function (require, exports, module) {
   const View = require('views/settings/clients');
   const WindowMock = require('../../../mocks/window');
 
-  describe('views/settings/clients', function () {
-    var able;
-    var account;
-    var attachedClients;
-    var broker;
-    var email;
-    var metrics;
-    var notifier;
-    var parentView;
-    var translator;
-    var UID = '123';
-    var user;
-    var view;
-    var windowMock;
+  describe('views/settings/clients', () => {
+    let able;
+    let account;
+    let attachedClients;
+    let broker;
+    let email;
+    let metrics;
+    let notifier;
+    let parentView;
+    let translator;
+    let user;
+    let view;
+    let windowMock;
+
+    const UID = '123';
 
     function initView () {
       view = new View({
@@ -55,7 +56,7 @@ define(function (require, exports, module) {
 
     function setupReRenderTest(testAction) {
       return initView()
-        .then(function () {
+        .then(() => {
           var deferred = p.defer();
 
           view.on('rendered', deferred.resolve.bind(deferred));
@@ -68,9 +69,9 @@ define(function (require, exports, module) {
         });
     }
 
-    beforeEach(function () {
+    beforeEach(() => {
       able = new Able();
-      sinon.stub(able, 'choose', function () {
+      sinon.stub(able, 'choose', () => {
         return true;
       });
       broker = new BaseBroker();
@@ -89,7 +90,7 @@ define(function (require, exports, module) {
         verified: true
       });
 
-      sinon.stub(account, 'isSignedIn', function () {
+      sinon.stub(account, 'isSignedIn', () => {
         return p(true);
       });
 
@@ -130,7 +131,10 @@ define(function (require, exports, module) {
       });
     });
 
-    afterEach(function () {
+    afterEach(() => {
+      metrics.destroy();
+      metrics = null;
+
       if ($.prototype.trigger.restore) {
         $.prototype.trigger.restore();
       }
@@ -140,8 +144,8 @@ define(function (require, exports, module) {
       view = null;
     });
 
-    describe('constructor', function () {
-      beforeEach(function () {
+    describe('constructor', () => {
+      beforeEach(() => {
         view = new View({
           notifier: notifier,
           parentView: parentView,
@@ -149,37 +153,37 @@ define(function (require, exports, module) {
         });
       });
 
-      it('creates an `AttachedClients` instance if one not passed in', function () {
+      it('creates an `AttachedClients` instance if one not passed in', () => {
         assert.ok(view._attachedClients);
       });
     });
 
-    describe('render', function () {
-      beforeEach(function () {
+    describe('render', () => {
+      beforeEach(() => {
         sinon.spy(attachedClients, 'fetch');
 
         return initView();
       });
 
-      it('does not fetch the device list immediately to avoid startup XHR requests', function () {
+      it('does not fetch the device list immediately to avoid startup XHR requests', () => {
         assert.isFalse(attachedClients.fetch.called);
       });
 
-      it('renders attachedClients already in the collection', function () {
+      it('renders attachedClients already in the collection', () => {
         assert.ok(view.$('li.client').length, 2);
       });
 
-      it('title attribute is added', function () {
+      it('title attribute is added', () => {
         assert.equal(view.$('#app-1 .client-name').attr('title'), '123Done');
         assert.equal(view.$('#app-2 .client-name').attr('title'), 'Pocket - profile,profile:write');
       });
 
-      it('renders attachedClients and apps', function () {
+      it('renders attachedClients and apps', () => {
         assert.equal(view.$('#clients .settings-unit-title').text().trim(), 'Devices & apps');
         assert.ok(view.$('#clients').text().trim().indexOf('manage your attachedClients and apps below'));
       });
 
-      it('properly sets the type of devices', function () {
+      it('properly sets the type of devices', () => {
         assert.ok(view.$('#device-1').hasClass('tablet'));
         assert.notOk(view.$('#device-1').hasClass('desktop'));
         assert.equal(view.$('#device-1').data('os'), 'Windows');
@@ -189,7 +193,7 @@ define(function (require, exports, module) {
         assert.equal($('#container [data-get-app]').length, 0, '0 mobile app placeholders');
       });
 
-      it('properly sets the type of apps', function () {
+      it('properly sets the type of apps', () => {
         attachedClients = new AttachedClients([
           {
             clientType: 'oAuthApp',
@@ -217,7 +221,7 @@ define(function (require, exports, module) {
         });
 
         return initView()
-          .then(function () {
+          .then(() => {
             $('#container').html(view.el);
             assert.ok(view.$('#app-1').hasClass('client-oAuthApp'));
             assert.notOk(view.$('#app-1').hasClass('desktop'));
@@ -232,7 +236,7 @@ define(function (require, exports, module) {
 
       });
 
-      it('app placeholders for mobile if there are no mobile clients', function () {
+      it('app placeholders for mobile if there are no mobile clients', () => {
         attachedClients = new AttachedClients([
           {
             clientType: 'device',
@@ -246,13 +250,13 @@ define(function (require, exports, module) {
         });
 
         return initView()
-          .then(function () {
+          .then(() => {
             $('#container').html(view.el);
             assert.equal($('#container [data-get-app]').length, 2, '2 mobile app placeholders');
           });
       });
 
-      it('no app placeholders if there is a tablet device', function () {
+      it('no app placeholders if there is a tablet device', () => {
         attachedClients = new AttachedClients([
           {
             clientType: 'device',
@@ -266,13 +270,13 @@ define(function (require, exports, module) {
         });
 
         return initView()
-          .then(function () {
+          .then(() => {
             $('#container').html(view.el);
             assert.equal($('#container [data-get-app]').length, 0, 'no mobile app placeholders');
           });
       });
 
-      it('names devices "Firefox" if there is no name', function () {
+      it('names devices "Firefox" if there is no name', () => {
         attachedClients = new AttachedClients([
           {
             clientType: 'device',
@@ -285,72 +289,51 @@ define(function (require, exports, module) {
         });
 
         return initView()
-          .then(function () {
+          .then(() => {
             $('#container').html(view.el);
             assert.equal($('#container #device-1 .client-name').text().trim(), 'Firefox', 'device name is Firefox');
           });
 
       });
-
     });
 
-    describe('device added to collection', function () {
-      beforeEach(function () {
-        return setupReRenderTest(function () {
-          attachedClients.add({
-            clientType: 'device',
-            id: 'device-3',
-            lastAccessTime: Date.now(),
-            lastAccessTimeFormatted: 'a few seconds ago',
-            name: 'delta',
-            type: 'desktop'
-          });
-        });
-      });
-
-      it('adds new device to list', function () {
-        assert.lengthOf(view.$('li.client-device'), 3);
-        assert.include(view.$('#device-3 .client-name').text().trim(), 'delta');
-        assert.include(view.$('#device-3 .client-name').attr('title'), 'delta', 'the title attr is correct');
-        assert.isTrue(view.$('#device-3 .last-connected').text().trim().indexOf('started syncing a few seconds ago') >= 0, 'formats connected date');
-        assert.ok(view.$('#device-3').hasClass('desktop'));
-      });
-    });
-
-    describe('device removed from collection', function () {
-      beforeEach(function () {
-        return setupReRenderTest(function () {
+    describe('device removed from collection', () => {
+      beforeEach(() => {
+        return setupReRenderTest(() => {
           // DOM needs to be written so that device remove animation completes
           $('#container').html(view.el);
           attachedClients.get('device-1').destroy();
         });
       });
 
-      it('removes device from list', function () {
+      it('removes device from list', () => {
         assert.lengthOf(view.$('li.client-device'), 1);
         assert.lengthOf(view.$('#device-2'), 1);
       });
     });
 
-    describe('openPanel', function () {
-      beforeEach(function () {
+    describe('openPanel', () => {
+      beforeEach(() => {
         return initView()
-          .then(function () {
+          .then(() => {
             sinon.spy($.prototype, 'trigger');
+            sinon.stub(view, '_fetchAttachedClients', () => p());
+            view.$('.clients-refresh').data('minProgressIndicatorMs', 0);
             return view.openPanel();
           });
       });
 
-      it('fetches the device list', function () {
+      it('fetches the device list', () => {
         assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.clients.open'));
-        assert.isTrue($.prototype.trigger.called, 'calls form submit of the ForView');
+        assert.isFalse(TestHelpers.isEventLogged(metrics, 'settings.clients.refresh'));
+        assert.isTrue(view._fetchAttachedClients.calledOnce);
       });
     });
 
-    describe('click to disconnect device', function () {
-      beforeEach(function () {
+    describe('click to disconnect device', () => {
+      beforeEach(() => {
         return initView()
-          .then(function () {
+          .then(() => {
             // click events require the view to be in the DOM
             $('#container').html(view.el);
 
@@ -360,7 +343,7 @@ define(function (require, exports, module) {
           });
       });
 
-      it('navigates to confirmation dialog', function () {
+      it('navigates to confirmation dialog', () => {
         assert.isTrue(view.navigate.calledOnce);
         var args = view.navigate.args[0];
         assert.equal(args.length, 2);
@@ -370,52 +353,67 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('refresh list behaviour', function () {
-      beforeEach(function () {
+    describe('refresh list behaviour', () => {
+      beforeEach(() => {
         return initView()
-          .then(function () {
+          .then(() => {
             // click events require the view to be in the DOM
             $('#container').html(view.el);
           });
       });
 
-      it('calls `render` when refreshed', function (done) {
-        sinon.spy(view, 'render');
-        sinon.stub(view, 'isPanelOpen', function () {
-          return true;
-        });
+      it('calls `validateAndSubmit` on `clients-refresh` click, starts the refresh', () => {
+        sinon.spy(view, 'startRefresh');
+        sinon.stub(view, 'validateAndSubmit', () => p());
 
-        sinon.stub(view, '_fetchAttachedClients', function () {
-          return p();
-        });
+        view.$('.clients-refresh').click();
 
-        $('.clients-refresh').click();
-        setTimeout(function () {
-          // render delayed by device request promises
-          assert.isTrue(view.render.called);
-          view.render.restore();
-          done();
-        }, 150);
+        assert.isTrue(view.startRefresh.calledOnce);
+        assert.isTrue(view.validateAndSubmit.calledOnce);
       });
-
-      it('calls `_fetchAttachedClients` using a button', function () {
-        sinon.spy($.prototype, 'trigger');
-        sinon.stub(view, 'isPanelOpen', function () {
-          return true;
-        });
-
-        sinon.stub(view, 'submit', function () {
-          return p();
-        });
-
-        $('.clients-refresh').click();
-        assert.isTrue($.prototype.trigger.called, 'calls form submit of the ForView');
-      });
-
     });
 
-    describe('_onGetApp', function () {
-      it('logs get event', function () {
+    describe('validateAndSubmit (refresh)', () => {
+      beforeEach(() => {
+        return initView()
+          .then(() => {
+            view.$('.clients-refresh').data('minProgressIndicatorMs', '1');
+          });
+      });
+
+      it('calls `_fetchAttachedClients`, refreshes', () => {
+        sinon.stub(view, 'isPanelOpen', () => true);
+        sinon.stub(view, '_fetchAttachedClients', () => p());
+        sinon.stub(view, 'render', () => p());
+
+        return view.validateAndSubmit()
+          .then(() => {
+            assert.isTrue(view._fetchAttachedClients.calledOnce);
+            assert.isTrue(view.render.calledOnce);
+          });
+      });
+    });
+
+    describe('startRefresh', () => {
+      beforeEach(() => {
+        return initView();
+      });
+
+      it('initializes the progress indicator and logs the refresh', () => {
+        sinon.spy(view, 'logViewEvent');
+
+        assert.isUndefined(view.$('.clients-refresh').data('minProgressIndicatorMs'));
+
+        view.startRefresh();
+
+        assert.equal(view.$('.clients-refresh').data('minProgressIndicatorMs'), 1800);
+        assert.isTrue(view.logViewEvent.calledOnce);
+        assert.isTrue(view.logViewEvent.calledWith('refresh'));
+      });
+    });
+
+    describe('_onGetApp', () => {
+      it('logs get event', () => {
         attachedClients = new AttachedClients([
           {
             clientType: 'device',
@@ -440,36 +438,36 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('_fetchAttachedClients', function () {
-      beforeEach(function () {
-        sinon.stub(user, 'fetchAccountSessions', function () {
+    describe('_fetchAttachedClients', () => {
+      beforeEach(() => {
+        sinon.stub(user, 'fetchAccountSessions', () => {
           return p();
         });
 
-        sinon.stub(user, 'fetchAccountOAuthApps', function () {
+        sinon.stub(user, 'fetchAccountOAuthApps', () => {
           return p();
         });
 
         return initView()
-          .then(function () {
+          .then(() => {
             return view._fetchAttachedClients();
           });
       });
 
-      it('delegates to the user to fetch the device list', function () {
+      it('delegates to the user to fetch the device list', () => {
         var account = view.getSignedInAccount();
         assert.isTrue(user.fetchAccountSessions.calledWith(account));
         assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.clients.items.zero'));
       });
 
-      it('logs the number of clients', function () {
+      it('logs the number of clients', () => {
         function createAttachedClientView(numOfClients) {
           return initView()
             .then(() => {
               if (view._attachedClients.fetchClients.restore) {
                 view._attachedClients.fetchClients.restore();
               }
-              sinon.stub(view._attachedClients, 'fetchClients', function () {
+              sinon.stub(view._attachedClients, 'fetchClients', () => {
                 view._attachedClients.length = numOfClients;
                 return p();
               });
@@ -497,8 +495,8 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('_formatAccessTimeAndScope', function () {
-      it('translates the last active string', function () {
+    describe('_formatAccessTimeAndScope', () => {
+      it('translates the last active string', () => {
         return initView()
           .then(() => {
             view.translator = {
@@ -524,7 +522,7 @@ define(function (require, exports, module) {
           });
       });
 
-      it('properly sets the title according to scope', function () {
+      it('properly sets the title according to scope', () => {
         return initView()
           .then(() => {
             $('#container').html(view.el);

--- a/tests/functional/settings_clients.js
+++ b/tests/functional/settings_clients.js
@@ -9,30 +9,34 @@ define([
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
 
-  var config = intern.config;
-  var SIGNIN_URL = config.fxaContentRoot + 'signin';
+  const config = intern.config;
+  const SIGNIN_URL = config.fxaContentRoot + 'signin';
 
-  var FIRST_PASSWORD = 'password';
-  var BROWSER_DEVICE_NAME = 'Browser Session Device';
-  var BROWSER_DEVICE_TYPE = 'desktop';
-  var TEST_DEVICE_NAME = 'Test Runner Session Device';
-  var TEST_DEVICE_NAME_UPDATED = 'Test Runner Session Device Updated';
-  var TEST_DEVICE_TYPE = 'mobile';
+  const FIRST_PASSWORD = 'password';
+  const BROWSER_DEVICE_NAME = 'Browser Session Device';
+  const BROWSER_DEVICE_TYPE = 'desktop';
+  const TEST_DEVICE_NAME = 'Test Runner Session Device';
+  const TEST_DEVICE_NAME_UPDATED = 'Test Runner Session Device Updated';
+  const TEST_DEVICE_TYPE = 'mobile';
+
+  const SELECTOR_REFRESH = '.clients-refresh';
+  const SELECTOR_REFRESHING = '.clients-refresh.disabled';
+
   var email;
   var client;
   var accountData;
 
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var click = FunctionalHelpers.click;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var noSuchElement = FunctionalHelpers.noSuchElement;
-  var noSuchStoredAccountByEmail = FunctionalHelpers.noSuchStoredAccountByEmail;
-  var openPage = FunctionalHelpers.openPage;
-  var pollUntil = FunctionalHelpers.pollUntil;
-  var pollUntilGoneByQSA = FunctionalHelpers.pollUntilGoneByQSA;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testElementTextEquals = FunctionalHelpers.testElementTextEquals;
+  const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const click = FunctionalHelpers.click;
+  const createUser = FunctionalHelpers.createUser;
+  const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
+  const noSuchElement = FunctionalHelpers.noSuchElement;
+  const noSuchStoredAccountByEmail = FunctionalHelpers.noSuchStoredAccountByEmail;
+  const openPage = FunctionalHelpers.openPage;
+  const pollUntil = FunctionalHelpers.pollUntil;
+  const pollUntilGoneByQSA = FunctionalHelpers.pollUntilGoneByQSA;
+  const testElementExists = FunctionalHelpers.testElementExists;
+  const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
 
   registerSuite({
     name: 'settings clients',
@@ -84,7 +88,9 @@ define([
         .waitForDeletedByCssSelector('.client-webSession:nth-child(2)')
         .end()
 
-        .then(click('.clients-refresh'))
+        .then(click(SELECTOR_REFRESH))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
+
         // second session is gone.
         .then(noSuchElement('.client-webSession:nth-child(2)'))
 
@@ -120,9 +126,10 @@ define([
         })
 
         // on a slow connection we wait until early refresh stops first
-        .then(pollUntilGoneByQSA('.clients-refresh.disabled'))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
 
-        .then(click('.clients-refresh'))
+        .then(click(SELECTOR_REFRESH))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
 
         .then(testElementTextEquals(
           '.client-device .client-name', TEST_DEVICE_NAME
@@ -142,7 +149,8 @@ define([
           );
         })
 
-        .then(click('.clients-refresh'))
+        .then(click(SELECTOR_REFRESH))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
 
         // wait for 2 devices
         .then(testElementExists('.client-device:nth-child(2)'))
@@ -169,7 +177,8 @@ define([
         ))
 
         // external update should show in the device list
-        .then(click('.clients-refresh'))
+        .then(click(SELECTOR_REFRESH))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
 
         // external text change is hard to track, use pollUntil
         .then(pollUntil(function (newName) {
@@ -206,7 +215,9 @@ define([
         .waitForDeletedByCssSelector('.client-device:nth-child(2)')
         .end()
 
-        .then(click('.clients-refresh'))
+        .then(click(SELECTOR_REFRESH))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
+
         // second device is still gone.
         .then(noSuchElement('.client-device:nth-child(2)'))
         .then(click('.client-device:nth-child(1) .client-disconnect'))


### PR DESCRIPTION
Done by having the progress indicator decorator look on the target element
for a `data-min-progress-indicator-ms` attribute. If it exists, wait for
the time to elapse before completing the submit action.

Use this in the "settings clients" functional tests to ensure the refresh
has completed to continue with the tests.

fixes #4570
fixes #5071 

@vbudhram, @philbooth - mind an r?