### PR TITLE
fix(WebChannel): Fix the startup hang if the UA errors fetching fxaccounts:fxa_status

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -412,6 +412,10 @@ define(function (require, exports, module) {
       // an attempt is made to write an account w/o a uid
       // to localStorage.
       message: 'Account has no uid'
+    },
+    INVALID_WEB_CHANNEL: {
+      errno: 1051,
+      message: 'Browser not configured to accept WebChannel messages from this domain'
     }
   };
   /*eslint-enable sorting/sort-object-props*/

--- a/app/scripts/lib/channels/duplex.js
+++ b/app/scripts/lib/channels/duplex.js
@@ -70,6 +70,12 @@ define(function (require, exports, module) {
 
   // Suffix to ensure each message has a unique messageId.
   // Every send increments the suffix by 1.
+  // A module variable is used instead of an instance variable because
+  // more than one channel can exist. Using an instance variable,
+  // it's possible for two messages on two channels to have the same
+  // messageId, if both channels send a message in the same millisecond.
+  // This might not cause any harm in reality, but this avoids
+  // that possibility.
   let messageIdSuffix = 0;
 
   function DuplexChannel() {
@@ -166,7 +172,6 @@ define(function (require, exports, module) {
      * @param {Object} [data]
      * @return {String}
      */
-    _messageCount: 0,
     createMessageId (command, data) {
       // If two messages are created within the same millisecond, Date.now()
       // returns the same value. Append a suffix that ensures uniqueness.

--- a/app/scripts/lib/channels/web.js
+++ b/app/scripts/lib/channels/web.js
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
       // or from this domain.
       if (/no such channel/i.test(errorMessage)) {
         // Since the channel is not supported, reject all outstanding
-        // requests otherwise they never receive a response.
+        // requests to avoid hanging until the requests time out.
         this.rejectAllOutstandingRequests(AuthErrors.toError('INVALID_WEB_CHANNEL'));
       }
 

--- a/app/scripts/lib/channels/web.js
+++ b/app/scripts/lib/channels/web.js
@@ -10,6 +10,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const _ = require('underscore');
+  const AuthErrors = require('lib/auth-errors');
   const Cocktail = require('cocktail');
   const DuplexChannel = require('lib/channels/duplex');
   const SearchParamMixin = require('lib/search-param-mixin');
@@ -84,6 +85,21 @@ define(function (require, exports, module) {
     isFxaStatusSupported (userAgent = this.getUserAgentString()) {
       const uap = this.getUserAgent(userAgent);
       return uap.isFirefoxDesktop() && uap.parseVersion().major >= FXA_STATUS_MIN_FIREFOX_DESKTOP_VERSION;
+    },
+
+    onErrorReceived (message) {
+      const { error } = this.parseError(message);
+      const errorMessage = error && error.message;
+
+      // Browser does not support WebChannels sent on this channel,
+      // or from this domain.
+      if (/no such channel/i.test(errorMessage)) {
+        // Since the channel is not supported, reject all outstanding
+        // requests otherwise they never receive a response.
+        this.rejectAllOutstandingRequests(AuthErrors.toError('INVALID_WEB_CHANNEL'));
+      }
+
+      DuplexChannel.prototype.onErrorReceived.call(this, message);
     }
   });
 


### PR DESCRIPTION
If the browser responds to an fxaccounts:fxa_status message with a `No Such Webchannel`
error, that means the UA either does not support the channel name, or is not set up
to communicate with this FxA server. In either case, FxA and the UA cannot communicate
using WebChannels.

If this happens, log the error and set the `fxaStatus` broker capability to `false`.
This will cause the session to use state stored in localStorage rather than the
state stored by the browser.

fixes #5114

@vladikoff, @vbudhram, @philbooth - r?

The core fix is pretty small, most of this PR is tests - which is how it should be. I realized I did not add tests to the base auth broker for fetch, so those were added. This is against train-88.