### PR TITLE
fix(l10n): Fix double escaping problems on /*_complete pages.

### DIFF
--- a/app/scripts/templates/ready.mustache
+++ b/app/scripts/templates/ready.mustache
@@ -1,6 +1,6 @@
 <div id="main-content" class="card">
   <header>
-    <h1 id="{{headerId}}">{{headerTitle}}</h1>
+    <h1 id="{{headerId}}">{{{escapedHeaderTitle}}}</h1>
   </header>
 
   <section>
@@ -9,7 +9,7 @@
     <div class="graphic graphic-checkbox">{{#t}}Success{{/t}}</div>
 
     {{#isSync}}
-      <p class="account-ready-service">{{readyToSyncText}}</p>
+      <p class="account-ready-service">{{{escapedReadyToSyncText}}}</p>
     {{/isSync}}
 
     {{^isSync}}

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -69,10 +69,10 @@ define(function (require, exports, module) {
 
     setInitialContext (context) {
       context.set({
+        escapedHeaderTitle: this._getEscapedHeaderTitle(),
+        escapedReadyToSyncText: this._getEscapedReadyToSyncText(),
         headerId: this._getHeaderId(),
-        headerTitle: this._getHeaderTitle(),
         isSync: this.relier.isSync(),
-        readyToSyncText: this._getReadyToSyncText(),
         redirectUri: this.relier.get('redirectUri'),
         secondaryEmailVerified: this.getSearchParam('secondary_email_verified') || null
       });
@@ -82,13 +82,25 @@ define(function (require, exports, module) {
       return this._templateInfo.headerId;
     },
 
-    _getHeaderTitle () {
-      var title = this._templateInfo.headerTitle;
+    /**
+     * Get the HTML escaped header title
+     *
+     * @returns {String}
+     */
+    _getEscapedHeaderTitle () {
+      const title = this._templateInfo.headerTitle;
+      // translateInTemplate HTML escapes
       return this.translateInTemplate(title);
     },
 
-    _getReadyToSyncText () {
-      var readyToSyncText = this._templateInfo.readyToSyncText;
+    /**
+     * Get the HTML escaped "Ready to Sync" text
+     *
+     * @returns {String}
+     */
+    _getEscapedReadyToSyncText () {
+      const readyToSyncText = this._templateInfo.readyToSyncText;
+      // translateInTemplate HTML escapes
       return this.translateInTemplate(readyToSyncText);
     }
   });


### PR DESCRIPTION
The header and button text are translated within the views
and passed to the templates. When the strings are translated
within the views, they are already HTML escaped. Then, the
template was escaping them again!

fixes #5407

@vladikoff - r?