### PR TITLE
fix(test): Only print relevant lines in functional test stack traces.

### DIFF
--- a/tests/intern.js
+++ b/tests/intern.js
@@ -52,6 +52,7 @@ function (intern, topic, firefoxProfile) {
       marionette: true
     }],
     excludeInstrumentation: true,
+    filterErrorStack: true,
     fixSessionCapabilities: false,
     functionalSuites: [
       'tests/functional/mocha',


### PR DESCRIPTION
By default, intern stack traces print all kinds of unimportant line numbers,
dojo, node_modules, etc. Fortunately, these extra lines can be
filtered by passing `filterErrorStack: true` to the intern config.

Not tied to any issue.

#### before
<img width="446" alt="screen shot 2017-09-04 at 13 17 24" src="https://user-images.githubusercontent.com/848085/30026237-86dc5750-916b-11e7-8895-5f866efbeb14.png">


#### after
<img width="449" alt="screen shot 2017-09-04 at 13 17 57" src="https://user-images.githubusercontent.com/848085/30026243-8e260088-916b-11e7-929c-aa41cd118224.png">

@philbooth - r?

