### PR TITLE
fix(test): Fix the change_password test when run against circle

### DIFF
--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -44,6 +44,7 @@ define([
     return this.parent
       .then(createUser(signUpEmail, FIRST_PASSWORD, { preVerified: true }))
       .then(clearBrowserState())
+      .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
       .then(fillOutSignIn(signInEmail, FIRST_PASSWORD))
 
       .then(testElementExists(selectors.SETTINGS.HEADER))


### PR DESCRIPTION
The change_password functional test was flakey against circle
because of a bad interaction with the previous suite, bounced_emails.

In change_password.js->setupTest, `fillOutSignIn` was called without
explicitly opening the signin page. Since the last test of bounced_emails
completed on the signin page, fillOutSignIn attempted to re-use the same
page.

fixes #5403

Builds on #5404 and should be reviewed afterwards.