### PR TITLE
fix(sms): Ensure SMS can be sent on Fx 55+.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -388,7 +388,7 @@ define(function (require, exports, module) {
 
             const browserAccountData  = this._authenticationBroker.get('browserSignedInAccount');
             if (user.shouldSetSignedInAccountFromBrowser(this._relier.get('service'))) {
-              user.setSignedInAccountFromBrowserAccountData(browserAccountData);
+              return user.setSignedInAccountFromBrowserAccountData(browserAccountData);
             }
           });
       }

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -490,7 +490,9 @@ define(function (require, exports, module) {
 
       it('creates a user, sets the uniqueUserId, populates from the browser', () => {
         return appStart.initializeUser()
-          .then(() => {
+          .then((result) => {
+            assert.isTrue(result);
+
             assert.isDefined(appStart._user);
             assert.isDefined(appStart._user.get('uniqueUserId'));
 

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -25,6 +25,9 @@ define([
   const click = FunctionalHelpers.click;
   const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
   const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
+  const getVerificationLink = FunctionalHelpers.getVerificationLink;
+  const getWebChannelMessageData = FunctionalHelpers.getWebChannelMessageData;
+  const storeWebChannelMessageData = FunctionalHelpers.storeWebChannelMessageData;
   const noPageTransition = FunctionalHelpers.noPageTransition;
   const noSuchElement = FunctionalHelpers.noSuchElement;
   const noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
@@ -90,6 +93,70 @@ define([
 
         // A post-verification email should be sent, this is Sync.
         .then(testEmailExpected(email, 1));
+    },
+
+    'Fx >= 55, verify same browser, force SMS': function () {
+      let accountInfo;
+      return this.remote
+        .then(openPage(SIGNUP_FX_55_PAGE_URL, selectors.SIGNUP.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:can_link_account': {
+              ok: true
+            },
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }))
+        .then(storeWebChannelMessageData('fxaccounts:login'))
+        .then(noSuchElement(selectors.SIGNUP.LINK_SUGGEST_SYNC))
+        .then(fillOutSignUp(email, PASSWORD))
+
+        // user should be transitioned to /choose_what_to_sync
+        .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
+
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(noSuchBrowserNotification('fxaccounts:login'))
+
+        .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
+
+        // user should be transitioned to the "go confirm your address" page
+        .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
+
+        // the login message is only sent after the sync preferences screen
+        // has been cleared.
+        .then(testIsBrowserNotified('fxaccounts:login'))
+        // verify the user
+        .then(getWebChannelMessageData('fxaccounts:login'))
+        .then(function (message) {
+          accountInfo = message.data;
+        })
+        .then(getVerificationLink(email, 0))
+        .then(function (verificationLink) {
+          return this.parent
+            .then(openPage(verificationLink, selectors.SMS_SEND.HEADER, {
+              query: {
+                automatedBrowser: true,
+                country: 'US',
+                forceExperiment: 'sendSms',
+                forceExperimentGroup: 'treatment',
+                forceUA: uaStrings.desktop_firefox_55
+              },
+              webChannelResponses: {
+                'fxaccounts:can_link_account': {
+                  ok: true
+                },
+                'fxaccounts:fxa_status': {
+                  signedInUser: {
+                    email: accountInfo.email,
+                    sessionToken: accountInfo.sessionToken,
+                    uid: accountInfo.uid,
+                    verified: accountInfo.verified
+                  }
+                }
+              }
+            }));
+        });
     },
 
     'Fx >= 56, engines not supported': function () {


### PR DESCRIPTION
After requesting account data from the browser it is written
to storage inside of a promise. We were not waiting for the
promise to complete before starting the complete_sign_up
view, which checks storage for the account data that is not
yet written. No account is returned, so a new account is
created with the data present in the verification link,
which does not include a sessionToken. When the SMS check
occurs, the account has no sessionToken, so we force
the user down the CAD flow.

The fix? Add a `return` so the promise is propagated
whenever user.setSignedInAccountFromBrowserAccountData is
called.

fixes #5285