### PR TITLE
chore(test): Throw an `ElementNotVisible` error in `visibleByQSA`.

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -133,7 +133,11 @@ define([
         if (pollError) {
           return this.parent.then(takeScreenshot())
             .then(() => {
-              throw pollError;
+              if (/ScriptTimeout/.test(String(pollError))) {
+                throw new Error(`ElementNotVisible - ${selector}`);
+              } else {
+                throw pollError;
+              }
             });
         }
       });


### PR DESCRIPTION
Currently, visibleByQSA shows its function body if an element is
not visible, this isn't useful when looking at a failing test's stack
trace. Instead, throw an `ElementNotVisible` error that contains
the selector being searched for.

Not tied to an issue.

@mozilla/fxa-devs - r?