### PR TITLE
fix(firstrun): After signin, send firstrun users to /signin_confirmed.

### DIFF
--- a/app/scripts/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/scripts/models/auth_brokers/fx-firstrun-v1.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
 
   const _ = require('underscore');
   const FxSyncWebChannelAuthenticationBroker = require('models/auth_brokers/fx-sync-web-channel');
-  const HaltBehavior = require('views/behaviors/halt');
+  const NavigateBehavior = require('views/behaviors/navigate');
 
   var proto = FxSyncWebChannelAuthenticationBroker.prototype;
 
@@ -25,6 +25,10 @@ define(function (require, exports, module) {
       SIGNUP_MUST_VERIFY: 'signup_must_verify',
       VERIFICATION_COMPLETE: 'verification_complete'
     },
+
+    defaultBehaviors: _.extend({}, proto.defaultBehaviors, {
+      afterSignIn: new NavigateBehavior('signin_confirmed')
+    }),
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       cadAfterSignUpConfirmationPoll: true,
@@ -40,29 +44,10 @@ define(function (require, exports, module) {
       return proto.initialize.call(this, options);
     },
 
-    fetch () {
-      return proto.fetch.call(this).then(() => {
-        // Some settings do not work in an iframe due to x-frame and
-        // same-origin policies. Allow the firstrun flow to decide whether
-        // they want to display the settings page after the `login` message
-        // is sent. If `haltAfterSignIn` is set to true, the firstrun page
-        // will take care of displaying an update to the user.
-        if (this.getSearchParam('haltAfterSignIn') === 'true') {
-          this.setBehavior('afterSignIn', new HaltBehavior());
-        }
-      });
-    },
-
     afterLoaded () {
       this._iframeChannel.send(this._iframeCommands.LOADED);
 
       return proto.afterLoaded.apply(this, arguments);
-    },
-
-    afterSignIn () {
-      this._iframeChannel.send(this._iframeCommands.LOGIN);
-
-      return proto.afterSignIn.apply(this, arguments);
     },
 
     afterSignInConfirmationPoll () {

--- a/app/tests/spec/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-firstrun-v1.js
@@ -96,39 +96,10 @@ define(function (require, exports, module) {
             });
         });
 
-        it('notifies the web channel', function () {
+        it('notifies the web channel, navigates to `signin_confirmed` by default', function () {
           assert.isTrue(channelMock.send.calledWith('fxaccounts:login'));
-        });
-
-        it('notifies the iframe channel', function () {
-          assert.isTrue(iframeChannel.send.calledWith(broker._iframeCommands.LOGIN));
-        });
-
-        it('does not halt by default', function () {
-          assert.isUndefined(result.halt);
-        });
-      });
-
-      describe('with the `haltAfterSignIn` query parameter set to `true`', function () {
-        beforeEach(function () {
-          windowMock.location.search = '?haltAfterSignIn=true';
-          broker = new FxFirstrunV1AuthenticationBroker({
-            iframeChannel: iframeChannel,
-            relier: relier,
-            window: windowMock
-          });
-
-          return broker.fetch()
-            .then(function () {
-              return broker.afterSignIn(account);
-            })
-            .then(function (_result) {
-              result = _result;
-            });
-        });
-
-        it('halts', function () {
-          assert.isTrue(result.halt);
+          assert.equal(result.type, 'navigate');
+          assert.equal(result.endpoint, 'signin_confirmed');
         });
       });
     });

--- a/docs/query-params.md
+++ b/docs/query-params.md
@@ -121,14 +121,6 @@ If they user arrived at Firefox Accounts from within Firefox browser chrome, spe
 * /force_auth
 * /settings
 
-### `haltAfterSignIn`
-Halt after the user signs in, do not redirect to the settings page.
-
-#### When to specify (must specify context=iframe&service=sync or context=fx_firstrun_v2)
-* /signin
-* /signup
-* /force_auth
-
 ### `migration`
 If the user is migrating their Sync account from "old sync" to "new sync", specify which sync they are migrating from.
 

