### PR TITLE
feat(CAD): Log clicks on app store links into flow metrics.

### DIFF
--- a/app/scripts/templates/marketing_snippet.mustache
+++ b/app/scripts/templates/marketing_snippet.mustache
@@ -7,7 +7,7 @@
           <br>
           {{#t}}Download Firefox for iOS!{{/t}}
         </p>
-        <a target="_blank" class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="53" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+        <a target="_blank" class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-flow-event="link.app-store.ios" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="53" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
       {{/isIos}}
 
       {{#isAndroid}}
@@ -16,7 +16,7 @@
           <br>
           {{#t}}Download Firefox for Android.{{/t}}
         </p>
-        <a target="_blank" class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45" src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}"></a>
+        <a target="_blank" class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-flow-event="link.app-store.android" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45" src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}"></a>
       {{/isAndroid}}
 
       {{#isOther}}
@@ -29,10 +29,10 @@
 
           <ul>
             <li>
-              <a target="_blank" class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+              <a target="_blank" class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-flow-event="link.app-store.ios" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
             </li>
             <li>
-              <a target="_blank" class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
+              <a target="_blank" class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-flow-event="link.app-store.android" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
             </li>
           </ul>
         </div>
@@ -41,17 +41,17 @@
   {{/isSpring2015}}
   {{#isAutumn2016}}
     {{#isIos}}
-      <a target="_blank" class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="53" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+      <a target="_blank" class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-flow-event="link.app-store.ios" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="53" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
     {{/isIos}}
 
     {{#isAndroid}}
-      <a target="_blank" class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45" src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
+      <a target="_blank" class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-flow-event="link.app-store.android" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45" src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
     {{/isAndroid}}
 
     {{#isOther}}
       <div class="links clearfix">
-        <a target="_blank" class="marketing-link marketing-link-ios left" href="{{ downloadLinkIos }}" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
-        <a target="_blank" class="marketing-link marketing-link-android right" href="{{ downloadLinkAndroid }}" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
+        <a target="_blank" class="marketing-link marketing-link-ios left" href="{{ downloadLinkIos }}" data-flow-event="link.app-store.ios" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+        <a target="_blank" class="marketing-link marketing-link-android right" href="{{ downloadLinkAndroid }}" data-flow-event="link.app-store.android" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
       </div>
     {{/isOther}}
   {{/isAutumn2016}}

--- a/app/scripts/views/mixins/flow-events-mixin.js
+++ b/app/scripts/views/mixins/flow-events-mixin.js
@@ -24,8 +24,8 @@ define(function (require, exports, module) {
     },
 
     _clickFlowEventsLink (event) {
-      if (event && event.target) {
-        const flowEvent = $(event.target).data('flowEvent');
+      if (event && event.currentTarget) {
+        const flowEvent = $(event.currentTarget).data('flowEvent');
         if (flowEvent) {
           this.logFlowEvent(flowEvent, this.viewName);
         }

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -13,6 +13,7 @@ define(function (require, exports, module) {
   const Cocktail = require('cocktail');
   const Constants = require('lib/constants');
   const ExperimentMixin = require('views/mixins/experiment-mixin');
+  const FlowEventsMixin = require('views/mixins/flow-events-mixin');
   const FormView = require('views/form');
   const MarketingMixin = require('views/mixins/marketing-mixin');
   const PulseGraphicMixin = require('views/mixins/pulse-graphic-mixin');
@@ -97,6 +98,7 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     ExperimentMixin,
+    FlowEventsMixin,
     MarketingMixin({ marketingId: Constants.MARKETING_ID_SPRING_2015 }),
     PulseGraphicMixin,
     ServiceMixin,

--- a/app/scripts/views/sms_sent.js
+++ b/app/scripts/views/sms_sent.js
@@ -14,6 +14,7 @@ define(function (require, exports, module) {
   const Cocktail = require('cocktail');
   const CountryTelephoneInfo = require('lib/country-telephone-info');
   const { FIREFOX_MOBILE_INSTALL } = require('lib/sms-message-ids');
+  const FlowEventsMixin = require('views/mixins/flow-events-mixin');
   const { MARKETING_ID_AUTUMN_2016 } = require('lib/constants');
   const MarketingMixin = require('views/mixins/marketing-mixin')({ marketingId: MARKETING_ID_AUTUMN_2016 });
   const ResendMixin = require('views/mixins/resend-mixin')({ successMessage: false });
@@ -64,6 +65,7 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     BackMixin,
+    FlowEventsMixin,
     MarketingMixin,
     ResendMixin
   );

--- a/app/tests/spec/views/mixins/flow-events-mixin.js
+++ b/app/tests/spec/views/mixins/flow-events-mixin.js
@@ -51,10 +51,10 @@ define((require, exports, module) => {
       });
     });
 
-    describe('_clickFlowEventsLink with target id', () => {
+    describe('_clickFlowEventsLink with currentTarget id', () => {
       beforeEach(() => {
         flowEventsMixin._clickFlowEventsLink({
-          target: {
+          currentTarget: {
             getAttribute () {
               return 'baz';
             },
@@ -73,10 +73,10 @@ define((require, exports, module) => {
       });
     });
 
-    describe('_clickFlowEventsLink without target id', () => {
+    describe('_clickFlowEventsLink without currentTarget id', () => {
       beforeEach(() => {
         flowEventsMixin._clickFlowEventsLink({
-          target: {
+          currentTarget: {
             getAttribute () {},
             nodeType: 1
           }


### PR DESCRIPTION
New flow events:

* flow.sms.link.app-store.(android|ios)
* flow.sms-sent.link.app-store.(android|ios)
* flow.reset-password-confirmed.link.app-store.(android|ios)
* flow.reset-password-verified.link.app-store.(android|ios)
* flow.secondary-email-verified.link.app-store.(android|ios)
* flow.signin-confirmed.link.app-store.(android|ios)
* flow.signin-verified.link.app-store.(android|ios)
* flow.signup-confirmed.link.app-store.(android|ios)
* flow.signup-verified.link.app-store.(android|ios)

fixes #5112

@philbooth - r?

I also opened this against train-88 in hopes that we can figure out how many users are clicking on the app store buttons.