### PR TITLE
refactor(client): Extract next steps from complete_sign_up into the brokers.

### DIFF
--- a/app/scripts/models/auth_brokers/fx-sync.js
+++ b/app/scripts/models/auth_brokers/fx-sync.js
@@ -16,19 +16,19 @@ define(function (require, exports, module) {
   const ConnectAnotherDeviceBehavior = require('views/behaviors/connect-another-device');
 
   const proto = BaseAuthenticationBroker.prototype;
+  const defaultBehaviors = proto.defaultBehaviors;
 
   module.exports = BaseAuthenticationBroker.extend({
     defaultBehaviors: _.extend({}, proto.defaultBehaviors, {
+      afterCompleteSignUp: new ConnectAnotherDeviceBehavior(defaultBehaviors.afterCompleteSignUp)
+    }),
+
+    defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       // Can CAD be displayed after the signup confirmation poll?
       cadAfterSignUpConfirmationPoll: false
     }),
 
     type: 'fx-sync',
-
-    initialize (options = {}) {
-      this._metrics = options.metrics;
-      proto.initialize.call(this, options);
-    },
 
     afterSignUpConfirmationPoll (account) {
       return proto.afterSignUpConfirmationPoll.call(this, account)
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
           if (this.hasCapability('cadAfterSignUpConfirmationPoll')) {
             // This is a hack to allow us to differentiate between users
             // who see CAD in the signup and verification tabs. CAD
-            // was added to the verifiation tab first, view names and view
+            // was added to the verification tab first, view names and view
             // events are all unprefixed. In the signup tab, we force add
             // the `signup` view name prefix so that events that contain
             // viewNames have `signup` view name prefix.
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
             // e.g.:
             // screen.sms <- view the sms screen in the verification tab.
             // screen.signup.sms <- view the sms screen in the signup tab.
-            this._metrics.setViewNamePrefix('signup');
+            this.metrics.setViewNamePrefix('signup');
             return new ConnectAnotherDeviceBehavior(defaultBehavior);
           }
 

--- a/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -47,18 +47,11 @@ define(function (require, exports, module) {
   module.exports = OAuthAuthenticationBroker.extend({
     type: 'redirect',
 
-    initialize (options) {
-      options = options || {};
-
-      this._metrics = options.metrics;
-      return proto.initialize.call(this, options);
-    },
-
     DELAY_BROKER_RESPONSE_MS: 100,
 
     sendOAuthResultToRelier (result) {
       var win = this.window;
-      return this._metrics.flush()
+      return this.metrics.flush()
         .then(function () {
           var extraParams = {};
           if (result.error) {
@@ -109,6 +102,7 @@ define(function (require, exports, module) {
     },
 
     afterCompleteResetPassword: finishOAuthFlowIfOriginalTab('afterCompleteResetPassword', 'finishOAuthSignInFlow'),
+    afterCompleteSignIn: finishOAuthFlowIfOriginalTab('afterCompleteSignIn', 'finishOAuthSignInFlow'),
     afterCompleteSignUp: finishOAuthFlowIfOriginalTab('afterCompleteSignUp', 'finishOAuthSignUpFlow'),
   });
 });

--- a/app/scripts/models/auth_brokers/web.js
+++ b/app/scripts/models/auth_brokers/web.js
@@ -12,22 +12,31 @@ define(function (require, exports, module) {
   const _ = require('underscore');
   const BaseBroker = require('models/auth_brokers/base');
   const { CONTENT_SERVER_CONTEXT } = require('lib/constants');
-  const NavigateBehavior = require('views/behaviors/navigate');
+  const SessionTernaryBehavior = require('views/behaviors/session-ternary');
+  const SettingsAfterVerificationBehavior = require('views/behaviors/settings-after-verification');
 
-  const t = (msg) => msg;
+  const { defaultBehaviors } = BaseBroker.prototype;
 
-  const proto = BaseBroker.prototype;
-
-  const redirectToSettingsBehavior = new NavigateBehavior('settings', {
-    success: t('Account verified successfully')
-  });
+  const settingsAfterVerificationBehavior = new SettingsAfterVerificationBehavior();
 
   module.exports = BaseBroker.extend({
-    defaultBehaviors: _.extend({}, proto.defaultBehaviors, {
-      afterCompleteResetPassword: redirectToSettingsBehavior,
-      afterResetPasswordConfirmationPoll: redirectToSettingsBehavior,
-      afterSignInConfirmationPoll: redirectToSettingsBehavior,
-      afterSignUpConfirmationPoll: redirectToSettingsBehavior
+    defaultBehaviors: _.extend({}, defaultBehaviors, {
+      afterCompleteAddSecondaryEmail: new SessionTernaryBehavior(
+        settingsAfterVerificationBehavior,
+        defaultBehaviors.afterCompleteAddSecondaryEmail
+      ),
+      afterCompleteResetPassword: settingsAfterVerificationBehavior,
+      afterCompleteSignIn: new SessionTernaryBehavior(
+        settingsAfterVerificationBehavior,
+        defaultBehaviors.afterCompleteSignIn
+      ),
+      afterCompleteSignUp: new SessionTernaryBehavior(
+        settingsAfterVerificationBehavior,
+        defaultBehaviors.afterCompleteSignUp
+      ),
+      afterResetPasswordConfirmationPoll: settingsAfterVerificationBehavior,
+      afterSignInConfirmationPoll: settingsAfterVerificationBehavior,
+      afterSignUpConfirmationPoll: settingsAfterVerificationBehavior
     }),
 
     type: CONTENT_SERVER_CONTEXT

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -940,7 +940,8 @@ define(function (require, exports, module) {
     },
 
     /**
-     * Invoke a behavior returned by an auth broker.
+     * Invoke `behavior` returned by an auth broker. If `behavior` returns
+     * another behavior, the returned behavior is recursively invoked.
      *
      * @method invokeBehavior
      * @param {Function} behavior
@@ -951,10 +952,17 @@ define(function (require, exports, module) {
     invokeBehavior (behavior, ...args) {
       return p().then(() => {
         if (_.isFunction(behavior)) {
+          // recursively invokes behaviors that return behaviors.
           return behavior(this, ...args);
         }
-
         return behavior;
+      })
+      .then((result) => {
+        if (_.isFunction(result)) {
+          // recursively invoke any returned behaviors.
+          return this.invokeBehavior(result, ...args);
+        }
+        return result;
       });
     }
   });

--- a/app/scripts/views/behaviors/connect-another-device.js
+++ b/app/scripts/views/behaviors/connect-another-device.js
@@ -29,7 +29,9 @@ define((require, exports, module) => {
       return view.invokeBehavior(defaultBehavior, account);
     };
 
+    // properties exposed for testing
     behavior.type = 'connect-another-device';
+    behavior.defaultBehavior = defaultBehavior;
 
     return behavior;
   };

--- a/app/scripts/views/behaviors/session-ternary.js
+++ b/app/scripts/views/behaviors/session-ternary.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Behavior that returns `signedInBehavior` if the
+ * account is signed in, and `signedOutBehavior` otherwise.
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  /**
+   * Invoke `signedInBehavior` if the account is signed in,
+   * and `signedOutBehavior` otherwise.
+   *
+   * @param {Function} signedInBehavior
+   * @param {Function} signedOutBehavior
+   * @returns {Function}
+   */
+  module.exports = function (signedInBehavior, signedOutBehavior) {
+    const behavior = (view, account) => {
+      return account.isSignedIn()
+        .then((isSignedIn) => {
+          return isSignedIn ? signedInBehavior : signedOutBehavior;
+        });
+    };
+
+    // properties exposed for testing
+    behavior.type = 'session-ternary';
+    behavior.signedInBehavior = signedInBehavior;
+    behavior.signedOutBehavior = signedOutBehavior;
+
+    return behavior;
+  };
+});

--- a/app/scripts/views/behaviors/settings-after-verification.js
+++ b/app/scripts/views/behaviors/settings-after-verification.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Behavior sends users to /settings after verifying their email.
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const NavigateBehavior = require('views/behaviors/navigate');
+  const t = (msg) => msg;
+
+  module.exports = function () {
+    return new NavigateBehavior('settings', {
+      success: t('Account verified successfully')
+    });
+  };
+});

--- a/app/scripts/views/mixins/verification-reason-mixin.js
+++ b/app/scripts/views/mixins/verification-reason-mixin.js
@@ -46,6 +46,15 @@ define(function (require, exports, module) {
     },
 
     /**
+     * Check if verification is to verify a secondary email
+     *
+     * @returns {Boolean}
+     */
+    isVerifySecondaryEmail () {
+      return this.model.get('type') === VerificationReasons.SECONDARY_EMAIL_VERIFIED;
+    },
+
+    /**
      * Get the key in VerificationReasons for the given verification reason
      *
      * @param {String} verificationReason

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -6,6 +6,7 @@ define((require, exports, module) => {
   'use strict';
 
   const { assert } = require('chai');
+  const { defaultBehaviors } = require('models/auth_brokers/base').prototype;
   const FxSyncAuthenticationBroker = require('models/auth_brokers/fx-sync');
   const Metrics = require('lib/metrics');
   const sinon = require('sinon');
@@ -18,7 +19,9 @@ define((require, exports, module) => {
     let windowMock;
 
     beforeEach(() => {
-      account = {};
+      account = {
+        get: sinon.spy()
+      };
       metrics = new Metrics();
       windowMock = new WindowMock();
 
@@ -45,7 +48,6 @@ define((require, exports, module) => {
           return broker.afterSignUpConfirmationPoll(account)
             .then((behavior) => {
               assert.equal(behavior.type, 'connect-another-device');
-
               assert.isTrue(metrics.setViewNamePrefix.calledOnce);
               assert.isTrue(metrics.setViewNamePrefix.calledWith('signup'));
             });
@@ -63,6 +65,16 @@ define((require, exports, module) => {
               assert.isFalse(metrics.setViewNamePrefix.called);
             });
         });
+      });
+    });
+
+    describe('afterCompleteSignUp', () => {
+      it('resolves to a `ConnectAnotherDeviceBehavior`', () => {
+        return broker.afterCompleteSignUp(account)
+          .then((behavior) => {
+            assert.equal(behavior.type, 'connect-another-device');
+            assert.strictEqual(behavior.defaultBehavior, defaultBehaviors.afterCompleteSignUp);
+          });
       });
     });
   });

--- a/app/tests/spec/models/auth_brokers/oauth-redirect.js
+++ b/app/tests/spec/models/auth_brokers/oauth-redirect.js
@@ -177,6 +177,27 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('afterCompleteSignIn', () => {
+      it('logs, finishes the oauth flow if the user verifies in the original tab', () => {
+        return broker.persistVerificationData(account)
+          .then(() => {
+            return broker.afterCompleteSignIn(account);
+          })
+          .then(() => {
+            assert.isTrue(broker.finishOAuthFlow.calledWith(account, {
+              action: Constants.OAUTH_ACTION_SIGNIN
+            }));
+          });
+      });
+
+      it('does not finish the oauth flow if the user verifies in another tab', () => {
+        return broker.afterCompleteSignIn(account)
+          .then(() => {
+            assert.isFalse(broker.finishOAuthFlow.calledWith(account));
+          });
+      });
+    });
+
     describe('afterCompleteResetPassword', () => {
       it('finishes the oauth flow if the user verifies in the original tab', () => {
         return broker.persistVerificationData(account)

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -1017,6 +1017,31 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('invokeBehavior', () => {
+      it('returns a non-function', () => {
+        return view.invokeBehavior('behavior')
+          .then((result) => {
+            assert.equal(result, 'behavior');
+          });
+      });
+
+      it('handles behaviors that return behaviors', () => {
+        const behavior2 = sinon.spy(() => 'result');
+        const behavior1 = sinon.spy(() => behavior2);
+
+        return view.invokeBehavior(behavior1, 'arg1', 'arg2')
+          .then((result) => {
+            assert.equal(result, 'result');
+
+            assert.isTrue(behavior1.calledOnce);
+            assert.isTrue(behavior1.calledWith(view, 'arg1', 'arg2'));
+
+            assert.isTrue(behavior2.calledOnce);
+            assert.isTrue(behavior2.calledWith(view, 'arg1', 'arg2'));
+          });
+      });
+    });
+
     describe('getViewName', function () {
       describe('with a `viewName` on the view prototype', function () {
         var view;

--- a/app/tests/spec/views/behaviors/session-ternary.js
+++ b/app/tests/spec/views/behaviors/session-ternary.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const Account = require('models/account');
+  const { assert } = require('chai');
+  const NavigateBehavior = require('views/behaviors/navigate');
+  const p = require('lib/promise');
+  const SessionTernaryBehavior = require('views/behaviors/session-ternary');
+  const sinon = require('sinon');
+
+  describe('views/behaviors/session-ternary', () => {
+    let sessionTernaryBehavior;
+    let signedInBehavior;
+    let signedOutBehavior;
+
+    before (() => {
+      signedInBehavior = new NavigateBehavior('settings');
+      signedOutBehavior = new NavigateBehavior('signin');
+      sessionTernaryBehavior = new SessionTernaryBehavior(signedInBehavior, signedOutBehavior);
+    });
+
+    describe('account is signed in', () => {
+      it('returns the `signedInBehavior`', () => {
+        const account = new Account({});
+        sinon.stub(account, 'isSignedIn', () => p(true));
+
+        return sessionTernaryBehavior({}, account)
+          .then((behavior) => {
+            assert.strictEqual(behavior, signedInBehavior);
+          });
+      });
+    });
+
+    describe('account is not signed in', () => {
+      it('returns the `signedOutBehavior`', () => {
+        const account = new Account({});
+        sinon.stub(account, 'isSignedIn', () => p(false));
+
+        return sessionTernaryBehavior({}, account)
+          .then((behavior) => {
+            assert.strictEqual(behavior, signedOutBehavior);
+          });
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/behaviors/settings-after-verification.js
+++ b/app/tests/spec/views/behaviors/settings-after-verification.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const { assert } = require('chai');
+  const SettingsAfterVerificationBehavior = require('views/behaviors/settings-after-verification');
+
+  describe('views/behaviors/settings-after-verification', () => {
+    let settingsAfterVerificationBehavior;
+
+    before (() => {
+      settingsAfterVerificationBehavior = new SettingsAfterVerificationBehavior();
+    });
+
+    it('returns a behavior that navigates to `/settings`', () => {
+      assert.equal(settingsAfterVerificationBehavior.type, 'navigate');
+      assert.equal(settingsAfterVerificationBehavior.endpoint, 'settings');
+    });
+  });
+});

--- a/app/tests/spec/views/mixins/verification-reason-mixin.js
+++ b/app/tests/spec/views/mixins/verification-reason-mixin.js
@@ -12,19 +12,19 @@ define(function (require, exports, module) {
   const VerificationReasons = require('lib/verification-reasons');
   const VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
 
-  var View = BaseView.extend({});
+  const View = BaseView.extend({});
   Cocktail.mixin(
     View,
     VerificationReasonMixin
   );
 
-  describe('views/mixins/verification-reason-mixin', function () {
-    describe('constructor', function () {
-      describe('model has a type', function () {
-        var view;
+  describe('views/mixins/verification-reason-mixin', () => {
+    describe('constructor', () => {
+      describe('model has a type', () => {
+        let view;
 
-        before(function () {
-          var model = new Backbone.Model();
+        before(() => {
+          const model = new Backbone.Model();
           model.set('type', VerificationReasons.SIGN_IN);
 
           view = new View({
@@ -32,82 +32,100 @@ define(function (require, exports, module) {
           });
         });
 
-        it('uses the type set in the model', function () {
+        it('uses the type set in the model', () => {
           assert.equal(view.model.get('type'), VerificationReasons.SIGN_IN);
         });
       });
 
-      describe('model has no type, option set', function () {
-        var view;
+      describe('model has no type, option set', () => {
+        let view;
 
-        before(function () {
+        before(() => {
           view = new View({
             type: VerificationReasons.SIGN_IN
           });
         });
 
-        it('uses the type set in the options', function () {
+        it('uses the type set in the options', () => {
           assert.equal(view.model.get('type'), VerificationReasons.SIGN_IN);
         });
       });
 
-      describe('model has no type, option not set', function () {
-        var view;
+      describe('model has no type, option not set', () => {
+        let view;
 
-        before(function () {
+        before(() => {
           view = new View({});
         });
 
-        it('uses the SIGN_UP type by default', function () {
+        it('uses the SIGN_UP type by default', () => {
           assert.equal(view.model.get('type'), VerificationReasons.SIGN_UP);
         });
       });
     });
 
-    describe('isSignIn', function () {
-      var view;
+    describe('isSignIn', () => {
+      let view;
 
-      before(function () {
+      before(() => {
         view = new View({});
       });
 
-      it('returns `true` for SIGN_IN type', function () {
+      it('returns `true` for SIGN_IN type', () => {
         view.model.set('type', VerificationReasons.SIGN_IN);
         assert.isTrue(view.isSignIn());
       });
 
-      it('returns `false` for other types', function () {
+      it('returns `false` for other types', () => {
         view.model.set('type', VerificationReasons.SIGN_UP);
         assert.isFalse(view.isSignIn());
       });
     });
 
-    describe('isSignUp', function () {
-      var view;
+    describe('isSignUp', () => {
+      let view;
 
-      before(function () {
+      before(() => {
         view = new View({});
       });
 
-      it('returns `true` for SIGN_UP type', function () {
+      it('returns `true` for SIGN_UP type', () => {
         view.model.set('type', VerificationReasons.SIGN_UP);
         assert.isTrue(view.isSignUp());
       });
 
-      it('returns `false` for other types', function () {
+      it('returns `false` for other types', () => {
         view.model.set('type', VerificationReasons.SIGN_IN);
         assert.isFalse(view.isSignUp());
       });
     });
 
-    describe('keyOfType', function () {
-      var view;
+    describe('isVerifySecondaryEmail', () => {
+      let view;
 
-      before(function () {
+      before(() => {
         view = new View({});
       });
 
-      it('returns the correct value', function () {
+      it('returns `true` for SECONDARY_EMAIL_VERIFIED type', () => {
+        view.model.set('type', VerificationReasons.SECONDARY_EMAIL_VERIFIED);
+        assert.isTrue(view.isVerifySecondaryEmail());
+      });
+
+      it('returns `false` for other types', () => {
+        view.model.set('type', VerificationReasons.SIGN_IN);
+        assert.isFalse(view.isVerifySecondaryEmail());
+      });
+    });
+
+    describe('keyOfType', () => {
+      let view;
+
+      before(() => {
+        view = new View({});
+      });
+
+      it('returns the correct value', () => {
         assert.equal(
           view.keyOfVerificationReason(VerificationReasons.SIGN_IN), 'SIGN_IN');
       });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -122,6 +122,8 @@ function (Translator, Session) {
     '../tests/spec/views/behaviors/halt',
     '../tests/spec/views/behaviors/navigate',
     '../tests/spec/views/behaviors/null',
+    '../tests/spec/views/behaviors/session-ternary',
+    '../tests/spec/views/behaviors/settings-after-verification',
     '../tests/spec/views/cannot_create_account',
     '../tests/spec/views/choose_what_to_sync',
     '../tests/spec/views/clear_storage',

--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -8,8 +8,9 @@ define([
   'app/scripts/lib/constants',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
-  'tests/functional/lib/fx-desktop'
-], function (intern, registerSuite, Constants, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
+  'tests/functional/lib/fx-desktop',
+  'tests/functional/lib/selectors'
+], function (intern, registerSuite, Constants, TestHelpers, FunctionalHelpers, FxDesktopHelpers, selectors) {
   var config = intern.config;
   var PAGE_COMPLETE_SIGNIN_URL = config.fxaContentRoot + 'complete_signin';
   var PAGE_SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
@@ -110,11 +111,11 @@ define([
       var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(url, '#fxa-settings-profile-header'))
+        .then(openPage(url, selectors.SIGNIN_COMPLETE.HEADER))
 
         // a successful user is immediately redirected to the
         // sign-in-complete page.
-        .then(testElementExists('#fxa-settings-profile-header'));
+        .then(testElementExists(selectors.SIGNIN_COMPLETE.HEADER));
     }
   });
 });


### PR DESCRIPTION
#### What is this?

Another refactor, this one nearly 6 months in the making. I'm making slow progress to ripping out screen->screen flow logic from the views and moving that into the brokers.

#### Why go through all the effort?

Flow logic should not live in the views. Views should take care of view stuff. complete_sign_up was turning into a mess, and the CAD code was more difficult than need be as a result. Decisions are being made based on whether a screen is displayed for sign up, sign in, or secondary email verification. In addition, certain features are enabled in certain flows, e.g., CAD is only available for sign up, and this knowledge had to be built into CAD's gating logic. This is kinda bonkers.

Brokers allow these types of decisions to be made declaratively. It's easier to think about. It's harder to make mistakes. Tests can shrink.