### PR TITLE
fix(test): Fix the Sync v2 force_auth/unverified account test.

### DIFF
--- a/tests/functional/sync_v2_force_auth.js
+++ b/tests/functional/sync_v2_force_auth.js
@@ -120,7 +120,7 @@ define([
         .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(openVerificationLinkInDifferentBrowser(email, 1))
-        .then(testElementExists(selectors.SIGNUP_COMPLETE.HEADER));
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
     },
 
     'verified, blocked': function () {


### PR DESCRIPTION
## UPLIFT


The user should be sent to /connect_another_device, not /signup_complete.

fixes #5511