### PR TITLE
feat(email-first): Handle relier specified emails in email-first flow.

### DIFF
--- a/app/scripts/views/index.js
+++ b/app/scripts/views/index.js
@@ -17,6 +17,7 @@ define(function (require, exports, module) {
   const FlowBeginMixin = require('views/mixins/flow-begin-mixin');
   const FormPrefillMixin = require('views/mixins/form-prefill-mixin');
   const FormView = require('views/form');
+  const p = require('lib/promise');
   const SearchParamMixin = require('lib/search-param-mixin');
   const ServiceMixin = require('views/mixins/service-mixin');
   const Template = require('stache!templates/index');
@@ -45,6 +46,13 @@ define(function (require, exports, module) {
       } else if (this.isInEmailFirstExperimentGroup('treatment') || action === 'email') {
         // let's the router know to use the email-first signin/signup page
         this.notifier.trigger('email-first-flow');
+        const email = this.relier.get('email');
+        if (email) {
+          const TEST_REQUEST_DELAY_MS = this.broker.isAutomatedBrowser() ? 500 : 0;
+          // The delay is to give the functional tests time to hook up
+          // WebChannel message response listeners.
+          return p().delay(TEST_REQUEST_DELAY_MS).then(() => this.checkEmail(email));
+        }
       } else {
         this.replaceCurrentPage('signup');
       }

--- a/app/tests/spec/views/index.js
+++ b/app/tests/spec/views/index.js
@@ -109,8 +109,8 @@ define((require, exports, module) => {
           });
         });
 
-        describe('relier.action set, === email', () => {
-          it('replaces current page with page specified by `action`', () => {
+        describe('relier.action === email', () => {
+          it('renders as expected, starts the flow metrics', () => {
             relier.set({
               action: 'email',
               service: 'sync',
@@ -134,6 +134,24 @@ define((require, exports, module) => {
 
                 assert.isTrue(view.logFlowEventOnce.calledOnce);
                 assert.isTrue(view.logFlowEventOnce.calledWith('begin'));
+              });
+          });
+
+          it('handles relier specified emails', () => {
+            relier.set({
+              action: 'email',
+              email: 'testuser@testuser.com',
+              service: 'sync',
+              serviceName: 'Firefox Sync'
+            });
+
+            sinon.stub(view, 'isInEmailFirstExperimentGroup', () => false);
+            sinon.stub(view, 'checkEmail', () => p());
+
+            return view.render()
+              .then(() => {
+                assert.isTrue(view.checkEmail.calledOnce);
+                assert.isTrue(view.checkEmail.calledWith('testuser@testuser.com'));
               });
           });
         });

--- a/tests/functional/fx_firstrun_v2_email_first.js
+++ b/tests/functional/fx_firstrun_v2_email_first.js
@@ -40,7 +40,6 @@ define([
       return this.remote
         .then(clearBrowserState({ force: true }));
     },
-
     'signup': function () {
       return this.remote
         .then(openPage(PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
@@ -147,6 +146,33 @@ define([
           .then(closeCurrentWindow())
 
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
-    }
+    },
+
+    'email specified by relier, not registered': function () {
+      return this.remote
+      .then(openPage(PAGE_URL, selectors.SIGNUP_PASSWORD.HEADER, {
+        query: {
+          email
+        },
+        webChannelResponses: {
+          'fxaccounts:can_link_account': { ok: true }
+        }
+      }))
+      .then(testElementValueEquals(selectors.SIGNUP_PASSWORD.EMAIL, email));
+    },
+
+    'email specified by relier, registered': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(PAGE_URL, selectors.SIGNIN_PASSWORD.HEADER, {
+          query: {
+            email
+          },
+          webChannelResponses: {
+            'fxaccounts:can_link_account': { ok: true }
+          }
+        }))
+        .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.EMAIL, email));
+    },
   });
 });

--- a/tests/functional/sync_v3_email_first.js
+++ b/tests/functional/sync_v3_email_first.js
@@ -197,6 +197,33 @@ define([
           .then(closeCurrentWindow())
 
         .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER));
-    }
+    },
+
+    'email specified by relier, not registered': function () {
+      return this.remote
+      .then(openPage(INDEX_PAGE_URL, selectors.SIGNUP_PASSWORD.HEADER, {
+        query: {
+          email
+        },
+        webChannelResponses: {
+          'fxaccounts:can_link_account': { ok: true }
+        }
+      }))
+      .then(testElementValueEquals(selectors.SIGNUP_PASSWORD.EMAIL, email));
+    },
+
+    'email specified by relier, registered': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(INDEX_PAGE_URL, selectors.SIGNIN_PASSWORD.HEADER, {
+          query: {
+            email
+          },
+          webChannelResponses: {
+            'fxaccounts:can_link_account': { ok: true }
+          }
+        }))
+        .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.EMAIL, email));
+    },
   });
 });


### PR DESCRIPTION
If the relier specifies an email, check whether the email is registered.
Do the right thing afterwards.

fixes #5353 

@mozilla/fxa-devs - r?