### PR TITLE
chore(text): Removed fake bold and a period

### DIFF
--- a/app/scripts/templates/cannot_create_account.mustache
+++ b/app/scripts/templates/cannot_create_account.mustache
@@ -5,10 +5,10 @@
 
   <section class="cannot-create-account-content">
     <p>
-      <strong>{{#unsafeTranslate}}You must meet certain age requirements to create a Firefox&nbsp;Account.{{/unsafeTranslate}}</strong>
+      {{#unsafeTranslate}}You must meet certain age requirements to create a Firefox&nbsp;Account.{{/unsafeTranslate}}
     </p>
     <p class="links">
-      <a class="ftc" href="http://www.ftc.gov/news-events/media-resources/protecting-consumer-privacy/kids-privacy-coppa" {{#isSync}} target="_blank"{{/isSync}}>{{#t}}Learn more.{{/t}}</a>
+      <a class="ftc" href="http://www.ftc.gov/news-events/media-resources/protecting-consumer-privacy/kids-privacy-coppa" {{#isSync}} target="_blank"{{/isSync}}>{{#t}}Learn more{{/t}}</a>
     </p>
 
   </section>


### PR DESCRIPTION
We don't load a bold font, so I removed the strong tag, and also a stray period on the link