--- a/tests/functional/fx_firstrun_v1_sign_in.js
+++ b/tests/functional/fx_firstrun_v1_sign_in.js
@@ -17,7 +17,6 @@ define([
   const SELECTOR_CONFIRM_SIGNIN_HEADER = '#fxa-confirm-signin-header';
   const SELECTOR_CONFIRM_SIGNUP_HEADER = '#fxa-confirm-header';
   const SELECTOR_CONNECT_ANOTHER_DEVICE_HEADER = '#fxa-connect-another-device-header';
-  const SELECTOR_SETTINGS_HEADER = '#fxa-settings-header';
   const SELECTOR_SIGNIN_HEADER = '#fxa-signin-header';
   const SELECTOR_SIGNIN_SUB_HEADER = '#fxa-signin-header .service';
   const SELECTOR_SIGNIN_UNBLOCK_HEADER = '#fxa-signin-unblock-header';
@@ -67,6 +66,16 @@ define([
         .then(clearBrowserState({
           force: true
         }));
+    },
+
+    'verified, signin confirmation not needed': function () {
+      email = TestHelpers.createEmail();
+
+      return this.remote
+        .then(setupTest({ preVerified: true }))
+
+        .then(testElementExists(SELECTOR_SIGNIN_COMPLETE_HEADER))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
     'verified, verify same browser': function () {
@@ -144,10 +153,7 @@ define([
         .then(testElementTextInclude(SELECTOR_VERIFICATION_EMAIL, email))
         .then(fillOutSignInUnblock(email, 0))
 
-        // Only users that go through signin confirmation see
-        // `/signin_complete`, and users that go through signin unblock see
-        // the default `settings` page.
-        .then(testElementExists(SELECTOR_SETTINGS_HEADER))
+        .then(testElementExists(SELECTOR_SIGNIN_COMPLETE_HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'));
     }
   });

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -18,6 +18,7 @@ define([
 
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
   const click = FunctionalHelpers.click;
+  const createUser = FunctionalHelpers.createUser;
   const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
   const openPage = FunctionalHelpers.openPage;
@@ -103,6 +104,36 @@ define([
     afterEach: function () {
       return this.remote
         .then(clearBrowserState());
+    },
+
+    'sign up with a verified account, signin confirmation not needed': function () {
+      email = TestHelpers.createEmail();
+
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(PAGE_URL, selectors.SIGNUP.HEADER))
+        .then(visibleByQSA(selectors.SIGNUP.SUB_HEADER))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
+
+        .then(fillOutSignUp(email, PASSWORD))
+
+        .then(testElementExists(selectors.SIGNIN_COMPLETE.HEADER))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
+    },
+
+    'sign up with a verified account, signin confirmation needed': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(PAGE_URL, selectors.SIGNUP.HEADER))
+        .then(visibleByQSA(selectors.SIGNUP.SUB_HEADER))
+        .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
+
+        .then(fillOutSignUp(email, PASSWORD))
+
+        .then(testElementExists(selectors.SIGNIN_COMPLETE.HEADER))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
     'sign up, verify same browser': function () {


### PR DESCRIPTION
Because of https://bugzilla.mozilla.org/show_bug.cgi?id=1378766,
the signin flow on the firstrun page was broken; With e10s enabled,
immediately after signin from firstrun, users are asked to signin again.

The `login` message sent to the firstrun page causes a redirect
to https://accounts.firefox.com/settings. Because of the Firefox E10s
issue, Firefox refused to return signed in user information because
`?service=sync` was not specified. FxA believed nobody was signed in
so asked the user to sign in again.

This PR works around the problem by no longer sending the `login`
message to the firstrun page, instead users are sent to `signin_confirmed`.

Not sending the `login` message will cause the firstrun team's
metrics to be off, but the metrics were already off because
we only sent the message for users who did not need to go through
signin confirmation.

fixes #5229

@vladikoff - r?

Note, this is against train-90. I can open a different PR against train-91 if we feel that's a better target.