### PR TITLE
fix(test): Fix "Firefox Desktop Sync v1 signin - unverified" functional test.

### DIFF
--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -70,7 +70,7 @@ define([
     beforeEach: function () {
       email = TestHelpers.createEmail('sync{id}');
       return this.remote
-        .then(clearBrowserState());
+        .then(clearBrowserState({ force: true }));
     },
 
     'verified, verify same browser': function () {


### PR DESCRIPTION
Ensure localStorage state is really cleared before starting test.

fixes #5633

@mozilla/fxa-devs - r?