### PR TITLE
fix(CAD): Ensure CAD is displayed if the user verifies at CWTS.

### DIFF
--- a/app/scripts/lib/cocktail.js
+++ b/app/scripts/lib/cocktail.js
@@ -6,7 +6,7 @@
  * A dropin replacement for Cocktail that ensure any of a mixin's
  * dependencies are also mixed in.
  *
- * A mixin that delcares `dependsOn` will have all dependencies
+ * A mixin that declares `dependsOn` will have all dependencies
  * mixed in beforehand.
  *
  * NOTE: This does not check for circular dependencies. We depend on
@@ -36,7 +36,24 @@ define(function (require, exports, module) {
     }, []));
   }
 
+  /**
+   * Check if `mixin` is mixed into `target` by checking
+   * whether `target` contains all of the properties/methods
+   * of `mixin`. Not foolproof, if `mixin` contains only
+   * properties and `target` already has all the properties,
+   * then `true` will be returned even if `target`s properties
+   * are not the same as `mixin`s properties.
+   *
+   * @param {Object} target
+   * @param {Object} mixin
+   * @returns {Boolean}
+   */
+  function isMixedIn(target, mixin) {
+    return _.every(Object.keys(mixin), (key) => key in target);
+  }
+
   module.exports = {
+    isMixedIn,
     mixin
   };
 });

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
       afterResetPasswordConfirmationPoll: new NullBehavior(),
       afterSignIn: new NullBehavior(),
       afterSignInConfirmationPoll: new NavigateBehavior('signin_confirmed'),
-      afterSignUp: new NullBehavior(),
+      afterSignUp: new NavigateBehavior('confirm'),
       afterSignUpConfirmationPoll: new NavigateBehavior('signup_confirmed'),
       beforeSignIn: new NullBehavior(),
       beforeSignUpConfirmationPoll: new NullBehavior()
