### PR TITLE
feat(sync): Extract the Sync Suggestion logic into a mixin to be shared.

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -113,7 +113,9 @@ define(function (require, exports, module) {
     MARKETING_ID_AUTUMN_2016: 'autumn-2016-connect-another-device',
 
     DOWNLOAD_LINK_TEMPLATE_ANDROID: 'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=android',
-    DOWNLOAD_LINK_TEMPLATE_IOS: 'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=ios&fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&ct=adjust_tracker&mt=8' //eslint-disable-line max-len
+    DOWNLOAD_LINK_TEMPLATE_IOS: 'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=ios&fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&ct=adjust_tracker&mt=8', //eslint-disable-line max-len
+
+    MOZ_ORG_SYNC_GET_STARTED_LINK: 'https://mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started', //eslint-disable-line max-len
   };
   /*eslint-enable sorting/sort-object-props*/
 });

--- a/app/scripts/templates/partial/sync-suggestion.mustache
+++ b/app/scripts/templates/partial/sync-suggestion.mustache
@@ -1,0 +1,6 @@
+{{#showSyncSuggestion}}
+  <div class="info nudge" id="suggest-sync">
+      {{#unsafeTranslate}}Looking for Firefox Sync? <a %(escapedSyncSuggestionAttrs)s>Get started here</a>{{/unsafeTranslate}}
+      <span class="dismiss" tabindex="-1">&#10005;</span>
+  </div>
+{{/showSyncSuggestion}}

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -20,12 +20,7 @@
     <div class="error"></div>
     <div class="success"></div>
 
-    {{#showSyncSuggestion}}
-      <div class="info nudge" id="suggest-sync">
-          {{#unsafeTranslate}}Looking for Firefox Sync? <a %(escapedSyncSuggestionAttrs)s>Get started here</a>{{/unsafeTranslate}}
-          <span class="dismiss" tabindex="-1">&#10005;</span>
-      </div>
-    {{/showSyncSuggestion}}
+    {{{ syncSuggestionHTML }}}
 
     {{#isSyncMigration}}
       <div class="info nudge" id="sync-migration">{{#unsafeTranslate}}Migrate your sync data by creating a new Firefox&nbsp;Account.{{/unsafeTranslate}}</div>

--- a/app/scripts/views/mixins/sync-suggestion-mixin.js
+++ b/app/scripts/views/mixins/sync-suggestion-mixin.js
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Mix into views that show the "Looking for Firefox Sync? Get started here"
+ * helper tooltip.
+ *
+ * Sets the context field `syncSuggestionHTML`
+ * which contains the HTML to display.
+ */
+
+define((require, exports, module) => {
+  'use strict';
+
+  const Constants = require('lib/constants');
+  const FlowEventsMixin = require('views/mixins/flow-events-mixin');
+  const SyncAuthMixin = require('views/mixins/sync-auth-mixin');
+  const SyncSuggestionTemplate = require('stache!templates/partial/sync-suggestion');
+
+  function required (name, opts) {
+    if (! (name in opts)) {
+      throw new Error(`${name} is required`);
+    }
+  }
+
+  /**
+   * Create the mixin
+   *
+   * @param {Object} config
+   *   @param {String} config.entrypoint
+   *   @param {String} config.flowEvent
+   *   @param {String} config.pathname
+   * @returns {Function}
+   */
+  module.exports = function (config) {
+    required('entrypoint', config);
+    required('flowEvent', config);
+    required('pathname', config);
+
+    return {
+      dependsOn: [ FlowEventsMixin, SyncAuthMixin ],
+
+      events: {
+        'click #suggest-sync .dismiss': 'onSuggestSyncDismiss'
+      },
+
+
+      afterVisible () {
+        if (this.isSyncSuggestionEnabled()) {
+          this.logViewEvent('sync-suggest.visible');
+        }
+      },
+
+      setInitialContext (context) {
+        let escapedSyncSuggestionUrl;
+        if (this.isSyncAuthSupported()) {
+          escapedSyncSuggestionUrl = this.getEscapedSyncUrl(config.pathname, config.entrypoint);
+        } else {
+          escapedSyncSuggestionUrl = encodeURI(Constants.MOZ_ORG_SYNC_GET_STARTED_LINK);
+        }
+
+        const escapedSyncSuggestionAttrs = `data-flow-event="${config.flowEvent}" href="${escapedSyncSuggestionUrl}"`;
+
+        const syncSuggestionHTML = this.renderTemplate(SyncSuggestionTemplate, {
+          escapedSyncSuggestionAttrs,
+          showSyncSuggestion: this.isSyncSuggestionEnabled()
+        });
+
+        context.set({
+          syncSuggestionHTML
+        });
+      },
+
+      /**
+       * Is the Sync suggestion enabled for this integration?
+       *
+       * @returns {Boolean}
+       */
+      isSyncSuggestionEnabled () {
+        return ! this.relier.get('service');
+      },
+
+      onSuggestSyncDismiss () {
+        this.$('#suggest-sync').hide();
+      },
+    };
+  };
+});

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
   const SignedInNotificationMixin = require('views/mixins/signed-in-notification-mixin');
   const SignInMixin = require('views/mixins/signin-mixin');
   const SignUpMixin = require('views/mixins/signup-mixin');
-  const SyncAuthMixin = require('views/mixins/sync-auth-mixin');
+  const SyncSuggestionMixin = require('views/mixins/sync-suggestion-mixin');
   const Template = require('stache!templates/sign_up');
 
   var t = BaseView.t;
@@ -117,8 +117,7 @@ define(function (require, exports, module) {
 
     events: {
       'blur input.email': 'onEmailBlur',
-      'click #amo-migration a': 'onAmoSignIn',
-      'click #suggest-sync .dismiss': 'onSuggestSyncDismiss'
+      'click #amo-migration a': 'onAmoSignIn'
     },
 
     getPrefillEmail () {
@@ -145,7 +144,7 @@ define(function (require, exports, module) {
       var relier = this.relier;
       var isSync = relier.isSync();
 
-      var contextData = {
+      context.set({
         chooseWhatToSyncCheckbox: this.broker.hasCapability('chooseWhatToSyncCheckbox'),
         email: prefillEmail,
         error: this.error,
@@ -158,22 +157,8 @@ define(function (require, exports, module) {
         isSyncMigration: this.isSyncMigration(),
         password: prefillPassword,
         shouldFocusEmail: autofocusEl === 'email',
-        shouldFocusPassword: autofocusEl === 'password',
-        showSyncSuggestion: this.isSyncSuggestionEnabled()
-      };
-
-      let escapedSyncSuggestionUrl;
-      if (this.isSyncAuthSupported()) {
-        escapedSyncSuggestionUrl = this.getEscapedSyncUrl('signup', View.ENTRYPOINT);
-      } else {
-        escapedSyncSuggestionUrl = encodeURI(
-                'https://mozilla.org/firefox/sync?' +
-                'utm_source=fx-website&utm_medium=fx-accounts&' +
-                'utm_campaign=fx-signup&utm_content=fx-sync-get-started');
-      }
-      contextData.escapedSyncSuggestionAttrs = `data-flow-event="link.signin" href="${escapedSyncSuggestionUrl}"`;
-
-      context.set(contextData);
+        shouldFocusPassword: autofocusEl === 'password'
+      });
     },
 
     beforeDestroy () {
@@ -315,10 +300,6 @@ define(function (require, exports, module) {
       mailcheck(this.$el.find('.email'), this);
     },
 
-    onSuggestSyncDismiss () {
-      this.$('#suggest-sync').hide();
-    },
-
     onAmoSignIn () {
       // The user has chosen to sign in with a different email, clear the
       // email from the relier so it's not used again on the signin page.
@@ -398,7 +379,11 @@ define(function (require, exports, module) {
     SignInMixin,
     SignUpMixin,
     SignedInNotificationMixin,
-    SyncAuthMixin
+    SyncSuggestionMixin({
+      entrypoint: View.ENTRYPOINT,
+      flowEvent: 'link.signin',
+      pathname: 'signup'
+    })
   );
 
   module.exports = View;

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -118,7 +118,7 @@ define(function (require, exports, module) {
     });
 
     describe('renderTemplate', () => {
-      it('invokes the template with merged `context` and `additionalContext`', () => {
+      it('invokes the template with merged `context` and `additionalContext` and translation helpers', () => {
         const template = sinon.spy();
         const additionalContext = {
           baz: 'buz'
@@ -130,7 +130,11 @@ define(function (require, exports, module) {
         view.renderTemplate(template, additionalContext);
 
         assert.isTrue(template.calledOnce);
-        assert.isTrue(template.calledWith({ baz: 'buz', foo: 'bar' }));
+        const args = template.args[0][0];
+        assert.equal(args.baz, 'buz');
+        assert.equal(args.foo, 'bar');
+        assert.isFunction(args.t);
+        assert.isFunction(args.unsafeTranslate);
       });
     });
 

--- a/app/tests/spec/views/mixins/sync-suggestion-mixin.js
+++ b/app/tests/spec/views/mixins/sync-suggestion-mixin.js
@@ -1,0 +1,154 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const { assert } = require('chai');
+  const BaseView = require('views/base');
+  const Cocktail = require('cocktail');
+  const Constants = require('lib/constants');
+  const Notifier = require('lib/channels/notifier');
+  const p = require('lib/promise');
+  const Relier = require('models/reliers/sync');
+  const sinon = require('sinon');
+  const SyncSuggestionMixin = require('views/mixins/sync-suggestion-mixin');
+
+  const SyncView = BaseView.extend({
+    template: (context) => context.syncSuggestionHTML
+  });
+
+  Cocktail.mixin(
+    SyncView,
+    SyncSuggestionMixin({
+      entrypoint: 'fxa:signup',
+      flowEvent: 'link.signin',
+      pathname: 'signup'
+    })
+  );
+
+  describe('views/mixins/sync-suggestion-mixin', () => {
+    let notifier;
+    let relier;
+    let view;
+
+    beforeEach(() => {
+      notifier = new Notifier();
+      relier = new Relier();
+
+      view = new SyncView({
+        notifier,
+        relier
+      });
+
+      sinon.stub(view, 'logViewEvent', () => {});
+    });
+
+    describe('sync suggestion', () => {
+      it('displays sync suggestion message if no migration', () => {
+        relier.set('service', null);
+
+        return view.render()
+          .then(() => {
+            return view.afterVisible();
+          })
+          .then(() => {
+            assert.lengthOf(view.$('#suggest-sync'), 1);
+
+            const $suggestSyncEl = view.$('#suggest-sync');
+            assert.include($suggestSyncEl.text(), 'Looking for Firefox Sync?');
+            assert.include($suggestSyncEl.text(), 'Get started here');
+
+            const $getStartedEl = $suggestSyncEl.find('a');
+            assert.equal($getStartedEl.attr('rel'), 'noopener noreferrer');
+
+            assert.isTrue(view.logViewEvent.calledWith('sync-suggest.visible'));
+          });
+      });
+
+      it('does not have sync auth supported', () => {
+        relier.set('service', null);
+        sinon.stub(view, 'isSyncAuthSupported', () => false);
+        return view.render()
+          .then(() => {
+            const $getStartedEl = view.$('#suggest-sync').find('a');
+            assert.equal($getStartedEl.attr('href'), Constants.MOZ_ORG_SYNC_GET_STARTED_LINK);
+          });
+      });
+
+      it('has sync auth supported on Firefox for Desktop', () => {
+        relier.set('service', null);
+        sinon.stub(view, 'isSyncAuthSupported', () => true);
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            isFirefoxAndroid: () => false,
+            isFirefoxDesktop: () => true,
+          };
+        });
+        return view.render()
+          .then(() => {
+            const $getStartedEl = view.$('#suggest-sync').find('a');
+            assert.equal($getStartedEl.attr('href'),
+              view.window.location.origin +
+              '/signup?context=fx_desktop_v3&entrypoint=fxa%3Asignup&service=sync');
+          });
+      });
+
+      it('has sync auth supported on Firefox for Android', () => {
+        relier.set('service', null);
+        sinon.stub(view, 'isSyncAuthSupported', () => true);
+        sinon.stub(view, 'getUserAgent', () => {
+          return {
+            isFirefoxAndroid: () => true,
+            isFirefoxDesktop: () => false,
+          };
+        });
+        return view.render()
+          .then(() => {
+            const $getStartedEl = view.$('#suggest-sync').find('a');
+            assert.equal($getStartedEl.attr('href'),
+              view.window.location.origin +
+              '/signup?context=fx_fennec_v1&entrypoint=fxa%3Asignup&service=sync');
+          });
+      });
+
+      it('can be dismissed', () => {
+        relier.set('service', null);
+
+        return view.render()
+          .then(() => {
+            $('#container').html(view.el);
+            assert.isTrue(view.$('#suggest-sync').is(':visible'), 'visible');
+            view.$('#suggest-sync .dismiss').click();
+            assert.isFalse(view.$('#suggest-sync').is(':visible'), 'hidden');
+          });
+      });
+
+      it('does not display sync suggestion message if there is a relier service', () => {
+        relier.set('service', 'sync');
+
+        return view.render()
+          .then(() => {
+            assert.lengthOf(view.$('#suggest-sync'), 0);
+          });
+      });
+
+      it('logs the link.signin event', () => {
+        // Without the _flusthMetricsThenRedirect override, the test
+        // causes the page to redirect.
+        sinon.stub(view, 'isSyncSuggestionEnabled', () => true);
+        sinon.stub(view, '_flushMetricsThenRedirect', () => p());
+        sinon.stub(view, 'logFlowEvent', () => {});
+
+        return view.render()
+          .then(() => {
+            assert.isFalse(view.logFlowEvent.calledWith('link.signin'));
+            assert.lengthOf(view.$('a[data-flow-event="link.signin"]'), 1);
+            view.$('a[data-flow-event="link.signin"]').click();
+            assert.isTrue(view.logFlowEvent.calledWith('link.signin'));
+          });
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -244,104 +244,6 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('sync suggestion', function () {
-
-      it('displays sync suggestion message if no migration', function () {
-        createView();
-        relier.set('service', null);
-
-        sinon.spy(view.metrics, 'logEvent');
-
-        return view.render()
-          .then(function () {
-            assert.lengthOf(view.$('#suggest-sync'), 1);
-
-            const $suggestSyncEl = view.$('#suggest-sync');
-            assert.include($suggestSyncEl.text(), 'Looking for Firefox Sync?');
-            assert.include($suggestSyncEl.text(), 'Get started here');
-
-            const $getStartedEl = $suggestSyncEl.find('a');
-            assert.equal($getStartedEl.attr('rel'), 'noopener noreferrer');
-
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'signup.sync-suggest.visible'), 'enrolled');
-          });
-      });
-
-      it('does not have sync auth supported', function () {
-        createView();
-        relier.set('service', null);
-        sinon.stub(view, 'isSyncAuthSupported', () => false);
-        return view.render()
-          .then(function () {
-            const $getStartedEl = view.$('#suggest-sync').find('a');
-            assert.equal($getStartedEl.attr('href'),
-              'https://mozilla.org/firefox/sync?' +
-              'utm_source=fx-website&utm_medium=fx-accounts&' +
-              'utm_campaign=fx-signup&utm_content=fx-sync-get-started');
-          });
-      });
-
-      it('has sync auth supported on Firefox for Desktop', function () {
-        createView();
-        relier.set('service', null);
-        sinon.stub(view, 'isSyncAuthSupported', () => true);
-        sinon.stub(view, 'getUserAgent', () => {
-          return {
-            isFirefoxAndroid: () => false,
-            isFirefoxDesktop: () => true,
-          };
-        });
-        return view.render()
-          .then(function () {
-            const $getStartedEl = view.$('#suggest-sync').find('a');
-            assert.equal($getStartedEl.attr('href'),
-              view.window.location.origin +
-              '/signup?context=fx_desktop_v3&entrypoint=fxa%3Asignup&service=sync');
-          });
-      });
-
-      it('has sync auth supported on Firefox for Android', function () {
-        createView();
-        relier.set('service', null);
-        sinon.stub(view, 'isSyncAuthSupported', () => true);
-        sinon.stub(view, 'getUserAgent', () => {
-          return {
-            isFirefoxAndroid: () => true,
-            isFirefoxDesktop: () => false,
-          };
-        });
-        return view.render()
-          .then(function () {
-            const $getStartedEl = view.$('#suggest-sync').find('a');
-            assert.equal($getStartedEl.attr('href'),
-              view.window.location.origin +
-              '/signup?context=fx_fennec_v1&entrypoint=fxa%3Asignup&service=sync');
-          });
-      });
-
-      it('can be dismissed', function () {
-        createView();
-        relier.set('service', null);
-
-        return view.render()
-          .then(function () {
-            $('#container').html(view.el);
-            assert.isTrue(view.$('#suggest-sync').is(':visible'), 'visible');
-            view.onSuggestSyncDismiss();
-            assert.isFalse(view.$('#suggest-sync').is(':visible'), 'hidden');
-          });
-      });
-
-      it('does not display sync suggestion message if there is a relier service', function () {
-        relier.set('service', 'sync');
-
-        return view.render()
-          .then(function () {
-            assert.lengthOf(view.$('#suggest-sync'), 0);
-          });
-      });
-    });
-
     describe('migration', function () {
       it('does not display migration message if no migration', function () {
         return view.render()
@@ -1341,20 +1243,6 @@ define(function (require, exports, module) {
         view.enableForm();
         view.$('#submit-btn').click();
         assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signup.submit'));
-      });
-
-      it('logs the link.signin event', () => {
-        // Without the _flusthMetricsThenRedirect override, the test
-        // causes the page to redirect.
-        sinon.stub(view, 'isSyncSuggestionEnabled', () => true);
-        sinon.stub(view, '_flushMetricsThenRedirect', () => p());
-        return view.render()
-          .then(() => {
-            assert.isFalse(TestHelpers.isEventLogged(metrics, 'flow.signup.link.signin'));
-            assert.lengthOf(view.$('a[data-flow-event="link.signin"]'), 1);
-            view.$('a[data-flow-event="link.signin"]').click();
-            assert.isTrue(TestHelpers.isEventLogged(metrics, 'flow.signup.link.signin'));
-          });
       });
     });
   });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -169,6 +169,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/signup-mixin',
     '../tests/spec/views/mixins/sms-mixin',
     '../tests/spec/views/mixins/sync-auth-mixin',
+    '../tests/spec/views/mixins/sync-suggestion-mixin',
     '../tests/spec/views/mixins/timer-mixin',
     '../tests/spec/views/mixins/verification-reason-mixin',
     '../tests/spec/views/oauth_index',


### PR DESCRIPTION
The Sync suggestion will be showed on the `/email` page in the Email-first flow.

Extraction from #5177 
~~Depends on #5251~~