### PR TITLE
fix(test): Fix the Sync v1 reset_password test.

### DIFF
--- a/app/scripts/models/auth_brokers/fx-sync-channel.js
+++ b/app/scripts/models/auth_brokers/fx-sync-channel.js
@@ -184,11 +184,11 @@ define(function (require, exports, module) {
     afterResetPasswordConfirmationPoll (account) {
       // We wouldn't expect `customizeSync` to be set when completing
       // a password reset, but the field must be present for the login
-      // message to be sent. Since this is a password reset instead of
-      // a signup, assume the user already chosen their sync buckets.
+      // message to be sent. false is the default value set in
+      // lib/fxa-client.js if the value is not present.
       // See #5528
       if (! account.has('customizeSync')) {
-        account.set('customizeSync', true);
+        account.set('customizeSync', false);
       }
 
       return this._notifyRelierOfLogin(account)

--- a/app/scripts/models/auth_brokers/fx-sync-channel.js
+++ b/app/scripts/models/auth_brokers/fx-sync-channel.js
@@ -182,6 +182,15 @@ define(function (require, exports, module) {
     },
 
     afterResetPasswordConfirmationPoll (account) {
+      // We wouldn't expect `customizeSync` to be set when completing
+      // a password reset, but the field must be present for the login
+      // message to be sent. Since this is a password reset instead of
+      // a signup, assume the user already chosen their sync buckets.
+      // See #5528
+      if (! account.has('customizeSync')) {
+        account.set('customizeSync', true);
+      }
+
       return this._notifyRelierOfLogin(account)
         .then(() => proto.afterResetPasswordConfirmationPoll.call(this, account));
     },

--- a/app/tests/spec/models/auth_brokers/fx-sync-channel.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync-channel.js
@@ -379,7 +379,7 @@ define(function (require, exports, module) {
             assert.isTrue(channelMock.send.calledOnce);
             assert.isTrue(channelMock.send.calledWith('login'));
             const loginData = channelMock.send.args[0][1];
-            assert.isTrue(loginData.customizeSync);
+            assert.isFalse(loginData.customizeSync);
 
             assert.isUndefined(result.halt);
           });

--- a/app/tests/spec/models/auth_brokers/fx-sync-channel.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync-channel.js
@@ -368,9 +368,19 @@ define(function (require, exports, module) {
 
     describe('afterResetPasswordConfirmationPoll', () => {
       it('notifies the channel of login, does not halt by default', () => {
+        // customizeSync is required to send the `login` message, but
+        // it won't be set because the user hasn't visited the signup/in
+        // page.
+
+        account.unset('customizeSync');
+
         return broker.afterResetPasswordConfirmationPoll(account)
           .then(function (result) {
+            assert.isTrue(channelMock.send.calledOnce);
             assert.isTrue(channelMock.send.calledWith('login'));
+            const loginData = channelMock.send.args[0][1];
+            assert.isTrue(loginData.customizeSync);
+
             assert.isUndefined(result.halt);
           });
       });


### PR DESCRIPTION
The `customizeSync` attribute was not available on the account.

This is a regression due to us filtering out `undefined` values
on login data, introduced in d31de3522a6e57bf172009ad5eb3a9369eff3624.

fixes #5528 

@vladikoff or @vbudhram - r?