### PR TITLE
refactor(reset_password): Use back-mixin in reset_password

### DIFF
--- a/app/scripts/templates/reset_password.mustache
+++ b/app/scripts/templates/reset_password.mustache
@@ -34,14 +34,11 @@
       </div>
     </form>
 
+    {{#canGoBack}}
     <div class="links">
-      {{#forceEmail}}
-        <a href="/force_auth" class="sign-in">{{#t}}Remember password? Sign in{{/t}}</a>
-      {{/forceEmail}}
-      {{^forceEmail}}
-        <a href="/signin" class="sign-in">{{#t}}Remember password? Sign in{{/t}}</a>
-      {{/forceEmail}}
+      <a href="#" id="back" class="sign-in">{{#t}}Remember password? Sign in{{/t}}</a>
     </div>
+    {{/canGoBack}}
 
   </section>
 </div>

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const AuthErrors = require('lib/auth-errors');
+  const BackMixin = require('views/mixins/back-mixin');
   const Cocktail = require('cocktail');
   const FormView = require('views/form');
   const FlowEventsMixin = require('views/mixins/flow-events-mixin');
@@ -90,6 +91,7 @@ define(function (require, exports, module) {
 
   Cocktail.mixin(
     ResetPasswordView,
+    BackMixin,
     FlowEventsMixin,
     PasswordResetMixin,
     ServiceMixin

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -72,7 +72,7 @@ define([], function () {
       HEADER: '#fxa-reset-password-header',
       LINK_ERROR_SIGNUP: '.error a[href="/signup"]',
       LINK_LEARN_HOW_SYNC_WORKS: 'a[href="https://support.mozilla.org/products/firefox/sync"]',
-      LINK_SIGNIN: 'a[href="/signin"]',
+      LINK_SIGNIN: '#back',
       SUBMIT: 'button[type="submit"]',
       SUCCESS: '.success'
     },


### PR DESCRIPTION
The reset_password view hard coded it's previous view,
which makes it more difficult to use reset_password
from other views than needs to be.

Use the back-mixin which provides generic functionality.

This was originally part of #5177, but no longer required for that patch.

@mozilla/fxa-devs - r?