### PR TITLE
fix(build): Use the newest bower to use newest registry.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.96.6",
+  "version": "1.97.2",
   "dependencies": {
     "babel-middleware": {
       "version": "0.3.4",
@@ -706,7 +706,7 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.26.0",
-              "from": "babel-runtime@>=6.26.0 <7.0.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
@@ -723,7 +723,7 @@
             },
             "babel-template": {
               "version": "6.26.0",
-              "from": "babel-template@>=6.26.0 <7.0.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
               "dependencies": {
                 "babylon": {
@@ -851,7 +851,7 @@
             },
             "babel-types": {
               "version": "6.26.0",
-              "from": "babel-types@>=6.26.0 <7.0.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
               "dependencies": {
                 "esutils": {
@@ -2856,7 +2856,7 @@
                 },
                 "private": {
                   "version": "0.1.7",
-                  "from": "private@>=0.1.6 <0.2.0",
+                  "from": "private@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
                 }
               }
@@ -2985,9 +2985,9 @@
       }
     },
     "bower": {
-      "version": "1.8.0",
-      "from": "bower@1.8.0",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz"
+      "version": "1.8.2",
+      "from": "bower@1.8.2",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz"
     },
     "celebrate": {
       "version": "4.0.1",
@@ -3005,9 +3005,9 @@
           "resolved": "https://registry.npmjs.org/fastseries/-/fastseries-1.7.2.tgz",
           "dependencies": {
             "reusify": {
-              "version": "1.0.2",
+              "version": "1.0.3",
               "from": "reusify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.3.tgz"
             },
             "xtend": {
               "version": "4.0.1",
@@ -3062,7 +3062,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.3 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "moment": {
@@ -3125,7 +3125,7 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "from": "object-assign@>=4.1.0 <5.0.0",
+          "from": "object-assign@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
         },
         "vary": {
@@ -3872,7 +3872,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <3.0.0",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "once": {
@@ -4133,9 +4133,9 @@
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000739",
+              "version": "1.0.30000746",
               "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000739.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000746.tgz"
             }
           }
         },
@@ -4514,7 +4514,7 @@
             },
             "private": {
               "version": "0.1.7",
-              "from": "private@>=0.1.6 <0.2.0",
+              "from": "private@>=0.1.7 <0.2.0",
               "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
             },
             "slash": {
@@ -4543,7 +4543,7 @@
       "dependencies": {
         "arrify": {
           "version": "1.0.1",
-          "from": "arrify@>=1.0.1 <2.0.0",
+          "from": "arrify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
         },
         "async": {
@@ -5191,7 +5191,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -5249,7 +5249,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -5307,7 +5307,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -5317,7 +5317,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -5420,7 +5420,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -5552,9 +5552,9 @@
               "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
             },
             "uglify-js": {
-              "version": "3.1.2",
+              "version": "3.1.3",
               "from": "uglify-js@>=3.1.0 <3.2.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.3.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.5.7",
@@ -5579,7 +5579,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -8710,7 +8710,7 @@
             },
             "jade": {
               "version": "1.11.0",
-              "from": "jade@>=1.11.0 <2.0.0",
+              "from": "jade@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
               "dependencies": {
                 "character-parser": {
@@ -9488,7 +9488,7 @@
       "dependencies": {
         "arrify": {
           "version": "1.0.1",
-          "from": "arrify@>=1.0.1 <2.0.0",
+          "from": "arrify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
         },
         "multimatch": {
@@ -9772,9 +9772,9 @@
               }
             },
             "es-abstract": {
-              "version": "1.8.2",
+              "version": "1.9.0",
               "from": "es-abstract@>=1.5.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
               "dependencies": {
                 "es-to-primitive": {
                   "version": "1.1.1",
@@ -9888,7 +9888,7 @@
         },
         "escape-html": {
           "version": "1.0.3",
-          "from": "escape-html@1.0.3",
+          "from": "escape-html@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "parseurl": {
@@ -9986,7 +9986,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -9996,7 +9996,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -10049,12 +10049,12 @@
           "dependencies": {
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "object-assign": {
               "version": "4.1.1",
-              "from": "object-assign@>=4.1.0 <5.0.0",
+              "from": "object-assign@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
             }
           }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-preset-es2015": "6.24.1",
     "bluebird": "3.5.0",
     "body-parser": "1.18.2",
-    "bower": "1.8.0",
+    "bower": "1.8.2",
     "celebrate": "4.0.1",
     "connect-cachify": "0.0.17",
     "connect-fonts-firasans": "0.0.6",


### PR DESCRIPTION
bower.herokuapp.com was discontinued, bower 1.8.2 points to
the new registry, registry.bower.io.

fixes #5570 

@mozilla/fxa-devs - r?