### PR TITLE
chore(tests): add new server test dependency on morgan

### DIFF
--- a/tests/teamcity/install-npm-deps.sh
+++ b/tests/teamcity/install-npm-deps.sh
@@ -20,6 +20,7 @@ node ./tests/teamcity/install-npm-deps.js \
   intern                          \
   joi                             \
   lodash                          \
+  morgan                          \
   mozlog                          \
   node-statsd                     \
   node-uap                        \


### PR DESCRIPTION
This is needed or 
```
FAIL: routeLogging - it logs a json blob if log format is not dev_fxa (1ms)
Error: Cannot find module 'morgan'
  at Function.Module._resolveFilename  <module.js:325:15>
  at Function.Module._load  <module.js:276:25>
  at Proxyquire._require  <node_modules/proxyquire/lib/proxyquire.js:151:36>
  at require  <internal/module.js:12:17>
  at Object.<anonymous>  <server/lib/logging/route_logging.js:9:16>
```

r? - @shane-tomlinson 