### PR TITLE
refactor(test): Modernize the sign_in view unit test.

### DIFF
--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -7,10 +7,10 @@ define(function (require, exports, module) {
 
   const $ = require('jquery');
   const Account = require('models/account');
+  const { assert } = require('chai');
   const AuthErrors = require('lib/auth-errors');
   const Backbone = require('backbone');
   const Broker = require('models/auth_brokers/base');
-  const chai = require('chai');
   const Constants = require('lib/constants');
   const FormPrefill = require('models/form-prefill');
   const Metrics = require('lib/metrics');
@@ -20,29 +20,26 @@ define(function (require, exports, module) {
   const Session = require('lib/session');
   const sinon = require('sinon');
   const Translator = require('lib/translator');
-  const TestHelpers = require('../../lib/helpers');
+  const { createEmail, isEventLogged, wrapAssertion } = require('../../lib/helpers');
   const User = require('models/user');
   const View = require('views/sign_in');
   const WindowMock = require('../../mocks/window');
 
-  var assert = chai.assert;
-  var wrapAssertion = TestHelpers.wrapAssertion;
+  describe('views/sign_in', () => {
+    let broker;
+    let email;
+    let formPrefill;
+    let metrics;
+    let model;
+    let notifier;
+    let relier;
+    let user;
+    let view;
+    let translator;
+    let windowMock;
 
-  describe('views/sign_in', function () {
-    var broker;
-    var email;
-    var formPrefill;
-    var metrics;
-    var model;
-    var notifier;
-    var relier;
-    var user;
-    var view;
-    var translator;
-    var windowMock;
-
-    beforeEach(function () {
-      email = TestHelpers.createEmail();
+    beforeEach(() => {
+      email = createEmail();
       formPrefill = new FormPrefill();
       model = new Backbone.Model();
       notifier = new Notifier();
@@ -73,19 +70,17 @@ define(function (require, exports, module) {
       $('body').attr('data-flow-id', 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103');
       $('body').attr('data-flow-begin', '42');
 
-      return view.render()
-          .then(function () {
-            $('#container').html(view.el);
-          });
+      return view.render();
     });
 
-    afterEach(function () {
+    afterEach(() => {
       metrics.destroy();
+      metrics = null;
 
       view.remove();
       view.destroy();
 
-      view = metrics = null;
+      view = null;
     });
 
     function initView () {
@@ -103,14 +98,14 @@ define(function (require, exports, module) {
       });
     }
 
-    describe('render', function () {
-      it('prefills email and password if stored in formPrefill (user comes from signup with existing account)', function () {
+    describe('render', () => {
+      it('prefills email and password if stored in formPrefill (user comes from signup with existing account)', () => {
         formPrefill.set('email', 'testuser@testuser.com');
         formPrefill.set('password', 'prefilled password');
 
         initView();
         return view.render()
-            .then(function () {
+            .then(() => {
               assert.ok(view.$('#fxa-signin-header').length);
               assert.equal(view.$('[type=email]').val(), 'testuser@testuser.com');
               assert.equal(view.$('[type=email]').attr('spellcheck'), 'false');
@@ -118,65 +113,60 @@ define(function (require, exports, module) {
             });
       });
 
-      it('Shows serviceName from the relier', function () {
-        relier.isSync = function () {
-          return true;
-        };
-        var serviceName = 'another awesome service by Mozilla';
+      it('Shows serviceName from the relier', () => {
+        relier.isSync = () => true;
+        const serviceName = 'another awesome service by Mozilla';
         relier.set('serviceName', serviceName);
 
         // initialize a new view to set the service name
         initView();
         return view.render()
-            .then(function () {
+            .then(() => {
               assert.include(view.$('#fxa-signin-header').text(), serviceName);
             });
       });
 
-      it('shows a prefilled email and password field of cached session', function () {
-        sinon.stub(view, 'getAccount', function () {
+      it('shows a prefilled email and password field of cached session', () => {
+        sinon.stub(view, 'getAccount', () => {
           return user.initAccount({
             email: 'a@a.com',
             sessionToken: 'abc123'
           });
         });
         return view.render()
-            .then(function () {
-              assert.ok($('#fxa-signin-header').length);
+            .then(() => {
+              assert.ok(view.$('#fxa-signin-header').length);
               assert.equal(view.$('.prefillEmail').html(), 'a@a.com');
               assert.equal(view.$('[type=password]').val(), '');
             });
       });
 
-      it('prefills email with email from relier if Session.prefillEmail is not set', function () {
+      it('prefills email with email from relier if Session.prefillEmail is not set', () => {
         relier.set('email', 'testuser@testuser.com');
 
         initView();
         return view.render()
-            .then(function () {
+            .then(() => {
               assert.equal(view.$('[type=email]').val(), 'testuser@testuser.com');
             });
       });
 
-      describe('with a cached account whose accessToken is invalidated after render', function () {
-        beforeEach(function () {
+      describe('with a cached account whose accessToken is invalidated after render', () => {
+        beforeEach(() => {
           initView();
 
-          var account = user.initAccount({
+          const account = user.initAccount({
             accessToken: 'access token',
             email: 'a@a.com',
             sessionToken: 'session token',
             sessionTokenContext: Constants.SYNC_SERVICE
           });
 
-          sinon.stub(view, '_suggestedAccount', function () {
-            return account;
-          });
-
+          sinon.stub(view, '_suggestedAccount', () => account);
           sinon.spy(view, 'render');
 
           return view.render()
-            .then(function () {
+            .then(() => {
               account.set({
                 accessToken: null,
                 sessionToken: null,
@@ -185,109 +175,97 @@ define(function (require, exports, module) {
             });
         });
 
-        it('re-renders', function () {
+        it('re-renders, keeps the original email, forces user to enter password', () => {
           assert.equal(view.render.callCount, 2);
-        });
-
-        it('keeps the original email', function () {
           assert.equal(view.$('.prefillEmail').text(), 'a@a.com');
           assert.equal(view.$('input[type=email]').val(), 'a@a.com');
-        });
-
-        it('forces the user to enter their password', function () {
           assert.lengthOf(view.$('input[type=password]'), 1);
         });
       });
     });
 
-    describe('migration', function () {
-      it('does not display migration message if no migration', function () {
+    describe('migration', () => {
+      it('does not display migration message if no migration', () => {
         initView();
 
         return view.render()
-          .then(function () {
+          .then(() => {
             assert.lengthOf(view.$('#sync-migration'), 0);
           });
       });
 
-      it('displays migration message if isSyncMigration returns true', function () {
+      it('displays migration message if isSyncMigration returns true', () => {
         initView();
-        sinon.stub(view, 'isSyncMigration', function () {
-          return true;
-        });
+        sinon.stub(view, 'isSyncMigration', () => true);
 
         return view.render()
-          .then(function () {
+          .then(() => {
             assert.equal(view.$('#sync-migration').html(), 'Migrate your sync data by signing in to your Firefox&nbsp;Account.');
             view.isSyncMigration.restore();
           });
       });
 
-      it('does not display migration message if isSyncMigration returns false', function () {
+      it('does not display migration message if isSyncMigration returns false', () => {
         initView();
-        sinon.stub(view, 'isSyncMigration', function () {
-          return false;
-        });
+        sinon.stub(view, 'isSyncMigration', () => false);
 
         return view.render()
-          .then(function () {
+          .then(() => {
             assert.lengthOf(view.$('#sync-migration'), 0);
             view.isSyncMigration.restore();
           });
       });
     });
 
-    describe('isValid', function () {
-      it('returns true if both email and password are valid', function () {
+    describe('isValid', () => {
+      it('returns true if both email and password are valid', () => {
         view.$('[type=email]').val('testuser@testuser.com');
         view.$('[type=password]').val('password');
         assert.isTrue(view.isValid());
       });
 
-      it('returns false if email is invalid', function () {
+      it('returns false if email is invalid', () => {
         view.$('[type=email]').val('testuser');
         view.$('[type=password]').val('password');
         assert.isFalse(view.isValid());
       });
 
-      it('returns false if password is invalid', function () {
+      it('returns false if password is invalid', () => {
         view.$('[type=email]').val('testuser@testuser.com');
         view.$('[type=password]').val('passwor');
         assert.isFalse(view.isValid());
       });
     });
 
-    describe('submit', function () {
-      beforeEach(function () {
+    describe('submit', () => {
+      beforeEach(() => {
         view.enableForm();
 
-        $('[type=email]').val(email);
-        $('[type=password]').val('password');
+        view.$('[type=email]').val(email);
+        view.$('[type=password]').val('password');
       });
 
-      describe('with a user that successfully signs in', function () {
-        beforeEach(function () {
-          sinon.stub(view, 'signIn', function () {
-            return p();
-          });
+      describe('with a user that successfully signs in', () => {
+        beforeEach(() => {
+          sinon.stub(view, 'signIn', () => p());
 
           return view.submit();
         });
 
-        it('delegates to view.signIn', function () {
+        it('delegates to view.signIn', () => {
           assert.isTrue(view.signIn.calledOnce);
 
-          var args = view.signIn.args[0];
-          var account = args[0];
+          const args = view.signIn.args[0];
+          const account = args[0];
           assert.instanceOf(account, Account);
-          var password = args[1];
+          const password = args[1];
           assert.equal(password, 'password');
         });
       });
 
-      describe('with a reset account', function () {
-        beforeEach(function () {
-          sinon.stub(view, 'signIn', function () {
+      describe('with a reset account', () => {
+        beforeEach(() => {
+          sinon.stub(view, 'signIn', () => {
             return p.reject(AuthErrors.toError('ACCOUNT_RESET'));
           });
 
@@ -296,38 +274,34 @@ define(function (require, exports, module) {
           return view.submit();
         });
 
-        it('notifies the user of the reset account', function () {
+        it('notifies the user of the reset account', () => {
           assert.isTrue(view.notifyOfResetAccount.called);
-          var args = view.notifyOfResetAccount.args[0];
-          var account = args[0];
+          const args = view.notifyOfResetAccount.args[0];
+          const account = args[0];
           assert.instanceOf(account, Account);
         });
       });
 
-      describe('with a user that cancels login', function () {
-        beforeEach(function () {
-          sinon.stub(view, 'signIn', function () {
+      describe('with a user that cancels login', () => {
+        beforeEach(() => {
+          sinon.stub(view, 'signIn', () => {
             return p.reject(AuthErrors.toError('USER_CANCELED_LOGIN'));
           });
 
           return view.submit();
         });
 
-        it('logs the error', function () {
-          assert.isTrue(TestHelpers.isEventLogged(metrics,
-                            'signin.canceled'));
-        });
-
-        it('does not display an error', function () {
+        it('logs, but does not display the error', () => {
+          assert.isTrue(isEventLogged(metrics, 'signin.canceled'));
           assert.isFalse(view.isErrorVisible());
         });
       });
 
-      describe('with an unknown account', function () {
-        beforeEach(function () {
+      describe('with an unknown account', () => {
+        beforeEach(() => {
           broker.setCapability('signup', true);
 
-          sinon.stub(view, 'signIn', function () {
+          sinon.stub(view, 'signIn', () => {
             return p.reject(AuthErrors.toError('UNKNOWN_ACCOUNT'));
           });
 
@@ -336,18 +310,18 @@ define(function (require, exports, module) {
           return view.submit();
         });
 
-        it('shows a link to the signup page', function () {
-          var err = view.unsafeDisplayError.args[0][0];
+        it('shows a link to the signup page', () => {
+          const err = view.unsafeDisplayError.args[0][0];
           assert.isTrue(AuthErrors.is(err, 'UNKNOWN_ACCOUNT'));
           assert.include(err.forceMessage, '/signup');
         });
       });
 
-      describe('other errors', function () {
-        var err;
+      describe('other errors', () => {
+        let err;
 
-        beforeEach(function () {
-          sinon.stub(view, 'signIn', function () {
+        beforeEach(() => {
+          sinon.stub(view, 'signIn', () => {
             return p.reject(AuthErrors.toError('INVALID_JSON'));
           });
 
@@ -359,21 +333,21 @@ define(function (require, exports, module) {
             });
         });
 
-        it('are displayed', function () {
-          var displayedError = view.displayError.args[0][0];
+        it('are displayed', () => {
+          const displayedError = view.displayError.args[0][0];
           assert.strictEqual(err, displayedError);
           assert.isTrue(AuthErrors.is(err, 'INVALID_JSON'));
         });
       });
     });
 
-    describe('showValidationErrors', function () {
+    describe('showValidationErrors', () => {
       it('shows an error if the email is invalid', function (done) {
         view.$('[type=email]').val('testuser');
         view.$('[type=password]').val('password');
 
         view.on('validation_error', function (which, msg) {
-          wrapAssertion(function () {
+          wrapAssertion(() => {
             assert.ok(msg);
           }, done);
         });
@@ -386,7 +360,7 @@ define(function (require, exports, module) {
         view.$('[type=password]').val('passwor');
 
         view.on('validation_error', function (which, msg) {
-          wrapAssertion(function () {
+          wrapAssertion(() => {
             assert.ok(msg);
           }, done);
         });
@@ -395,10 +369,9 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('useLoggedInAccount', function () {
-      it('shows an error if session is expired', function () {
-
-        sinon.stub(view, 'getAccount', function () {
+    describe('useLoggedInAccount', () => {
+      it('shows an error if session is expired', () => {
+        sinon.stub(view, 'getAccount', () => {
           return user.initAccount({
             email: 'a@a.com',
             sessionToken: 'abc123',
@@ -407,7 +380,7 @@ define(function (require, exports, module) {
         });
 
         return view.useLoggedInAccount()
-          .then(function () {
+          .then(() => {
             assert.isTrue(view._isErrorVisible);
             // do not show email input
             assert.notOk(view.$('#email').length);
@@ -417,22 +390,19 @@ define(function (require, exports, module) {
           });
       });
 
-      it('signs in with a valid session', function () {
-        var account = user.initAccount({
+      it('signs in with a valid session', () => {
+        const account = user.initAccount({
           email: 'a@a.com',
           sessionToken: 'abc123'
         });
-        sinon.stub(view, 'getAccount', function () {
-          return account;
-        });
-
-        sinon.stub(user, 'signInAccount', function (account) {
+        sinon.stub(view, 'getAccount', () => account);
+        sinon.stub(user, 'signInAccount', (account) => {
           account.set('verified', true);
           return p(account);
         });
 
         return view.useLoggedInAccount()
-          .then(function () {
+          .then(() => {
             assert.isTrue(user.signInAccount.calledWith(account));
             assert.equal(view.$('.error').text(), '');
             assert.notOk(view._isErrorVisible);
@@ -440,85 +410,72 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('useDifferentAccount', function () {
-      it('can switch to signin with the useDifferentAccount button', function () {
-        var account = user.initAccount({
+    describe('useDifferentAccount', () => {
+      it('can switch to signin with the useDifferentAccount button', () => {
+        let account = user.initAccount({
           email: 'a@a.com',
           sessionToken: 'abc123',
           uid: 'foo'
         });
-        sinon.stub(view, 'getAccount', function () {
-          return account;
-        });
-        sinon.stub(user, 'removeAllAccounts', function () {
+        sinon.stub(view, 'getAccount', () => account);
+        sinon.stub(user, 'removeAllAccounts', () => {
           account = user.initAccount();
         });
 
         return view.useLoggedInAccount()
-          .then(function () {
+          .then(() => {
             assert.ok(view.$('.use-different').length, 'has use different button');
             return view.useDifferentAccount();
           })
-          .then(function () {
+          .then(() => {
             assert.ok(view.$('.email').length, 'should show email input');
             assert.ok(view.$('.password').length, 'should show password input');
 
             assert.equal(view.$('.email').val(), '', 'should have an empty email input');
-            assert.isTrue(TestHelpers.isEventLogged(metrics,
+            assert.isTrue(isEventLogged(metrics,
                               'signin.use-different-account'));
           });
       });
     });
 
-    describe('_suggestedAccount', function () {
-      it('can suggest the user based on session variables', function () {
+    describe('_suggestedAccount', () => {
+      it('can suggest the user based on session variables', () => {
         assert.isTrue(view._suggestedAccount().isDefault(), 'null when no account set');
 
-        sinon.stub(user, 'getChooserAccount', function () {
-          return user.initAccount({ sessionToken: 'abc123' });
-        });
+        sinon.stub(user, 'getChooserAccount', () => user.initAccount({ sessionToken: 'abc123' }));
         assert.isTrue(view._suggestedAccount().isDefault(), 'null when no email set');
 
         user.getChooserAccount.restore();
-        sinon.stub(user, 'getChooserAccount', function () {
-          return user.initAccount({ email: 'a@a.com' });
-        });
+        sinon.stub(user, 'getChooserAccount', () => user.initAccount({ email: 'a@a.com' }));
         assert.isTrue(view._suggestedAccount().isDefault(), 'null when no session token set');
 
         user.getChooserAccount.restore();
         formPrefill.set('email', 'a@a.com');
-        sinon.stub(user, 'getChooserAccount', function () {
-          return user.initAccount({ email: 'b@b.com', sessionToken: 'abc123' });
-        });
+        sinon.stub(user, 'getChooserAccount', () => user.initAccount({ email: 'b@b.com', sessionToken: 'abc123' }));
         assert.isTrue(view._suggestedAccount().isDefault(), 'null when prefill does not match');
 
         delete view.prefillEmail;
         user.getChooserAccount.restore();
-        sinon.stub(user, 'getChooserAccount', function () {
-          return user.initAccount({ email: 'a@a.com', sessionToken: 'abc123' });
-        });
+        sinon.stub(user, 'getChooserAccount', () => user.initAccount({ email: 'a@a.com', sessionToken: 'abc123' }));
         assert.equal(view._suggestedAccount().get('email'), 'a@a.com');
-
       });
 
-      it('initializes getAccount from user.getChooserAccount', function () {
-        var account = user.initAccount({
+      it('initializes getAccount from user.getChooserAccount', () => {
+        const account = user.initAccount({
           email: 'a@a.com',
           sessionToken: 'abc123'
         });
-        sinon.stub(user, 'getChooserAccount', function () {
-          return account;
-        });
+        sinon.stub(user, 'getChooserAccount', () => account);
 
         return view.render()
-          .then(function () {
+          .then(() => {
             assert.equal(view.getAccount(), account);
           });
       });
 
-      it('shows if there is the same email in relier', function () {
+      it('shows if there is the same email in relier', () => {
         relier.set('email', 'a@a.com');
-        var account = user.initAccount({
+        const account = user.initAccount({
           accessToken: 'foo',
           email: 'a@a.com',
           sessionToken: 'abc123',
@@ -526,34 +483,30 @@ define(function (require, exports, module) {
           verified: true
         });
 
-        var imgUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
+        const imgUrl = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQYV2P4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
 
-        sinon.stub(user, 'getChooserAccount', function () {
-          return account;
-        });
+        sinon.stub(user, 'getChooserAccount', () => account);
 
         metrics.events.clear();
         return view.render()
-          .then(function () {
-            sinon.stub(account, 'getAvatar', function () {
-              return p({ avatar: imgUrl, id: 'bar' });
-            });
+          .then(() => {
+            sinon.stub(account, 'getAvatar', () => p({ avatar: imgUrl, id: 'bar' }));
             return view.afterVisible();
           })
-          .then(function () {
+          .then(() => {
             assert.notOk(view.$('.password').length, 'should not show password input');
             assert.ok(view.$('.avatar-view img').length, 'should show suggested avatar');
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.skipped'));
-            var askPasswordEvents = metrics.getFilteredData().events.filter(function (event) {
+            assert.isTrue(isEventLogged(metrics, 'signin.ask-password.skipped'));
+            const askPasswordEvents = metrics.getFilteredData().events.filter(function (event) {
               return event.type === 'signin.ask-password.skipped';
             });
             assert.equal(askPasswordEvents.length, 1, 'event should only be logged once');
           });
       });
 
-      it('does not show if there is an email in relier that does not match', function () {
+      it('does not show if there is an email in relier that does not match', () => {
         relier.set('email', 'b@b.com');
-        var account = user.initAccount({
+        const account = user.initAccount({
           accessToken: 'foo',
           email: 'a@a.com',
           sessionToken: 'abc123',
@@ -561,26 +514,21 @@ define(function (require, exports, module) {
           verified: true
         });
 
-        sinon.stub(user, 'getChooserAccount', function () {
-          return account;
-        });
+        sinon.stub(user, 'getChooserAccount', () => account);
 
         return view.render()
-          .then(function () {
+          .then(() => {
             assert.equal(view.$('.email').attr('type'), 'email', 'should show email input');
             assert.ok(view.$('.password').length, 'should show password input');
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.account-unknown'));
+            assert.isTrue(isEventLogged(metrics, 'signin.ask-password.shown.account-unknown'));
           });
       });
 
-      it('does not show if the relier overrules cached credentials', function () {
-        sinon.stub(relier, 'allowCachedCredentials', function () {
-          return false;
-        });
-
+      it('does not show if the relier overrules cached credentials', () => {
+        sinon.stub(relier, 'allowCachedCredentials', () => false);
         relier.set('email', 'a@a.com');
 
-        sinon.stub(user, 'getChooserAccount', function () {
+        sinon.stub(user, 'getChooserAccount', () => {
           return user.initAccount({
             accessToken: 'foo',
             email: 'a@a.com',
@@ -591,17 +539,17 @@ define(function (require, exports, module) {
         });
 
         return view.render()
-          .then(function () {
+          .then(() => {
             assert.equal(view.$('input[type=email]').length, 1, 'should show email input');
             assert.equal(view.$('input[type=password]').length, 1, 'should show password input');
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.account-unknown'));
+            assert.isTrue(isEventLogged(metrics, 'signin.ask-password.shown.account-unknown'));
           });
       });
     });
 
-    describe('_suggestedAccountAskPassword', function () {
-      it('asks for password right away if the relier wants keys (Sync)', function () {
-        var account = user.initAccount({
+    describe('_suggestedAccountAskPassword', () => {
+      it('asks for password right away if the relier wants keys (Sync)', () => {
+        const account = user.initAccount({
           accessToken: 'foo',
           email: 'a@a.com',
           sessionToken: 'abc123',
@@ -609,24 +557,19 @@ define(function (require, exports, module) {
           verified: true
         });
 
-        sinon.stub(view, 'getAccount', function () {
-          return account;
-        });
-
-        sinon.stub(relier, 'wantsKeys', function () {
-          return true;
-        });
+        sinon.stub(view, 'getAccount', () => account);
+        sinon.stub(relier, 'wantsKeys', () => true);
 
         return view.render()
-          .then(function () {
-            assert.isTrue($('.email').hasClass('hidden'), 'should not show email input');
-            assert.ok($('.password').length, 'should show password input');
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.keys-required'));
+          .then(() => {
+            assert.isTrue(view.$('.email').hasClass('hidden'), 'should not show email input');
+            assert.ok(view.$('.password').length, 'should show password input');
+            assert.isTrue(isEventLogged(metrics, 'signin.ask-password.shown.keys-required'));
           });
       });
 
-      it('does not ask for password right away if service is not sync', function () {
-        var account = user.initAccount({
+      it('does not ask for password right away if service is not sync', () => {
+        const account = user.initAccount({
           accessToken: 'foo',
           email: 'a@a.com',
           sessionToken: 'abc123',
@@ -634,44 +577,38 @@ define(function (require, exports, module) {
           verified: true
         });
 
-        sinon.stub(view, 'getAccount', function () {
-          return account;
-        });
-
+        sinon.stub(view, 'getAccount', () => account);
         relier.set('service', 'loop');
 
         return view.render()
-          .then(function () {
-            assert.ok($('.avatar-view').length, 'should show suggested avatar');
-            assert.notOk($('.password').length, 'should not show password input');
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.skipped'));
+          .then(() => {
+            assert.ok(view.$('.avatar-view').length, 'should show suggested avatar');
+            assert.notOk(view.$('.password').length, 'should not show password input');
+            assert.isTrue(isEventLogged(metrics, 'signin.ask-password.skipped'));
           });
       });
 
-      it('asks for the password if the stored session is not from sync', function () {
-        var account = user.initAccount({
+      it('asks for the password if the stored session is not from sync', () => {
+        const account = user.initAccount({
           accessToken: 'foo',
           email: 'a@a.com',
           sessionToken: 'abc123',
           verified: true
         });
 
-        sinon.stub(view, 'getAccount', function () {
-          return account;
-        });
-
+        sinon.stub(view, 'getAccount', () => account);
         relier.set('service', 'loop');
 
         return view.render()
-          .then(function () {
-            assert.isTrue($('.email').hasClass('hidden'), 'should not show email input');
-            assert.ok($('.password').length, 'should show password input');
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.session-from-web'));
+          .then(() => {
+            assert.isTrue(view.$('.email').hasClass('hidden'), 'should not show email input');
+            assert.ok(view.$('.password').length, 'should show password input');
+            assert.isTrue(isEventLogged(metrics, 'signin.ask-password.shown.session-from-web'));
           });
       });
 
-      it('asks for the password if the prefill email is different', function () {
-        var account = user.initAccount({
+      it('asks for the password if the prefill email is different', () => {
+        const account = user.initAccount({
           accessToken: 'foo',
           email: 'a@a.com',
           sessionToken: 'abc123',
@@ -679,26 +616,20 @@ define(function (require, exports, module) {
           verified: true
         });
 
-        sinon.stub(view, 'getAccount', function () {
-          return account;
-        });
-
-        sinon.stub(view, 'getPrefillEmail', function () {
-          return 'b@b.com';
-        });
-
+        sinon.stub(view, 'getAccount', () => account);
+        sinon.stub(view, 'getPrefillEmail', () => 'b@b.com');
         relier.set('service', 'loop');
 
         return view.render()
-          .then(function () {
-            assert.isTrue($('.email').hasClass('hidden'), 'should not show email input');
-            assert.ok($('.password').length, 'should show password input');
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.email-mismatch'));
+          .then(() => {
+            assert.isTrue(view.$('.email').hasClass('hidden'), 'should not show email input');
+            assert.ok(view.$('.password').length, 'should show password input');
+            assert.isTrue(isEventLogged(metrics, 'signin.ask-password.shown.email-mismatch'));
           });
       });
 
-      it('asks for the password when re-rendered due to an expired session', function () {
-        var account = user.initAccount({
+      it('asks for the password when re-rendered due to an expired session', () => {
+        const account = user.initAccount({
           accessToken: 'foo',
           email: 'a@a.com',
           sessionToken: 'abc123',
@@ -706,31 +637,28 @@ define(function (require, exports, module) {
           verified: true
         });
 
-        sinon.stub(view, 'getAccount', function () {
-          return account;
-        });
-
+        sinon.stub(view, 'getAccount', () => account);
         relier.set('service', 'loop');
 
         view.chooserAskForPassword = true;
         return view.render()
-          .then(function () {
-            assert.isTrue($('.email').hasClass('hidden'), 'should not show email input');
-            assert.ok($('.password').length, 'should show password input');
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signin.ask-password.shown.session-expired'));
+          .then(() => {
+            assert.isTrue(view.$('.email').hasClass('hidden'), 'should not show email input');
+            assert.ok(view.$('.password').length, 'should show password input');
+            assert.isTrue(isEventLogged(metrics, 'signin.ask-password.shown.session-expired'));
           });
       });
     });
 
-    describe('_signIn', function () {
-      it('throws on an empty account', function () {
+    describe('_signIn', () => {
+      it('throws on an empty account', () => {
         return view._signIn().then(assert.fail, function (err) {
           assert.isTrue(AuthErrors.is(err, 'UNEXPECTED_ERROR'));
         });
       });
 
-      it('throws on an empty account', function () {
-        var account = user.initAccount({
+      it('throws on an empty account', () => {
+        const account = user.initAccount({
           email: 'a@a.com'
         });
 
@@ -740,8 +668,8 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('beforeDestroy', function () {
-      it('saves the form info to formPrefill', function () {
+    describe('beforeDestroy', () => {
+      it('saves the form info to formPrefill', () => {
         view.$('.email').val('testuser@testuser.com');
         view.$('.password').val('password');
 
@@ -766,50 +694,52 @@ define(function (require, exports, module) {
       });
 
       it('logs the begin event', () => {
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.begin'));
+        assert.isTrue(isEventLogged(metrics, 'flow.begin'));
       });
 
       it('logs the engage event (click)', () => {
-        assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.signin.engage'));
+        assert.isFalse(isEventLogged(metrics, 'flow.signin.engage'));
         view.$('input').trigger('click');
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signin.engage'));
+        assert.isTrue(isEventLogged(metrics, 'flow.signin.engage'));
       });
 
       it('logs the engage event (input)', () => {
-        assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.signin.engage'));
+        assert.isFalse(isEventLogged(metrics, 'flow.signin.engage'));
         view.$('input').trigger('input');
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signin.engage'));
+        assert.isTrue(isEventLogged(metrics, 'flow.signin.engage'));
       });
 
       it('logs the engage event (keyup)', () => {
-        assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.signin.engage'));
+        assert.isFalse(isEventLogged(metrics, 'flow.signin.engage'));
         view.$('input').trigger({
           type: 'keyup',
           which: 9
         });
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signin.engage'));
+        assert.isTrue(isEventLogged(metrics, 'flow.signin.engage'));
       });
 
       it('logs the create-account event', () => {
-        assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.signin.create-account'));
+        assert.isFalse(isEventLogged(metrics, 'flow.signin.create-account'));
         view.$('[data-flow-event="create-account"]').click();
-        assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.signin.engage'));
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signin.create-account'));
+        assert.isFalse(isEventLogged(metrics, 'flow.signin.engage'));
+        assert.isTrue(isEventLogged(metrics, 'flow.signin.create-account'));
       });
 
       it('logs the forgot-password event', () => {
-        assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.signin.forgot-password'));
+        assert.isFalse(isEventLogged(metrics, 'flow.signin.forgot-password'));
         view.$('[data-flow-event="forgot-password"]').click();
-        assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.signin.engage'));
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signin.forgot-password'));
+        assert.isFalse(isEventLogged(metrics, 'flow.signin.engage'));
+        assert.isTrue(isEventLogged(metrics, 'flow.signin.forgot-password'));
       });
 
       it('logs the submit event', () => {
+        $('#container').html(view.$el);
+
         view.$('#submit-btn').click();
-        assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.signin.submit'));
+        assert.isFalse(isEventLogged(metrics, 'flow.signin.submit'));
         view.enableForm();
         view.$('#submit-btn').click();
-        assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signin.submit'));
+        assert.isTrue(isEventLogged(metrics, 'flow.signin.submit'));
       });
     });
 


### PR DESCRIPTION
Use fat arrows to make code more consise, let, const, etc.
Only render to the DOM when absolutely needed to speed up tests.