### PR TITLE
Revert #5386

### DIFF
--- a/app/scripts/models/auth_brokers/fx-sync-channel.js
+++ b/app/scripts/models/auth_brokers/fx-sync-channel.js
@@ -109,9 +109,7 @@ define(function (require, exports, module) {
 
     beforeSignIn (account) {
       const email = account.get('email');
-      const uid = account.get('uid');
-      if (this._verifiedCanLinkEmail === email &&
-          this._verifiedCanLinkUid === uid) {
+      if (this._verifiedCanLinkEmail === email) {
         // This user has already been asked and responded that
         // they want to link the account. Do not ask again or
         // else the user sees the "can link account" browser
@@ -123,14 +121,13 @@ define(function (require, exports, module) {
       // we should cancel the login to sync or not based on Desktop
       // specific checks and dialogs. It throws an error with
       // message='USER_CANCELED_LOGIN' and errno=1001 if that's the case.
-      return this.request(this.getCommand('CAN_LINK_ACCOUNT'), { email, uid })
+      return this.request(this.getCommand('CAN_LINK_ACCOUNT'), { email })
         .then((response) => {
           if (response && ! response.ok) {
             throw AuthErrors.toError('USER_CANCELED_LOGIN');
           }
 
           this._verifiedCanLinkEmail = email;
-          this._verifiedCanLinkUid = uid;
           return proto.beforeSignIn.call(this, account);
         }, (err) => {
           this._logger.error('beforeSignIn failed with', err);
@@ -279,9 +276,7 @@ define(function (require, exports, module) {
     _getLoginData (account) {
       const loginData = account.pick(ALLOWED_LOGIN_FIELDS);
       loginData.verified = !! loginData.verified;
-      loginData.verifiedCanLinkAccount = !! this._verifiedCanLinkEmail &&
-                                         !! this._verifiedCanLinkUid;
-
+      loginData.verifiedCanLinkAccount = !! this._verifiedCanLinkEmail;
       return _.omit(loginData, _.isUndefined);
     }
   }, {

--- a/app/tests/spec/lib/channels/web.js
+++ b/app/tests/spec/lib/channels/web.js
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
           });
         });
 
-        return channel.request('can_link_account', { email: 'testuser@testuser.com', uid: 'uid' })
+        return channel.request('can_link_account', { email: 'testuser@testuser.com' })
           .then(function (response) {
             assert.isTrue(response.ok);
           });

--- a/app/tests/spec/models/auth_brokers/fx-sync-channel.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync-channel.js
@@ -206,7 +206,6 @@ define(function (require, exports, module) {
           .then(() => {
             assert.equal(channelMock.send.args[0][0], 'can_link_account');
             const data = channelMock.send.args[1][1];
-            assert.equal(data.uid, 'uid');
             assert.equal(data.email, 'testuser@testuser.com');
             assert.isFalse(data.verified);
             assert.isTrue(data.verifiedCanLinkAccount);


### PR DESCRIPTION
We realized that #5386 was broken and wasn't sending uid (because the message is sent before account creation/login).