### PR TITLE
fix(signup): Show signup bounced errors in about:accounts from /confirm

### DIFF
--- a/app/scripts/models/auth_brokers/fx-desktop-v1.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v1.js
@@ -38,10 +38,12 @@ define(function (require, exports, module) {
       // about:accounts displays its own screen after sign in, no need
       // to show anything.
       afterSignIn: new HaltBehavior(),
-      // the browser is already polling, no need for the content server
-      // code to poll as well, otherwise two sets of polls are going on
-      // for the same user.
-      beforeSignUpConfirmationPoll: new HaltBehavior()
+      // about:accounts displays its own screen after sign in, no need
+      // to show anything.
+      afterSignInConfirmationPoll: new HaltBehavior(),
+      // about:accounts displays its own screen after sign in, no need
+      // to show anything.
+      afterSignUpConfirmationPoll: new HaltBehavior()
     }),
 
     createChannel () {

--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -25,8 +25,8 @@ define(function (require, exports, module) {
       afterForceAuth: new HaltIfBrowserTransitions(defaultBehaviors.afterForceAuth),
       afterResetPasswordConfirmationPoll: new HaltIfBrowserTransitions(defaultBehaviors.afterResetPasswordConfirmationPoll),
       afterSignIn: new HaltIfBrowserTransitions(defaultBehaviors.afterSignIn),
-      afterSignUpConfirmationPoll: new HaltIfBrowserTransitions(defaultBehaviors.afterSignUpConfirmationPoll),
-      beforeSignUpConfirmationPoll: new HaltIfBrowserTransitions(defaultBehaviors.beforeSignUpConfirmationPoll),
+      afterSignInConfirmationPoll: new HaltIfBrowserTransitions(defaultBehaviors.afterSignInConfirmationPoll),
+      afterSignUpConfirmationPoll: new HaltIfBrowserTransitions(defaultBehaviors.afterSignUpConfirmationPoll)
     }),
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {

--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -14,7 +14,7 @@ define(function (require, exports, module) {
   const $ = require('jquery');
   const Constants = require('../../lib/constants');
   const FxDesktopV1AuthenticationBroker = require('../auth_brokers/fx-desktop-v1');
-  const NullBehavior = require('../../views/behaviors/null');
+  const NavigateBehavior = require('../../views/behaviors/navigate');
   const p = require('../../lib/promise');
   const UserAgent = require('../../lib/user-agent');
 
@@ -38,7 +38,9 @@ define(function (require, exports, module) {
         // so that the user sees the "Signup complete!" screen after they
         // verify their email.
         this.setBehavior(
-          'beforeSignUpConfirmationPoll', new NullBehavior());
+          'afterSignInConfirmationPoll', new NavigateBehavior('signin_confirmed'));
+        this.setBehavior(
+          'afterSignUpConfirmationPoll', new NavigateBehavior('signup_confirmed'));
       }
     },
 

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v1.js
@@ -92,15 +92,32 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('afterSignInConfirmationPoll', () => {
+      it('halts by default', () => {
+        return broker.afterSignInConfirmationPoll(account)
+        .then((result) => {
+          assert.isTrue(result.halt);
+        });
+      });
+    });
+
     describe('beforeSignUpConfirmationPoll', function () {
-      it('notifies the channel of login, halts the flow by default', function () {
+      it('notifies the channel of login', function () {
         sinon.spy(broker, 'send');
 
         return broker.beforeSignUpConfirmationPoll(account)
-          .then(function (result) {
+          .then((result) => {
             assert.isTrue(broker.send.calledWith('login'));
-            assert.isTrue(result.halt);
           });
+      });
+    });
+
+    describe('afterSignUpConfirmationPoll', () => {
+      it('halts by default', () => {
+        return broker.afterSignUpConfirmationPoll(account)
+        .then((result) => {
+          assert.isTrue(result.halt);
+        });
       });
     });
 

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -88,11 +88,28 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('afterSignInConfirmationPoll', () => {
+      it('halts if browser transitions', () => {
+        return broker.afterSignInConfirmationPoll(account)
+          .then((result) => {
+            assert.equal(result.type, 'halt-if-browser-transitions');
+          });
+      });
+    });
+
     describe('beforeSignUpConfirmationPoll', () => {
       it('notifies the channel with `fxaccounts:login`, halts if browser transitions', () => {
         return broker.beforeSignUpConfirmationPoll(account)
-          .then(function (result) {
+          .then((result) => {
             assert.isTrue(channelMock.send.calledWith('fxaccounts:login'));
+          });
+      });
+    });
+
+    describe('afterSignUpConfirmationPoll', () => {
+      it('halts if browser transitions', () => {
+        return broker.afterSignUpConfirmationPoll(account)
+          .then((result) => {
             assert.equal(result.type, 'halt-if-browser-transitions');
           });
       });

--- a/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -51,7 +51,8 @@ define(function (require, exports, module) {
           assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
           assert.isFalse(broker.hasCapability('immediateUnverifiedLogin'));
 
-          assert.equal(broker.getBehavior('beforeSignUpConfirmationPoll').type, 'halt');
+          assert.equal(broker.getBehavior('afterSignInConfirmationPoll').type, 'halt');
+          assert.equal(broker.getBehavior('afterSignUpConfirmationPoll').type, 'halt');
         });
       });
 
@@ -64,7 +65,10 @@ define(function (require, exports, module) {
           assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
           assert.isTrue(broker.hasCapability('immediateUnverifiedLogin'));
 
-          assert.equal(broker.getBehavior('beforeSignUpConfirmationPoll').type, 'null');
+          assert.equal(broker.getBehavior('afterSignInConfirmationPoll').type, 'navigate');
+          assert.equal(broker.getBehavior('afterSignInConfirmationPoll').endpoint, 'signin_confirmed');
+          assert.equal(broker.getBehavior('afterSignUpConfirmationPoll').type, 'navigate');
+          assert.equal(broker.getBehavior('afterSignUpConfirmationPoll').endpoint, 'signup_confirmed');
         });
       });
     });

--- a/tests/functional/bounced_email.js
+++ b/tests/functional/bounced_email.js
@@ -10,29 +10,31 @@ define([
   'tests/functional/lib/selectors',
   'tests/functional/lib/ua-strings'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors, uaStrings) {
-  var bouncedEmail;
-  var deliveredEmail;
+  let bouncedEmail;
+  let deliveredEmail;
   const PASSWORD = '12345678';
-  const SIGNIN_URL = `${intern.config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true&forceUA=${encodeURIComponent(uaStrings.desktop_firefox_57)}`; //eslint-disable-line max-len
-  const SIGNUP_URL = `${intern.config.fxaContentRoot}signup?context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true&forceUA=${encodeURIComponent(uaStrings.desktop_firefox_57)}`; //eslint-disable-line max-len
+  const SIGNIN_URL = `${intern.config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true&forceUA=${encodeURIComponent(uaStrings.desktop_firefox_56)}`; //eslint-disable-line max-len
+  const SIGNUP_URL = `${intern.config.fxaContentRoot}signup?context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true&forceUA=${encodeURIComponent(uaStrings.desktop_firefox_56)}`; //eslint-disable-line max-len
 
-  const clearBrowserState = FunctionalHelpers.clearBrowserState;
-  const click = FunctionalHelpers.click;
-  const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-  const createUser = FunctionalHelpers.createUser;
-  const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-  const getFxaClient = FunctionalHelpers.getFxaClient;
-  const openPage = FunctionalHelpers.openPage;
-  const pollUntil = FunctionalHelpers.pollUntil;
-  const respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  const switchToWindow = FunctionalHelpers.switchToWindow;
-  const testElementExists = FunctionalHelpers.testElementExists;
-  const testElementValueEquals = FunctionalHelpers.testElementValueEquals;
-  const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
-  const thenify = FunctionalHelpers.thenify;
-  const type = FunctionalHelpers.type;
-  const visibleByQSA = FunctionalHelpers.visibleByQSA;
+  const {
+    clearBrowserState,
+    click,
+    closeCurrentWindow,
+    createUser,
+    fillOutSignIn,
+    fillOutSignUp,
+    getFxaClient,
+    openPage,
+    pollUntil,
+    respondToWebChannelMessage,
+    switchToWindow,
+    testElementExists,
+    testElementValueEquals,
+    testIsBrowserNotified,
+    thenify,
+    type,
+    visibleByQSA,
+  } = FunctionalHelpers;
 
   registerSuite({
     name: 'signup with an email that bounces',

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1496,14 +1496,14 @@ define([
    * Check to ensure the page does not transition
    *
    * @param {String} selector
-   * @param {Number} [timeout] time to wait in ms. Defaults to 2000ms
+   * @param {Number} [timeout] time to wait in ms. Defaults to 5000ms
    * @returns {promise} that resolves if the selector is found
    * before and after the timeout.
    */
   const noPageTransition = thenify(function (selector, timeout) {
     return this.parent
       .then(testElementExists(selector))
-      .sleep(timeout || 2000)
+      .sleep(timeout || 5000)
       .then(testElementExists(selector));
   });
 

--- a/tests/functional/settings_secondary_emails.js
+++ b/tests/functional/settings_secondary_emails.js
@@ -53,7 +53,7 @@ define([
       secondaryEmail = TestHelpers.createEmail();
       client = FunctionalHelpers.getFxaClient();
 
-      return this.remote.then(clearBrowserState());
+      return this.remote.then(clearBrowserState({ force: true }));
     },
 
     afterEach: function () {

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -233,7 +233,7 @@ define([
         .then(fillOutSignUp(email + '-', PASSWORD))
 
         // wait five seconds to allow any errant navigation to occur
-        .then(noPageTransition(selectors.SIGNUP.HEADER, 5000))
+        .then(noPageTransition(selectors.SIGNUP.HEADER))
 
         // the validation tooltip should be visible
         .then(visibleByQSA('.tooltip'));
@@ -448,7 +448,7 @@ define([
         }))
         .then(fillOutSignUp(email, PASSWORD, { vpassword: DROWSSAP }))
         // wait five seconds to allow any errant navigation to occur
-        .then(noPageTransition(selectors.SIGNUP.HEADER, 5000))
+        .then(noPageTransition(selectors.SIGNUP.HEADER))
         // the validation tooltip should be visible
         .then(visibleByQSA('.error'));
     },

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -74,7 +74,7 @@ define([
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.
         // Add an affordance just in case the poll happens unexpectedly.
-        .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER, 5000))
+        .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER))
 
         // A post-verification email should be sent, this is Sync.
         .then(testEmailExpected(email, 1));
@@ -122,7 +122,7 @@ define([
         .then(openVerificationLinkInDifferentBrowser(email, 0))
 
         // The original tab should not transition
-        .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER, 5000));
+        .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER));
     },
 
     'signup, verify different browser - from new browser\'s P.O.V.': function () {

--- a/tests/functional/sync_v2_sign_up.js
+++ b/tests/functional/sync_v2_sign_up.js
@@ -84,7 +84,7 @@ define([
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.
         // Add an affordance just in case the poll happens unexpectedly.
-        .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER, 5000))
+        .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER))
 
         // A post-verification email should be sent, this is Sync.
         .then(testEmailExpected(email, 1));

--- a/tests/functional/sync_v3_reset_password.js
+++ b/tests/functional/sync_v3_reset_password.js
@@ -90,7 +90,7 @@ define([
         .then(setupTest(query))
 
         // In fx <= 56, about:accounts takes over the screen, no need to transition
-        .then(noPageTransition(selectors.CONFIRM_RESET_PASSWORD.HEADER, 5000))
+        .then(noPageTransition(selectors.CONFIRM_RESET_PASSWORD.HEADER))
         .then(testSuccessWasShown())
         // Only expect the login message in the verification tab to avoid
         // a race condition within the browser when it receives two login messages.

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -77,7 +77,7 @@ define([
           // switch back to the original window, it should transition to CAD.
           .then(closeCurrentWindow())
         // about:accounts takes over, so no screen transition
-        .then(noPageTransition(selectors.CHOOSE_WHAT_TO_SYNC.HEADER, 5000))
+        .then(noPageTransition(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
         // but the login message is sent automatically.
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
@@ -152,7 +152,7 @@ define([
         // We do not expect the verification poll to occur. The poll
         // will take a few seconds to complete if it erroneously occurs.
         // Add an affordance just in case the poll happens unexpectedly.
-        .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER, 5000))
+        .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER))
 
         // A post-verification email should be sent, this is Sync.
         .then(testEmailExpected(email, 1));
@@ -306,7 +306,7 @@ define([
         .then(openVerificationLinkInDifferentBrowser(email))
 
         // about:accounts takes over, no screen transition
-        .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER, 5000));
+        .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER));
     },
 
     'Fx >= 57, verify from original tab\'s P.O.V.': function () {


### PR DESCRIPTION
Fx Desktop <= 58 takes control of about:accounts to redirect the user
to about:preferences#sync once it detects a user has verified their email.

We originally used this to reduce polling load on the server. Since
the browser was polling and would redirect once it detected the user
had verified their email, FxA did not poll. The problem is that
we added bounce detection, and we cannot detect bounces within
FxA w/o polling.

This change has FxA poll within about:accounts, but lets the browser
perform the screen transition once verification has been detected.

fixes #5566

@mozilla/fxa-devs - r?

ref #5565 