### PR TITLE
Dockerpush fix pin train 90 l10n sha take 2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,9 +25,6 @@ machine:
     version: 4
   services:
     - docker
-  # N.B., changing this will require a rebuild without cache
-  environment:
-    FXA_L10N_SHA: 2f7ac75835024d3f9125459b77c1d280f1cafb57
 
 test:
   override:

--- a/scripts/download_l10n.sh
+++ b/scripts/download_l10n.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# hard code this for train-90
+export FXA_L10N_SHA=2f7ac75835024d3f9125459b77c1d280f1cafb57
+
 if [ -z "$FXA_L10N_SHA" ]; then
     FXA_L10N_SHA="master"
 fi


### PR DESCRIPTION
@vladikoff - I got this wrong. This has to be set *inside* the image as it's built, which isn't the environment of the host. So this puts the pinning right inside.