### PR TITLE
fix(style): Account for emoji shifting line height of device information

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -531,6 +531,7 @@ section.modal-panel {
   }
 
   .client-name {
+    line-height: 1.2;
     overflow: hidden;
     text-overflow: ellipsis;
     /*allows 5% gutter between device-name and .device-disconnected button*/


### PR DESCRIPTION
Restrict line height to 1.2 to account for emoji in device names.
Previously, the device information line height got out of alignment
with emoji in device names.

Closes #5516