### PR TITLE
fix(style): Only add `centered` to links containers that need it.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -489,17 +489,26 @@ define(function (require, exports, module) {
      * Stack side-by-side links if they are too long to fit on one line
      */
     stackWideLinks () {
-      this.$('.links').each((index, linkContainer) => {
+      const $links = this.$('.links');
+      $links.each((index, linkContainer) => {
         const $linkContainer = this.$(linkContainer);
         const $links = $linkContainer.children('a');
         // Math.floor takes care of odd number widths
-        const maxLinkWidthWithoutStacking = Math.floor($linkContainer.width() / 2);
+        const maxLinkWidthWithoutStacking = Math.floor($linkContainer.width() / $links.length);
 
         // if any link is equal to or more than half its parent's width,
         // make *all* links in the same parent to be stacked
-        const $tooWideLinks = $links.filter(
-          (i, item) => this.$(item).outerWidth() >= maxLinkWidthWithoutStacking
-        );
+        const $tooWideLinks = $links.filter((i, item) => {
+          const $item = this.$(item);
+          // disable wrapping and width constraints to get the natural width of the element
+          $item.css('max-width', '100%');
+          $item.css('white-space', 'nowrap');
+          const isTooWide = $item.outerWidth() >= maxLinkWidthWithoutStacking;
+          // re-enable wrapping
+          $item.css('white-space', '');
+          $item.css('max-width', '');
+          return isTooWide;
+        });
 
         if ($tooWideLinks.length) {
           $linkContainer.addClass('centered');

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -478,31 +478,34 @@ define(function (require, exports, module) {
       // jQuery 3.x requires the view to be visible
       // before animating the status messages.
       this.displayStatusMessages();
-
-      // restyle side-by-side links to stack if they are too long
-      // to fit on one line
-      var linkContainer = this.$el.find('.links');
-      if (linkContainer.length > 0) {
-        // takes care of odd number widths
-        var halfContainerWidth = Math.floor(linkContainer.width() / 2);
-        var shouldResetLinkSize = false;
-
-        linkContainer.children('a').each(function (i, item) {
-          var linkWidth = linkContainer.find(item).width();
-          // if any link is equal to or more than half its parent's width,
-          // make *all* links in the same parent to be stacked
-          if (linkWidth >= halfContainerWidth) {
-            shouldResetLinkSize = true;
-          }
-        });
-
-        if (shouldResetLinkSize === true) {
-          linkContainer.addClass('centered');
-        }
-      }
-
+      this.stackWideLinks();
       this.focusAutofocusElement();
+
       return p();
+    },
+
+
+    /**
+     * Stack side-by-side links if they are too long to fit on one line
+     */
+    stackWideLinks () {
+      this.$('.links').each((index, linkContainer) => {
+        const $linkContainer = this.$(linkContainer);
+        const $links = $linkContainer.children('a');
+        // Math.floor takes care of odd number widths
+        const maxLinkWidthWithoutStacking = Math.floor($linkContainer.width() / 2);
+
+        // if any link is equal to or more than half its parent's width,
+        // make *all* links in the same parent to be stacked
+        const $tooWideLinks = $links.filter(
+          (i, item) => this.$(item).outerWidth() >= maxLinkWidthWithoutStacking
+        );
+
+        if ($tooWideLinks.length) {
+          $linkContainer.addClass('centered');
+          $links.removeClass('left').removeClass('right');
+        }
+      });
     },
 
     destroy (remove) {

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -158,7 +158,6 @@ define(function (require, exports, module) {
         };
         return view.render()
             .then(function () {
-              $('#container').html(view.el);
               assert.equal(view.titleFromView(), 'Main title: Sub title');
             });
       });
@@ -366,28 +365,6 @@ define(function (require, exports, module) {
         assert.equal(view.$('.error').text(), 'error message');
       });
 
-      it('adds `centered` class to `.links` if any child has width >= half of `.links` width', function () {
-        var link1 = '<a href="/reset_password" class="left reset-password">Forgot password?</a>';
-        var link2 = '<a href="/signup" class="right sign-up">Create an account with really really looooooooooooooong text</a>';
-        $('#container').html(view.el);
-        $('.links').html(link1 + link2);
-        // force the width to be 50%
-        $('.links > .right').css({'display': 'inline-block', 'width': '50%'});
-        view.afterVisible();
-        assert.isTrue($('.links').hasClass('centered'));
-      });
-
-      it('does not add `centered` class to `.links` if all children have width < half of `.links` width', function () {
-        var link1 = '<a href="/reset_password" class="left reset-password">Forgot password?</a>';
-        var link2 = '<a href="/signup" class="right sign-up">Create an account</a>';
-        $('#container').html(view.el);
-        $('.links').html(link1 + link2);
-        // force the widths of all children to be less than 50%
-        $('.links').children().css({'display': 'inline-block', 'width': '49%'});
-        view.afterVisible();
-        assert.isFalse($('.links').hasClass('centered'));
-      });
-
       it('focuses descendent element containing `autofocus` if html has `no-touch` class', function (done) {
         requiresFocus(function () {
           $('#container').html(view.el);
@@ -418,6 +395,38 @@ define(function (require, exports, module) {
 
           view.afterVisible();
         }, done);
+      });
+    });
+
+    describe('stackWideLinks', () => {
+      beforeEach(() => {
+        $('#container').html(view.el);
+      });
+
+      it('adds `centered` class to `.links` if any child has width >= half of `.links` width', () => {
+        const link1 = '<a href="/reset_password" class="left reset-password">Forgot password?</a>';
+        const link2 = '<a href="/signup" class="right sign-up">Create an account with really really looooooooooooooong text</a>';
+        $('.links:nth(0)').html(link1 + link2);
+        // force the width to be 50%
+        $('.links:nth(0) > .right').css({'display': 'inline-block', 'width': '50%'});
+        view.stackWideLinks();
+        assert.isTrue($('.links:nth(0)').hasClass('centered'));
+        // only affects the links with the wide elements
+        assert.isFalse($('.links:nth(1)').hasClass('centered'));
+
+        assert.lengthOf($('.links:nth(0) > .left'), 0);
+        assert.lengthOf($('.links:nth(0) > .right'), 0);
+      });
+
+      it('does not add `centered` class to `.links` if all children have width < half of `.links` width', () => {
+        var link1 = '<a href="/reset_password" class="left reset-password">Forgot password?</a>';
+        var link2 = '<a href="/signup" class="right sign-up">Create an account</a>';
+        $('.links:nth(0)').html(link1 + link2);
+        // force the widths of all children to be less than 50%
+        $('.links:nth(0)').children().css({'display': 'inline-block', 'width': '49%'});
+        view.stackWideLinks();
+        assert.isFalse($('.links:nth(0)').hasClass('centered'));
+        assert.isFalse($('.links:nth(1)').hasClass('centered'));
       });
     });
 


### PR DESCRIPTION
If a view contained more than one `.links` element and only one
of them needed to stack the links, the `centered` class would
be applied to all `.links` containers.

This iterates through each `.links` element and determines
if any of its child elements cause stackage.

fixes #5392