### PR TITLE
fix(signup): Focus the age input if email/password prefilled 

### DIFF
--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -37,12 +37,12 @@
           <input type="email" class="email hidden tooltip-below" value="{{ forceEmail }}" disabled />
         {{/forceEmail}}
         {{^forceEmail}}
-          <input name="email" type="email" class="email tooltip-below" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" {{#shouldFocusEmail}}autofocus{{/shouldFocusEmail}} required />
+          <input name="email" type="email" class="email tooltip-below" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" required />
         {{/forceEmail}}
       </div>
 
       <div class="input-row password-row">
-        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#shouldFocusPassword}}autofocus{{/shouldFocusPassword}} />
+        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required />
         <div class="input-help input-help-focused input-help-signup">{{#t}}A strong, unique password will keep your Firefox data safe from intruders.{{/t}}</div>
       </div>
 

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -30,13 +30,14 @@ define(function (require, exports, module) {
 
   function selectAutoFocusEl(bouncedEmail, email, password) {
     if (bouncedEmail) {
-      return 'email';
+      return 'input[type=email]';
     } else if (! email) {
-      return 'email';
+      return 'input[type=email]';
     } else if (! password) {
-      return 'password';
+      return 'input[type=password]';
+    } else {
+      return '#age';
     }
-    return null;
   }
 
   var View = FormView.extend({
@@ -54,6 +55,11 @@ define(function (require, exports, module) {
       }
 
       return FormView.prototype.beforeRender.call(this);
+    },
+
+    afterRender () {
+      const autofocusEl = this._selectAutoFocusEl();
+      this.$(autofocusEl).attr('autofocus', 'autofocus');
     },
 
     afterVisible () {
@@ -94,7 +100,6 @@ define(function (require, exports, module) {
     },
 
     setInitialContext (context) {
-      var autofocusEl = this._selectAutoFocusEl();
       var forceEmail = this.model.get('forceEmail');
       var prefillEmail = this.getPrefillEmail();
 
@@ -110,9 +115,7 @@ define(function (require, exports, module) {
         isCustomizeSyncChecked: relier.isCustomizeSyncChecked(),
         isSignInEnabled: ! forceEmail,
         isSync: isSync,
-        isSyncMigration: this.isSyncMigration(),
-        shouldFocusEmail: autofocusEl === 'email',
-        shouldFocusPassword: autofocusEl === 'password'
+        isSyncMigration: this.isSyncMigration()
       });
     },
 

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -298,11 +298,27 @@ define(function (require, exports, module) {
     });
 
     describe('autofocus behavior', () => {
-      it('focuses the email element by default', () => {
-        $('html').addClass('no-touch');
+      it('focuses the email element if not pre-filled', () => {
         return view.render()
           .then(() => {
             assert.ok(view.$('input[type="email"]').attr('autofocus'));
+          });
+      });
+
+      it('focuses the password element if email is pre-filled', () => {
+        formPrefill.set('email', 'testuser@testuser.com');
+        return view.render()
+          .then(() => {
+            assert.ok(view.$('input[type="password"]').attr('autofocus'));
+          });
+      });
+
+      it('focuses the age element if email and password are both pre-filled', () => {
+        formPrefill.set('email', 'testuser@testuser.com');
+        formPrefill.set('password', 'password');
+        return view.render()
+          .then(() => {
+            assert.ok(view.$('#age').attr('autofocus'));
           });
       });
     });


### PR DESCRIPTION
Determines which input element should be focused and sets `autofocus` in afterRender
instead of within the template. With COPPA being handled separately in its own template,
this solution is cleaner than attempting to pass which element to focus to the CoppaMixin.

Builds on #5261 and should be reviewed afterwards.

fixes #5280  

The mile high bug.


