### PR TITLE
feat(sms): Re-add the SMS deeplink tests.

### DIFF
--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -13,6 +13,7 @@ define([
 
   const config = intern.config;
   const SIGNIN_PAGE_URL = `${config.fxaContentRoot}signin?context=fx_fennec_v1&service=sync`;
+  const SMS_PAGE_URL = `${config.fxaContentRoot}sms?context=fx_desktop_v1&service=sync&signinCodes=true`;
 
   let email;
   const PASSWORD = '12345678';
@@ -20,17 +21,23 @@ define([
   const thenify = FunctionalHelpers.thenify;
 
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const click = FunctionalHelpers.click;
   const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   const createUser = FunctionalHelpers.createUser;
+  const deleteAllSms = FunctionalHelpers.deleteAllSms;
+  const disableInProd = FunctionalHelpers.disableInProd;
   const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   const fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
+  const getSmsSigninCode = FunctionalHelpers.getSmsSigninCode;
   const openPage = FunctionalHelpers.openPage;
   const openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
   const testElementExists = FunctionalHelpers.testElementExists;
+  const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
   const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  const type = FunctionalHelpers.type;
 
   const setupTest = thenify(function (successSelector, options) {
     options = options || {};
@@ -105,6 +112,31 @@ define([
 
         .then(testElementExists('#fxa-sign-in-complete-header'))
         .then(testIsBrowserNotified('fxaccounts:login'));
-    }
+    },
+
+    'signup in desktop, send an SMS, open deferred deeplink in Fennec': disableInProd(function () {
+      const testPhoneNumber = TestHelpers.createPhoneNumber();
+      let signinUrlWithSigninCode;
+
+      return this.remote
+        // The phoneNumber is reused across tests, delete all
+        // if its SMS messages to ensure a clean slate.
+        .then(deleteAllSms(testPhoneNumber))
+        .then(setupTest(selectors.CONFIRM_SIGNUP.HEADER))
+
+        .then(openPage(SMS_PAGE_URL, selectors.SMS_SEND.HEADER))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+        .then(click(selectors.SMS_SEND.SUBMIT))
+
+        .then(testElementExists(selectors.SMS_SENT.HEADER))
+        .then(getSmsSigninCode(testPhoneNumber, 0))
+        .then(function (signinCode) {
+          signinUrlWithSigninCode = `${SIGNIN_PAGE_URL}&signin=${signinCode}`;
+          return this.parent
+            .then(clearBrowserState())
+            .then(openPage(signinUrlWithSigninCode, selectors.SIGNIN.HEADER))
+            .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email));
+        });
+    })
   });
 });

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -16,25 +16,32 @@ define([
 
   const config = intern.config;
   const SIGNIN_PAGE_URL = `${config.fxaContentRoot}signin?context=fx_ios_v1&service=sync`;
+  const SMS_PAGE_URL = `${config.fxaContentRoot}sms?context=fx_desktop_v1&service=sync&signinCodes=true`;
 
   let email;
   const PASSWORD = '12345678';
 
   const thenify = FunctionalHelpers.thenify;
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const click = FunctionalHelpers.click;
   const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   const createUser = FunctionalHelpers.createUser;
+  const deleteAllSms = FunctionalHelpers.deleteAllSms;
+  const disableInProd = FunctionalHelpers.disableInProd;
   const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   const fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
+  const getSmsSigninCode = FunctionalHelpers.getSmsSigninCode;
   const listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
   const noPageTransition = FunctionalHelpers.noPageTransition;
   const openPage = FunctionalHelpers.openPage;
   const openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
   const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   const testElementExists = FunctionalHelpers.testElementExists;
+  const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
   const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   const testIsBrowserNotified = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
   const testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+  const type = FunctionalHelpers.type;
   const visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   const setupTest = thenify(function (options) {
@@ -158,6 +165,31 @@ define([
         // about:accounts will take over post-unblock, no transition
         .then(noPageTransition('#fxa-signin-unblock-header'))
         .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }));
-    }
+    },
+
+    'signup in desktop, send an SMS, open deferred deeplink in Fx for iOS': disableInProd(function () {
+      const testPhoneNumber = TestHelpers.createPhoneNumber();
+      let signinUrlWithSigninCode;
+
+      return this.remote
+        // The phoneNumber is reused across tests, delete all
+        // if its SMS messages to ensure a clean slate.
+        .then(deleteAllSms(testPhoneNumber))
+        .then(setupTest(selectors.CONFIRM_SIGNUP.HEADER))
+
+        .then(openPage(SMS_PAGE_URL, selectors.SMS_SEND.HEADER))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+        .then(click(selectors.SMS_SEND.SUBMIT))
+
+        .then(testElementExists(selectors.SMS_SENT.HEADER))
+        .then(getSmsSigninCode(testPhoneNumber, 0))
+        .then(function (signinCode) {
+          signinUrlWithSigninCode = `${SIGNIN_PAGE_URL}&signin=${signinCode}`;
+          return this.parent
+            .then(clearBrowserState())
+            .then(openPage(signinUrlWithSigninCode, selectors.SIGNIN.HEADER))
+            .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email));
+        });
+    })
   });
 });


### PR DESCRIPTION
The deeplink tests were removed because they were being rate limited.
This PR re-adds them.

Depends on a fix for https://github.com/mozilla/fxa-customs-server/issues/205 or
just working around the rate limiting.

fixes #5136 