### PR TITLE
feat(emails): Add secondary email feature flag

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -485,7 +485,9 @@ define(function (require, exports, module) {
      * @param {String} viewName
      */
     logView (viewName) {
-      this.logEvent(this.viewToId(viewName));
+      // `screen.` is a legacy artifact from when each View was a screen.
+      // The identifier is kept to avoid updating all metrics queries.
+      this.logEvent(`screen.${viewName}`);
     },
 
     /**
@@ -495,25 +497,9 @@ define(function (require, exports, module) {
      * @param {String} eventName
      */
     logViewEvent (viewName, eventName) {
-      var event = Strings.interpolate('%(viewName)s.%(eventName)s', {
-        eventName: eventName,
-        viewName: viewName,
-      });
-
-      this.logEvent(event);
+      this.logEvent(`${viewName}.${eventName}`);
     },
 
-    /**
-     * Convert a viewName to an identifier used in metrics.
-     *
-     * @param {String} viewName
-     * @return {String} identifier
-     */
-    viewToId (viewName) {
-      // `screen.` is a legacy artifact from when each View was a screen.
-      // The idenifier is kept to avoid updating all metrics queries.
-      return 'screen.' + viewName;
-    },
     /**
      * Log when an experiment is shown to the user
      *

--- a/app/scripts/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/scripts/models/auth_brokers/fx-firstrun-v1.js
@@ -27,6 +27,7 @@ define(function (require, exports, module) {
     },
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
+      cadAfterSignUpConfirmationPoll: true,
       chooseWhatToSyncCheckbox: true,
       chooseWhatToSyncWebV1: false,
       openWebmailButtonVisible: true

--- a/app/scripts/templates/marketing_snippet.mustache
+++ b/app/scripts/templates/marketing_snippet.mustache
@@ -7,7 +7,7 @@
           <br>
           {{#t}}Download Firefox for iOS!{{/t}}
         </p>
-        <a class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="53" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+        <a target="_blank" class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="53" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
       {{/isIos}}
 
       {{#isAndroid}}
@@ -16,7 +16,7 @@
           <br>
           {{#t}}Download Firefox for Android.{{/t}}
         </p>
-        <a class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45" src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}"></a>
+        <a target="_blank" class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45" src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}"></a>
       {{/isAndroid}}
 
       {{#isOther}}
@@ -29,10 +29,10 @@
 
           <ul>
             <li>
-              <a class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+              <a target="_blank" class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
             </li>
             <li>
-              <a class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
+              <a target="_blank" class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
             </li>
           </ul>
         </div>
@@ -41,17 +41,17 @@
   {{/isSpring2015}}
   {{#isAutumn2016}}
     {{#isIos}}
-      <a class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="53" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+      <a target="_blank" class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="53" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
     {{/isIos}}
 
     {{#isAndroid}}
-      <a class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45" src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
+      <a target="_blank" class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45" src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
     {{/isAndroid}}
 
     {{#isOther}}
       <div class="links clearfix">
-        <a class="marketing-link marketing-link-ios left" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
-        <a class="marketing-link marketing-link-android right" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
+        <a target="_blank" class="marketing-link marketing-link-ios left" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+        <a target="_blank" class="marketing-link marketing-link-android right" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
       </div>
     {{/isOther}}
   {{/isAutumn2016}}

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -682,9 +682,7 @@ define(function (require, exports, module) {
         err = new Error(err);
       }
 
-      if (! err.context) {
-        err.context = this.getViewName();
-      }
+      err.viewName = this.getViewName();
 
       return err;
     },
@@ -733,7 +731,7 @@ define(function (require, exports, module) {
     logFlowEvent (eventName, viewName, data) {
       this.notifier.trigger('flow.event', _.assign({}, data, {
         event: eventName,
-        view: viewName
+        viewName
       }));
     },
 

--- a/app/scripts/views/behaviors/connect-another-device.js
+++ b/app/scripts/views/behaviors/connect-another-device.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A behavior that sends eligible users to the appropriate
+ * connect-another-device screen. If ineligible, fallback
+ * to `defaultBehavior`.
+ *
+ * Requires the view to mixin the ConnectAnotherDeviceMixin
+ */
+
+define((require, exports, module) => {
+  'use strict';
+
+  /**
+   * Create a ConnectAnotherDevice behavior.
+   *
+   * @param {Object} defaultBehavior - behavior to invoke if ineligible
+   *   for ConnectAnotherDevice
+   * @returns {Function} behavior
+   */
+  module.exports = function (defaultBehavior) {
+    const behavior = function (view, account) {
+      if (view.isEligibleForConnectAnotherDevice(account)) {
+        return view.navigateToConnectAnotherDeviceScreen(account);
+      }
+
+      return view.invokeBehavior(defaultBehavior, account);
+    };
+
+    behavior.type = 'connect-another-device';
+
+    return behavior;
+  };
+});

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -10,6 +10,7 @@ define(function (require, exports, module) {
   const BackMixin = require('views/mixins/back-mixin');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
+  const ConnectAnotherDeviceMixin = require('views/mixins/connect-another-device-mixin');
   const Constants = require('lib/constants');
   const ExperimentMixin = require('views/mixins/experiment-mixin');
   const OpenConfirmationEmailMixin = require('views/mixins/open-webmail-mixin');
@@ -19,6 +20,7 @@ define(function (require, exports, module) {
   const ResumeTokenMixin = require('views/mixins/resume-token-mixin');
   const ServiceMixin = require('views/mixins/service-mixin');
   const Template = require('stache!templates/confirm');
+  const UserAgentMixin = require('views/mixins/user-agent-mixin');
   const VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
 
   const proto = BaseView.prototype;
@@ -160,12 +162,14 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     BackMixin,
+    ConnectAnotherDeviceMixin,
     ExperimentMixin,
     OpenConfirmationEmailMixin,
     PulseGraphicMixin,
     ResendMixin,
     ResumeTokenMixin,
     ServiceMixin,
+    UserAgentMixin,
     VerificationReasonMixin
   );
 

--- a/app/scripts/views/connect_another_device.js
+++ b/app/scripts/views/connect_another_device.js
@@ -12,10 +12,10 @@ define(function (require, exports, module) {
   'use strict';
 
   const Cocktail = require('cocktail');
-  const Constants = require('lib/constants');
   const ExperimentMixin = require('views/mixins/experiment-mixin');
   const FlowEventsMixin = require('views/mixins/flow-events-mixin');
   const FormView = require('views/form');
+  const { MARKETING_ID_AUTUMN_2016, SYNC_SERVICE } = require('lib/constants');
   const MarketingMixin = require('views/mixins/marketing-mixin');
   const MarketingSnippet = require('views/marketing_snippet');
   const SyncAuthMixin = require('views/mixins/sync-auth-mixin');
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
 
     afterRender () {
       const options = {
-        marketingId: Constants.MARKETING_ID_AUTUMN_2016
+        marketingId: MARKETING_ID_AUTUMN_2016
       };
 
       // If the user signed up and verified in Firefox for Android,
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
 
     getAccount () {
       if (! this.model.get('account')) {
-        this.model.set('account', this.user.initAccount({}));
+        this.model.set('account', this.user.getSignedInAccount());
       }
 
       return this.model.get('account');
@@ -195,7 +195,11 @@ define(function (require, exports, module) {
     FlowEventsMixin,
     MarketingMixin({
       // The marketing area is manually created to which badges are displayed.
-      autocreate: false
+      autocreate: false,
+      // This screen is only shown to Sync users. The service is always Sync,
+      // even if not specified on the URL. This makes manual testing slightly
+      // easier where sometimes ?service=sync is forgotten. See #4948.
+      service: SYNC_SERVICE
     }),
     SyncAuthMixin,
     UserAgentMixin

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -229,7 +229,8 @@ define(function (require, exports, module) {
 
           // all good, do the beforeSubmit, submit, and afterSubmit chain.
           this.logViewEvent('submit');
-          return this._submitForm();
+          return this._submitForm()
+            .then(() => this.afterSubmit());
         });
     }),
 
@@ -246,8 +247,7 @@ define(function (require, exports, module) {
           // display error and surface for testing.
           this.displayError(err);
           throw err;
-        })
-        .then(_.bind(this.afterSubmit, this));
+        });
     })),
 
     /**

--- a/app/scripts/views/marketing_snippet.js
+++ b/app/scripts/views/marketing_snippet.js
@@ -117,6 +117,10 @@ define(function (require, exports, module) {
       this.$('.marketing-link').each((index, element) => {
         this._logMarketingImpression(element);
       });
+
+      // Add the marketingId as a class so that different styles
+      // can be applied to different snippets.
+      this.$el.addClass(this._marketingId);
     },
 
     _shouldShowSignUpMarketing () {

--- a/app/scripts/views/mixins/modal-panel-mixin.js
+++ b/app/scripts/views/mixins/modal-panel-mixin.js
@@ -13,6 +13,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const $ = require('jquery');
+  const Environment = require('lib/environment');
 
   module.exports = {
     isModal: true,
@@ -35,6 +36,13 @@ define(function (require, exports, module) {
       });
 
       this.$el.on($.modal.AFTER_CLOSE, () => this.onAfterClose());
+
+      if (this._needsToSetBodyMinHeight()) {
+        // ensure the body is at least as tall as the modal. This is used
+        // when inside the firstrun iframe and the "why connect another device"
+        // content is larger than the body on the /connect_another_device page.
+        this._setBodyMinHeight();
+      }
 
       this._boundBlockerClick = this.onBlockerClick.bind(this);
       $('.blocker').on('click', this._boundBlockerClick);
@@ -80,6 +88,41 @@ define(function (require, exports, module) {
      */
     destroy () {
       this.closePanel();
+      if (this._needsToSetBodyMinHeight() && this.model.has('origMinHeight')) {
+        $('body').css('min-height', this.model.get('origMinHeight'));
+        this.model.unset('origMinHeight');
+      }
+    },
+
+    /**
+     * Check whether the `body` element needs it's `min-height` set
+     * so that the body expands to be at least as tall as the modal.
+     *
+     * @returns {Boolean}
+     * @private
+     */
+    _needsToSetBodyMinHeight() {
+      const environment = new Environment(this.window);
+      return environment.isFramed();
+    },
+
+    /**
+     * Ensure the body is at least as tall as the modal. This is used
+     * when inside the firstrun iframe and the "why connect another device"
+     * content is larger than the body on the /connect_another_device page.
+     *
+     * @private
+     */
+    _setBodyMinHeight () {
+      const RADIX = 10;
+      const bodyMinHeightCssValue = $('body').css('min-height');
+      const bodyMinHeight = parseInt(bodyMinHeightCssValue || 0, RADIX);
+      const modalHeight = $('.modal').outerHeight();
+
+      if (modalHeight > bodyMinHeight) {
+        this.model.set('origMinHeight', bodyMinHeightCssValue);
+        $('body').css('min-height', `${modalHeight}px`);
+      }
     }
   };
 });

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -57,15 +57,22 @@ define(function (require, exports, module) {
           item.title += ' - ' + item.scope;
         }
         if (item.lastAccessTimeFormatted) {
-          // only format if not a web session
+
           if (item.isWebSession) {
             item.title = this.translate(
               t('Web Session, %(userAgent)s'), {userAgent: item.userAgent});
             item.lastAccessTimeFormatted = this.translate(
               t('%(translatedTimeAgo)s'), {translatedTimeAgo: item.lastAccessTimeFormatted});
-          } else {
+          }
+
+          if (item.isDevice) {
             item.lastAccessTimeFormatted = this.translate(
-              t('Last active %(translatedTimeAgo)s'), {translatedTimeAgo: item.lastAccessTimeFormatted});
+              t('started syncing %(translatedTimeAgo)s'), {translatedTimeAgo: item.lastAccessTimeFormatted});
+          }
+
+          if (item.clientType === Constants.CLIENT_TYPE_OAUTH_APP) {
+            item.lastAccessTimeFormatted = this.translate(
+              t('last active %(translatedTimeAgo)s'), {translatedTimeAgo: item.lastAccessTimeFormatted});
           }
         } else {
           // unknown lastAccessTimeFormatted or not possible to format.

--- a/app/scripts/views/sms_send.js
+++ b/app/scripts/views/sms_send.js
@@ -15,7 +15,7 @@ define(function (require, exports, module) {
   const { FIREFOX_MOBILE_INSTALL } = require('lib/sms-message-ids');
   const FlowEventsMixin = require('views/mixins/flow-events-mixin');
   const FormView = require('views/form');
-  const { MARKETING_ID_AUTUMN_2016 } = require('lib/constants');
+  const { MARKETING_ID_AUTUMN_2016, SYNC_SERVICE } = require('lib/constants');
   const MarketingMixin = require('views/mixins/marketing-mixin');
   const PulseGraphicMixin = require('views/mixins/pulse-graphic-mixin');
   const SmsErrors = require('lib/sms-errors');
@@ -174,7 +174,13 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     FlowEventsMixin,
-    MarketingMixin({ marketingId: MARKETING_ID_AUTUMN_2016 }),
+    MarketingMixin({
+      marketingId: MARKETING_ID_AUTUMN_2016,
+      // This screen is only shown to Sync users. The service is always Sync,
+      // even if not specified on the URL. This makes manual testing slightly
+      // easier where sometimes ?service=sync is forgotten. See #4948.
+      service: SYNC_SERVICE
+    }),
     PulseGraphicMixin
   );
 

--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -124,12 +124,6 @@ header {
       }
     }
 
-    .service {
-      .chromeless & {
-        display: none;
-      }
-    }
-
     .email {
       color: $faint-text-color;
       // allow long email addresses to be

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -78,7 +78,7 @@ $link-color: $button-background-color;
 $marketing-border-color: $color-grey-spinner;
 $message-text-color: $color-white;
 $mobile-html-background-color: $color-white;
-$modal-border-color: $color-black;
+
 $secondary-button-background-color: $color-grey-lightest;
 $secondary-button-border-color: lighten($color-grey, 5);
 
@@ -88,6 +88,10 @@ $show-password-label-color: $color-grey-faint-text;
 
 $success-background-color: #5fad47;
 $text-color: $color-grey-text;
+
+//Modal colors
+$modal-border-color: $color-black;
+$modal-background-color-iframe: $color-white;
 
 //Settings Specific Colors
 $settings-header-border-bottom: #b4bdc3;

--- a/app/styles/modules/_marketing.scss
+++ b/app/styles/modules/_marketing.scss
@@ -15,17 +15,19 @@
   }
 
   .chromeless.iframe & {
-    @include respond-to('reasonableUI') {
-      // This is a hack. The width of the firstrun iframe is 400px.
-      // The max-width of the main-content area is 360px, leaving 20px
-      // on either side. A 20px bottom-padding exists on the body.
-      // This leaves a 20px white area around the marketing snippet.
+    &.spring-2015-android-ios-sync {
+      @include respond-to('reasonableUI') {
+        // This is a hack. The width of the firstrun iframe is 400px.
+        // The max-width of the main-content area is 360px, leaving 20px
+        // on either side. A 20px bottom-padding exists on the body.
+        // This leaves a 20px white area around the marketing snippet.
 
-      // For the firstrun flow only, pull the marketing box
-      // out to the sides to get rid of the padding.
-      bottom: -20px;
-      margin: 0 -20px;
-      position: relative;
+        // For the firstrun flow only, pull the marketing box
+        // out to the sides to get rid of the padding.
+        bottom: -20px;
+        margin: 0 -20px;
+        position: relative;
+      }
     }
   }
 

--- a/app/styles/modules/_modal.scss
+++ b/app/styles/modules/_modal.scss
@@ -1,6 +1,18 @@
+.blocker {
+  .iframe & {
+    background-color: $modal-background-color-iframe;
+    padding: 0;
+  }
+}
+
 .modal {
   border-radius: $big-border-radius;
   box-shadow: 0 1px 5px $modal-border-color;
+
+  .iframe & {
+    border-radius: 0;
+    box-shadow: none;
+  }
 
 
   @include respond-to('big') {

--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -592,22 +592,12 @@ section.modal-panel {
 }
 
 .client-device {
-  // device clients currently have their 'last active' time hidden
-  // See issue https://github.com/mozilla/fxa/issues/190
-  .client-name {
-    padding-top: 8px;
-  }
-
   &.client-current {
     background-position: left 5px;
 
     .client-name {
       padding-top: 5px;
     }
-  }
-
-  .last-connected {
-    display: none;
   }
 }
 

--- a/app/tests/lib/helpers.js
+++ b/app/tests/lib/helpers.js
@@ -133,11 +133,6 @@ define(function (require, exports, module) {
     return isEventLogged(metrics, eventName);
   }
 
-  function isViewLogged(metrics, viewName) {
-    var eventName = metrics.viewToId(viewName);
-    return isEventLogged(metrics, eventName);
-  }
-
   function toSearchString(obj) {
     var searchString = '?';
     var pairs = [];
@@ -174,7 +169,6 @@ define(function (require, exports, module) {
     indexOfEvent: indexOfEvent,
     isErrorLogged: isErrorLogged,
     isEventLogged: isEventLogged,
-    isViewLogged: isViewLogged,
     removeFxaClientSpy: removeFxaClientSpy,
     requiresFocus: requiresFocus,
     stubbedProfileClient: stubbedProfileClient,

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -678,7 +678,8 @@ define(function (require, exports, module) {
     describe('logView', function () {
       it('logs the screen', function () {
         metrics.logView('signup');
-        assert.isTrue(TestHelpers.isViewLogged(metrics, 'signup'));
+
+        assert.isTrue(TestHelpers.isEventLogged(metrics, 'screen.signup'));
       });
     });
 

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -7,17 +7,63 @@ define((require, exports, module) => {
 
   const { assert } = require('chai');
   const FxSyncAuthenticationBroker = require('models/auth_brokers/fx-sync');
+  const Metrics = require('lib/metrics');
+  const sinon = require('sinon');
   const WindowMock = require('../../../mocks/window');
 
   describe('models/auth_brokers/fx-sync', () => {
+    let account;
+    let broker;
+    let metrics;
     let windowMock;
 
     beforeEach(() => {
+      account = {};
+      metrics = new Metrics();
       windowMock = new WindowMock();
+
+      broker = new FxSyncAuthenticationBroker({
+        metrics,
+        window: windowMock
+      });
     });
 
-    it('can be created', () => {
-      assert.ok(new FxSyncAuthenticationBroker({ window: windowMock }));
+    afterEach(() => {
+      account = null;
+      broker = null;
+      metrics.destroy();
+      metrics = null;
+      windowMock = null;
+    });
+
+    describe('afterSignUpConfirmationPoll', () => {
+      describe('broker has `cadAfterSignUpConfirmationPoll` capability', () => {
+        it('sets the metrics viewName prefix, resolves to a `ConnectAnotherDeviceBehavior`', () => {
+          broker.setCapability('cadAfterSignUpConfirmationPoll', true);
+          sinon.spy(metrics, 'setViewNamePrefix');
+
+          return broker.afterSignUpConfirmationPoll(account)
+            .then((behavior) => {
+              assert.equal(behavior.type, 'connect-another-device');
+
+              assert.isTrue(metrics.setViewNamePrefix.calledOnce);
+              assert.isTrue(metrics.setViewNamePrefix.calledWith('signup'));
+            });
+        });
+      });
+
+      describe('broker does not have `cadAfterSignUpConfirmationPoll` capability', () => {
+        it('resolves to the default behavior', () => {
+          sinon.spy(metrics, 'setViewNamePrefix');
+
+          return broker.afterSignUpConfirmationPoll(account)
+            .then((behavior) => {
+              assert.equal(behavior.type, broker.getBehavior('afterSignUpConfirmationPoll').type);
+
+              assert.isFalse(metrics.setViewNamePrefix.called);
+            });
+        });
+      });
     });
   });
 });

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -532,6 +532,7 @@ define(function (require, exports, module) {
         view.displayError(error);
         assert.isTrue(view.logError.called);
         assert.isTrue(error.logged);
+        assert.equal(error.viewName, 'view');
       });
 
       it('does not log an already logged error', function () {
@@ -988,72 +989,30 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('invokeBrokerMethod', () => {
-      it('invokes the broker method, passing along any extra parameters, invokes the behavior', function () {
-        const behavior = sinon.spy();
-        sinon.stub(broker, 'afterSignIn', () => behavior);
-        sinon.stub(view, 'invokeBehavior', () => {});
+    describe('invokeBrokerMethod', function () {
+      it('invokes the broker method, passing along any extra parameters, invokes the value returned from the broker if a function', function () {
+        var behavior = sinon.spy();
 
-        const extraData = { key: 'value' };
+        sinon.stub(broker, 'afterSignIn', function () {
+          return behavior;
+        });
+
+        var extraData = { key: 'value' };
         return view.invokeBrokerMethod('afterSignIn', extraData)
           .then(function () {
-            assert.isTrue(broker.afterSignIn.calledOnce);
             assert.isTrue(broker.afterSignIn.calledWith(extraData));
-
-            assert.isTrue(view.invokeBehavior.calledOnce);
-            assert.isTrue(view.invokeBehavior.calledWith(behavior, extraData));
+            assert.isTrue(behavior.calledWith(view));
           });
       });
 
-      it('correctly handles rejected broker promises', () => {
-        const error = new Error('propagated error');
-        const behavior = p.reject(error);
-        sinon.stub(broker, 'afterSignIn', () => behavior);
-        sinon.spy(view, 'invokeBehavior');
-
-        return view.invokeBrokerMethod('afterSignIn')
-          .then(assert.fail, (caughtError) => {
-            assert.isTrue(broker.afterSignIn.calledOnce);
-
-            assert.isFalse(view.invokeBehavior.called);
-          });
-      });
-
-      it('correctly handles broker returning an object', function () {
-        const behavior = {};
-        sinon.stub(broker, 'afterSignIn', () => behavior);
-        sinon.stub(view, 'invokeBehavior', () => {});
+      it('does not explode if the value returned from the broker is not a function', function () {
+        sinon.stub(broker, 'afterSignIn', function () {
+          return {};
+        });
 
         return view.invokeBrokerMethod('afterSignIn')
           .then(function () {
-            assert.isTrue(broker.afterSignIn.calledOnce);
-
-            assert.isTrue(view.invokeBehavior.calledOnce);
-            assert.isTrue(view.invokeBehavior.calledWith(behavior));
-          });
-      });
-    });
-
-    describe('invokeBehavior', () => {
-      it('correctly handles a function', () => {
-        const behavior = sinon.spy(() => behavior);
-        const extraData = {};
-
-        return view.invokeBehavior(behavior, extraData)
-          .then((value) => {
-            assert.strictEqual(value, behavior);
-
-            assert.isTrue(behavior.calledOnce);
-            assert.isTrue(behavior.calledWith(view, extraData));
-          });
-      });
-
-      it('correctly handles an object', () => {
-        const behavior = {};
-
-        return view.invokeBehavior(behavior)
-          .then((value) => {
-            assert.strictEqual(value, behavior);
+            assert.isTrue(broker.afterSignIn.called);
           });
       });
     });

--- a/app/tests/spec/views/behaviors/connect-another-device.js
+++ b/app/tests/spec/views/behaviors/connect-another-device.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define((require, exports, module) => {
+  'use strict';
+
+  const { assert } = require('chai');
+  const ConnectAnotherDeviceBehavior = require('views/behaviors/connect-another-device');
+  const NullBehavior = require('views/behaviors/null');
+  const sinon = require('sinon');
+
+  describe('views/behaviors/connect-another-device', () => {
+    let account;
+    let cadBehavior;
+    let defaultBehavior;
+
+    before(() => {
+      account = {};
+      defaultBehavior = new NullBehavior();
+      cadBehavior = new ConnectAnotherDeviceBehavior(defaultBehavior);
+    });
+
+    describe('eligible for CAD', () => {
+      it('delegates to `view.navigateToConnectAnotherDeviceScreen`', () => {
+        const view = {
+          invokeBehavior: sinon.spy(),
+          isEligibleForConnectAnotherDevice: sinon.spy(() => true),
+          navigateToConnectAnotherDeviceScreen: sinon.spy()
+        };
+
+        cadBehavior(view, account);
+
+        assert.isTrue(view.isEligibleForConnectAnotherDevice.calledOnce);
+        assert.isTrue(view.isEligibleForConnectAnotherDevice.calledWith(account));
+
+        assert.isTrue(view.navigateToConnectAnotherDeviceScreen.calledOnce);
+        assert.isTrue(view.navigateToConnectAnotherDeviceScreen.calledWith(account));
+
+        assert.isFalse(view.invokeBehavior.called);
+      });
+    });
+
+    describe('ineligible for CAD', () => {
+      it('invokes the defaultBehavior', () => {
+        const view = {
+          invokeBehavior: sinon.spy(),
+          isEligibleForConnectAnotherDevice: sinon.spy(() => false),
+          navigateToConnectAnotherDeviceScreen: sinon.spy()
+        };
+
+        cadBehavior(view, account);
+
+        assert.isTrue(view.isEligibleForConnectAnotherDevice.calledOnce);
+        assert.isTrue(view.isEligibleForConnectAnotherDevice.calledWith(account));
+
+        assert.isFalse(view.navigateToConnectAnotherDeviceScreen.called);
+
+        assert.isTrue(view.invokeBehavior.calledOnce);
+        assert.isTrue(view.invokeBehavior.calledWith(defaultBehavior, account));
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/marketing_snippet.js
+++ b/app/tests/spec/views/marketing_snippet.js
@@ -60,11 +60,12 @@ define(function (require, exports, module) {
     testMarketingCampaign(Constants.MARKETING_ID_AUTUMN_2016);
 
     function testMarketingCampaign (marketingId) {
-      function assertLinkHasExpectedIdAndType(view, expectedId, expectedType) {
+      function assertLinkHasExpectedAttributes(view, expectedId, expectedType) {
         const $linkEl = view.$(`.marketing-link-${expectedType}`);
         assert.lengthOf($linkEl, 1);
         assert.equal($linkEl.data('marketing-id'), expectedId);
         assert.equal($linkEl.data('marketing-type'), expectedType);
+        assert.equal($linkEl.prop('target'), '_blank');
       }
 
       describe(`render for ${marketingId}`, function () {
@@ -101,7 +102,7 @@ define(function (require, exports, module) {
 
           return view.render()
           .then(() => {
-            assertLinkHasExpectedIdAndType(view, marketingId, 'ios');
+            assertLinkHasExpectedAttributes(view, marketingId, 'ios');
             assert.lengthOf(view.$('.marketing-link-android'), 0);
           });
         });
@@ -114,7 +115,7 @@ define(function (require, exports, module) {
           return view.render()
           .then(() => {
             assert.lengthOf(view.$('.marketing-link-ios'), 0);
-            assertLinkHasExpectedIdAndType(view, marketingId, 'android');
+            assertLinkHasExpectedAttributes(view, marketingId, 'android');
           });
         });
 
@@ -125,8 +126,8 @@ define(function (require, exports, module) {
 
           return view.render()
           .then(() => {
-            assertLinkHasExpectedIdAndType(view, marketingId, 'ios');
-            assertLinkHasExpectedIdAndType(view, marketingId, 'android');
+            assertLinkHasExpectedAttributes(view, marketingId, 'ios');
+            assertLinkHasExpectedAttributes(view, marketingId, 'android');
           });
         });
 

--- a/app/tests/spec/views/marketing_snippet.js
+++ b/app/tests/spec/views/marketing_snippet.js
@@ -51,9 +51,14 @@ define(function (require, exports, module) {
     });
 
     afterEach(function () {
+      metrics.destroy();
+      metrics = null;
+
       view.remove();
       view.destroy();
-      view = windowMock = null;
+      view = null;
+
+      windowMock = null;
     });
 
     testMarketingCampaign(Constants.MARKETING_ID_SPRING_2015);
@@ -90,6 +95,7 @@ define(function (require, exports, module) {
           .then(() => {
             assert.lengthOf(view.$('.marketing-link-ios'), 1);
             assert.lengthOf(view.$('.marketing-link-android'), 1);
+            assert.isTrue(view.$el.hasClass(marketingId));
           });
         });
 
@@ -104,6 +110,7 @@ define(function (require, exports, module) {
           .then(() => {
             assertLinkHasExpectedAttributes(view, marketingId, 'ios');
             assert.lengthOf(view.$('.marketing-link-android'), 0);
+            assert.isTrue(view.$el.hasClass(marketingId));
           });
         });
 
@@ -116,6 +123,7 @@ define(function (require, exports, module) {
           .then(() => {
             assert.lengthOf(view.$('.marketing-link-ios'), 0);
             assertLinkHasExpectedAttributes(view, marketingId, 'android');
+            assert.isTrue(view.$el.hasClass(marketingId));
           });
         });
 

--- a/app/tests/spec/views/mixins/modal-panel-mixin.js
+++ b/app/tests/spec/views/mixins/modal-panel-mixin.js
@@ -19,11 +19,11 @@ define(function (require, exports, module) {
     ModalPanelMixin
   );
 
-  describe('views/mixins/modal-panel-mixin', function () {
+  describe('views/mixins/modal-panel-mixin', () => {
     let notifier;
     let view;
 
-    beforeEach(function () {
+    beforeEach(() => {
       notifier = new Notifier();
       view = new ModalPanelView({
         notifier
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
       return view.render();
     });
 
-    afterEach(function () {
+    afterEach(() => {
       view.remove();
       view.destroy();
 
@@ -40,12 +40,32 @@ define(function (require, exports, module) {
     });
 
 
-    it('open and close', function () {
-      view.openPanel();
-      assert.isTrue($.modal.isActive());
+    describe('open and close', () => {
+      it('does the right thing when body min-height needed', () => {
+        sinon.stub(view, '_needsToSetBodyMinHeight', () => true);
 
-      view.closePanel();
-      assert.isFalse($.modal.isActive());
+        assert.equal($('body').css('min-height'), '0px');
+        view.openPanel();
+        assert.isTrue($.modal.isActive());
+        assert.ok(parseInt($('body').css('min-height'), 10) > 0);
+
+        view.closePanel();
+        assert.isFalse($.modal.isActive());
+        assert.equal($('body').css('min-height'), '0px');
+      });
+
+      it('does the right thing when body min-height not needed', () => {
+        sinon.stub(view, '_needsToSetBodyMinHeight', () => false);
+
+        assert.equal($('body').css('min-height'), '0px');
+        view.openPanel();
+        assert.isTrue($.modal.isActive());
+        assert.equal($('body').css('min-height'), '0px');
+
+        view.closePanel();
+        assert.isFalse($.modal.isActive());
+        assert.equal($('body').css('min-height'), '0px');
+      });
     });
 
     it('closePanel destroys the view', () => {

--- a/app/tests/spec/views/settings/clients.js
+++ b/app/tests/spec/views/settings/clients.js
@@ -312,8 +312,7 @@ define(function (require, exports, module) {
         assert.lengthOf(view.$('li.client-device'), 3);
         assert.include(view.$('#device-3 .client-name').text().trim(), 'delta');
         assert.include(view.$('#device-3 .client-name').attr('title'), 'delta', 'the title attr is correct');
-        assert.isTrue(view.$('#device-3 .last-connected').text().trim().indexOf('Last active') === 0, 'formats last active string');
-        assert.isTrue(view.$('#device-3 .last-connected').text().trim().indexOf('a few seconds ago') >= 0, 'formats connected date');
+        assert.isTrue(view.$('#device-3 .last-connected').text().trim().indexOf('started syncing a few seconds ago') >= 0, 'formats connected date');
         assert.ok(view.$('#device-3').hasClass('desktop'));
       });
     });
@@ -504,7 +503,7 @@ define(function (require, exports, module) {
           .then(() => {
             view.translator = {
               get: (untranslatedText) => {
-                if (untranslatedText === 'Last active %(translatedTimeAgo)s') {
+                if (untranslatedText === 'started syncing %(translatedTimeAgo)s') {
                   return 'Translated %(translatedTimeAgo)s';
                 }
 
@@ -514,6 +513,7 @@ define(function (require, exports, module) {
 
             const formatted = view._formatAccessTimeAndScope([
               {
+                isDevice: true,
                 lastAccessTimeFormatted: 'a few seconds ago',
                 name: 'client-1'
               }
@@ -534,6 +534,7 @@ define(function (require, exports, module) {
                 clientType: 'oAuthApp',
                 id: 'app-1',
                 lastAccessTime: Date.now(),
+                lastAccessTimeFormatted: 'a few seconds ago',
                 name: '123Done',
                 scope: ['profile']
               },
@@ -541,6 +542,7 @@ define(function (require, exports, module) {
                 clientType: 'oAuthApp',
                 id: 'app-2',
                 lastAccessTime: Date.now(),
+                lastAccessTimeFormatted: '32 minutes ago',
                 name: 'Pocket',
                 scope: ['profile', 'profile:write']
               },
@@ -548,11 +550,13 @@ define(function (require, exports, module) {
                 clientType: 'oAuthApp',
                 id: 'app-3',
                 lastAccessTime: Date.now(),
+                lastAccessTimeFormatted: 'a month ago',
                 name: 'Add-ons'
               }
             ]);
 
             assert.equal(formatted[0].title, '123Done - profile');
+            assert.equal(formatted[0].lastAccessTimeFormatted, 'last active a few seconds ago');
             assert.equal(formatted[1].title, 'Pocket - profile,profile:write');
             assert.equal(formatted[2].title, 'Add-ons');
           });

--- a/app/tests/spec/views/settings/clients.js
+++ b/app/tests/spec/views/settings/clients.js
@@ -22,20 +22,21 @@ define(function (require, exports, module) {
   const View = require('views/settings/clients');
   const WindowMock = require('../../../mocks/window');
 
-  describe('views/settings/clients', function () {
-    var able;
-    var account;
-    var attachedClients;
-    var broker;
-    var email;
-    var metrics;
-    var notifier;
-    var parentView;
-    var translator;
-    var UID = '123';
-    var user;
-    var view;
-    var windowMock;
+  describe('views/settings/clients', () => {
+    let able;
+    let account;
+    let attachedClients;
+    let broker;
+    let email;
+    let metrics;
+    let notifier;
+    let parentView;
+    let translator;
+    let user;
+    let view;
+    let windowMock;
+
+    const UID = '123';
 
     function initView () {
       view = new View({
@@ -55,7 +56,7 @@ define(function (require, exports, module) {
 
     function setupReRenderTest(testAction) {
       return initView()
-        .then(function () {
+        .then(() => {
           var deferred = p.defer();
 
           view.on('rendered', deferred.resolve.bind(deferred));
@@ -68,9 +69,9 @@ define(function (require, exports, module) {
         });
     }
 
-    beforeEach(function () {
+    beforeEach(() => {
       able = new Able();
-      sinon.stub(able, 'choose', function () {
+      sinon.stub(able, 'choose', () => {
         return true;
       });
       broker = new BaseBroker();
@@ -89,7 +90,7 @@ define(function (require, exports, module) {
         verified: true
       });
 
-      sinon.stub(account, 'isSignedIn', function () {
+      sinon.stub(account, 'isSignedIn', () => {
         return p(true);
       });
 
@@ -130,7 +131,10 @@ define(function (require, exports, module) {
       });
     });
 
-    afterEach(function () {
+    afterEach(() => {
+      metrics.destroy();
+      metrics = null;
+
       if ($.prototype.trigger.restore) {
         $.prototype.trigger.restore();
       }
@@ -140,8 +144,8 @@ define(function (require, exports, module) {
       view = null;
     });
 
-    describe('constructor', function () {
-      beforeEach(function () {
+    describe('constructor', () => {
+      beforeEach(() => {
         view = new View({
           notifier: notifier,
           parentView: parentView,
@@ -149,37 +153,37 @@ define(function (require, exports, module) {
         });
       });
 
-      it('creates an `AttachedClients` instance if one not passed in', function () {
+      it('creates an `AttachedClients` instance if one not passed in', () => {
         assert.ok(view._attachedClients);
       });
     });
 
-    describe('render', function () {
-      beforeEach(function () {
+    describe('render', () => {
+      beforeEach(() => {
         sinon.spy(attachedClients, 'fetch');
 
         return initView();
       });
 
-      it('does not fetch the device list immediately to avoid startup XHR requests', function () {
+      it('does not fetch the device list immediately to avoid startup XHR requests', () => {
         assert.isFalse(attachedClients.fetch.called);
       });
 
-      it('renders attachedClients already in the collection', function () {
+      it('renders attachedClients already in the collection', () => {
         assert.ok(view.$('li.client').length, 2);
       });
 
-      it('title attribute is added', function () {
+      it('title attribute is added', () => {
         assert.equal(view.$('#app-1 .client-name').attr('title'), '123Done');
         assert.equal(view.$('#app-2 .client-name').attr('title'), 'Pocket - profile,profile:write');
       });
 
-      it('renders attachedClients and apps', function () {
+      it('renders attachedClients and apps', () => {
         assert.equal(view.$('#clients .settings-unit-title').text().trim(), 'Devices & apps');
         assert.ok(view.$('#clients').text().trim().indexOf('manage your attachedClients and apps below'));
       });
 
-      it('properly sets the type of devices', function () {
+      it('properly sets the type of devices', () => {
         assert.ok(view.$('#device-1').hasClass('tablet'));
         assert.notOk(view.$('#device-1').hasClass('desktop'));
         assert.equal(view.$('#device-1').data('os'), 'Windows');
@@ -189,7 +193,7 @@ define(function (require, exports, module) {
         assert.equal($('#container [data-get-app]').length, 0, '0 mobile app placeholders');
       });
 
-      it('properly sets the type of apps', function () {
+      it('properly sets the type of apps', () => {
         attachedClients = new AttachedClients([
           {
             clientType: 'oAuthApp',
@@ -217,7 +221,7 @@ define(function (require, exports, module) {
         });
 
         return initView()
-          .then(function () {
+          .then(() => {
             $('#container').html(view.el);
             assert.ok(view.$('#app-1').hasClass('client-oAuthApp'));
             assert.notOk(view.$('#app-1').hasClass('desktop'));
@@ -232,7 +236,7 @@ define(function (require, exports, module) {
 
       });
 
-      it('app placeholders for mobile if there are no mobile clients', function () {
+      it('app placeholders for mobile if there are no mobile clients', () => {
         attachedClients = new AttachedClients([
           {
             clientType: 'device',
@@ -246,13 +250,13 @@ define(function (require, exports, module) {
         });
 
         return initView()
-          .then(function () {
+          .then(() => {
             $('#container').html(view.el);
             assert.equal($('#container [data-get-app]').length, 2, '2 mobile app placeholders');
           });
       });
 
-      it('no app placeholders if there is a tablet device', function () {
+      it('no app placeholders if there is a tablet device', () => {
         attachedClients = new AttachedClients([
           {
             clientType: 'device',
@@ -266,13 +270,13 @@ define(function (require, exports, module) {
         });
 
         return initView()
-          .then(function () {
+          .then(() => {
             $('#container').html(view.el);
             assert.equal($('#container [data-get-app]').length, 0, 'no mobile app placeholders');
           });
       });
 
-      it('names devices "Firefox" if there is no name', function () {
+      it('names devices "Firefox" if there is no name', () => {
         attachedClients = new AttachedClients([
           {
             clientType: 'device',
@@ -285,72 +289,51 @@ define(function (require, exports, module) {
         });
 
         return initView()
-          .then(function () {
+          .then(() => {
             $('#container').html(view.el);
             assert.equal($('#container #device-1 .client-name').text().trim(), 'Firefox', 'device name is Firefox');
           });
 
       });
-
     });
 
-    describe('device added to collection', function () {
-      beforeEach(function () {
-        return setupReRenderTest(function () {
-          attachedClients.add({
-            clientType: 'device',
-            id: 'device-3',
-            lastAccessTime: Date.now(),
-            lastAccessTimeFormatted: 'a few seconds ago',
-            name: 'delta',
-            type: 'desktop'
-          });
-        });
-      });
-
-      it('adds new device to list', function () {
-        assert.lengthOf(view.$('li.client-device'), 3);
-        assert.include(view.$('#device-3 .client-name').text().trim(), 'delta');
-        assert.include(view.$('#device-3 .client-name').attr('title'), 'delta', 'the title attr is correct');
-        assert.isTrue(view.$('#device-3 .last-connected').text().trim().indexOf('started syncing a few seconds ago') >= 0, 'formats connected date');
-        assert.ok(view.$('#device-3').hasClass('desktop'));
-      });
-    });
-
-    describe('device removed from collection', function () {
-      beforeEach(function () {
-        return setupReRenderTest(function () {
+    describe('device removed from collection', () => {
+      beforeEach(() => {
+        return setupReRenderTest(() => {
           // DOM needs to be written so that device remove animation completes
           $('#container').html(view.el);
           attachedClients.get('device-1').destroy();
         });
       });
 
-      it('removes device from list', function () {
+      it('removes device from list', () => {
         assert.lengthOf(view.$('li.client-device'), 1);
         assert.lengthOf(view.$('#device-2'), 1);
       });
     });
 
-    describe('openPanel', function () {
-      beforeEach(function () {
+    describe('openPanel', () => {
+      beforeEach(() => {
         return initView()
-          .then(function () {
+          .then(() => {
             sinon.spy($.prototype, 'trigger');
+            sinon.stub(view, '_fetchAttachedClients', () => p());
+            view.$('.clients-refresh').data('minProgressIndicatorMs', 0);
             return view.openPanel();
           });
       });
 
-      it('fetches the device list', function () {
+      it('fetches the device list', () => {
         assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.clients.open'));
-        assert.isTrue($.prototype.trigger.called, 'calls form submit of the ForView');
+        assert.isFalse(TestHelpers.isEventLogged(metrics, 'settings.clients.refresh'));
+        assert.isTrue(view._fetchAttachedClients.calledOnce);
       });
     });
 
-    describe('click to disconnect device', function () {
-      beforeEach(function () {
+    describe('click to disconnect device', () => {
+      beforeEach(() => {
         return initView()
-          .then(function () {
+          .then(() => {
             // click events require the view to be in the DOM
             $('#container').html(view.el);
 
@@ -360,7 +343,7 @@ define(function (require, exports, module) {
           });
       });
 
-      it('navigates to confirmation dialog', function () {
+      it('navigates to confirmation dialog', () => {
         assert.isTrue(view.navigate.calledOnce);
         var args = view.navigate.args[0];
         assert.equal(args.length, 2);
@@ -370,52 +353,67 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('refresh list behaviour', function () {
-      beforeEach(function () {
+    describe('refresh list behaviour', () => {
+      beforeEach(() => {
         return initView()
-          .then(function () {
+          .then(() => {
             // click events require the view to be in the DOM
             $('#container').html(view.el);
           });
       });
 
-      it('calls `render` when refreshed', function (done) {
-        sinon.spy(view, 'render');
-        sinon.stub(view, 'isPanelOpen', function () {
-          return true;
-        });
+      it('calls `validateAndSubmit` on `clients-refresh` click, starts the refresh', () => {
+        sinon.spy(view, 'startRefresh');
+        sinon.stub(view, 'validateAndSubmit', () => p());
 
-        sinon.stub(view, '_fetchAttachedClients', function () {
-          return p();
-        });
+        view.$('.clients-refresh').click();
 
-        $('.clients-refresh').click();
-        setTimeout(function () {
-          // render delayed by device request promises
-          assert.isTrue(view.render.called);
-          view.render.restore();
-          done();
-        }, 150);
+        assert.isTrue(view.startRefresh.calledOnce);
+        assert.isTrue(view.validateAndSubmit.calledOnce);
       });
-
-      it('calls `_fetchAttachedClients` using a button', function () {
-        sinon.spy($.prototype, 'trigger');
-        sinon.stub(view, 'isPanelOpen', function () {
-          return true;
-        });
-
-        sinon.stub(view, 'submit', function () {
-          return p();
-        });
-
-        $('.clients-refresh').click();
-        assert.isTrue($.prototype.trigger.called, 'calls form submit of the ForView');
-      });
-
     });
 
-    describe('_onGetApp', function () {
-      it('logs get event', function () {
+    describe('validateAndSubmit (refresh)', () => {
+      beforeEach(() => {
+        return initView()
+          .then(() => {
+            view.$('.clients-refresh').data('minProgressIndicatorMs', '1');
+          });
+      });
+
+      it('calls `_fetchAttachedClients`, refreshes', () => {
+        sinon.stub(view, 'isPanelOpen', () => true);
+        sinon.stub(view, '_fetchAttachedClients', () => p());
+        sinon.stub(view, 'render', () => p());
+
+        return view.validateAndSubmit()
+          .then(() => {
+            assert.isTrue(view._fetchAttachedClients.calledOnce);
+            assert.isTrue(view.render.calledOnce);
+          });
+      });
+    });
+
+    describe('startRefresh', () => {
+      beforeEach(() => {
+        return initView();
+      });
+
+      it('initializes the progress indicator and logs the refresh', () => {
+        sinon.spy(view, 'logViewEvent');
+
+        assert.isUndefined(view.$('.clients-refresh').data('minProgressIndicatorMs'));
+
+        view.startRefresh();
+
+        assert.equal(view.$('.clients-refresh').data('minProgressIndicatorMs'), View.MIN_REFRESH_INDICATOR_MS);
+        assert.isTrue(view.logViewEvent.calledOnce);
+        assert.isTrue(view.logViewEvent.calledWith('refresh'));
+      });
+    });
+
+    describe('_onGetApp', () => {
+      it('logs get event', () => {
         attachedClients = new AttachedClients([
           {
             clientType: 'device',
@@ -440,36 +438,36 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('_fetchAttachedClients', function () {
-      beforeEach(function () {
-        sinon.stub(user, 'fetchAccountSessions', function () {
+    describe('_fetchAttachedClients', () => {
+      beforeEach(() => {
+        sinon.stub(user, 'fetchAccountSessions', () => {
           return p();
         });
 
-        sinon.stub(user, 'fetchAccountOAuthApps', function () {
+        sinon.stub(user, 'fetchAccountOAuthApps', () => {
           return p();
         });
 
         return initView()
-          .then(function () {
+          .then(() => {
             return view._fetchAttachedClients();
           });
       });
 
-      it('delegates to the user to fetch the device list', function () {
+      it('delegates to the user to fetch the device list', () => {
         var account = view.getSignedInAccount();
         assert.isTrue(user.fetchAccountSessions.calledWith(account));
         assert.isTrue(TestHelpers.isEventLogged(metrics, 'settings.clients.items.zero'));
       });
 
-      it('logs the number of clients', function () {
+      it('logs the number of clients', () => {
         function createAttachedClientView(numOfClients) {
           return initView()
             .then(() => {
               if (view._attachedClients.fetchClients.restore) {
                 view._attachedClients.fetchClients.restore();
               }
-              sinon.stub(view._attachedClients, 'fetchClients', function () {
+              sinon.stub(view._attachedClients, 'fetchClients', () => {
                 view._attachedClients.length = numOfClients;
                 return p();
               });
@@ -497,8 +495,8 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('_formatAccessTimeAndScope', function () {
-      it('translates the last active string', function () {
+    describe('_formatAccessTimeAndScope', () => {
+      it('translates the last active string', () => {
         return initView()
           .then(() => {
             view.translator = {
@@ -524,7 +522,7 @@ define(function (require, exports, module) {
           });
       });
 
-      it('properly sets the title according to scope', function () {
+      it('properly sets the title according to scope', () => {
         return initView()
           .then(() => {
             $('#container').html(view.el);

--- a/app/tests/spec/views/settings/emails.js
+++ b/app/tests/spec/views/settings/emails.js
@@ -97,6 +97,38 @@ define(function (require, exports, module) {
     });
 
     describe('feature disabled', () => {
+      describe('for email', () => {
+        beforeEach(() => {
+          account = user.initAccount({
+            email: 'a@notenabled.com',
+            sessionToken: 'abc123',
+            uid: UID,
+            verified: true
+          });
+
+          view = new View({
+            broker: broker,
+            emails: emails,
+            metrics: metrics,
+            notifier: notifier,
+            parentView: parentView,
+            translator: translator,
+            user: user,
+            window: windowMock
+          });
+
+          sinon.stub(view, 'remove', () => {
+            return true;
+          });
+
+          return view.render();
+        });
+
+        it('should be disabled when feature is disabled for email', () => {
+          assert.equal(view.remove.callCount, 1);
+        });
+      });
+
       describe('for user', () => {
         beforeEach(() => {
           sinon.stub(account, 'recoveryEmails', () => {

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -762,7 +762,7 @@ define(function (require, exports, module) {
         assert.equal(notifier.trigger.callCount, 2);
         assert.equal(notifier.trigger.args[0][0], 'flow.initialize');
         assert.equal(notifier.trigger.args[1][0], 'flow.event');
-        assert.deepEqual(notifier.trigger.args[1][1], { event: 'begin', once: true, view: undefined });
+        assert.deepEqual(notifier.trigger.args[1][1], { event: 'begin', once: true, viewName: undefined });
       });
 
       it('logs the begin event', () => {

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -1299,7 +1299,7 @@ define(function (require, exports, module) {
         assert.equal(notifier.trigger.callCount, 2);
         assert.equal(notifier.trigger.args[0][0], 'flow.initialize');
         assert.equal(notifier.trigger.args[1][0], 'flow.event');
-        assert.deepEqual(notifier.trigger.args[1][1], { event: 'begin', once: true, view: undefined });
+        assert.deepEqual(notifier.trigger.args[1][1], { event: 'begin', once: true, viewName: undefined });
       });
 
       it('logs the begin event', () => {

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -107,6 +107,7 @@ function (Translator, Session) {
     '../tests/spec/models/web-session',
     '../tests/spec/views/app',
     '../tests/spec/views/base',
+    '../tests/spec/views/behaviors/connect-another-device',
     '../tests/spec/views/behaviors/halt',
     '../tests/spec/views/behaviors/navigate',
     '../tests/spec/views/behaviors/null',

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -451,6 +451,13 @@ const conf = module.exports = convict({
     }
   },
   sms: {
+    redirect: {
+      targetLink: {
+        default: 'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&adgroup=sms&creative=link',
+        doc: 'Target URL for redirection',
+        format: 'url'
+      }
+    },
     testPhoneNumber: {
       default: '',
       doc: 'Phone number to send SMS messages to in function tests',

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -45,6 +45,7 @@ module.exports = function (config, i18n) {
     require('./routes/post-metrics')(),
     require('./routes/post-metrics-errors')(),
     require('./routes/redirect-complete-to-verified')(),
+    require('./routes/redirect-m-to-adjust')(config),
     require('./routes/get-500')(config)
   ];
 

--- a/server/lib/routes/redirect-m-to-adjust.js
+++ b/server/lib/routes/redirect-m-to-adjust.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const SIGNIN_CODE = require('../validation').TYPES.SIGNIN_CODE;
+
+module.exports = function (config) {
+  const targetUrl = config.get('sms.redirect.targetLink');
+
+  return {
+    method: 'get',
+    path: '/m/:signinCode',
+    validate: {
+      params: {
+        signinCode: SIGNIN_CODE
+      }
+    },
+    process: function (req, res) {
+      // The signinCode is already URL safe if it has validated correctly,
+      // so encodeURIComponent is not called.
+      res.redirect(302, `${targetUrl}&signin=${req.params.signinCode}`);
+    }
+  };
+};

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -8,29 +8,35 @@
 
 const joi = require('joi');
 
-module.exports = {
-  PATTERNS: {
-    BROKER: /^[0-9a-z-]+$/,
-    CLIENT_ID: /^[0-9a-f]{16}/,
-    CONTEXT: /^[0-9a-z_-]+$/,
-    ENTRYPOINT: /^[\w.:-]+$/,
-    EVENT_TYPE: /^[\w\s.:-]+$/, // the space is to allow for error contexts that contain spaces, e.g., `error.unknown context.auth.108`
-    EXPERIMENT: /^[\w.-]+$/,
-    MIGRATION: /^(sync11|amo|none)$/,
-    SERVICE: /^(sync|content-server|none|[0-9a-f]{16})$/,
-    UNIQUE_USER_ID: /^[0-9a-z-]{36}$/
-  },
+const PATTERNS = {
+  BASE64: /^[A-Za-z0-9\/+]+={0,2}$/,
+  BASE64_URL_SAFE: /^[A-Za-z0-9_-]+$/,
+  BROKER: /^[0-9a-z-]+$/,
+  CLIENT_ID: /^[0-9a-f]{16}/,
+  CONTEXT: /^[0-9a-z_-]+$/,
+  ENTRYPOINT: /^[\w.:-]+$/,
+  EVENT_TYPE: /^[\w\s.:-]+$/, // the space is to allow for error contexts that contain spaces, e.g., `error.unknown context.auth.108`
+  EXPERIMENT: /^[\w.-]+$/,
+  MIGRATION: /^(sync11|amo|none)$/,
+  SERVICE: /^(sync|content-server|none|[0-9a-f]{16})$/,
+  UNIQUE_USER_ID: /^[0-9a-z-]{36}$/
+};
 
-  TYPES: {
-    BOOLEAN: joi.boolean(),
-    DIMENSION: joi.number().integer().min(0),
-    INTEGER: joi.number().integer(),
-    OFFSET: joi.number().integer().min(0),
-    REFERRER: joi.string().max(2048).uri({ scheme: [ 'android-app', 'http', 'https' ]}).allow('none'),
-    RESUME: joi.string().regex(/^[a-zA-Z0-9\/+]+={0,2}$/), // match any valid base64 character
-    STRING: joi.string().max(1024), // 1024 is arbitrary, seems like it should give CSP reports plenty of space.
-    TIME: joi.number().integer().min(0),
-    URL: joi.string().max(2048).uri({ scheme: [ 'http', 'https' ]}), // 2048 is also arbitrary, the same limit we use on the front end.
-    UTM: joi.string().max(128).regex(/^[\w\/.%-]+/) // values here can be 'firefox/sync'
-  }
+const TYPES = {
+  BOOLEAN: joi.boolean(),
+  DIMENSION: joi.number().integer().min(0),
+  INTEGER: joi.number().integer(),
+  OFFSET: joi.number().integer().min(0),
+  REFERRER: joi.string().max(2048).uri({ scheme: [ 'android-app', 'http', 'https' ]}).allow('none'),
+  RESUME: joi.string().regex(PATTERNS.BASE64),
+  SIGNIN_CODE: joi.string().regex(PATTERNS.BASE64_URL_SAFE).length(8),
+  STRING: joi.string().max(1024), // 1024 is arbitrary, seems like it should give CSP reports plenty of space.
+  TIME: joi.number().integer().min(0),
+  URL: joi.string().max(2048).uri({ scheme: [ 'http', 'https' ]}), // 2048 is also arbitrary, the same limit we use on the front end.
+  UTM: joi.string().max(128).regex(/^[\w\/.%-]+/) // values here can be 'firefox/sync'
+};
+
+module.exports = {
+  PATTERNS,
+  TYPES
 };

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -8,36 +8,38 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var config = intern.config;
-  var PAGE_URL = config.fxaContentRoot + 'signin?context=iframe&service=sync';
+  const config = intern.config;
+  const PAGE_URL = config.fxaContentRoot + 'signin?context=iframe&service=sync';
 
   var email;
-  var PASSWORD = '12345678';
+  const PASSWORD = '12345678';
 
-  var thenify = FunctionalHelpers.thenify;
+  const thenify = FunctionalHelpers.thenify;
 
-  var clearBrowserNotifications = FunctionalHelpers.clearBrowserNotifications;
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-  var noPageTransition = FunctionalHelpers.noPageTransition;
-  var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
-  var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
-  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  const clearBrowserNotifications = FunctionalHelpers.clearBrowserNotifications;
+  const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  const createUser = FunctionalHelpers.createUser;
+  const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
+  const fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
+  const noPageTransition = FunctionalHelpers.noPageTransition;
+  const noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
+  const openPage = FunctionalHelpers.openPage;
+  const openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
+  const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
+  const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  const testElementExists = FunctionalHelpers.testElementExists;
+  const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
+  const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  const visibleByQSA = FunctionalHelpers.visibleByQSA;
 
-  var setupTest = thenify(function (options) {
+  const setupTest = thenify(function (options) {
     options = options || {};
 
     return this.parent
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(options.pageUrl || PAGE_URL, '.email'))
+      .then(visibleByQSA('#fxa-signin-header .service'))
       .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: options.canLinkAccountResponse !== false }))
       // delay for the webchannel message
       .sleep(500)

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -14,6 +14,16 @@ define([
   var email;
   const PASSWORD = '12345678';
 
+  const SELECTOR_CONFIRM_SIGNIN_HEADER = '#fxa-confirm-signin-header';
+  const SELECTOR_CONFIRM_SIGNUP_HEADER = '#fxa-confirm-header';
+  const SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER = '#fxa-connect-another-device-header';
+  const SELECTOR_SETTINGS_HEADER = '#fxa-settings-header';
+  const SELECTOR_SIGNIN_HEADER = '#fxa-signin-header';
+  const SELECTOR_SIGNIN_SUB_HEADER = '#fxa-signin-header .service';
+  const SELECTOR_SIGNIN_UNBLOCK_HEADER = '#fxa-signin-unblock-header';
+  const SELECTOR_SIGNIN_COMPLETE_HEADER = '#fxa-sign-in-complete-header';
+  const SELECTOR_VERIFICATION_EMAIL = '.verification-email-message';
+
   const thenify = FunctionalHelpers.thenify;
 
   const clearBrowserNotifications = FunctionalHelpers.clearBrowserNotifications;
@@ -39,7 +49,7 @@ define([
     return this.parent
       .then(createUser(email, PASSWORD, { preVerified: options.preVerified }))
       .then(openPage(options.pageUrl || PAGE_URL, '.email'))
-      .then(visibleByQSA('#fxa-signin-header .service'))
+      .then(visibleByQSA(SELECTOR_SIGNIN_SUB_HEADER))
       .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: options.canLinkAccountResponse !== false }))
       // delay for the webchannel message
       .sleep(500)
@@ -63,17 +73,17 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testElementExists(SELECTOR_CONFIRM_SIGNIN_HEADER))
 
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
 
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')
-          .then(testElementExists('#fxa-sign-in-complete-header'))
+          .then(testElementExists(SELECTOR_SIGNIN_COMPLETE_HEADER))
           .then(closeCurrentWindow())
 
-        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(testElementExists(SELECTOR_SIGNIN_COMPLETE_HEADER))
         .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
@@ -81,13 +91,13 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testElementExists(SELECTOR_CONFIRM_SIGNIN_HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
 
         .then(openVerificationLinkInDifferentBrowser(email))
 
-        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(testElementExists(SELECTOR_SIGNIN_COMPLETE_HEADER))
         .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
@@ -96,7 +106,7 @@ define([
       return this.remote
         .then(setupTest({ preVerified: false }))
 
-        .then(testElementExists('#fxa-confirm-header'))
+        .then(testElementExists(SELECTOR_CONFIRM_SIGNUP_HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(clearBrowserNotifications())
 
@@ -105,10 +115,12 @@ define([
         // email 2 - "You have verified your Firefox Account"
         .then(openVerificationLinkInNewTab(email, 1))
         .switchToWindow('newwindow')
-          .then(testElementExists('#fxa-connect-another-device-header'))
+          .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER))
           .then(closeCurrentWindow())
 
-        .then(testElementExists('#fxa-sign-up-complete-header'))
+        // Since this is really a signup flow, the original tab
+        // redirects to CAD too.
+        .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER))
         .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
@@ -119,7 +131,7 @@ define([
         .then(noSuchBrowserNotification('fxaccounts:login'))
 
         // user should not transition to the next screen
-        .then(noPageTransition('#fxa-signin-header'));
+        .then(noPageTransition(SELECTOR_SIGNIN_HEADER));
     },
 
     'blocked, valid code entered': function () {
@@ -128,14 +140,14 @@ define([
       return this.remote
         .then(setupTest({ preVerified: true }))
 
-        .then(testElementExists('#fxa-signin-unblock-header'))
-        .then(testElementTextInclude('.verification-email-message', email))
+        .then(testElementExists(SELECTOR_SIGNIN_UNBLOCK_HEADER))
+        .then(testElementTextInclude(SELECTOR_VERIFICATION_EMAIL, email))
         .then(fillOutSignInUnblock(email, 0))
 
         // Only users that go through signin confirmation see
         // `/signin_complete`, and users that go through signin unblock see
         // the default `settings` page.
-        .then(testElementExists('#fxa-settings-header'))
+        .then(testElementExists(SELECTOR_SETTINGS_HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'));
     }
   });

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -14,6 +14,11 @@ define([
   var email;
   const PASSWORD = '12345678';
 
+  const SELECTOR_CONFIRM_HEADER = '#fxa-confirm-header';
+  const SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER = '#fxa-connect-another-device-header';
+  const SELECTOR_SIGN_UP_HEADER = '#fxa-signup-header';
+  const SELECTOR_SIGN_UP_SUB_HEADER = '#fxa-signup-header .service';
+
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
   const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
@@ -40,12 +45,12 @@ define([
 
     'sign up, verify same browser in a different tab': function () {
       return this.remote
-        .then(openPage(PAGE_URL, '#fxa-signup-header'))
-        .then(visibleByQSA('#fxa-signup-header .service'))
+        .then(openPage(PAGE_URL, SELECTOR_SIGN_UP_HEADER))
+        .then(visibleByQSA(SELECTOR_SIGN_UP_SUB_HEADER))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 
-        .then(testElementExists('#fxa-confirm-header'))
+        .then(testElementExists(SELECTOR_CONFIRM_HEADER))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))
 
@@ -54,15 +59,12 @@ define([
         .then(openVerificationLinkInNewTab(email, 0))
         .switchToWindow('newwindow')
 
-        // user should be redirected to "Success!" screen.
-        // In real life, the original browser window would show
-        // a "welcome to sync!" screen that has a manage button
-        // on it, and this screen should show the FxA success screen.
-        .then(testElementExists('#fxa-connect-another-device-header'))
+        // user should see the CAD screen in both signup and verification tabs.
+        .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER))
         // switch back to the original window, it should transition.
         .then(closeCurrentWindow())
 
-        .then(testElementExists('#fxa-sign-up-complete-header'))
+        .then(testElementExists(SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER))
 
         // A post-verification email should be sent, this is Sync.
         .then(testEmailExpected(email, 1));
@@ -70,12 +72,12 @@ define([
 
     'sign up, cancel merge warning': function () {
       return this.remote
-        .then(openPage(PAGE_URL, '#fxa-signup-header'))
+        .then(openPage(PAGE_URL, SELECTOR_SIGN_UP_HEADER))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: false } ))
         .then(fillOutSignUp(email, PASSWORD))
 
         // user should not transition to the next screen
-        .then(noSuchElement('#fxa-confirm-header'))
+        .then(noSuchElement(SELECTOR_CONFIRM_HEADER))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'));
     }
   });

--- a/tests/functional/fx_firstrun_v1_sign_up.js
+++ b/tests/functional/fx_firstrun_v1_sign_up.js
@@ -8,22 +8,23 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var config = intern.config;
-  var PAGE_URL = config.fxaContentRoot + 'signup?context=iframe&service=sync';
+  const config = intern.config;
+  const PAGE_URL = config.fxaContentRoot + 'signup?context=iframe&service=sync';
 
   var email;
-  var PASSWORD = '12345678';
+  const PASSWORD = '12345678';
 
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-  var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testEmailExpected = FunctionalHelpers.testEmailExpected;
-  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
+  const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
+  const noSuchElement = FunctionalHelpers.noSuchElement;
+  const openPage = FunctionalHelpers.openPage;
+  const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
+  const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
+  const testElementExists = FunctionalHelpers.testElementExists;
+  const testEmailExpected = FunctionalHelpers.testEmailExpected;
+  const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  const visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   registerSuite({
     name: 'Firstrun Sync v1 sign_up',
@@ -40,6 +41,7 @@ define([
     'sign up, verify same browser in a different tab': function () {
       return this.remote
         .then(openPage(PAGE_URL, '#fxa-signup-header'))
+        .then(visibleByQSA('#fxa-signup-header .service'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignUp(email, PASSWORD))
 

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -26,6 +26,7 @@ define([
   const SELECTOR_SEND_SMS_HEADER = '#fxa-send-sms-header';
   const SELECTOR_SEND_SMS_PHONE_NUMBER = 'input[type="tel"]';
   const SELECTOR_SIGN_UP_HEADER = '#fxa-signup-header';
+  const SELECTOR_SIGN_UP_SUB_HEADER = '#fxa-signup-header .service';
   const SELECTOR_SIGN_UP_COMPLETE_HEADER = '#fxa-sign-up-complete-header';
 
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
@@ -42,10 +43,12 @@ define([
   const testEmailExpected = FunctionalHelpers.testEmailExpected;
   const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
   const thenify = FunctionalHelpers.thenify;
+  const visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   const setupTest = thenify(function () {
     return this.parent
       .then(openPage(PAGE_URL, SELECTOR_SIGN_UP_HEADER))
+      .then(visibleByQSA(SELECTOR_SIGN_UP_SUB_HEADER))
       .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
 
       .then(fillOutSignUp(email, PASSWORD))

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -14,6 +14,17 @@
    CountryTelephoneInfo, serverConfig) {
    const config = intern.config;
 
+   const ADJUST_LINK_ANDROID =
+    'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +
+    'creative=button-autumn-2016-connect-another-device&adgroup=android';
+
+   const ADJUST_LINK_IOS =
+    'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +
+    'creative=button-autumn-2016-connect-another-device&adgroup=ios&' +
+    'fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&' +
+    'ct=adjust_tracker&mt=8';
+
+
    const SEND_SMS_URL = config.fxaContentRoot + 'sms?service=sync&country=US';
    const SEND_SMS_NO_QUERY_URL = config.fxaContentRoot + 'sms';
 
@@ -23,6 +34,8 @@
    const SELECTOR_LEARN_MORE = 'a#learn-more';
    const SELECTOR_LEARN_MORE_HEADER = '#websites-notice';
    const SELECTOR_MARKETING_LINK = '.marketing-link';
+   const SELECTOR_MARKETING_LINK_ANDROID = '.marketing-link-android';
+   const SELECTOR_MARKETING_LINK_IOS = '.marketing-link-ios';
    const SELECTOR_SEND_SMS_HEADER = '#fxa-send-sms-header';
    const SELECTOR_SEND_SMS_PHONE_NUMBER = 'input[type="tel"]';
    const SELECTOR_SEND_SMS_SUBMIT = 'button[type="submit"]';
@@ -48,6 +61,7 @@
    const testElementExists = FunctionalHelpers.testElementExists;
    const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
    const testElementValueEquals = FunctionalHelpers.testElementValueEquals;
+   const testHrefEquals = FunctionalHelpers.testHrefEquals;
    const type = FunctionalHelpers.type;
 
    const suite = {
@@ -67,7 +81,9 @@
        return this.remote
          .then(openPage(SEND_SMS_NO_QUERY_URL, SELECTOR_SEND_SMS_HEADER))
          .then(testElementValueEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, ''))
-         .then(testAttributeEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, 'data-country', 'US'));
+         .then(testAttributeEquals(SELECTOR_SEND_SMS_PHONE_NUMBER, 'data-country', 'US'))
+         .then(testHrefEquals(SELECTOR_MARKETING_LINK_IOS, ADJUST_LINK_IOS))
+         .then(testHrefEquals(SELECTOR_MARKETING_LINK_ANDROID, ADJUST_LINK_ANDROID));
      },
 
      'with no service, unsupported country': function () {

--- a/tests/functional/settings_clients.js
+++ b/tests/functional/settings_clients.js
@@ -9,30 +9,34 @@ define([
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
 
-  var config = intern.config;
-  var SIGNIN_URL = config.fxaContentRoot + 'signin';
+  const config = intern.config;
+  const SIGNIN_URL = config.fxaContentRoot + 'signin';
 
-  var FIRST_PASSWORD = 'password';
-  var BROWSER_DEVICE_NAME = 'Browser Session Device';
-  var BROWSER_DEVICE_TYPE = 'desktop';
-  var TEST_DEVICE_NAME = 'Test Runner Session Device';
-  var TEST_DEVICE_NAME_UPDATED = 'Test Runner Session Device Updated';
-  var TEST_DEVICE_TYPE = 'mobile';
+  const FIRST_PASSWORD = 'password';
+  const BROWSER_DEVICE_NAME = 'Browser Session Device';
+  const BROWSER_DEVICE_TYPE = 'desktop';
+  const TEST_DEVICE_NAME = 'Test Runner Session Device';
+  const TEST_DEVICE_NAME_UPDATED = 'Test Runner Session Device Updated';
+  const TEST_DEVICE_TYPE = 'mobile';
+
+  const SELECTOR_REFRESH = '.clients-refresh';
+  const SELECTOR_REFRESHING = '.clients-refresh.disabled';
+
   var email;
   var client;
   var accountData;
 
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var click = FunctionalHelpers.click;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var noSuchElement = FunctionalHelpers.noSuchElement;
-  var noSuchStoredAccountByEmail = FunctionalHelpers.noSuchStoredAccountByEmail;
-  var openPage = FunctionalHelpers.openPage;
-  var pollUntil = FunctionalHelpers.pollUntil;
-  var pollUntilGoneByQSA = FunctionalHelpers.pollUntilGoneByQSA;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testElementTextEquals = FunctionalHelpers.testElementTextEquals;
+  const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const click = FunctionalHelpers.click;
+  const createUser = FunctionalHelpers.createUser;
+  const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
+  const noSuchElement = FunctionalHelpers.noSuchElement;
+  const noSuchStoredAccountByEmail = FunctionalHelpers.noSuchStoredAccountByEmail;
+  const openPage = FunctionalHelpers.openPage;
+  const pollUntil = FunctionalHelpers.pollUntil;
+  const pollUntilGoneByQSA = FunctionalHelpers.pollUntilGoneByQSA;
+  const testElementExists = FunctionalHelpers.testElementExists;
+  const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
 
   registerSuite({
     name: 'settings clients',
@@ -84,7 +88,9 @@ define([
         .waitForDeletedByCssSelector('.client-webSession:nth-child(2)')
         .end()
 
-        .then(click('.clients-refresh'))
+        .then(click(SELECTOR_REFRESH))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
+
         // second session is gone.
         .then(noSuchElement('.client-webSession:nth-child(2)'))
 
@@ -120,9 +126,10 @@ define([
         })
 
         // on a slow connection we wait until early refresh stops first
-        .then(pollUntilGoneByQSA('.clients-refresh.disabled'))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
 
-        .then(click('.clients-refresh'))
+        .then(click(SELECTOR_REFRESH))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
 
         .then(testElementTextEquals(
           '.client-device .client-name', TEST_DEVICE_NAME
@@ -142,7 +149,8 @@ define([
           );
         })
 
-        .then(click('.clients-refresh'))
+        .then(click(SELECTOR_REFRESH))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
 
         // wait for 2 devices
         .then(testElementExists('.client-device:nth-child(2)'))
@@ -169,7 +177,8 @@ define([
         ))
 
         // external update should show in the device list
-        .then(click('.clients-refresh'))
+        .then(click(SELECTOR_REFRESH))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
 
         // external text change is hard to track, use pollUntil
         .then(pollUntil(function (newName) {
@@ -206,7 +215,9 @@ define([
         .waitForDeletedByCssSelector('.client-device:nth-child(2)')
         .end()
 
-        .then(click('.clients-refresh'))
+        .then(click(SELECTOR_REFRESH))
+        .then(pollUntilGoneByQSA(SELECTOR_REFRESHING))
+
         // second device is still gone.
         .then(noSuchElement('.client-device:nth-child(2)'))
         .then(click('.client-device:nth-child(1) .client-disconnect'))

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -36,7 +36,8 @@ define([
     'tests/server/routes/get-openid-configuration',
     'tests/server/routes/get-index',
     'tests/server/routes/post-csp',
-    'tests/server/routes/post-metrics'
+    'tests/server/routes/post-metrics',
+    'tests/server/routes/redirect-m-to-adjust',
   ];
 
   return intern;

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -107,6 +107,10 @@ define([
   }
 
   var redirectedRoutes = {
+    '/m/12345678': {
+      location: config.get('sms.redirect.targetLink') + '&signin=12345678',
+      statusCode: 302
+    },
     '/reset_password_complete': {
       location: '/reset_password_verified',
       statusCode: 302
@@ -131,9 +135,7 @@ define([
     routeTest(key, routes[key].statusCode, requestOptions);
   });
 
-  Object.keys(redirectedRoutes).forEach(function (key) {
-    redirectTest(key);
-  });
+  Object.keys(redirectedRoutes).forEach(redirectTest);
 
   registerSuite(suite);
 

--- a/tests/server/routes/redirect-m-to-adjust.js
+++ b/tests/server/routes/redirect-m-to-adjust.js
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'intern/dojo/node!bluebird',
+  'intern/dojo/node!path',
+  'intern/dojo/node!sinon',
+  'intern/dojo/node!../../../server/lib/routes/redirect-m-to-adjust',
+  'intern/dojo/node!../../../server/lib/configuration',
+], function (registerSuite, assert, Promise, path, sinon, route, config) {
+  var instance, request, response;
+
+  registerSuite({
+    name: 'routes/get-app',
+
+    'route interface is correct': function () {
+      assert.isFunction(route);
+      assert.lengthOf(route, 1);
+    },
+
+    'initialise route': {
+      setup: function () {
+        instance = route(config);
+      },
+
+      'instance interface is correct': function () {
+        assert.isObject(instance);
+        assert.lengthOf(Object.keys(instance), 4);
+        assert.equal(instance.method, 'get');
+        assert.equal(instance.path, '/m/:signinCode');
+        assert.isObject(instance.validate);
+        assert.isFunction(instance.process);
+        assert.lengthOf(instance.process, 2);
+      },
+
+      'route.validate': {
+        'validates :signinCode correctly': function() {
+          const validate = val => instance.validate.params.signinCode.validate(val);
+
+          assert.ok(validate('1234567').error); // too short
+          assert.ok(validate('123456789').error); // too long
+          assert.ok(validate('1234567+').error); // not URL safe base64
+          assert.ok(validate('1234567/').error); // not URL safe base64
+
+          assert.equal(validate('12345678').value, '12345678');
+        }
+      },
+
+      'route.process': {
+        setup: function () {
+          request = {
+            params: {
+              signinCode: '12345678'
+            }
+          };
+          response = { redirect: sinon.spy() };
+          instance.process(request, response);
+        },
+
+        'response.redirect was called correctly': function () {
+          assert.equal(response.redirect.callCount, 1);
+
+          const statusCode = response.redirect.args[0][0];
+          assert.equal(statusCode, 302);
+
+          const targetUrl = response.redirect.args[0][1];
+          assert.include(targetUrl, 'signin=12345678');
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
The adds the secondary email feature flag onto the content-server. With this, the content server will not attempt to retrieve secondary emails from auth-server if account email does not have feature enabled on auth. This is a temporary fix for https://github.com/mozilla/fxa-auth-server/issues/1908 to stop the 502/503s requests.

@mozilla/fxa-devs r?