### PR TITLE
fix(experiments): Do not delegate to `experiments` methods after view destroy

### DIFF
--- a/app/scripts/views/mixins/experiment-mixin.js
+++ b/app/scripts/views/mixins/experiment-mixin.js
@@ -43,11 +43,13 @@ define(function (require, exports, module) {
      * @returns {Object} experiment object, if created.
      */
     createExperiment (...args) {
-      // force the flow model to be initialized so that
-      // the experiment is logged.
-      this.notifier.trigger('flow.initialize');
+      if (this.experiments) {
+        // force the flow model to be initialized so that
+        // the experiment is logged.
+        this.notifier.trigger('flow.initialize');
 
-      return this.experiments.createExperiment(...args);
+        return this.experiments.createExperiment(...args);
+      }
     }
   };
 
@@ -58,7 +60,9 @@ define(function (require, exports, module) {
     'isInExperimentGroup'
   ].forEach((methodName) => {
     module.exports[methodName] = function (...args) {
-      return this.experiments[methodName](...args);
+      if (this.experiments) {
+        return this.experiments[methodName](...args);
+      }
     };
   });
 });

--- a/app/tests/spec/views/mixins/experiment-mixin.js
+++ b/app/tests/spec/views/mixins/experiment-mixin.js
@@ -37,7 +37,10 @@ define(function (require, exports, module) {
         createExperiment: sinon.spy(() => {
           return {};
         }),
-        destroy () {}
+        destroy () {},
+        getExperimentGroup: sinon.spy(),
+        isInExperiment: sinon.spy(),
+        isInExperimentGroup: sinon.spy()
       };
 
       notifier = {
@@ -82,12 +85,29 @@ define(function (require, exports, module) {
         assert.isTrue(experiments.createExperiment.calledOnce);
         assert.isTrue(experiments.createExperiment.calledWith('experimentName', 'control'));
       });
+
+      it('does nothing if the view has been destroyed', () => {
+        view.destroy();
+        assert.notOk(view.createExperiment('experimentName', 'control'));
+      });
     });
 
-    it('contains delegate functions', () => {
-      assert.isFunction(view.getExperimentGroup);
-      assert.isFunction(view.isInExperiment);
-      assert.isFunction(view.isInExperimentGroup);
+    describe('delegate methods', () => {
+      const delegateMethods = ['getExperimentGroup', 'isInExperiment', 'isInExperimentGroup'];
+      delegateMethods.forEach((methodName) => {
+        it(`delegates ${methodName} correctly`, () => {
+          assert.isFunction(view[methodName]);
+
+          view[methodName]('foo', 'bar', 'baz');
+          assert.isTrue(experiments[methodName].calledOnce);
+          assert.isTrue(experiments[methodName].calledWith('foo', 'bar', 'baz'));
+
+          view.destroy();
+          view[methodName]('foo', 'bar', 'baz');
+          // the view is destroyed, can no longer delegate to experiments.
+          assert.isTrue(experiments[methodName].calledOnce);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
The experiment mixin made an assumption that `this.experiments` was always
available in the delegate methods. This assumption is invalid once view.destroy
is called.

This caused a problem on the confirm page - if the app was polling for
an email confirmation and the user clicks the browser's `back` button,
the confirm view was destroyed when the page went back to CWTS, but
the poll continued. If the user verified their email, the poll would
complete, which would then attempt to call the confirm view's
`isInExperimentGroup` function. Since the view was destroyed,
`view.experiments` was `null`. Kaboom.

issue #5323
fixes #5324

@mozilla/fxa-devs - r?