### PR TITLE
fix(tests): pull entrained sub-resources in all locales (tests/server/l10n-entrained.js)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   },
   "devDependencies": {
     "coveralls": "2.11.9",
+    "css": "2.2.1",
     "eslint-plugin-fxa": "git://github.com/mozilla/eslint-plugin-fxa.git#41504c9dd30e8b52900c15b524946aa0428aef95",
     "eslint-plugin-sorting": "git://github.com/shane-tomlinson/eslint-plugin-sorting.git#bcacb99d",
     "firefox-profile": "0.3.12",

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -11,6 +11,7 @@ define([
   intern.functionalSuites = [];
   intern.suites = [
     'tests/server/routes',
+    'tests/server/l10n-entrained',
     'tests/server/ver.json.js',
     'tests/server/csp',
     'tests/server/flow-event',

--- a/tests/intern_server_resources.js
+++ b/tests/intern_server_resources.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  './intern'
+], function (intern) {
+  intern.capabilities = {};
+  intern.webdriver = {};
+  intern.environments = [];
+  intern.functionalSuites = [];
+  intern.suites = [
+    'tests/server/l10n-entrained',
+  ];
+
+  return intern;
+});

--- a/tests/server/helpers/routesHelpers.js
+++ b/tests/server/helpers/routesHelpers.js
@@ -1,0 +1,346 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../../server/lib/configuration',
+  'intern/dojo/node!crypto',
+  'intern/dojo/node!css',
+  'intern/dojo/node!extend',
+  'intern/dojo/node!got',
+  'intern/dojo/node!htmlparser2',
+  'intern/dojo/node!path',
+  'intern/dojo/node!url',
+  'intern/browser_modules/dojo/Promise'
+], function (intern,
+             registerSuite,
+             assert,
+             config,
+             crypto,
+             css,
+             extend,
+             got,
+             htmlparser2,
+             path,
+             url,
+             Promise) {
+
+  // keep a cache of checked URLs to avoid duplicate tests and
+  // speed up the tests.
+  var checkedUrlPromises = {};
+
+  var httpUrl, httpsUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
+  if (intern.config.fxaProduction) {
+    assert.equal(0, httpsUrl.indexOf('https://'), 'uses https scheme');
+    httpUrl = httpsUrl.replace('https://', 'http://');
+  } else {
+    httpUrl = httpsUrl.replace(config.get('port'), config.get('http_port'));
+  }
+
+  function computeSri(algorithm, data) {
+    if ([ 'sha256', 'sha384', 'sha512' ].indexOf(algorithm) === -1) {
+      throw new Error('Unsupported hash algorithm ' + algorithm);
+    }
+
+    const sri = crypto.createHash(algorithm)
+      .update(data, 'utf8')
+      .digest('base64');
+
+    return algorithm + '-' + sri;
+  }
+
+  function isProductionLike() {
+    return intern.config.fxaProduction && intern.config.fxaDevBox;
+  }
+
+  function makeRequest(url, requestOptions) {
+    return got(url, requestOptions)
+      .catch(function (err) {
+        return err.response;
+      });
+  }
+
+  function checkHeaders(routes, route, res) {
+    var headers = res.headers;
+
+    if (headers['content-type'].indexOf('text/html') > -1) {
+      // all HTML pages by default have x-frame-options: DENY
+      assert.equal(headers['x-frame-options'], 'DENY');
+      assert.equal(headers['x-robots-tag'], 'noindex,nofollow');
+
+      if (routes[route].csp !== false) {
+        assert.ok(headers.hasOwnProperty('content-security-policy'));
+      }
+    }
+
+    assert.equal(headers['x-content-type-options'], 'nosniff');
+    assert.include(headers['strict-transport-security'], 'max-age=');
+  }
+
+  /**
+   * Go through each of the HTML files, look for URLs, check that
+   * each URL exists, responds with a 200, and in the case of JS, CSS
+   * and fonts, that the correct CORS headers are set.
+   */
+  function extractAndCheckUrls(res) {
+    var href = url.parse(res.url);
+    var origin = [ href.protocol, '//', href.host ].join('');
+    return extractUrls(res.body)
+      .then(checkUrls.bind(null, origin));
+  }
+
+  function extractUrls(body) {
+    return new Promise(function (resolve, reject) {
+      var dependencyResources = [];
+      var comments = [];
+      var parser;
+
+      var handlers = {
+        onopentag: function onopentag(tagname, attribs) {
+          if ([ 'script', 'link', 'a' ].indexOf(tagname) === -1) {
+            return;
+          }
+
+          const resource = {
+            integrity: attribs.integrity || null
+          };
+
+          if (tagname === 'script') {
+            resource.url = attribs.src;
+          } else if (tagname === 'link' || tagname === 'a') {
+            resource.url = attribs.href;
+          }
+
+          if (! resource) {
+            return;
+          }
+
+          if (! isAbsoluteUrl(resource.url)) {
+            resource.url = httpsUrl + resource.url;
+          }
+
+          dependencyResources.push(resource);
+        },
+
+        oncomment: function oncomment(text) {
+          comments.push(text);
+        },
+
+        onend: function onend() {
+          // TODO: could scan the accumulated comments for IE-style resource links.
+          resolve(dependencyResources);
+        }
+      };
+
+      const parserOptions = {
+        lowerCaseAttributeNames: true,
+        lowerCaseTags: true
+      };
+
+      parser = new htmlparser2.Parser(handlers, parserOptions);
+
+      parser.write(body);
+      parser.end();
+    });
+  }
+
+  function checkUrls(origin, resources) {
+    findCssSubResources(origin, resources)
+      .then((cssSubResources) => {
+        resources = resources.concat(cssSubResources);
+
+        var requests = resources.map(function (resource) {
+          if (checkedUrlPromises[resource.url]) {
+            return checkedUrlPromises[resource.url];
+          }
+
+          var requestOptions = {};
+          if (doesURLRequireCORS(resource.url)) {
+            requestOptions = {
+              headers: {
+                'Origin': origin
+              }
+            };
+          }
+
+          var promise = makeRequest(resource.url, requestOptions)
+            .then(function (res) {
+              if (/support.mozilla.org/.test(resource.url) || /localhost:35729/.test(resource.url)) {
+                // Do not check support.mozilla.org URLs. Issue #4712
+                // In February 2017 SUMO links started returning 404s to non-browser redirect requests
+                // Also skip the livereload link in the mocha tests
+                return;
+              }
+
+              assert.equal(res.statusCode, 200);
+
+              // If prod-like, Check all CSS and JS (except experiments.bundle.js)
+              // for SRI `integrity=` attribute on the link, and that the checksum
+              // of the returned content matches.
+              if (isProductionLike() && isJsOrCss(resource.url) &&
+                  ! /experiments\.bundle\.js$/.test(resource.url)) {
+                assert.ok(resource.integrity, 'JS/CSS link has SRI integrity attribute');
+                var algorithm = resource.integrity.split('-')[0];
+                var computedSri = computeSri(algorithm, res.body);
+                assert.equal(resource.integrity, computedSri, 'SRI attribute integrity matches downloaded content');
+              }
+
+              var hasCORSHeaders = res.headers.hasOwnProperty('access-control-allow-origin');
+              if (doesURLRequireCORS(resource.url)) {
+                assert.ok(hasCORSHeaders, resource.url + ' should have CORS headers');
+              } else {
+                assert.notOk(hasCORSHeaders, resource.url + ' should not have CORS headers');
+              }
+            });
+
+          checkedUrlPromises[resource.url] = promise;
+
+          return promise;
+        });
+
+        return Promise.all(requests);
+      });
+  }
+
+  function findCssUrlMatches(value, base) {
+    const CSSURL_RE = /url\(\s*['"]?([^)'"]+)['"]?\s*\)/g;
+
+    var urls = {};
+    var match;
+
+    while (match = CSSURL_RE.exec(value)) { // eslint-disable-line no-cond-assign
+      var resolved = url.resolve(base, match[1]);
+      var protocol = url.parse(resolved).protocol;
+      if (protocol.match(/^http/)) {
+        urls[resolved] = 1;
+      }
+    }
+
+    return urls;
+  }
+
+  function parseCssUrls(content, base) {
+    var ast = css.parse(content);
+    var urls = {};
+
+    ast.stylesheet.rules.forEach(function(rule) {
+      if (rule.type === 'font-face' || rule.type === 'rule') {
+        rule.declarations.forEach(function(declaration) {
+          extend(urls, findCssUrlMatches(declaration.value, base));
+        });
+      } else if (rule.type === 'media') {
+        rule.rules.forEach(function(mediaRule) {
+          mediaRule.declarations.forEach(function(declaration) {
+            extend(urls, findCssUrlMatches(declaration.value, base));
+          });
+        });
+      }
+    });
+
+    return Object.keys(urls).sort();
+  }
+
+  function filterCssUrls(resources) {
+    return resources.filter(function (resource) {
+      var parsedUri = url.parse(resource.url);
+      var extension = path.extname(parsedUri.pathname);
+      if (extension === '.css') {
+        return resource.url;
+      }
+    });
+  }
+
+  function findCssSubResources(origin, resources) {
+    // For urls with extension `.css`, find the font and image resources
+    // entrained from CSS.
+    var cssResources = filterCssUrls(resources);
+
+    var requests = cssResources.map(function (resource) {
+      if (checkedUrlPromises[resource.url]) {
+        return checkedUrlPromises[resource.url];
+      }
+
+      var requestOptions = {
+        headers: {
+          Accept: 'text/css,*/*;q=0.1'
+        }
+      };
+
+      if (doesURLRequireCORS(resource.url)) {
+        requestOptions.headers.Origin = origin;
+      }
+
+      var promise = makeRequest(resource.url, requestOptions)
+        .then(function (res) {
+          // Only a minimal check here. The resolved Promise response will be
+          // checked in detail again in `checkUrls()`.
+          assert.equal(res.statusCode, 200);
+
+          return parseCssUrls(res.body, resource.url);
+        });
+
+      checkedUrlPromises[resource.url] = promise;
+
+      return promise;
+    });
+
+    return Promise.all(requests)
+      .then(function (resources) {
+        // convert the return value to a flattened list of resource objects
+        var flattened = [].concat.apply([], resources);
+        return flattened.map((url) => {
+          return {
+            url: url
+          };
+        });
+      });
+  }
+
+  function isAbsoluteUrl(url) {
+    return /^http/.test(url);
+  }
+
+  function doesURLRequireCORS(url) {
+    return isExternalUrl(url) && doesExtensionRequireCORS(url);
+  }
+
+  function isContentServerUrl(url) {
+    return url.indexOf(httpsUrl) === 0 ||
+           url.indexOf(httpUrl) === 0;
+  }
+
+  function isExternalUrl(url) {
+    return ! isContentServerUrl(url);
+  }
+
+  function doesExtensionRequireCORS(uri) {
+    var parsedUri = url.parse(uri);
+    var extension = path.extname(parsedUri.pathname);
+    return /^\.(js|css|woff|woff2|eot|ttf)$/.test(extension);
+  }
+
+  function isJs(uri) {
+    var parsedUri = url.parse(uri);
+    var extension = path.extname(parsedUri.pathname);
+    return extension === '.js';
+  }
+
+  function isCss(uri) {
+    var parsedUri = url.parse(uri);
+    var extension = path.extname(parsedUri.pathname);
+    return extension === '.css';
+  }
+
+  function isJsOrCss(url) {
+    return isJs(url) || isCss(url);
+  }
+
+  return {
+    checkHeaders: checkHeaders,
+    extractAndCheckUrls: extractAndCheckUrls,
+    makeRequest: makeRequest
+  };
+});

