### PR TITLE
fix(cwts): Check addresses and creditcards by default.

### DIFF
--- a/app/scripts/models/sync-engines.js
+++ b/app/scripts/models/sync-engines.js
@@ -60,7 +60,7 @@ define((require, exports, module) => {
       text: t('Preferences')
     },
     {
-      checked: false,
+      checked: true,
       id: 'addresses',
       // We know addresses will be available in Firefox 56, even before
       // the capabilities code has landed in the browser. This check can be
@@ -72,7 +72,7 @@ define((require, exports, module) => {
       text: t('Addresses')
     },
     {
-      checked: false,
+      checked: true,
       id: 'creditcards',
       // credit cards will only be available via capabilities.
       test: () => false,

--- a/app/tests/spec/views/choose_what_to_sync.js
+++ b/app/tests/spec/views/choose_what_to_sync.js
@@ -158,7 +158,7 @@ define(function (require, exports, module) {
             //decline the first engine
             $('.customize-sync').first().click();
             const declined = view._getDeclinedEngineIds();
-            assert.sameMembers(declined, ['tabs', 'creditcards']);
+            assert.sameMembers(declined, ['tabs']);
           });
       });
     });
@@ -188,7 +188,7 @@ define(function (require, exports, module) {
 
       it('updates and saves the account, logs metrics, calls onSubmitComplete', () => {
         const declined = account.get('declinedSyncEngines');
-        assert.sameMembers(declined, ['tabs', 'creditcards']);
+        assert.sameMembers(declined, ['tabs']);
 
         const offered = account.get('offeredSyncEngines');
         assert.sameMembers(offered, DISPLAYED_ENGINE_IDS);


### PR DESCRIPTION
Addresses and creditcards were not checked by default. @markh
says they should be.

fixes #5269 

Need to find out from @ryanfeeley whether this fix is the right thing to do.