### PR TITLE
 fix(css): Show password border radius problem

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -125,7 +125,7 @@ $media-adjustment: 2px;
 //Border-Radius Variables
 $small-border-radius: 2px;
 //order matters here, cannot be sorted
-$big-border-radius: $small-border-radius * 2;
+$big-border-radius: 4px;
 $border-radius-inner: 3px;
 $border-radius-osx: 4px;
 $border-radius-outer: 4px;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -125,7 +125,7 @@ $media-adjustment: 2px;
 //Border-Radius Variables
 $small-border-radius: 2px;
 //order matters here, cannot be sorted
-$big-border-radius: 4px;
+$big-border-radius: $small-border-radius * 2;
 $border-radius-inner: 3px;
 $border-radius-osx: 4px;
 $border-radius-outer: 4px;

--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -94,18 +94,18 @@
     }
 
     @include respond-to('big') {
-      border-radius: 0 $small-border-radius $small-border-radius 0;
+      border-radius: 0 $big-border-radius $big-border-radius 0;
 
       height: 43px;
       line-height: 42px;
 
       html[dir='rtl'] & {
-        border-radius: $small-border-radius 0 0 $small-border-radius;
+        border-radius: $big-border-radius 0 0 $big-border-radius;
       }
     }
 
     @include respond-to('small') {
-      border-radius: 0;
+      border-radius: 0 $small-border-radius $small-border-radius 0;;
       height: 38px;
       line-height: 38px;
     }


### PR DESCRIPTION
fixes  #5233 

in `_password-row.scss` styling for `.show-password-label`
- ensure use of `$big-border-radius instead` of `$small-border-radius` while responding to `big`
- ensure use of `$small-border-radius` while responding to `small`

