### PR TITLE
fix(email-first): Bump the email-first sample rate to 2.5%.

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/email-first.js
+++ b/app/scripts/lib/experiments/grouping-rules/email-first.js
@@ -57,23 +57,12 @@ define((require, exports, module) => {
      * @private
      */
     _isSampledUser (subject) {
-      // DataDog metrics have to be enabled for user to be a part of the experiment.
-      // sampleRate is the % of DataDog reporting users.
-      const sampleRate = EmailFirstGroupingRule.sampleRate(subject.env);
-
-      return subject.experimentGroupingRules.choose('isSampledUser', subject) &&
-              this.bernoulliTrial(sampleRate, subject.uniqueUserId);
-    }
-
-    /**
-     * Get the sample rate for `env`
-     *
-     * @static
-     * @param {String} env
-     * @returns {Number}
-     */
-    static sampleRate (env) {
-      return env === 'development' ? 1.0 : 0.2;
+      // All users that make it to this point that also report metrics are
+      // sampled users.
+      // There are 4 experiments in q3FormChanges, and 10% of users report metrics.
+      // 100% / 4 = 25% in each of the 4 experiments.
+      // 25% * .1 = 2.5% overall sample rate for this experiment.
+      return subject.experimentGroupingRules.choose('isSampledUser', subject);
     }
   }
 


### PR DESCRIPTION
With #5479, we isolated the email-first experiment from
other "q3FormChanges" experiments, which caused the number
of users in this experiment to drop to 25% of its original
value. This PR says that enable the experiment for all
users that are chosen in q3FormChanges, as long as
they have metrics reporting enabled. The result is
a 2.5% sample rate.

fixes #5502

@mozilla/fxa-devs - r?