### PR TITLE
fix(cwts): Ensure a two column display on CWTS in EN.

### DIFF
--- a/app/styles/modules/_branding.scss
+++ b/app/styles/modules/_branding.scss
@@ -103,6 +103,10 @@
       margin: 20px auto 0 auto;
       width: 300px;
     }
+
+    @include respond-to('trustedUI') {
+      margin: 10px auto 20px auto;
+    }
   }
 
   .success-email-created {

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -248,4 +248,20 @@ ul.permission-links {
   .choose-what-to-sync-row {
     margin-bottom: 10px;
   }
+
+  .fxa-checkbox__label {
+    color: $color-grey-faint-text;
+  }
+
+  @include respond-to('trustedUI') {
+    column-width: 118px;
+
+    .fxa-checkbox {
+      line-height: 18px;
+    }
+
+    .fxa-checkbox__label {
+      font-size: 14px;
+    }
+  }
 }


### PR DESCRIPTION
* For the trustedUI form factor, set the column width to 118px
* Set the font size of the items to 14px
* Set the label color to grey

fixes #5442 

@ryanfeeley - r?

Here's what it looks like now:

<img width="329" alt="screen shot 2017-09-19 at 13 25 48" src="https://user-images.githubusercontent.com/848085/30592344-e75b075e-9d35-11e7-8e97-8d2c7b2f232d.png">
