### PR TITLE
feat(clients): display approximate last active times for old clients

### DIFF
--- a/app/scripts/models/device.js
+++ b/app/scripts/models/device.js
@@ -14,6 +14,8 @@ define(function (require, exports, module) {
 
   var Device = Backbone.Model.extend({
     defaults: {
+      approximateLastAccessTime: null,
+      approximateLastAccessTimeFormatted: null,
       clientType: Constants.CLIENT_TYPE_DEVICE,
       genericOS: null,
       id: null,

--- a/app/scripts/models/oauth-app.js
+++ b/app/scripts/models/oauth-app.js
@@ -13,6 +13,8 @@ define(function (require, exports, module) {
 
   module.exports = Backbone.Model.extend({
     defaults: {
+      approximateLastAccessTime: null,
+      approximateLastAccessTimeFormatted: null,
       clientType: Constants.CLIENT_TYPE_OAUTH_APP,
       id: null,
       lastAccessTime: null,

--- a/app/scripts/models/web-session.js
+++ b/app/scripts/models/web-session.js
@@ -13,6 +13,8 @@ define(function (require, exports, module) {
 
   module.exports = Backbone.Model.extend({
     defaults: {
+      approximateLastAccessTime: null,
+      approximateLastAccessTimeFormatted: null,
       clientType: Constants.CLIENT_TYPE_WEB_SESSION,
       genericOS: null,
       id: null,

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -67,8 +67,8 @@ define(function (require, exports, module) {
         if (item.scope) {
           item.title += ' - ' + item.scope;
         }
-        if (item.lastAccessTimeFormatted) {
 
+        if (item.lastAccessTimeFormatted) {
           if (item.isWebSession) {
             if (item.userAgent) {
               item.title = this.translate(
@@ -76,23 +76,28 @@ define(function (require, exports, module) {
             } else {
               item.title = t('Web Session');
             }
-            item.lastAccessTimeFormatted = this.translate(
-              t('%(translatedTimeAgo)s'), {translatedTimeAgo: item.lastAccessTimeFormatted});
+
+            this._setLastAccessTimeFormatted(
+              item,
+              t('%(translatedTimeAgo)s'),
+              t('over %(translatedTimeAgo)s')
+            );
           }
 
           if (item.isDevice) {
-            if (item.lastAccessTime === item.createdTime) {
-              item.lastAccessTimeFormatted = this.translate(
-                t('first sync %(translatedTimeAgo)s'), {translatedTimeAgo: item.createdTimeFormatted});
-            } else {
-              item.lastAccessTimeFormatted = this.translate(
-                t('last sync %(translatedTimeAgo)s'), {translatedTimeAgo: item.lastAccessTimeFormatted});
-            }
+            this._setLastAccessTimeFormatted(
+              item,
+              t('last sync %(translatedTimeAgo)s'),
+              t('last sync over %(translatedTimeAgo)s')
+            );
           }
 
           if (item.clientType === Constants.CLIENT_TYPE_OAUTH_APP) {
-            item.lastAccessTimeFormatted = this.translate(
-              t('last active %(translatedTimeAgo)s'), {translatedTimeAgo: item.lastAccessTimeFormatted});
+            this._setLastAccessTimeFormatted(
+              item,
+              t('last active %(translatedTimeAgo)s'),
+              t('last active over %(translatedTimeAgo)s')
+            );
           }
         } else {
           if (item.isDevice) {
@@ -104,6 +109,18 @@ define(function (require, exports, module) {
         }
         return item;
       });
+    },
+
+    _setLastAccessTimeFormatted (item, format, approximateFormat) {
+      let translatedTimeAgo = item.lastAccessTimeFormatted;
+      let correctFormat = format;
+
+      if (item.approximateLastAccessTime > item.lastAccessTime) {
+        translatedTimeAgo = item.approximateLastAccessTimeFormatted;
+        correctFormat = approximateFormat;
+      }
+
+      item.lastAccessTimeFormatted = this.translate(correctFormat, { translatedTimeAgo });
     },
 
     setInitialContext (context) {

--- a/app/tests/spec/views/settings/clients.js
+++ b/app/tests/spec/views/settings/clients.js
@@ -494,7 +494,7 @@ define(function (require, exports, module) {
           .then(() => {
             view.translator = {
               get: (untranslatedText) => {
-                if (untranslatedText === 'first sync %(translatedTimeAgo)s') {
+                if (untranslatedText === 'last sync %(translatedTimeAgo)s') {
                   return 'Translated %(translatedTimeAgo)s';
                 }
 
@@ -515,7 +515,7 @@ define(function (require, exports, module) {
           });
       });
 
-      it('supports first sync formatting', () => {
+      it('supports approximate sync formatting', () => {
         return initView()
           .then(() => {
             const now = Date.now();
@@ -532,18 +532,86 @@ define(function (require, exports, module) {
                 type: 'desktop'
               },
               {
+                approximateLastAccessTime: now,
+                approximateLastAccessTimeFormatted: '1 hour ago',
                 clientType: 'device',
                 id: 'device-2',
                 isCurrentDevice: false,
                 isDevice: true,
-                lastAccessTime: Date.now(),
-                lastAccessTimeFormatted: '30 minutes ago',
+                lastAccessTime: now - 1,
+                lastAccessTimeFormatted: '2 days ago',
                 type: 'mobile'
-              }
+              },
+              {
+                approximateLastAccessTime: now,
+                approximateLastAccessTimeFormatted: '3 weeks ago',
+                clientType: 'device',
+                id: 'device-3',
+                isCurrentDevice: false,
+                isDevice: true,
+                lastAccessTime: now,
+                lastAccessTimeFormatted: '4 months ago',
+                type: 'mobile'
+              },
+              {
+                createdTime: now,
+                createdTimeFormatted: '1 day ago',
+                id: 'session-1',
+                isWebSession: true,
+                lastAccessTime: now,
+                lastAccessTimeFormatted: '1 day ago'
+              },
+              {
+                approximateLastAccessTime: now,
+                approximateLastAccessTimeFormatted: '3 weeks ago',
+                id: 'session-2',
+                isWebSession: true,
+                lastAccessTime: now - 1,
+                lastAccessTimeFormatted: '4 months ago',
+              },
+              {
+                approximateLastAccessTime: now,
+                approximateLastAccessTimeFormatted: '5 years ago',
+                id: 'session-3',
+                isWebSession: true,
+                lastAccessTime: now,
+                lastAccessTimeFormatted: '6 decades ago',
+              },
+              {
+                clientType: 'oAuthApp',
+                createdTime: now,
+                createdTimeFormatted: 'wibble',
+                id: 'oauth-1',
+                lastAccessTime: now,
+                lastAccessTimeFormatted: 'blee'
+              },
+              {
+                approximateLastAccessTime: now,
+                approximateLastAccessTimeFormatted: 'wibble',
+                clientType: 'oAuthApp',
+                id: 'oauth-2',
+                lastAccessTime: now - 1,
+                lastAccessTimeFormatted: 'blee',
+              },
+              {
+                approximateLastAccessTime: now,
+                approximateLastAccessTimeFormatted: 'wibble',
+                clientType: 'oAuthApp',
+                id: 'oauth-3',
+                lastAccessTime: now,
+                lastAccessTimeFormatted: 'blee',
+              },
             ]);
 
-            assert.equal(formatted[0].lastAccessTimeFormatted, 'first sync 32 minutes ago');
-            assert.equal(formatted[1].lastAccessTimeFormatted, 'last sync 30 minutes ago');
+            assert.equal(formatted[0].lastAccessTimeFormatted, 'last sync 32 minutes ago');
+            assert.equal(formatted[1].lastAccessTimeFormatted, 'last sync over 1 hour ago');
+            assert.equal(formatted[2].lastAccessTimeFormatted, 'last sync 4 months ago');
+            assert.equal(formatted[3].lastAccessTimeFormatted, '1 day ago');
+            assert.equal(formatted[4].lastAccessTimeFormatted, 'over 3 weeks ago');
+            assert.equal(formatted[5].lastAccessTimeFormatted, '6 decades ago');
+            assert.equal(formatted[6].lastAccessTimeFormatted, 'last active blee');
+            assert.equal(formatted[7].lastAccessTimeFormatted, 'last active over wibble');
+            assert.equal(formatted[8].lastAccessTimeFormatted, 'last active blee');
           });
       });
 


### PR DESCRIPTION
Fixes #5599. Pairs with mozilla/fxa-auth-server#2182.

For the device manager OKR, we're replacing the first sync time with an approximate last sync time such as "last sync over 2 months ago".

There are two parts to that change, one here and one in the auth server. This PR does the content server portion and I tried to implement both to be independently deployable of each other.

If you want to try it out in `fxa-local-dev`, you'll just need to hack the `lastAccessTime` for your device in Redis. I used [`redis-commander`](https://github.com/joeferner/redis-commander) to do that, which you can find in npm. That was much easier to do than I probably made it sound.

Here's what it looks like:

![Screen shot of the new approximate last Sync time](https://user-images.githubusercontent.com/64367/31832643-a956e584-b5bf-11e7-9b6b-107e0548b928.png)

@mozilla/fxa-devs r?