### PR TITLE
fix(sync): Only show `addresses` if the browser says it's supported.

### DIFF
--- a/app/scripts/models/sync-engines.js
+++ b/app/scripts/models/sync-engines.js
@@ -18,8 +18,6 @@ define((require, exports, module) => {
 
   const t = msg => msg;
 
-  const MIN_FIREFOX_VERSION_FOR_ADDRESS = 56;
-
   /**
    * Fields available in each engine:
    * - `checked` whether the item should be checked when CWTS opens.
@@ -62,13 +60,8 @@ define((require, exports, module) => {
     {
       checked: true,
       id: 'addresses',
-      // We know addresses will be available in Firefox 56, even before
-      // the capabilities code has landed in the browser. This check can be
-      // removed when capabilities have landed.
-      test: (userAgent) => {
-        return userAgent.isFirefoxDesktop() &&
-               userAgent.parseVersion().major >= MIN_FIREFOX_VERSION_FOR_ADDRESS;
-      },
+      // addresses will only be available via capabilities.
+      test: () => false,
       text: t('Addresses')
     },
     {

--- a/app/tests/spec/models/sync-engines.js
+++ b/app/tests/spec/models/sync-engines.js
@@ -52,14 +52,8 @@ define((require, exports, module) => {
     });
 
     describe('getSupportedEngineIds', () => {
-      it('Fx Desktop <= 55 returns the expected list', () => {
+      it('returns the expected list', () => {
         assert.deepEqual(syncEngines.getSupportedEngineIds(), DEFAULT_SYNC_ENGINE_IDS);
-      });
-
-      it('Fx Desktop >= 56 returns the expected list', () => {
-        windowMock.navigator.userAgent = FIREFOX_56_USER_AGENT_STRING;
-        assert.deepEqual(
-          syncEngines.getSupportedEngineIds(), DEFAULT_SYNC_ENGINE_IDS.concat('addresses'));
       });
     });
 
@@ -84,9 +78,9 @@ define((require, exports, module) => {
         assert.isFalse(syncEngines.isEngineSupportedByUA('creditcards', fx56UserAgent));
       });
 
-      it('returns true for `addresses` for Fx Desktop >= 56', () => {
+      it('always returns `false` for `addresses', () => {
         assert.isFalse(syncEngines.isEngineSupportedByUA('addresses', fx55UserAgent));
-        assert.isTrue(syncEngines.isEngineSupportedByUA('addresses', fx56UserAgent));
+        assert.isFalse(syncEngines.isEngineSupportedByUA('addresses', fx56UserAgent));
       });
     });
 

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -63,6 +63,8 @@ define([
 
         // user should be transitioned to /choose_what_to_sync
         .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
+        .then(noSuchElement(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_ADDRESSES))
+        .then(noSuchElement(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_CREDIT_CARDS))
 
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(noSuchBrowserNotification('fxaccounts:login'))
@@ -108,11 +110,11 @@ define([
 
         // user should be transitioned to /choose_what_to_sync
         .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
-        .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_ADDRESSES))
+        .then(noSuchElement(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_ADDRESSES))
         .then(noSuchElement(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_CREDIT_CARDS));
     },
 
-    'Fx >= 56, `creditcards` not supported': function () {
+    'Fx >= 56, neither `creditcards` nor `addresses` supported': function () {
       return this.remote
         .then(openPage(SIGNUP_FX_56_PAGE_URL, selectors.SIGNUP.HEADER, {
           webChannelResponses: {
@@ -131,11 +133,11 @@ define([
 
         // user should be transitioned to /choose_what_to_sync
         .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
-        .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_ADDRESSES))
+        .then(noSuchElement(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_ADDRESSES))
         .then(noSuchElement(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_CREDIT_CARDS));
     },
 
-    'Fx >= 56, `creditcards` supported': function () {
+    'Fx >= 56, `creditcards` and `addresses` supported': function () {
       return this.remote
         .then(openPage(SIGNUP_FX_56_PAGE_URL, selectors.SIGNUP.HEADER, {
           webChannelResponses: {


### PR DESCRIPTION
fixes #5292 

@mozilla/fxa-devs - r?