### PR TITLE
refactor(client): Extract a form-prefill-mixin.

### DIFF
--- a/app/scripts/templates/force_auth.mustache
+++ b/app/scripts/templates/force_auth.mustache
@@ -16,7 +16,7 @@
       <p class="prefillEmail">{{ email }}</p>
       <input type="email" class="email hidden" value="{{ email }}" disabled />
       <div class="input-row password-row">
-        <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" required pattern=".{8,}" value="{{ password }}" required {{#email}}autofocus{{/email}} />
+        <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" required pattern=".{8,}" required {{#email}}autofocus{{/email}} />
       </div>
 
       <div class="button-row">

--- a/app/scripts/templates/reset_password.mustache
+++ b/app/scripts/templates/reset_password.mustache
@@ -25,7 +25,7 @@
           <input type="email" class="email hidden" value="{{ forceEmail }}" disabled />
         {{/forceEmail}}
         {{^forceEmail}}
-          <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" spellcheck="false" autofocus required>
+          <input name="email" type="email" class="email" placeholder="{{#t}}Email{{/t}}" spellcheck="false" autofocus required autocomplete="off" />
         {{/forceEmail}}
       </div>
 

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -64,7 +64,7 @@
       {{^suggestedAccount}}
         <form novalidate>
         <div class="input-row">
-          <input type="email" class="email{{#email}} prefilled{{/email}}" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" {{^email}}autofocus{{/email}}>
+          <input name="email" type="email" class="email{{#email}} prefilled{{/email}}" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" {{^email}}autofocus{{/email}}>
         </div>
 
         <div class="input-row password-row">

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -36,7 +36,7 @@
             <input type="email" class="email hidden" value="{{ email }}" />
 
             <div class="input-row password-row">
-              <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" required pattern=".{8,}" autofocus />
+              <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" required pattern=".{8,}" autofocus />
             </div>
 
             <div class="button-row">
@@ -68,7 +68,7 @@
         </div>
 
         <div class="input-row password-row">
