### PR TITLE
fix(markup): remove redundant viewport meta tag

### DIFF
--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -6,7 +6,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="">
-        <meta name="viewport" content="width=device-width">
         <meta name="referrer" content="origin">
         <meta name="robots" content="noindex,nofollow">
         <meta name="fxa-content-server/config" content="{{ config }}" />


### PR DESCRIPTION
I don't think we need two of these. I've removed the original one from 2013 (5c49dfa1c) and kept the newer one from this year (48c2534f7).

@mozilla/fxa-devs r?