### PR TITLE
fix(sms): Handle errors to /sms/status

### DIFF
--- a/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -144,6 +144,11 @@ define((require, exports, module) => {
           if (resp.ok && this.isInExperiment('sendSmsEnabledForCountry', { country })) {
             return country;
           }
+        }, (err) => {
+          // Log and throw away errors from smsStatus, it shouldn't
+          // prevent verification from completing. Send the user to
+          // /connect_another_device instead. See #5109
+          this.logError(err);
         });
     }
   };

--- a/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -145,6 +145,9 @@ define((require, exports, module) => {
             return country;
           }
         }, (err) => {
+          // Add `.smsStatus` to the context so we can differentiate between errors
+          // checking smsStatus from other XHR errors that occur in the consumer modules.
+          err.context = `${this.getViewName()}.smsStatus`;
           // Log and throw away errors from smsStatus, it shouldn't
           // prevent verification from completing. Send the user to
           // /connect_another_device instead. See #5109

--- a/app/tests/spec/views/mixins/connect-another-device-mixin.js
+++ b/app/tests/spec/views/mixins/connect-another-device-mixin.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');
+  const AuthErrors = require('lib/auth-errors');
   const BaseView = require('views/base');
   const ConnectAnotherDeviceMixin = require('views/mixins/connect-another-device-mixin');
   const Constants = require('lib/constants');
@@ -164,6 +165,31 @@ define(function (require, exports, module) {
               assert.isTrue(account.smsStatus.calledOnce);
               assert.isTrue(account.smsStatus.calledWith({ country: 'US' }));
               assert.isFalse(view.isInExperiment.called);
+            });
+        });
+      });
+
+      describe('pre-reqs are met, auth-server errors, Able says OK', () => {
+        let err;
+
+        beforeEach(() => {
+          err = AuthErrors.toError('UNEXPECTED_ERROR');
+          sinon.stub(view, '_areSmsRequirementsMet', () => true);
+          sinon.spy(view, 'isInExperiment');
+          sinon.spy(view, 'logError');
+          sinon.stub(account, 'smsStatus', () => p.reject(err));
+        });
+
+        it('resolves to object with `ok: false`, logs error', () => {
+          return view._isEligibleForSms(account)
+            .then((resp) => {
+              assert.isFalse(resp.ok);
+              assert.isTrue(view._areSmsRequirementsMet.calledOnce);
+              assert.isTrue(view._areSmsRequirementsMet.calledWith(account));
+              assert.isTrue(account.smsStatus.calledOnce);
+              assert.isTrue(account.smsStatus.calledWith({ country: 'US' }));
+              assert.isTrue(view.logError.calledOnce);
+              assert.isTrue(view.logError.calledWith(err));
             });
         });
       });

--- a/app/tests/spec/views/mixins/connect-another-device-mixin.js
+++ b/app/tests/spec/views/mixins/connect-another-device-mixin.js
@@ -24,7 +24,8 @@ define(function (require, exports, module) {
   const VALID_UID = createRandomHexString(Constants.UID_LENGTH);
 
   var View = BaseView.extend({
-    template: Template
+    template: Template,
+    viewName: 'connect-another-device'
   });
 
   Cocktail.mixin(
@@ -188,8 +189,11 @@ define(function (require, exports, module) {
               assert.isTrue(view._areSmsRequirementsMet.calledWith(account));
               assert.isTrue(account.smsStatus.calledOnce);
               assert.isTrue(account.smsStatus.calledWith({ country: 'US' }));
+
               assert.isTrue(view.logError.calledOnce);
               assert.isTrue(view.logError.calledWith(err));
+              // context is updated to include extra `.smsStatus` for reporting.
+              assert.equal(err.context, 'connect-another-device.smsStatus');
             });
         });
       });


### PR DESCRIPTION
Before this fix, if a call to /sms/status failed,
signup confirmation would appear to fail with an
"Unexpected error".

Instead of failing, log and drop errors to /sms/status.

fixes #5109