### PR TITLE
fix(sign_in): Fix how the listener is bound for account->change:accessToken

### DIFF
--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -163,9 +163,11 @@ define(function (require, exports, module) {
           });
 
           sinon.stub(view, '_suggestedAccount', () => account);
+          sinon.stub(view, 'displayAccountProfileImage', () => p());
           sinon.spy(view, 'render');
 
           return view.render()
+            .then(() => view.afterVisible())
             .then(() => {
               account.set({
                 accessToken: null,
@@ -181,6 +183,38 @@ define(function (require, exports, module) {
           assert.equal(view.$('input[type=email]').val(), 'a@a.com');
           assert.lengthOf(view.$('input[type=password]'), 1);
         });
+      });
+    });
+
+    describe('destroy', () => {
+      beforeEach(() => {
+        initView();
+
+        const account = user.initAccount({
+          accessToken: 'access token',
+          email: 'a@a.com',
+          sessionToken: 'session token',
+          sessionTokenContext: Constants.SYNC_SERVICE
+        });
+
+        sinon.stub(view, '_suggestedAccount', () => account);
+        sinon.stub(view, 'displayAccountProfileImage', () => p());
+        sinon.spy(view, 'render');
+
+        return view.render()
+          .then(() => view.afterVisible())
+          .then(() => view.destroy())
+          .then(() => {
+            account.set({
+              accessToken: null,
+              sessionToken: null,
+              sessionTokenContext: null
+            });
+          });
+      });
+
+      it('does not re-render once destroyed if the accessToken is invalidated', () => {
+        assert.equal(view.render.callCount, 1);
       });
     });
 


### PR DESCRIPTION
We were binding using `account.on` in `beforeRender`. This didn't cause any
visible problems, but caused two problems behind the scenes:

1. The view to be retained in memory after being torn down because the
   account kept a reference to the View.
2. If the accessToken was invalidated after the view was destroyed, the
   *view would re-render anyways*, just not visibly.

Using view.listenTo, the listener is removed from the account whenever
the view is torn down. In addition, this is only done in afterVisible
so that only one listener is ever bound. If done in `beforeRender`,
a new listener was attached on every render.

Not attached to an issue.