### PR TITLE
fix(email-first): Remove the vpassword field in email-first.

### DIFF
--- a/app/scripts/templates/sign_up_password.mustache
+++ b/app/scripts/templates/sign_up_password.mustache
@@ -25,10 +25,6 @@
         <div class="input-help input-help-focused input-help-signup">{{#t}}A strong, unique password will keep your Firefox data safe from intruders.{{/t}}</div>
       </div>
 
-      <div class="input-row password-row">
-        <input id="vpassword" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Verify password{{/t}}" value="{{ password }}" pattern=".{8,}" required data-form-prefill="vpassword" data-synchronize-show="true" />
-      </div>
-
       {{{ coppaHTML }}}
 
       <div class="extra-links">

--- a/app/scripts/views/sign_up_password.js
+++ b/app/scripts/views/sign_up_password.js
@@ -5,7 +5,6 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const AuthErrors = require('lib/auth-errors');
   const BackMixin = require('views/mixins/back-mixin');
   const CheckboxMixin = require('views/mixins/checkbox-mixin');
   const Cocktail = require('cocktail');
@@ -41,16 +40,6 @@ define(function (require, exports, module) {
       context.set(this.getAccount().pick('email'));
     }
 
-    isValidEnd () {
-      return this._doPasswordsMatch();
-    }
-
-    showValidationErrorsEnd () {
-      if (! this._doPasswordsMatch()) {
-        this.displayError(AuthErrors.toError('PASSWORDS_DO_NOT_MATCH'));
-      }
-    }
-
     submit () {
       return p().then(() => {
         if (! this.isUserOldEnough()) {
@@ -63,16 +52,8 @@ define(function (require, exports, module) {
       });
     }
 
-    _doPasswordsMatch () {
-      return this._getPassword() === this._getVPassword();
-    }
-
     _getPassword () {
       return this.getElementValue('#password');
-    }
-
-    _getVPassword () {
-      return this.getElementValue('#vpassword');
     }
   }
 

--- a/app/tests/spec/views/sign_up_password.js
+++ b/app/tests/spec/views/sign_up_password.js
@@ -8,7 +8,6 @@ define(function (require, exports, module) {
   const $ = require('jquery');
   const Account = require('models/account');
   const { assert } = require('chai');
-  const AuthErrors = require('lib/auth-errors');
   const Backbone = require('backbone');
   const FormPrefill = require('models/form-prefill');
   const Notifier = require('lib/channels/notifier');
@@ -95,7 +94,6 @@ define(function (require, exports, module) {
         assert.lengthOf(view.$('input[type=email]'), 1);
         assert.equal(view.$('input[type=email]').val(), EMAIL);
         assert.lengthOf(view.$('#password'), 1);
-        assert.lengthOf(view.$('#vpassword'), 1);
         assert.lengthOf(view.$('#age'), 1);
         assert.lengthOf(view.$('#fxa-tos'), 1);
         assert.lengthOf(view.$('#fxa-pp'), 1);
@@ -112,28 +110,9 @@ define(function (require, exports, module) {
         sinon.spy(view, 'displayError');
       });
 
-      describe('passwords are different', () => {
-        it('shows a `PASSWORDS_DO_NOT_MATCH` error', () => {
-          view.$('#password').val('password');
-          view.$('#vpassword').val('password2');
-          view.$('#age').val('21');
-
-          return p().then()
-            .then(() => view.enableSubmitIfValid())
-            .then(() => view.validateAndSubmit())
-            .then(() => {
-              assert.isFalse(view.signUp.calledOnce);
-              assert.isTrue(view.displayError.calledOnce);
-              const displayedError = view.displayError.args[0][0];
-              assert.isTrue(AuthErrors.is(displayedError, 'PASSWORDS_DO_NOT_MATCH'));
-            });
-        });
-      });
-
-      describe('passwords are the same, user is too young', () => {
+      describe('user is too young', () => {
         it('delegates to `tooYoung`', () => {
           view.$('#password').val('password');
-          view.$('#vpassword').val('password');
           view.$('#age').val('11');
 
           return p().then()
@@ -147,10 +126,9 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('passwords are the same, user is old enough', () => {
+      describe('user is old enough', () => {
         it('signs up the user', () => {
           view.$('#password').val('password');
-          view.$('#vpassword').val('password');
           view.$('#age').val('21');
 
           sinon.stub(view, 'hasOptedInToMarketingEmail').callsFake(() => true);

--- a/tests/functional/fx_firstrun_v2_email_first.js
+++ b/tests/functional/fx_firstrun_v2_email_first.js
@@ -16,7 +16,6 @@ define([
 
   let email;
   const PASSWORD = '12345678';
-  const PASSWORD_MISMATCH = '123456789';
 
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
   const click = FunctionalHelpers.click;
@@ -25,7 +24,6 @@ define([
   const openPage = FunctionalHelpers.openPage;
   const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   const testElementExists = FunctionalHelpers.testElementExists;
-  const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   const testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
   const type = FunctionalHelpers.type;
@@ -54,14 +52,7 @@ define([
 
         .then(testElementValueEquals(selectors.SIGNUP_PASSWORD.EMAIL, email))
         .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, PASSWORD))
-        // intentional password mismatch
-        .then(type(selectors.SIGNUP_PASSWORD.VPASSWORD, PASSWORD_MISMATCH))
         .then(type(selectors.SIGNUP_PASSWORD.AGE, 21))
-
-        // password mismatch, no screen transition.
-        .then(click(selectors.SIGNUP_PASSWORD.SUBMIT, selectors.SIGNUP_PASSWORD.HEADER))
-        .then(testElementTextInclude(selectors.SIGNUP_PASSWORD.ERROR_PASSWORDS_DO_NOT_MATCH, 'do not match'))
-        .then(type(selectors.SIGNUP_PASSWORD.VPASSWORD, PASSWORD))
         .then(click(selectors.SIGNUP_PASSWORD.SUBMIT, selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
 
         .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT, selectors.CONFIRM_SIGNUP.HEADER))

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -196,7 +196,6 @@ define([], function () {
       HEADER: '#fxa-signup-password-header',
       PASSWORD: '#password',
       SUBMIT: 'button[type="submit"]',
-      VPASSWORD: '#vpassword',
     },
     SMS_LEARN_MORE: {
       HEADER: '#websites-notice'

--- a/tests/functional/sync_v3_email_first.js
+++ b/tests/functional/sync_v3_email_first.js
@@ -20,7 +20,6 @@ define([
 
   let email;
   const PASSWORD = '12345678';
-  const PASSWORD_MISMATCH = '123456789';
 
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
   const click = FunctionalHelpers.click;
@@ -30,7 +29,6 @@ define([
   const openPage = FunctionalHelpers.openPage;
   const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
   const testElementExists = FunctionalHelpers.testElementExists;
-  const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
   const testElementValueEquals = FunctionalHelpers.testElementValueEquals;
   const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
   const type = FunctionalHelpers.type;
@@ -95,14 +93,7 @@ define([
 
         .then(testElementValueEquals(selectors.SIGNUP_PASSWORD.EMAIL, email))
         .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, PASSWORD))
-        // intentional password mismatch
-        .then(type(selectors.SIGNUP_PASSWORD.VPASSWORD, PASSWORD_MISMATCH))
         .then(type(selectors.SIGNUP_PASSWORD.AGE, 21))
-
-        // password mismatch, no screen transition.
-        .then(click(selectors.SIGNUP_PASSWORD.SUBMIT, selectors.SIGNUP_PASSWORD.HEADER))
-        .then(testElementTextInclude(selectors.SIGNUP_PASSWORD.ERROR_PASSWORDS_DO_NOT_MATCH, 'do not match'))
-        .then(type(selectors.SIGNUP_PASSWORD.VPASSWORD, PASSWORD))
         .then(click(selectors.SIGNUP_PASSWORD.SUBMIT, selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
 
         .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))


### PR DESCRIPTION
We have seen from the verification password experiment that
the 2nd password field causes ~ 6% drop in registrations.
Including the verification password here makes it impossible
to compare apples and apples because not all users in
the control group have `vpassword` either.

issue #5469