### PR TITLE
feat(CAD): Make it easier to find `.smsStatus` errors in the logs.

### DIFF
--- a/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -145,6 +145,9 @@ define((require, exports, module) => {
             return country;
           }
         }, (err) => {
+          // Add `.smsStatus` to the context so we can differentiate between errors
+          // checking smsStatus from other XHR errors that occur in the consumer modules.
+          err.context = `${this.getViewName()}.smsStatus`;
           // Log and throw away errors from smsStatus, it shouldn't
           // prevent verification from completing. Send the user to
           // /connect_another_device instead. See #5109

--- a/app/tests/spec/views/mixins/connect-another-device-mixin.js
+++ b/app/tests/spec/views/mixins/connect-another-device-mixin.js
@@ -24,7 +24,8 @@ define(function (require, exports, module) {
   const VALID_UID = createRandomHexString(Constants.UID_LENGTH);
 
   var View = BaseView.extend({
-    template: Template
+    template: Template,
+    viewName: 'connect-another-device'
   });
 
   Cocktail.mixin(
@@ -187,8 +188,11 @@ define(function (require, exports, module) {
               assert.isTrue(view._areSmsRequirementsMet.calledWith(account));
               assert.isTrue(account.smsStatus.calledOnce);
               assert.isTrue(account.smsStatus.calledWith({ country: 'US' }));
+
               assert.isTrue(view.logError.calledOnce);
               assert.isTrue(view.logError.calledWith(err));
+              // context is updated to include extra `.smsStatus` for reporting.
+              assert.equal(err.context, 'connect-another-device.smsStatus');
             });
         });
       });


### PR DESCRIPTION
Add an `.smsStatus` suffix to the error context, which is included
in messages sent to DataDog, e.g.,:

error.verify-email.smsStatus.auth.999

issue #5109

This is the 2nd commit to https://github.com/mozilla/fxa-content-server/pull/5120, ported over to train-88