### PR TITLE
fix(cwts): Success message updates.

### DIFF
--- a/app/scripts/templates/choose_what_to_sync.mustache
+++ b/app/scripts/templates/choose_what_to_sync.mustache
@@ -1,5 +1,5 @@
 <div id="main-content" class="card">
-  <div class="success visible success-email-created">{{#unsafeTranslate}}%(escapedEmail)s created. <a %(escapedBackLinkParams)s>Mistyped email?</a>{{/unsafeTranslate}}</div>
+  <div class="success visible success-email-created">{{#unsafeTranslate}}%(escapedEmail)s registered. <a %(escapedBackLinkParams)s>Mistyped email?</a>{{/unsafeTranslate}}</div>
   <div id="choose-what-to-sync-graphic"></div>
 
   <header>

--- a/app/scripts/templates/choose_what_to_sync.mustache
+++ b/app/scripts/templates/choose_what_to_sync.mustache
@@ -1,5 +1,5 @@
 <div id="main-content" class="card">
-  <div class="success visible success-email-created">{{#t}}%(email)s created{{/t}}</div>
+  <div class="success visible success-email-created">{{#unsafeTranslate}}%(escapedEmail)s created. <a %(escapedBackLinkParams)s>Mistyped email?</a>{{/unsafeTranslate}}</div>
   <div id="choose-what-to-sync-graphic"></div>
 
   <header>
@@ -29,10 +29,5 @@
         <button id="submit-btn" type="submit" tabindex="1" autofocus>{{#t}}Save settings{{/t}}</button>
       </div>
     </form>
-
-    <div class="links">
-      <a href="#" id="back">{{#t}}Back{{/t}}</a>
-    </div>
-
   </section>
 </div>

--- a/app/scripts/views/choose_what_to_sync.js
+++ b/app/scripts/views/choose_what_to_sync.js
@@ -57,8 +57,11 @@ define(function (require, exports, module) {
       const engines = this._getOfferedEngines();
 
       context.set({
-        email: account.get('email'),
-        engines
+        engines,
+        // the below string isn't escaped, but it doesn't
+        // contain anything that causes XSS.
+        escapedBackLinkParams: 'id="back" href="#"',
+        escapedEmail: _.escape(account.get('email')),
       });
     },
 

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -59,8 +59,12 @@ define(function (require, exports, module) {
         if (item.lastAccessTimeFormatted) {
 
           if (item.isWebSession) {
-            item.title = this.translate(
-              t('Web Session, %(userAgent)s'), {userAgent: item.userAgent});
+            if (item.userAgent) {
+              item.title = this.translate(
+                t('Web Session, %(userAgent)s'), {userAgent: item.userAgent });
+            } else {
+              item.title = t('Web Session');
+            }
             item.lastAccessTimeFormatted = this.translate(
               t('%(translatedTimeAgo)s'), {translatedTimeAgo: item.lastAccessTimeFormatted});
           }

--- a/app/tests/spec/views/choose_what_to_sync.js
+++ b/app/tests/spec/views/choose_what_to_sync.js
@@ -108,9 +108,13 @@ define(function (require, exports, module) {
       it('renders email info, adds SCREEN_CLASS to body', () => {
         return initView()
           .then(() => {
-            assert.include(view.$('.success-email-created').text(), email,
-              'email is in the view');
+            assert.include(
+              view.$('.success-email-created').text(), email);
+            const $backEls = view.$('#back');
+            assert.lengthOf($backEls, 1);
+
             assert.isTrue($('body').hasClass(View.SCREEN_CLASS));
+
             const $rowEls = view.$('.choose-what-to-sync-row');
             assert.lengthOf($rowEls, DISPLAYED_ENGINE_IDS.length);
           });

--- a/app/tests/spec/views/settings/clients.js
+++ b/app/tests/spec/views/settings/clients.js
@@ -515,11 +515,9 @@ define(function (require, exports, module) {
           });
       });
 
-      it('properly sets the title according to scope', () => {
+      it('properly sets the title', () => {
         return initView()
           .then(() => {
-            $('#container').html(view.el);
-
             const formatted = view._formatAccessTimeAndScope([
               {
                 clientType: 'oAuthApp',
@@ -543,6 +541,22 @@ define(function (require, exports, module) {
                 lastAccessTime: Date.now(),
                 lastAccessTimeFormatted: 'a month ago',
                 name: 'Add-ons'
+              },
+              {
+                deviceName: 'User\'s Web Session',
+                id: 'session-1',
+                isWebSession: true,
+                lastAccessTime: Date.now(),
+                lastAccessTimeFormatted: '12 minutes ago',
+                userAgent: 'Firefox 40'
+              },
+              {
+                deviceName: 'User\'s Second Web Session',
+                id: 'session-2',
+                isWebSession: true,
+                lastAccessTime: Date.now(),
+                lastAccessTimeFormatted: '18 minutes ago',
+                userAgent: ''
               }
             ]);
 
@@ -550,6 +564,8 @@ define(function (require, exports, module) {
             assert.equal(formatted[0].lastAccessTimeFormatted, 'last active a few seconds ago');
             assert.equal(formatted[1].title, 'Pocket - profile,profile:write');
             assert.equal(formatted[2].title, 'Add-ons');
+            assert.equal(formatted[3].title, 'Web Session, Firefox 40');
+            assert.equal(formatted[4].title, 'Web Session');
           });
       });
     });

--- a/tests/functional/settings_clients.js
+++ b/tests/functional/settings_clients.js
@@ -79,7 +79,7 @@ define([
         // second session is the node.js session from test setup
         .then(testElementTextEquals(
           '.client-webSession:nth-child(2) .client-name',
-          'Web Session, node-XMLHttpRequest'
+          'Web Session'
         ))
 
         // clicking disconnect on the second session should update the list


### PR DESCRIPTION
* Update the success message to include a "Mistyped email?" link.
* Remove the "Back" link since this is duplicate functionality.

fixes #4726 

Here's the screen caps:

<img width="450" alt="screen shot 2017-07-11 at 16 25 07" src="https://user-images.githubusercontent.com/848085/28076132-98ad8148-6655-11e7-9db3-33d58ad7ea0a.png">

<img width="337" alt="screen shot 2017-07-11 at 16 25 21" src="https://user-images.githubusercontent.com/848085/28076136-9c9cdd30-6655-11e7-8e5e-f32327999422.png">

@ryanfeeley, @vladikoff - r?

