### PR TITLE
feat(sms): Add the `/m/:signinCode` redirect handler.

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -453,7 +453,7 @@ const conf = module.exports = convict({
   sms: {
     redirect: {
       targetLink: {
-        default: 'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&adgroup=android&creative=button',
+        default: 'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&adgroup=sms&creative=link',
         doc: 'Target URL for redirection',
         format: 'url'
       }

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -451,6 +451,13 @@ const conf = module.exports = convict({
     }
   },
   sms: {
+    redirect: {
+      targetLink: {
+        default: 'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&adgroup=android&creative=button',
+        doc: 'Target URL for redirection',
+        format: 'url'
+      }
+    },
     testPhoneNumber: {
       default: '',
       doc: 'Phone number to send SMS messages to in function tests',

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -45,6 +45,7 @@ module.exports = function (config, i18n) {
     require('./routes/post-metrics')(),
     require('./routes/post-metrics-errors')(),
     require('./routes/redirect-complete-to-verified')(),
+    require('./routes/redirect-m-to-adjust')(config),
     require('./routes/get-500')(config)
   ];
 

--- a/server/lib/routes/redirect-m-to-adjust.js
+++ b/server/lib/routes/redirect-m-to-adjust.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const SIGNIN_CODE = require('../validation').TYPES.SIGNIN_CODE;
+
+module.exports = function (config) {
+  const targetUrl = config.get('sms.redirect.targetLink');
+
+  return {
+    method: 'get',
+    path: '/m/:signinCode',
+    validate: {
+      params: {
+        signinCode: SIGNIN_CODE
+      }
+    },
+    process: function (req, res) {
+      // The signinCode is already URL safe if it has validated correctly,
+      // so encodeURIComponent is not called.
+      res.redirect(302, `${targetUrl}&signin=${req.params.signinCode}`);
+    }
+  };
+};

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -8,29 +8,35 @@
 
 const joi = require('joi');
 
-module.exports = {
-  PATTERNS: {
-    BROKER: /^[0-9a-z-]+$/,
-    CLIENT_ID: /^[0-9a-f]{16}/,
-    CONTEXT: /^[0-9a-z_-]+$/,
-    ENTRYPOINT: /^[\w.:-]+$/,
-    EVENT_TYPE: /^[\w\s.:-]+$/, // the space is to allow for error contexts that contain spaces, e.g., `error.unknown context.auth.108`
-    EXPERIMENT: /^[\w.-]+$/,
-    MIGRATION: /^(sync11|amo|none)$/,
-    SERVICE: /^(sync|content-server|none|[0-9a-f]{16})$/,
-    UNIQUE_USER_ID: /^[0-9a-z-]{36}$/
-  },
+const PATTERNS = {
+  BASE64: /^[A-Za-z0-9\/+]+={0,2}$/,
+  BASE64_URL_SAFE: /^[A-Za-z0-9_-]+$/,
+  BROKER: /^[0-9a-z-]+$/,
+  CLIENT_ID: /^[0-9a-f]{16}/,
+  CONTEXT: /^[0-9a-z_-]+$/,
+  ENTRYPOINT: /^[\w.:-]+$/,
+  EVENT_TYPE: /^[\w\s.:-]+$/, // the space is to allow for error contexts that contain spaces, e.g., `error.unknown context.auth.108`
+  EXPERIMENT: /^[\w.-]+$/,
+  MIGRATION: /^(sync11|amo|none)$/,
+  SERVICE: /^(sync|content-server|none|[0-9a-f]{16})$/,
+  UNIQUE_USER_ID: /^[0-9a-z-]{36}$/
+};
 
-  TYPES: {
-    BOOLEAN: joi.boolean(),
-    DIMENSION: joi.number().integer().min(0),
-    INTEGER: joi.number().integer(),
-    OFFSET: joi.number().integer().min(0),
-    REFERRER: joi.string().max(2048).uri({ scheme: [ 'android-app', 'http', 'https' ]}).allow('none'),
-    RESUME: joi.string().regex(/^[a-zA-Z0-9\/+]+={0,2}$/), // match any valid base64 character
-    STRING: joi.string().max(1024), // 1024 is arbitrary, seems like it should give CSP reports plenty of space.
-    TIME: joi.number().integer().min(0),
-    URL: joi.string().max(2048).uri({ scheme: [ 'http', 'https' ]}), // 2048 is also arbitrary, the same limit we use on the front end.
-    UTM: joi.string().max(128).regex(/^[\w\/.%-]+/) // values here can be 'firefox/sync'
-  }
+const TYPES = {
+  BOOLEAN: joi.boolean(),
+  DIMENSION: joi.number().integer().min(0),
+  INTEGER: joi.number().integer(),
+  OFFSET: joi.number().integer().min(0),
+  REFERRER: joi.string().max(2048).uri({ scheme: [ 'android-app', 'http', 'https' ]}).allow('none'),
+  RESUME: joi.string().regex(PATTERNS.BASE64),
+  SIGNIN_CODE: joi.string().regex(PATTERNS.BASE64_URL_SAFE).length(8),
+  STRING: joi.string().max(1024), // 1024 is arbitrary, seems like it should give CSP reports plenty of space.
+  TIME: joi.number().integer().min(0),
+  URL: joi.string().max(2048).uri({ scheme: [ 'http', 'https' ]}), // 2048 is also arbitrary, the same limit we use on the front end.
+  UTM: joi.string().max(128).regex(/^[\w\/.%-]+/) // values here can be 'firefox/sync'
+};
+
+module.exports = {
+  PATTERNS,
+  TYPES
 };

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -36,7 +36,8 @@ define([
     'tests/server/routes/get-openid-configuration',
     'tests/server/routes/get-index',
     'tests/server/routes/post-csp',
-    'tests/server/routes/post-metrics'
+    'tests/server/routes/post-metrics',
+    'tests/server/routes/redirect-m-to-adjust',
   ];
 
   return intern;

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -107,6 +107,10 @@ define([
   }
 
   var redirectedRoutes = {
+    '/m/12345678': {
+      location: config.get('sms.redirect.targetLink') + '&signin=12345678',
+      statusCode: 302
+    },
     '/reset_password_complete': {
       location: '/reset_password_verified',
       statusCode: 302
@@ -131,9 +135,7 @@ define([
     routeTest(key, routes[key].statusCode, requestOptions);
   });
 
-  Object.keys(redirectedRoutes).forEach(function (key) {
-    redirectTest(key);
-  });
+  Object.keys(redirectedRoutes).forEach(redirectTest);
 
   registerSuite(suite);
 

--- a/tests/server/routes/redirect-m-to-adjust.js
+++ b/tests/server/routes/redirect-m-to-adjust.js
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!bluebird',
+  'intern/dojo/node!path',
+  'intern/dojo/node!sinon',
+  'intern/dojo/node!../../../server/lib/routes/redirect-m-to-adjust',
+  'intern/dojo/node!../../../server/lib/configuration',
+], function (registerSuite, assert, Promise, path, sinon, route, config) {
+  var instance, request, response;
+
+  registerSuite({
+    name: 'routes/get-app',
+
+    'route interface is correct': function () {
+      assert.isFunction(route);
+      assert.lengthOf(route, 1);
+    },
+
+    'initialise route': {
+      setup: function () {
+        instance = route(config);
+      },
+
+      'instance interface is correct': function () {
+        assert.isObject(instance);
+        assert.lengthOf(Object.keys(instance), 4);
+        assert.equal(instance.method, 'get');
+        assert.equal(instance.path, '/m/:signinCode');
+        assert.isObject(instance.validate);
+        assert.isFunction(instance.process);
+        assert.lengthOf(instance.process, 2);
+      },
+
+      'route.validate': {
+        'validates :signinCode correctly': function() {
+          const validate = val => instance.validate.params.signinCode.validate(val);
+
+          assert.ok(validate('1234567').error); // too short
+          assert.ok(validate('123456789').error); // too long
+          assert.ok(validate('1234567+').error); // not URL safe base64
+          assert.ok(validate('1234567/').error); // not URL safe base64
+
+          assert.equal(validate('12345678').value, '12345678');
+        }
+      },
+
+      'route.process': {
+        setup: function () {
+          request = {
+            params: {
+              signinCode: '12345678'
+            }
+          };
+          response = { redirect: sinon.spy() };
+          instance.process(request, response);
+        },
+
+        'response.redirect was called correctly': function () {
+          assert.equal(response.redirect.callCount, 1);
+
+          const statusCode = response.redirect.args[0][0];
+          assert.equal(statusCode, 302);
+
+          const targetUrl = response.redirect.args[0][1];
+          assert.include(targetUrl, 'signin=12345678');
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Redirect `/m/:signinCode` to Adjust, with the signinCode appended
as the `signin` query parameter.

fixes #5081

@philbooth - r?