### PR TITLE
feat(emails): Disable secondary emails for everyone

### DIFF
--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -20,7 +20,6 @@ define(function (require, exports, module) {
   const ClientsView = require('views/settings/clients');
   const ClientDisconnectView = require('views/settings/client_disconnect');
   const DisplayNameView = require('views/settings/display_name');
-  const EmailsView = require('views/settings/emails');
   const Duration = require('duration');
   const LoadingMixin = require('views/mixins/loading-mixin');
   const modal = require('modal'); //eslint-disable-line no-unused-vars
@@ -31,7 +30,6 @@ define(function (require, exports, module) {
   const Template = require('stache!templates/settings');
 
   var PANEL_VIEWS = [
-    EmailsView,
     AvatarView,
     ClientsView,
     ClientDisconnectView,

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -47,7 +47,6 @@ define([
   './functional/settings',
   './functional/settings_clients',
   './functional/settings_common',
-  './functional/settings_secondary_emails.js',
   './functional/sync_settings',
   './functional/change_password',
   './functional/force_auth',

--- a/tests/intern_functional_circle.js
+++ b/tests/intern_functional_circle.js
@@ -8,7 +8,6 @@ define([
 ], function (intern, selectCircleTests) {
 
   intern.functionalSuites = selectCircleTests([
-    'tests/functional/settings_secondary_emails.js',
     // flaky tests go above here.
     'tests/functional/avatar',
     'tests/functional/back_button_after_start',


### PR DESCRIPTION
This was the most straightforward way I found for `disabling` secondary emails. It removes the view from settings and disables failing functional tests. This will be used in case of a rollback.

@vladikoff @shane-tomlinson r?