### PR TITLE
fix(style): Update the color of the devices "open panel" spinner.

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -264,6 +264,7 @@ body.settings #main-content.card {
       background: $button-background-default-color;
       border: solid 1px $button-border-disabled-color;
       color: $button-disabled-color;
+      opacity: 0.5;
     }
   }
 


### PR DESCRIPTION
Add an opacity of 0.5 so that it matches the "Refresh" spinner.

fixes #5568 

@ryanfeeley - here you go!

#### Opening spinner now matches the Refresh button
<img width="557" alt="screen shot 2017-10-18 at 12 32 35" src="https://user-images.githubusercontent.com/848085/31716630-507d757c-b3f8-11e7-9ec3-47747f9ea5f5.png">

#### Refresh button
<img width="329" alt="screen shot 2017-10-18 at 12 33 48" src="https://user-images.githubusercontent.com/848085/31716635-55a3ec52-b3f8-11e7-9238-8d61357df690.png">