@@ -296,7 +296,11 @@ define(function (require, exports, module) {
      * @param {Object} account
      * @return {Promise}
      */
-    afterSignUp (/* account */) {
+    afterSignUp (account) {
+      if (account.get('verified')) {
+        // If the account is already verified, go to the step after /confirm
+        return this.afterSignUpConfirmationPoll(account);
+      }
       return p(this.getBehavior('afterSignUp'));
     },
 

--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -25,6 +25,7 @@ define(function (require, exports, module) {
       afterForceAuth: new HaltIfBrowserTransitions(defaultBehaviors.afterForceAuth),
       afterResetPasswordConfirmationPoll: new HaltIfBrowserTransitions(defaultBehaviors.afterResetPasswordConfirmationPoll),
       afterSignIn: new HaltIfBrowserTransitions(defaultBehaviors.afterSignIn),
+      afterSignUpConfirmationPoll: new HaltIfBrowserTransitions(defaultBehaviors.afterSignUpConfirmationPoll),
       beforeSignUpConfirmationPoll: new HaltIfBrowserTransitions(defaultBehaviors.beforeSignUpConfirmationPoll),
     }),
 

--- a/app/scripts/models/auth_brokers/fx-fennec-v1.js
+++ b/app/scripts/models/auth_brokers/fx-fennec-v1.js
@@ -18,8 +18,7 @@ define(function (require, exports, module) {
 
   var FxFennecV1AuthenticationBroker = FxSyncWebChannelAuthenticationBroker.extend({
     defaultBehaviors: _.extend({}, proto.defaultBehaviors, {
-      afterSignIn: new NavigateBehavior('signin_confirmed'),
-      afterSignUpConfirmationPoll: new NavigateBehavior('signup_confirmed')
+      afterSignIn: new NavigateBehavior('signin_confirmed')
     }),
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {

--- a/app/scripts/views/behaviors/connect-another-device.js
+++ b/app/scripts/views/behaviors/connect-another-device.js
@@ -15,6 +15,8 @@
 define((require, exports, module) => {
   'use strict';
 
+  const Cocktail = require('cocktail');
+  const ConnectAnotherDeviceMixin = require('../mixins/connect-another-device-mixin');
   const p = require('../../lib/promise');
 
   /**
@@ -27,6 +29,8 @@ define((require, exports, module) => {
   module.exports = function (defaultBehavior) {
     const behavior = function (view, account) {
       return p().then(() => {
+        behavior.ensureConnectAnotherDeviceMixin(view);
+
         if (view.isEligibleForConnectAnotherDevice(account)) {
           return view.navigateToConnectAnotherDeviceScreen(account);
         }
@@ -41,6 +45,12 @@ define((require, exports, module) => {
         }
         return defaultBehavior;
       });
+    };
+
+    behavior.ensureConnectAnotherDeviceMixin = function (view) {
+      if (! Cocktail.isMixedIn(view, ConnectAnotherDeviceMixin)) {
+        Cocktail.mixin(view, ConnectAnotherDeviceMixin);
+      }
     };
 
     behavior.type = 'connect-another-device';

--- a/app/scripts/views/mixins/signup-mixin.js
+++ b/app/scripts/views/mixins/signup-mixin.js
@@ -67,19 +67,7 @@ define(function (require, exports, module) {
       this.logViewEvent('success');
       this.logViewEvent('signup.success');
 
-      if (account.get('verified')) {
-        // user was pre-verified.
-        this.logViewEvent('preverified.success');
-        return this.invokeBrokerMethod('afterSignIn', account)
-          .then(() => {
-            this.navigate('signup_confirmed');
-          });
-      }
-
-      return this.invokeBrokerMethod('afterSignUp', account)
-        .then(() => {
-          this.navigate('confirm', { account });
-        });
+      return this.invokeBrokerMethod('afterSignUp', account);
     },
 
     onSuggestSyncClick () {

--- a/app/tests/spec/lib/cocktail.js
+++ b/app/tests/spec/lib/cocktail.js
@@ -106,5 +106,24 @@ define(function (require, exports, module) {
       view.functionFrom3And4();
       assert.equal(functionFrom3And4Count, 2);
     });
+
+    it('isMixedIn returns `true` if `target` contains all properties of `mixin`', () => {
+      const view = new View();
+      const mixin = {
+        methodName () {
+          return true;
+        },
+
+        propertyName: 'propertyValue'
+      };
+
+      assert.isFalse(Cocktail.isMixedIn(view, mixin));
+
+      Cocktail.mixin(view, mixin);
+
+      assert.isTrue(Cocktail.isMixedIn(view, mixin));
+      assert.isTrue(view.methodName());
+      assert.equal(view.propertyName, 'propertyValue');
+    });
   });
 });

--- a/app/tests/spec/models/auth_brokers/base.js
+++ b/app/tests/spec/models/auth_brokers/base.js
@@ -301,6 +301,23 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('afterSignUp', function () {
+      it('delegates to `afterSignUpConfirmationPoll` if account is verified', () => {
+        account.set('verified', true);
+        sinon.stub(broker, 'afterSignUpConfirmationPoll').callsFake(() => p());
+        return broker.afterSignUp(account)
+          .then(() => {
+            assert.isTrue(broker.afterSignUpConfirmationPoll.calledOnce);
+            assert.isTrue(broker.afterSignUpConfirmationPoll.calledWith(account));
+          });
+      });
+
+      it('returns the `afterSignUp` behavior if account is not verified', () => {
+        return broker.afterSignUp(account)
+          .then(testNavigates('confirm'));
+      });
+    });
+
     describe('afterSignUpConfirmationPoll', function () {
       it('returns a promise, behavior navigates to signup_confirmed', function () {
         return broker.afterSignUpConfirmationPoll(account)
@@ -432,6 +449,10 @@ define(function (require, exports, module) {
     });
 
     describe('_consumeSigninCode', () => {
+      beforeEach(() => {
+        sinon.stub(metrics, '_initializeFlowModel').callsFake(() => {});
+      });
+
       it('delegates to the user, clears signinCode when complete', () => {
         sinon.stub(fxaClient, 'consumeSigninCode').callsFake(function () {
           return p({ email: 'signed-in-email@testuser.com' });

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
@@ -33,6 +33,7 @@ define(function (require, exports, module) {
       account = user.initAccount({
         email: 'testuser@testuser.com',
         keyFetchToken: 'key-fetch-token',
+        uid: 'uid',
         unwrapBKey: 'unwrap-b-key'
       });
 

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -32,6 +32,7 @@ define(function (require, exports, module) {
       account = user.initAccount({
         email: 'testuser@testuser.com',
         keyFetchToken: 'key-fetch-token',
+        uid: 'uid',
         unwrapBKey: 'unwrap-b-key'
       });
 

--- a/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -33,6 +33,7 @@ define(function (require, exports, module) {
       account = user.initAccount({
         email: 'testuser@testuser.com',
         keyFetchToken: 'key-fetch-token',
+        uid: 'uid',
         unwrapBKey: 'unwrap-b-key'
       });
 

--- a/app/tests/spec/models/auth_brokers/fx-firstrun-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-firstrun-v1.js
@@ -28,6 +28,7 @@ define(function (require, exports, module) {
       account = new Account({
         email: 'testuser@testuser.com',
         keyFetchToken: 'key-fetch-token',
+        uid: 'uid',
         unwrapBKey: 'unwrap-b-key'
       });
       channelMock = new NullChannel();

--- a/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -94,7 +94,9 @@ define(function (require, exports, module) {
           timeoutSpy = sinon.spy(callback);
         });
         sinon.spy(windowMock, 'clearTimeout');
-        account = new Account({});
+        account = new Account({
+          uid: 'uid'
+        });
       });
 
       function testLoginSent(triggerLoginCB) {

--- a/app/tests/spec/models/auth_brokers/fx-sync-channel.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync-channel.js
@@ -327,10 +327,12 @@ define(function (require, exports, module) {
       describe('browser does not support `sendAfterSignUpConfirmationPollNotice`', () => {
         it('notifies the channel of login, does not halt the flow by default', () => {
           broker.setCapability('sendAfterSignUpConfirmationPollNotice', false);
+
           return broker.afterSignUpConfirmationPoll(account)
             .then((result) => {
               assert.ok(result);
-              assert.isFalse(channelMock.send.called);
+              assert.isTrue(channelMock.send.calledOnce);
+              assert.isTrue(channelMock.send.calledWith('login'));
             });
         });
       });
@@ -352,7 +354,8 @@ define(function (require, exports, module) {
             .then((result) => {
               assert.ok(result);
 
-              assert.isTrue(channelMock.send.calledOnce);
+              assert.isTrue(channelMock.send.called);
+              assert.isTrue(channelMock.send.calledWith('login'));
               assert.isTrue(channelMock.send.calledWith('verified'));
 
               const loginData = channelMock.send.args[0][1];

--- a/app/tests/spec/views/behaviors/connect-another-device.js
+++ b/app/tests/spec/views/behaviors/connect-another-device.js
@@ -6,7 +6,9 @@ define((require, exports, module) => {
   'use strict';
 
   const { assert } = require('chai');
+  const Cocktail = require('cocktail');
   const ConnectAnotherDeviceBehavior = require('views/behaviors/connect-another-device');
+  const ConnectAnotherDeviceMixin = require('views/mixins/connect-another-device-mixin');
   const NullBehavior = require('views/behaviors/null');
   const sinon = require('sinon');
 
@@ -21,14 +23,22 @@ define((require, exports, module) => {
       cadBehavior = new ConnectAnotherDeviceBehavior(defaultBehavior);
     });
 
+    it('ensureConnectAnotherDeviceMixin adds the ConnectAnotherDeviceMixin to a view', () => {
+      const view = {};
+      cadBehavior.ensureConnectAnotherDeviceMixin(view);
+      assert.isFunction(view.isEligibleForConnectAnotherDevice);
+      assert.isFunction(view.navigateToConnectAnotherDeviceScreen);
+    });
+
     describe('eligible for CAD', () => {
       it('delegates to `view.navigateToConnectAnotherDeviceScreen`', () => {
         const view = {
-          hasNavigated: sinon.spy(() => false),
-          isEligibleForConnectAnotherDevice: sinon.spy(() => true),
-          isSignIn: sinon.spy(() => false),
-          navigateToConnectAnotherDeviceScreen: sinon.spy()
+          hasNavigated: sinon.spy(() => false)
         };
+        Cocktail.mixin(view, ConnectAnotherDeviceMixin);
+
+        sinon.stub(view, 'isEligibleForConnectAnotherDevice').callsFake(() => true);
+        sinon.stub(view, 'navigateToConnectAnotherDeviceScreen').callsFake(() => {});
 
         return cadBehavior(view, account)
           .then((behavior) => {
@@ -48,11 +58,12 @@ define((require, exports, module) => {
     describe('ineligible for CAD', () => {
       it('invokes the defaultBehavior', () => {
         const view = {
-          hasNavigated: sinon.spy(() => false),
-          isEligibleForConnectAnotherDevice: sinon.spy(() => false),
-          isSignIn: sinon.spy(() => false),
-          navigateToConnectAnotherDeviceScreen: sinon.spy()
+          hasNavigated: sinon.spy(() => false)
         };
+        Cocktail.mixin(view, ConnectAnotherDeviceMixin);
+
+        sinon.stub(view, 'isEligibleForConnectAnotherDevice').callsFake(() => false);
+        sinon.stub(view, 'navigateToConnectAnotherDeviceScreen').callsFake(() => {});
 
         return cadBehavior(view, account)
           .then((behavior) => {

--- a/app/tests/spec/views/mixins/signup-mixin.js
+++ b/app/tests/spec/views/mixins/signup-mixin.js
@@ -125,64 +125,7 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('verified account', function () {
-        beforeEach(function () {
-          account.set('verified', true);
-
-          return view.signUp(account, 'password');
-        });
-
-        it('calls user.signUpAccount correctly', () => {
-          assert.isTrue(user.signUpAccount.calledOnce);
-          assert.isTrue(user.signUpAccount.calledWith(
-            account, 'password', relier, { resume: 'resume token' }));
-
-          assert.isTrue(view.getStringifiedResumeToken.calledOnce);
-          assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
-        });
-
-        it('calls view.logViewEvent correctly', function () {
-          assert.equal(view.logViewEvent.callCount, 3);
-
-          assert.isTrue(view.logViewEvent.calledWith('success'));
-          assert.isTrue(view.logViewEvent.calledWith('signup.success'));
-          assert.isTrue(view.logViewEvent.calledWith('preverified.success'));
-        });
-
-        it('calls view.logFlowEvent correctly', () => {
-          assert.equal(view.logFlowEvent.callCount, 1);
-          assert.equal(view.logFlowEvent.args[0].length, 2);
-          assert.equal(view.logFlowEvent.args[0][0], 'attempt');
-          assert.equal(view.logFlowEvent.args[0][1], 'signup');
-        });
-
-        it('calls view.formPrefill.clear', function () {
-          assert.equal(view.formPrefill.clear.callCount, 1);
-        });
-
-        it('calls view.invokeBrokerMethod correctly', function () {
-          assert.equal(view.invokeBrokerMethod.callCount, 2);
-
-          var args = view.invokeBrokerMethod.args[0];
-          assert.lengthOf(args, 2);
-          assert.equal(args[0], 'beforeSignIn');
-          assert.equal(args[1], account);
-
-          args = view.invokeBrokerMethod.args[1];
-          assert.lengthOf(args, 2);
-          assert.equal(args[0], 'afterSignIn');
-          assert.deepEqual(args[1], account);
-        });
-
-        it('calls view.navigate correctly', function () {
-          assert.equal(view.navigate.callCount, 1);
-          var args = view.navigate.args[0];
-          assert.lengthOf(args, 1);
-          assert.equal(args[0], 'signup_confirmed');
-        });
-      });
-
-      describe('unverified account', function () {
+      describe('everyone else', function () {
         beforeEach(function () {
           account.set('verified', false);
 
@@ -221,16 +164,6 @@ define(function (require, exports, module) {
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'afterSignUp');
           assert.deepEqual(args[1], account);
-        });
-
-        it('calls view.navigate correctly', function () {
-          assert.equal(view.navigate.callCount, 1);
-          var args = view.navigate.args[0];
-          assert.lengthOf(args, 2);
-          assert.equal(args[0], 'confirm');
-          assert.isObject(args[1]);
-          assert.lengthOf(Object.keys(args[1]), 1);
-          assert.deepEqual(args[1], { account });
         });
       });
 

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -92,7 +92,7 @@ define([
   });
 
   registerSuite({
-    name: 'Firstrun Sync v2 sign_up',
+    name: 'Firstrun Sync v2 signup',
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
@@ -105,7 +105,7 @@ define([
         .then(clearBrowserState());
     },
 
-    'sign up, user verifies at CWTS': function () {
+    'verify at CWTS': function () {
       return this.remote
         .then(openPage(PAGE_URL, selectors.SIGNUP.HEADER, {
           webChannelResponses: {
@@ -120,13 +120,12 @@ define([
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(openVerificationLinkInDifferentBrowser(email, 0))
 
-        // user should be transitioned straight to the "your address is confirmed"
-        .then(testElementExists(selectors.SIGNUP_COMPLETE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
         // the login message is sent automatically.
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
-    'sign up, verify same browser': function () {
+    'verify same browser': function () {
       return this.remote
         .then(setupTest())
 
@@ -144,7 +143,7 @@ define([
         .then(testEmailExpected(email, 1));
     },
 
-    'sign up, verify different browser': function () {
+    'verify different browser': function () {
       return this.remote
         .then(setupTest())
         // First, synthesize opening the verification link in a different browser
@@ -161,7 +160,7 @@ define([
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
     },
 
-    'sign up, verify different browser, force SMS': function () {
+    'verify different browser, force SMS': function () {
       const options =  {
         query: {
           forceExperiment: 'sendSms',
@@ -185,7 +184,7 @@ define([
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
     },
 
-    'sign up, verify same browser, force SMS, force supported country': function () {
+    'verify same browser, force SMS, force supported country': function () {
       const options =  {
         query: {
           country: 'CA',
@@ -210,7 +209,7 @@ define([
         .then(testElementExists(selectors.SMS_SEND.HEADER));
     },
 
-    'sign up, force SMS, force unsupported country in signup tab': function () {
+    'force SMS, force unsupported country in signup tab': function () {
       return this.remote
         .then(openPage(PAGE_URL, selectors['400'].HEADER, {
           query: {
@@ -222,7 +221,7 @@ define([
         .then(testElementTextInclude(selectors['400'].ERROR, 'country'));
     },
 
-    'sign up, verify same browser, force SMS, force unsupported country in verification tab': function () {
+    'verify same browser, force SMS, force unsupported country in verification tab': function () {
       return this.remote
         .then(setupTest())
 
@@ -246,22 +245,22 @@ define([
         .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER));
     },
 
-    'sign up, verify Chrome on Android, force SMS sends to connect_another_device': function () {
+    'verify Chrome on Android, force SMS sends to connect_another_device': function () {
       return this.remote
         .then(verifyMobileTest(UA_STRINGS['android_chrome']));
     },
 
-    'sign up, verify Firefox on Android, force SMS sends to connect_another_device': function () {
+    'verify Firefox on Android, force SMS sends to connect_another_device': function () {
       return this.remote
         .then(verifyMobileTest(UA_STRINGS['android_firefox']));
     },
 
-    'sign up, verify Firefox on iOS, force SMS sends to connect_another_device': function () {
+    'verify Firefox on iOS, force SMS sends to connect_another_device': function () {
       return this.remote
         .then(verifyMobileTest(UA_STRINGS['ios_firefox']));
     },
 
-    'sign up, verify Safari on iOS, force SMS sends to connect_another_device': function () {
+    'verify Safari on iOS, force SMS sends to connect_another_device': function () {
       return this.remote
         .then(verifyMobileTest(UA_STRINGS['ios_safari']));
     },

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -53,7 +53,7 @@ define([
       return this.remote.then(clearBrowserState());
     },
 
-    'Fx <= 56, user verifies at CWTS': function () {
+    'Fx <= 56, verify at CWTS': function () {
       return this.remote
         .then(openPage(SIGNUP_FX_55_PAGE_URL, selectors.SIGNUP.HEADER, {
           webChannelResponses: {
@@ -70,12 +70,12 @@ define([
         .then(openVerificationLinkInDifferentBrowser(email, 0))
 
         // about:accounts takes over, so no screen transition
-        .then(noPageTransition(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
+        .then(noPageTransition(selectors.CHOOSE_WHAT_TO_SYNC.HEADER, 5000))
         // but the login message is sent automatically.
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
-    'Fx >= 57, user verifies at CWTS': function () {
+    'Fx >= 57, verify at CWTS': function () {
       return this.remote
         .then(openPage(SIGNUP_FX_57_PAGE_URL, selectors.SIGNUP.HEADER, {
           webChannelResponses: {
@@ -91,9 +91,9 @@ define([
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(openVerificationLinkInDifferentBrowser(email, 0))
 
-        // In fx >= 57, about:accounts does not take over.
+        // In Fx >= 57, about:accounts does not take over.
         // Expect a screen transition.
-        .then(testElementExists(selectors.SIGNUP_COMPLETE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
         // but the login message is sent automatically.
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
@@ -289,6 +289,7 @@ define([
         .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
 
         .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(openVerificationLinkInDifferentBrowser(email))
 
@@ -307,6 +308,7 @@ define([
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
         .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
+        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
 


### PR DESCRIPTION
Users who verify their email while looking at CWTS
have `account.verifed=true` when signup-mixin.onSignUpSuccess
is called. This resulted in the `broker.afterSignIn` function
being called, which only sends users to CAD if they are
part of the CAD on signin experiment.

This was wrong. These users are signing up and should be sent
to CAD.

The problem is the code that sent users to `afterSignIn` was
leftover to handle pre-verified users for users coming from
AMO. We removed this feature long ago, but this code hung
around, and in this case, caused a problem.

To fix this problem, in signinMixin.onSignUpSuccess, always
send users to broker.afterSignUp. If the account is verified,
broker.afterSignUp delegates to broker.afterSignUpConfirmationPoll,
which is the step after `/confirm`.

Extraction from #5518 

@mozilla/fxa-devs - r?