### PR TITLE
fix(cwts): Remove the leftover CWTS styles.

### DIFF
--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -73,10 +73,6 @@ ul.links {
   color: $link-color;
 }
 
-.extra-links-choose-what-to-sync {
-  margin-top: 0;
-}
-
 .verification-email-message,
 .signed-in-email-message {
   word-wrap: break-word;


### PR DESCRIPTION
`.extra-links-choose-what-to-sync` is no longer needed, removing.