### PR TITLE
chore(text): Removed pad class

### DIFF
--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -32,7 +32,7 @@
     {{/isSyncMigration}}
 
     {{#isAmoMigration}}
-        <div class="info nudge pad" id="amo-migration">{{#t}}Looking for your Add-ons data? Sign up for a Firefox Account with your old Add-ons account email address.{{/t}}</div>
+        <div class="info nudge" id="amo-migration">{{#t}}Looking for your Add-ons data? Sign up for a Firefox Account with your old Add-ons account email address.{{/t}}</div>
     {{/isAmoMigration}}
 
     <form novalidate>


### PR DESCRIPTION
Noticed this AMO migration message had a pad. Doesn't need it, so I removed it.