### PR TITLE
feat(sms): Re-add "Use a distinct phone number for every SMS test."

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -445,16 +445,6 @@ const conf = module.exports = convict({
         doc: 'Target URL for redirection',
         format: 'url'
       }
-    },
-    testPhoneNumber: {
-      default: '',
-      doc: 'Phone number to send SMS messages to in function tests',
-      format: String
-    },
-    testPhoneNumberCountry: {
-      default: 'US',
-      doc: 'The country `testPhoneNumber` is in, see app/scripts/lib/country-telephone-info.js',
-      format: String
     }
   },
   static_directory: {

--- a/tests/functional/fx_desktop_handshake.js
+++ b/tests/functional/fx_desktop_handshake.js
@@ -8,14 +8,11 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
   'tests/functional/lib/selectors',
-  'tests/functional/lib/ua-strings',
-  'intern/dojo/node!../../server/lib/configuration',
-], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors, uaStrings, serverConfig) {
+  'tests/functional/lib/ua-strings'
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors, uaStrings) {
   'use strict';
 
   const config = intern.config;
-
-  const testPhoneNumber = serverConfig.get('sms.testPhoneNumber');
 
   const userAgent = uaStrings['desktop_firefox_55'];
 
@@ -144,46 +141,45 @@ define([
     },
 
     'Sync signin page w/ signin code - user signed into browser': function () {
-      if (testPhoneNumber) {
-        let signinUrlWithSigninCode;
+      const testPhoneNumber = TestHelpers.createPhoneNumber();
+      let signinUrlWithSigninCode;
 
-        return this.remote
-          // The phoneNumber is reused across tests, delete all
-          // if its SMS messages to ensure a clean slate.
-          .then(deleteAllSms(testPhoneNumber))
+      return this.remote
+        // The phoneNumber can be reused by different tests, delete all
+        // of its SMS messages to ensure a clean slate.
+        .then(deleteAllSms(testPhoneNumber))
 
-          .then(openPage(SYNC_SMS_PAGE_URL, selectors.SMS_SEND.HEADER, {
-            webChannelResponses: {
-              'fxaccounts:fxa_status': {
-                signedInUser: browserSignedInAccount
-              }
+        .then(openPage(SYNC_SMS_PAGE_URL, selectors.SMS_SEND.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
             }
-          }))
-          .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
-          .then(click(selectors.SMS_SEND.SUBMIT))
+          }
+        }))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+        .then(click(selectors.SMS_SEND.SUBMIT))
 
-          .then(testElementExists(selectors.SMS_SENT.HEADER))
-          .then(getSmsSigninCode(testPhoneNumber, 0))
-          .then(function (signinCode) {
-            signinUrlWithSigninCode = `${SYNC_SIGNIN_PAGE_URL}&signin=${signinCode}`;
-            return this.parent
-              .then(clearBrowserState())
-              // Synthesize opening the SMS message in a browser where another
-              // user is already signed in.
-              .then(openPage(signinUrlWithSigninCode, selectors.SIGNIN.HEADER, {
-                webChannelResponses: {
-                  'fxaccounts:fxa_status': {
-                    signedInUser: otherAccount
-                  }
+        .then(testElementExists(selectors.SMS_SENT.HEADER))
+        .then(getSmsSigninCode(testPhoneNumber, 0))
+        .then(function (signinCode) {
+          signinUrlWithSigninCode = `${SYNC_SIGNIN_PAGE_URL}&signin=${signinCode}`;
+          return this.parent
+            .then(clearBrowserState())
+            // Synthesize opening the SMS message in a browser where another
+            // user is already signed in.
+            .then(openPage(signinUrlWithSigninCode, selectors.SIGNIN.HEADER, {
+              webChannelResponses: {
+                'fxaccounts:fxa_status': {
+                  signedInUser: otherAccount
                 }
-              }))
-              // user opened an SMS w/ deferred deeplink in a browser that supports
-              // fxa_status. This can't happen currently because only Fx Desktop
-              // supports the query, but I want a test to ensure the behavior is
-              // defined so that we are ready when Fennec or iOS adds fxa_status support.
-              .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, browserSignedInEmail));
-          });
-      }
+              }
+            }))
+            // user opened an SMS w/ deferred deeplink in a browser that supports
+            // fxa_status. This can't happen currently because only Fx Desktop
+            // supports the query, but I want a test to ensure the behavior is
+            // defined so that we are ready when Fennec or iOS adds fxa_status support.
+            .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, browserSignedInEmail));
+        });
     },
 
     'Non-Sync signin page - user signed into browser, no user signed in locally': function () {

--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -7,40 +7,30 @@ define([
   'intern!object',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
-  'tests/functional/lib/selectors',
-  'intern/dojo/node!../../server/lib/configuration',
-], function (intern, registerSuite, TestHelpers, FunctionalHelpers,
-  selectors, serverConfig) {
+  'tests/functional/lib/selectors'
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors) {
   'use strict';
 
   const config = intern.config;
   const SIGNIN_PAGE_URL = `${config.fxaContentRoot}signin?context=fx_fennec_v1&service=sync`;
-  const SMS_PAGE_URL = `${config.fxaContentRoot}sms?context=fx_desktop_v1&service=sync&signinCodes=true`;
 
   let email;
   const PASSWORD = '12345678';
 
-  const testPhoneNumber = serverConfig.get('sms.testPhoneNumber');
-
   const thenify = FunctionalHelpers.thenify;
 
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
-  const click = FunctionalHelpers.click;
   const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   const createUser = FunctionalHelpers.createUser;
-  const deleteAllSms = FunctionalHelpers.deleteAllSms;
   const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   const fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-  const getSmsSigninCode = FunctionalHelpers.getSmsSigninCode;
   const openPage = FunctionalHelpers.openPage;
   const openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   const testElementExists = FunctionalHelpers.testElementExists;
-  const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
   const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
-  const type = FunctionalHelpers.type;
 
   const setupTest = thenify(function (successSelector, options) {
     options = options || {};
@@ -115,30 +105,6 @@ define([
 
         .then(testElementExists('#fxa-sign-in-complete-header'))
         .then(testIsBrowserNotified('fxaccounts:login'));
-    },
-
-    'signup in desktop, send an SMS, open deferred deeplink in Fennec': function () {
-      if (testPhoneNumber) {
-        let signinUrlWithSigninCode;
-
-        return this.remote
-          // The phoneNumber is reused across tests, delete all
-          // if its SMS messages to ensure a clean slate.
-          .then(deleteAllSms(testPhoneNumber))
-          .then(setupTest(selectors.CONFIRM_SIGNUP.HEADER))
-          .then(openPage(SMS_PAGE_URL, selectors.SMS_SEND.HEADER))
-          .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
-          .then(click(selectors.SMS_SEND.SUBMIT))
-          .then(testElementExists(selectors.SMS_SENT.HEADER))
-          .then(getSmsSigninCode(testPhoneNumber, 0))
-          .then(function (signinCode) {
-            signinUrlWithSigninCode = `${SIGNIN_PAGE_URL}&signin=${signinCode}`;
-            return this.parent
-              .then(clearBrowserState())
-              .then(openPage(signinUrlWithSigninCode, selectors.SIGNIN.HEADER))
-              .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email));
-          });
-      }
     }
   });
 });

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -9,41 +9,32 @@ define([
   'tests/functional/lib/helpers',
   'tests/functional/lib/fx-desktop',
   'tests/functional/lib/selectors',
-  'tests/functional/lib/ua-strings',
-  'intern/dojo/node!../../server/lib/configuration',
+  'tests/functional/lib/ua-strings'
 ], function (intern, registerSuite,
-  TestHelpers, FunctionalHelpers, FxDesktopHelpers, selectors, UA_STRINGS, serverConfig) {
+  TestHelpers, FunctionalHelpers, FxDesktopHelpers, selectors, UA_STRINGS) {
   'use strict';
 
   const config = intern.config;
   const SIGNIN_PAGE_URL = `${config.fxaContentRoot}signin?context=fx_ios_v1&service=sync`;
-  const SMS_PAGE_URL = `${config.fxaContentRoot}sms?context=fx_desktop_v1&service=sync&signinCodes=true`;
 
   let email;
   const PASSWORD = '12345678';
 
-  const testPhoneNumber = serverConfig.get('sms.testPhoneNumber');
-
   const thenify = FunctionalHelpers.thenify;
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
-  const click = FunctionalHelpers.click;
   const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   const createUser = FunctionalHelpers.createUser;
-  const deleteAllSms = FunctionalHelpers.deleteAllSms;
   const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   const fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-  const getSmsSigninCode = FunctionalHelpers.getSmsSigninCode;
   const listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   const noPageTransition = FunctionalHelpers.noPageTransition;
   const openPage = FunctionalHelpers.openPage;
   const openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   const testElementExists = FunctionalHelpers.testElementExists;
-  const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
   const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   const testIsBrowserNotified = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
   const testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
-  const type = FunctionalHelpers.type;
   const visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   const setupTest = thenify(function (options) {
@@ -167,30 +158,6 @@ define([
         // about:accounts will take over post-unblock, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'))
         .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }));
-    },
-
-    'signup in desktop, send an SMS, open deferred deeplink in Fx for iOS': function () {
-      if (testPhoneNumber) {
-        let signinUrlWithSigninCode;
-
-        return this.remote
-          // The phoneNumber is reused across tests, delete all
-          // if its SMS messages to ensure a clean slate.
-          .then(deleteAllSms(testPhoneNumber))
-          .then(setupTest(selectors.CONFIRM_SIGNUP.HEADER))
-          .then(openPage(SMS_PAGE_URL, selectors.SMS_SEND.HEADER))
-          .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
-          .then(click(selectors.SMS_SEND.SUBMIT))
-          .then(testElementExists(selectors.SMS_SENT.HEADER))
-          .then(getSmsSigninCode(testPhoneNumber, 0))
-          .then(function (signinCode) {
-            signinUrlWithSigninCode = `${SIGNIN_PAGE_URL}&signin=${signinCode}`;
-            return this.parent
-              .then(clearBrowserState())
-              .then(openPage(signinUrlWithSigninCode, selectors.SIGNIN.HEADER))
-              .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email));
-          });
-      }
     }
   });
 });

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -5,6 +5,7 @@
 define([
   'app/scripts/lib/constants'
 ], function (Constants) {
+  'use strict';
 
   function createRandomHexString(length) {
     var str = '';
@@ -30,15 +31,46 @@ define([
     return template.replace('{id}', Math.random()) + '@restmail.net';
   }
 
+  /**
+   * Create a phone number with `prefix` with `length` digits.
+   *
+   * @param {String} [prefix='9164']
+   * @param {Number} [length=10]
+   * @returns {String}
+   */
+  function createPhoneNumber (prefix, length) {
+    if (typeof prefix === 'undefined') {
+      prefix = '9164';
+    }
+    if (typeof length === 'undefined') {
+      length = 10;
+    }
+    // start with an area code and known good first number,
+    // append a 6 character suffix.
+    const suffixLength = length - prefix.length;
+    let suffix = Math.floor(Math.random() * Math.pow(10, suffixLength));
+    suffix = padright(suffix, suffixLength, '0');
+    return `${prefix}${suffix}`;
+  }
+
+  function padright (str, len, filler) {
+    let padded = '' + str;
+    while (padded.length < len) {
+      padded += filler;
+    }
+    return padded;
+  }
+
   function emailToUser(email) {
     return email.split('@')[0];
   }
 
   return {
-    createEmail: createEmail,
-    createRandomHexString: createRandomHexString,
-    createUID: createUID,
-    emailToUser: emailToUser
+    createEmail,
+    createPhoneNumber,
+    createRandomHexString,
+    createUID,
+    emailToUser
   };
 });
 


### PR DESCRIPTION
This is mostly a revert of d342fab2e61d4a14f9b139c8afeef74b1cc83b95, without the deeplink tests.

fixes #5136