### PR TITLE
fix(back): Clicks on the hash button no longer append # to the URL.

### DIFF
--- a/app/scripts/views/mixins/back-mixin.js
+++ b/app/scripts/views/mixins/back-mixin.js
@@ -5,24 +5,28 @@
 /**
  * View mixin to handle an in-content back button.
  *
- * @class BackMixin
+ * Adds `canGoBack` to context.
+ *
+ * Hooks up click and key handlers on elements w/
+ * the selectors `#back` and `.back`.
+ *
+ * @mixin BackMixin
  */
 
 define(function (require, exports, module) {
   'use strict';
 
-  const BaseView = require('views/base');
+  const { preventDefaultThen } = require('views/base');
   const KeyCodes = require('lib/key-codes');
 
   module.exports = {
-    _canGoBack: false,
     initialize (options = {}) {
-      this._canGoBack = options.canGoBack;
+      this._canGoBack = !! options.canGoBack;
     },
 
     events: {
-      'click #back': 'back',
-      'keyup #back': BaseView.preventDefaultThen('backOnEnter')
+      'click #back,.back': preventDefaultThen('back'),
+      'keyup #back,.back': 'backOnEnter'
     },
 
     setInitialContext (context) {
@@ -56,6 +60,8 @@ define(function (require, exports, module) {
      */
     backOnEnter (event) {
       if (event.which === KeyCodes.ENTER) {
+        event.preventDefault();
+
         this.back();
       }
     },

--- a/app/tests/spec/views/mixins/back-mixin.js
+++ b/app/tests/spec/views/mixins/back-mixin.js
@@ -12,10 +12,9 @@ define(function (require, exports, module) {
   const KeyCodes = require('lib/key-codes');
   const Notifier = require('lib/channels/notifier');
   const sinon = require('sinon');
-  const TestTemplate = require('stache!templates/test_template');
 
   const View = BaseView.extend({
-    template: TestTemplate
+    template: (context) => '<a href="#" id="back">Back</a>'
   });
 
   Cocktail.mixin(
@@ -69,21 +68,27 @@ define(function (require, exports, module) {
     });
 
     describe('backOnEnter', function () {
-      it('calls back if user presses ENTER key', function () {
-        sinon.spy(view, 'back');
+      let preventDefaultSpy;
 
-        view.backOnEnter({ which: KeyCodes.ENTER });
-        assert.isTrue(view.back.called);
+      beforeEach(() => {
+        sinon.spy(view, 'back');
+        preventDefaultSpy = sinon.spy();
+      });
+
+      it('calls back if user presses ENTER key', function () {
+        view.backOnEnter({ preventDefault: preventDefaultSpy, which: KeyCodes.ENTER });
+
+        assert.isTrue(view.back.calledOnce);
+        assert.isTrue(preventDefaultSpy.calledOnce);
       });
 
       it('does not call back if user presses any key besides ENTER', function () {
-        sinon.stub(view, 'canGoBack', function () {
-          return true;
-        });
-        sinon.spy(view, 'back');
+        sinon.stub(view, 'canGoBack', () => true);
 
-        view.backOnEnter({ which: KeyCodes.ENTER + 1});
+        view.backOnEnter({ preventDefault: preventDefaultSpy, which: KeyCodes.ENTER + 1});
+
         assert.isFalse(view.back.called);
+        assert.isFalse(preventDefaultSpy.called);
       });
     });
 

--- a/app/tests/spec/views/mixins/back-mixin.js
+++ b/app/tests/spec/views/mixins/back-mixin.js
@@ -65,6 +65,18 @@ define(function (require, exports, module) {
         assert.isTrue(view.logViewEvent.calledOnce);
         assert.isTrue(view.logViewEvent.calledWith('back'));
       });
+
+      describe('clicks on `#back`', () => {
+        it('calls `event.preventDefault`', () => {
+          $('#container').html(view.el);
+
+          const clickEvent = $.Event('click');
+          clickEvent.currentTarget = $('a#back');
+
+          view.$('#back').trigger(clickEvent);
+          assert.isTrue(clickEvent.isDefaultPrevented());
+        });
+      });
     });
 
     describe('backOnEnter', function () {


### PR DESCRIPTION
`preventDefaultThen` was being called in the wrong place. We were not
calling it on click handlers, but we were always calling it on keyup,
event if the key was not `ENTER`.

fixes #5290

@mozilla/fxa-devs - r?