### PR TITLE
refactor(build): Replace babel-preset-2015-nostrict with babel-preset-2015

### DIFF
--- a/grunttasks/babel.js
+++ b/grunttasks/babel.js
@@ -5,7 +5,9 @@
 module.exports = function (grunt) {
   grunt.config('babel', {
     options: {
-      presets: ['babel-preset-es2015-nostrict'],
+      presets: [['babel-preset-es2015', {
+        modules: false
+      }]],
       sourceMap: false
     },
     scripts: {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -233,9 +233,9 @@
               }
             },
             "babylon": {
-              "version": "6.17.3",
+              "version": "6.17.4",
               "from": "babylon@>=6.17.2 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
             },
             "convert-source-map": {
               "version": "1.5.0",
@@ -620,221 +620,16 @@
         }
       }
     },
-    "babel-preset-es2015-nostrict": {
-      "version": "6.6.2",
-      "from": "babel-preset-es2015-nostrict@6.6.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015-nostrict/-/babel-preset-es2015-nostrict-6.6.2.tgz",
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "from": "babel-preset-es2015@6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "dependencies": {
-        "babel-plugin-transform-es2015-template-literals": {
+        "babel-plugin-check-es2015-constants": {
           "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+          "from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
           "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-literals": {
-          "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-function-name": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-function-name@>=6.3.13 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-          "dependencies": {
-            "babel-helper-function-name": {
-              "version": "6.24.1",
-              "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-              "dependencies": {
-                "babel-traverse": {
-                  "version": "6.25.0",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                    },
-                    "babylon": {
-                      "version": "6.17.3",
-                      "from": "babylon@>=6.17.2 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.18.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "3.0.1",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-helper-get-function-arity": {
-                  "version": "6.24.1",
-                  "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
-                },
-                "babel-template": {
-                  "version": "6.25.0",
-                  "from": "babel-template@>=6.24.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-                  "dependencies": {
-                    "babylon": {
-                      "version": "6.17.3",
-                      "from": "babylon@>=6.17.2 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            },
             "babel-runtime": {
               "version": "6.23.0",
               "from": "babel-runtime@>=6.22.0 <7.0.0",
@@ -856,7 +651,7 @@
         },
         "babel-plugin-transform-es2015-arrow-functions": {
           "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
+          "from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
           "dependencies": {
             "babel-runtime": {
@@ -880,7 +675,7 @@
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
           "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
+          "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
           "dependencies": {
             "babel-runtime": {
@@ -902,9 +697,178 @@
             }
           }
         },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.25.0",
+              "from": "babel-traverse@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.1",
+                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "from": "babel-messages@>=6.23.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                },
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "debug@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "ms@2.0.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.18.0",
+                  "from": "globals@>=9.0.0 <10.0.0",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
         "babel-plugin-transform-es2015-classes": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-classes@>=6.6.0 <7.0.0",
+          "from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
           "dependencies": {
             "babel-helper-optimise-call-expression": {
@@ -935,9 +899,9 @@
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
               "dependencies": {
                 "babylon": {
-                  "version": "6.17.3",
+                  "version": "6.17.4",
                   "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
                 }
               }
             },
@@ -1010,9 +974,9 @@
                   }
                 },
                 "babylon": {
-                  "version": "6.17.3",
+                  "version": "6.17.4",
                   "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
                 },
                 "debug": {
                   "version": "2.6.8",
@@ -1098,231 +1062,9 @@
             }
           }
         },
-        "babel-plugin-transform-es2015-object-super": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-          "dependencies": {
-            "babel-helper-replace-supers": {
-              "version": "6.24.1",
-              "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-              "dependencies": {
-                "babel-helper-optimise-call-expression": {
-                  "version": "6.24.1",
-                  "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
-                },
-                "babel-traverse": {
-                  "version": "6.25.0",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-                        }
-                      }
-                    },
-                    "babylon": {
-                      "version": "6.17.3",
-                      "from": "babylon@>=6.17.2 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.18.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "3.0.1",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.23.0",
-                  "from": "babel-messages@>=6.23.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                },
-                "babel-template": {
-                  "version": "6.25.0",
-                  "from": "babel-template@>=6.24.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-                  "dependencies": {
-                    "babylon": {
-                      "version": "6.17.3",
-                      "from": "babylon@>=6.17.2 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-          "dependencies": {
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
         "babel-plugin-transform-es2015-computed-properties": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
+          "from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
           "dependencies": {
             "babel-template": {
@@ -1331,9 +1073,9 @@
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
               "dependencies": {
                 "babylon": {
-                  "version": "6.17.3",
+                  "version": "6.17.4",
                   "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.25.0",
@@ -1484,9 +1226,33 @@
             }
           }
         },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
         "babel-plugin-transform-es2015-duplicate-keys": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
+          "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
           "dependencies": {
             "babel-runtime": {
@@ -1527,7 +1293,7 @@
         },
         "babel-plugin-transform-es2015-for-of": {
           "version": "6.23.0",
-          "from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
+          "from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
           "dependencies": {
             "babel-runtime": {
@@ -1549,15 +1315,150 @@
             }
           }
         },
-        "babel-plugin-transform-es2015-sticky-regex": {
+        "babel-plugin-transform-es2015-function-name": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+          "from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
           "dependencies": {
-            "babel-helper-regex": {
+            "babel-helper-function-name": {
               "version": "6.24.1",
-              "from": "babel-helper-regex@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz"
+              "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+              "dependencies": {
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "babylon": {
+                      "version": "6.17.4",
+                      "from": "babylon@>=6.17.2 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-helper-get-function-arity": {
+                  "version": "6.24.1",
+                  "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+                },
+                "babel-template": {
+                  "version": "6.25.0",
+                  "from": "babel-template@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.17.4",
+                      "from": "babylon@>=6.17.2 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                    }
+                  }
+                }
+              }
             },
             "babel-types": {
               "version": "6.25.0",
@@ -1595,16 +1496,156 @@
             }
           }
         },
-        "babel-plugin-transform-es2015-unicode-regex": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
           "dependencies": {
-            "babel-helper-regex": {
-              "version": "6.24.1",
-              "from": "babel-helper-regex@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
                 "babel-types": {
                   "version": "6.25.0",
                   "from": "babel-types@>=6.24.1 <7.0.0",
@@ -1640,492 +1681,12 @@
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
-            },
-            "regexpu-core": {
-              "version": "2.0.0",
-              "from": "regexpu-core@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-              "dependencies": {
-                "regenerate": {
-                  "version": "1.3.2",
-                  "from": "regenerate@>=1.2.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
-                },
-                "regjsgen": {
-                  "version": "0.2.0",
-                  "from": "regjsgen@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                },
-                "regjsparser": {
-                  "version": "0.1.5",
-                  "from": "regjsparser@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                  "dependencies": {
-                    "jsesc": {
-                      "version": "0.5.0",
-                      "from": "jsesc@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-check-es2015-constants": {
-          "version": "6.22.0",
-          "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-spread": {
-          "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-parameters@>=6.6.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-          "dependencies": {
-            "babel-traverse": {
-              "version": "6.25.0",
-              "from": "babel-traverse@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.22.0",
-                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "3.0.1",
-                      "from": "js-tokens@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.23.0",
-                  "from": "babel-messages@>=6.23.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                },
-                "babylon": {
-                  "version": "6.17.3",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
-                },
-                "debug": {
-                  "version": "2.6.8",
-                  "from": "debug@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "from": "ms@2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "9.18.0",
-                  "from": "globals@>=9.0.0 <10.0.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.2",
-                  "from": "invariant@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.3.1",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-helper-call-delegate": {
-              "version": "6.24.1",
-              "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-              "dependencies": {
-                "babel-helper-hoist-variables": {
-                  "version": "6.24.1",
-                  "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz"
-                }
-              }
-            },
-            "babel-helper-get-function-arity": {
-              "version": "6.24.1",
-              "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
-            },
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.3",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-          "version": "6.23.0",
-          "from": "babel-plugin-transform-es2015-destructuring@>=6.6.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-block-scoping@>=6.6.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-          "dependencies": {
-            "babel-traverse": {
-              "version": "6.25.0",
-              "from": "babel-traverse@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.22.0",
-                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "3.0.1",
-                      "from": "js-tokens@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.23.0",
-                  "from": "babel-messages@>=6.23.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                },
-                "babylon": {
-                  "version": "6.17.3",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
-                },
-                "debug": {
-                  "version": "2.6.8",
-                  "from": "debug@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "from": "ms@2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "9.18.0",
-                  "from": "globals@>=9.0.0 <10.0.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.2",
-                  "from": "invariant@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.3.1",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            },
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.3",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-          "version": "6.23.0",
-          "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
             }
           }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.6.0 <7.0.0",
+          "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
           "dependencies": {
             "babel-types": {
@@ -2168,9 +1729,9 @@
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
               "dependencies": {
                 "babylon": {
-                  "version": "6.17.3",
+                  "version": "6.17.4",
                   "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.25.0",
@@ -2292,9 +1853,964 @@
             }
           }
         },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-helper-hoist-variables": {
+              "version": "6.24.1",
+              "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-replace-supers": {
+              "version": "6.24.1",
+              "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+              "dependencies": {
+                "babel-helper-optimise-call-expression": {
+                  "version": "6.24.1",
+                  "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "babylon": {
+                      "version": "6.17.4",
+                      "from": "babylon@>=6.17.2 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.1",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "from": "babel-messages@>=6.23.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                },
+                "babel-template": {
+                  "version": "6.25.0",
+                  "from": "babel-template@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.17.4",
+                      "from": "babylon@>=6.17.2 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.25.0",
+              "from": "babel-traverse@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.1",
+                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "from": "babel-messages@>=6.23.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                },
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "debug@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "ms@2.0.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.18.0",
+                  "from": "globals@>=9.0.0 <10.0.0",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.1",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-helper-call-delegate": {
+              "version": "6.24.1",
+              "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+              "dependencies": {
+                "babel-helper-hoist-variables": {
+                  "version": "6.24.1",
+                  "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz"
+                }
+              }
+            },
+            "babel-helper-get-function-arity": {
+              "version": "6.24.1",
+              "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+          "dependencies": {
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-regex": {
+              "version": "6.24.1",
+              "from": "babel-helper-regex@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz"
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-regex": {
+              "version": "6.24.1",
+              "from": "babel-helper-regex@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            },
+            "regexpu-core": {
+              "version": "2.0.0",
+              "from": "regexpu-core@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+              "dependencies": {
+                "regenerate": {
+                  "version": "1.3.2",
+                  "from": "regenerate@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                },
+                "regjsparser": {
+                  "version": "0.1.5",
+                  "from": "regjsparser@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "babel-plugin-transform-regenerator": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-regenerator@>=6.6.0 <7.0.0",
+          "from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
           "dependencies": {
             "regenerator-transform": {
@@ -2507,7 +3023,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.3.1",
+          "from": "underscore@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
@@ -2612,7 +3128,7 @@
         },
         "vary": {
           "version": "1.1.1",
-          "from": "vary@>=1.0.0 <2.0.0",
+          "from": "vary@>=1.1.1 <1.2.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
         }
       }
@@ -2835,7 +3351,7 @@
             },
             "mime-types": {
               "version": "2.1.15",
-              "from": "mime-types@>=2.1.15 <2.2.0",
+              "from": "mime-types@>=2.1.11 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
               "dependencies": {
                 "mime-db": {
@@ -2854,7 +3370,7 @@
         },
         "vary": {
           "version": "1.1.1",
-          "from": "vary@>=1.0.0 <2.0.0",
+          "from": "vary@>=1.1.1 <1.2.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
         }
       }
@@ -3306,7 +3822,7 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2.0.3",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "once": {
@@ -3610,9 +4126,9 @@
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000684",
+              "version": "1.0.30000692",
               "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000684.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000692.tgz"
             }
           }
         },
@@ -3628,7 +4144,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -3638,7 +4154,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
@@ -3655,7 +4171,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
@@ -3710,7 +4226,7 @@
       "dependencies": {
         "babel-core": {
           "version": "6.25.0",
-          "from": "babel-core@>=6.9.1 <7.0.0",
+          "from": "babel-core@>=6.0.12 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
           "dependencies": {
             "babel-code-frame": {
@@ -3836,7 +4352,7 @@
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "babel-runtime@>=6.18.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -3918,7 +4434,7 @@
             },
             "babel-types": {
               "version": "6.25.0",
-              "from": "babel-types@>=6.25.0 <7.0.0",
+              "from": "babel-types@>=6.19.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
               "dependencies": {
                 "esutils": {
@@ -3934,9 +4450,9 @@
               }
             },
             "babylon": {
-              "version": "6.17.3",
+              "version": "6.17.4",
               "from": "babylon@>=6.17.2 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz"
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
             },
             "convert-source-map": {
               "version": "1.5.0",
@@ -4356,9 +4872,9 @@
                       }
                     },
                     "readable-stream": {
-                      "version": "2.2.11",
+                      "version": "2.3.0",
                       "from": "readable-stream@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -4376,14 +4892,21 @@
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "safe-buffer": {
-                          "version": "5.0.1",
-                          "from": "safe-buffer@>=5.0.1 <5.1.0",
-                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                          "version": "5.1.0",
+                          "from": "safe-buffer@>=5.1.0 <5.2.0",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                         },
                         "string_decoder": {
                           "version": "1.0.2",
                           "from": "string_decoder@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                          "dependencies": {
+                            "safe-buffer": {
+                              "version": "5.0.1",
+                              "from": "safe-buffer@>=5.0.1 <5.1.0",
+                              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                            }
+                          }
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
@@ -4460,9 +4983,9 @@
               "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "2.2.11",
+                  "version": "2.3.0",
                   "from": "readable-stream@>=2.1.5 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -4471,7 +4994,7 @@
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.3 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
@@ -4485,14 +5008,21 @@
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "safe-buffer": {
-                      "version": "5.0.1",
-                      "from": "safe-buffer@>=5.0.1 <5.1.0",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                      "version": "5.1.0",
+                      "from": "safe-buffer@>=5.1.0 <5.2.0",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                     },
                     "string_decoder": {
                       "version": "1.0.2",
                       "from": "string_decoder@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                      "dependencies": {
+                        "safe-buffer": {
+                          "version": "5.0.1",
+                          "from": "safe-buffer@>=5.0.1 <5.1.0",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                        }
+                      }
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
@@ -4763,7 +5293,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -4821,7 +5351,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -4934,7 +5464,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -5267,7 +5797,7 @@
                 },
                 "object-assign": {
                   "version": "4.1.1",
-                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
                 }
               }
@@ -5284,7 +5814,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.3 <3.0.0",
+                      "from": "inherits@2.0.3",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "typedarray": {
@@ -5293,9 +5823,9 @@
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
-                      "version": "2.2.11",
+                      "version": "2.3.0",
                       "from": "readable-stream@>=2.2.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -5313,14 +5843,21 @@
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "safe-buffer": {
-                          "version": "5.0.1",
-                          "from": "safe-buffer@>=5.0.1 <5.1.0",
-                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                          "version": "5.1.0",
+                          "from": "safe-buffer@>=5.1.0 <5.2.0",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                         },
                         "string_decoder": {
                           "version": "1.0.2",
                           "from": "string_decoder@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                          "dependencies": {
+                            "safe-buffer": {
+                              "version": "5.0.1",
+                              "from": "safe-buffer@>=5.0.1 <5.1.0",
+                              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                            }
+                          }
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
@@ -6723,9 +7260,9 @@
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
                     "readable-stream": {
-                      "version": "2.2.11",
+                      "version": "2.3.0",
                       "from": "readable-stream@>=2.0.6 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -6734,7 +7271,7 @@
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@>=2.0.3 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "isarray": {
@@ -6748,14 +7285,21 @@
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "safe-buffer": {
-                          "version": "5.0.1",
-                          "from": "safe-buffer@>=5.0.1 <5.1.0",
-                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                          "version": "5.1.0",
+                          "from": "safe-buffer@>=5.1.0 <5.2.0",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                         },
                         "string_decoder": {
                           "version": "1.0.2",
                           "from": "string_decoder@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                          "dependencies": {
+                            "safe-buffer": {
+                              "version": "5.0.1",
+                              "from": "safe-buffer@>=5.0.1 <5.1.0",
+                              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                            }
+                          }
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
@@ -7109,9 +7653,9 @@
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
                 },
                 "uuid": {
-                  "version": "3.0.1",
+                  "version": "3.1.0",
                   "from": "uuid@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
                 }
               }
             },
@@ -7463,9 +8007,9 @@
               "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "2.2.11",
+                  "version": "2.3.0",
                   "from": "readable-stream@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -7474,7 +8018,7 @@
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.3 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
@@ -7488,14 +8032,21 @@
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "safe-buffer": {
-                      "version": "5.0.1",
-                      "from": "safe-buffer@>=5.0.1 <5.1.0",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                      "version": "5.1.0",
+                      "from": "safe-buffer@>=5.1.0 <5.2.0",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                     },
                     "string_decoder": {
                       "version": "1.0.2",
                       "from": "string_decoder@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                      "dependencies": {
+                        "safe-buffer": {
+                          "version": "5.0.1",
+                          "from": "safe-buffer@>=5.0.1 <5.1.0",
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                        }
+                      }
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
@@ -7895,9 +8446,9 @@
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
                 },
                 "uuid": {
-                  "version": "3.0.1",
+                  "version": "3.1.0",
                   "from": "uuid@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
                 }
               }
             }
@@ -8743,7 +9294,7 @@
             },
             "gettext-parser": {
               "version": "1.2.2",
-              "from": "gettext-parser@>=1.1.0 <2.0.0",
+              "from": "gettext-parser@>=1.1.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.2.2.tgz",
               "dependencies": {
                 "encoding": {
@@ -8762,7 +9313,7 @@
             },
             "jade": {
               "version": "1.11.0",
-              "from": "jade@>=1.0.0 <2.0.0",
+              "from": "jade@>=1.11.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
               "dependencies": {
                 "character-parser": {
@@ -8941,7 +9492,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "from": "align-text@>=0.1.3 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
@@ -9118,7 +9669,7 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "from": "minimatch@>=3.0.0 <4.0.0",
+              "from": "minimatch@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
@@ -9589,7 +10140,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -9642,7 +10193,7 @@
           "dependencies": {
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "object-assign": {
@@ -9972,13 +10523,13 @@
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.3.1",
+          "from": "underscore@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         },
         "uuid": {
-          "version": "3.0.1",
+          "version": "3.1.0",
           "from": "uuid@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "babel-middleware": "git://github.com/shane-tomlinson/babel-middleware.git#4c70de91",
-    "babel-preset-es2015-nostrict": "6.6.2",
+    "babel-preset-es2015": "6.24.1",
     "bluebird": "3.5.0",
     "body-parser": "1.17.2",
     "bower": "1.8.0",

--- a/server/lib/routes/get-babelified-source.js
+++ b/server/lib/routes/get-babelified-source.js
@@ -12,7 +12,9 @@ module.exports = function (config) {
     path: '/scripts/*\.(js|map)',
     process: babel({
       babelOptions: {
-        presets: ['babel-preset-es2015-nostrict'],
+        presets: [['babel-preset-es2015', {
+          modules: false
+        }]],
         sourceMaps: true
       },
       cachePath: path.join(__dirname, '..', '..', '..', '.es5cache'),


### PR DESCRIPTION
babel-preset-2015 is maintained by the babel team, the -nostrict variant
is not. I used the -nostrict variant because it doesn't try to wrap
all of our modules in an AMD wrapper, but I didn't know it is
possible to supply the "modules: false" option to the original plugin
to have the same effect.