### PR TITLE
fix(metrics): Use `enter-email` as the viewName for `/`.

### DIFF
--- a/app/scripts/views/index.js
+++ b/app/scripts/views/index.js
@@ -28,9 +28,13 @@ define(function (require, exports, module) {
       this.template = Template;
     }
 
+    get viewName () {
+      return 'enter-email';
+    }
+
     afterRender () {
       // 1. COPPA checks whether the user is too young in beforeRender.
-      // So that COPPA takes precedece, do all other checks afterwards.
+      // So that COPPA takes precedence, do all other checks afterwards.
       // 2. action=email is specified by the firstrun page to specify
       // the email-first flow.
       const action = this.relier.get('action');

--- a/app/tests/spec/views/index.js
+++ b/app/tests/spec/views/index.js
@@ -43,7 +43,6 @@ define((require, exports, module) => {
         notifier,
         relier,
         user,
-        viewName: 'email',
         window: windowMock
       });
 
@@ -58,6 +57,9 @@ define((require, exports, module) => {
       view = null;
     });
 
+    it('getViewName returns `enter-email`', () => {
+      assert.equal(view.getViewName(), 'enter-email');
+    });
 
     describe('render', () => {
       beforeEach(() => {


### PR DESCRIPTION
viewNames are normally created from the URL pathname.
The pathname for `/` is ``, meaning the view had no name.
This would show up in metrics with things like `flow..view`

This sets the viewName for `/` to `email-first`

fixes #5372 

@philbooth - mind reviewing?