### PR TITLE
fix(experiments): Only enable the experiment defined by `forceExperiment`.

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/disabled-button-state.js
+++ b/app/scripts/lib/experiments/grouping-rules/disabled-button-state.js
@@ -30,15 +30,7 @@ define((require, exports, module) => {
         return false;
       }
 
-      let choice;
-
-      if (subject.forceExperiment === this.name && subject.forceExperimentGroup) {
-        choice = subject.forceExperimentGroup;
-      } else {
-        choice = this.uniformChoice(GROUPS, subject.uniqueUserId);
-      }
-
-      return choice;
+      return this.uniformChoice(GROUPS, subject.uniqueUserId);
     }
   };
 });

--- a/app/scripts/lib/experiments/grouping-rules/email-first.js
+++ b/app/scripts/lib/experiments/grouping-rules/email-first.js
@@ -26,8 +26,6 @@ define((require, exports, module) => {
 
       if (! this._areSubjectPrereqsMet(subject)) {
         return false;
-      } else if (subject.forceExperiment === this.name && subject.forceExperimentGroup) {
-        return subject.forceExperimentGroup;
       } else if (! subject.isEmailFirstSupported) {
         // isEmailFirstSupported is `true` for brokers that support the email-first flow.
         return false;

--- a/app/scripts/lib/experiments/grouping-rules/q3-form-changes.js
+++ b/app/scripts/lib/experiments/grouping-rules/q3-form-changes.js
@@ -25,15 +25,7 @@ define((require, exports, module) => {
         return false;
       }
 
-      let choice;
-
-      if (subject.forceExperiment) {
-        choice = subject.forceExperiment;
-      } else {
-        choice = this.uniformChoice(EXPERIMENTS, subject.uniqueUserId);
-      }
-
-      return choice;
+      return this.uniformChoice(EXPERIMENTS, subject.uniqueUserId);
     }
   };
 });