-          <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required {{#email}}autofocus{{/email}} />
+          <input type="password" class="password tooltip-below" id="password" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#email}}autofocus{{/email}} />
         </div>
 
         <div class="button-row">

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -37,7 +37,7 @@
           <input type="email" class="email hidden tooltip-below" value="{{ forceEmail }}" disabled />
         {{/forceEmail}}
         {{^forceEmail}}
-          <input type="email" class="email tooltip-below" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" {{#shouldFocusEmail}}autofocus{{/shouldFocusEmail}} required />
+          <input name="email" type="email" class="email tooltip-below" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" {{#shouldFocusEmail}}autofocus{{/shouldFocusEmail}} required />
         {{/forceEmail}}
       </div>
 

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -42,7 +42,7 @@
       </div>
 
       <div class="input-row password-row">
-        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required {{#shouldFocusPassword}}autofocus{{/shouldFocusPassword}} />
+        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#shouldFocusPassword}}autofocus{{/shouldFocusPassword}} />
         <div class="input-help input-help-focused input-help-signup">{{#t}}A strong, unique password will keep your Firefox data safe from intruders.{{/t}}</div>
       </div>
 

--- a/app/scripts/templates/sms_send.mustache
+++ b/app/scripts/templates/sms_send.mustache
@@ -10,7 +10,7 @@
 
       <form novalidate>
         <div class="input-row sms-row">
-          <input class="phone-number" type="tel" data-country="{{country}}" value="{{phoneNumber}}" placeholder="{{#t}}Mobile phone number{{/t}}" required autofocus="autofocus" />
+          <input name="phoneNumber" class="phone-number" type="tel" data-country="{{country}}" value="{{phoneNumber}}" placeholder="{{#t}}Mobile phone number{{/t}}" required autofocus="autofocus" />
           <button type="submit" class="sms-send disabled">{{#t}}Send{{/t}}</button>
         </div>
       </form>

--- a/app/scripts/views/coppa/coppa-age-input.js
+++ b/app/scripts/views/coppa/coppa-age-input.js
@@ -8,6 +8,7 @@ define(function (require, exports, module) {
   const AuthErrors = require('lib/auth-errors');
   const Cocktail = require('cocktail');
   const FloatingPlaceholderMixin = require('views/mixins/floating-placeholder-mixin');
+  const FormPrefillMixin = require('views/mixins/form-prefill-mixin');
   const FormView = require('views/form');
   const KeyCodes = require('lib/key-codes');
   const Template = require('stache!templates/partial/coppa-age-input');
@@ -16,14 +17,9 @@ define(function (require, exports, module) {
   const AGE_SIZE_LIMIT = 3;
   const CUTOFF_AGE = 13;
 
-  const proto = FormView.prototype;
   const View = FormView.extend({
     template: Template,
     className: 'coppa-age-input',
-
-    initialize (options = {}) {
-      this._formPrefill = options.formPrefill;
-    },
 
     events: {
       'input': 'onInput',
@@ -78,11 +74,6 @@ define(function (require, exports, module) {
       }
     },
 
-    afterRender () {
-      this._selectPrefillAge('age');
-      return proto.afterRender.call(this);
-    },
-
     /**
      * Called by the parent view to show any validation errors.
      *
@@ -111,25 +102,13 @@ define(function (require, exports, module) {
 
     _getAge () {
       return parseInt(this.$(AGE_ELEMENT).val(), 10);
-    },
-
-    _selectPrefillAge (context) {
-      var prefillYear = this._formPrefill.get(context);
-      if (prefillYear) {
-        var ageEl = this.$(AGE_ELEMENT);
-        ageEl.val(prefillYear);
-        this.showFloatingPlaceholder(ageEl);
-      }
-    },
-
-    beforeDestroy () {
-      this._formPrefill.set('age', this.$(AGE_ELEMENT).val());
     }
   });
 
   Cocktail.mixin(
     View,
-    FloatingPlaceholderMixin
+    FloatingPlaceholderMixin,
+    FormPrefillMixin
   );
 
   module.exports = View;

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -154,18 +154,13 @@ define(function (require, exports, module) {
 
       context.set({
         buttonSignInText,
-        email: this.relier.get('email'),
-        password: this._formPrefill.get('password')
+        email: this.relier.get('email')
       });
     },
 
     events: _.extend({}, SignInView.prototype.events, {
       'click a[href="/reset_password"]': cancelEventThen('_navigateToForceResetPassword')
     }),
-
-    beforeDestroy () {
-      this._formPrefill.set('password', this.getElementValue('.password'));
-    },
 
     onSignInError (account, password, error) {
       if (AuthErrors.is(error, 'UNKNOWN_ACCOUNT')) {

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -22,7 +22,6 @@ define(function (require, exports, module) {
 
   require('views/elements/jquery-plugin');
 
-  const $ = require('jquery');
   const _ = require('underscore');
   const allowOnlyOneSubmit = require('views/decorators/allow_only_one_submit');
   const AuthErrors = require('lib/auth-errors');
@@ -119,19 +118,30 @@ define(function (require, exports, module) {
      */
     getFormValues () {
       var values = {};
-      var inputEls = this.$('input,textarea,select');
 
-      for (var i = 0, length = inputEls.length; i < length; ++i) {
-        var el = $(inputEls[i]);
-        // elements that have data-novalue (like password show fields)
-        // are not added to the values.
-        if (typeof el.attr('data-novalue') === 'undefined') {
-          var name = el.attr('name') || el.attr('id');
-          values[name] = this.getElementValue(el);
-        }
-      }
+      this.getFormElements().each((index, el) => {
+        const $el = this.$(el);
+        // If the element has neither a name nor id, use the index as key
+        const key = $el.attr('name') || $el.attr('id') || index;
+        values[key] = this.getElementValue($el);
+      });
 
       return values;
+    },
+
+    /**
+     * Get a list of form elements that do not have the `data-novalue` attribute.
+     *
+     * @method getFormElements
+     * @returns {Object}
+     */
+    getFormElements () {
+      return this.$('input,textarea,select').filter((index, el) => {
+        const $el = this.$(el);
+        // elements that have data-novalue (like password show fields)
+        // are not added to the values.
+        return _.isUndefined($el.attr('data-novalue'));
+      });
     },
 
     /**

--- a/app/scripts/views/mixins/form-prefill-mixin.js
+++ b/app/scripts/views/mixins/form-prefill-mixin.js
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Save/load values for input, textarea and select elements.
+ *
+ * Values are loaded for elements w/ neither `data-novalue`
+ *   and `autocomplete="off"` attributes.
+ * Values are saved for elements w/o the data-novalue attribute.
+ *
+ * `name` or `id` element properties are the keys into
+ * the formPrefill model. `name` is preferred for elements with both.
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  function getKey ($el) {
+    return $el.prop('name') || $el.prop('id');
+  }
+
+  function isElementFillable ($el, formPrefill) {
+    const key = getKey($el);
+    return ! $el.__val() &&
+           $el.attr('autocomplete') !== 'off' &&
+           key &&
+           formPrefill.has(key);
+  }
+
+  module.exports = {
+    initialize (options = {}) {
+      this.formPrefill = options.formPrefill;
+    },
+
+    afterRender () {
+      this.getFormElements().each((index, el) => {
+        const $el = this.$(el);
+        if (isElementFillable($el, this.formPrefill)) {
+          const key = getKey($el);
+          $el.val(this.formPrefill.get(key)).trigger('input');
+        }
+      });
+    },
+
+    beforeDestroy () {
+      this.getFormElements().each((index, el) => {
+        const $el = this.$(el);
+        const key = getKey($el);
+        if (key) {
+          this.formPrefill.set(key, $el.__val());
+        }
+      });
+    }
+  };
+});

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -51,8 +51,8 @@ define(function (require, exports, module) {
           });
         })
         .then((account) => {
-          if (this._formPrefill) {
-            this._formPrefill.clear();
+          if (this.formPrefill) {
+            this.formPrefill.clear();
           }
 
           if (this.relier.accountNeedsPermissions(account)) {

--- a/app/scripts/views/mixins/signup-mixin.js
+++ b/app/scripts/views/mixins/signup-mixin.js
@@ -45,8 +45,8 @@ define(function (require, exports, module) {
           });
         })
         .then((account) => {
-          if (this._formPrefill) {
-            this._formPrefill.clear();
+          if (this.formPrefill) {
+            this.formPrefill.clear();
           }
 
           var onSubmitComplete = this.onSignUpSuccess.bind(this);

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -10,6 +10,7 @@ define(function (require, exports, module) {
   const Cocktail = require('cocktail');
   const FormView = require('views/form');
   const FlowEventsMixin = require('views/mixins/flow-events-mixin');
+  const FormPrefillMixin = require('views/mixins/form-prefill-mixin');
   const PasswordResetMixin = require('views/mixins/password-reset-mixin');
   const ServiceMixin = require('views/mixins/service-mixin');
   const Session = require('lib/session');
@@ -20,12 +21,6 @@ define(function (require, exports, module) {
   var View = FormView.extend({
     template: Template,
     className: 'reset_password',
-
-    initialize (options) {
-      options = options || {};
-
-      this._formPrefill = options.formPrefill;
-    },
 
     setInitialContext (context) {
       context.set({
@@ -45,10 +40,6 @@ define(function (require, exports, module) {
       }
 
       return FormView.prototype.beforeRender.call(this);
-    },
-
-    beforeDestroy () {
-      this._formPrefill.set('email', this.getElementValue('.email'));
     },
 
     submit () {
@@ -77,6 +68,7 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     FlowEventsMixin,
+    FormPrefillMixin,
     PasswordResetMixin,
     ServiceMixin
   );

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -58,7 +58,6 @@ define(function (require, exports, module) {
 
       this._experimentGroupingRules = options.experimentGroupingRules;
       this._subPanels = options.subPanels || this._initializeSubPanels(options);
-      this._formPrefill = options.formPrefill;
 
       var uid = this.relier.get('uid');
 

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
   const AvatarMixin = require('views/mixins/avatar-mixin');
   const Cocktail = require('cocktail');
   const FlowBeginMixin = require('views/mixins/flow-begin-mixin');
+  const FormPrefillMixin = require('views/mixins/form-prefill-mixin');
   const FormView = require('views/form');
   const MigrationMixin = require('views/mixins/migration-mixin');
   const PasswordMixin = require('views/mixins/password-mixin');
@@ -29,8 +30,6 @@ define(function (require, exports, module) {
     className: 'sign-in',
 
     initialize (options = {}) {
-      this._formPrefill = options.formPrefill;
-
       // The number of stored accounts is logged to see if we can simplify
       // the User model. User grew a lot of complexity to support a user
       // being able to sign in using more than one email address, and we
@@ -72,7 +71,7 @@ define(function (require, exports, module) {
       // formPrefill.email comes first because users can edit the email,
       // go to another view, edit the email again, and come back here. We
       // want the last used email.
-      return this._formPrefill.get('email') || this.relier.get('email');
+      return this.formPrefill.get('email') || this.relier.get('email');
     },
 
     getEmail () {
@@ -101,7 +100,7 @@ define(function (require, exports, module) {
         headerSignInText,
         isAmoMigration: this.isAmoMigration(),
         isSyncMigration: this.isSyncMigration(),
-        password: this._formPrefill.get('password'),
+        password: this.formPrefill.get('password'),
         suggestedAccount: hasSuggestedAccount
       });
     },
@@ -109,11 +108,6 @@ define(function (require, exports, module) {
     events: {
       'click .use-different': 'useDifferentAccount',
       'click .use-logged-in': 'useLoggedInAccount'
-    },
-
-    beforeDestroy () {
-      this._formPrefill.set('email', this.getElementValue('.email'));
-      this._formPrefill.set('password', this.getElementValue('.password'));
     },
 
     submit () {
@@ -195,7 +189,7 @@ define(function (require, exports, module) {
       // only clear the current account.
       this.user.removeAllAccounts();
       Session.clear();
-      this._formPrefill.clear();
+      this.formPrefill.clear();
       this.logViewEvent('use-different-account');
 
       return this.render();
@@ -280,6 +274,7 @@ define(function (require, exports, module) {
     AccountResetMixin,
     AvatarMixin,
     FlowBeginMixin,
+    FormPrefillMixin,
     MigrationMixin,
     PasswordMixin,
     PasswordResetMixin,

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -139,7 +139,6 @@ define(function (require, exports, module) {
       var autofocusEl = this._selectAutoFocusEl();
       var forceEmail = this.model.get('forceEmail');
       var prefillEmail = this.getPrefillEmail();
-      var prefillPassword = this.formPrefill.get('password');
 
       var relier = this.relier;
       var isSync = relier.isSync();
@@ -155,16 +154,9 @@ define(function (require, exports, module) {
         isSignInEnabled: ! forceEmail,
         isSync: isSync,
         isSyncMigration: this.isSyncMigration(),
-        password: prefillPassword,
         shouldFocusEmail: autofocusEl === 'email',
         shouldFocusPassword: autofocusEl === 'password'
       });
-    },
-
-    beforeDestroy () {
-      var formPrefill = this.formPrefill;
-      formPrefill.set('email', this.getElementValue('.email'));
-      formPrefill.set('password', this.getElementValue('.password'));
     },
 
     isValidEnd () {

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -12,6 +12,7 @@ define(function (require, exports, module) {
   const CoppaAgeInput = require('views/coppa/coppa-age-input');
   const ExperimentMixin = require('views/mixins/experiment-mixin');
   const FlowBeginMixin = require('views/mixins/flow-begin-mixin');
+  const FormPrefillMixin = require('views/mixins/form-prefill-mixin');
   const FormView = require('views/form');
   const mailcheck = require('lib/mailcheck');
   const MigrationMixin = require('views/mixins/migration-mixin');
@@ -44,7 +45,6 @@ define(function (require, exports, module) {
     initialize (options = {}) {
       this._coppa = options.coppa;
       this._experimentGroupingRules = options.experimentGroupingRules;
-      this._formPrefill = options.formPrefill;
     },
 
     beforeRender () {
@@ -69,7 +69,7 @@ define(function (require, exports, module) {
       var autofocusEl = this._selectAutoFocusEl();
       var coppaOptions = {
         el: this.$('#coppa'),
-        formPrefill: this._formPrefill,
+        formPrefill: this.formPrefill,
         metrics: this.metrics,
         notifier: this.notifier,
         shouldFocus: autofocusEl === null,
@@ -124,12 +124,12 @@ define(function (require, exports, module) {
       // formPrefill.email comes first because users can edit the email,
       // go to another view, edit the email again, and come back here. We
       // want the last used email.
-      return this._formPrefill.get('email') || this.relier.get('email');
+      return this.formPrefill.get('email') || this.relier.get('email');
     },
 
     _selectAutoFocusEl () {
       var prefillEmail = this.model.get('forceEmail') || this.getPrefillEmail();
-      var prefillPassword = this._formPrefill.get('password');
+      var prefillPassword = this.formPrefill.get('password');
 
       return selectAutoFocusEl(
             this.model.get('bouncedEmail'), prefillEmail, prefillPassword);
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
       var autofocusEl = this._selectAutoFocusEl();
       var forceEmail = this.model.get('forceEmail');
       var prefillEmail = this.getPrefillEmail();
-      var prefillPassword = this._formPrefill.get('password');
+      var prefillPassword = this.formPrefill.get('password');
 
       var relier = this.relier;
       var isSync = relier.isSync();
@@ -162,7 +162,7 @@ define(function (require, exports, module) {
     },
 
     beforeDestroy () {
-      var formPrefill = this._formPrefill;
+      var formPrefill = this.formPrefill;
       formPrefill.set('email', this.getElementValue('.email'));
       formPrefill.set('password', this.getElementValue('.password'));
     },
@@ -373,6 +373,7 @@ define(function (require, exports, module) {
     CheckboxMixin,
     ExperimentMixin,
     FlowBeginMixin,
+    FormPrefillMixin,
     MigrationMixin,
     PasswordMixin,
     ServiceMixin,

--- a/app/scripts/views/sms_send.js
+++ b/app/scripts/views/sms_send.js
@@ -15,6 +15,7 @@ define(function (require, exports, module) {
   const CountryTelephoneInfo = require('lib/country-telephone-info');
   const { FIREFOX_MOBILE_INSTALL } = require('lib/sms-message-ids');
   const FlowEventsMixin = require('views/mixins/flow-events-mixin');
+  const FormPrefillMixin = require('views/mixins/form-prefill-mixin');
   const FormView = require('views/form');
   const { MARKETING_ID_AUTUMN_2016, SYNC_SERVICE } = require('lib/constants');
   const MarketingMixin = require('views/mixins/marketing-mixin');
@@ -33,15 +34,6 @@ define(function (require, exports, module) {
       proto.initialize.call(this, options);
 
       this._createView = options.createView;
-      this._formPrefill = options.formPrefill;
-    },
-
-    beforeDestroy() {
-      // Save phoneNumber to formPrefill in case the user
-      // enters an incorrect phone number and then returns.
-      // save the number as the user entered it, if they come back
-      // to this screen it will display as they entered it.
-      this._formPrefill.set('phoneNumber', this.$(SELECTOR_PHONE_NUMBER).__val());
     },
 
     getAccount () {
@@ -57,7 +49,7 @@ define(function (require, exports, module) {
       // user submits a phone number, sees the incorrect
       // number in the success message on /sms/sent, and
       // clicks "Mistyped number?"
-      let phoneNumber = this._formPrefill.get('phoneNumber');
+      let phoneNumber = this.formPrefill.get('phoneNumber');
       let country = this._getCountry();
       if (! CountryTelephoneInfo[country]) {
         // this shouldn't be possible because only the Sync relier imports
@@ -176,6 +168,7 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     FlowEventsMixin,
+    FormPrefillMixin,
     MarketingMixin({
       marketingId: MARKETING_ID_AUTUMN_2016,
       // This screen is only shown to Sync users. The service is always Sync,

--- a/app/tests/spec/views/coppa/coppa-age-input.js
+++ b/app/tests/spec/views/coppa/coppa-age-input.js
@@ -54,9 +54,11 @@ define(function (require, exports, module) {
       it('works', function () {
         createView();
 
+        formPrefill.set('age', 12);
+
         return view.render()
           .then(function () {
-            assert.equal(view.$('#age').val(), '');
+            assert.equal(view.$('#age').val(), '12');
           });
       });
     });
@@ -172,14 +174,6 @@ define(function (require, exports, module) {
 
       it('hasValue returns false', function () {
         assert.isFalse(view.hasValue());
-      });
-    });
-
-    describe('_selectPrefillAge', function () {
-      it('recovers data from formPrefill', function () {
-        formPrefill.set('age', '11');
-        view._selectPrefillAge('age');
-        assert.equal(view.$('#age').val(), '11');
       });
     });
 

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -436,6 +436,18 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('getFormElements', () => {
+      it('gets a list of form fields that do not have the `data-novalue` attribute', function () {
+        var $els = view.getFormElements();
+        assert.lengthOf($els, 12);
+
+        $els.each((index, el) => {
+          const $el = view.$(el);
+          assert.isUndefined($el.attr('data-novalue'));
+        });
+      });
+    });
+
     describe('getFormValues', function () {
       it('gets the value of form fields that do not have the `data-novalue` attribute', function () {
         view.$('#focusMe').val('the value');

--- a/app/tests/spec/views/mixins/form-prefill-mixin.js
+++ b/app/tests/spec/views/mixins/form-prefill-mixin.js
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const { assert } = require('chai');
+  const Backbone = require('backbone');
+  const FormView = require('views/form');
+  const Cocktail = require('cocktail');
+  const FormPrefillMixin = require('views/mixins/form-prefill-mixin');
+
+  const View = FormView.extend({
+    template: () => `
+      <input class="nameless" />
+      <input id="id-only" />
+      <input name="already-filled" value="this is filled in" />
+      <input name="has-data-novalue" data-novalue />
+      <input name="name-only" />
+      <input name="name-preferred" id="id-ignored" />
+      <input name="not-filled-but-saved" autocomplete="off" />
+      <textarea name="textarea" />
+    `
+  });
+  Cocktail.mixin(
+    View,
+    FormPrefillMixin
+  );
+
+  describe('views/mixins/form-prefill-mixin', () => {
+    let formPrefill;
+    let view;
+
+    beforeEach(() => {
+      formPrefill = new Backbone.Model({
+        'id-only': 'id only value',
+        'already-filled': 'a different already-filled value', //eslint-disable-line
+        'has-data-novalue': 'has-data-novalue value',
+        'name-only': 'name only value',
+        'name-preferred': 'name preferred',
+        'not-filled-but-saved': 'should not be filled',
+        'textarea': 'the value for the text area'
+      });
+
+      view = new View({
+        formPrefill
+      });
+
+      return view.render();
+    });
+
+    it('pre-fills input elements w/ name/id without `autocomplete=off` attribute', () => {
+      assert.equal(view.$('.nameless').val(), '');
+      assert.equal(view.$('#id-only').val(), 'id only value');
+      assert.equal(view.$('[name="already-filled"]').val(), 'this is filled in');
+      assert.equal(view.$('[name="has-data-novalue"]').val(), '');
+      assert.equal(view.$('[name="name-only"]').val(), 'name only value');
+      assert.equal(view.$('[name="name-preferred"]').val(), 'name preferred');
+      assert.equal(view.$('[name="not-filled-but-saved"]').val(), '');
+      assert.equal(view.$('[name="textarea"]').val(), 'the value for the text area');
+    });
+
+    it('formPrefill saves all input elements w/ name/id', () => {
+      view.$('[name="has-data-novalue"]').val('has-data-novalue value updated');
+      view.$('[name="name-only"]').val('name only value updated');
+      view.$('#id-only').val('id only value updated');
+      view.$('[name="name-preferred"]').val('name preferred updated');
+      view.$('.nameless').val('updated');
+      view.$('[name="not-filled-but-saved"]').val('not filled but saved updated');
+      view.$('[name="textarea"]').val('the value for the text area updated');
+
+      view.destroy();
+      assert.deepEqual(formPrefill.toJSON(), {
+        'id-only': 'id only value updated',
+        'already-filled': 'this is filled in', //eslint-disable-line
+        'has-data-novalue': 'has-data-novalue value',
+        'name-only': 'name only value updated',
+        'name-preferred': 'name preferred updated',
+        'not-filled-but-saved': 'not filled but saved updated',
+        'textarea': 'the value for the text area updated'
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/mixins/signin-mixin.js
+++ b/app/tests/spec/views/mixins/signin-mixin.js
@@ -52,7 +52,7 @@ define(function (require, exports, module) {
         view = {
           _clickLink: SignInMixin._clickLink,
           _engageSignInForm: SignInMixin._engageSignInForm,
-          _formPrefill: {
+          formPrefill: {
             clear: sinon.spy()
           },
           _submitSignInForm: SignInMixin._submitSignInForm,
@@ -132,9 +132,9 @@ define(function (require, exports, module) {
             assert.isTrue(view.logEvent.calledWith('signin.success.skip-confirm'));
           });
 
-          it('calls view._formPrefill.clear correctly', function () {
-            assert.equal(view._formPrefill.clear.callCount, 1);
-            assert.lengthOf(view._formPrefill.clear.args[0], 0);
+          it('calls view.formPrefill.clear correctly', function () {
+            assert.equal(view.formPrefill.clear.callCount, 1);
+            assert.lengthOf(view.formPrefill.clear.args[0], 0);
           });
 
           it('calls view.invokeBrokerMethod correctly', function () {
@@ -319,9 +319,9 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('_formPrefill undefined', function () {
+      describe('formPrefill undefined', function () {
         beforeEach(function () {
-          view._formPrefill = undefined;
+          view.formPrefill = undefined;
         });
 
         it('does not throw', function () {

--- a/app/tests/spec/views/mixins/signup-mixin.js
+++ b/app/tests/spec/views/mixins/signup-mixin.js
@@ -41,10 +41,10 @@ define(function (require, exports, module) {
         };
 
         view = {
-          _formPrefill: {
+          broker,
+          formPrefill: {
             clear: sinon.spy()
           },
-          broker,
           getStringifiedResumeToken: sinon.spy(() => 'resume token'),
           invokeBrokerMethod: sinon.spy(function () {
             return p();
@@ -156,8 +156,8 @@ define(function (require, exports, module) {
           assert.equal(view.logFlowEvent.args[0][1], 'signup');
         });
 
-        it('calls view._formPrefill.clear', function () {
-          assert.equal(view._formPrefill.clear.callCount, 1);
+        it('calls view.formPrefill.clear', function () {
+          assert.equal(view.formPrefill.clear.callCount, 1);
         });
 
         it('calls view.invokeBrokerMethod correctly', function () {
@@ -204,9 +204,9 @@ define(function (require, exports, module) {
           assert.isTrue(view.logViewEvent.calledWith('signup.success'));
         });
 
-        it('calls view._formPrefill.clear correctly', function () {
-          assert.equal(view._formPrefill.clear.callCount, 1);
-          assert.lengthOf(view._formPrefill.clear.args[0], 0);
+        it('calls view.formPrefill.clear correctly', function () {
+          assert.equal(view.formPrefill.clear.callCount, 1);
+          assert.lengthOf(view.formPrefill.clear.args[0], 0);
         });
 
         it('calls view.invokeBrokerMethod correctly', function () {
@@ -234,9 +234,9 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('_formPrefill undefined', function () {
+      describe('formPrefill undefined', function () {
         beforeEach(function () {
-          view._formPrefill = undefined;
+          view.formPrefill = undefined;
         });
 
         it('does not throw', function () {

--- a/app/tests/spec/views/settings/emails.js
+++ b/app/tests/spec/views/settings/emails.js
@@ -171,7 +171,7 @@ define(function (require, exports, module) {
             type: 'keyup',
             which: 9
           });
-          assert.ok(view.$('.email-add.primary:not(.disabled)').length, 1);
+          assert.lengthOf(view.$('.email-add.primary:not(.disabled)'), 1);
         });
       });
 

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -725,7 +725,9 @@ define(function (require, exports, module) {
       it('logs the begin event', () => {
         assert.isTrue(isEventLogged(metrics, 'flow.begin'));
       });
+    });
 
+    describe('flowEvents', () => {
       it('logs the engage event (click)', () => {
         assert.isFalse(isEventLogged(metrics, 'flow.signin.engage'));
         view.$('input').trigger('click');

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -150,6 +150,7 @@ function (Translator, Session) {
     '../tests/spec/views/mixins/floating-placeholder-mixin',
     '../tests/spec/views/mixins/flow-begin-mixin',
     '../tests/spec/views/mixins/flow-events-mixin',
+    '../tests/spec/views/mixins/form-prefill-mixin',
     '../tests/spec/views/mixins/loading-mixin',
     '../tests/spec/views/mixins/marketing-mixin',
     '../tests/spec/views/mixins/migration-mixin',


### PR DESCRIPTION
Form elements that have a `name` or `id` attribute and
do not have `data-novalue` are eligible for form-prefill.

Values are prefilled if:
* Above prerequisites are met.
* Element does not have an `autocomplete="off"` attribute.
* Form prefill model has a value for the field.

Values are saved if:
* Above prerequisites are met.

Element name/id attributes are used as the key into
the formPrefill model.

Extraction from #5177