### PR TITLE
fix(firstrun): Fix styles in firstrun.

### DIFF
--- a/app/styles/modules/_branding.scss
+++ b/app/styles/modules/_branding.scss
@@ -83,6 +83,12 @@
 
 
 .choose-what-to-sync {
+  @include respond-to('trustedUI') {
+    // padding-bottom fixes a problem where the "Save settings"
+    // button can be cut off in the firstrun flow. See #5273
+    padding-bottom: 10px;
+  }
+
   #choose-what-to-sync-graphic {
     background: image-url('choose_what_to_sync_devices.svg');
     background-position: center top;

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -86,6 +86,10 @@ ul.links {
 .marketing-email-optin-row {
   color: $input-placeholder-color;
 
+  @include respond-to('trustedUI') {
+     font-size: 12px;
+  }
+
   @include respond-to('small') {
     margin: 10px 0;
   }
@@ -97,7 +101,6 @@ ul.links {
   .fxa-checkbox {
     line-height: 18px;
   }
-
 }
 
 .choose-what-to-sync-row,


### PR DESCRIPTION
* Set the font-size of the marketing opt-in text to 12px.
* Ensure the entire "Save settings" button text displays in CWTS.

fixes #5271
fixes #5273

@ryanfeeley - r?

#### email opt-in text

<img width="328" alt="screen shot 2017-07-25 at 16 37 41" src="https://user-images.githubusercontent.com/848085/28580903-bae5ee72-7158-11e7-88e8-84c7c0d73866.png">

#### CWTS w/ entire "Save settings" button.

<img width="331" alt="screen shot 2017-07-25 at 16 38 44" src="https://user-images.githubusercontent.com/848085/28580930-cc473284-7158-11e7-8bf4-1b13d374875c.png">

@ryanfeeley - I didn't modify the columns and the CWTS font size yet, that's going to require a bit more work to get just right and we are waiting on this PR to cut train-92.
