### PR TITLE
fix(test): Fix the broken "settings clients - sessions" test.

### DIFF
--- a/tests/functional/settings_clients.js
+++ b/tests/functional/settings_clients.js
@@ -79,7 +79,7 @@ define([
         // second session is the node.js session from test setup
         .then(testElementTextEquals(
           '.client-webSession:nth-child(2) .client-name',
-          'Web Session, node-XMLHttpRequest null'
+          'Web Session, node-XMLHttpRequest'
         ))
 
         // clicking disconnect on the second session should update the list


### PR DESCRIPTION
@philbooth fixed the auth-server in mozilla/fxa-auth-server#1982
so that the UA string never contains `null`.

Our test looked for the string `null` as part of the UA string.
This removes the `null` part of the check.

fixes #5226

@philbooth - r?