### PR TITLE
fix(test): Remove the testPhoneNumber default to fix tests.

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -459,8 +459,7 @@ const conf = module.exports = convict({
       }
     },
     testPhoneNumber: {
-      // This is a test phone number that always says "All circuits are busy now"
-      default: '9164400029',
+      default: '',
       doc: 'Phone number to send SMS messages to in function tests',
       format: String
     },


### PR DESCRIPTION
Tests that send an SMS look for the existence
of testPhoneNumber before sending. Disable these
tests until we have a better plan.

@jrgm - r?