### PR TITLE
feat(emails): Check with auth-server to ensure secondary emails is enabled

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -837,6 +837,14 @@ define(function (require, exports, module) {
     resendEmailCode: createClientDelegate('recoveryEmailResendCode'),
 
     deleteEmail: createClientDelegate('deleteEmail'),
+
+    /**
+     * Responds with whether or not secondary emails is enabled for a user.
+     *
+     * @param {String} sessionToken User session token
+     * @return {Promise} resolves when complete
+     */
+    recoveryEmailSecondaryEmailEnabled: createClientDelegate('recoveryEmailSecondaryEmailEnabled')
   };
 
   module.exports = FxaClientWrapper;

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -341,6 +341,31 @@ define(function (require, exports, module) {
         });
     },
 
+    /**
+     * Check to see if secondary emails is enabled for this user, using support email
+     * domain and is in a verified session.
+     *
+     * @returns {Promise} Resolve to true/false
+     */
+    recoveryEmailSecondaryEmailEnabled () {
+      const sessionToken = this.get('sessionToken');
+      if (! sessionToken) {
+        return p.reject(AuthErrors.toError('INVALID_TOKEN'));
+      }
+
+      return this._fxaClient.recoveryEmailSecondaryEmailEnabled(sessionToken)
+        .then((resp) => {
+          return resp.ok;
+        }, (err) => {
+          if (AuthErrors.is(err, 'INVALID_TOKEN')) {
+            // sessionToken is no longer valid, kill it.
+            this.unset('sessionToken');
+          }
+
+          throw err;
+        });
+    },
+
     isSignedIn () {
       return this._fxaClient.isSignedIn(this.get('sessionToken'));
     },

--- a/app/scripts/views/settings/emails.js
+++ b/app/scripts/views/settings/emails.js
@@ -22,8 +22,6 @@ define(function (require, exports, module) {
   const EMAIL_REFRESH_SELECTOR = 'button.settings-button.email-refresh';
   const EMAIL_REFRESH_DELAYMS = 350;
 
-  const EMAIL_ENABLED_REGEX = /.+@mozilla\.com$|.+@restmail\.net$|.+@softvisioninc\.eu$|.+@softvision\.(com|ro)$/;
-
   var View = FormView.extend({
     template: Template,
     className: 'emails',
@@ -70,18 +68,9 @@ define(function (require, exports, module) {
       // Only show secondary email panel if the user is in a verified session and feature is enabled.
       const account = this.getSignedInAccount();
 
-      // This matches the enable feature flag for secondary emails, on the auth-server
-      // https://github.com/mozilla/fxa-auth-server/blob/master/config/index.js#L762
-      // By adding the check here, we do not have to issue a request to the auth-server and risk
-      // getting a 502/502 response. While this solution works, a longer term fix
-      // should be in place for handling feature rollouts.
-      if (! EMAIL_ENABLED_REGEX.test(account.get('email'))) {
-        return this.remove();
-      }
-
-      return account.sessionVerificationStatus()
-        .then((res) => {
-          if (! res.sessionVerified) {
+      return account.recoveryEmailSecondaryEmailEnabled()
+        .then((isEnabled) => {
+          if (! isEnabled) {
             return this.remove();
           }
 

--- a/app/tests/spec/views/settings/emails.js
+++ b/app/tests/spec/views/settings/emails.js
@@ -97,46 +97,14 @@ define(function (require, exports, module) {
     });
 
     describe('feature disabled', () => {
-      describe('for email', () => {
-        beforeEach(() => {
-          account = user.initAccount({
-            email: 'a@notenabled.com',
-            sessionToken: 'abc123',
-            uid: UID,
-            verified: true
-          });
-
-          view = new View({
-            broker: broker,
-            emails: emails,
-            metrics: metrics,
-            notifier: notifier,
-            parentView: parentView,
-            translator: translator,
-            user: user,
-            window: windowMock
-          });
-
-          sinon.stub(view, 'remove', () => {
-            return true;
-          });
-
-          return view.render();
-        });
-
-        it('should be disabled when feature is disabled for email', () => {
-          assert.equal(view.remove.callCount, 1);
-        });
-      });
-
       describe('for user', () => {
         beforeEach(() => {
           sinon.stub(account, 'recoveryEmails', () => {
-            return p.reject();
+            return p();
           });
 
-          sinon.stub(account, 'sessionVerificationStatus', () => {
-            return p({sessionVerified: true});
+          sinon.stub(account, 'recoveryEmailSecondaryEmailEnabled', () => {
+            return p(false);
           });
 
           view = new View({
@@ -161,39 +129,6 @@ define(function (require, exports, module) {
           assert.equal(view.remove.callCount, 1);
         });
       });
-
-      describe('for unverified session', () => {
-        beforeEach(() => {
-          sinon.stub(account, 'recoveryEmails', () => {
-            return p();
-          });
-
-          sinon.stub(account, 'sessionVerificationStatus', () => {
-            return p({sessionVerified: false});
-          });
-
-          view = new View({
-            broker: broker,
-            emails: emails,
-            metrics: metrics,
-            notifier: notifier,
-            parentView: parentView,
-            translator: translator,
-            user: user,
-            window: windowMock
-          });
-
-          sinon.stub(view, 'remove', () => {
-            return true;
-          });
-
-          return view.render();
-        });
-
-        it('should be disabled when in unverified session', () => {
-          assert.equal(view.remove.callCount, 1);
-        });
-      });
     });
 
     describe('feature enabled', () => {
@@ -202,8 +137,8 @@ define(function (require, exports, module) {
           return p(emails);
         });
 
-        sinon.stub(account, 'sessionVerificationStatus', () => {
-          return p({sessionVerified: true});
+        sinon.stub(account, 'recoveryEmailSecondaryEmailEnabled', () => {
+          return p(true);
         });
 
         sinon.stub(account, 'recoveryEmailDestroy', () => {

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "cocktail": "0.5.9",
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
     "fxa-checkbox": "mozilla/fxa-checkbox#7f856afffd394a144f718e28e6fb79092d6ccddd",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.57",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.58",
     "html5shiv": "3.7.2",
     "jquery": "3.1.0",
     "jquery-modal": "https://github.com/shane-tomlinson/jquery-modal.git#0576775d1b4590314b114386019f4c7421c77503",


### PR DESCRIPTION
This PR removes the regex that was added in https://github.com/mozilla/fxa-content-server/pull/5093. This queries the auth-server to ensure that a user can be shown the emails panel.

@mozilla/fxa-devs r?