### PR TITLE
refactor(sms): Use formatted phone number returned from auth-server.

### DIFF
--- a/app/scripts/lib/country-telephone-info.js
+++ b/app/scripts/lib/country-telephone-info.js
@@ -12,10 +12,10 @@ define((require, exports, module) => {
    * Each country entry should have the fields listed below.
    */
   /**
-   * Format a normalized phone number, expects country code prefix.
+   * Format `serverPhoneNumber` for display.
    *
    * @method format
-   * @param {String} num phone number to format.
+   * @param {String} serverPhoneNumber phone number returned by the server
    * @return {String} phone number formatted for country
    */
 
@@ -41,12 +41,20 @@ define((require, exports, module) => {
    * @type {String}
    */
 
+  /**
+   * Create a `format` function. `${serverPhoneNumber}` in `format`
+   * will be replaced with `serverPhoneNumber`
+   *
+   * @param {String} format
+   * @returns {Function}
+   */
+  function formatter (format) {
+    return (serverPhoneNumber) => format.replace(/\$\{serverPhoneNumber\}/, serverPhoneNumber);
+  }
+
   module.exports = {
     GB: {
-      format (num) {
-        // +44 1234 567890
-        return num.slice(0, 3) + ' ' + num.slice(3, 7) + ' ' + num.slice(7, 14);
-      },
+      format: formatter('+44 ${serverPhoneNumber}'),
       normalize (num) {
         if (/^\+44/.test(num)) {
           return num;
@@ -57,10 +65,7 @@ define((require, exports, module) => {
       prefix: '+44'
     },
     RO: {
-      format(num) {
-        // +40 7xx xxxxxx
-        return num.slice(0, 3) + ' ' + num.slice(3, 6) + ' ' + num.slice(6, 12);
-      },
+      format: formatter('+40 ${serverPhoneNumber}'),
       normalize(num) {
         // allow +40 country code prefix
         // as well as an extra 0 before the 7 prefix.
@@ -72,16 +77,12 @@ define((require, exports, module) => {
       },
       // +407xxxxxxxx, allow leading 0 for sloppiness.
       pattern: /^(?:\+40)?0?7\d{8,8}$/,
-      // The country code is +40, all mobile phones have a 7 prefix.
-      prefix: '+407'
-
+      prefix: '+40'
     },
     US: {
-      format (num) {
-        // Americans don't use country codes, drop the country code prefix
-        // 123-456-7890
-        return num.slice(2, 5) + '-' + num.slice(5, 8) + '-' + num.slice(8);
-      },
+      // Americans don't use country codes, just return the number
+      // as formatted by the backend.
+      format: (formattedNumber) => formattedNumber,
       normalize (num) {
         if (/^\+1/.test(num)) {
           return num;

--- a/app/tests/spec/lib/country-telephone-info.js
+++ b/app/tests/spec/lib/country-telephone-info.js
@@ -14,7 +14,7 @@ define((require, exports, module) => {
 
       describe('format', () => {
         it('formats correctly', () => {
-          assert.equal(format('+441234567890'), '+44 1234 567890');
+          assert.equal(format('1234567890'), '+44 1234567890');
         });
       });
 
@@ -41,7 +41,7 @@ define((require, exports, module) => {
       const { format, normalize, pattern } = CountryTelephoneInfo.RO;
 
       it('formats correctly', () => {
-        assert.equal(format('+40712345678'), '+40 712 345678');
+        assert.equal(format('712345678'), '+40 712345678');
       });
 
       describe('normalize', () => {
@@ -72,8 +72,7 @@ define((require, exports, module) => {
       const { format, normalize, pattern } = CountryTelephoneInfo.US;
 
       it('formats correctly', () => {
-        assert.equal(format('+11234567890'), '123-456-7890');
-        assert.equal(format('+14234567890'), '423-456-7890');
+        assert.equal(format('1234567890'), '1234567890');
       });
 
       describe('normalize', () => {

--- a/app/tests/spec/views/sms_sent.js
+++ b/app/tests/spec/views/sms_sent.js
@@ -30,7 +30,7 @@ define((require, exports, module) => {
       metrics = new Metrics();
       model = new Backbone.Model({
         account,
-        country: 'US',
+        formattedPhoneNumber: '123-456-7890',
         normalizedPhoneNumber: '+11234567890'
       });
 
@@ -54,6 +54,18 @@ define((require, exports, module) => {
       view = null;
     });
 
+    it('returns to `sms` if no `formattedPhoneNumber`', () => {
+      sinon.spy(view, 'navigate');
+
+      model.unset('formattedPhoneNumber');
+
+      return view.render()
+       .then(() => {
+         assert.isTrue(view.navigate.calledOnce);
+         assert.isTrue(view.navigate.calledWith('sms'));
+       });
+    });
+
     it('returns to `sms` if no `normalizedPhoneNumber`', () => {
       sinon.spy(view, 'navigate');
 
@@ -66,24 +78,7 @@ define((require, exports, module) => {
        });
     });
 
-    it('returns to `sms` if no `country`', () => {
-      sinon.spy(view, 'navigate');
-
-      model.unset('country');
-
-      return view.render()
-       .then(() => {
-         assert.isTrue(view.navigate.calledOnce);
-         assert.isTrue(view.navigate.calledWith('sms'));
-       });
-    });
-
-    it('renders a US phone number correctly, shows marketing', () => {
-      model.set({
-        country: 'US',
-        phoneNumber: '+11234567890'
-      });
-
+    it('renders phone number, shows marketing', () => {
       return view.render()
        .then(() => {
          assert.include(view.$('.success').text(), '123-456-7890');
@@ -105,18 +100,6 @@ define((require, exports, module) => {
          assert.equal(metrics.logMarketingClick.args[1][0], 'autumn-2016-connect-another-device');
          assert.isTrue(view.logFlowEvent.calledTwice);
          assert.isTrue(view.logFlowEvent.calledWith('link.app-store.android', 'sms-sent'));
-       });
-    });
-
-    it('renders a GB phone number correctly', () => {
-      model.set({
-        country: 'GB',
-        normalizedPhoneNumber: '+441234567890'
-      });
-
-      return view.render()
-       .then(() => {
-         assert.include(view.$('.success').text(), '+44 1234 567890');
        });
     });
 

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -113,7 +113,7 @@
              country: 'RO'
            }
          }))
-         .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, '+407'))
+         .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, '+40'))
          .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'RO'));
      },
 


### PR DESCRIPTION
In support of #5572, goes along with https://github.com/mozilla/fxa-auth-server/pull/2178.

fixes #5615 