### PR TITLE
fix(metrics): add missing reason property to disconnect event

### DIFF
--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -175,6 +175,22 @@ define([
       }, {
         headers: {}
       }, {
+        deviceId: 'b',
+        flowBeginTime: 'c',
+        flowId: 'd',
+        lang: 'e',
+        uid: 'f'
+      });
+      assert.equal(process.stderr.write.callCount, 0);
+    },
+
+    'settings.clients.disconnect.submit.suspicious': () => {
+      amplitude({
+        time: 'a',
+        type: 'settings.clients.disconnect.submit.suspicious'
+      }, {
+        headers: {}
+      }, {
         deviceId: 'none',
         flowBeginTime: 'b',
         flowId: 'c',
@@ -184,9 +200,29 @@ define([
       assert.equal(process.stderr.write.callCount, 1);
       const arg = JSON.parse(process.stderr.write.args[0]);
       assert.equal(arg.event_type, 'fxa_pref - disconnect_device');
+      assert.equal(arg.event_properties.reason, 'suspicious');
       assert.isUndefined(arg.device_id);
       assert.isUndefined(arg.event_properties.device_id);
       assert.isUndefined(arg.user_id);
+    },
+
+    'settings.clients.disconnect.submit.duplicate': () => {
+      amplitude({
+        time: 'a',
+        type: 'settings.clients.disconnect.submit.duplicate'
+      }, {
+        headers: {}
+      }, {
+        deviceId: 'b',
+        flowBeginTime: 'c',
+        flowId: 'd',
+        lang: 'e',
+        uid: 'f'
+      });
+      assert.equal(process.stderr.write.callCount, 1);
+      const arg = JSON.parse(process.stderr.write.args[0]);
+      assert.equal(arg.event_type, 'fxa_pref - disconnect_device');
+      assert.equal(arg.event_properties.reason, 'duplicate');
     },
 
     'settings.signout.success': () => {


### PR DESCRIPTION
Fixes #5598. Supercedes #5605.

The taxonomy specifies a `reason` property on the `fxa_pref - disconnect_device` event, which I wasn't emitting. This PR adds it.

Targeted at train 98 so that we can do the other parts of this OKR sooner too (we need this data to measure the outcome).

@mozilla/fxa-devs r?