### PR TITLE
fix(tests): make npm-install-deps reusable

### DIFF
--- a/tests/teamcity/install-npm-deps.sh
+++ b/tests/teamcity/install-npm-deps.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+export NPM_CONFIG_LOGLEVEL=warn
+
+node ./tests/teamcity/install-npm-deps.js \
+  bluebird                        \
+  bower                           \
+  convict                         \
+  css                             \
+  extend                          \
+  firefox-profile                 \
+  fxa-shared                      \
+  got                             \
+  helmet                          \
+  htmlparser2                     \
+  intern                          \
+  joi                             \
+  lodash                          \
+  mozlog                          \
+  node-statsd                     \
+  node-uap                        \
+  on-headers                      \
+  proxyquire                      \
+  raven                           \
+  sinon                           \
+  sync-exec                       \
+  universal-analytics             \
+  xmlhttprequest
+

--- a/tests/teamcity/run-server.sh
+++ b/tests/teamcity/run-server.sh
@@ -73,30 +73,7 @@ export npm_config_tmp=~/fxatemp
 
 set -o xtrace # echo the following commands
 
-node ./tests/teamcity/install-npm-deps.js \
-  bluebird                        \
-  bower                           \
-  convict                         \
-  css                             \
-  extend                          \
-  firefox-profile                 \
-  fxa-shared                      \
-  got                             \
-  helmet                          \
-  htmlparser2                     \
-  intern                          \
-  joi                             \
-  lodash                          \
-  mozlog                          \
-  node-statsd                     \
-  node-uap                        \
-  on-headers                      \
-  proxyquire                      \
-  raven                           \
-  sinon                           \
-  sync-exec                       \
-  universal-analytics             \
-  xmlhttprequest
+./tests/teamcity/install-npm-deps.sh
 
 FXA_TEST_CONFIG=${FXA_TEST_CONFIG:-tests/intern_server}
 


### PR DESCRIPTION
r? - @shane-tomlinson 

Just splitting this out so I can re-use it in a different script.