### PR TITLE
feat(metrics): emit raw navtiming flow events

### DIFF
--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -156,13 +156,15 @@ module.exports = (req, metrics, requestReceivedTime) => {
     // the raw navigation timing data so that we can analyse which
     // to use long-term for our performance OKR.
     Object.keys(navigationTiming).forEach(key => {
-      const value = navigationTiming[key];
-      if (value >= 0) {
-        logFlowEvent({
-          flowTime: value,
-          time: metrics.flowBeginTime + value,
-          type: `flow.performance.raw.${key}`
-        }, metrics, req);
+      if (key !== 'navigationStart') {
+        const value = navigationTiming[key];
+        if (value >= 0) {
+          logFlowEvent({
+            flowTime: value,
+            time: metrics.flowBeginTime + value,
+            type: `flow.performance.raw.${key}`
+          }, metrics, req);
+        }
       }
     });
   }

--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -151,6 +151,20 @@ module.exports = (req, metrics, requestReceivedTime) => {
         }, metrics, req);
       }
     });
+
+    // In addition to the friendlier events above, emit events for
+    // the raw navigation timing data so that we can analyse which
+    // to use long-term for our performance OKR.
+    Object.keys(navigationTiming).forEach(key => {
+      const value = navigationTiming[key];
+      if (value >= 0) {
+        logFlowEvent({
+          flowTime: value,
+          time: metrics.flowBeginTime + value,
+          type: `flow.performance.raw.${key}`
+        }, metrics, req);
+      }
+    });
   }
 };
 

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -1071,6 +1071,7 @@ define([
         migration: data.migration || 'sync11',
         navigationTiming: clobberNavigationTiming ? null : {
           /*eslint-disable sorting/sort-object-props*/
+          navigationStart: 0,
           domainLookupStart: navigationTimingValue || 100,
           domainLookupEnd: navigationTimingValue || 200,
           connectStart: navigationTimingValue || 300,

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -206,8 +206,8 @@ define([
         }, 2000);
       },
 
-      'process.stderr.write was called four times': () => {
-        assert.equal(process.stderr.write.callCount, 4);
+      'process.stderr.write was called thirteen times': () => {
+        assert.equal(process.stderr.write.callCount, 13);
       },
 
       'first call to process.stderr.write was correct': () => {
@@ -236,6 +236,61 @@ define([
         assert.equal(arg.event, 'flow.performance.auth.client');
         assert.equal(arg.time, new Date(mocks.time - 2000 + 200).toISOString());
         assert.equal(arg.flow_time, 200);
+      },
+
+      'fifth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[4][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domainLookupStart');
+        assert.equal(arg.flow_time, 100);
+        assert.equal(arg.time, new Date(mocks.time - 2000 + 100).toISOString());
+      },
+
+      'sixth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[5][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domainLookupEnd');
+        assert.equal(arg.flow_time, 200);
+      },
+
+      'seventh call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[6][0]);
+        assert.equal(arg.event, 'flow.performance.raw.connectStart');
+        assert.equal(arg.flow_time, 300);
+      },
+
+      'eighth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[7][0]);
+        assert.equal(arg.event, 'flow.performance.raw.connectEnd');
+        assert.equal(arg.flow_time, 400);
+      },
+
+      'ninth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[8][0]);
+        assert.equal(arg.event, 'flow.performance.raw.requestStart');
+        assert.equal(arg.flow_time, 500);
+      },
+
+      'tenth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[9][0]);
+        assert.equal(arg.event, 'flow.performance.raw.responseStart');
+        assert.equal(arg.flow_time, 600);
+      },
+
+      'eleventh call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[10][0]);
+        assert.equal(arg.event, 'flow.performance.raw.responseEnd');
+        assert.equal(arg.flow_time, 700);
+      },
+
+      'twelfth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[11][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domLoading');
+        assert.equal(arg.flow_time, 800);
+      },
+
+      'thirteenth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[12][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domComplete');
+        assert.equal(arg.flow_time, 1000);
       },
 
       'amplitude was called once': () => {
@@ -831,23 +886,77 @@ define([
         }, 1000);
       },
 
