### PR TITLE
fix(metrics): include deviceId in metricsContext data

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -803,6 +803,7 @@ define(function (require, exports, module) {
      * @param {String} signinCode
      * @param {String} flowId
      * @param {String} flowBeginTime
+     * @param {String} [deviceId]
      * @returns {Promise} resolves to an object with Account information.
      */
     consumeSigninCode: createClientDelegate('consumeSigninCode'),

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -618,6 +618,7 @@ define(function (require, exports, module) {
     getFlowEventMetadata () {
       const metadata = (this._flowModel && this._flowModel.attributes) || {};
       return {
+        deviceId: this._deviceId,
         flowBeginTime: metadata.flowBegin,
         flowId: metadata.flowId
       };

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -41,6 +41,7 @@ define(function (require, exports, module) {
         clientHeight: 966,
         clientWidth: 1033,
         context: 'fx_desktop_v1',
+        deviceId: 'wibble',
         devicePixelRatio: 2,
         entrypoint: 'menupanel',
         isSampledUser: true,
@@ -86,6 +87,7 @@ define(function (require, exports, module) {
     it('observable flow state is correct', () => {
       assert.isUndefined(metrics.getFlowModel());
       assert.deepEqual(metrics.getFlowEventMetadata(), {
+        deviceId: 'wibble',
         flowBeginTime: undefined,
         flowId: undefined
       });
@@ -100,6 +102,7 @@ define(function (require, exports, module) {
         assert.equal(metrics.getFlowModel().get('flowId'), FLOW_ID);
         assert.equal(metrics.getFlowModel().get('flowBegin'), FLOW_BEGIN_TIME);
         assert.deepEqual(metrics.getFlowEventMetadata(), {
+          deviceId: 'wibble',
           flowBeginTime: FLOW_BEGIN_TIME,
           flowId: FLOW_ID
         });
@@ -141,6 +144,7 @@ define(function (require, exports, module) {
           assert.equal(metrics.getFlowModel().get('flowId'), FLOW_ID);
           assert.equal(metrics.getFlowModel().get('flowBegin'), FLOW_BEGIN_TIME);
           assert.deepEqual(metrics.getFlowEventMetadata(), {
+            deviceId: 'wibble',
             flowBeginTime: FLOW_BEGIN_TIME,
             flowId: FLOW_ID
           });

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "cocktail": "0.5.9",
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
     "fxa-checkbox": "mozilla/fxa-checkbox#7f856afffd394a144f718e28e6fb79092d6ccddd",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.61",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.63",
     "html5shiv": "3.7.2",
     "jquery": "3.1.0",
     "jquery-modal": "https://github.com/shane-tomlinson/jquery-modal.git#0576775d1b4590314b114386019f4c7421c77503",


### PR DESCRIPTION
Fixes mozilla/fxa-auth-server#2072.

In mozilla/fxa-auth-server#2069 we added `deviceId` to the `metricsContext` payload. That went in to train 95 so we're now safe to do the client-side part. The js client bit happened in mozilla/fxa-js-client#257 and this PR rounds it all off.

The end result we're after is for amplitude events in the auth server to have a `device_id` property that matches `device_id` in the content server. Behold!

Content server:
```
{"op":"amplitudeEvent","time":1504904500170,"device_id":"b1d04d532dcf472cbbc1cad922a7e4ce","event_type":"fxa_login - view","session_id":1504904497813,"event_properties":{"device_id":"b1d04d532dcf472cbbc1cad922a7e4ce"},"user_properties":{"flow_id":"b74c3467040c3c845f1445c179de51e7deca8d15ef1d6ff871ff4958d666df77","utm_campaign":"fx-welcome","utm_content":"fx-activate","utm_medium":"email","utm_source":"email"},"app_version":"95","language":"en"}
{"op":"amplitudeEvent","time":1504904501451,"device_id":"b1d04d532dcf472cbbc1cad922a7e4ce","event_type":"fxa_login - engage","session_id":1504904497813,"event_properties":{"device_id":"b1d04d532dcf472cbbc1cad922a7e4ce"},"user_properties":{"flow_id":"b74c3467040c3c845f1445c179de51e7deca8d15ef1d6ff871ff4958d666df77","utm_campaign":"fx-welcome","utm_content":"fx-activate","utm_medium":"email","utm_source":"email"},"app_version":"95","language":"en"}
{"op":"amplitudeEvent","time":1504904505940,"device_id":"b1d04d532dcf472cbbc1cad922a7e4ce","event_type":"fxa_login - submit","session_id":1504904497813,"event_properties":{"device_id":"b1d04d532dcf472cbbc1cad922a7e4ce"},"user_properties":{"flow_id":"b74c3467040c3c845f1445c179de51e7deca8d15ef1d6ff871ff4958d666df77","utm_campaign":"fx-welcome","utm_content":"fx-activate","utm_medium":"email","utm_source":"email"},"app_version":"95","language":"en"}
```

Auth server:
```
amplitudeEvent {"time":1504904506124,"user_id":"1ac39dea3f6841caba917f90bfb8737b","device_id":"b1d04d532dcf472cbbc1cad922a7e4ce","event_type":"fxa_login - success","session_id":1504904497813,"event_properties":{"device_id":"b1d04d532dcf472cbbc1cad922a7e4ce"},"user_properties":{"flow_id":"b74c3467040c3c845f1445c179de51e7deca8d15ef1d6ff871ff4958d666df77","ua_browser":"Firefox","ua_version":"57","ua_os":"Mac OS X","fxa_uid":"1ac39dea3f6841caba917f90bfb8737b"},"app_version":"95","language":"en"}
amplitudeEvent {"time":1504904506124,"user_id":"1ac39dea3f6841caba917f90bfb8737b","device_id":"b1d04d532dcf472cbbc1cad922a7e4ce","event_type":"fxa_login - complete","session_id":1504904497813,"event_properties":{"device_id":"b1d04d532dcf472cbbc1cad922a7e4ce"},"user_properties":{"flow_id":"b74c3467040c3c845f1445c179de51e7deca8d15ef1d6ff871ff4958d666df77","ua_browser":"Firefox","ua_version":"57","ua_os":"Mac OS X","fxa_uid":"1ac39dea3f6841caba917f90bfb8737b"},"app_version":"95","language":"en"}
```

@mozilla/fxa-devs r?