### PR TITLE
fix(handshake): Fix the OAuth handshake test against latest.

### DIFF
--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -11,7 +11,9 @@ define([], function () {
   /*eslint-disable max-len*/
   return {
     '123DONE': {
-      LOGOUT: '#logout'
+      BUTTON_SIGNIN: '.sign-in-button.signin',
+      BUTTON_SIGNUP: '.sign-in-button.signup',
+      LINK_LOGOUT: '#logout'
     },
     '400': {
       ERROR: '.error',

--- a/tests/functional/oauth_handshake.js
+++ b/tests/functional/oauth_handshake.js
@@ -31,6 +31,7 @@ define([
   const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
   const testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   const thenify = FunctionalHelpers.thenify;
+  const visibleByQSA = FunctionalHelpers.visibleByQSA;
 
   const ensureUsers = thenify(function () {
     return this.parent
@@ -107,7 +108,13 @@ define([
           }
         }))
         .then(fillOutSignIn(otherEmail, PASSWORD))
-        .then(click(selectors['123DONE'].LOGOUT))
+        .then(click(selectors['123DONE'].LINK_LOGOUT))
+
+        // Wait for the signin button to be visible before
+        // attempting to refresh the page. If the refresh is
+        // done before signout has completed, 123done shows
+        // an alert box which blocks the rest of the text.
+        .then(visibleByQSA(selectors['123DONE'].BUTTON_SIGNIN))
 
         // Then, sign in the user again, synthesizing the user having signed
         // into Sync after the initial sign in.


### PR DESCRIPTION
There was a timing problem - after clicking the logout link,
the test did not wait for the logout action to complete before
attempting to reload the page. 123done would cause a browser
modal dialog to display, which caused the test to fail.

fixes #5307

@mozilla/fxa-devs - r?