### PR TITLE
refactor(config): remove allowedParentOrigins from front-end config

### DIFF
--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -6,7 +6,6 @@
 const flowMetrics = require('../flow-metrics');
 
 module.exports = function (config) {
-  const ALLOWED_PARENT_ORIGINS = config.get('allowed_parent_origins');
   const AUTH_SERVER_URL = config.get('fxaccount_url');
   const CLIENT_ID = config.get('oauth_client_id');
   const ENV = config.get('env');
@@ -20,7 +19,6 @@ module.exports = function (config) {
   const RELEASE = require('../../../package.json').version;
 
   const serializedConfig = encodeURIComponent(JSON.stringify({
-    allowedParentOrigins: ALLOWED_PARENT_ORIGINS,
     authServerUrl: AUTH_SERVER_URL,
     env: ENV,
     marketingEmailPreferencesUrl: MARKETING_EMAIL_PREFERENCES_URL,

--- a/tests/server/routes/get-index.js
+++ b/tests/server/routes/get-index.js
@@ -62,8 +62,6 @@ define([
           assert.isString(renderParams.config);
           var sentConfig = JSON.parse(decodeURIComponent(renderParams.config));
 
-          assert.deepEqual(sentConfig.allowedParentOrigins,
-                           config.get('allowed_parent_origins'));
           assert.equal(sentConfig.authServerUrl, config.get('fxaccount_url'));
           assert.equal(sentConfig.env, config.get('env'));
           assert.equal(sentConfig.marketingEmailPreferencesUrl,


### PR DESCRIPTION
@shane-tomlinson r?

I don't think we use this value on the front-end