### PR TITLE
fix(tests): provide a way to pre-flight check entrained resources

### DIFF
--- a/tests/server/l10n-entrained.js
+++ b/tests/server/l10n-entrained.js
@@ -13,9 +13,10 @@ define([
   'intern/dojo/node!url',
   'intern/browser_modules/dojo/Promise',
   'tests/server/helpers/routesHelpers',
-  'intern/dojo/node!fxa-shared'
-], function (intern, registerSuite, assert, config, csp,
-  htmlparser2, got, url, Promise, routesHelpers, fxaShared) {
+  'intern/dojo/node!fxa-shared',
+  'intern/dojo/node!./lib/dnshook'
+], function (intern, registerSuite, assert, config, csp, htmlparser2,
+             got, url, Promise, routesHelpers, fxaShared, dnshook) {
 
   var checkHeaders = routesHelpers.checkHeaders;
   var extractAndCheckUrls = routesHelpers.extractAndCheckUrls;
@@ -26,6 +27,10 @@ define([
 
   if (intern.config.fxaProduction) {
     assert.equal(0, httpsUrl.indexOf('https://'), 'uses https scheme');
+  }
+
+  if (process.env.FXA_DNS_ELB && process.env.FXA_DNS_ALIAS) {
+    dnshook(process.env.FXA_DNS_ELB, process.env.FXA_DNS_ALIAS);
   }
 
   var suite = {

--- a/tests/server/lib/dnshook.js
+++ b/tests/server/lib/dnshook.js
@@ -1,0 +1,39 @@
+'use strict';
+
+// Replace the builtin `dns.lookup` with one that will divert lookups of
+// `alias` to a test `elb`. Useful for testing deployments before going live,
+// specifically for `tests/server/l10n-entrained`.
+//
+// Caveats:
+// - the `got` module appears to wind up using `dns.lookup`, but this is a
+//   fragile assumption.
+// - no provision is made for unwrapping `dns.lookup`; maybe I should allow
+//   for cleanup, but this module is not intended to be used outside of a
+//   narrow testing use case.
+// - Written for node4; may need to be rewritten for more modern nodejs
+//   major versions.
+
+const dns = require('dns');
+var originalLookup;
+
+module.exports = function hookedLookup(elb, alias) {
+  if (! elb || ! alias) {
+    return;
+  }
+
+  if (dns.lookup._wrapped) {
+    return;
+  }
+
+  originalLookup = dns.lookup;
+
+  dns.lookup = function lookup(hostname, options, callback) {
+    if (hostname === alias) {
+      return originalLookup(elb, options, callback);
+    }
+
+    originalLookup(hostname, options, callback);
+  };
+
+  dns.lookup._wrapped = true;
+};


### PR DESCRIPTION
This change, which only has effect if FXA_DNS_ELB and FXA_DNS_ALIAS are set in the environment, provides a way to test that all entrained resources (on CDN and origin server) can be reached before proceeding with release deployment.

r? - @shane-tomlinson 