### PR TITLE
fix(sms): Allow the user to go back after resending an SMS.

### DIFF
--- a/app/scripts/templates/sms_sent.mustache
+++ b/app/scripts/templates/sms_sent.mustache
@@ -1,10 +1,16 @@
 <div id="main-content" class="card">
   <header class="hidden" id="fxa-sms-sent-header"><h1>{{#t}}Install Firefox on your smartphone and sign in to complete set-up{{/t}}</h1></header>
   <section>
-    <div class="success visible">
-      {{#unsafeTranslate}}App link sent to %(escapedPhoneNumber)s. <a %(escapedBackLinkAttrs)s>Mistyped&nbsp;number?</a>{{/unsafeTranslate}}
-
-    </div>
+    {{^isResend}}
+        <div class="success visible">
+          {{#unsafeTranslate}}App link sent to %(escapedPhoneNumber)s. <a %(escapedBackLinkAttrs)s>Mistyped&nbsp;number?</a>{{/unsafeTranslate}}
+        </div>
+      {{/isResend}}
+      {{#isResend}}
+        <div class="success visible shake">
+          {{#unsafeTranslate}}App link resent to %(escapedPhoneNumber)s. <a %(escapedBackLinkAttrs)s>Mistyped&nbsp;number?</a>{{/unsafeTranslate}}
+        </div>
+      {{/isResend}}
     <div class="error"></div>
 
     <div class="graphic graphic-sms-sent">{{#t}}Success{{/t}}</div>

--- a/app/scripts/views/sms_sent.js
+++ b/app/scripts/views/sms_sent.js
@@ -21,10 +21,6 @@ define(function (require, exports, module) {
   const SmsMixin = require('views/mixins/sms-mixin');
   const Template = require('stache!templates/sms_sent');
 
-  const t = msg => msg;
-
-  const UNTRANSLATED_RESENT_MESSAGE = t('App link resent to %(phoneNumber)s');
-
   const View = BaseView.extend({
     template: Template,
     mustAuth: true,
@@ -41,7 +37,8 @@ define(function (require, exports, module) {
         // escape them, causing the id to be the string `"back"`, and the href
         // to be the string `"#"`.
         escapedBackLinkAttrs: _.escape('id=back href=#'),
-        escapedPhoneNumber: _.escape(this._getFormattedPhoneNumber())
+        escapedPhoneNumber: _.escape(this._getFormattedPhoneNumber()),
+        isResend: this.model.get('isResend')
       });
     },
 
@@ -52,9 +49,8 @@ define(function (require, exports, module) {
         features: this.getSmsFeatures()
       })
       .then(() => {
-        this.displaySuccess(this.translate(UNTRANSLATED_RESENT_MESSAGE, {
-          phoneNumber: this._getFormattedPhoneNumber()
-        }));
+        this.model.set('isResend', true);
+        return this.render();
       });
     },
 

--- a/app/tests/spec/views/sms_sent.js
+++ b/app/tests/spec/views/sms_sent.js
@@ -122,7 +122,7 @@
 
      it('resend success, displays the success message', () => {
        sinon.stub(account, 'sendSms', () => p());
-       sinon.spy(view, 'displaySuccess');
+       sinon.spy(view, 'render');
        sinon.stub(view, 'getSmsFeatures', () => ['signinCodes']);
 
        return view.resend()
@@ -131,8 +131,8 @@
            assert.isTrue(account.sendSms.calledWith('+11234567890', FIREFOX_MOBILE_INSTALL, { features: ['signinCodes']}));
 
            assert.isTrue(view.getSmsFeatures.calledOnce);
-           assert.isTrue(view.displaySuccess.calledOnce);
-           const successText = view.displaySuccess.args[0][0];
+           assert.isTrue(view.render.calledOnce);
+           const successText = view.$('.success').text();
            assert.include(successText, 'resent');
            assert.include(successText, '123-456-7890');
          });

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -243,7 +243,14 @@
 
         .then(click(selectors.SMS_SENT.LINK_RESEND))
         .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
-        .then(getSms(testPhoneNumber, 1));
+        .then(getSms(testPhoneNumber, 1))
+
+        // user realizes they made a mistake
+        .then(click(selectors.SMS_SENT.LINK_BACK))
+        .then(testElementExists(selectors.SMS_SEND.HEADER))
+
+        // original phone number should still be in place
+        .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber));
      }),
 
      'valid phone number, enable signinCode': disableInProd(function () {


### PR DESCRIPTION
All the text has been moved to the template.

fixes #5244

Something easy to get back into the swing of things. @mozilla/fxa-devs - r?