### PR TITLE
fix(metrics): `engaged` flow events should only be triggered if the user engages!

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -227,13 +227,13 @@ define(function (require, exports, module) {
           // be returned.
           this._context = null;
           this.$el.html(this.renderTemplate(this.template.bind(this)));
+          this.trigger('rendered');
 
           // Track whether status messages were made visible via the template.
           this._isErrorVisible = this.$('.error').hasClass('visible');
           this._isSuccessVisible = this.$('.success').hasClass('visible');
 
-          return p(this.afterRender())
-            .then(() => this.trigger('rendered'));
+          return this.afterRender();
         })
         .then((shouldDisplay) => {
           return shouldDisplay !== false && ! this._hasNavigated;

--- a/app/scripts/views/mixins/form-prefill-mixin.js
+++ b/app/scripts/views/mixins/form-prefill-mixin.js
@@ -25,20 +25,27 @@ define(function (require, exports, module) {
     return ! $el.__val() &&
            $el.attr('autocomplete') !== 'off' &&
            key &&
-           formPrefill.has(key);
+           !! formPrefill.get(key);
   }
 
   module.exports = {
     initialize (options = {}) {
       this.formPrefill = options.formPrefill;
+
+      // NOTE: this assumes `rendered` will be triggered after
+      // the view has been rendered, but before `afterRender`.
+      // `afterRender` takes care of seeding the model that tracks
+      // whether form values have changed and enabling the form
+      // if valid.
+      this.on('rendered', () => this.fillPrefillableValues());
     },
 
-    afterRender () {
+    fillPrefillableValues () {
       this.getFormElements().each((index, el) => {
         const $el = this.$(el);
         if (isElementFillable($el, this.formPrefill)) {
           const key = getKey($el);
-          $el.val(this.formPrefill.get(key)).trigger('input');
+          $el.val(this.formPrefill.get(key));
         }
       });
     },

--- a/app/tests/spec/views/mixins/form-prefill-mixin.js
+++ b/app/tests/spec/views/mixins/form-prefill-mixin.js
@@ -7,15 +7,19 @@ define(function (require, exports, module) {
 
   const { assert } = require('chai');
   const Backbone = require('backbone');
-  const FormView = require('views/form');
   const Cocktail = require('cocktail');
+  const FlowEventsMixin = require('views/mixins/flow-events-mixin');
+  const FormView = require('views/form');
   const FormPrefillMixin = require('views/mixins/form-prefill-mixin');
+  const Notifier = require('lib/channels/notifier');
+  const sinon = require('sinon');
 
   const View = FormView.extend({
     template: () => `
       <input class="nameless" />
       <input id="id-only" />
       <input name="already-filled" value="this is filled in" />
+      <input name="empty" />
       <input name="has-data-novalue" data-novalue />
       <input name="name-only" />
       <input name="name-preferred" id="id-ignored" />
@@ -23,19 +27,23 @@ define(function (require, exports, module) {
       <textarea name="textarea" />
     `
   });
+
   Cocktail.mixin(
     View,
+    FlowEventsMixin,
     FormPrefillMixin
   );
 
   describe('views/mixins/form-prefill-mixin', () => {
     let formPrefill;
+    let notifier;
     let view;
 
     beforeEach(() => {
       formPrefill = new Backbone.Model({
         'id-only': 'id only value',
         'already-filled': 'a different already-filled value', //eslint-disable-line
+        'empty': '',
         'has-data-novalue': 'has-data-novalue value',
         'name-only': 'name only value',
         'name-preferred': 'name preferred',
@@ -43,22 +51,36 @@ define(function (require, exports, module) {
         'textarea': 'the value for the text area'
       });
 
+      notifier = new Notifier();
+
       view = new View({
-        formPrefill
+        formPrefill,
+        notifier
       });
 
+      sinon.spy(view, '_engageFlowEventsForm');
+
       return view.render();
+    });
+
+    afterEach(() => {
+      view.destroy(true);
+      view = null;
     });
 
     it('pre-fills input elements w/ name/id without `autocomplete=off` attribute', () => {
       assert.equal(view.$('.nameless').val(), '');
       assert.equal(view.$('#id-only').val(), 'id only value');
       assert.equal(view.$('[name="already-filled"]').val(), 'this is filled in');
+      assert.equal(view.$('[name="empty"]').val(), '');
       assert.equal(view.$('[name="has-data-novalue"]').val(), '');
       assert.equal(view.$('[name="name-only"]').val(), 'name only value');
       assert.equal(view.$('[name="name-preferred"]').val(), 'name preferred');
       assert.equal(view.$('[name="not-filled-but-saved"]').val(), '');
       assert.equal(view.$('[name="textarea"]').val(), 'the value for the text area');
+
+      // Prefilling a form element should not cause an `engaged` event.
+      assert.isFalse(view._engageFlowEventsForm.called);
     });
 
     it('formPrefill saves all input elements w/ name/id', () => {
@@ -71,9 +93,11 @@ define(function (require, exports, module) {
       view.$('[name="textarea"]').val('the value for the text area updated');
 
       view.destroy();
+
       assert.deepEqual(formPrefill.toJSON(), {
         'id-only': 'id only value updated',
         'already-filled': 'this is filled in', //eslint-disable-line
+        'empty': '',
         'has-data-novalue': 'has-data-novalue value',
         'name-only': 'name only value updated',
         'name-preferred': 'name preferred updated',


### PR DESCRIPTION
There were two problems:

- If any of the view's input elements have a value prefilled from the
  form-prefill model, an engaged event will be logged as a result of
  the input event being fired on the element.
- The check for whether an element should be prefilled will respond
  with true even if the formPrefill model contains an empty string
  for that field. Users that go from the signin to signup page w/o
  entering anything on the signin page will have an empty string saved
  for both the email and password fields.

This fixes the problem by:

- No longer trigger an `input` event to cause the form to be enabled. Instead,
  update the element values in a `rendered` event handler, which is triggered
  before `afterRender` is run. `afterRender` will take care of enabling the form
  if valid.
- Only update a form value if the prefill model has a string with a length. Not
  strictly necessary, but it seems like the right thing to do.
- Move where the `rendered` event is triggered in the BaseView. It now occurs
  just after the template is rendered, before `afterRender`. Before this,
  `rendered` was only listened for in unit tests, so this is safe.

fixes #5388

@philbooth, @vladikoff or @vbudhram - r?

To test this, tail the content-server logs. Ensure form prefill works from screen->screen. Ensure when switching from signin->signup, an `engaged` event is only emit if the user actually does something that counts as an engagement (e.g., typing something). Ensure if a form is valid due to form prefill, the submit button is enabled.

I opened this against train-94 because this has a pretty big effect on our signup funnel metrics.

Aye.