### PR TITLE
fix(metrics): categorise the performance flow events

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -46,6 +46,7 @@ define(function (require, exports, module) {
     'flowBeginTime',
     'flowId',
     'flushTime',
+    'initialView',
     'isSampledUser',
     'lang',
     'marketing',
@@ -136,19 +137,6 @@ define(function (require, exports, module) {
     this.initialize(options);
   }
 
-  /**
-   * Log an event once. Use in the `notifications` hash to
-   * log an event whenever a notification is triggered.
-   *
-   * @param  {String} eventName name of event to log
-   * @return {Function} function that does logging.
-   */
-  function logEventOnce(eventName) {
-    return function () {
-      this.logEventOnce(eventName);
-    };
-  }
-
   _.extend(Metrics.prototype, Backbone.Events, {
     ALLOWED_FIELDS: ALLOWED_FIELDS,
 
@@ -180,7 +168,7 @@ define(function (require, exports, module) {
        * first screen is rendered and the user can interact
        * with FxA. Similar to window.onload, but FxA specific.
        */
-      'view-shown': logEventOnce('loaded')
+      'once!view-shown': '_setInitialView'
       /* eslint-enable sorting/sort-object-props */
     },
 
@@ -234,6 +222,16 @@ define(function (require, exports, module) {
       } else {
         this.logEvent(eventName);
       }
+    },
+
+    /**
+     * Set the initial view name and emit the loaded event.
+     *
+     * @param {View} view
+     */
+    _setInitialView (view) {
+      this._initialViewName = view.viewName;
+      this.logEventOnce('loaded');
     },
 
     /**
@@ -335,6 +333,7 @@ define(function (require, exports, module) {
         flowBeginTime: flowData.flowBeginTime,
         flowId: flowData.flowId,
         flushTime: Date.now(),
+        initialView: this._initialViewName,
         isSampledUser: this._isSampledUser,
         lang: this._lang,
         marketing: flattenHashIntoArrayOfObjects(this._marketingImpressions),

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
 
       assert.isTrue('flow.initialize' in metrics.notifications);
       assert.isTrue('flow.event' in metrics.notifications);
-      assert.isTrue('view-shown' in metrics.notifications);
+      assert.isTrue('once!view-shown' in metrics.notifications);
     });
 
     it('observable flow state is correct', () => {
@@ -262,9 +262,9 @@ define(function (require, exports, module) {
           metrics.logEvent('foo');
           notifier.trigger('flow.event', { event: 'bar', once: true });
           metrics.logEvent('baz');
-          notifier.trigger('view-shown');
+          notifier.trigger('view-shown', { viewName: 'wibble' });
           // trigger `view-shown` twice, ensure it's only logged once.
-          notifier.trigger('view-shown');
+          notifier.trigger('view-shown', { viewName: 'blee' });
         });
 
         describe('has sendBeacon', function () {
@@ -297,7 +297,7 @@ define(function (require, exports, module) {
               assert.equal(windowMock.navigator.sendBeacon.getCall(0).args[0], '/metrics');
 
               var data = JSON.parse(windowMock.navigator.sendBeacon.getCall(0).args[1]);
-              assert.lengthOf(Object.keys(data), 26);
+              assert.lengthOf(Object.keys(data), 27);
               assert.equal(data.broker, 'none');
               assert.equal(data.context, Constants.CONTENT_SERVER_CONTEXT);
               assert.isNumber(data.duration);
@@ -310,6 +310,7 @@ define(function (require, exports, module) {
               assert.equal(data.events[3].type, 'loaded');
               assert.equal(data.flowId, FLOW_ID);
               assert.equal(data.flowBeginTime, FLOW_BEGIN_TIME);
+              assert.equal(data.initialView, 'wibble');
               assert.equal(data.isSampledUser, false);
               assert.equal(data.lang, 'unknown');
               assert.isArray(data.marketing);
@@ -426,7 +427,7 @@ define(function (require, exports, module) {
               assert.equal(settings.contentType, 'application/json');
 
               var data = JSON.parse(settings.data);
-              assert.lengthOf(Object.keys(data), 25);
+              assert.lengthOf(Object.keys(data), 26);
               assert.isArray(data.events);
               assert.lengthOf(data.events, 5);
               assert.equal(data.events[0].type, 'foo');
@@ -504,7 +505,7 @@ define(function (require, exports, module) {
             assert.isTrue(metrics._send.getCall(0).args[1]);
 
             var data = metrics._send.getCall(0).args[0];
-            assert.lengthOf(Object.keys(data), 25);
+            assert.lengthOf(Object.keys(data), 26);
             assert.lengthOf(data.events, 5);
             assert.equal(data.events[0].type, 'foo');
             assert.equal(data.events[1].type, 'flow.bar');
@@ -529,7 +530,7 @@ define(function (require, exports, module) {
             assert.isTrue(metrics._send.getCall(0).args[1]);
 
             var data = metrics._send.getCall(0).args[0];
-            assert.lengthOf(Object.keys(data), 25);
+            assert.lengthOf(Object.keys(data), 26);
             assert.lengthOf(data.events, 5);
             assert.equal(data.events[0].type, 'foo');
             assert.equal(data.events[1].type, 'flow.bar');

--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -78,6 +78,8 @@ const PERFORMANCE_TIMINGS = [
   }
 ];
 
+const AUTH_VIEWS = new Set([ 'force-auth', 'signin', 'signup' ]);
+
 module.exports = (req, metrics, requestReceivedTime) => {
   if (IS_DISABLED || ! isValidFlowData(metrics, requestReceivedTime)) {
     return;
@@ -85,11 +87,12 @@ module.exports = (req, metrics, requestReceivedTime) => {
 
   let emitPerformanceEvents = false;
   const events = metrics.events || [];
+  const performanceCategory = AUTH_VIEWS.has(metrics.initialView) ? 'auth' : 'other';
   const flowEvents = events.map(event => {
     if (event.type === 'loaded') {
       emitPerformanceEvents = true;
       return Object.assign({}, event, {
-        type: 'flow.performance'
+        type: `flow.performance.${performanceCategory}`
       });
     }
 
@@ -143,7 +146,7 @@ module.exports = (req, metrics, requestReceivedTime) => {
         logFlowEvent({
           flowTime: relativeTime,
           time: absoluteTime,
-          type: `flow.performance.${item.event}`
+          type: `flow.performance.${performanceCategory}.${item.event}`
         }, metrics, req);
       }
     });

--- a/server/lib/routes/post-metrics.js
+++ b/server/lib/routes/post-metrics.js
@@ -54,6 +54,7 @@ const BODY_SCHEMA = {
   flowBeginTime: OFFSET_TYPE.optional(),
   flowId: STRING_TYPE.hex().length(64).optional(),
   flushTime: TIME_TYPE.required(),
+  initialView: STRING_TYPE.regex(/^[a-z._-]+$/).optional(),
   isSampledUser: BOOLEAN_TYPE.required(),
   lang: STRING_TYPE.regex(/^[a-z]+(?:-[A-Za-z]+)?$/).required(),
   marketing: joi.array().items(joi.object().keys({

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -137,6 +137,7 @@ define([
           events: [
             { offset: 2000, type: 'loaded' }
           ],
+          initialView: 'signup'
         }, 2000);
       },
 
@@ -146,28 +147,28 @@ define([
 
       'first call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[0][0]);
-        assert.equal(arg.event, 'flow.performance');
+        assert.equal(arg.event, 'flow.performance.auth');
         assert.equal(arg.time, new Date(mocks.time).toISOString());
         assert.equal(arg.flow_time, 2000);
       },
 
       'second call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[1][0]);
-        assert.equal(arg.event, 'flow.performance.network');
+        assert.equal(arg.event, 'flow.performance.auth.network');
         assert.equal(arg.time, new Date(mocks.time - 2000 + 300).toISOString());
         assert.equal(arg.flow_time, 300);
       },
 
       'third call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[2][0]);
-        assert.equal(arg.event, 'flow.performance.server');
+        assert.equal(arg.event, 'flow.performance.auth.server');
         assert.equal(arg.time, new Date(mocks.time - 2000 + 100).toISOString());
         assert.equal(arg.flow_time, 100);
       },
 
       'fourth call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[3][0]);
-        assert.equal(arg.event, 'flow.performance.client');
+        assert.equal(arg.event, 'flow.performance.auth.client');
         assert.equal(arg.time, new Date(mocks.time - 2000 + 200).toISOString());
         assert.equal(arg.flow_time, 200);
       }
@@ -713,6 +714,7 @@ define([
             // The value of offset here puts the loaded event in the distant future
             { offset: 31536000000, type: 'loaded' }
           ],
+          initialView: 'settings'
         }, 1000);
       },
 
@@ -722,17 +724,17 @@ define([
 
       'second call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[0][0]);
-        assert.equal(arg.event, 'flow.performance.network');
+        assert.equal(arg.event, 'flow.performance.other.network');
       },
 
       'third call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[1][0]);
-        assert.equal(arg.event, 'flow.performance.server');
+        assert.equal(arg.event, 'flow.performance.other.server');
       },
 
       'fourth call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[2][0]);
-        assert.equal(arg.event, 'flow.performance.client');
+        assert.equal(arg.event, 'flow.performance.other.client');
       }
     },
 
@@ -743,6 +745,7 @@ define([
           events: [
             { offset: 1000, type: 'loaded' }
           ],
+          initialView: 'reset-password'
         // The last arg here puts the navtiming events in the distant future
         }, 1000, false, 31536000000);
       },
@@ -753,7 +756,7 @@ define([
 
       'first call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[0][0]);
-        assert.equal(arg.event, 'flow.performance');
+        assert.equal(arg.event, 'flow.performance.other');
       }
     },
 
@@ -764,13 +767,14 @@ define([
           events: [
             { offset: 2000, type: 'loaded' }
           ],
+          initialView: 'signin'
         }, 2000, true);
       },
 
       'process.stderr.write was called correctly': () => {
         assert.equal(process.stderr.write.callCount, 1);
         const arg = JSON.parse(process.stderr.write.args[0][0]);
-        assert.equal(arg.event, 'flow.performance');
+        assert.equal(arg.event, 'flow.performance.auth');
       }
     }
   });
@@ -787,6 +791,7 @@ define([
         flowBeginTime,
         flowId: data.flowId || '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
         flushTime: flowBeginTime,
+        initialView: data.initialView || 'signup',
         migration: data.migration || 'sync11',
         navigationTiming: clobberNavigationTiming ? null : {
           /*eslint-disable sorting/sort-object-props*/

--- a/tests/server/metrics.js
+++ b/tests/server/metrics.js
@@ -38,6 +38,7 @@ define([
         testValidMetricsEvent('type', 'error.unknown context.auth.108'),
     'valid error-type (signin-permissions.checkbox.change.profile:display_name.unchecked)':
       testValidMetricsEvent('type', 'signin-permissions.checkbox.change.profile:display_name.unchecked'),
+    'valid initialView': testValidMetricsField('initialView', 'az_-'),
     'valid lang (pt)': testValidMetricsField('lang', 'pt'),
     'valid lang (pt-BR)': testValidMetricsField('lang', 'pt-BR'),
     'valid lang (pt-br)': testValidMetricsField('lang', 'pt-br'),
@@ -71,6 +72,7 @@ define([
     'invalid flowBeginTime (asdf)': testInvalidMetricsField('flowBeginTime', 'asdf'),
     'invalid flowId (deadbeef)': testInvalidMetricsField('flowId', 'deadbeef'),
     'invalid flushTime (<script>)': testInvalidMetricsField('flushTime', '<script>'),
+    'invalid initialView': testInvalidMetricsField('initialView', 'A'),
     'invalid isSampledUser (no)': testInvalidMetricsField('isSampledUser', 'no'),
     'invalid lang (es:ES)': testInvalidMetricsField('lang', 'es:ES'),
     'invalid marketing ({})': testInvalidMetricsField('marketing', {}),


### PR DESCRIPTION
For Q3, we need to differentiate our performance metrics for the signup/signin/force-auth views, so that we can better measure some of our proposed performance improvements. This PR adds a category to the event name, which can be `auth` or `other`. The rationale for `auth` is that these are auth views (ubiquitous language alert!), but I'm open to alternative suggestions if people think that might be confusing with e.g. the auth server.

Example log lines showing the new events:

```
{"event":"flow.performance.auth","flow_id":"f45dec936baa930a14821c1af2788adeea288c827890fcb0ebdcd3e8e796c44f","flow_time":6775,"hostname":"Phils-MacBook-Pro.local","op":"flowEvent","pid":4186,"time":"2017-06-30T23:48:36.913Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:56.0) Gecko/20100101 Firefox/56.0","v":1,"context":"web"}
{"event":"flow.performance.auth.network","flow_id":"f45dec936baa930a14821c1af2788adeea288c827890fcb0ebdcd3e8e796c44f","flow_time":1,"hostname":"Phils-MacBook-Pro.local","op":"flowEvent","pid":4186,"time":"2017-06-30T23:48:30.139Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:56.0) Gecko/20100101 Firefox/56.0","v":1,"context":"web"}
{"event":"flow.performance.auth.server","flow_id":"f45dec936baa930a14821c1af2788adeea288c827890fcb0ebdcd3e8e796c44f","flow_time":48,"hostname":"Phils-MacBook-Pro.local","op":"flowEvent","pid":4186,"time":"2017-06-30T23:48:30.186Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:56.0) Gecko/20100101 Firefox/56.0","v":1,"context":"web"}
{"event":"flow.performance.auth.client","flow_id":"f45dec936baa930a14821c1af2788adeea288c827890fcb0ebdcd3e8e796c44f","flow_time":6333,"hostname":"Phils-MacBook-Pro.local","op":"flowEvent","pid":4186,"time":"2017-06-30T23:48:36.471Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:56.0) Gecko/20100101 Firefox/56.0","v":1,"context":"web"}
```

@mozilla/fxa-devs r?