### PR TITLE
fix(email): Add success message when removing secondary email

### DIFF
--- a/app/scripts/templates/settings/emails.mustache
+++ b/app/scripts/templates/settings/emails.mustache
@@ -50,7 +50,7 @@
                                         </button>
                                         {{/canChangePrimaryEmail }}
                                     {{/verified}}
-                                    <button class="settings-button warning email-disconnect unpaired" data-id="{{email}}">
+                                    <button class="settings-button warning email-disconnect" data-id="{{email}}">
                                         {{#t}}Remove{{/t}}
                                     </button>
                                 </div>

--- a/app/scripts/views/settings/emails.js
+++ b/app/scripts/views/settings/emails.js
@@ -111,7 +111,10 @@ define(function (require, exports, module) {
         .then(()=> {
           return this.render()
             .then(()=> {
-              this.navigate('/settings/emails');
+              this.displaySuccess(t('Secondary email removed'), {
+                closePanel: true
+              });
+              this.navigate('/settings');
             });
         });
     },

--- a/app/tests/spec/views/settings/emails.js
+++ b/app/tests/spec/views/settings/emails.js
@@ -198,6 +198,7 @@ define(function (require, exports, module) {
               // click events require the view to be in the DOM
               $('#container').html(view.el);
               sinon.spy(view, 'navigate');
+              sinon.spy(view, 'displaySuccess');
             });
         });
 
@@ -219,7 +220,8 @@ define(function (require, exports, module) {
               assert.isTrue(view.navigate.calledOnce);
               const args = view.navigate.args[0];
               assert.equal(args.length, 1);
-              assert.equal(args[0], '/settings/emails');
+              assert.equal(args[0], '/settings');
+              assert.equal(view.displaySuccess.callCount, 1);
             }, done);
           }, 150);
         });
@@ -269,6 +271,7 @@ define(function (require, exports, module) {
               // click events require the view to be in the DOM
               $('#container').html(view.el);
               sinon.spy(view, 'navigate');
+              sinon.spy(view, 'displaySuccess');
             });
         });
 
