### PR TITLE
fix(sms): Adjust redirect endpoint enhancements.

### DIFF
--- a/docs/query-params.md
+++ b/docs/query-params.md
@@ -83,13 +83,26 @@ Specify an alternate style for Firefox Accounts.
 #### When to specify
 When authenticating a user with OAuth and an alternate style is needed.
 
-## Firefox/Sync parameters
-
 #### When to specify
 
 * /signin
 * /signup
 * /force_auth
+
+## Firefox/Sync parameters
+
+### `channel`
+Force which Firefox release channel should be installed
+after redirecting from `/m/:signinCode`.
+
+#### Options
+* `beta`
+* `nightly`
+* `release`
+
+#### When to specify
+
+* /m/:signinCode
 
 ### `country`
 Force a country to be used when testing the SMS feature.

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -440,10 +440,31 @@ const conf = module.exports = convict({
   },
   sms: {
     redirect: {
-      targetLink: {
-        default: 'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&adgroup=sms&creative=link',
-        doc: 'Target URL for redirection',
-        format: 'url'
+      channels: {
+        beta: {
+          default: 'c71cw4',
+          doc: 'Adjust Firefox beta channel app ID',
+          env: 'SMS_ADJUST_BETA_CHANNEL_APP_ID',
+          format: String
+        },
+        nightly: {
+          default: '8jy086',
+          doc: 'Adjust Firefox nightly channel app ID',
+          env: 'SMS_ADJUST_NIGHTLY_CHANNEL_APP_ID',
+          format: String
+        },
+        release: {
+          default: '2uo1qc',
+          doc: 'Adjust Firefox release channel app ID',
+          env: 'SMS_ADJUST_RELEASE_CHANNEL_APP_ID',
+          format: String
+        }
+      },
+      targetURITemplate: {
+        default: 'https://app.adjust.com/${ channel }?campaign=fxa-conf-page&adgroup=sms&creative=link&deep_link=firefox%3A%2F%2Ffxa-signin%3Futm_source%3Dsms%26signin%3D${ signinCode }', //eslint-disable-line max-len
+        doc: 'Redirect URI - ES6 format template string. The variables `channel` and `signinCode` are interpolated',
+        env: 'SMS_REDIRECT_TARGET_URI_TEMPLATE',
+        format: String
       }
     }
   },

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -9,6 +9,7 @@
 const joi = require('joi');
 
 const PATTERNS = {
+  ADJUST_CHANNEL_APP_ID: /^(beta|nightly|release)$/,
   BASE64: /^[A-Za-z0-9\/+]+={0,2}$/,
   BASE64_URL_SAFE: /^[A-Za-z0-9_-]+$/,
   BROKER: /^[0-9a-z-]+$/,
@@ -23,6 +24,7 @@ const PATTERNS = {
 };
 
 const TYPES = {
+  ADJUST_CHANNEL_APP_ID: joi.string().regex(PATTERNS.ADJUST_CHANNEL_APP_ID),
   BOOLEAN: joi.boolean(),
   DIMENSION: joi.number().integer().min(0),
   INTEGER: joi.number().integer(),

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -10,11 +10,12 @@ define([
   'intern/dojo/node!../../server/lib/csp',
   'intern/dojo/node!htmlparser2',
   'intern/dojo/node!got',
+  'intern/dojo/node!lodash',
   'intern/dojo/node!url',
   'intern/browser_modules/dojo/Promise',
   'tests/server/helpers/routesHelpers'
 ], function (intern, registerSuite, assert, config, csp,
-  htmlparser2, got, url, Promise, routesHelpers) {
+  htmlparser2, got, _, url, Promise, routesHelpers) {
 
   var checkHeaders = routesHelpers.checkHeaders;
   var extractAndCheckUrls = routesHelpers.extractAndCheckUrls;
@@ -114,7 +115,10 @@ define([
 
   var redirectedRoutes = {
     '/m/12345678': {
-      location: config.get('sms.redirect.targetLink') + '&signin=12345678',
+      location: _.template(config.get('sms.redirect.targetURITemplate'))({
+        channel: config.get('sms.redirect.channels.release'),
+        signinCode: '12345678'
+      }),
       statusCode: 302
     },
     '/reset_password_complete': {


### PR DESCRIPTION
* Add the `deep_link` query parameter to the adjust URL. Without it,
  adjust does not know which page to open on Firefox after installation.
* Allow testers to specify the `?channel=(beta|nightly|release)` query
  parameter so they can specify which Firefox release channel should
  be installed.

fixes #5175
fixes #5218

@philbooth - since I was already fixing the `deep_link` issue, I figured I might as well handle the `release=<channel>` idea we discussed yesterday.

Mind an r?