### PR TITLE
fix(test): Fixes related to the email-opt-in on signup tests.

### DIFF
--- a/tests/functional/email_opt_in.js
+++ b/tests/functional/email_opt_in.js
@@ -31,7 +31,7 @@ define([
   var testElementTextEquals = FunctionalHelpers.testElementTextEquals;
   var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
   var visibleByQSA = FunctionalHelpers.visibleByQSA;
-  var waitForBasket = thenify(_waitForBasket);
+  var waitForBasket = _waitForBasket;
 
   var testOptedIn = thenify(function () {
     return this.parent

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -179,7 +179,7 @@ define([], function () {
       LINK_SUGGEST_EMAIL_DOMAIN_CORRECTION: '#email-suggestion',
       LINK_SUGGEST_SIGN_IN: '.error a[href="/signin"]',
       LINK_SUGGEST_SYNC: '#suggest-sync a',
-      MARKETING_EMAIL_OPTIN: 'input.marketing-email-optin',
+      MARKETING_EMAIL_OPTIN: 'input.marketing-email-optin + span',
       PASSWORD: '#password',
       SUBMIT: 'button[type="submit"]',
       SUBMIT_DISABLED: 'button[type="submit"].disabled',


### PR DESCRIPTION
1. Click the `span` next to the checkbox. The checkbox isn't clickable.
2. Remove the `thenify` wrapper on `_waitForBasket`, it prevents
   the function from being called.

Note, the functional test still fails locally because the auth-server
does not notify the fake-basket server because we have no message queue
to pass the notifications.

issue #5433

@mozilla/fxa-devs - r?