### PR TITLE
fix(metrics): include deviceId in metricsContext data

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -803,6 +803,7 @@ define(function (require, exports, module) {
      * @param {String} signinCode
      * @param {String} flowId
      * @param {String} flowBeginTime
+     * @param {String} [deviceId]
      * @returns {Promise} resolves to an object with Account information.
      */
     consumeSigninCode: createClientDelegate('consumeSigninCode'),

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -618,6 +618,7 @@ define(function (require, exports, module) {
     getFlowEventMetadata () {
       const metadata = (this._flowModel && this._flowModel.attributes) || {};
       return {
+        deviceId: this._deviceId,
         flowBeginTime: metadata.flowBegin,
         flowId: metadata.flowId
       };

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -41,6 +41,7 @@ define(function (require, exports, module) {
         clientHeight: 966,
         clientWidth: 1033,
         context: 'fx_desktop_v1',
+        deviceId: 'wibble',
         devicePixelRatio: 2,
         entrypoint: 'menupanel',
         isSampledUser: true,
@@ -86,6 +87,7 @@ define(function (require, exports, module) {
     it('observable flow state is correct', () => {
       assert.isUndefined(metrics.getFlowModel());
       assert.deepEqual(metrics.getFlowEventMetadata(), {
+        deviceId: 'wibble',
         flowBeginTime: undefined,
         flowId: undefined
       });
@@ -100,6 +102,7 @@ define(function (require, exports, module) {
         assert.equal(metrics.getFlowModel().get('flowId'), FLOW_ID);
         assert.equal(metrics.getFlowModel().get('flowBegin'), FLOW_BEGIN_TIME);
         assert.deepEqual(metrics.getFlowEventMetadata(), {
+          deviceId: 'wibble',
           flowBeginTime: FLOW_BEGIN_TIME,
           flowId: FLOW_ID
         });
@@ -141,6 +144,7 @@ define(function (require, exports, module) {
           assert.equal(metrics.getFlowModel().get('flowId'), FLOW_ID);
           assert.equal(metrics.getFlowModel().get('flowBegin'), FLOW_BEGIN_TIME);
           assert.deepEqual(metrics.getFlowEventMetadata(), {
+            deviceId: 'wibble',
             flowBeginTime: FLOW_BEGIN_TIME,
             flowId: FLOW_ID
           });

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "cocktail": "0.5.9",
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
     "fxa-checkbox": "mozilla/fxa-checkbox#7f856afffd394a144f718e28e6fb79092d6ccddd",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.61",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.63",
     "html5shiv": "3.7.2",
     "jquery": "3.1.0",
     "jquery-modal": "https://github.com/shane-tomlinson/jquery-modal.git#0576775d1b4590314b114386019f4c7421c77503",


### PR DESCRIPTION
As discussed in the back-end meeting just now, this is an uplift of the amplitude device id fix for a proposed `95.3` tag.

@vladikoff r? (if/when it goes green)