--- a/tests/server/l10n-entrained.js
+++ b/tests/server/l10n-entrained.js
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!../../server/lib/configuration',
+  'intern/dojo/node!../../server/lib/csp',
+  'intern/dojo/node!htmlparser2',
+  'intern/dojo/node!got',
+  'intern/dojo/node!url',
+  'intern/browser_modules/dojo/Promise',
+  'tests/server/helpers/routesHelpers',
+  'intern/dojo/node!fxa-shared'
+], function (intern, registerSuite, assert, config, csp,
+  htmlparser2, got, url, Promise, routesHelpers, fxaShared) {
+
+  var checkHeaders = routesHelpers.checkHeaders;
+  var extractAndCheckUrls = routesHelpers.extractAndCheckUrls;
+  var makeRequest = routesHelpers.makeRequest;
+
+  var languages = fxaShared.l10n.supportedLanguages;
+  var httpsUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
+
+  if (intern.config.fxaProduction) {
+    assert.equal(0, httpsUrl.indexOf('https://'), 'uses https scheme');
+  }
+
+  var suite = {
+    name: 'check resources entrained by /signin in all locales'
+  };
+
+  var routes = {
+    '/signin': { statusCode: 200 }
+  };
+
+  Object.keys(routes).forEach(function (key) {
+    languages.forEach(function (lang) {
+      var requestOptions = {
+        headers: {
+          'Accept': routes[key].headerAccept || 'text/html',
+          'Accept-Language': lang
+        }
+      };
+
+      routeTest(key, routes[key].statusCode, requestOptions);
+    });
+  });
+
+  registerSuite(suite);
+
+  function routeTest(route, expectedStatusCode, requestOptions) {
+    suite['#https get ' + httpsUrl + route + ' ' + requestOptions.headers['Accept-Language']] = function () {
+      var dfd = this.async(intern.config.asyncTimeout);
+
+      makeRequest(httpsUrl + route, requestOptions)
+        .then((res) => {
+          assert.equal(res.statusCode, expectedStatusCode);
+          checkHeaders(routes, route, res);
+
+          return res;
+        })
+        .then(extractAndCheckUrls)
+        .then(dfd.resolve.bind(dfd), dfd.reject.bind(dfd));
+
+      return dfd;
+    };
+  }
+
+});

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -11,9 +11,15 @@ define([
   'intern/dojo/node!htmlparser2',
   'intern/dojo/node!got',
   'intern/dojo/node!url',
-  'intern/browser_modules/dojo/Promise'
+  'intern/browser_modules/dojo/Promise',
+  'tests/server/helpers/routesHelpers'
 ], function (intern, registerSuite, assert, config, csp,
-  htmlparser2, got, url, Promise) {
+  htmlparser2, got, url, Promise, routesHelpers) {
+
+  var checkHeaders = routesHelpers.checkHeaders;
+  var extractAndCheckUrls = routesHelpers.extractAndCheckUrls;
+  var makeRequest = routesHelpers.makeRequest;
+
   var httpUrl, httpsUrl = intern.config.fxaContentRoot.replace(/\/$/, '');
 
   if (intern.config.fxaProduction) {
@@ -146,7 +152,7 @@ define([
       makeRequest(httpsUrl + route, requestOptions)
         .then(function (res) {
           assert.equal(res.statusCode, expectedStatusCode);
-          checkHeaders(route, res);
+          checkHeaders(routes, route, res);
 
           return res;
         })
@@ -162,7 +168,7 @@ define([
 
       makeRequest(httpUrl + route, requestOptions)
         .then(function (res) {
-          checkHeaders(route, res);
+          checkHeaders(routes, route, res);
           assert.equal(res.statusCode, expectedStatusCode);
         })
         .then(dfd.resolve.bind(dfd), dfd.reject.bind(dfd));
@@ -195,132 +201,4 @@ define([
     };
   }
 
-  function makeRequest(url, requestOptions) {
-    return got(url, requestOptions)
-      .catch(function (err) {
-        return err.response;
-      });
-  }
-
-  function checkHeaders(route, res) {
-    var headers = res.headers;
-
-    if (headers['content-type'].indexOf('text/html') > -1) {
-      // all HTML pages by default have x-frame-options: DENY
-      assert.equal(headers['x-frame-options'], 'DENY');
-      assert.equal(headers['x-robots-tag'], 'noindex,nofollow');
-
-      if (routes[route].csp !== false) {
-        assert.ok(headers.hasOwnProperty('content-security-policy'));
-      }
-    }
-
-    assert.equal(headers['x-content-type-options'], 'nosniff');
-    assert.include(headers['strict-transport-security'], 'max-age=');
-  }
-
-  /**
-   * Go through each of the HTML files, look for URLs, check that
-   * each URL exists, responds with a 200, and in the case of JS, CSS
-   * and fonts, that the correct CORS headers are set.
-   */
-  function extractAndCheckUrls(res) {
-    var href = url.parse(res.url);
-    var origin = [ href.protocol, '//', href.host ].join('');
-    return extractUrls(res.body)
-      .then(checkUrls.bind(null, origin));
-  }
-
-  function extractUrls(body) {
-    return new Promise(function (resolve, reject) {
-      var dependencyUrls = [];
-
-      var parser = new htmlparser2.Parser({
-        onattribute: function (attrName, attrValue) {
-          if (attrName === 'href' || attrName === 'src') {
-            var depUrl;
-            if (isAbsoluteUrl(attrValue)) {
-              depUrl = attrValue;
-            } else {
-              depUrl = httpsUrl + attrValue;
-            }
-            dependencyUrls.push(depUrl);
-          }
-        },
-        onend: function () {
-          resolve(dependencyUrls);
-        }
-      });
-
-      parser.write(body);
-      parser.end();
-    });
-  }
-
-  // keep a cache of checked URLs to avoid duplicate tests and
-  // speed up the tests.
-  var checkedUrlPromises = {};
-
-  function checkUrls(origin, urls) {
-    var requests = urls.map(function (url) {
-      if (checkedUrlPromises[url]) {
-        return checkedUrlPromises[url];
-      }
-
-      var requestOptions = {};
-      if (doesURLRequireCORS(url)) {
-        requestOptions = {
-          headers: {
-            'Origin': origin
-          }
-        };
-      }
-
-      var promise = makeRequest(url, requestOptions)
-        .then(function (res) {
-          if (/support.mozilla.org/.test(url) || /localhost:35729/.test(url)) {
-            // Do not check support.mozilla.org URLs. Issue #4712
-            // In February 2017 SUMO links started returning 404s to non-browser redirect requests
-            // Also skip the livereload link in the mocha tests
-            return;
-          }
-          assert.equal(res.statusCode, 200);
-
-          var headers = res.headers;
-          var hasCORSHeaders = headers.hasOwnProperty('access-control-allow-origin');
-
-          if (doesURLRequireCORS(url)) {
-            assert.ok(hasCORSHeaders, url + ' should have CORS headers');
-          } else {
-            assert.notOk(hasCORSHeaders, url + ' should not have CORS headers');
-          }
-        });
-
-      checkedUrlPromises[url] = promise;
-      return promise;
-    });
-
-    return Promise.all(requests);
-  }
-
-  function isAbsoluteUrl(url) {
-    return /^http/.test(url);
-  }
-
-  function doesURLRequireCORS(url) {
-    return isExternalUrl(url) && doesExtensionRequireCORS(url);
-  }
-
-  function isContentServerUrl(url) {
-    return url.indexOf(httpsUrl) === 0 ||
-           url.indexOf(httpUrl) === 0;
-  }
-
-  function isExternalUrl(url) {
-    return ! isContentServerUrl(url);
-  }
-
-  function doesExtensionRequireCORS(url) {
-    return /\.(js|css|woff|woff2|eot|ttf)/.test(url);
-  }
 });

--- a/tests/teamcity/prod
+++ b/tests/teamcity/prod
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+FXA_CONTENT_ROOT="https://accounts.firefox.com/"
+FXA_AUTH_ROOT="https://api.accounts.firefox.com/v1"
+FXA_OAUTH_ROOT="https://oauth.accounts.firefox.com"
+FXA_PROFILE_ROOT="https://profile.accounts.firefox.com"
+FXA_TOKEN_ROOT="https://token.services.mozilla.com"
+FXA_TEST_CONFIG="tests/intern_server_resources"
+
+FXA_OAUTH_APP_ROOT="https://123done.dev.lcip.org/"
+FXA_UNTRUSTED_OAUTH_APP_ROOT="https://321done.dev.lcip.org/"
+
+FXA_CONTENT_VERSION="https://accounts.firefox.com/__version__"
+FXA_OAUTH_VERSION="https://oauth.accounts.firefox.com/__version__"
+FXA_PROFILE_VERSION="https://profile.accounts.firefox.com/__version__"
+FXA_AUTH_VERSION="https://api.accounts.firefox.com/__version__"

--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -98,8 +98,10 @@ node ./tests/teamcity/install-npm-deps.js \
   universal-analytics             \
   xmlhttprequest
 
+FXA_TEST_CONFIG=${FXA_TEST_CONFIG:-tests/intern_server}
+
 ./node_modules/.bin/intern-client \
-  config=tests/intern_server \
+  config="$FXA_TEST_CONFIG" \
   fxaAuthRoot="$FXA_AUTH_ROOT" \
   fxaContentRoot="$FXA_CONTENT_ROOT" \
   fxaOAuthRoot="$FXA_OAUTH_ROOT" \

--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -77,6 +77,7 @@ node ./tests/teamcity/install-npm-deps.js \
   bluebird                        \
   bower                           \
   convict                         \
+  css                             \
   extend                          \
   firefox-profile                 \
   fxa-shared                      \


### PR DESCRIPTION
- extracts some logic from tests/server/routes.js to a shared tests/server/helpers/routesHelpers.js
- adds a test that will load /signin in all supported locales and extracts urls from that content, and pulls those resources (from CDN in prod/stage).
- maybe this could go deeper into the css, to extract image resources from that content (I think I actually wrote this some time ago, and never committed). 
- also, this could eventually be taught to validate SRI for the sub-resources.
- can be run safely against production

Putting this up for review. Maybe needs an iteration.

URLs fetched in a test run in prod:
```
  href: 'https://accounts.firefox.com/signin',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.ar.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/137f2456.head.js',
  href: 'https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral',
  href: 'https://accounts.firefox.com/experiments.bundle.js',
  href: 'https://accounts.cdn.mozilla.net/scripts/18217b91.main.ar.js',
  href: 'https://www.mozilla.org/en-US/about/?amp;utm_medium=Referral&utm_source=firefox-accounts',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.ast.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/a532a7b1.main.ast.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.az.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/869c3c59.main.az.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.bg.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/d867a34b.main.bg.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.bn_BD.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/0f39e9b9.main.bn_BD.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.cs.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/6b7977c5.main.cs.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.cy.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/6d6d4dcd.main.cy.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.da.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/112050af.main.da.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.de.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/1bebc70b.main.de.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.dsb.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/97a1a773.main.dsb.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.en.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/e820c61f.main.en.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.en_GB.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/c3794149.main.en_GB.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.es.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/91e38864.main.es.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.es_AR.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/2d52d470.main.es_AR.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.es_CL.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/f689d5a6.main.es_CL.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.es_ES.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/f8a770b6.main.es_ES.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.es_MX.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/99f5ac69.main.es_MX.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.et.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/d3eb85b9.main.et.js',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.fa.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/85ed2864.main.fa.js',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.ff.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/c8942626.main.ff.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.fi.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/44650e0f.main.fi.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.fr.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/526b216f.main.fr.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.fy.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/a03a109d.main.fy.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.fy_NL.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/65de47aa.main.fy_NL.js',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.he.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/26bf6dac.main.he.js',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.hi_IN.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/910e2b36.main.hi_IN.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.hsb.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/a50055cd.main.hsb.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.hu.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/7054e715.main.hu.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.id.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/afec9d0b.main.id.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.it.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/ead65c89.main.it.js',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.ja.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/0bedda36.main.ja.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.ka.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/cae76054.main.ka.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.kab.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/10640f81.main.kab.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.kk.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/9a1adb6f.main.kk.js',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.ko.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/2e0b0473.main.ko.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.lt.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/86af0659.main.lt.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.lv.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/4cc6e8f8.main.lv.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.nl.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/f93f9241.main.nl.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.nn_NO.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/95357d51.main.nn_NO.js',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.pa.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/7578cfb5.main.pa.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.pl.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/0ae679bc.main.pl.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.pt.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/06fea8d8.main.pt.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.pt_BR.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/b0eb0b8c.main.pt_BR.js',
  href: 'https://accounts.cdn.mozilla.net/styles/fc5c40db.pt_PT.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/c10b2979.main.pt_PT.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.rm.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/69d9a20f.main.rm.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.ro.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/42b79b7a.main.ro.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.ru.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/21c72e33.main.ru.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.sk.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/38fca82c.main.sk.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.sl.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/fa98266e.main.sl.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.sq.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/e423e1b1.main.sq.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.sr.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/61529e3c.main.sr.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.sr_Latn.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/b566acaa.main.sr_Latn.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.sv.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/577563dd.main.sv.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.sv_SE.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/41b2018f.main.sv_SE.js',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.te.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/77973304.main.te.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.tr.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/9373e5e6.main.tr.js',
  href: 'https://accounts.cdn.mozilla.net/styles/ffdf9a79.uk.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/e393628e.main.uk.js',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.zh_CN.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/b64deb77.main.zh_CN.js',
  href: 'https://accounts.cdn.mozilla.net/styles/670535cd.zh_TW.css',
  href: 'https://accounts.cdn.mozilla.net/scripts/46ed6f57.main.zh_TW.js',
```
