### PR TITLE
feat(sms): Remove the `control` group from the `sendSms` experiment.

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
+++ b/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
@@ -10,7 +10,11 @@ define((require, exports, module) => {
 
   const BaseGroupingRule = require('./base');
 
-  const GROUPS = ['control', 'treatment', 'signinCodes'];
+  // 'control' was CAD phase 1, normal ConnectAnotherDevice.
+  // Both SMS groups perform better than CAD phase 1, so for
+  // those eligible for SMS at all, push them through one
+  // of the two better flows. See #5561
+  const GROUPS = ['treatment', 'signinCodes'];
 
   function isEmailInSigninCodesGroup (email) {
     return /@softvision\.(com|ro)$/.test(email) ||

--- a/app/tests/spec/lib/experiments/grouping-rules/send-sms-install-link.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/send-sms-install-link.js
@@ -40,12 +40,12 @@ define(function (require, exports, module) {
 
       describe('others', () => {
         it('delegates to uniformChoice', () => {
-          sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
+          sinon.stub(experiment, 'uniformChoice').callsFake(() => 'treatment');
           account.set('email', 'testuser@testuser.com');
 
-          assert.equal(experiment.choose({ account, uniqueUserId: 'user-id' }), 'control');
+          assert.equal(experiment.choose({ account, uniqueUserId: 'user-id' }), 'treatment');
           assert.isTrue(experiment.uniformChoice.calledOnce);
-          assert.isTrue(experiment.uniformChoice.calledWith(['control', 'treatment', 'signinCodes'], 'user-id'));
+          assert.isTrue(experiment.uniformChoice.calledWith(['treatment', 'signinCodes'], 'user-id'));
         });
       });
     });


### PR DESCRIPTION
`control` performs worse than either `treatment` or `sendSms`. We
are continuing with the experiment pushing all users through
`treatment` and `sendSms`. This should boost the # of users in
each of the remaining groups.

fixes #5561 

@mozilla/fxa-devs - r?