### PR TITLE
refactor(CAD): Simplify logic to decide whether to show CAD after email verification.

### DIFF
--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -29,9 +29,6 @@ define(function (require, exports, module) {
     }),
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
-      browserTransitionsAfterEmailVerification: true,
-      cadAfterSignInConfirmationPoll: true,
-      cadAfterSignUpConfirmationPoll: true,
       chooseWhatToSyncCheckbox: false,
       chooseWhatToSyncWebV1: true,
       openWebmailButtonVisible: true

--- a/app/scripts/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/scripts/models/auth_brokers/fx-firstrun-v1.js
@@ -27,8 +27,7 @@ define(function (require, exports, module) {
     },
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
-      cadAfterSignInConfirmationPoll: true,
-      cadAfterSignUpConfirmationPoll: true,
+      browserTransitionsAfterEmailVerification: false,
       chooseWhatToSyncCheckbox: true,
       chooseWhatToSyncWebV1: false,
       openWebmailButtonVisible: true

--- a/app/scripts/models/auth_brokers/fx-sync.js
+++ b/app/scripts/models/auth_brokers/fx-sync.js
@@ -25,13 +25,6 @@ define(function (require, exports, module) {
       afterCompleteSignUp: new ConnectAnotherDeviceBehavior(proto.defaultBehaviors.afterCompleteSignUp)
     }),
 
-    defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
-      // Can CAD be displayed after the signin confirmation poll?
-      cadAfterSignInConfirmationPoll: false,
-      // Can CAD be displayed after the signup confirmation poll?
-      cadAfterSignUpConfirmationPoll: false
-    }),
-
     type: 'fx-sync',
 
     initialize (options = {}) {
@@ -76,7 +69,7 @@ define(function (require, exports, module) {
     afterSignInConfirmationPoll (account) {
       return proto.afterSignInConfirmationPoll.call(this, account)
         .then((defaultBehavior) => {
-          if (this.hasCapability('cadAfterSignInConfirmationPoll')) {
+          if (! this.hasCapability('browserTransitionsAfterEmailVerification')) {
             // This is a hack to allow us to differentiate between users
             // who see CAD in the signin and verification tabs. CAD
             // was added to the verification tab first, view names and view
@@ -98,7 +91,7 @@ define(function (require, exports, module) {
     afterSignUpConfirmationPoll (account) {
       return proto.afterSignUpConfirmationPoll.call(this, account)
         .then((defaultBehavior) => {
-          if (this.hasCapability('cadAfterSignUpConfirmationPoll')) {
+          if (! this.hasCapability('browserTransitionsAfterEmailVerification')) {
             // This is a hack to allow us to differentiate between users
             // who see CAD in the signup and verification tabs. CAD
             // was added to the verification tab first, view names and view

--- a/app/tests/spec/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-firstrun-v1.js
@@ -54,19 +54,10 @@ define(function (require, exports, module) {
       metrics = null;
     });
 
-    it('has the `cadAfterSignUpConfirmationPoll` capability by default', function () {
-      assert.isTrue(broker.hasCapability('cadAfterSignUpConfirmationPoll'));
-    });
-
-    it('has the `signup` capability by default', function () {
+    it('has the expected capabilities', () => {
+      assert.isFalse(broker.hasCapability('browserTransitionsAfterEmailVerification'));
       assert.isTrue(broker.hasCapability('signup'));
-    });
-
-    it('has the `handleSignedInNotification` capability by default', function () {
       assert.isTrue(broker.hasCapability('handleSignedInNotification'));
-    });
-
-    it('has the `emailVerificationMarketingSnippet` capability by default', function () {
       assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
     });
 

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -127,9 +127,9 @@ define((require, exports, module) => {
     });
 
     describe('afterSignUpConfirmationPoll', () => {
-      describe('broker has `cadAfterSignUpConfirmationPoll` capability', () => {
+      describe('broker does not have `browserTransitionsAfterEmailVerification` capability', () => {
         it('sets the metrics viewName prefix, resolves to a `ConnectAnotherDeviceBehavior`', () => {
-          broker.setCapability('cadAfterSignUpConfirmationPoll', true);
+          broker.setCapability('browserTransitionsAfterEmailVerification', false);
           sinon.spy(metrics, 'setViewNamePrefix');
 
           return broker.afterSignUpConfirmationPoll(account)
@@ -143,9 +143,9 @@ define((require, exports, module) => {
       });
 
       describe('afterSignInConfirmationPoll', () => {
-        describe('broker has `cadAfterSignInConfirmationPoll` capability', () => {
+        describe('broker does not have `browserTransitionsAfterEmailVerification` capability', () => {
           it('sets the metrics viewName prefix, resolves to a `ConnectAnotherDeviceBehavior`', () => {
-            broker.setCapability('cadAfterSignInConfirmationPoll', true);
+            broker.setCapability('browserTransitionsAfterEmailVerification', false);
             sinon.spy(metrics, 'setViewNamePrefix');
 
             return broker.afterSignInConfirmationPoll(account)
@@ -158,8 +158,9 @@ define((require, exports, module) => {
           });
         });
 
-        describe('broker does not have `cadAfterSignInConfirmationPoll` capability', () => {
+        describe('broker has `browserTransitionsAfterEmailVerification` capability', () => {
           it('resolves to the default behavior', () => {
+            broker.setCapability('browserTransitionsAfterEmailVerification', true);
             sinon.spy(metrics, 'setViewNamePrefix');
 
             return broker.afterSignInConfirmationPoll(account)


### PR DESCRIPTION
There were two capabilities, `cadAfterSignInConfirmationPoll`
and `cadAfterSignUpConfirmationPoll` that were used to decide
whether to show CAD after an email confirmation poll. These
two capabilities are set to `true` only when another capabilty,
`browserTransitionsAfterEmailVerification` is set to `false`.

Might as well ditch the extra capabilities and just use
`browserTransitionsAfterEmailVerification` and simplify the logic.

Extraction from #5518

@mozilla/fxa-devs - r?