-      'process.stderr.write was called three times': () => {
-        assert.equal(process.stderr.write.callCount, 3);
+      'process.stderr.write was called 12 times': () => {
+        assert.equal(process.stderr.write.callCount, 12);
       },
 
-      'second call to process.stderr.write was correct': () => {
+      'first call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[0][0]);
         assert.equal(arg.event, 'flow.performance.other.network');
       },
 
-      'third call to process.stderr.write was correct': () => {
+      'second call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[1][0]);
         assert.equal(arg.event, 'flow.performance.other.server');
       },
 
-      'fourth call to process.stderr.write was correct': () => {
+      'third call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[2][0]);
         assert.equal(arg.event, 'flow.performance.other.client');
+      },
+
+      'fourth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[3][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domainLookupStart');
+        assert.equal(arg.flow_time, 100);
+      },
+
+      'fifth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[4][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domainLookupEnd');
+        assert.equal(arg.flow_time, 200);
+      },
+
+      'sixth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[5][0]);
+        assert.equal(arg.event, 'flow.performance.raw.connectStart');
+        assert.equal(arg.flow_time, 300);
+      },
+
+      'seventh call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[6][0]);
+        assert.equal(arg.event, 'flow.performance.raw.connectEnd');
+        assert.equal(arg.flow_time, 400);
+      },
+
+      'eighth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[7][0]);
+        assert.equal(arg.event, 'flow.performance.raw.requestStart');
+        assert.equal(arg.flow_time, 500);
+      },
+
+      'ninth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[8][0]);
+        assert.equal(arg.event, 'flow.performance.raw.responseStart');
+        assert.equal(arg.flow_time, 600);
+      },
+
+      'tenth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[9][0]);
+        assert.equal(arg.event, 'flow.performance.raw.responseEnd');
+        assert.equal(arg.flow_time, 700);
+      },
+
+      'eleventh call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[10][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domLoading');
+        assert.equal(arg.flow_time, 800);
+      },
+
+      'twelfth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[11][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domComplete');
+        assert.equal(arg.flow_time, 1000);
       }
     },
 
@@ -863,13 +972,67 @@ define([
         }, 1000, false, 31536000000);
       },
 
-      'process.stderr.write was called once': () => {
-        assert.equal(process.stderr.write.callCount, 1);
+      'process.stderr.write was called nine times': () => {
+        assert.equal(process.stderr.write.callCount, 10);
       },
 
       'first call to process.stderr.write was correct': () => {
         const arg = JSON.parse(process.stderr.write.args[0][0]);
         assert.equal(arg.event, 'flow.performance.other');
+      },
+
+      'second call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[1][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domainLookupStart');
+        assert.equal(arg.flow_time, 31536000000);
+      },
+
+      'third call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[2][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domainLookupEnd');
+        assert.equal(arg.flow_time, 31536000000);
+      },
+
+      'fourth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[3][0]);
+        assert.equal(arg.event, 'flow.performance.raw.connectStart');
+        assert.equal(arg.flow_time, 31536000000);
+      },
+
+      'fifth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[4][0]);
+        assert.equal(arg.event, 'flow.performance.raw.connectEnd');
+        assert.equal(arg.flow_time, 31536000000);
+      },
+
+      'sixth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[5][0]);
+        assert.equal(arg.event, 'flow.performance.raw.requestStart');
+        assert.equal(arg.flow_time, 31536000000);
+      },
+
+      'seventh call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[6][0]);
+        assert.equal(arg.event, 'flow.performance.raw.responseStart');
+        assert.equal(arg.flow_time, 31536000000);
+      },
+
+      'eighth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[7][0]);
+        assert.equal(arg.event, 'flow.performance.raw.responseEnd');
+        assert.equal(arg.flow_time, 31536000000);
+      },
+
+      'ninth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[8][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domLoading');
+        assert.equal(arg.flow_time, 31536000000);
+      },
+
+      'tenth call to process.stderr.write was correct': () => {
+        const arg = JSON.parse(process.stderr.write.args[9][0]);
+        assert.equal(arg.event, 'flow.performance.raw.domComplete');
+        assert.equal(arg.flow_time, 31536000000);
       }
     },
 


### PR DESCRIPTION
This came out of my meeting about the perf metrics OKR with @irrationalagent just now.

He's going to do some kind of clever-clogs stats wizardry (technical term) to find out which metrics best correlate with positive user behaviour like successful sign-ins etc. To give him the richest possible data set for that analysis, this PR exposes all of the non-null navigation timing attributes as flow events.

After the analysis is complete, we can rein them in again so that we're only emitting events for the interesting stuff. I opted to keep my existing perf events for now as they're driving my dashboard but ultimately those will probably disappear too.

Here's some sample log data showing the new events:

```
{"event":"flow.performance.raw.unloadEventStart","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":79,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.441Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.unloadEventEnd","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":84,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.446Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.redirectStart","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":0,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.362Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.redirectEnd","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":0,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.362Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.fetchStart","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":1,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.363Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.domainLookupStart","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":2,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.364Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.domainLookupEnd","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":3,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.365Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.connectStart","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":3,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.365Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.connectEnd","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":4,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.366Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.secureConnectionStart","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":0,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.362Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.requestStart","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":32,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.394Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.responseStart","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":75,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.437Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.responseEnd","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":75,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.437Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.domLoading","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":79,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.441Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.domInteractive","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":225,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.587Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.domContentLoadedEventStart","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":225,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.587Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.domContentLoadedEventEnd","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":226,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.588Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.domComplete","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":264,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.626Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.loadEventStart","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":264,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.626Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
{"event":"flow.performance.raw.loadEventEnd","flow_id":"a1c3488cd25444acf27a5f66aa9fecdb61ae9d80f3295aab5c946aef2c2fa837","flow_time":264,"hostname":"Phils-MBP","op":"flowEvent","pid":12109,"time":"2017-10-19T11:19:22.626Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/58.0","v":1,"context":"web"}
```

Opened against train 98 so that we can start collecting numbers sooner.

@mozilla/fxa-devs r?