### PR TITLE
fix(docs): Remove the extra "When to specify" header.

### DIFF
--- a/docs/query-params.md
+++ b/docs/query-params.md
@@ -83,8 +83,6 @@ Specify an alternate style for Firefox Accounts.
 #### When to specify
 When authenticating a user with OAuth and an alternate style is needed.
 
-#### When to specify
-
 * /signin
 * /signup
 * /force_auth


### PR DESCRIPTION
@philbooth noticed I had an extra "When to specify" title in
PR #5221.