### PR TITLE
fix(config): remove non-existing config files before attempting to load

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -529,7 +529,7 @@ let files;
 // files to process, which will be overlayed in order, in the CONFIG_FILES
 // environment variable
 if (process.env.CONFIG_FILES && process.env.CONFIG_FILES.trim() !== '') {
-  files = process.env.CONFIG_FILES.split(',');
+  files = process.env.CONFIG_FILES.split(',').filter(fs.existsSync);
 } else if (fs.existsSync(DEV_CONFIG_PATH)) {
   files = [ DEV_CONFIG_PATH ];
 }


### PR DESCRIPTION
I had ass-u-me-d that content server had this similar defense against loading non-existing config files. But it didn't.

This will fix nightly.dev.lcip.org, and get it running again.

r? - @vladikoff @shane-tomlinson 