### PR TITLE
fix(password-reset): Fix password reset for fx-desktop-v2, v3.

### DIFF
--- a/app/scripts/models/auth_brokers/fx-sync-channel.js
+++ b/app/scripts/models/auth_brokers/fx-sync-channel.js
@@ -181,20 +181,6 @@ define(function (require, exports, module) {
         });
     },
 
-    afterResetPasswordConfirmationPoll (account) {
-      // We wouldn't expect `customizeSync` to be set when completing
-      // a password reset, but the field must be present for the login
-      // message to be sent. false is the default value set in
-      // lib/fxa-client.js if the value is not present.
-      // See #5528
-      if (! account.has('customizeSync')) {
-        account.set('customizeSync', false);
-      }
-
-      return this._notifyRelierOfLogin(account)
-        .then(() => proto.afterResetPasswordConfirmationPoll.call(this, account));
-    },
-
     afterChangePassword (account) {
       // If the message is sent over the WebChannel by the global WebChannel,
       // no need to send it from within the auth broker too.

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
@@ -113,9 +113,18 @@ define(function (require, exports, module) {
       it('notifies the channel of login, halts by default', function () {
         sinon.spy(broker, 'send');
 
+        // customizeSync is required to send the `login` message, but
+        // it won't be set because the user hasn't visited the signup/in
+        // page.
+        account.unset('customizeSync');
+
         return broker.afterResetPasswordConfirmationPoll(account)
           .then(function (result) {
             assert.isTrue(broker.send.calledWith('login'));
+            assert.isTrue(broker.send.calledOnce);
+            const loginData = broker.send.args[0][1];
+            assert.isFalse(loginData.customizeSync);
+
             assert.isTrue(result.halt);
           });
       });

--- a/app/tests/spec/models/auth_brokers/fx-sync-channel.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync-channel.js
@@ -366,26 +366,6 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('afterResetPasswordConfirmationPoll', () => {
-      it('notifies the channel of login, does not halt by default', () => {
-        // customizeSync is required to send the `login` message, but
-        // it won't be set because the user hasn't visited the signup/in
-        // page.
-
-        account.unset('customizeSync');
-
-        return broker.afterResetPasswordConfirmationPoll(account)
-          .then(function (result) {
-            assert.isTrue(channelMock.send.calledOnce);
-            assert.isTrue(channelMock.send.calledWith('login'));
-            const loginData = channelMock.send.args[0][1];
-            assert.isFalse(loginData.customizeSync);
-
-            assert.isUndefined(result.halt);
-          });
-      });
-    });
-
     describe('afterChangePassword', () => {
       it('notifies the channel of change_password with the new login info', () => {
         account.set({

--- a/tests/functional/sync_v2_reset_password.js
+++ b/tests/functional/sync_v2_reset_password.js
@@ -72,6 +72,8 @@ define([
         .then(closeCurrentWindow())
 
         .then(testSuccessWasShown())
+        // Only expect the login message in the verification tab to avoid
+        // a race condition within the browser when it receives two login messages.
         .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 

--- a/tests/functional/sync_v3_reset_password.js
+++ b/tests/functional/sync_v3_reset_password.js
@@ -27,6 +27,7 @@ define([
     fillOutResetPassword,
     fillOutCompleteResetPassword,
     noPageTransition,
+    noSuchBrowserNotification,
     openPage,
     openVerificationLinkInNewTab,
     testElementExists,
@@ -89,7 +90,10 @@ define([
 
         // In fx <= 56, about:accounts takes over the screen, no need to transition
         .then(noPageTransition(selectors.CONFIRM_RESET_PASSWORD.HEADER, 5000))
-        .then(testSuccessWasShown());
+        .then(testSuccessWasShown())
+        // Only expect the login message in the verification tab to avoid
+        // a race condition within the browser when it receives two login messages.
+        .then(noSuchBrowserNotification('fxaccounts:login'));
     },
 
     'reset password, verify same browser, Fx >= 57': function () {
@@ -99,7 +103,10 @@ define([
         .then(setupTest(query))
 
         // In fx >= 57, about:accounts expects FxA to transition after email verification
-        .then(testElementExists(selectors.RESET_PASSWORD_COMPLETE.HEADER));
+        .then(testElementExists(selectors.RESET_PASSWORD_COMPLETE.HEADER))
+        // Only expect the login message in the verification tab to avoid
+        // a race condition within the browser when it receives two login messages.
+        .then(noSuchBrowserNotification('fxaccounts:login'));
     },
   });
 


### PR DESCRIPTION
to allow the `login` message to be sent to the browser
in afterResetPasswordConfirmationPoll for fx_desktop_v1.

This unfortunately broke fx_desktop_v2 and fx_desktop_v3
where the verification tab sends the `login` message, and
the original tab is forbidden from sending the message
so that timing issues within the browser are avoided.

This fixes the problem by moving the logic to send
the `login` message afterResetPasswordConfirmationPoll
to the only broker that needs - fx_desktop_v1, which
is propagated to it's decendent, fx_ios_v1.

fixes #5533 

@vladikoff - r?

To test this, I had to use Firefox 38 available at:

http://download.cdn.mozilla.net/pub/firefox/releases/38.0/mac/en-US/Firefox%2038.0.dmg

The app is unsigned, to run it in Mac OS Sierra, I followed this process:

http://osxdaily.com/2015/07/15/add-remove-gatekeeper-app-command-line-mac-os-x/

Then I used fxa-dev-launcher to create a profile with context=fx_desktop_v1:

```bash
FXA_DESKTOP_CONTEXT=fx_desktop_v1 npm start
```

Test steps:

1. Open about:accounts
2. Initiate a password reset, keep the tab open
3. Open the password link in the same browser
4. Fill out password reset
5. The original tab should redirect to about:accounts and the dropdown displayed that says the user is syncing. The user should be connected to Sync.