### PR TITLE
fix(email-first): Show a readonly email field on the signin/signup pages.

### DIFF
--- a/app/scripts/templates/sign_in_password.mustache
+++ b/app/scripts/templates/sign_in_password.mustache
@@ -16,9 +16,8 @@
     <div class="success"></div>
 
     <form novalidate>
-      <div class="input-row">
-        <input name="email" type="email" class="email back" value="{{ email }}" />
-      </div>
+      <p class="prefillEmail">{{ email }}</p>
+      <input type="email" class="email hidden" value="{{ email }}" disabled />
 
       <div class="input-row password-row">
         <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus />

--- a/app/scripts/templates/sign_up_password.mustache
+++ b/app/scripts/templates/sign_up_password.mustache
@@ -16,9 +16,8 @@
     <div class="success"></div>
 
     <form novalidate>
-      <div class="input-row">
-        <input name="email" type="email" class="email back" value="{{ email }}" />
-      </div>
+      <p class="prefillEmail">{{ email }}</p>
+      <input type="email" class="email hidden" value="{{ email }}" disabled />
 
       <div class="input-row password-row">
         <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus data-form-prefill="password" data-synchronize-show="true" />

--- a/app/tests/spec/views/sign_in_password.js
+++ b/app/tests/spec/views/sign_in_password.js
@@ -5,7 +5,6 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const $ = require('jquery');
   const Account = require('models/account');
   const { assert } = require('chai');
   const Backbone = require('backbone');
@@ -110,16 +109,6 @@ define(function (require, exports, module) {
               assert.isTrue(view.signIn.calledWith(account, 'password'));
             });
         });
-      });
-    });
-
-    describe('click on the email field', () => {
-      it('navigates back', () => {
-        $('#container').html(view.el);
-
-        sinon.spy(view, 'back');
-        view.$('input[type=email]').click();
-        assert.isTrue(view.back.calledOnce);
       });
     });
   });

--- a/app/tests/spec/views/sign_up_password.js
+++ b/app/tests/spec/views/sign_up_password.js
@@ -5,7 +5,6 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const $ = require('jquery');
   const Account = require('models/account');
   const { assert } = require('chai');
   const Backbone = require('backbone');
@@ -144,16 +143,6 @@ define(function (require, exports, module) {
               assert.isFalse(view.displayError.called);
             });
         });
-      });
-    });
-
-    describe('click on the email field', () => {
-      it('navigates back', () => {
-        $('#container').html(view.el);
-
-        sinon.spy(view, 'back');
-        view.$('input[type=email]').click();
-        assert.isTrue(view.back.calledOnce);
       });
     });
   });


### PR DESCRIPTION
We believe the editible email fields may be causing user dropoff.
The editible looking email fields are replaced with readonly
fields like /force_auth's.

fixes #5582 

Here's what it looks like now:

#### signup

<img width="431" alt="screen shot 2017-10-16 at 13 45 09" src="https://user-images.githubusercontent.com/848085/31612940-0c853ca2-b271-11e7-9687-2bcef0b39df9.png">

#### signin

<img width="465" alt="screen shot 2017-10-16 at 13 54 50" src="https://user-images.githubusercontent.com/848085/31613013-52467e9a-b271-11e7-98c3-0c4a7670a01e.png">

@davismtl and @ryanfeeley - what do you think?
