### PR TITLE
fix(metrics): Do not log views that navigate in afterRender.

### DIFF
--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -194,17 +194,31 @@ define(function (require, exports, module) {
             });
       });
 
-      it('does not render if the view has already navigated', () => {
+      it('does not render, returns `false` if the view navigates in `beforeRender`', () => {
         sinon.spy(view, 'renderTemplate');
         sinon.spy(view, 'navigate');
-        sinon.stub(view, 'beforeRender', function () {
-          this.navigate('signin');
-        });
+        sinon.stub(view, 'beforeRender', () => view.navigate('signin'));
 
         return view.render()
-          .then(() => {
-            assert.isTrue(view.navigate.called);
+          .then((shouldDisplay) => {
+            assert.isFalse(shouldDisplay);
+            assert.isTrue(view.navigate.calledOnce);
+            assert.isTrue(view.navigate.calledWith('signin'));
             assert.isFalse(view.renderTemplate.called);
+          });
+      });
+
+      it('returns `false` if the view navigates in `afterRender`', () => {
+        sinon.spy(view, 'renderTemplate');
+        sinon.spy(view, 'navigate');
+        sinon.stub(view, 'afterRender', () => view.navigate('signin'));
+
+        return view.render()
+          .then((shouldDisplay) => {
+            assert.isFalse(shouldDisplay);
+            assert.isTrue(view.navigate.calledOnce);
+            assert.isTrue(view.navigate.calledWith('signin'));
+            assert.isTrue(view.renderTemplate.calledOnce);
           });
       });
 


### PR DESCRIPTION
Views that navigate in `beforeRender` are not rendered to the DOM
and are not logged in metrics. Views that navigate in `afterRender`
erroneously are. This unifies the behavior so that if `navigate`
is called any time during `render`, the view is not rendered
to the DOM, nor is the view logged in metrics.

This fixes a problem where users that visit `/` and immediately
redirect to `/signup` or `/settings` still have the `/` view
logged, skewing the metrics making it seem like more people
see `/` than really do.

fixes #5375 

@mozilla/fxa-devs - r?