### PR TITLE
fix(behavior): Propagate account info in the navigate behavior.

### DIFF
--- a/app/scripts/views/behaviors/navigate.js
+++ b/app/scripts/views/behaviors/navigate.js
@@ -9,13 +9,13 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const _ = require('underscore');
   const p = require('../../lib/promise');
 
-  var NavigationBehavior = function (endpoint, options) {
-    options = options || {};
-
-    var behavior = function (view) {
-      view.navigate(endpoint, options);
+  const NavigationBehavior = function (endpoint, options = {}) {
+    const behavior = function (view, account) {
+      const navigateOptions = _.assign({}, options, { account });
+      view.navigate(endpoint, navigateOptions);
 
       // halt the flow after navigating.
       return p.defer().promise;

--- a/app/tests/spec/views/behaviors/navigate.js
+++ b/app/tests/spec/views/behaviors/navigate.js
@@ -5,35 +5,36 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const chai = require('chai');
+  const { assert } = require('chai');
   const NavigateBehavior = require('views/behaviors/navigate');
   const sinon = require('sinon');
 
-  var assert = chai.assert;
-
   describe('views/behaviors/navigate', function () {
     it('navigates to the indicated view, passing in success/error options', function () {
-      var options = {
+      const options = {
         error: 'error',
         success: 'success'
       };
 
-      var navigateBehavior = new NavigateBehavior('settings', options);
-      var viewMock = {
+      const navigateBehavior = new NavigateBehavior('settings', options);
+      const viewMock = {
         navigate: sinon.spy()
       };
 
-      var promise = navigateBehavior(viewMock);
+      const accountMock = {};
+
+      const promise = navigateBehavior(viewMock, accountMock);
       // navigateBehavior returns a promise that never resolves,
       // aborting the rest of the flow.
       assert.equal(promise.inspect().state, 'pending');
 
-      var endpoint = viewMock.navigate.args[0][0];
-      var navigateOptions = viewMock.navigate.args[0][1];
+      const endpoint = viewMock.navigate.args[0][0];
+      const navigateOptions = viewMock.navigate.args[0][1];
 
       assert.equal(endpoint, 'settings');
       assert.equal(navigateOptions.success, 'success');
       assert.equal(navigateOptions.error, 'error');
+      assert.strictEqual(navigateOptions.account, accountMock);
     });
   });
 });


### PR DESCRIPTION
Behaviors are passed a view and an account. The account was not
propagated to the next view in the `view.navigate` call.

This PR changes that by propagating the account.

Extraction from #5518

@mozilla/fxa-devs - r?