### PR TITLE
fix(css): Fix the sass warning about height/margin being in the wrong order.

### DIFF
--- a/app/styles/modules/_graphic.scss
+++ b/app/styles/modules/_graphic.scss
@@ -58,8 +58,8 @@
 .graphic-connect-another-device {
   background-image: url('/images/account-verified.svg');
   background-position: center center;
-  margin-top: 35px;
   height: 130px;
+  margin-top: 35px;
   width: auto;
 
   @include respond-to('small') {


### PR DESCRIPTION
Not attached to an issue.

@mozilla/fxa-devs - r?