@@ -288,7 +291,8 @@ define(function (require, exports, module) {
               assert.isTrue(view.navigate.calledOnce);
               const args = view.navigate.args[0];
               assert.equal(args.length, 1);
-              assert.equal(args[0], '/settings/emails');
+              assert.equal(args[0], '/settings');
+              assert.equal(view.displaySuccess.callCount, 1);
             }, done);
           }, 150);
         });

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -60,7 +60,9 @@ define([], function () {
       INPUT: '.new-email',
       MENU_BUTTON: '#emails .settings-unit-stub button',
       NOT_VERIFIED_LABEL: '.not-verified',
+      REMOVE_BUTTON: '.email-address .settings-button.warning.email-disconnect',
       SET_PRIMARY_EMAIL_BUTTON: '.email-address .set-primary',
+      TOOLTIP: '.tooltip',
       VERIFIED_LABEL: '.verified'
     },
     ENTER_EMAIL: {
@@ -90,6 +92,7 @@ define([], function () {
       SUCCESS: '.success'
     },
     SETTINGS: {
+      CONTENT: '#fxa-settings-content',
       HEADER: '#fxa-settings-header',
       PROFILE_HEADER: '#fxa-settings-profile-header .card-header',
       PROFILE_SUB_HEADER: '#fxa-settings-profile-header .card-subheader',
@@ -122,7 +125,8 @@ define([], function () {
     },
     SIGNIN_UNBLOCK: {
       EMAIL_FIELD: '.verification-email-message',
-      HEADER: '#fxa-signin-unblock-header'
+      HEADER: '#fxa-signin-unblock-header',
+      SUBMIT: 'button[type="submit"]',
     },
     SIGNUP: {
       AGE: '#age',

--- a/tests/functional/settings_secondary_emails.js
+++ b/tests/functional/settings_secondary_emails.js
@@ -22,25 +22,27 @@ define([
   let email;
   let secondaryEmail;
 
-  const clearBrowserState = FunctionalHelpers.clearBrowserState;
-  const click = FunctionalHelpers.click;
-  const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-  const createUser = FunctionalHelpers.createUser;
-  const fillOutResetPassword = FunctionalHelpers.fillOutResetPassword;
-  const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  const getUnblockInfo = FunctionalHelpers.getUnblockInfo;
-  const openPage = FunctionalHelpers.openPage;
-  const openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
-  const openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
-  const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  const testElementExists = FunctionalHelpers.testElementExists;
-  const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
-  const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
-  const testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
-  const type = FunctionalHelpers.type;
-  const visibleByQSA = FunctionalHelpers.visibleByQSA;
+  const {
+    clearBrowserState,
+    click,
+    closeCurrentWindow,
+    createUser,
+    fillOutResetPassword,
+    fillOutSignIn,
+    fillOutSignUp,
+    getUnblockInfo,
+    openPage,
+    openVerificationLinkInDifferentBrowser,
+    openVerificationLinkInNewTab,
+    openVerificationLinkInSameTab,
+    respondToWebChannelMessage,
+    testElementExists,
+    testElementTextEquals,
+    testElementTextInclude,
+    testErrorTextInclude,
+    type,
+    visibleByQSA
+  } = FunctionalHelpers;
 
   registerSuite({
     name: 'settings secondary emails',
@@ -62,39 +64,39 @@ define([
         // sign up via the UI, we need a verified session to use secondary email
         .then(openPage(SIGNUP_URL, selectors.SIGNUP.HEADER))
         .then(fillOutSignUp(email, PASSWORD))
-        .then(testElementExists('#fxa-confirm-header'))
+        .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
         .then(openVerificationLinkInSameTab(email, 0))
         .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(click('#emails .settings-unit-stub button'))
+        .then(click(selectors.EMAIL.MENU_BUTTON))
 
         // attempt to the same email as primary
-        .then(type('.new-email', email))
-        .then(click('.email-add:not(.disabled)'))
-        .then(visibleByQSA('.tooltip'))
+        .then(type(selectors.EMAIL.INPUT, email))
+        .then(click(selectors.EMAIL.ADD_BUTTON))
+        .then(visibleByQSA(selectors.EMAIL.TOOLTIP))
 
         // add secondary email, resend and remove
-        .then(type('.new-email', TestHelpers.createEmail()))
-        .then(click('.email-add:not(.disabled)'))
-        .then(testElementExists('.not-verified'))
+        .then(type(selectors.EMAIL.INPUT, TestHelpers.createEmail()))
+        .then(click(selectors.EMAIL.ADD_BUTTON))
+        .then(testElementExists(selectors.EMAIL.NOT_VERIFIED_LABEL))
 
-        .then(click('.email-address .settings-button.warning.email-disconnect'))
-        .waitForDeletedByCssSelector('.email-address .settings-button.warning.email-disconnect')
+        .then(click(selectors.EMAIL.REMOVE_BUTTON))
+        .waitForDeletedByCssSelector(selectors.EMAIL.REMOVE_BUTTON)
 
-        .then(click('#emails .settings-unit-stub button'))
+        .then(click(selectors.EMAIL.MENU_BUTTON))
 
         // add secondary email, verify
-        .then(type('.new-email', secondaryEmail))
-        .then(click('.email-add:not(.disabled)'))
-        .then(testElementExists('.not-verified'))
+        .then(type(selectors.EMAIL.INPUT, secondaryEmail))
+        .then(click(selectors.EMAIL.ADD_BUTTON))
+        .then(testElementExists(selectors.EMAIL.NOT_VERIFIED_LABEL))
         .then(openVerificationLinkInSameTab(secondaryEmail, 0))
 
-        .then(click('#emails .settings-unit-stub button'))
+        .then(click(selectors.EMAIL.MENU_BUTTON))
 
-        .then(testElementTextEquals('#emails .address', secondaryEmail))
-        .then(testElementExists('.verified'))
+        .then(testElementTextEquals(selectors.EMAIL.ADDRESS_LABEL, secondaryEmail))
+        .then(testElementExists(selectors.EMAIL.VERIFIED_LABEL))
 
         // sign out, try to sign in with secondary
-        .then(click('#signout'))
+        .then(click(selectors.SETTINGS.SIGNOUT))
         .then(testElementExists(selectors.SIGNIN.HEADER))
         .then(fillOutSignIn(secondaryEmail, PASSWORD))
         .then(testErrorTextInclude('primary account email required'))
@@ -120,17 +122,17 @@ define([
 
         .then(openPage(SIGNUP_URL, selectors.SIGNUP.HEADER))
         .then(fillOutSignUp(unverifiedAccountEmail, PASSWORD))
-        .then(testElementExists('#fxa-confirm-header'))
+        .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
 
         // sign up and verify
         .then(openPage(SIGNUP_URL, selectors.SIGNUP.HEADER))
         .then(fillOutSignUp(email, PASSWORD))
-        .then(testElementExists('#fxa-confirm-header'))
+        .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
         .then(openVerificationLinkInSameTab(email, 0))
-        .then(click('#emails .settings-unit-stub button'))
-        .then(type('.new-email', unverifiedAccountEmail))
-        .then(click('.email-add:not(.disabled)'))
-        .then(visibleByQSA('.tooltip'));
+        .then(click(selectors.EMAIL.MENU_BUTTON))
+        .then(type(selectors.EMAIL.INPUT, unverifiedAccountEmail))
+        .then(click(selectors.EMAIL.ADD_BUTTON))
+        .then(visibleByQSA(selectors.EMAIL.TOOLTIP));
     },
 
     'signin and signup with existing secondary email': function () {
@@ -138,19 +140,19 @@ define([
         // sign up via the UI, we need a verified session to use secondary email
         .then(openPage(SIGNUP_URL, selectors.SIGNUP.HEADER))
         .then(fillOutSignUp(email, PASSWORD))
-        .then(testElementExists('#fxa-confirm-header'))
+        .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
         .then(openVerificationLinkInSameTab(email, 0))
         .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(click('#emails .settings-unit-stub button'))
+        .then(click(selectors.EMAIL.MENU_BUTTON))
 
-        .then(type('.new-email', secondaryEmail))
-        .then(click('.email-add:not(.disabled)'))
-        .then(testElementExists('.not-verified'))
+        .then(type(selectors.EMAIL.INPUT, secondaryEmail))
+        .then(click(selectors.EMAIL.ADD_BUTTON))
+        .then(testElementExists(selectors.EMAIL.NOT_VERIFIED_LABEL))
         .then(openVerificationLinkInSameTab(secondaryEmail, 0))
 
-        .then(click('#emails .settings-unit-stub button'))
-        .then(testElementExists('.verified'))
-        .then(click('#signout'))
+        .then(click(selectors.EMAIL.MENU_BUTTON))
+        .then(testElementExists(selectors.EMAIL.VERIFIED_LABEL))
+        .then(click(selectors.SETTINGS.SIGNOUT))
         .then(testElementExists(selectors.SIGNIN.HEADER))
         // try to signin with the secondary email
         .then(fillOutSignIn(secondaryEmail, PASSWORD))
@@ -158,7 +160,7 @@ define([
         // try to signup with the secondary email
         .then(openPage(SIGNUP_URL, selectors.SIGNUP.HEADER))
         .then(fillOutSignUp(email, PASSWORD))
-        .then(testElementExists('#fxa-settings-content'));
+        .then(testElementExists(selectors.SETTINGS.CONTENT));
     },
 
     'unblock code is sent to secondary emails': function () {
@@ -177,13 +179,13 @@ define([
           return this.parent
             .then(type('#unblock_code', '   ' + unblockInfo.unblockCode));
         })
-        .then(click('button[type=submit]'))
+        .then(click(selectors.SIGNIN_UNBLOCK.SUBMIT))
 
         .then(testElementExists(selectors.SETTINGS.HEADER))
         .then(openVerificationLinkInSameTab(secondaryEmail, 0))
-        .then(click('#emails .settings-unit-stub button'))
-        .then(testElementExists('.verified'))
-        .then(click('#signout'))
+        .then(click(selectors.EMAIL.MENU_BUTTON))
+        .then(testElementExists(selectors.EMAIL.VERIFIED_LABEL))
+        .then(click(selectors.SETTINGS.SIGNOUT))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testElementTextInclude(selectors.SIGNIN_UNBLOCK.EMAIL_FIELD, email))
         .then(getUnblockInfo(email, 0))
@@ -196,7 +198,7 @@ define([
           return this.parent
             .then(type('#unblock_code', '   ' + unblockInfo.unblockCode));
         })
-        .then(click('button[type=submit]'))
+        .then(click(selectors.SIGNIN_UNBLOCK.SUBMIT))
 
         .then(testElementExists(selectors.SETTINGS.HEADER));
     },
@@ -217,7 +219,7 @@ define([
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, PASSWORD))
 
-        .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
         .then(openVerificationLinkInDifferentBrowser(email))
 
         // wait until account data is in localstorage before redirecting
@@ -229,19 +231,19 @@ define([
         .then(openPage(SETTINGS_URL, selectors.SETTINGS.HEADER))
         .then(testElementExists(selectors.SETTINGS.HEADER))
         .then(openVerificationLinkInSameTab(secondaryEmail, 0))
-        .then(click('#emails .settings-unit-stub button'))
-        .then(testElementExists('.verified'))
+        .then(click(selectors.EMAIL.MENU_BUTTON))
+        .then(testElementExists(selectors.EMAIL.VERIFIED_LABEL))
 
         .then(clearBrowserState())
 
         .then(openPage(PAGE_SIGNIN_DESKTOP, selectors.SIGNIN.HEADER))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true }))
         .then(fillOutSignIn(email, PASSWORD))
-        .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
 
         .then(openVerificationLinkInNewTab(secondaryEmail, 1))
         .switchToWindow('newwindow')
-        .then(testElementExists('#fxa-sign-in-complete-header'))
+        .then(testElementExists(selectors.SIGNIN_COMPLETE.HEADER))
         .then(closeCurrentWindow());
     }
   });

--- a/tests/functional/settings_secondary_emails.js
+++ b/tests/functional/settings_secondary_emails.js
@@ -76,7 +76,11 @@ define([
         .then(type('.new-email', TestHelpers.createEmail()))
         .then(click('.email-add:not(.disabled)'))
         .then(testElementExists('.not-verified'))
+
         .then(click('.email-address .settings-button.warning.email-disconnect'))
+        .waitForDeletedByCssSelector('.email-address .settings-button.warning.email-disconnect')
+
+        .then(click('#emails .settings-unit-stub button'))
 
         // add secondary email, verify
         .then(type('.new-email', secondaryEmail))


### PR DESCRIPTION
This PR Fixes #5367 and updates selectors. I split into separate commits to help with review.

@shane-tomlinson @mozilla/fxa-devs r?