### PR TITLE
refactor(brokers): Extract next steps from complete_sign_up to broker behaviors.

### DIFF
--- a/app/scripts/models/auth_brokers/fx-sync.js
+++ b/app/scripts/models/auth_brokers/fx-sync.js
@@ -20,6 +20,10 @@ define(function (require, exports, module) {
 
   module.exports = BaseAuthenticationBroker.extend({
     defaultBehaviors: _.extend({}, proto.defaultBehaviors, {
+      afterCompleteSignUp: new ConnectAnotherDeviceBehavior(proto.defaultBehaviors.afterCompleteSignUp)
+    }),
+
+    defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       // Can CAD be displayed after the signup confirmation poll?
       cadAfterSignUpConfirmationPoll: false
     }),

--- a/app/scripts/models/auth_brokers/web.js
+++ b/app/scripts/models/auth_brokers/web.js
@@ -13,6 +13,7 @@ define(function (require, exports, module) {
   const BaseBroker = require('models/auth_brokers/base');
   const { CONTENT_SERVER_CONTEXT } = require('lib/constants');
   const NavigateBehavior = require('views/behaviors/navigate');
+  const SettingsIfSignedInBehavior = require('views/behaviors/settings');
 
   const t = (msg) => msg;
 
@@ -25,6 +26,8 @@ define(function (require, exports, module) {
   module.exports = BaseBroker.extend({
     defaultBehaviors: _.extend({}, proto.defaultBehaviors, {
       afterCompleteResetPassword: redirectToSettingsBehavior,
+      afterCompleteSignIn: new SettingsIfSignedInBehavior(proto.defaultBehaviors.afterCompleteSignIn),
+      afterCompleteSignUp: new SettingsIfSignedInBehavior(proto.defaultBehaviors.afterCompleteSignUp),
       afterResetPasswordConfirmationPoll: redirectToSettingsBehavior,
       afterSignInConfirmationPoll: redirectToSettingsBehavior,
       afterSignUpConfirmationPoll: redirectToSettingsBehavior

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -971,7 +971,9 @@ define(function (require, exports, module) {
     },
 
     /**
-     * Invoke a behavior returned by an auth broker.
+     * Invoke a behavior returned by an auth broker. If a behavior returns
+     * another behavior, the returned behavior is recursively invoked.
+     * Method resolves to the final behavior's result.
      *
      * @method invokeBehavior
      * @param {Function} behavior
@@ -984,8 +986,14 @@ define(function (require, exports, module) {
         if (_.isFunction(behavior)) {
           return behavior(this, ...args);
         }
-
         return behavior;
+      })
+      .then((result) => {
+        // recursively invoke returned behaviors.
+        if (_.isFunction(behavior)) {
+          return this.invokeBehavior(result, ...args);
+        }
+        return result;
       });
     }
   });

--- a/app/scripts/views/behaviors/connect-another-device.js
+++ b/app/scripts/views/behaviors/connect-another-device.js
@@ -13,6 +13,8 @@
 define((require, exports, module) => {
   'use strict';
 
+  const p = require('lib/promise');
+
   /**
    * Create a ConnectAnotherDevice behavior.
    *
@@ -23,10 +25,13 @@ define((require, exports, module) => {
   module.exports = function (defaultBehavior) {
     const behavior = function (view, account) {
       if (view.isEligibleForConnectAnotherDevice(account)) {
-        return view.navigateToConnectAnotherDeviceScreen(account);
+        view.navigateToConnectAnotherDeviceScreen(account);
+        // Cause the invokeBrokerMethod chain to stop, the screen
+        // has already redirected.
+        return p.defer().promise;
       }
 
-      return view.invokeBehavior(defaultBehavior, account);
+      return defaultBehavior;
     };
 
     behavior.type = 'connect-another-device';

--- a/app/scripts/views/behaviors/settings.js
+++ b/app/scripts/views/behaviors/settings.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Redirects to settings if `account` is signed in,
+ * returns `defaultBehavior` otherwise.
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const NavigateBehavior = require('views/behaviors/navigate');
+
+  const t = (msg) => msg;
+  const success = t('Account verified successfully');
+
+  module.exports = function (defaultBehavior) {
+    const behavior = function (view, account) {
+      return account.isSignedIn()
+        .then((isSignedIn) => {
+          if (isSignedIn) {
+            return new NavigateBehavior('settings', { success });
+          }
+
+          return defaultBehavior;
+        });
+    };
+
+    behavior.type = 'settings';
+
+    return behavior;
+  };
+});

--- a/app/scripts/views/mixins/verification-reason-mixin.js
+++ b/app/scripts/views/mixins/verification-reason-mixin.js
@@ -46,6 +46,15 @@ define(function (require, exports, module) {
     },
 
     /**
+     * Is a secondary email being verified?
+     *
+     * @returns {Boolean}
+     */
+    isSecondaryEmail () {
+      return this.model.get('type') === VerificationReasons.SECONDARY_EMAIL_VERIFIED;
+    },
+
+    /**
      * Get the key in VerificationReasons for the given verification reason
      *
      * @param {String} verificationReason

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -224,14 +224,38 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('afterCompleteSignUp', function () {
-      beforeEach(function () {
+    describe('afterCompleteSecondaryEmail', function () {
+      it('unpersist VerificationData, returns the expected behavior', function () {
         sinon.spy(broker, 'unpersistVerificationData');
-        return broker.afterCompleteSignUp(account);
+        return broker.afterCompleteSecondaryEmail(account)
+          .then((behavior) => {
+            assert.isTrue(broker.unpersistVerificationData.calledWith(account));
+            assert.equal(behavior.type, 'settings');
+          });
       });
+    });
 
-      it('unpersistVerificationDatas data', function () {
-        assert.isTrue(broker.unpersistVerificationData.calledWith(account));
+    describe('afterCompleteSignIn', function () {
+      it('unpersist VerificationData, returns the expected behavior', function () {
+        sinon.spy(broker, 'unpersistVerificationData');
+        return broker.afterCompleteSignIn(account)
+          .then((behavior) => {
+            assert.isTrue(broker.unpersistVerificationData.calledWith(account));
+            assert.equal(behavior.type, 'navigate');
+            assert.equal(behavior.endpoint, 'signin_verified');
+          });
+      });
+    });
+
+    describe('afterCompleteSignUp', function () {
+      it('unpersist VerificationData, returns the expected behavior', function () {
+        sinon.spy(broker, 'unpersistVerificationData');
+        return broker.afterCompleteSignUp(account)
+          .then((behavior) => {
+            assert.isTrue(broker.unpersistVerificationData.calledWith(account));
+            assert.equal(behavior.type, 'navigate');
+            assert.equal(behavior.endpoint, 'signup_verified');
+          });
       });
     });
 

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -154,5 +154,15 @@ define((require, exports, module) => {
         });
       });
     });
+
+    describe('afterCompleteSignUp', () => {
+      it('resolves to a `ConnectAnotherDeviceBehavior`', () => {
+        account.get = sinon.spy();
+        return broker.afterCompleteSignUp(account)
+        .then((behavior) => {
+          assert.equal(behavior.type, 'connect-another-device');
+        });
+      });
+    });
   });
 });

--- a/app/tests/spec/models/auth_brokers/web.js
+++ b/app/tests/spec/models/auth_brokers/web.js
@@ -27,10 +27,24 @@ define(function (require, exports, module) {
       });
     }
 
+    function testRedirectsToSettingsIfSignedIn(brokerMethod) {
+      describe(brokerMethod, () => {
+        it('returns a NavigateBehavior to settings', () => {
+          return broker[brokerMethod]({ get: () => {} })
+            .then((behavior) => {
+              assert.equal(behavior.type, 'settings');
+            });
+        });
+      });
+    }
+
     testRedirectsToSettings('afterCompleteResetPassword');
     testRedirectsToSettings('afterResetPasswordConfirmationPoll');
     testRedirectsToSettings('afterSignInConfirmationPoll');
     testRedirectsToSettings('afterSignUpConfirmationPoll');
+
+    testRedirectsToSettingsIfSignedIn('afterCompleteSignIn');
+    testRedirectsToSettingsIfSignedIn('afterCompleteSignUp');
   });
 });
 

--- a/app/tests/spec/views/base.js
+++ b/app/tests/spec/views/base.js
@@ -1056,6 +1056,25 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('invokeBehavior', () => {
+      it('recursively invokes behaviors', () => {
+        const account = {};
+        const behavior2 = sinon.spy(() => true);
+        const behavior1 = sinon.spy(() => behavior2);
+
+        return view.invokeBehavior(behavior1, account)
+          .then((result) => {
+            assert.isTrue(result);
+
+            assert.isTrue(behavior1.calledOnce);
+            assert.isTrue(behavior1.calledWith(view, account));
+
+            assert.isTrue(behavior2.calledOnce);
+            assert.isTrue(behavior2.calledWith(view, account));
+          });
+      });
+    });
+
     describe('getViewName', function () {
       describe('with a `viewName` on the view prototype', function () {
         var view;

--- a/app/tests/spec/views/behaviors/connect-another-device.js
+++ b/app/tests/spec/views/behaviors/connect-another-device.js
@@ -24,40 +24,36 @@ define((require, exports, module) => {
     describe('eligible for CAD', () => {
       it('delegates to `view.navigateToConnectAnotherDeviceScreen`', () => {
         const view = {
-          invokeBehavior: sinon.spy(),
           isEligibleForConnectAnotherDevice: sinon.spy(() => true),
           navigateToConnectAnotherDeviceScreen: sinon.spy()
         };
 
-        cadBehavior(view, account);
+        const promise = cadBehavior(view, account);
+        assert.ok(promise);
+        assert.isFunction(promise.then);
 
         assert.isTrue(view.isEligibleForConnectAnotherDevice.calledOnce);
         assert.isTrue(view.isEligibleForConnectAnotherDevice.calledWith(account));
 
         assert.isTrue(view.navigateToConnectAnotherDeviceScreen.calledOnce);
         assert.isTrue(view.navigateToConnectAnotherDeviceScreen.calledWith(account));
-
-        assert.isFalse(view.invokeBehavior.called);
       });
     });
 
     describe('ineligible for CAD', () => {
       it('invokes the defaultBehavior', () => {
         const view = {
-          invokeBehavior: sinon.spy(),
           isEligibleForConnectAnotherDevice: sinon.spy(() => false),
           navigateToConnectAnotherDeviceScreen: sinon.spy()
         };
 
-        cadBehavior(view, account);
+        const behavior = cadBehavior(view, account);
 
         assert.isTrue(view.isEligibleForConnectAnotherDevice.calledOnce);
         assert.isTrue(view.isEligibleForConnectAnotherDevice.calledWith(account));
 
         assert.isFalse(view.navigateToConnectAnotherDeviceScreen.called);
-
-        assert.isTrue(view.invokeBehavior.calledOnce);
-        assert.isTrue(view.invokeBehavior.calledWith(defaultBehavior, account));
+        assert.strictEqual(behavior, defaultBehavior);
       });
     });
   });

--- a/app/tests/spec/views/behaviors/settings.js
+++ b/app/tests/spec/views/behaviors/settings.js
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define((require, exports, module) => {
+  'use strict';
+
+  const Account = require('models/account');
+  const { assert } = require('chai');
+  const p = require('lib/promise');
+  const SettingsBehavior = require('views/behaviors/settings');
+  const NullBehavior = require('views/behaviors/null');
+  const sinon = require('sinon');
+
+  describe('views/behaviors/settings', () => {
+    let settingsBehavior;
+    let defaultBehavior;
+
+    before(() => {
+      defaultBehavior = new NullBehavior();
+      settingsBehavior = new SettingsBehavior(defaultBehavior);
+    });
+
+    it('has the expected type', () => {
+      assert.equal(settingsBehavior.type, 'settings');
+    });
+
+    describe('user is signed in', () => {
+      it('returns a NavigateBehavior', () => {
+        const view = {
+          invokeBehavior: sinon.spy(),
+        };
+        const account = new Account();
+        sinon.stub(account, 'isSignedIn').callsFake(() => p(true));
+
+        return settingsBehavior(view, account)
+          .then((behavior) => {
+            assert.equal(behavior.type, 'navigate');
+            assert.equal(behavior.endpoint, 'settings');
+          });
+      });
+    });
+
+    describe('user is not signed in', () => {
+      it('returns the defaultBehavior', () => {
+        const view = {
+          invokeBehavior: sinon.spy(),
+        };
+        const account = new Account();
+        sinon.stub(account, 'isSignedIn').callsFake(() => p(false));
+
+        return settingsBehavior(view, account)
+          .then((behavior) => {
+            assert.strictEqual(behavior, defaultBehavior);
+          });
+      });
+    });
+  });
+});

--- a/app/tests/spec/views/mixins/verification-reason-mixin.js
+++ b/app/tests/spec/views/mixins/verification-reason-mixin.js
@@ -12,19 +12,25 @@ define(function (require, exports, module) {
   const VerificationReasons = require('lib/verification-reasons');
   const VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
 
-  var View = BaseView.extend({});
+  const View = BaseView.extend({});
   Cocktail.mixin(
     View,
     VerificationReasonMixin
   );
 
-  describe('views/mixins/verification-reason-mixin', function () {
-    describe('constructor', function () {
-      describe('model has a type', function () {
-        var view;
+  describe('views/mixins/verification-reason-mixin', () => {
+    let view;
 
-        before(function () {
-          var model = new Backbone.Model();
+    before(() => {
+      view = new View({});
+    });
+
+    describe('constructor', () => {
+      describe('model has a type', () => {
+        let view;
+
+        before(() => {
+          const model = new Backbone.Model();
           model.set('type', VerificationReasons.SIGN_IN);
 
           view = new View({
@@ -32,82 +38,70 @@ define(function (require, exports, module) {
           });
         });
 
-        it('uses the type set in the model', function () {
+        it('uses the type set in the model', () => {
           assert.equal(view.model.get('type'), VerificationReasons.SIGN_IN);
         });
       });
 
-      describe('model has no type, option set', function () {
-        var view;
+      describe('model has no type, option set', () => {
+        let view;
 
-        before(function () {
+        before(() => {
           view = new View({
             type: VerificationReasons.SIGN_IN
           });
         });
 
-        it('uses the type set in the options', function () {
+        it('uses the type set in the options', () => {
           assert.equal(view.model.get('type'), VerificationReasons.SIGN_IN);
         });
       });
 
-      describe('model has no type, option not set', function () {
-        var view;
-
-        before(function () {
-          view = new View({});
-        });
-
-        it('uses the SIGN_UP type by default', function () {
+      describe('model has no type, option not set', () => {
+        it('uses the SIGN_UP type by default', () => {
           assert.equal(view.model.get('type'), VerificationReasons.SIGN_UP);
         });
       });
     });
 
-    describe('isSignIn', function () {
-      var view;
-
-      before(function () {
-        view = new View({});
-      });
-
-      it('returns `true` for SIGN_IN type', function () {
+    describe('isSignIn', () => {
+      it('returns `true` for SIGN_IN type', () => {
         view.model.set('type', VerificationReasons.SIGN_IN);
         assert.isTrue(view.isSignIn());
       });
 
-      it('returns `false` for other types', function () {
+      it('returns `false` for other types', () => {
         view.model.set('type', VerificationReasons.SIGN_UP);
         assert.isFalse(view.isSignIn());
       });
     });
 
-    describe('isSignUp', function () {
-      var view;
-
-      before(function () {
-        view = new View({});
-      });
-
-      it('returns `true` for SIGN_UP type', function () {
+    describe('isSignUp', () => {
+      it('returns `true` for SIGN_UP type', () => {
         view.model.set('type', VerificationReasons.SIGN_UP);
         assert.isTrue(view.isSignUp());
       });
 
-      it('returns `false` for other types', function () {
+      it('returns `false` for other types', () => {
         view.model.set('type', VerificationReasons.SIGN_IN);
         assert.isFalse(view.isSignUp());
       });
     });
 
-    describe('keyOfType', function () {
-      var view;
-
-      before(function () {
-        view = new View({});
+    describe('isSecondaryEmail', () => {
+      it('returns `true` for SECONDARY_EMAIL_VERIFIED type', () => {
+        view.model.set('type', VerificationReasons.SECONDARY_EMAIL_VERIFIED);
+        assert.isTrue(view.isSecondaryEmail());
       });
 
-      it('returns the correct value', function () {
+      it('returns `false` for other types', () => {
+        view.model.set('type', VerificationReasons.SIGN_IN);
+        assert.isFalse(view.isSecondaryEmail());
+      });
+    });
+
+    describe('keyOfType', () => {
+      it('returns the correct value', () => {
         assert.equal(
           view.keyOfVerificationReason(VerificationReasons.SIGN_IN), 'SIGN_IN');
       });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -129,6 +129,7 @@ function (Translator, Session) {
     '../tests/spec/views/behaviors/halt',
     '../tests/spec/views/behaviors/navigate',
     '../tests/spec/views/behaviors/null',
+    '../tests/spec/views/behaviors/settings',
     '../tests/spec/views/cannot_create_account',
     '../tests/spec/views/choose_what_to_sync',
     '../tests/spec/views/clear_storage',

--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -8,29 +8,32 @@ define([
   'app/scripts/lib/constants',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
-  'tests/functional/lib/fx-desktop'
-], function (intern, registerSuite, Constants, TestHelpers, FunctionalHelpers, FxDesktopHelpers) {
-  var config = intern.config;
-  var PAGE_COMPLETE_SIGNIN_URL = config.fxaContentRoot + 'complete_signin';
-  var PAGE_SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
-  var PASSWORD = 'password';
-  var user;
-  var email;
-  var code;
-  var uid;
+  'tests/functional/lib/fx-desktop',
+  'tests/functional/lib/selectors'
+], function (intern, registerSuite, Constants, TestHelpers, FunctionalHelpers, FxDesktopHelpers, selectors) {
+  const config = intern.config;
+  const PAGE_COMPLETE_SIGNIN_URL = config.fxaContentRoot + 'complete_signin';
+  const PAGE_SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
+  const PASSWORD = 'password';
 
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var getEmailHeaders = FunctionalHelpers.getEmailHeaders;
-  var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
-  var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = FunctionalHelpers.openPage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
-  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+  let code;
+  let email;
+  let uid;
+  let user;
+  let verificationLink;
 
-  var createRandomHexString = TestHelpers.createRandomHexString;
+  const clearBrowserState = FunctionalHelpers.clearBrowserState;
+  const createUser = FunctionalHelpers.createUser;
+  const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
+  const getEmailHeaders = FunctionalHelpers.getEmailHeaders;
+  const listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
+  const noSuchElement = FunctionalHelpers.noSuchElement;
+  const openPage = FunctionalHelpers.openPage;
+  const testElementExists = FunctionalHelpers.testElementExists;
+  const testIsBrowserNotified = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
+  const testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
+
+  const createRandomHexString = TestHelpers.createRandomHexString;
 
   registerSuite({
     name: 'complete_sign_in',
@@ -41,80 +44,60 @@ define([
       return this.remote
         .then(clearBrowserState())
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(openPage(PAGE_SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(PAGE_SIGNIN_URL, selectors.SIGNIN.HEADER))
         .execute(listenForFxaCommands)
         .then(fillOutSignIn(email, PASSWORD))
-        .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
         .then(testIsBrowserNotified('can_link_account'))
         .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: false }))
         .then(getEmailHeaders(user, 0))
         .then((headers) => {
           code = headers['x-verify-code'];
           uid = headers['x-uid'];
+          verificationLink = headers['x-link'];
         });
     },
 
     'open verification link with malformed code': function () {
       code = createRandomHexString(Constants.CODE_LENGTH - 1);
-      var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
+      const url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(url, '#fxa-verification-link-damaged-header'))
-
-        // a successful user is immediately redirected to the
-        // sign-in-complete page.
-        .then(testElementExists('#fxa-verification-link-damaged-header'))
-        .then(noSuchElement('#resend'));
+        .then(openPage(url, selectors.COMPLETE_SIGNIN.VERIFICATION_LINK_DAMAGED))
+        .then(noSuchElement(selectors.COMPLETE_SIGNIN.LINK_RESEND));
     },
 
     'open verification link with server reported bad code': function () {
-      var code = createRandomHexString(Constants.CODE_LENGTH);
-      var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
+      const code = createRandomHexString(Constants.CODE_LENGTH);
+      const url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(url, '#fxa-verification-link-reused-header'))
-
-        // Ensure that a link expired error message is displayed
-        // rather than a damaged link error
-        .then(testElementExists('#fxa-verification-link-reused-header'))
-        .then(noSuchElement('#resend'));
+        .then(openPage(url, selectors.COMPLETE_SIGNIN.VERIFICATION_LINK_REUSED))
+        .then(noSuchElement(selectors.COMPLETE_SIGNIN.LINK_RESEND));
     },
 
     'open verification link with malformed uid': function () {
-      var uid = createRandomHexString(Constants.UID_LENGTH - 1);
-      var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
+      const uid = createRandomHexString(Constants.UID_LENGTH - 1);
+      const url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(url, '#fxa-verification-link-damaged-header'))
-
-        // a successful user is immediately redirected to the
-        // sign-in-complete page.
-        .then(testElementExists('#fxa-verification-link-damaged-header'))
-        .then(noSuchElement('#resend'));
+        .then(openPage(url, selectors.COMPLETE_SIGNIN.VERIFICATION_LINK_DAMAGED))
+        .then(noSuchElement(selectors.COMPLETE_SIGNIN.LINK_RESEND));
     },
 
     'open verification link with server reported bad uid': function () {
-      var uid = createRandomHexString(Constants.UID_LENGTH);
-      var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
+      const uid = createRandomHexString(Constants.UID_LENGTH);
+      const url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
 
       return this.remote
-        .then(openPage(url, '#fxa-verification-link-expired-header'))
-
-        // Ensure that a link expired error message is displayed
-        // rather than a damaged link error
-        .then(testElementExists('#fxa-verification-link-expired-header'))
-        .then(noSuchElement('#resend'));
+        .then(openPage(url, selectors.COMPLETE_SIGNIN.VERIFICATION_LINK_EXPIRED))
+        .then(noSuchElement(selectors.COMPLETE_SIGNIN.LINK_RESEND));
     },
 
     'open valid email verification link': function () {
-      var url = PAGE_COMPLETE_SIGNIN_URL + '?uid=' + uid + '&code=' + code;
-
       return this.remote
-        .then(openPage(url, '#fxa-settings-profile-header'))
-
-        // a successful user is immediately redirected to the
-        // sign-in-complete page.
-        .then(testElementExists('#fxa-settings-profile-header'));
+        .then(clearBrowserState())
+        .then(openPage(verificationLink, selectors.SIGNIN_COMPLETE.HEADER));
     }
   });
 });

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -40,6 +40,12 @@ define([], function () {
       EXPIRED_LINK_HEADER: '#fxa-reset-link-expired-header',
       HEADER: '#fxa-complete-reset-password-header',
     },
+    COMPLETE_SIGNIN: {
+      LINK_RESEND: '#resend',
+      VERIFICATION_LINK_DAMAGED: '#fxa-verification-link-damaged-header',
+      VERIFICATION_LINK_EXPIRED: '#fxa-verification-link-expired-header',
+      VERIFICATION_LINK_REUSED: '#fxa-verification-link-reused-header'
+    },
     CONFIRM_RESET_PASSWORD: {
       HEADER: '#fxa-confirm-reset-password-header',
       LINK_RESEND: '#resend',


### PR DESCRIPTION
The next step logic in views/complete_sign_up.js was a rats nest, and easy
to mess up when adding new verification reasons, including mading the CAD
on signin modifications. This complexity has always been a sore point of mine,
and I've had 3 or 4 stabs at this previously but was never happy with the
result. This time I am.

Brokers are great at isolating behaviors for a particular integration
without affecting others. `afterCompleteSignUp` has two corresponding
siblings, `afterCompleteSignIn` and `afterCompleteSecondaryEmail`.

The broker behaviors define the next steps for each of these.

Much cleaner.

Extraction from #5308

@mozilla/fxa-devs - r?