### PR TITLE
refactor(client): ServiceMixin sets `service`, `serviceName` in setInitialContext.

### DIFF
--- a/app/scripts/views/mixins/service-mixin.js
+++ b/app/scripts/views/mixins/service-mixin.js
@@ -16,6 +16,10 @@ define(function (require, exports, module) {
       this.transformLinks();
     },
 
+    setInitialContext (context) {
+      context.set(this.relier.pick('service', 'serviceName'));
+    },
+
     transformLinks () {
       // need to add /oauth to urls, but also maintain the existing query params
       const $linkEls = this.$('a[href^="/signin"],a[href^="/signup"],a[href^="/reset_password"]');

--- a/app/scripts/views/permissions.js
+++ b/app/scripts/views/permissions.js
@@ -78,7 +78,6 @@ define(function (require, exports, module) {
         this._getApplicablePermissions(account, requestedPermissions);
 
       context.set({
-        serviceName: this.relier.get('serviceName'),
         unsafePermissionsHTML: this._getPermissionsHTML(account, applicablePermissions)
       });
     },

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -74,9 +74,7 @@ define(function (require, exports, module) {
         isSync: this.relier.isSync(),
         readyToSyncText: this._getReadyToSyncText(),
         redirectUri: this.relier.get('redirectUri'),
-        secondaryEmailVerified: this.getSearchParam('secondary_email_verified') || null,
-        service: this.relier.get('service'),
-        serviceName: this.relier.get('serviceName')
+        secondaryEmailVerified: this.getSearchParam('secondary_email_verified') || null
       });
     },
 

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -29,8 +29,7 @@ define(function (require, exports, module) {
 
     setInitialContext (context) {
       context.set({
-        forceEmail: this.model.get('forceEmail'),
-        serviceName: this.relier.get('serviceName')
+        forceEmail: this.model.get('forceEmail')
       });
     },
 

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -105,7 +105,6 @@ define(function (require, exports, module) {
         isAmoMigration: this.isAmoMigration(),
         isSyncMigration: this.isSyncMigration(),
         password: this._formPrefill.get('password'),
-        serviceName: this.relier.get('serviceName'),
         suggestedAccount: hasSuggestedAccount
       });
     },

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -160,7 +160,6 @@ define(function (require, exports, module) {
         isSync: isSync,
         isSyncMigration: this.isSyncMigration(),
         password: prefillPassword,
-        serviceName: relier.get('serviceName'),
         shouldFocusEmail: autofocusEl === 'email',
         shouldFocusPassword: autofocusEl === 'password',
         showSyncSuggestion: this.isSyncSuggestionEnabled()

--- a/app/tests/spec/views/mixins/service-mixin.js
+++ b/app/tests/spec/views/mixins/service-mixin.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');
+  const Backbone = require('backbone');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
   const NullBroker = require('models/auth_brokers/base');
@@ -55,6 +56,18 @@ define(function (require, exports, module) {
         window: windowMock
       });
 
+    });
+
+    describe('setInitialContext', () => {
+      it('sets `service`, `serviceName` from the relier', () => {
+        relier.set('service', 'sync');
+        relier.set('serviceName', 'Firefox Sync');
+
+        const context = new Backbone.Model({});
+        view.setInitialContext(context);
+        assert.equal(context.get('service'), 'sync');
+        assert.equal(context.get('serviceName'), 'Firefox Sync');
+      });
     });
 
     describe('render', () => {


### PR DESCRIPTION
`serviceName` especially was set in all of the views that consumed the ServiceMixin.
Might as well reduce duplicate effort and set the value in one place.

Extraction from #5177 

@mozilla/fxa-devs - r?