### PR TITLE
fix(settings): stop logging screen.settings when closing child views

### DIFF
--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -138,8 +138,6 @@ define(function (require, exports, module) {
         $.modal.close();
       }
       this.displayStatusMessages();
-
-      this.logView();
     },
 
     beforeRender () {

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -197,7 +197,7 @@ define(function (require, exports, module) {
         sinon.stub($.modal, 'close').callsFake(function () { });
         notifier.trigger('navigate-from-child-view');
         assert.isTrue(view.displayStatusMessages.called);
-        assert.isTrue(view.logView.called);
+        assert.isFalse(view.logView.called);
         assert.isTrue($.modal.isActive.called);
         assert.isTrue($.modal.close.called);
         $.modal.isActive.restore();


### PR DESCRIPTION
Fixes #5428.

For once, a content server issue turned out to be an easy fix. First time that's happened to me in 2+ years, I think.

@mozilla/fxa-devs r?