### PR TITLE
fix(form): On device disconnect,"Rather not say" is selected by default

### DIFF
--- a/app/scripts/templates/settings/client_disconnect.mustache
+++ b/app/scripts/templates/settings/client_disconnect.mustache
@@ -27,7 +27,7 @@
               {{#t}}Duplicate device{{/t}}
             </label>
             <label>
-              <input type="radio" name="disconnect-reasons" value="no"/>
+              <input type="radio" name="disconnect-reasons" value="no" checked="checked"/>
               {{#t}}Rather not say{{/t}}
             </label>
           </p>

--- a/app/tests/spec/views/settings/client_disconnect.js
+++ b/app/tests/spec/views/settings/client_disconnect.js
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
     describe('render', () => {
       it('renders initial view', () => {
         return view.render().then(() => {
-          sinon.spy(view, 'enableForm')
+          sinon.spy(view, 'enableForm');
           assert.ok($(view.el).find('.intro').length, 'intro text');
           assert.ok($(view.el).find('.disconnect-reasons').length, 'radio');
           assert.notOk($(view.el).find('.reason-help').length, 'help');

--- a/app/tests/spec/views/settings/client_disconnect.js
+++ b/app/tests/spec/views/settings/client_disconnect.js
@@ -133,24 +133,6 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('selectOption event', () => {
-      it('select disables form properly', () => {
-        sinon.spy(view, 'disableForm');
-        sinon.spy(view, 'enableForm');
-
-        return view.render().then(() => {
-          assert.ok(view.disableForm.calledOnce);
-          assert.notOk(view.enableForm.calledOnce);
-          assert.ok($(view.el).find('.warning.disabled').length, 'has disabled class');
-
-          // choose an option
-          $(view.el).find('input[name=disconnect-reasons][value=no]').prop('checked', true).change();
-          assert.notOk($(view.el).find('.warning.disabled').length, 'no disabled button');
-          assert.ok(view.disableForm.calledOnce);
-          assert.ok(view.enableForm.calledOnce);
-        });
-      });
-    });
 
     describe('_returnToClientListAfterDisconnect event', () => {
       it('does not navigate if not disconnected', () => {

--- a/app/tests/spec/views/settings/client_disconnect.js
+++ b/app/tests/spec/views/settings/client_disconnect.js
@@ -108,6 +108,7 @@ define(function (require, exports, module) {
           assert.ok($(view.el).find('.intro').length, 'intro text');
           assert.ok($(view.el).find('.disconnect-reasons').length, 'radio');
           assert.notOk($(view.el).find('.reason-help').length, 'help');
+          assert.ok($(view.el).find('input[name=disconnect-reasons][value=no]').prop('checked'), 'Rather not Say');
         });
       });
 

--- a/app/tests/spec/views/settings/client_disconnect.js
+++ b/app/tests/spec/views/settings/client_disconnect.js
@@ -105,6 +105,7 @@ define(function (require, exports, module) {
     describe('render', () => {
       it('renders initial view', () => {
         return view.render().then(() => {
+          sinon.spy(view, 'enableForm')
           assert.ok($(view.el).find('.intro').length, 'intro text');
           assert.ok($(view.el).find('.disconnect-reasons').length, 'radio');
           assert.notOk($(view.el).find('.reason-help').length, 'help');


### PR DESCRIPTION
<fix>(<app/scripts/templates/settings/client_disconnect.mustache>):<change made to the form under the heading Disconnect from Sync?:Rather not say option made the default option>

fixes #5277