### PR TITLE
feat(metrics): emit flow events for newsletter subscription

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -88,6 +88,7 @@ define(function (require, exports, module) {
       this._fxaClient = options.fxaClient;
       this._marketingEmailClient = options.marketingEmailClient;
       this._metrics = options.metrics;
+      this._notifier = options.notifier;
       this._sentryMetrics = options.sentryMetrics;
 
       /**
@@ -542,7 +543,13 @@ define(function (require, exports, module) {
           if (this.get('needsOptedInToMarketingEmail')) {
             this.unset('needsOptedInToMarketingEmail');
             var emailPrefs = this.getMarketingEmailPrefs();
-            return emailPrefs.optIn(NEWSLETTER_ID);
+            return emailPrefs.optIn(NEWSLETTER_ID)
+              .then(() => {
+                this._notifier.trigger('flow.initialize');
+                this._notifier.trigger('flow.event', {
+                  event: 'newsletter.subscribed'
+                });
+              });
           }
         });
     },

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -138,6 +138,7 @@ define(function (require, exports, module) {
         fxaClient: this._fxaClient,
         marketingEmailClient: this._marketingEmailClient,
         metrics: this._metrics,
+        notifier: this._notifier,
         oAuthClient: this._oAuthClient,
         oAuthClientId: this._oAuthClientId,
         profileClient: this._profileClient,

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -84,6 +84,7 @@ define(function (require, exports, module) {
       it('creates an account', function () {
         assert.equal(account.get('email'), email);
         assert.deepEqual(account.pick('email'), { email: email });
+        assert.equal(account._notifier, notifier);
       });
     });
 


### PR DESCRIPTION
Fixes mozilla/fxa-activity-metrics#79, adding new flow events, `flow.newsletter.subscribed` and `flow.newsletter.unsubscribed`, for tracking newsletter subscriptions.

I had to stretch the definition of a flow event somewhat, in order to make this work. Until now we've been quite strict about saying that flow events only occur during sign-in and sign-up. However, users can change their newsletter subscription preferences at any time via the settings screen. So in order to produce meaningful metrics, I've introduced the possibility of emitting these flow events outside of the normal flows. Are we okay with that?

In addition to the events emitted from settings, a subscribed event is also emitted after verification if the user checked the newsletter checkbox during sign-up.

Here are some sample log lines showing the new events:

```
{"event":"flow.newsletter.subscribed","flow_id":"1d73263b05a807a55a16352b195dc46791d29be9f304dc567068764e8ccefd97","flow_time":4113,"hostname":"Phils-MBP","op":"flowEvent","pid":99411,"time":"2017-06-19T12:59:39.778Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:55.0) Gecko/20100101 Firefox/55.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
{"event":"flow.newsletter.unsubscribed","flow_id":"1d73263b05a807a55a16352b195dc46791d29be9f304dc567068764e8ccefd97","flow_time":7265,"hostname":"Phils-MBP","op":"flowEvent","pid":99411,"time":"2017-06-19T12:59:42.930Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:55.0) Gecko/20100101 Firefox/55.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
```

@mozilla/fxa-devs r?