### PR TITLE
fix(test): Fix the change password tests.

### DIFF
--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -10,33 +10,35 @@ define([
   'tests/functional/lib/helpers',
   'tests/functional/lib/ua-strings'
 ], function (intern, registerSuite, path, TestHelpers, FunctionalHelpers, uaStrings) {
-  var config = intern.config;
+  const config = intern.config;
 
   const ios10UserAgent = uaStrings['ios_firefox_6_1'];
 
-  var ADD_AVATAR_BUTTON_SELECTOR  = '#change-avatar .settings-unit-toggle.primary';
-  var AVATAR_CHANGE_URL = config.fxaContentRoot + 'settings/avatar/change';
-  var AVATAR_CHANGE_URL_AUTOMATED = config.fxaContentRoot + 'settings/avatar/change?automatedBrowser=true';
-  var PASSWORD = 'password';
-  var SETTINGS_URL = config.fxaContentRoot + 'settings';
-  var SETTINGS_URL_IOS10 = `${SETTINGS_URL}?forceUA='${encodeURIComponent(ios10UserAgent)}`;
-  var SIGNIN_URL = config.fxaContentRoot + 'signin';
-  var UPLOAD_IMAGE_PATH = path.join(this.process.cwd(), 'app', 'apple-touch-icon-152x152.png');
+  const ADD_AVATAR_BUTTON_SELECTOR  = '#change-avatar .settings-unit-toggle.primary';
+  const AVATAR_CHANGE_URL = config.fxaContentRoot + 'settings/avatar/change';
+  const AVATAR_CHANGE_URL_AUTOMATED = config.fxaContentRoot + 'settings/avatar/change?automatedBrowser=true';
+  const PASSWORD = 'password';
+  const SETTINGS_URL = config.fxaContentRoot + 'settings';
+  const SETTINGS_URL_IOS10 = `${SETTINGS_URL}?forceUA='${encodeURIComponent(ios10UserAgent)}`;
+  const SIGNIN_URL = config.fxaContentRoot + 'signin';
+  const UPLOAD_IMAGE_PATH = path.join(this.process.cwd(), 'app', 'apple-touch-icon-152x152.png');
 
-  var email;
+  let email;
 
-  var thenify = FunctionalHelpers.thenify;
+  const {
+    clearBrowserState,
+    click,
+    createUser,
+    fillOutSignIn,
+    noSuchElement,
+    openPage,
+    pollUntilHiddenByQSA,
+    testElementExists,
+    testIsBrowserNotified,
+    thenify,
+  } = FunctionalHelpers;
 
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var click = FunctionalHelpers.click;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = FunctionalHelpers.openPage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
-
-  var testIsBrowserNotifiedOfAvatarChange = thenify(function () {
+  const testIsBrowserNotifiedOfAvatarChange = thenify(function () {
     return this.parent
       .then(testIsBrowserNotified('profile:change'));
   });
@@ -140,7 +142,8 @@ define([
         .then(click('.rotate'))
         .then(click('.modal-panel #submit-btn'))
 
-        .then(testElementExists('#fxa-settings-header'))
+        .then(pollUntilHiddenByQSA('#imageLoader'))
+
         .then(testIsBrowserNotifiedOfAvatarChange())
         //success is seeing the image loaded
         .then(FunctionalHelpers.imageLoadedByQSA('.change-avatar > img'));

--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -31,7 +31,6 @@ define([
     openPage,
     testElementExists,
     testElementTextEquals,
-    testSuccessWasShown,
     thenify,
     type,
     visibleByQSA,
@@ -68,7 +67,7 @@ define([
 
         // Go to change password screen
         .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
-        .then(fillOutChangePassword('INCORRECT', SECOND_PASSWORD))
+        .then(fillOutChangePassword('INCORRECT', SECOND_PASSWORD, { expectSuccess: false }))
         // the validation tooltip should be visible
         .then(visibleByQSA(selectors.CHANGE_PASSWORD.TOOLTIP))
 
@@ -95,8 +94,6 @@ define([
         .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(testSuccessWasShown())
 
         .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
         .then(click(selectors.SIGNIN.LINK_USE_DIFFERENT))
@@ -113,8 +110,6 @@ define([
         .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(testSuccessWasShown())
 
         .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
         .then(click(selectors.SIGNIN.LINK_USE_DIFFERENT))
@@ -137,8 +132,6 @@ define([
         .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(testSuccessWasShown())
 
         .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
         .then(click(selectors.SIGNIN.LINK_USE_DIFFERENT))

--- a/tests/functional/fx_fennec_v1_settings.js
+++ b/tests/functional/fx_fennec_v1_settings.js
@@ -8,30 +8,32 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var click = FunctionalHelpers.click;
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutChangePassword = FunctionalHelpers.fillOutChangePassword;
-  var fillOutDeleteAccount = FunctionalHelpers.fillOutDeleteAccount;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
-  var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
-  var visibleByQSA = FunctionalHelpers.visibleByQSA;
 
-  var config = intern.config;
-  var SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_fennec_v1&service=sync&forceAboutAccounts=true';
-  var SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_fennec_v1&service=sync&forceAboutAccounts=true';
-  var SETTINGS_NOCONTEXT_URL = config.fxaContentRoot + 'settings';
+  const {
+    click,
+    clearBrowserState,
+    createUser,
+    fillOutChangePassword,
+    fillOutDeleteAccount,
+    fillOutSignIn,
+    noSuchBrowserNotification,
+    noSuchElement,
+    openPage,
+    openVerificationLinkInDifferentBrowser,
+    respondToWebChannelMessage,
+    testElementExists,
+    testIsBrowserNotified,
+    visibleByQSA,
+  } = FunctionalHelpers;
 
-  var FIRST_PASSWORD = 'password';
-  var SECOND_PASSWORD = 'new_password';
-  var email;
+  const config = intern.config;
+  const SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_fennec_v1&service=sync&forceAboutAccounts=true';
+  const SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_fennec_v1&service=sync&forceAboutAccounts=true';
+  const SETTINGS_NOCONTEXT_URL = config.fxaContentRoot + 'settings';
 
+  const FIRST_PASSWORD = 'password';
+  const SECOND_PASSWORD = 'new_password';
+  let email;
 
   registerSuite({
     name: 'Firefox Fennec Sync v1 settings',
@@ -56,7 +58,7 @@ define([
 
         // wait until account data is in localstorage before redirecting
         .then(FunctionalHelpers.pollUntil(function () {
-          var accounts = Object.keys(JSON.parse(localStorage.getItem('__fxa_storage.accounts')) || {});
+          const accounts = Object.keys(JSON.parse(localStorage.getItem('__fxa_storage.accounts')) || {});
           return accounts.length === 1 ? true : null;
         }, [], 10000))
 
@@ -69,8 +71,7 @@ define([
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     },
 
     'sign in, change the password by browsing directly to settings': function () {
@@ -80,8 +81,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
         .then(noSuchBrowserNotification('fxaccounts:change_password'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     },
 
     'sign in, delete the account': function () {

--- a/tests/functional/fx_firstrun_v1_settings.js
+++ b/tests/functional/fx_firstrun_v1_settings.js
@@ -8,27 +8,28 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var click = FunctionalHelpers.click;
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutChangePassword = FunctionalHelpers.fillOutChangePassword;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
-  var visibleByQSA = FunctionalHelpers.visibleByQSA;
+  const {
+    click,
+    clearBrowserState,
+    createUser,
+    fillOutChangePassword,
+    fillOutSignIn,
+    openPage,
+    openVerificationLinkInDifferentBrowser,
+    respondToWebChannelMessage,
+    testElementExists,
+    testIsBrowserNotified,
+    visibleByQSA,
+  } = FunctionalHelpers;
 
-  var config = intern.config;
-  var SIGNIN_URL = config.fxaContentRoot + 'signin?context=iframe&service=sync';
-  var SETTINGS_URL = config.fxaContentRoot + 'settings?context=iframe&service=sync';
-  var SETTINGS_NOCONTEXT_URL = config.fxaContentRoot + 'settings';
+  const config = intern.config;
+  const SIGNIN_URL = config.fxaContentRoot + 'signin?context=iframe&service=sync';
+  const SETTINGS_URL = config.fxaContentRoot + 'settings?context=iframe&service=sync';
+  const SETTINGS_NOCONTEXT_URL = config.fxaContentRoot + 'settings';
 
-  var FIRST_PASSWORD = 'password';
-  var SECOND_PASSWORD = 'new_password';
-  var email;
-
+  const FIRST_PASSWORD = 'password';
+  const SECOND_PASSWORD = 'new_password';
+  let email;
 
   registerSuite({
     name: 'Firstrun Sync v1 settings',
@@ -42,15 +43,15 @@ define([
         .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
         .then(respondToWebChannelMessage('fxaccounts:can_link_account', { ok: true } ))
         .then(fillOutSignIn(email, FIRST_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-        .then(testIsBrowserNotified('fxaccounts:login'))
 
         .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
         .then(openVerificationLinkInDifferentBrowser(email))
 
         // wait until account data is in localstorage before redirecting
         .then(FunctionalHelpers.pollUntil(function () {
-          var accounts = Object.keys(JSON.parse(localStorage.getItem('__fxa_storage.accounts')) || {});
+          const accounts = Object.keys(JSON.parse(localStorage.getItem('__fxa_storage.accounts')) || {});
           return accounts.length === 1 ? true : null;
         }, [], 10000))
 
@@ -62,8 +63,7 @@ define([
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     },
 
     'sign in, change the password by browsing directly to settings': function () {
@@ -72,8 +72,7 @@ define([
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     }
   });
 });

--- a/tests/functional/fx_firstrun_v2_settings.js
+++ b/tests/functional/fx_firstrun_v2_settings.js
@@ -8,27 +8,28 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var click = FunctionalHelpers.click;
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutChangePassword = FunctionalHelpers.fillOutChangePassword;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
-  var visibleByQSA = FunctionalHelpers.visibleByQSA;
+  const {
+    click,
+    clearBrowserState,
+    createUser,
+    fillOutChangePassword,
+    fillOutSignIn,
+    openPage,
+    openVerificationLinkInDifferentBrowser,
+    respondToWebChannelMessage,
+    testElementExists,
+    testIsBrowserNotified,
+    visibleByQSA,
+  } = FunctionalHelpers;
 
-  var config = intern.config;
-  var SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_firstrun_v2&service=sync';
-  var SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_firstrun_v2&service=sync';
-  var SETTINGS_NOCONTEXT_URL = config.fxaContentRoot + 'settings';
+  const config = intern.config;
+  const SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_firstrun_v2&service=sync';
+  const SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_firstrun_v2&service=sync';
+  const SETTINGS_NOCONTEXT_URL = config.fxaContentRoot + 'settings';
 
-  var FIRST_PASSWORD = 'password';
-  var SECOND_PASSWORD = 'new_password';
-  var email;
-
+  const FIRST_PASSWORD = 'password';
+  const SECOND_PASSWORD = 'new_password';
+  let email;
 
   registerSuite({
     name: 'Firstrun Sync v2 settings',
@@ -51,7 +52,7 @@ define([
 
         // wait until account data is in localstorage before redirecting
         .then(FunctionalHelpers.pollUntil(function () {
-          var accounts = Object.keys(JSON.parse(localStorage.getItem('__fxa_storage.accounts')) || {});
+          const accounts = Object.keys(JSON.parse(localStorage.getItem('__fxa_storage.accounts')) || {});
           return accounts.length === 1 ? true : null;
         }, [], 10000))
 
@@ -63,8 +64,7 @@ define([
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     },
 
     'sign in, change the password by browsing directly to settings': function () {
@@ -73,8 +73,7 @@ define([
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     }
   });
 });

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -454,6 +454,69 @@ define([
   }
 
   /**
+   * Poll until an element is either removed from the DOM or hidden.
+   *
+   * @param {String} selector
+   *        QSA compatible selector string
+   * @param {Number} [timeout=config.pageLoadTimeout]
+   *        Timeout to wait until element is gone or hidden
+   */
+  const pollUntilHiddenByQSA = thenify(function (selector, timeout = config.pageLoadTimeout) {
+    let pollError;
+
+    return this.parent
+      .then(pollUntil(function (selector) {
+        const matchingEls = document.querySelectorAll(selector);
+
+        if (matchingEls.length === 0) {
+          return true;
+        }
+
+        if (matchingEls.length > 1) {
+          throw new Error('Multiple elements matched. Make a more precise selector - ' + selector);
+        }
+
+        const matchingEl = matchingEls[0];
+
+        // Check if the element is visible. This is from jQuery source - see
+        // https://github.com/jquery/jquery/blob/e1b1b2d7fe5aff907a9accf59910bc3b7e4d1dec/src/css/hiddenVisibleSelectors.js#L12
+        if (! (matchingEl.offsetWidth || matchingEl.offsetHeight || matchingEl.getClientRects().length)) {
+          return true;
+        }
+
+        // use jQuery if available to check for jQuery animations.
+        if (typeof $ !== 'undefined' && $(selector).is(':animated')) {
+          // If the element is animating, try again after a delay. Clicks
+          // do not always register if the element is in the midst of
+          // an animation.
+          return null;
+        }
+
+        return null;
+      }, [ selector ], timeout))
+      .then(null, function (err) {
+        // The error has to be swallowed before a screenshot
+        // can be taken or else takeScreenshot is never called
+        // because `this.parent` is a promise that has already
+        // been rejected.
+        pollError = err;
+      })
+      .then(() => {
+        if (pollError) {
+          return this.parent.then(takeScreenshot())
+            .then(() => {
+              if (/ScriptTimeout/.test(String(pollError))) {
+                throw new Error(`ElementNotHidden - ${selector}`);
+              } else {
+                throw pollError;
+              }
+            });
+        }
+      });
+  });
+
+
+  /**
    * Ensure no such element exists.
    *
    * @param   {string} selector of element to ensure does not exist.
@@ -1380,15 +1443,26 @@ define([
    *
    * @param   {string} oldPassword user's old password
    * @param   {string} newPassword user's new password
+   * @param   {object} [options]
+   *   @param {boolean} [options.expectSuccess=true] if set to `true`, tests whether
+   *     the password change succeeds.
    * @returns {promise} resolves when complete
    */
-  const fillOutChangePassword = thenify(function (oldPassword, newPassword) {
+  const fillOutChangePassword = thenify(function (oldPassword, newPassword, options = {}) {
     return this.parent
       .setFindTimeout(intern.config.pageLoadTimeout)
 
       .then(type('#old_password', oldPassword))
       .then(type('#new_password', newPassword))
-      .then(click('#change-password button[type="submit"]'));
+      .then(click('#change-password button[type="submit"]'))
+      .then(function () {
+        if (options.expectSuccess !== false) {
+          return this.parent
+            .then(pollUntilHiddenByQSA(selectors.CHANGE_PASSWORD.DETAILS))
+            .then(testSuccessWasShown())
+            .then(testIsBrowserNotified('fxaccounts:change_password')); //eslint-disable-line no-use-before-define
+        }
+      });
   });
 
   /**
@@ -2048,6 +2122,7 @@ define([
     openVerificationLinkInSameTab: openVerificationLinkInSameTab,
     pollUntil: pollUntil,
     pollUntilGoneByQSA: pollUntilGoneByQSA,
+    pollUntilHiddenByQSA,
     reOpenWithAdditionalQueryParams: reOpenWithAdditionalQueryParams,
     respondToWebChannelMessage: respondToWebChannelMessage,
     storeWebChannelMessageData,

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -21,6 +21,7 @@ define([], function () {
       HEADER: '#fxa-400-header'
     },
     CHANGE_PASSWORD: {
+      DETAILS: '#change-password .settings-unit-details',
       ERROR: '#change-password .error',
       LINK_RESET_PASSWORD: '.reset-password',
       MENU_BUTTON: '#change-password .settings-unit-toggle',

--- a/tests/functional/settings_change_email.js
+++ b/tests/functional/settings_change_email.js
@@ -38,7 +38,6 @@ define([
     openVerificationLinkInSameTab,
     noSuchElement,
     switchToWindow,
-    testIsBrowserNotified,
     testElementExists,
     testElementTextEquals,
     testErrorTextInclude,
@@ -125,9 +124,6 @@ define([
         // change password
         .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
         .then(fillOutChangePassword(PASSWORD, NEW_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(testSuccessWasShown())
 
         // sign out and fails login with old password
         .then(click(selectors.SETTINGS.SIGNOUT))
@@ -155,6 +151,7 @@ define([
           .then(testElementExists(selectors.COMPLETE_RESET_PASSWORD.HEADER))
           .then(fillOutCompleteResetPassword(NEW_PASSWORD, NEW_PASSWORD))
 
+          .then(testElementExists(selectors.SETTINGS.HEADER))
           .then(testElementTextEquals(selectors.SETTINGS.PROFILE_HEADER, secondaryEmail))
 
           // sign out and fails login with old password
@@ -174,9 +171,6 @@ define([
       // change password
         .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
         .then(fillOutChangePassword(PASSWORD, NEW_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(testSuccessWasShown())
 
         // sign out and fails login with old password
         .then(click(selectors.SETTINGS.SIGNOUT))

--- a/tests/functional/sync_settings.js
+++ b/tests/functional/sync_settings.js
@@ -10,22 +10,27 @@ define([
   'tests/functional/lib/fx-desktop'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers,
   FxDesktopHelpers) {
-  var thenify = FunctionalHelpers.thenify;
 
-  var click = FunctionalHelpers.click;
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutChangePassword = FunctionalHelpers.fillOutChangePassword;
-  var fillOutDeleteAccount = FunctionalHelpers.fillOutDeleteAccount;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var listenForFxaCommands = FxDesktopHelpers.listenForFxaCommands;
-  var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotifiedOfLogin = FxDesktopHelpers.testIsBrowserNotifiedOfLogin;
-  var testIsBrowserNotifiedOfMessage = FxDesktopHelpers.testIsBrowserNotifiedOfMessage;
-  var visibleByQSA = FunctionalHelpers.visibleByQSA;
+  const {
+    clearBrowserState,
+    click,
+    createUser,
+    fillOutChangePassword,
+    fillOutDeleteAccount,
+    fillOutSignIn,
+    noSuchElement,
+    openPage,
+    openVerificationLinkInDifferentBrowser,
+    testElementExists,
+    thenify,
+    visibleByQSA,
+  } = FunctionalHelpers;
+
+  const {
+    listenForFxaCommands,
+    testIsBrowserNotifiedOfLogin,
+    testIsBrowserNotifiedOfMessage,
+  } = FxDesktopHelpers;
 
   var config = intern.config;
   var SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
@@ -69,8 +74,7 @@ define([
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotifiedOfMessage('change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     },
 
     'sign in, delete the account': function () {

--- a/tests/functional/sync_v2_settings.js
+++ b/tests/functional/sync_v2_settings.js
@@ -8,26 +8,28 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var click = FunctionalHelpers.click;
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutChangePassword = FunctionalHelpers.fillOutChangePassword;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
-  var visibleByQSA = FunctionalHelpers.visibleByQSA;
+  const {
+    click,
+    clearBrowserState,
+    createUser,
+    fillOutChangePassword,
+    fillOutSignIn,
+    openPage,
+    openVerificationLinkInDifferentBrowser,
+    respondToWebChannelMessage,
+    testElementExists,
+    testIsBrowserNotified,
+    visibleByQSA,
+  } = FunctionalHelpers;
 
-  var config = intern.config;
-  var SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v2&service=sync&forceAboutAccounts=true';
-  var SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_desktop_v2&service=sync&forceAboutAccounts=true';
-  var SETTINGS_NOCONTEXT_URL = config.fxaContentRoot + 'settings';
+  const config = intern.config;
+  const SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v2&service=sync&forceAboutAccounts=true';
+  const SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_desktop_v2&service=sync&forceAboutAccounts=true';
+  const SETTINGS_NOCONTEXT_URL = config.fxaContentRoot + 'settings';
 
-  var FIRST_PASSWORD = 'password';
-  var SECOND_PASSWORD = 'new_password';
-  var email;
+  const FIRST_PASSWORD = 'password';
+  const SECOND_PASSWORD = 'new_password';
+  let email;
 
 
   registerSuite({
@@ -50,7 +52,7 @@ define([
 
         // wait until account data is in localstorage before redirecting
         .then(FunctionalHelpers.pollUntil(function () {
-          var accounts = Object.keys(JSON.parse(localStorage.getItem('__fxa_storage.accounts')) || {});
+          const accounts = Object.keys(JSON.parse(localStorage.getItem('__fxa_storage.accounts')) || {});
           return accounts.length === 1 ? true : null;
         }, [], 10000))
 
@@ -62,8 +64,7 @@ define([
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     },
 
     'sign in, change the password by browsing directly to settings': function () {
@@ -72,8 +73,7 @@ define([
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     }
   });
 });

--- a/tests/functional/sync_v3_settings.js
+++ b/tests/functional/sync_v3_settings.js
@@ -8,29 +8,31 @@ define([
   'tests/lib/helpers',
   'tests/functional/lib/helpers'
 ], function (intern, registerSuite, TestHelpers, FunctionalHelpers) {
-  var click = FunctionalHelpers.click;
-  var clearBrowserState = FunctionalHelpers.clearBrowserState;
-  var createUser = FunctionalHelpers.createUser;
-  var fillOutChangePassword = FunctionalHelpers.fillOutChangePassword;
-  var fillOutDeleteAccount = FunctionalHelpers.fillOutDeleteAccount;
-  var fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-  var noSuchBrowserNotification = FunctionalHelpers.noSuchBrowserNotification;
-  var noSuchElement = FunctionalHelpers.noSuchElement;
-  var openPage = FunctionalHelpers.openPage;
-  var openVerificationLinkInDifferentBrowser = FunctionalHelpers.openVerificationLinkInDifferentBrowser;
-  var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-  var testElementExists = FunctionalHelpers.testElementExists;
-  var testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
-  var visibleByQSA = FunctionalHelpers.visibleByQSA;
+  const {
+    click,
+    clearBrowserState,
+    createUser,
+    fillOutChangePassword,
+    fillOutDeleteAccount,
+    fillOutSignIn,
+    noSuchBrowserNotification,
+    noSuchElement,
+    openPage,
+    openVerificationLinkInDifferentBrowser,
+    respondToWebChannelMessage,
+    testElementExists,
+    testIsBrowserNotified,
+    visibleByQSA,
+  } = FunctionalHelpers;
 
-  var config = intern.config;
-  var SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
-  var SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
-  var SETTINGS_NOCONTEXT_URL = config.fxaContentRoot + 'settings';
+  const config = intern.config;
+  const SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
+  const SETTINGS_URL = config.fxaContentRoot + 'settings?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
+  const SETTINGS_NOCONTEXT_URL = config.fxaContentRoot + 'settings';
 
-  var FIRST_PASSWORD = 'password';
-  var SECOND_PASSWORD = 'new_password';
-  var email;
+  const FIRST_PASSWORD = 'password';
+  const SECOND_PASSWORD = 'new_password';
+  let email;
 
 
   registerSuite({
@@ -53,7 +55,7 @@ define([
 
         // wait until account data is in localstorage before redirecting
         .then(FunctionalHelpers.pollUntil(function () {
-          var accounts = Object.keys(JSON.parse(localStorage.getItem('__fxa_storage.accounts')) || {});
+          const accounts = Object.keys(JSON.parse(localStorage.getItem('__fxa_storage.accounts')) || {});
           return accounts.length === 1 ? true : null;
         }, [], 10000))
 
@@ -65,8 +67,7 @@ define([
         .then(click('#change-password .settings-unit-toggle'))
         .then(visibleByQSA('#change-password .settings-unit-details'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     },
 
     'sign in, change the password by browsing directly to settings': function () {
@@ -76,8 +77,7 @@ define([
         .then(visibleByQSA('#change-password .settings-unit-details'))
         .then(noSuchBrowserNotification('fxaccounts:change_password'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD))
-        .then(testIsBrowserNotified('fxaccounts:change_password'));
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     },
 
     'sign in, delete the account': function () {


### PR DESCRIPTION
Almost all of the change password tests checked whether the browser
was notified before waiting for a DOM update that indicated the XHR
request was complete.

Check to ensure the change password panel is closed before
checking whether the browser is notified.

To avoid duplicating this logic in each test, the check
is done in helpers.js->`fillOutChangePassword`.

fixes #5649