### PR TITLE
fix(metrics): map service event property from client id

### DIFF
--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -21,6 +21,8 @@
 
 'use strict';
 
+const SERVICES = require('./configuration').get('oauth_client_id_map');
+
 const APP_VERSION = /^[0-9]+\.([0-9]+)\./.exec(require('../../package.json').version)[1];
 
 const GROUPS = {
@@ -232,7 +234,7 @@ function mapEntrypoint (eventCategory, data) {
 function mapService (eventCategory, data) {
   const service = marshallOptionalValue(data.service);
   if (service) {
-    return { service };
+    return { service: SERVICES[service] || service };
   }
 }
 

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -344,6 +344,12 @@ const conf = module.exports = convict({
     env: 'FXA_OAUTH_CLIENT_ID',
     format: String
   },
+  oauth_client_id_map: {
+    default: {},
+    doc: 'Mappings from client id to service name: { "id1": "name-1", "id2": "name-2" }',
+    env: 'OAUTH_CLIENT_IDS',
+    format: Object
+  },
   oauth_url: {
     default: 'http://127.0.0.1:9010',
     doc: 'The url of the Firefox Account OAuth server',

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -7,10 +7,21 @@
 define([
   'intern!object',
   'intern/chai!assert',
+  'intern/dojo/node!path',
+  'intern/dojo/node!proxyquire',
   'intern/dojo/node!sinon',
-  'intern/dojo/node!../../server/lib/amplitude',
   'intern/dojo/node!../../package.json',
-], (registerSuite, assert, sinon, amplitude, package) => {
+], (registerSuite, assert, path, proxyquire, sinon, package) => {
+  const amplitude = proxyquire(path.resolve('server/lib/amplitude'), {
+    './configuration': {
+      get () {
+        return {
+          '0': 'amo',
+          '1': 'pocket'
+        };
+      }
+    }
+  });
   const APP_VERSION = /^[0-9]+\.([0-9]+)\./.exec(package.version)[1];
 
   registerSuite({
@@ -56,7 +67,7 @@ define([
         flowBeginTime: 'qux',
         flowId: 'wibble',
         lang: 'blee',
-        service: 'juff',
+        service: '0',
         uid: 'soop',
         utm_campaign: 'melm',
         utm_content: 'florg',
@@ -75,7 +86,7 @@ define([
         event_properties: {
           device_id: 'bar',
           entrypoint: 'baz',
-          service: 'juff'
+          service: 'amo'
         },
         event_type: 'fxa_login - forgot_submit',
         language: 'blee',
@@ -211,7 +222,7 @@ define([
         flowBeginTime: 'd',
         flowId: 'e',
         lang: 'f',
-        service: 'g',
+        service: '1',
         uid: 'h',
         utm_campaign: 'i',
         utm_content: 'j',
@@ -228,7 +239,7 @@ define([
         event_properties: {
           device_id: 'b',
           entrypoint: 'c',
-          service: 'g'
+          service: 'pocket'
         },
         event_type: 'fxa_reg - engage',
         language: 'f',


### PR DESCRIPTION
Fixes mozilla/fxa-amplitude-send#21.

Instead of a sending raw client ids to Amplitude, we should send a service name instead. Requires new config, which I'll add to the deploy doc once merged.

@mozilla/fxa-devs r?