### PR TITLE
feat(metrics): include utm params in metrics context

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,6 +2,8 @@
   "exceptions": [
     // uglify-js
     "https://nodesecurity.io/advisories/39",
-    "https://nodesecurity.io/advisories/48"
+    "https://nodesecurity.io/advisories/48",
+    // tough-cookie@2.3.2
+    "https://nodesecurity.io/advisories/525"
   ]
 }

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -90,6 +90,12 @@ define(function (require, exports, module) {
     return `flow.${viewName.replace(/^oauth\./, '')}.${eventName}`;
   }
 
+  function marshallUtmParam (utmParam) {
+    if (utmParam && utmParam !== NOT_REPORTED_VALUE) {
+      return utmParam;
+    }
+  }
+
   function Metrics (options = {}) {
     this._speedTrap = new SpeedTrap();
     this._speedTrap.init();
@@ -620,7 +626,12 @@ define(function (require, exports, module) {
       return {
         deviceId: this._deviceId,
         flowBeginTime: metadata.flowBegin,
-        flowId: metadata.flowId
+        flowId: metadata.flowId,
+        utmCampaign: marshallUtmParam(this._utmCampaign),
+        utmContent: marshallUtmParam(this._utmContent),
+        utmMedium: marshallUtmParam(this._utmMedium),
+        utmSource: marshallUtmParam(this._utmSource),
+        utmTerm: marshallUtmParam(this._utmTerm)
       };
     },
 

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -56,8 +56,8 @@ define(function (require, exports, module) {
         utmCampaign: 'utm_campaign',
         utmContent: 'utm_content',
         utmMedium: 'utm_medium',
-        utmSource: 'utm_source',
-        utmTerm: 'utm_term',
+        utmSource: 'none',
+        utmTerm: '',
         window: windowMock
       }));
     }
@@ -89,7 +89,12 @@ define(function (require, exports, module) {
       assert.deepEqual(metrics.getFlowEventMetadata(), {
         deviceId: 'wibble',
         flowBeginTime: undefined,
-        flowId: undefined
+        flowId: undefined,
+        utmCampaign: 'utm_campaign',
+        utmContent: 'utm_content',
+        utmMedium: 'utm_medium',
+        utmSource: undefined,
+        utmTerm: undefined
       });
     });
 
@@ -104,7 +109,12 @@ define(function (require, exports, module) {
         assert.deepEqual(metrics.getFlowEventMetadata(), {
           deviceId: 'wibble',
           flowBeginTime: FLOW_BEGIN_TIME,
-          flowId: FLOW_ID
+          flowId: FLOW_ID,
+          utmCampaign: 'utm_campaign',
+          utmContent: 'utm_content',
+          utmMedium: 'utm_medium',
+          utmSource: undefined,
+          utmTerm: undefined
         });
       });
 
@@ -146,7 +156,12 @@ define(function (require, exports, module) {
           assert.deepEqual(metrics.getFlowEventMetadata(), {
             deviceId: 'wibble',
             flowBeginTime: FLOW_BEGIN_TIME,
-            flowId: FLOW_ID
+            flowId: FLOW_ID,
+            utmCampaign: 'utm_campaign',
+            utmContent: 'utm_content',
+            utmMedium: 'utm_medium',
+            utmSource: undefined,
+            utmTerm: undefined
           });
         });
       });
@@ -191,8 +206,8 @@ define(function (require, exports, module) {
         assert.equal(filteredData.utm_campaign, 'utm_campaign');
         assert.equal(filteredData.utm_content, 'utm_content');
         assert.equal(filteredData.utm_medium, 'utm_medium');
-        assert.equal(filteredData.utm_source, 'utm_source');
-        assert.equal(filteredData.utm_term, 'utm_term');
+        assert.equal(filteredData.utm_source, 'none');
+        assert.equal(filteredData.utm_term, 'none');
       });
     });
 

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "cocktail": "0.5.9",
     "easteregg": "https://github.com/mozilla/fxa-easter-egg.git#ab20cd517cf8ae9feee115e48745189d28e13bc3",
     "fxa-checkbox": "mozilla/fxa-checkbox#7f856afffd394a144f718e28e6fb79092d6ccddd",
-    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.64",
+    "fxa-js-client": "https://github.com/mozilla/fxa-js-client.git#0.1.65",
     "html5shiv": "3.7.2",
     "jquery": "3.1.0",
     "jquery-modal": "https://github.com/shane-tomlinson/jquery-modal.git#0576775d1b4590314b114386019f4c7421c77503",


### PR DESCRIPTION
For a 96.1 patch release, fixes #5487.

There are no outwardly visible symptoms that this change is working, so I just stuck a `console.log(request.payload.metricsContext)` at the top of the `/account/login` handler in the auth server to prove that the data is being propagated correctly.

When signing in with no utm params, you should see something like this:

```
2|auth-ser | { deviceId: '027015d64a984572b6caa72357355dab',
2|auth-ser |   flowId: '1504d8bed2aa49b8af210e40c2d7b6e4b984d3ebbc2f3d5d71c01c67b88b64ca',
2|auth-ser |   flowBeginTime: 1506016749679 }
```

Or with utm parameters like so:

```
http://127.0.0.1:3030/signin?utm_campaign=foo&utm_contnet=bar&utm_medium=baz&
utm_source=qux&utm_term=wibble
```

It shows the following in the auth server logs:

```
2|auth-ser | { deviceId: '0054e893baf14e16be90d081222aeb71',
2|auth-ser |   flowId: 'be036b787c530f78fd146e39f9f4bbb7cc74cc3642f7e9033a2235fa31b255c8',
2|auth-ser |   flowBeginTime: 1506016853228,
2|auth-ser |   utmCampaign: 'foo',
2|auth-ser |   utmMedium: 'baz',
2|auth-ser |   utmSource: 'qux',
2|auth-ser |   utmTerm: 'wibble' }
```

@mozilla/fxa-devs r?