### PR TITLE
fix(test): Fix the fx_firstrun_v2 signup tests in Fx 54.

### DIFF
--- a/app/scripts/templates/choose_what_to_sync.mustache
+++ b/app/scripts/templates/choose_what_to_sync.mustache
@@ -16,8 +16,8 @@
       <div class="two-col-items">
         {{#engines}}
           <div class="input-row choose-what-to-sync-row">
-            <label class="fxa-checkbox">
-              <input name="sync-content" type="checkbox" class="customize-sync" {{#checked}}checked="checked"{{/checked}} value="{{id}}" id="sync-engine-{{id}}" tabindex="{{tabindex}}">
+            <label class="fxa-checkbox" id="sync-engine-{{id}}">
+              <input name="sync-content" type="checkbox" class="customize-sync" {{#checked}}checked="checked"{{/checked}} value="{{id}}" tabindex="{{tabindex}}">
               <span class="fxa-checkbox__label">
                 {{text}}
               </span>


### PR DESCRIPTION
The tests that deselected a bucket on CWTS failed on Fx 54
because the original input element is too small to click
after being updated to use the Google Material style.

The fixes the problem by moving the label used as the selector
from the input element to the label, which is always visible.

fixes #5330 

@vladikoff - mind giving this an r? since you did the original code?