### PR TITLE
Removed desktop-only caveat

### DIFF
--- a/app/scripts/templates/choose_what_to_sync.mustache
+++ b/app/scripts/templates/choose_what_to_sync.mustache
@@ -83,7 +83,6 @@
             {{/hasDesktopPreferencesSupport}}
           </div>
         </div>
-        <div class="extra-links extra-links-choose-what-to-sync">{{#t}}Add-ons and Preferences do not currently sync on mobile devices.{{/t}}</div>
         <div class="button-row">
           <button id="submit-btn" type="submit" tabindex="1" autofocus>{{#t}}Save settings{{/t}}</button>
         </div>


### PR DESCRIPTION
Add-ons, preferences, and soon addresses and credit cards will not be in parity on Android. I don't think this point in the process is the right time to mention it. Few care, and those that do won't be noticing here.

@davismtl thoughts?