### PR TITLE
fix(email-first): Navigate to `/`, not `/email` if no account.

### DIFF
--- a/app/scripts/views/sign_in_password.js
+++ b/app/scripts/views/sign_in_password.js
@@ -19,23 +19,26 @@ define(function (require, exports, module) {
       super(options);
 
       this.template = Template;
-      this._account = this.model.get('account');
+    }
+
+    getAccount () {
+      return this.model.get('account');
     }
 
     beforeRender () {
-      if (! this._account) {
-        this.navigate('email');
+      if (! this.getAccount()) {
+        this.navigate('/');
       }
     }
 
     setInitialContext (context) {
-      context.set(this._account.pick('email'));
+      context.set(this.getAccount().pick('email'));
     }
 
     submit () {
       const password = this.getElementValue('input[type=password]');
 
-      return this.signIn(this._account, password);
+      return this.signIn(this.getAccount(), password);
     }
   }
 

--- a/app/scripts/views/sign_up_password.js
+++ b/app/scripts/views/sign_up_password.js
@@ -24,17 +24,20 @@ define(function (require, exports, module) {
       super(options);
 
       this.template = Template;
-      this._account = this.model.get('account');
+    }
+
+    getAccount () {
+      return this.model.get('account');
     }
 
     beforeRender () {
-      if (! this._account) {
-        this.navigate('email');
+      if (! this.getAccount()) {
+        this.navigate('/');
       }
     }
 
     setInitialContext (context) {
-      context.set(this._account.pick('email'));
+      context.set(this.getAccount().pick('email'));
     }
 
     isValidEnd () {
@@ -53,8 +56,9 @@ define(function (require, exports, module) {
           return this.tooYoung();
         }
 
-        this._account.set('needsOptedInToMarketingEmail', this.hasOptedInToMarketingEmail());
-        return this.signUp(this._account, this._getPassword());
+        const account = this.getAccount();
+        account.set('needsOptedInToMarketingEmail', this.hasOptedInToMarketingEmail());
+        return this.signUp(account, this._getPassword());
       });
     }
 

--- a/app/tests/spec/views/sign_in_password.js
+++ b/app/tests/spec/views/sign_in_password.js
@@ -58,6 +58,29 @@ define(function (require, exports, module) {
       view = null;
     });
 
+    describe('beforeRender', () => {
+      beforeEach(() => {
+        sinon.spy(view, 'navigate');
+      });
+
+      it('redirects to `/` if no account', () => {
+        sinon.stub(view, 'getAccount', () => null);
+
+        view.beforeRender();
+
+        assert.isTrue(view.navigate.calledOnce);
+        assert.isTrue(view.navigate.calledWith('/'));
+      });
+
+      it('does nothing if an account passed in', () => {
+        sinon.stub(view, 'getAccount', () => account);
+
+        view.beforeRender();
+
+        assert.isFalse(view.navigate.called);
+      });
+    });
+
     describe('render', () => {
       it('renders as expected', () => {
         assert.include(view.$('.service').text(), 'Firefox Sync');

--- a/app/tests/spec/views/sign_up_password.js
+++ b/app/tests/spec/views/sign_up_password.js
@@ -64,6 +64,29 @@ define(function (require, exports, module) {
       view = null;
     });
 
+    describe('beforeRender', () => {
+      beforeEach(() => {
+        sinon.spy(view, 'navigate');
+      });
+
+      it('redirects to `/` if no account', () => {
+        sinon.stub(view, 'getAccount', () => null);
+
+        view.beforeRender();
+
+        assert.isTrue(view.navigate.calledOnce);
+        assert.isTrue(view.navigate.calledWith('/'));
+      });
+
+      it('does nothing if an account passed in', () => {
+        sinon.stub(view, 'getAccount', () => account);
+
+        view.beforeRender();
+
+        assert.isFalse(view.navigate.called);
+      });
+    });
+
     describe('render', () => {
       it('renders as expected', () => {
         assert.include(view.$('.service').text(), 'Firefox Sync');


### PR DESCRIPTION
The signin and signup pages for the email-first flow erroneously
redirected the user to `/email` instead of `/`.

Not attached to a bug.

@philbooth - r?