--- a/app/scripts/lib/experiments/grouping-rules/send-sms-enabled-for-country.js
+++ b/app/scripts/lib/experiments/grouping-rules/send-sms-enabled-for-country.js
@@ -28,6 +28,8 @@ define((require, exports, module) => {
     constructor () {
       super();
       this.name = 'sendSmsEnabledForCountry';
+      // This experiment must be allowed if `sendSms` is forced.
+      this.forceExperimentAllow = 'sendSms';
       this.ENABLED_COUNTRY_LIST = ENABLED_COUNTRY_LIST;
     }
 

--- a/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
+++ b/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
@@ -30,9 +30,7 @@ define((require, exports, module) => {
 
       let choice;
 
-      if (subject.forceExperiment === this.name && subject.forceExperimentGroup) {
-        choice = subject.forceExperimentGroup;
-      } else if (isEmailInSigninCodesGroup(subject.account.get('email'))) {
+      if (isEmailInSigninCodesGroup(subject.account.get('email'))) {
         choice = 'signinCodes';
       } else {
         choice = this.uniformChoice(GROUPS, subject.uniqueUserId);

--- a/app/scripts/lib/experiments/grouping-rules/signup-password-confirm.js
+++ b/app/scripts/lib/experiments/grouping-rules/signup-password-confirm.js
@@ -20,10 +20,6 @@ define((require, exports, module) => {
         return false;
       }
 
-      if (subject.forceExperiment === this.name && subject.forceExperimentGroup) {
-        return subject.forceExperimentGroup;
-      }
-
       if (! subject.experimentGroupingRules || subject.experimentGroupingRules.choose('q3FormChanges', subject) !== this.name) {
         return false;
       }

--- a/app/tests/spec/lib/experiments/grouping-rules/disabled-button-state.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/disabled-button-state.js
@@ -31,16 +31,6 @@ define(function (require, exports, module) {
         assert.isFalse(experiment.choose({}));
       });
 
-      it('returns experiment if forceExperiment', () => {
-        assert.equal(experiment.choose({
-          account,
-          experimentGroupingRules,
-          forceExperiment: 'disabledButtonState',
-          forceExperimentGroup: 'control',
-          uniqueUserId: 'user-id'
-        }), 'control');
-      });
-
       it('returns chooses some experiment ', () => {
         assert.ok(experiment.choose({
           account,

--- a/app/tests/spec/lib/experiments/grouping-rules/email-first.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/email-first.js
@@ -46,15 +46,6 @@ define(function (require, exports, module) {
         assert.isFalse(experiment.choose({ uniqueUserId: 'user-id' }));
       });
 
-      it('returns experiment if forceExperiment', () => {
-        assert.equal(experiment.choose({
-          experimentGroupingRules,
-          forceExperiment: 'emailFirst',
-          forceExperimentGroup: 'control',
-          uniqueUserId: 'user-id'
-        }), 'control');
-      });
-
       it('returns `false` if `isEmailFirstSupported=false`', () => {
         assert.isFalse(experiment.choose({
           experimentGroupingRules,

--- a/app/tests/spec/lib/experiments/grouping-rules/send-sms-install-link.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/send-sms-install-link.js
@@ -25,13 +25,6 @@ define(function (require, exports, module) {
         assert.isFalse(experiment.choose({ uniqueUserId: 'user-id' }));
       });
 
-      describe('forceExperiment, forceExperimentGroup set', () => {
-        it('returns `treatment`', () => {
-          account.set('email', 'testuser@testuser.com');
-          assert.equal(experiment.choose({ account, forceExperiment: 'sendSms', forceExperimentGroup: 'treatment', uniqueUserId: 'user-id' }), 'treatment');
-        });
-      });
-
       describe('email forces `signinCodes`', () => {
         it('returns true', () => {
           account.set('email', 'testuser@softvision.com');

--- a/app/tests/spec/lib/experiments/grouping-rules/signup-password-confirm.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/signup-password-confirm.js
@@ -31,41 +31,6 @@ define((require, exports, module) => {
         assert.isTrue(experiment.uniformChoice.calledOnce);
         assert.isTrue(experiment.uniformChoice.calledWith(['control', 'treatment'], 'user-id'));
       });
-
-      describe('forceExperiment set', () => {
-        describe('to name', () => {
-          it('returns group', () => {
-            assert.equal(experiment.choose({
-              experimentGroupingRules,
-              forceExperiment: 'signupPasswordConfirm',
-              forceExperimentGroup: 'treatment',
-              uniqueUserId: 'user-id'
-            }), 'treatment');
-
-            assert.equal(experiment.choose({
-              experimentGroupingRules,
-              forceExperiment: 'signupPasswordConfirm',
-              forceExperimentGroup: 'control',
-              uniqueUserId: 'user-id'
-            }), 'control');
-          });
-        });
-
-        describe('to other experiment', () => {
-          it('returns false', () => {
-            sinon.stub(experiment, 'uniformChoice').callsFake(() => true);
-            experimentGroupingRules.choose = () => 'disabledButtonState';
-
-            assert.isFalse(experiment.choose({
-              experimentGroupingRules,
-              forceExperiment: 'disabledButtonState',
-              forceExperimentGroup: 'treatment',
-              uniqueUserId: 'user-id'
-            }));
-            assert.isFalse(experiment.uniformChoice.called);
-          });
-        });
-      });
     });
   });
 });


### PR DESCRIPTION
In the functional test we use the forceExperiment and
forceExperimentGroup query parameters to force users
into an experiment. To avoid unexpected behaviors,
within the functional tests experiments are usually
disabled, unless of course, forceExperiment is defined.
The problem is, if forceExperiment is defined, all
experiments are then enabled. Independent experiments
that do not have a meta-experiment to choose between
them, e.g., q3FormChanges, can all be chosen. This
leads to unexpected behaviors in the functional tests.

If forceExperiment is defined, only that experiment should be enabled.

fixes #5446 

@vladikoff - r?

blocks #5408 