### PR TITLE
fix(sign-in): Put registration links on left/top

### DIFF
--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -45,8 +45,8 @@
            </form>
 
            <div class="links">
-             <a href="/reset_password" class="left reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>
-             <a href="/signin?email=blank" class="right use-different" data-flow-event="use-different-account">{{#t}}Use a different account{{/t}}</a><br/>
+             <a href="/signin?email=blank" class="left use-different" data-flow-event="use-different-account">{{#t}}Use a different account{{/t}}</a><br/>
+             <a href="/reset_password" class="right reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>
            </div>
         {{/chooserAskForPassword}}
 
@@ -77,8 +77,8 @@
       </form>
 
       <div class="links">
-          <a href="/reset_password" class="left reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>
-          <a href="/signup" class="right sign-up" data-flow-event="create-account">{{#t}}Create an account{{/t}}</a>
+          <a href="/signup" class="left sign-up" data-flow-event="create-account">{{#t}}Create an account{{/t}}</a>
+          <a href="/reset_password" class="right reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>
       </div>
 
       <div class="extra-links">

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -45,8 +45,8 @@
            </form>
 
            <div class="links">
-             <a href="/signin?email=blank" class="left use-different" data-flow-event="use-different-account">{{#t}}Use a different account{{/t}}</a><br/>
-             <a href="/reset_password" class="right reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>
+             <a href="/signin?email=blank" class="left use-different" data-flow-event="use-different-account">{{#t}}Use a different account{{/t}}</a>
+             <a href="/reset_password" class="right reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a><br/>
            </div>
         {{/chooserAskForPassword}}
 


### PR DESCRIPTION
Putting registration links on left OR top (responsive) based on feedback that some users struggle to find the registration links.