### PR TITLE
fix(sms): Handle errors to /sms/status

### DIFF
--- a/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -144,6 +144,11 @@ define((require, exports, module) => {
           if (resp.ok && this.isInExperiment('sendSmsEnabledForCountry', { country })) {
             return country;
           }
+        }, (err) => {
+          // Log and throw away errors from smsStatus, it shouldn't
+          // prevent verification from completing. Send the user to
+          // /connect_another_device instead. See #5109
+          this.logError(err);
         });
     }
   };


### PR DESCRIPTION
Before this fix, if a call to /sms/status failed,
signup confirmation would appear to fail with an
"Unexpected error".

Instead of failing, log and drop errors to /sms/status.

fixes #5109 

Note, this is against train-88 in the hopes that @jbuck doesn't mind spinning a new release. 

@philbooth - r?