### PR TITLE
fix(nodejs): upgrade to 6.11.1 for security fixes

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,4 +1,4 @@
-FROM node:6.11.0-alpine
+FROM node:6.11.1-alpine
 
 RUN addgroup -g 10001 app && \
     adduser -D -G app -h /app -u 10001 app


### PR DESCRIPTION
This needs to be in a 1.91.1 tag.