### PR TITLE
fix(CAD): Do not show the "sign in" button if the user is at CWTS.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -326,6 +326,7 @@ define(function (require, exports, module) {
           assertionLibrary: this._assertionLibrary,
           fxaClient: this._fxaClient,
           iframeChannel: this._iframeChannel,
+          isVerificationSameBrowser: this._isVerificationSameBrowser(),
           metrics: this._metrics,
           notificationChannel: this._notificationChannel,
           notifier: this._notifier,
@@ -708,6 +709,17 @@ define(function (require, exports, module) {
       return this._isSignUpVerification() ||
              this._isPasswordResetVerification() ||
              this._isReportSignIn();
+    },
+
+    /**
+     * Is the user verifying in the same browser they signed up/in to?
+     *
+     * @returns {Boolean}
+     * @private
+     */
+    _isVerificationSameBrowser () {
+      return this._isVerification() &&
+             !! this._getSameBrowserVerificationModel('context').get('context');
     },
 
     _isInAnIframe () {

--- a/app/scripts/views/choose_what_to_sync.js
+++ b/app/scripts/views/choose_what_to_sync.js
@@ -49,12 +49,20 @@ define(function (require, exports, module) {
     },
 
     afterVisible () {
-      this.waitForSessionVerification(
-        this.getAccount(),
-        () => this.validateAndSubmit()
-      );
-
-      return proto.afterVisible.call(this);
+      const account = this.getAccount();
+      return proto.afterVisible.call(this)
+        // The verification data needs to be written to localStorage
+        // in case the user verifies while at CWTS. The data is used
+        // by CAD to determine that the user is verifying in the same
+        // browser, and to avoid asking the user to sign in again.
+        // See #5554
+        .then(() => this.broker.persistVerificationData(account))
+        .then(() => {
+          this.waitForSessionVerification(
+            account,
+            () => this.validateAndSubmit()
+          );
+        });
     },
 
     destroy (...args) {

--- a/app/scripts/views/connect_another_device.js
+++ b/app/scripts/views/connect_another_device.js
@@ -164,7 +164,18 @@ define(function (require, exports, module) {
      * @private
      */
     _isSignedIn () {
-      return this.user.isSignedInAccount(this.getAccount());
+      // If a user verifies at CWTS, the browser will not have yet received
+      // the fxaccounts:login message, and the fxaccounts:fxa_status request on
+      // startup will return `signedInUser: null`, resulting in us believing no
+      // user is signed in. Users that aren't signed in are asked to sign in.
+      // Whoops.
+      // Fortunately, we can guess that the user *will* be signed in
+      // if we know the user is verifying in the same browser. Some data
+      // is written in CWTS to let us know the user is verifying in the same
+      // browser. If this is the case, assume the user is signed in.
+      // See #5554
+      return this.user.isSignedInAccount(this.getAccount()) ||
+             this.broker.get('isVerificationSameBrowser');
     }
 
     /**

--- a/app/tests/spec/views/connect_another_device.js
+++ b/app/tests/spec/views/connect_another_device.js
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
     describe('render/afterVisible', () => {
       describe('with a Fx desktop user that is signed in', () => {
         beforeEach(() => {
-          sinon.stub(user, 'isSignedInAccount').callsFake(() => true);
+          sinon.stub(view, '_isSignedIn').callsFake(() => true);
           windowMock.navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
 
           return view.render()
@@ -75,6 +75,7 @@ define(function (require, exports, module) {
         });
 
         it('shows the marketing area, logs appropriately', () => {
+          assert.isTrue(view._isSignedIn.called);
           assert.lengthOf(view.$('.marketing-area'), 1);
           testIsFlowEventLogged('signedin.true');
           testIsFlowEventLogged('signin.ineligible');
@@ -95,7 +96,7 @@ define(function (require, exports, module) {
             };
           });
 
-          sinon.stub(user, 'isSignedInAccount').callsFake(() => true);
+          sinon.stub(view, '_isSignedIn').callsFake(() => true);
 
           return view.render()
             .then(() => {
@@ -104,6 +105,7 @@ define(function (require, exports, module) {
         });
 
         it('shows the marketing area, logs appropriately', () => {
+          assert.isTrue(view._isSignedIn.called);
           assert.lengthOf(view.$('.marketing-area'), 1);
           testIsFlowEventLogged('signedin.true');
           testIsFlowEventLogged('signin.ineligible');
@@ -125,7 +127,7 @@ define(function (require, exports, module) {
           });
 
           account.set('email', 'testuser@testuser.com');
-          sinon.stub(user, 'isSignedInAccount').callsFake(() => false);
+          sinon.stub(view, '_isSignedIn').callsFake(() => false);
           sinon.stub(view, '_canSignIn').callsFake(() => true);
 
           return view.render()
@@ -135,6 +137,7 @@ define(function (require, exports, module) {
         });
 
         it('shows a sign in button with the appropriate link, logs appropriately', () => {
+          assert.isTrue(view._isSignedIn.called);
           assert.lengthOf(view.$('#signin'), 1);
           testIsFlowEventLogged('signedin.false');
           testIsFlowEventLogged('signin.eligible');
@@ -156,7 +159,7 @@ define(function (require, exports, module) {
           });
 
           account.set('email', 'testuser@testuser.com');
-          sinon.stub(user, 'isSignedInAccount').callsFake(() => false);
+          sinon.stub(view, '_isSignedIn').callsFake(() => false);
           sinon.stub(view, '_canSignIn').callsFake(() => true);
 
           return view.render()
@@ -166,6 +169,7 @@ define(function (require, exports, module) {
         });
 
         it('shows a sign in button with the appropriate link, logs appropriately', () => {
+          assert.isTrue(view._isSignedIn.called);
           assert.lengthOf(view.$('#signin'), 1);
           testIsFlowEventLogged('signedin.false');
           testIsFlowEventLogged('signin.eligible');
@@ -175,7 +179,7 @@ define(function (require, exports, module) {
 
       describe('with a user that cannot sign in', () => {
         beforeEach(() => {
-          sinon.stub(user, 'isSignedInAccount').callsFake(() => false);
+          sinon.stub(view, '_isSignedIn').callsFake(() => false);
           sinon.stub(view, '_canSignIn').callsFake(() => false);
         });
 
@@ -194,6 +198,7 @@ define(function (require, exports, module) {
           return view.render()
             .then(() => {
               view.afterVisible();
+              assert.isTrue(view._isSignedIn.called);
 
               assert.lengthOf(view.$('#signin-fxios'), 1);
               assert.lengthOf(view.$('.marketing-area'), 0);
@@ -292,12 +297,27 @@ define(function (require, exports, module) {
     });
 
     describe('_isSignedIn', () => {
-      it('delegates to user.isSignedInAccount', () => {
+      it('returns `true` if the account is signed', () => {
         sinon.stub(user, 'isSignedInAccount').callsFake(() => true);
+        broker.set('isVerificationSameBrowser', false);
 
         assert.isTrue(view._isSignedIn());
         assert.isTrue(user.isSignedInAccount.calledOnce);
         assert.isTrue(user.isSignedInAccount.calledWith(account));
+      });
+
+      it('returns `true` if verifying in the same browser', () => {
+        sinon.stub(user, 'isSignedInAccount').callsFake(() => false);
+        broker.set('isVerificationSameBrowser', true);
+
+        assert.isTrue(view._isSignedIn());
+      });
+
+      it('returns `false` otherwise', () => {
+        sinon.stub(user, 'isSignedInAccount').callsFake(() => false);
+        broker.set('isVerificationSameBrowser', false);
+
+        assert.isFalse(view._isSignedIn());
       });
     });
 

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -16,22 +16,25 @@ define([
   var email;
   const PASSWORD = '12345678';
 
-  const clearBrowserState = FunctionalHelpers.clearBrowserState;
-  const click = FunctionalHelpers.click;
-  const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-  const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  const openPage = FunctionalHelpers.openPage;
-  const openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
-  const openVerificationLinkInSameTab = FunctionalHelpers.openVerificationLinkInSameTab;
-  const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  const testAttributeEquals = FunctionalHelpers.testAttributeEquals;
-  const testElementExists = FunctionalHelpers.testElementExists;
-  const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
-  const testEmailExpected = FunctionalHelpers.testEmailExpected;
-  const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
-  const thenify = FunctionalHelpers.thenify;
-  const visibleByQSA = FunctionalHelpers.visibleByQSA;
+  const {
+    clearBrowserState,
+    click,
+    closeCurrentWindow,
+    fillOutSignUp,
+    noSuchElement,
+    openPage,
+    openVerificationLinkInDifferentBrowser,
+    openVerificationLinkInNewTab,
+    openVerificationLinkInSameTab,
+    respondToWebChannelMessage,
+    testAttributeEquals,
+    testElementExists,
+    testElementTextInclude,
+    testEmailExpected,
+    testIsBrowserNotified,
+    thenify,
+    visibleByQSA,
+  } = FunctionalHelpers;
 
   const setupTest = thenify(function (options) {
     return this.parent
@@ -118,7 +121,12 @@ define([
 
         .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-        .then(openVerificationLinkInDifferentBrowser(email, 0))
+        .then(openVerificationLinkInNewTab(email, 0))
+          .switchToWindow('newwindow')
+          .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+          .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SIGNIN_BUTTON))
+          // switch back to the original window, it should transition to CAD.
+          .then(closeCurrentWindow())
 
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
         // the login message is sent automatically.

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -177,6 +177,7 @@ define([], function () {
       // The original checkbox is not clickable after the material conversion. The span
       // next to the element holds the label text, click it instead. See #5425
       CUSTOMIZE_SYNC_CHECKBOX: '#customize-sync + span',
+      CUSTOMIZE_SYNC_INPUT: '#customize-sync',
       EMAIL: 'input[type=email]',
       ERROR: '.error',
       HEADER: '#fxa-signup-header',
@@ -185,6 +186,7 @@ define([], function () {
       LINK_SUGGEST_SIGN_IN: '.error a[href="/signin"]',
       LINK_SUGGEST_SYNC: '#suggest-sync a',
       MARKETING_EMAIL_OPTIN: 'input.marketing-email-optin + span',
+      MIGRATING_USER: '.info.nudge',
       PASSWORD: '#password',
       SUBMIT: 'button[type="submit"]',
       SUBMIT_DISABLED: 'button[type="submit"].disabled',

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -15,19 +15,22 @@ define([
   var email;
   const PASSWORD = '12345678';
 
-  const click = FunctionalHelpers.click;
-  const clearBrowserState = FunctionalHelpers.clearBrowserState;
-  const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-  const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  const noPageTransition = FunctionalHelpers.noPageTransition;
-  const noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
-  const openPage = FunctionalHelpers.openPage;
-  const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
-  const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  const testAttributeExists = FunctionalHelpers.testAttributeExists;
-  const testElementExists = FunctionalHelpers.testElementExists;
-  const testEmailExpected = FunctionalHelpers.testEmailExpected;
-  const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+  const {
+    click,
+    clearBrowserState,
+    closeCurrentWindow,
+    fillOutSignUp,
+    noPageTransition,
+    noSuchBrowserNotification,
+    noSuchElement,
+    openPage,
+    openVerificationLinkInNewTab,
+    respondToWebChannelMessage,
+    testAttributeExists,
+    testElementExists,
+    testEmailExpected,
+    testIsBrowserNotified,
+  } = FunctionalHelpers;
 
   registerSuite({
     name: 'Firefox Desktop Sync v2 sign_up',
@@ -70,10 +73,12 @@ define([
         .then(testIsBrowserNotified('fxaccounts:login'))
         // verify the user
         .then(openVerificationLinkInNewTab(email, 0))
-        .switchToWindow('newwindow')
+          .switchToWindow('newwindow')
 
-        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
-        .then(closeCurrentWindow())
+          .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+          .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SIGNIN_BUTTON))
+
+          .then(closeCurrentWindow())
 
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -23,23 +23,25 @@ define([
   let email;
   const PASSWORD = '12345678';
 
-  const clearBrowserState = FunctionalHelpers.clearBrowserState;
-  const click = FunctionalHelpers.click;
-  const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-  const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  const getVerificationLink = FunctionalHelpers.getVerificationLink;
-  const getWebChannelMessageData = FunctionalHelpers.getWebChannelMessageData;
-  const storeWebChannelMessageData = FunctionalHelpers.storeWebChannelMessageData;
-  const noPageTransition = FunctionalHelpers.noPageTransition;
-  const noSuchElement = FunctionalHelpers.noSuchElement;
-  const noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
-  const openPage = FunctionalHelpers.openPage;
-  const openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  const openVerificationLinkInNewTab = FunctionalHelpers.openVerificationLinkInNewTab;
-  const testElementExists = FunctionalHelpers.testElementExists;
-  const testEmailExpected = FunctionalHelpers.testEmailExpected;
-  const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
-  const visibleByQSA = FunctionalHelpers.visibleByQSA;
+  const {
+    clearBrowserState,
+    click,
+    closeCurrentWindow,
+    fillOutSignUp,
+    getVerificationLink,
+    getWebChannelMessageData,
+    storeWebChannelMessageData,
+    noPageTransition,
+    noSuchElement,
+    noSuchBrowserNotification,
+    openPage,
+    openVerificationLinkInDifferentBrowser,
+    openVerificationLinkInNewTab,
+    testElementExists,
+    testEmailExpected,
+    testIsBrowserNotified,
+    visibleByQSA,
+  } = FunctionalHelpers;
 
   registerSuite({
     name: 'Firefox Desktop Sync v3 signup',
@@ -67,8 +69,12 @@ define([
 
         .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-        .then(openVerificationLinkInDifferentBrowser(email, 0))
-
+        .then(openVerificationLinkInNewTab(email, 0))
+          .switchToWindow('newwindow')
+          .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+          .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SIGNIN_BUTTON))
+          // switch back to the original window, it should transition to CAD.
+          .then(closeCurrentWindow())
         // about:accounts takes over, so no screen transition
         .then(noPageTransition(selectors.CHOOSE_WHAT_TO_SYNC.HEADER, 5000))
         // but the login message is sent automatically.
@@ -89,7 +95,12 @@ define([
 
         .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-        .then(openVerificationLinkInDifferentBrowser(email, 0))
+        .then(openVerificationLinkInNewTab(email, 0))
+          .switchToWindow('newwindow')
+          .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+          .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SIGNIN_BUTTON))
+          // switch back to the original window, it should transition to CAD.
+          .then(closeCurrentWindow())
 
         // In Fx >= 57, about:accounts does not take over.
         // Expect a screen transition.


### PR DESCRIPTION
If a user verifies at CWTS, no verification data has been
written to localStorage, nor has the browser been informed
of the user's intent to signup/in. When the verification page
is opened, it looks like no user is signed in, so the user
was being asked to sign in again.

This PR fixes the problem by writing the "SameBrowserVerificationInfo"
to localStorage when the user first views CWTS. When the user verifies,
we look for the SameBrowserVerificationInfo, if it's available and
the user has made it as far as CAD, we know the account has been verified
in the same browser and the user will be fully signed in momentarily.

fixes #5554 

I opened this against train-97, it's kind of a crappy experience now that I know it's there.