### PR TITLE
fix(styles): add hover state to primary buttons

### DIFF
--- a/app/styles/modules/_button-row.scss
+++ b/app/styles/modules/_button-row.scss
@@ -44,11 +44,6 @@
       padding: 8px 0;
     }
 
-    &:hover {
-      background: $button-background-hover-color;
-      border-color: $button-border-hover-color;
-    }
-
     &:active {
       background: $button-background-active-color;
       border-color: $button-border-active-color;

--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -214,6 +214,11 @@ body.settings #main-content.card {
     border: solid 1px $button-border-default-color;
     color: $message-text-color;
 
+    &:hover {
+      background: $button-background-hover-color;
+      border-color: $button-border-hover-color;
+    }
+
     &:disabled,
     &.disabled {
       background: $button-background-default-color;


### PR DESCRIPTION
fixes https://github.com/mozilla/fxa-content-server/issues/5062

as @philbooth noted it wasn't applying them since the panel wasn't open. Hover styles were only applied to buttons in `button-row`. Changed to apply to all primary buttons in `_settings`.

cc: @ryanfeeley 

screencap: invisible mouse 😞 
![contentgif](https://user-images.githubusercontent.com/9160471/27244403-52b67e6a-52b4-11e7-833c-6198e4a71216.gif)
