### PR TITLE
fix(devices): Correctly print a session's name if no userAgent is sent.

### DIFF
--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -59,8 +59,12 @@ define(function (require, exports, module) {
         if (item.lastAccessTimeFormatted) {
 
           if (item.isWebSession) {
-            item.title = this.translate(
-              t('Web Session, %(userAgent)s'), {userAgent: item.userAgent});
+            if (item.userAgent) {
+              item.title = this.translate(
+                t('Web Session, %(userAgent)s'), {userAgent: item.userAgent });
+            } else {
+              item.title = t('Web Session');
+            }
             item.lastAccessTimeFormatted = this.translate(
               t('%(translatedTimeAgo)s'), {translatedTimeAgo: item.lastAccessTimeFormatted});
           }

--- a/app/tests/spec/views/settings/clients.js
+++ b/app/tests/spec/views/settings/clients.js
@@ -515,11 +515,9 @@ define(function (require, exports, module) {
           });
       });
 
-      it('properly sets the title according to scope', () => {
+      it('properly sets the title', () => {
         return initView()
           .then(() => {
-            $('#container').html(view.el);
-
             const formatted = view._formatAccessTimeAndScope([
               {
                 clientType: 'oAuthApp',
@@ -543,6 +541,22 @@ define(function (require, exports, module) {
                 lastAccessTime: Date.now(),
                 lastAccessTimeFormatted: 'a month ago',
                 name: 'Add-ons'
+              },
+              {
+                deviceName: 'User\'s Web Session',
+                id: 'session-1',
+                isWebSession: true,
+                lastAccessTime: Date.now(),
+                lastAccessTimeFormatted: '12 minutes ago',
+                userAgent: 'Firefox 40'
+              },
+              {
+                deviceName: 'User\'s Second Web Session',
+                id: 'session-2',
+                isWebSession: true,
+                lastAccessTime: Date.now(),
+                lastAccessTimeFormatted: '18 minutes ago',
+                userAgent: ''
               }
             ]);
 
@@ -550,6 +564,8 @@ define(function (require, exports, module) {
             assert.equal(formatted[0].lastAccessTimeFormatted, 'last active a few seconds ago');
             assert.equal(formatted[1].title, 'Pocket - profile,profile:write');
             assert.equal(formatted[2].title, 'Add-ons');
+            assert.equal(formatted[3].title, 'Web Session, Firefox 40');
+            assert.equal(formatted[4].title, 'Web Session');
           });
       });
     });

--- a/tests/functional/settings_clients.js
+++ b/tests/functional/settings_clients.js
@@ -79,7 +79,7 @@ define([
         // second session is the node.js session from test setup
         .then(testElementTextEquals(
           '.client-webSession:nth-child(2) .client-name',
-          'Web Session, node-XMLHttpRequest'
+          'Web Session'
         ))
 
         // clicking disconnect on the second session should update the list


### PR DESCRIPTION
If no userAgent was sent for a session, we displayed the session
name as "Web Session,". Notice the extra comma.

This gets rid of the extra comma if no userAgent is sent,
instead printing "Web Session".

fixes #5230