### PR TITLE
fix(cwts): Handle bounced emails and confirmations while on CWTS.

### DIFF
--- a/app/scripts/views/choose_what_to_sync.js
+++ b/app/scripts/views/choose_what_to_sync.js
@@ -10,6 +10,7 @@ define(function (require, exports, module) {
   const CheckboxMixin = require('views/mixins/checkbox-mixin');
   const Cocktail = require('cocktail');
   const FormView = require('views/form');
+  const SessionVerificationPollMixin = require('views/mixins/session-verification-poll-mixin');
   const Template = require('stache!templates/choose_what_to_sync');
 
   const SCREEN_CLASS = 'screen-choose-what-to-sync';
@@ -19,7 +20,7 @@ define(function (require, exports, module) {
     template: Template,
     className: 'choose-what-to-sync',
 
-    initialize () {
+    initialize (options = {}) {
       // Account data is passed in from sign up flow.
       this._account = this.user.initAccount(this.model.get('account'));
 
@@ -45,6 +46,15 @@ define(function (require, exports, module) {
       // where we want to hide the logo and not animate it
       // it uses `!important` to avoid the fade-in effect and inline styles.
       $('body').addClass(SCREEN_CLASS);
+    },
+
+    afterVisible () {
+      this.waitForSessionVerification(
+        this.getAccount(),
+        () => this.validateAndSubmit()
+      );
+
+      return proto.afterVisible.call(this);
     },
 
     destroy (...args) {
@@ -142,7 +152,8 @@ define(function (require, exports, module) {
   Cocktail.mixin(
     View,
     BackMixin,
-    CheckboxMixin
+    CheckboxMixin,
+    SessionVerificationPollMixin
   );
 
   module.exports = View;

--- a/app/tests/spec/views/confirm.js
+++ b/app/tests/spec/views/confirm.js
@@ -215,7 +215,7 @@ define(function (require, exports, module) {
           sinon.stub(view, 'isSignUp', () => true);
           sinon.stub(view, 'isSignIn', () => false);
 
-          return testgotoNextScreen('afterSignUpConfirmationPoll');
+          return testGotoNextScreen('afterSignUpConfirmationPoll');
         });
       });
 
@@ -224,11 +224,11 @@ define(function (require, exports, module) {
           sinon.stub(view, 'isSignUp', () => false);
           sinon.stub(view, 'isSignIn', () => true);
 
-          return testgotoNextScreen('afterSignInConfirmationPoll');
+          return testGotoNextScreen('afterSignInConfirmationPoll');
         });
       });
 
-      function testgotoNextScreen(expectedBrokerCall) {
+      function testGotoNextScreen(expectedBrokerCall) {
         const notifySpy = sinon.spy(view.notifier, 'trigger');
 
         sinon.stub(broker, expectedBrokerCall, () => p());

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -105,6 +105,27 @@ define([
         .then(clearBrowserState());
     },
 
+    'sign up, user verifies at CWTS': function () {
+      return this.remote
+        .then(openPage(PAGE_URL, selectors.SIGNUP.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:can_link_account': { ok: true }
+          }
+        }))
+        .then(visibleByQSA(selectors.SIGNUP.SUB_HEADER))
+
+        .then(fillOutSignUp(email, PASSWORD))
+
+        .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(openVerificationLinkInDifferentBrowser(email, 0))
+
+        // user should be transitioned straight to the "your address is confirmed"
+        .then(testElementExists(selectors.SIGNUP_COMPLETE.HEADER))
+        // the login message is sent automatically.
+        .then(testIsBrowserNotified('fxaccounts:login'));
+    },
+
     'sign up, verify same browser': function () {
       return this.remote
         .then(setupTest())

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -130,11 +130,13 @@ define([], function () {
       MARKETING_EMAIL_OPTIN: 'input.marketing-email-optin',
       PASSWORD: '#password',
       SUBMIT: 'button[type="submit"]',
+      SUBMIT_DISABLED: 'button[type="submit"].disabled',
       SUB_HEADER: '#fxa-signup-header .service',
       SUGGEST_EMAIL_DOMAIN_CORRECTION: '.tooltip-suggest',
       SUGGEST_SIGN_IN: '.error',
       SUGGEST_SYNC: '#suggest-sync',
-      VPASSWORD: '#vpassword'
+      TOOLTIP_BOUNCED_EMAIL: '.tooltip',
+      VPASSWORD: '#vpassword',
     },
     SIGNUP_COMPLETE: {
       HEADER: '#fxa-sign-up-complete-header'


### PR DESCRIPTION
Use the session-verification-poll-mixin in the CWTS page to
handle both bounces and auto-submit the form if verification completes.

fixes #4094
fixes #4193 

Builds on #5342 and should be reviewed afterwards

![bounce-submit-cwts](https://user-images.githubusercontent.com/848085/29071768-e49559c6-7c3c-11e7-8a34-035eaf4fd05b.gif)
