### PR TITLE
fix(client): Fix "context" data setting w/ mixins.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -359,20 +359,24 @@ define(function (require, exports, module) {
       // use cached context, if available. This prevents the context()
       // function from being called multiple times per render.
       if (! this._context) {
-        this._context = this.context() || {};
+        this._context = new Backbone.Model({
+          // `t` is a Mustache helper to translate and HTML escape strings.
+          t: this.translateInTemplate.bind(this),
+          // `unsafeTranslate` is a Mustache helper that translates a
+          // string without HTML escaping. Prefer `t`
+          unsafeTranslate: this.unsafeTranslateInTemplate.bind(this)
+        });
+        this.setInitialContext(this._context);
       }
-      var ctx = this._context;
-
-      // `t` is a Mustache helper to translate and HTML escape strings.
-      ctx.t = this.translateInTemplate.bind(this);
-      // `unsafeTranslate` is a Mustache helper that translates a
-      // string without HTML escaping. Prefer `t`
-      ctx.unsafeTranslate = this.unsafeTranslateInTemplate.bind(this);
-
-      return ctx;
+      return this._context.toJSON();
     },
 
-    context () {
+    /**
+     * Update the `context` model
+     *
+     * @param {Object} context
+     */
+    setInitialContext (context) {
       // Implement in subclasses
     },
 

--- a/app/scripts/views/cannot_create_account.js
+++ b/app/scripts/views/cannot_create_account.js
@@ -12,10 +12,8 @@ define(function (require, exports, module) {
     template: CannotCreateAccountTemplate,
     className: 'cannot-create-account',
 
-    context () {
-      return {
-        isSync: this.relier.isSync()
-      };
+    setInitialContext (context) {
+      context.set('isSync', this.relier.isSync());
     }
 
   });

--- a/app/scripts/views/choose_what_to_sync.js
+++ b/app/scripts/views/choose_what_to_sync.js
@@ -52,10 +52,10 @@ define(function (require, exports, module) {
       return proto.destroy.call(this, ...args);
     },
 
-    context () {
+    setInitialContext (context) {
       var account = this.getAccount();
 
-      return {
+      context.set({
         email: account.get('email'),
         hasBookmarkSupport: this._isEngineSupported('bookmarks'),
         hasDesktopAddonSupport: this._isEngineSupported('desktop-addons'),
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
         hasHistorySupport: this._isEngineSupported('history'),
         hasPasswordSupport: this._isEngineSupported('passwords'),
         hasTabSupport: this._isEngineSupported('tabs')
-      };
+      });
     },
 
     submit () {

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -66,20 +66,20 @@ define(function (require, exports, module) {
       return proto.afterVisible.call(this);
     },
 
-    context () {
+    setInitialContext (context) {
       var verificationInfo = this._verificationInfo;
       var doesLinkValidate = verificationInfo.isValid();
       var isLinkExpired = verificationInfo.isExpired();
       var showSyncWarning = this.relier.get('resetPasswordConfirm');
 
       // damaged and expired links have special messages.
-      return {
+      context.set({
         email: verificationInfo.get('email'),
         isLinkDamaged: ! doesLinkValidate,
         isLinkExpired: isLinkExpired,
         isLinkValid: doesLinkValidate && ! isLinkExpired,
         showSyncWarning: showSyncWarning
-      };
+      });
     },
 
     isValidEnd () {

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -89,16 +89,16 @@ define(function (require, exports, module) {
         .fail((err) => this._handleVerificationErrors(err));
     },
 
-    context () {
+    setInitialContext (context) {
       const verificationInfo = this._verificationInfo;
-      return {
+      context.set({
         canResend: this._canResend(),
         error: this.model.get('error'),
         // If the link is invalid, print a special error message.
         isLinkDamaged: ! verificationInfo.isValid(),
         isLinkExpired: verificationInfo.isExpired(),
         isLinkUsed: verificationInfo.isUsed()
-      };
+      });
     },
 
     /**

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -43,12 +43,12 @@ define(function (require, exports, module) {
       return this._account;
     },
 
-    context () {
+    setInitialContext (context) {
       var email = this.getAccount().get('email');
       var isSignIn = this.isSignIn();
       var isSignUp = this.isSignUp();
 
-      return {
+      context.set({
         // Back button is only available for signin for now. We haven't fully
         // figured out whether re-signing up a user and sending a new
         // email/sessionToken to the browser will cause problems. I don't think
@@ -59,7 +59,7 @@ define(function (require, exports, module) {
         escapedEmail: _.escape(email),
         isSignIn,
         isSignUp
-      };
+      });
     },
 
     _bouncedEmailSignup () {

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -31,16 +31,16 @@ define(function (require, exports, module) {
         options.verificationPollMS || VERIFICATION_POLL_IN_MS;
     },
 
-    context () {
+    setInitialContext (context) {
       var email = this.model.get('email');
       var isSignInEnabled = this.relier.get('resetPasswordConfirm');
 
-      return {
+      context.set({
         email: email,
         encodedEmail: encodeURIComponent(email),
         forceAuth: this.broker.isForceAuth(),
         isSignInEnabled: isSignInEnabled
-      };
+      });
     },
 
     beforeRender () {

--- a/app/scripts/views/connect_another_device.js
+++ b/app/scripts/views/connect_another_device.js
@@ -123,7 +123,7 @@ define(function (require, exports, module) {
       }
     },
 
-    context () {
+    setInitialContext (context) {
       const isSignedIn = this._isSignedIn();
       const canSignIn = this._canSignIn();
       const email = this.getAccount().get('email');
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
       const isOtherIos = isIos && ! isFirefoxIos;
       const isOther = ! isAndroid && ! isIos && ! isFirefoxDesktop;
 
-      return {
+      context.set({
         canSignIn,
         email,
         escapedSignInUrl,
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
         isOtherAndroid,
         isOtherIos,
         isSignedIn
-      };
+      });
     },
 
     /**

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -148,15 +148,15 @@ define(function (require, exports, module) {
       });
     },
 
-    context () {
+    setInitialContext (context) {
       /// submit button
       const buttonSignInText = this.translate(t('Sign in'), { msgctxt: 'submit button' });
 
-      return {
+      context.set({
         buttonSignInText,
         email: this.relier.get('email'),
         password: this._formPrefill.get('password')
-      };
+      });
     },
 
     events: _.extend({}, SignInView.prototype.events, {

--- a/app/scripts/views/marketing_snippet.js
+++ b/app/scripts/views/marketing_snippet.js
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
       'click .marketing-link': '_onMarketingClick'
     },
 
-    context () {
+    setInitialContext (context) {
       const showSignUpMarketing = this._shouldShowSignUpMarketing();
       const isIos = this._isIos();
       const isAndroid = this._isAndroid();
@@ -98,7 +98,7 @@ define(function (require, exports, module) {
       const isAutumn2016 = marketingId === Constants.MARKETING_ID_AUTUMN_2016;
       const isSpring2015 = marketingId === Constants.MARKETING_ID_SPRING_2015;
 
-      return {
+      context.set({
         appStoreImage,
         downloadLinkAndroid,
         downloadLinkIos,
@@ -110,7 +110,7 @@ define(function (require, exports, module) {
         marketingId,
         playStoreImage,
         showSignUpMarketing
-      };
+      });
     },
 
     afterRender () {

--- a/app/scripts/views/mixins/back-mixin.js
+++ b/app/scripts/views/mixins/back-mixin.js
@@ -25,22 +25,10 @@ define(function (require, exports, module) {
       'keyup #back': BaseView.preventDefaultThen('backOnEnter')
     },
 
-    /**
-     * Monkey patch BaseView.prototype.getContext to return a
-     * context with the `canGoBack` field. Note, this unfortunately
-     * means the mixed-in class cannot override `canGoBack`.
-     *
-     * @method getContext
-     * @returns {Object}
-     */
-    getContext () {
-      var context = BaseView.prototype.getContext.call(this);
-
-      if (! ('canGoBack' in context)) {
-        context.canGoBack = this.canGoBack();
+    setInitialContext (context) {
+      if (! context.has('canGoBack')) {
+        context.set('canGoBack', this.canGoBack());
       }
-
-      return context;
     },
 
     /**

--- a/app/scripts/views/mixins/open-webmail-mixin.js
+++ b/app/scripts/views/mixins/open-webmail-mixin.js
@@ -68,20 +68,14 @@ define(function (require, exports, module) {
       });
     },
 
-    /**
-     * Monkey patch BaseView.prototype.getContext to return a context
-     * @method getContext
-     * @returns {Object}
-     */
-    getContext () {
-      const context = BaseView.prototype.getContext.call(this);
-      const email = context.email;
+    setInitialContext (context) {
+      const email = context.get('email');
       const isOpenWebmailButtonVisible = this.isOpenWebmailButtonVisible(email);
 
-      context.isOpenWebmailButtonVisible = isOpenWebmailButtonVisible;
+      context.set('isOpenWebmailButtonVisible', isOpenWebmailButtonVisible);
 
       if (email && isOpenWebmailButtonVisible) {
-        _.extend(context, {
+        context.set({
           escapedWebmailLink: encodeURI(this.getWebmailLink(email)),
           // function.bind is used to avoid infinite recursion.
           // getWebmailButtonText calls this.translate which calls
@@ -93,8 +87,6 @@ define(function (require, exports, module) {
           webmailType: this.getWebmailType(email)
         });
       }
-
-      return context;
     },
 
     getWebmailLink (email) {

--- a/app/scripts/views/permissions.js
+++ b/app/scripts/views/permissions.js
@@ -71,16 +71,16 @@ define(function (require, exports, module) {
       return this._account;
     },
 
-    context () {
+    setInitialContext (context) {
       var account = this.getAccount();
       var requestedPermissions = this.relier.get('permissions');
       var applicablePermissions =
         this._getApplicablePermissions(account, requestedPermissions);
 
-      return {
+      context.set({
         serviceName: this.relier.get('serviceName'),
         unsafePermissionsHTML: this._getPermissionsHTML(account, applicablePermissions)
-      };
+      });
     },
 
     /**

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -67,8 +67,8 @@ define(function (require, exports, module) {
       this._templateInfo = TEMPLATE_INFO[this.keyOfVerificationReason(options.type)];
     },
 
-    context () {
-      return {
+    setInitialContext (context) {
+      context.set({
         headerId: this._getHeaderId(),
         headerTitle: this._getHeaderTitle(),
         isSync: this.relier.isSync(),
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
         secondaryEmailVerified: this.getSearchParam('secondary_email_verified') || null,
         service: this.relier.get('service'),
         serviceName: this.relier.get('serviceName')
-      };
+      });
     },
 
     _getHeaderId () {

--- a/app/scripts/views/report_sign_in.js
+++ b/app/scripts/views/report_sign_in.js
@@ -39,17 +39,17 @@ define(function (require, exports, module) {
         .then(() => this.navigate('signin_reported'));
     },
 
-    context () {
+    setInitialContext (context) {
       const isLinkDamaged = ! this._signInToReport.isValid();
       const isLinkValid = ! isLinkDamaged;
       const supportLink = this._getSupportLink();
 
-      return {
+      context.set({
         escapedSupportLink: encodeURI(supportLink),
         hasSupportLink: !! supportLink,
         isLinkDamaged,
         isLinkValid
-      };
+      });
     },
 
     /**

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -27,11 +27,11 @@ define(function (require, exports, module) {
       this._formPrefill = options.formPrefill;
     },
 
-    context () {
-      return {
+    setInitialContext (context) {
+      context.set({
         forceEmail: this.model.get('forceEmail'),
         serviceName: this.relier.get('serviceName')
-      };
+      });
     },
 
     beforeRender () {

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -110,13 +110,13 @@ define(function (require, exports, module) {
       });
     },
 
-    context () {
+    setInitialContext (context) {
       const account = this.getSignedInAccount();
 
-      return {
+      context.set({
         showSignOut: ! account.isFromSync(),
         unsafeHeaderHTML: this._getHeaderHTML(account)
-      };
+      });
     },
 
     events: {

--- a/app/scripts/views/settings/avatar.js
+++ b/app/scripts/views/settings/avatar.js
@@ -20,11 +20,9 @@ define(function (require, exports, module) {
       this.render();
     },
 
-    context () {
+    setInitialContext (context) {
       var account = this.getSignedInAccount();
-      return {
-        avatar: account.has('profileImageUrl')
-      };
+      context.set('avatar', account.has('profileImageUrl'));
     }
 
   });

--- a/app/scripts/views/settings/avatar_camera.js
+++ b/app/scripts/views/settings/avatar_camera.js
@@ -35,10 +35,10 @@ define(function (require, exports, module) {
     className: 'avatar-camera',
     viewName: 'settings.avatar.camera',
 
-    context () {
-      return {
+    setInitialContext (context) {
+      context.set({
         streaming: this.streaming
-      };
+      });
     },
 
     initialize (options) {

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -46,11 +46,11 @@ define(function (require, exports, module) {
       }
     },
 
-    context () {
+    setInitialContext (context) {
       var account = this.getSignedInAccount();
-      return {
+      context.set({
         'hasProfileImage': account.has('profileImageUrl')
-      };
+      });
     },
 
     afterVisible () {

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -24,11 +24,9 @@ define(function (require, exports, module) {
     className: 'change-password',
     viewName: 'settings.change-password',
 
-    context () {
+    setInitialContext (context) {
       const account = this.getSignedInAccount();
-      return {
-        email: account.get('email')
-      };
+      context.set('email', account.get('email'));
     },
 
     submit () {

--- a/app/scripts/views/settings/client_disconnect.js
+++ b/app/scripts/views/settings/client_disconnect.js
@@ -50,17 +50,15 @@ define(function (require, exports, module) {
       this.client = clients.get(clientId);
     },
 
-    context () {
-      var context = {
+    setInitialContext (context) {
+      context.set({
         hasDisconnected: this.hasDisconnected,
         reasonHelp: this.reasonHelp
-      };
+      });
 
       if (! this.hasDisconnected) {
-        context.deviceName = this.client.get('name');
+        context.set('deviceName', this.client.get('name'));
       }
-
-      return context;
     },
 
     onChangeRadioButton() {

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -82,10 +82,10 @@ define(function (require, exports, module) {
       });
     },
 
-    context () {
+    setInitialContext (context) {
       const clients = this._attachedClients.toJSON();
 
-      return {
+      context.set({
         areWebSessionsVisible: this._areWebSessionsVisible(),
         clients: this._formatAccessTimeAndScope(clients),
         devicesSupportUrl: DEVICES_SUPPORT_URL,
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
         linkAndroid: FIREFOX_ANDROID_DOWNLOAD_LINK,
         linkIOS: FIREFOX_IOS_DOWNLOAD_LINK,
         showMobileApps: this._showMobileApps(clients)
-      };
+      });
     },
 
     events: {

--- a/app/scripts/views/settings/communication_preferences.js
+++ b/app/scripts/views/settings/communication_preferences.js
@@ -72,12 +72,12 @@ define(function (require, exports, module) {
         });
     },
 
-    context () {
+    setInitialContext (context) {
       var emailPrefs = this.getMarketingEmailPrefs();
       var isOptedIn = emailPrefs.isOptedIn(NEWSLETTER_ID);
       this.logViewEvent('newsletter.optin.' + String(isOptedIn));
 
-      return {
+      context.set({
         error: this._error,
         isBasketReady: !! this._isBasketReady,
         isOptedIn: isOptedIn,
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
         // preferencesURL is only available if the user is already
         // registered with basket.
         preferencesUrl: Xss.href(emailPrefs.get('preferencesUrl'))
-      };
+      });
     },
 
     submit () {

--- a/app/scripts/views/settings/delete_account.js
+++ b/app/scripts/views/settings/delete_account.js
@@ -22,10 +22,8 @@ define(function (require, exports, module) {
     className: 'delete-account',
     viewName: 'settings.delete-account',
 
-    context () {
-      return {
-        email: this.getSignedInAccount().get('email')
-      };
+    setInitialContext (context) {
+      context.set('email', this.getSignedInAccount().get('email'));
     },
 
     submit () {

--- a/app/scripts/views/settings/display_name.js
+++ b/app/scripts/views/settings/display_name.js
@@ -24,10 +24,8 @@ define(function (require, exports, module) {
       this.render();
     },
 
-    context () {
-      return {
-        displayName: this._displayName
-      };
+    setInitialContext (context) {
+      context.set('displayName', this._displayName);
     },
 
     events: {

--- a/app/scripts/views/settings/emails.js
+++ b/app/scripts/views/settings/emails.js
@@ -43,15 +43,15 @@ define(function (require, exports, module) {
       }
     },
 
-    context () {
-      return {
+    setInitialContext (context) {
+      context.set({
         buttonClass: this._hasSecondaryEmail() ? 'secondary' : 'primary',
         emails: this._emails,
         hasSecondaryEmail: this._hasSecondaryEmail(),
         hasSecondaryVerifiedEmail: this._hasSecondaryVerifiedEmail(),
         isPanelOpen: this.isPanelOpen(),
         newEmail: this.newEmail
-      };
+      });
     },
 
     beforeRender () {

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
         suggestedAccount.get('email') : this.getPrefillEmail();
     },
 
-    context () {
+    setInitialContext (context) {
       var suggestedAccount = this.getAccount();
       var hasSuggestedAccount = suggestedAccount.get('email');
       var email = this.getEmail();
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
       /// header text
       const headerSignInText = this.translate(t('Sign in'), { msgctxt: 'header text' });
 
-      return {
+      context.set({
         buttonSignInText,
         chooserAskForPassword: this._suggestedAccountAskPassword(suggestedAccount),
         email: email,
@@ -107,7 +107,7 @@ define(function (require, exports, module) {
         password: this._formPrefill.get('password'),
         serviceName: this.relier.get('serviceName'),
         suggestedAccount: hasSuggestedAccount
-      };
+      });
     },
 
     events: {

--- a/app/scripts/views/sign_in_unblock.js
+++ b/app/scripts/views/sign_in_unblock.js
@@ -32,16 +32,16 @@ define(function (require, exports, module) {
       }
     },
 
-    context () {
+    setInitialContext (context) {
       const email = this.getAccount().get('email');
       const supportLink = this._getSupportLink();
 
-      return {
+      context.set({
         email,
         escapedSupportLink: encodeURI(supportLink),
         hasSupportLink: !! supportLink,
         unblockCodeLength: Constants.UNBLOCK_CODE_LENGTH
-      };
+      });
     },
 
     submit () {

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
             this.model.get('bouncedEmail'), prefillEmail, prefillPassword);
     },
 
-    context () {
+    setInitialContext (context) {
       var autofocusEl = this._selectAutoFocusEl();
       var forceEmail = this.model.get('forceEmail');
       var prefillEmail = this.getPrefillEmail();
@@ -148,7 +148,7 @@ define(function (require, exports, module) {
       var relier = this.relier;
       var isSync = relier.isSync();
 
-      var context = {
+      var contextData = {
         chooseWhatToSyncCheckbox: this.broker.hasCapability('chooseWhatToSyncCheckbox'),
         email: prefillEmail,
         error: this.error,
@@ -175,9 +175,9 @@ define(function (require, exports, module) {
                 'utm_source=fx-website&utm_medium=fx-accounts&' +
                 'utm_campaign=fx-signup&utm_content=fx-sync-get-started');
       }
-      context.escapedSyncSuggestionAttrs = `data-flow-event="link.signin" href="${escapedSyncSuggestionUrl}"`;
+      contextData.escapedSyncSuggestionAttrs = `data-flow-event="link.signin" href="${escapedSyncSuggestionUrl}"`;
 
-      return context;
+      context.set(contextData);
     },
 
     beforeDestroy () {

--- a/app/scripts/views/sms_send.js
+++ b/app/scripts/views/sms_send.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
       return this.model.get('account') || this.user.getSignedInAccount();
     },
 
-    context () {
+    setInitialContext (context) {
       const escapedLearnMoreAttributes =
           `id="learn-more" href="${encodeURI(View.LEARN_MORE_LINK)}" target="_learn-more" data-flow-event="link.learn_more"`;
 
@@ -70,11 +70,11 @@ define(function (require, exports, module) {
         phoneNumber = prefix;
       }
 
-      return {
+      context.set({
         country,
         escapedLearnMoreAttributes,
         phoneNumber
-      };
+      });
     },
 
     showChildView (ChildView, options = {}) {

--- a/app/scripts/views/sms_sent.js
+++ b/app/scripts/views/sms_sent.js
@@ -35,14 +35,14 @@ define(function (require, exports, module) {
       }
     },
 
-    context () {
-      return {
+    setInitialContext (context) {
+      context.set({
         // The attributes are not surrounded by quotes because _.escape would
         // escape them, causing the id to be the string `"back"`, and the href
         // to be the string `"#"`.
         escapedBackLinkAttrs: _.escape('id=back href=#'),
         escapedPhoneNumber: _.escape(this._getFormattedPhoneNumber())
-      };
+      });
     },
 
     resend () {

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -47,11 +47,11 @@ define(function (require, exports, module) {
       },
       layoutClassName: 'layout',
       template: Template,
-      context: function () {
-        return {
+      setInitialContext (context) {
+        context.set({
           error: this.model.get('templateWrittenError'),
           success: this.model.get('templateWrittenSuccess')
-        };
+        });
       },
 
       _onRequiredClick () {
@@ -965,16 +965,16 @@ define(function (require, exports, module) {
       it('multiple calls to `getContext` only call `context` once', function () {
         view._context = null;
 
-        sinon.spy(view, 'context');
+        sinon.spy(view, 'setInitialContext');
 
         view.getContext();
         view.getContext();
 
-        assert.equal(view.context.callCount, 1);
+        assert.equal(view.setInitialContext.callCount, 1);
       });
 
       it('the context cache is cleared each time `render` is called', function () {
-        sinon.spy(view, 'context');
+        sinon.spy(view, 'setInitialContext');
 
         return view.render()
           .then(function () {
@@ -984,7 +984,7 @@ define(function (require, exports, module) {
             return view.render();
           })
           .then(function () {
-            assert.equal(view.context.callCount, 3);
+            assert.equal(view.setInitialContext.callCount, 3);
           });
       });
     });

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -38,11 +38,11 @@ define(function (require, exports, module) {
       this.isFormSubmitted = true;
     },
 
-    context: function () {
-      return {
+    setInitialContext (context) {
+      context.set({
         error: this.model.get('templateWrittenError'),
         success: this.model.get('templateWrittenSuccess')
-      };
+      });
     }
   });
 

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -105,11 +105,9 @@ define(function (require, exports, module) {
       // regression test for #1216
       it('does not show service name if service is defined but serviceName is not', function () {
         createView(VerificationReasons.SIGN_UP);
-        view.context = function () {
-          return {
-            service: 'sync'
-          };
-        };
+        sinon.stub(view, 'setInitialContext', (context) => {
+          context.set('service', 'sync');
+        });
 
         return view.render()
           .then(function () {

--- a/app/tests/spec/views/settings/client_disconnect.js
+++ b/app/tests/spec/views/settings/client_disconnect.js
@@ -125,9 +125,10 @@ define(function (require, exports, module) {
     describe('context', () => {
       it('has props', () => {
         view.beforeRender();
-        assert.ok(view.context().deviceName);
-        assert.notOk(view.context().reasonHelp);
-        assert.notOk(view.context().hasDisconnected, false);
+        const context = view.getContext();
+        assert.ok(context.deviceName);
+        assert.notOk(context.reasonHelp);
+        assert.notOk(context.hasDisconnected);
       });
     });
 

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -1162,7 +1162,7 @@ define(function (require, exports, module) {
 
         it('checkbox is not visible if no `chooseWhatToSyncCheckbox` capability', function () {
           broker.setCapability('chooseWhatToSyncCheckbox', false);
-          view.context();
+          view.getContext();
           return setupCustomizeSyncTest('sync', true)
             .then(function () {
               assert.isFalse(view.$el.find('#customize-sync').length > 0);


### PR DESCRIPTION
#### What is the problem?
When rendering a template, or translating a string, a view's `context()` function returns an object. This paradigm makes it almost impossible for `context` to be overridden easily in mixins.

#### How does this fix the problem?
First, rename `context` to `updateContext`. Instead of having `updateContext` return an object, pass in a Backbone model that each `updateContext` method can update. Mixins can override `updateContext` and set the data on the passed in model.