### PR TITLE
fix(signin): redirect to signin if bounced screen has no email

### DIFF
--- a/app/scripts/views/sign_in_bounced.js
+++ b/app/scripts/views/sign_in_bounced.js
@@ -26,6 +26,15 @@ define(function (require, exports, module) {
       this._formPrefill = options.formPrefill;
     },
 
+    beforeRender () {
+      if (! this.model.has('email')) {
+        // This may occur if the user has refreshed the page. In that case,
+        // we have no context for properly rendering the view, so kick them
+        // out to /signin where they can start again.
+        this.navigate('signin');
+      }
+    },
+
     setInitialContext (context) {
       context.set({
         email: this.model.get('email'),

--- a/app/tests/spec/views/sign_in_bounced.js
+++ b/app/tests/spec/views/sign_in_bounced.js
@@ -33,6 +33,31 @@ define((require, exports, module) => {
       assert.strictEqual(view.template, template);
     });
 
+    describe('beforeRender', () => {
+      beforeEach(() => {
+        view.navigate = sinon.spy();
+        view.beforeRender();
+      });
+
+      it('did not call navigate', () => {
+        assert.equal(view.navigate.callCount, 0);
+      });
+    });
+
+    describe('beforeRender, this.model.has(\'email\') === false', () => {
+      beforeEach(() => {
+        model.unset('email');
+        view.navigate = sinon.spy();
+        view.beforeRender();
+      });
+
+      it('called navigate correctly', () => {
+        assert.equal(view.navigate.callCount, 1);
+        assert.lengthOf(view.navigate.args[0], 1);
+        assert.equal(view.navigate.args[0][0], 'signin');
+      });
+    });
+
     describe('setInitialContext', () => {
       let context;
 

--- a/tests/functional/bounced_email.js
+++ b/tests/functional/bounced_email.js
@@ -154,6 +154,13 @@ define([
         .then(switchToWindow(1))
         .then(pollUntil(() => window.location.href.startsWith('https://support.mozilla.org/')))
         .then(closeCurrentWindow());
+    },
+
+    'refresh': function () {
+      return this.remote
+        .then(setUpBouncedSignIn())
+        .refresh()
+        .then(testElementExists(selectors.SIGNIN.HEADER));
     }
   });
 });


### PR DESCRIPTION
Fixes #5334.

![Screen capture showing refresh on the signin-bounced screen redirecting to signin](https://user-images.githubusercontent.com/64367/28960160-74901840-78f5-11e7-9f0a-71aa92720b7f.gif)

@mozilla/fxa-devs r?