### PR TITLE
fix(test): Fix the OAuth with handshake tests on latest/stage/prod.

### DIFF
--- a/tests/functional/fx_desktop_handshake.js
+++ b/tests/functional/fx_desktop_handshake.js
@@ -20,7 +20,6 @@ define([
   const SYNC_FORCE_AUTH_PAGE_URL = `${FORCE_AUTH_PAGE_URL}&service=sync`;
 
   const SIGNIN_PAGE_URL = `${config.fxaContentRoot}signin?automatedBrowser=true&forceUA=${encodeURIComponent(userAgent)}`;
-  const OAUTH_SIGNIN_PAGE_URL = `${config.fxaContentRoot}oauth/signin?automatedBrowser=true&forceUA=${encodeURIComponent(userAgent)}&client_id=dcdb5ae7add825d2&state=asdf&scope=profile`; //eslint-disable-line max-len
   const SYNC_SIGNIN_PAGE_URL = `${SIGNIN_PAGE_URL}&service=sync`;
 
   const SIGNUP_PAGE_URL = `${config.fxaContentRoot}signup?automatedBrowser=true&forceUA=${encodeURIComponent(userAgent)}`;
@@ -214,51 +213,6 @@ define([
         // Then, sign in the user again, synthesizing the user having signed
         // into Sync after the initial sign in.
         .then(openPage(SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
-          webChannelResponses: {
-            'fxaccounts:fxa_status': {
-              signedInUser: browserSignedInAccount
-            }
-          }
-        }))
-        // browsers version of the world is ignored for non-Sync signins if another
-        // user has already signed in.
-        .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, otherEmail))
-        // normal email element is in the DOM to help password managers.
-        .then(testElementValueEquals(selectors.SIGNIN.EMAIL, otherEmail))
-        .then(testElementExists(selectors.SIGNIN.PASSWORD));
-    },
-
-    'OAuth signin page - user signed into browser, no user signed in locally': function () {
-      return this.remote
-        .then(openPage(OAUTH_SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
-          webChannelResponses: {
-            'fxaccounts:fxa_status': {
-              signedInUser: browserSignedInAccount
-            }
-          }
-        }))
-        .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, browserSignedInEmail))
-        // User can sign in with cached credentials, no password needed.
-        .then(noSuchElement(selectors.SIGNIN.PASSWORD))
-        .sleep(15000);
-    },
-
-    'OAuth signin page - user signed into browser, user signed in locally': function () {
-      return this.remote
-        // First, sign in the user to populate localStorage
-        .then(openPage(SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
-          webChannelResponses: {
-            'fxaccounts:fxa_status': {
-              signedInUser: null
-            }
-          }
-        }))
-        .then(fillOutSignIn(otherEmail, PASSWORD))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-
-        // Then, sign in the user again, synthesizing the user having signed
-        // into Sync after the initial sign in.
-        .then(openPage(OAUTH_SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, {
           webChannelResponses: {
             'fxaccounts:fxa_status': {
               signedInUser: browserSignedInAccount

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1080,14 +1080,14 @@ define([
    * @param   {string} waitForSelector query selector that indicates load is complete
    * @returns {promise} resolves when complete.
    */
-  const reOpenWithAdditionalQueryParams = thenify(function (additionalQueryParams, waitForSelector) {
+  const reOpenWithAdditionalQueryParams = thenify(function (additionalQueryParams, waitForSelector, options) {
     return this.parent
       .getCurrentUrl()
       .then(function (url) {
         var urlToOpen = addQueryParamsToLink(url, additionalQueryParams);
 
         return this.parent
-          .then(openPage(urlToOpen, waitForSelector));
+          .then(openPage(urlToOpen, waitForSelector, options));
       });
   });
 
@@ -1126,7 +1126,7 @@ define([
             return;
           }
           return this.parent
-            .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader));
+            .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader, options));
         });
     }
 
@@ -1141,7 +1141,7 @@ define([
       .then(function () {
         if (Object.keys(queryParams).length) {
           return this.parent
-            .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader));
+            .then(reOpenWithAdditionalQueryParams(queryParams, expectedHeader, options));
         }
       });
   });

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -10,6 +10,9 @@ define([], function () {
 
   /*eslint-disable max-len*/
   return {
+    '123DONE': {
+      LOGOUT: '#logout'
+    },
     '400': {
       ERROR: '.error',
       HEADER: '#fxa-400-header'

--- a/tests/functional/oauth_handshake.js
+++ b/tests/functional/oauth_handshake.js
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!object',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers',
+  'tests/functional/lib/selectors',
+  'tests/functional/lib/ua-strings'
+], function (registerSuite, TestHelpers, FunctionalHelpers, selectors, uaStrings) {
+  'use strict';
+
+  const userAgent = uaStrings['desktop_firefox_55'];
+
+  var browserSignedInEmail;
+  let browserSignedInAccount;
+
+  let otherEmail;
+  let otherAccount;
+
+  const PASSWORD = '12345678';
+
+  const click = FunctionalHelpers.click;
+  const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const createUser = FunctionalHelpers.createUser;
+  const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
+  const openFxaFromRp = FunctionalHelpers.openFxaFromRp;
+  const noSuchElement = FunctionalHelpers.noSuchElement;
+  const testElementExists = FunctionalHelpers.testElementExists;
+  const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
+  const testElementValueEquals = FunctionalHelpers.testElementValueEquals;
+  const thenify = FunctionalHelpers.thenify;
+
+  const ensureUsers = thenify(function () {
+    return this.parent
+      .then(() => {
+        if (! browserSignedInAccount) {
+          browserSignedInEmail = TestHelpers.createEmail();
+          return this.parent
+            .then(createUser(browserSignedInEmail, PASSWORD, { preVerified: true }))
+            .then((_browserSignedInAccount) => {
+              browserSignedInAccount = _browserSignedInAccount;
+              browserSignedInAccount.email = browserSignedInEmail;
+              browserSignedInAccount.verified = true;
+            });
+        }
+      })
+      .then(() => {
+        if (! otherAccount) {
+          otherEmail = TestHelpers.createEmail();
+          return this.parent
+            .then(createUser(otherEmail, PASSWORD, { preVerified: true }))
+            .then((_otherAccount) => {
+              otherAccount = _otherAccount;
+              otherAccount.email = otherEmail;
+              otherAccount.verified = true;
+            });
+        }
+      });
+  });
+
+  registerSuite({
+    name: 'Firefox desktop user info handshake - OAuth flows',
+
+    beforeEach: function () {
+      return this.remote.then(clearBrowserState())
+        .then(ensureUsers());
+    },
+
+    afterEach: function () {
+      return this.remote.then(clearBrowserState());
+    },
+
+    'OAuth signin page - user signed into browser, no user signed in locally': function () {
+      return this.remote
+        .then(openFxaFromRp('signin', {
+          header: selectors.SIGNIN.HEADER,
+          query: {
+            automatedBrowser: true,
+            forceUA: userAgent
+          },
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, browserSignedInEmail))
+        // User can sign in with cached credentials, no password needed.
+        .then(noSuchElement(selectors.SIGNIN.PASSWORD));
+    },
+
+    'OAuth signin page - user signed into browser, user signed in locally': function () {
+      return this.remote
+        // First, sign in the user to populate localStorage
+        .then(openFxaFromRp('signin', {
+          header: selectors.SIGNIN.HEADER,
+          query: {
+            automatedBrowser: true,
+            forceUA: userAgent
+          },
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: null
+            }
+          }
+        }))
+        .then(fillOutSignIn(otherEmail, PASSWORD))
+        .then(click(selectors['123DONE'].LOGOUT))
+
+        // Then, sign in the user again, synthesizing the user having signed
+        // into Sync after the initial sign in.
+        .then(openFxaFromRp('signin', {
+          header: selectors.SIGNIN.HEADER,
+          query: {
+            automatedBrowser: true,
+            forceUA: userAgent
+          },
+          webChannelResponses: {
+            'fxaccounts:fxa_status': {
+              signedInUser: browserSignedInAccount
+            }
+          }
+        }))
+        // browsers version of the world is ignored for non-Sync signins if another
+        // user has already signed in.
+        .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, otherEmail))
+        // normal email element is in the DOM to help password managers.
+        .then(testElementValueEquals(selectors.SIGNIN.EMAIL, otherEmail))
+        .then(testElementExists(selectors.SIGNIN.PASSWORD));
+    }
+  });
+});

--- a/tests/functional_oauth.js
+++ b/tests/functional_oauth.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
+  './functional/oauth_handshake',
   './functional/amo_sign_up',
   './functional/oauth_choose_redirect',
   './functional/oauth_query_param_validation',


### PR DESCRIPTION
The OAuth handshake tests hard coded a test client_id that is valid
against the local server. The same client_id is not valid against
latest/stage/prod.

To get a real client_id, go to an actual 123done instance, then
redirect to the content server and continue the tests.

Note, these tests were extracted from fx_desktop_handshake
into oauth_handshake because OAuth tests cannot be run on circle
since circle doesn't have access to an OAuth relier.

The test is added to the OAuth list, which *is* run when running
the full list. TeamCity uses the full list, so the test will
be run there.

fixes #5300