### PR TITLE
fix(l10n): pin FXA_L10N_SHA: 2f7ac75835024d3f9125459b77c1d280f1cafb57

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,9 @@ machine:
     version: 4
   services:
     - docker
+  # N.B., changing this will require a rebuild without cache
+  environment:
+    FXA_L10N_SHA: 2f7ac75835024d3f9125459b77c1d280f1cafb57
 
 test:
   override:


### PR DESCRIPTION
This is the quick and dirty way. (An alternative, off the top of my head, might be adding an `l10n.txt` file, stat-ing and cat-ing that to `FXA_L10N_SHA=$(load-l10n.sh)`, but that's no less kludgey, and we shouldn't have to fiddle with this setting in most cases).

Targetted to merge into train-90, and never go back to master.

r? - @vladikoff 