### PR TITLE
fix(test): Bump the automated test startup delay to 750ms.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -59,6 +59,8 @@ define(function (require, exports, module) {
   const UserAgent = require('lib/user-agent');
   const WebChannel = require('lib/channels/web');
 
+  const AUTOMATED_BROWSER_STARTUP_DELAY = 750;
+
   function Start(options = {}) {
     this._authenticationBroker = options.broker;
     this._configLoader = new ConfigLoader();
@@ -77,7 +79,10 @@ define(function (require, exports, module) {
 
   Start.prototype = {
     startApp () {
-      return p()
+      // The delay is to give the functional tests time to hook up
+      // WebChannel message response listeners.
+      const START_DELAY_MS = this._isAutomatedBrowser() ? AUTOMATED_BROWSER_STARTUP_DELAY : 0;
+      return p().delay(START_DELAY_MS)
         .then(this.initializeDeps.bind(this))
         .then(this.testLocalStorage.bind(this))
         .then(this.allResourcesReady.bind(this))

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -129,11 +129,8 @@ define(function (require, exports, module) {
      * @private
      */
     _fetchFxaStatus () {
-      const TEST_REQUEST_DELAY_MS = this.isAutomatedBrowser() ? 500 : 0;
-
       const channel = this._notificationChannel;
-      return p().delay(TEST_REQUEST_DELAY_MS)
-        .then(() => channel.request(channel.COMMANDS.FXA_STATUS, this.relier.pick('service')))
+      return channel.request(channel.COMMANDS.FXA_STATUS, this.relier.pick('service'))
         .then((response = {}) => {
           // The browser will respond with a signedInUser in the following cases:
           // - non-PB mode, service=*

--- a/app/scripts/views/index.js
+++ b/app/scripts/views/index.js
@@ -17,7 +17,6 @@ define(function (require, exports, module) {
   const FlowBeginMixin = require('views/mixins/flow-begin-mixin');
   const FormPrefillMixin = require('views/mixins/form-prefill-mixin');
   const FormView = require('views/form');
-  const p = require('lib/promise');
   const SearchParamMixin = require('lib/search-param-mixin');
   const ServiceMixin = require('views/mixins/service-mixin');
   const Template = require('stache!templates/index');
@@ -48,10 +47,7 @@ define(function (require, exports, module) {
         this.notifier.trigger('email-first-flow');
         const email = this.relier.get('email');
         if (email) {
-          const TEST_REQUEST_DELAY_MS = this.broker.isAutomatedBrowser() ? 500 : 0;
-          // The delay is to give the functional tests time to hook up
-          // WebChannel message response listeners.
-          return p().delay(TEST_REQUEST_DELAY_MS).then(() => this.checkEmail(email));
+          return this.checkEmail(email);
         }
       } else {
         this.replaceCurrentPage('signup');

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -831,34 +831,39 @@ define([
     var attachedId = Math.floor(Math.random() * 10000);
     return this.parent
       .execute(function (expectedCommand, response, attachedId) {
-        function startListening() {
-          try {
-            addEventListener('WebChannelMessageToChrome', function listener(e) {
-              var command = e.detail.message.command;
-              var messageId = e.detail.message.messageId;
+        function listener(e) {
+          var command = e.detail.message.command;
+          var messageId = e.detail.message.messageId;
 
-              if (command === expectedCommand) {
-                removeEventListener('WebChannelMessageToChrome', listener);
-                var event = new CustomEvent('WebChannelMessageToContent', {
-                  detail: {
-                    id: 'account_updates',
-                    message: {
-                      command: command,
-                      data: response,
-                      messageId: messageId
-                    }
-                  }
-                });
-
-                dispatchEvent(event);
+          if (command === expectedCommand) {
+            removeEventListener('WebChannelMessageToChrome', listener);
+            var event = new CustomEvent('WebChannelMessageToContent', {
+              detail: {
+                id: 'account_updates',
+                message: {
+                  command: command,
+                  data: response,
+                  messageId: messageId
+                }
               }
             });
-            $('body').append('<div>').addClass('attached' + attachedId);
+
+            dispatchEvent(event);
+          }
+        }
+
+        function startListening() {
+          try {
+            addEventListener('WebChannelMessageToChrome', listener);
           } catch (e) {
             // problem adding the listener, window may not be
             // ready, try again.
             setTimeout(startListening, 0);
           }
+
+          const el = document.createElement('div');
+          el.classList.add(`attached${attachedId}`);
+          document.body.appendChild(el);
         }
 
         startListening();


### PR DESCRIPTION
The Firstrun Sync v2 email first - email specified by relier, not registered
test frequently fails, I believe because the WebChannel listener is not
yet hooked up for the fxaccounts:can_link_account message.

I moved the delays that were in the auth_brokers/base.js broker and views/index.js
and moved this to app-start.js so that we can stop thinking about it.

In addition, I noticed while testing that sometimes a single listener could
be added multiple times. The listener would be added, but jQuery was not yet
in the DOM, and the try/catch block used in respondToWebChannelMessage would
try to attach a 2nd listener.

Instead of using jQuery, create the element manually.

issue #5390

@vladikoff - r? I'm not totally convinced bumping up the delay is the right thing to do, but centralizing the startup delay does seem to be.