### PR TITLE
fix(email-first): email-first experiment is isolated from other experiments.

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/email-first.js
+++ b/app/scripts/lib/experiments/grouping-rules/email-first.js
@@ -31,6 +31,8 @@ define((require, exports, module) => {
       } else if (! subject.isEmailFirstSupported) {
         // isEmailFirstSupported is `true` for brokers that support the email-first flow.
         return false;
+      } else if (subject.experimentGroupingRules.choose('q3FormChanges', subject) !== this.name) {
+        return  false;
       } else if (! this._isSampledUser(subject)) {
         return false;
       }
@@ -74,17 +76,6 @@ define((require, exports, module) => {
      */
     static sampleRate (env) {
       return env === 'development' ? 1.0 : 0.2;
-    }
-
-    /**
-     * The experiment name
-     *
-     * @readonly
-     * @static
-     * @return {String}
-     */
-    static get name () {
-      return EXPERIMENT_NAME;
     }
   }
 

--- a/app/scripts/lib/experiments/grouping-rules/q3-form-changes.js
+++ b/app/scripts/lib/experiments/grouping-rules/q3-form-changes.js
@@ -20,8 +20,7 @@ define((require, exports, module) => {
      * @returns {Any}
      */
     choose (subject) {
-      const EXPERIMENTS = ['disabledButtonState', 'signupPasswordConfirm'];
-
+      const EXPERIMENTS = ['disabledButtonState', 'signupPasswordConfirm', 'emailFirst'];
       if (! subject || ! subject.uniqueUserId) {
         return false;
       }

--- a/app/scripts/views/mixins/email-first-experiment-mixin.js
+++ b/app/scripts/views/mixins/email-first-experiment-mixin.js
@@ -13,7 +13,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const ExperimentMixin = require('views/mixins/experiment-mixin');
-  const EXPERIMENT_NAME = require('lib/experiments/grouping-rules/email-first').name;
+  const EXPERIMENT_NAME = 'emailFirst';
 
   /**
    * Creates the mixin

--- a/app/tests/spec/views/mixins/email-first-experiment-mixin.js
+++ b/app/tests/spec/views/mixins/email-first-experiment-mixin.js
@@ -74,7 +74,6 @@ define((require, exports, module) => {
     });
 
     it('isInEmailFirstExperiment delegates to `isInExperiment` correctly', () => {
-      sandbox.spy(view, '_getEmailFirstExperimentSubject');
       sandbox.stub(view, 'isInExperiment').callsFake(() => true);
 
       assert.isTrue(view.isInEmailFirstExperiment());
@@ -89,7 +88,6 @@ define((require, exports, module) => {
     });
 
     it('isInEmailFirstExperimentGroup delegates to `isInExperimentGroup` correctly', () => {
-      sandbox.spy(view, '_getEmailFirstExperimentSubject');
       sandbox.stub(view, 'isInExperimentGroup').callsFake(() => true);
 
       assert.isTrue(view.isInEmailFirstExperimentGroup('treatment'));


### PR DESCRIPTION
Remove `static get name` from the email-first experiment rule
which blew up Safari 9 on iOS.

When combined with #5478,
fixes #5469
fixes #5452 

@vladikoff - r?

I opened this and #5478 against train-95 hoping we could do a point release to get faster feedback.