### PR TITLE
feat(signup): add a Confirm Password field

### DIFF
--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -18,7 +18,8 @@ define(function (require, exports, module) {
    */
   const STARTUP_EXPERIMENTS = {
     'disabledButtonState': BaseExperiment,
-    'q3FormChanges': BaseExperiment
+    'q3FormChanges': BaseExperiment,
+    'signupPasswordConfirm': BaseExperiment
   };
 
   /**

--- a/app/scripts/lib/experiments/grouping-rules/disabled-button-state.js
+++ b/app/scripts/lib/experiments/grouping-rules/disabled-button-state.js
@@ -32,7 +32,7 @@ define((require, exports, module) => {
 
       let choice;
 
-      if (subject.forceExperiment === this.name) {
+      if (subject.forceExperiment === this.name && subject.forceExperimentGroup) {
         choice = subject.forceExperimentGroup;
       } else {
         choice = this.uniformChoice(GROUPS, subject.uniqueUserId);

--- a/app/scripts/lib/experiments/grouping-rules/disabled-button-state.js
+++ b/app/scripts/lib/experiments/grouping-rules/disabled-button-state.js
@@ -26,13 +26,13 @@ define((require, exports, module) => {
         return false;
       }
 
-      if (! subject.experimentGroupingRules || ! subject.experimentGroupingRules.choose('q3FormChanges', subject)) {
+      if (! subject.experimentGroupingRules || subject.experimentGroupingRules.choose('q3FormChanges', subject) !== this.name) {
         return false;
       }
 
       let choice;
 
-      if (subject.forceExperimentGroup) {
+      if (subject.forceExperiment === this.name) {
         choice = subject.forceExperimentGroup;
       } else {
         choice = this.uniformChoice(GROUPS, subject.uniqueUserId);

--- a/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/app/scripts/lib/experiments/grouping-rules/index.js
@@ -15,11 +15,12 @@ define((require, exports, module) => {
     require('./communication-prefs'),
     require('./disabled-button-state'),
     require('./is-sampled-user'),
+    require('./q3-form-changes'),
     require('./send-sms-enabled-for-country'),
     require('./send-sms-install-link'),
     require('./sentry'),
     require('./sessions'),
-    require('./q3-form-changes')
+    require('./signup-password-confirm')
   ];
 
   module.exports = class ExperimentChoiceIndex {

--- a/app/scripts/lib/experiments/grouping-rules/q3-form-changes.js
+++ b/app/scripts/lib/experiments/grouping-rules/q3-form-changes.js
@@ -20,7 +20,7 @@ define((require, exports, module) => {
      * @returns {Any}
      */
     choose (subject) {
-      const EXPERIMENTS = ['disabledButtonState'];
+      const EXPERIMENTS = ['disabledButtonState', 'signupPasswordConfirm'];
 
       if (! subject || ! subject.uniqueUserId) {
         return false;

--- a/app/scripts/lib/experiments/grouping-rules/signup-password-confirm.js
+++ b/app/scripts/lib/experiments/grouping-rules/signup-password-confirm.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define((require, exports, module) => {
+  'use strict';
+
+  const BaseGroupingRule = require('./base');
+
+  const GROUPS = ['control', 'treatment'];
+
+  module.exports = class SignupPasswordConfirmGroupingRule extends BaseGroupingRule {
+    constructor () {
+      super();
+      this.name = 'signupPasswordConfirm';
+    }
+
+    choose (subject = {}) {
+      if (! subject || ! subject.uniqueUserId) {
+        return false;
+      }
+
+      if (subject.forceExperiment === this.name && subject.forceExperimentGroup) {
+        return subject.forceExperimentGroup;
+      }
+
+      if (! subject.experimentGroupingRules || subject.experimentGroupingRules.choose('q3FormChanges', subject) !== this.name) {
+        return false;
+      }
+
+      return this.uniformChoice(GROUPS, subject.uniqueUserId);
+    }
+  };
+});

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -42,9 +42,16 @@
       </div>
 
       <div class="input-row password-row">
-        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required />
+        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#showPasswordConfirm}}data-synchronize-show="true"{{/showPasswordConfirm}} />
         <div class="input-help input-help-focused input-help-signup">{{#t}}A strong, unique password will keep your Firefox data safe from intruders.{{/t}}</div>
       </div>
+
+      {{#showPasswordConfirm}}
+      <div class="input-row password-row">
+        <label class="label-helper"></label>
+        <input id="vpassword" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Repeat password{{/t}}" pattern=".{8,}" required data-synchronize-show="true" />
+      </div>
+      {{/showPasswordConfirm}}
 
       {{{ coppaHTML }}}
 

--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -5,6 +5,14 @@
 .password-row {
   position: relative;
 
+  + .password-row {
+    /**
+     * The extra padding is so the "repeat password" floating placeholder
+     * does not overlap the "A string unique password..." help text.
+     */
+    margin-top: 15px;
+  }
+
   &.input-row .password {
 
     html[dir='ltr'] & {

--- a/app/tests/spec/lib/experiments/grouping-rules/disabled-button-state.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/disabled-button-state.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
         assert.equal(experiment.choose({
           account,
           experimentGroupingRules,
+          forceExperiment: 'disabledButtonState',
           forceExperimentGroup: 'control',
           uniqueUserId: 'user-id'
         }), 'control');

--- a/app/tests/spec/lib/experiments/grouping-rules/q3-form-changes.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/q3-form-changes.js
@@ -27,6 +27,7 @@ define(function (require, exports, module) {
       it('returns experiment if forceExperiment', () => {
         assert.equal(experiment.choose({
           account,
+          forceExperiment: 'disabledButtonState',
           forceExperimentGroup: 'control',
           uniqueUserId: 'user-id'
         }), 'disabledButtonState');

--- a/app/tests/spec/lib/experiments/grouping-rules/signup-password-confirm.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/signup-password-confirm.js
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define((require, exports, module) => {
+  'use strict';
+
+  const { assert } = require('chai');
+  const Experiment = require('lib/experiments/grouping-rules/signup-password-confirm');
+  const sinon = require('sinon');
+
+  describe('lib/experiments/grouping-rules/signup-password-confirm', () => {
+    let experiment;
+    let experimentGroupingRules;
+
+    beforeEach(() => {
+      experiment = new Experiment();
+      experimentGroupingRules = {
+        choose: () => 'signupPasswordConfirm'
+      };
+    });
+
+    describe('choose', () => {
+      it('delegates to uniformChoice', () => {
+        sinon.stub(experiment, 'uniformChoice', () => 'control');
+
+        assert.equal(experiment.choose({
+          experimentGroupingRules,
+          uniqueUserId: 'user-id'
+        }), 'control');
+        assert.isTrue(experiment.uniformChoice.calledOnce);
+        assert.isTrue(experiment.uniformChoice.calledWith(['control', 'treatment'], 'user-id'));
+      });
+
+      describe('forceExperiment set', () => {
+        describe('to name', () => {
+          it('returns group', () => {
+            assert.equal(experiment.choose({
+              experimentGroupingRules,
+              forceExperiment: 'signupPasswordConfirm',
+              forceExperimentGroup: 'treatment',
+              uniqueUserId: 'user-id'
+            }), 'treatment');
+
+            assert.equal(experiment.choose({
+              experimentGroupingRules,
+              forceExperiment: 'signupPasswordConfirm',
+              forceExperimentGroup: 'control',
+              uniqueUserId: 'user-id'
+            }), 'control');
+          });
+        });
+
+        describe('to other experiment', () => {
+          it('returns false', () => {
+            sinon.stub(experiment, 'uniformChoice', () => true);
+            experimentGroupingRules.choose = () => 'disabledButtonState';
+
+            assert.isFalse(experiment.choose({
+              experimentGroupingRules,
+              forceExperiment: 'disabledButtonState',
+              forceExperimentGroup: 'treatment',
+              uniqueUserId: 'user-id'
+            }));
+            assert.isFalse(experiment.uniformChoice.called);
+          });
+        });
+      });
+    });
+  });
+});

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -46,6 +46,7 @@ function (Translator, Session) {
     '../tests/spec/lib/experiments/grouping-rules/send-sms-install-link',
     '../tests/spec/lib/experiments/grouping-rules/sentry',
     '../tests/spec/lib/experiments/grouping-rules/sessions',
+    '../tests/spec/lib/experiments/grouping-rules/signup-password-confirm',
     '../tests/spec/lib/fxa-client',
     '../tests/spec/lib/height-observer',
     '../tests/spec/lib/image-loader',

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -7,6 +7,7 @@ define([
   'require',
   'tests/lib/restmail',
   'tests/lib/helpers',
+  'tests/functional/lib/selectors',
   'intern/dojo/node!leadfoot/helpers/pollUntil',
   'intern/browser_modules/dojo/node!url',
   'intern/browser_modules/dojo/node!querystring',
@@ -14,7 +15,7 @@ define([
   'intern/chai!assert',
   'app/bower_components/fxa-js-client/fxa-client',
   'intern/dojo/node!got'
-], function (intern, require, restmail, TestHelpers, pollUntil,
+], function (intern, require, restmail, TestHelpers, selectors, pollUntil,
   Url, Querystring, nodeXMLHttpRequest, assert, FxaClient, got) {
   const config = intern.config;
 
@@ -1255,6 +1256,7 @@ define([
     var optInToMarketingEmail = options.optInToMarketingEmail || false;
     var age = options.age || 24;
     var submit = options.submit !== false;
+    const vpassword = options.vpassword;
 
     return this.parent
       .getCurrentUrl()
@@ -1271,26 +1273,31 @@ define([
 
       .then(function () {
         if (enterEmail) {
-          return type('input[type=email]', email).call(this);
+          return type(selectors.SIGNUP.EMAIL, email).call(this);
         }
       })
-      .then(type('input[type=password]', password))
-      .then(type('#age', age || '24'))
+      .then(type(selectors.SIGNUP.PASSWORD, password))
+      .then(() => {
+        if (vpassword) {
+          return type(selectors.SIGNUP.VPASSWORD, vpassword).call(this);
+        }
+      })
+      .then(type(selectors.SIGNUP.AGE, age))
 
       .then(function () {
         if (customizeSync) {
-          return click('form input.customize-sync').call(this);
+          return click(selectors.SIGNUP.CUSTOMIZE_SYNC_CHECKBOX).call(this);
         }
       })
 
       .then(function () {
         if (optInToMarketingEmail) {
-          return click('form input.marketing-email-optin').call(this);
+          return click(selectors.SIGNUP.MARKETING_EMAIL_OPTIN).call(this);
         }
       })
       .then(function () {
         if (submit) {
-          return click('button[type="submit"]').call(this);
+          return click(selectors.SIGNUP.SUBMIT).call(this);
         }
       });
   });

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -127,11 +127,14 @@ define([], function () {
       LINK_SUGGEST_EMAIL_DOMAIN_CORRECTION: '#email-suggestion',
       LINK_SUGGEST_SIGN_IN: '.error a[href="/signin"]',
       LINK_SUGGEST_SYNC: '#suggest-sync a',
-      PASSWORD: 'input[type=password]',
+      MARKETING_EMAIL_OPTIN: 'input.marketing-email-optin',
+      PASSWORD: '#password',
+      SUBMIT: 'button[type="submit"]',
       SUB_HEADER: '#fxa-signup-header .service',
       SUGGEST_EMAIL_DOMAIN_CORRECTION: '.tooltip-suggest',
       SUGGEST_SIGN_IN: '.error',
       SUGGEST_SYNC: '#suggest-sync',
+      VPASSWORD: '#vpassword'
     },
     SIGNUP_COMPLETE: {
       HEADER: '#fxa-sign-up-complete-header'

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -435,6 +435,47 @@ define([
         .then(testSuccessWasShown());
     },
 
+    'signup experiment passwordConfirm, non matching passwords': function () {
+      const DROWSSAP = 'drowssap';
+      return this.remote
+        .then(openPage(PAGE_URL, selectors.SIGNUP.HEADER, {
+          query: {
+            forceExperiment: 'signupPasswordConfirm',
+            forceExperimentGroup: 'treatment'
+          }
+        }))
+        .then(fillOutSignUp(email, PASSWORD, { vpassword: DROWSSAP }))
+        // wait five seconds to allow any errant navigation to occur
+        .then(noPageTransition(selectors.SIGNUP.HEADER, 5000))
+        // the validation tooltip should be visible
+        .then(visibleByQSA('.error'));
+    },
+
+    'signup experiment passwordConfirm, matching passwords': function () {
+      return this.remote
+        .then(openPage(PAGE_URL, selectors.SIGNUP.HEADER, {
+          query: {
+            forceExperiment: 'signupPasswordConfirm',
+            forceExperimentGroup: 'treatment'
+          }
+        }))
+        .then(fillOutSignUp(email, PASSWORD, { vpassword: PASSWORD }))
+        .then(testAtConfirmScreen(email));
+    },
+
+    'signup experiment passwordConfirm control': function () {
+      return this.remote
+        .then(openPage(PAGE_URL, selectors.SIGNUP.HEADER, {
+          query: {
+            forceExperiment: 'signupPasswordConfirm',
+            forceExperimentGroup: 'control'
+          }
+        }))
+        .then(noSuchElement(selectors.SIGNUP.VPASSWORD))
+        .then(fillOutSignUp(email, PASSWORD))
+        .then(testAtConfirmScreen(email));
+    },
+
     'data-flow-begin attribute is set': function () {
       return this.remote
         .then(openPage(PAGE_URL, selectors.SIGNUP.HEADER))


### PR DESCRIPTION
This adds a second password field on the Sign **Up** screen, along with validation that when submitting the field, the user has typed their password the same in both fields. The goal is to reduce typos that can occur by only typing the password once (and the field is usually dots, so typos aren't easy to spot).

Closes #5193 

@ryanfeeley for feedback on the strings used here:

- The help tooltip text I just invented is `"Confirm that you've typed your password correctly."`
- The error message if the fields don't match is `Passwords must match`
- The placeholder text in the second field is `Confirm Password`

@shane-tomlinson I also opted to make the password fields match before being pulled in to the form prefill. However, I'm not sure I have all ways that the prefill might have been populated before. Would the password have been filled in if the user came from Sign In? In that case, it probably makes sense to not fill in the confirm field, since they might have typoed their password on the previous view...

