### PR TITLE
fix(metrics): Fix the "working" error being reported in cwts.

### DIFF
--- a/app/scripts/views/mixins/signup-mixin.js
+++ b/app/scripts/views/mixins/signup-mixin.js
@@ -67,7 +67,12 @@ define(function (require, exports, module) {
       this.logViewEvent('success');
       this.logViewEvent('signup.success');
 
-      return this.invokeBrokerMethod('afterSignUp', account);
+      // do NOT propagate the returned promise. The broker
+      // delegates to a NavigateBehavior which returns a promise
+      // that never resolves. The next screen ends up invoking
+      // this function in their submit handler, which causes
+      // a "Working" error to be logged. See #5655
+      this.invokeBrokerMethod('afterSignUp', account);
     },
 
     onSuggestSyncClick () {

--- a/app/tests/spec/views/mixins/signup-mixin.js
+++ b/app/tests/spec/views/mixins/signup-mixin.js
@@ -128,6 +128,7 @@ define(function (require, exports, module) {
       describe('everyone else', function () {
         beforeEach(function () {
           account.set('verified', false);
+          sinon.stub(view, 'onSignUpSuccess').callsFake(() => p());
 
           return view.signUp(account, 'password');
         });
@@ -141,29 +142,23 @@ define(function (require, exports, module) {
           assert.isTrue(view.getStringifiedResumeToken.calledWith(account));
         });
 
-        it('calls view.logViewEvent correctly', function () {
-          assert.equal(view.logViewEvent.callCount, 2);
-          assert.isTrue(view.logViewEvent.calledWith('success'));
-          assert.isTrue(view.logViewEvent.calledWith('signup.success'));
-        });
-
         it('calls view.formPrefill.clear correctly', function () {
           assert.equal(view.formPrefill.clear.callCount, 1);
           assert.lengthOf(view.formPrefill.clear.args[0], 0);
         });
 
         it('calls view.invokeBrokerMethod correctly', function () {
-          assert.equal(view.invokeBrokerMethod.callCount, 2);
+          assert.equal(view.invokeBrokerMethod.callCount, 1);
 
           var args = view.invokeBrokerMethod.args[0];
           assert.lengthOf(args, 2);
           assert.equal(args[0], 'beforeSignIn');
           assert.equal(args[1], account);
+        });
 
-          args = view.invokeBrokerMethod.args[1];
-          assert.lengthOf(args, 2);
-          assert.equal(args[0], 'afterSignUp');
-          assert.deepEqual(args[1], account);
+        it('calls view.onSignUpSuccess correctly', () => {
+          assert.isTrue(view.onSignUpSuccess.calledOnce);
+          assert.isTrue(view.onSignUpSuccess.calledWith(account));
         });
       });
 
@@ -174,8 +169,24 @@ define(function (require, exports, module) {
 
         it('does not throw', function () {
           assert.doesNotThrow(function () {
-            return view.onSignUpSuccess(account);
+            return view.signUp(account);
           });
+        });
+      });
+
+      describe('onSignUpSuccess', () => {
+        it('logs and calls view.invokeBrokerMethod correctly', () => {
+          assert.isUndefined(view.onSignUpSuccess(account));
+
+          assert.equal(view.logViewEvent.callCount, 2);
+          assert.isTrue(view.logViewEvent.calledWith('success'));
+          assert.isTrue(view.logViewEvent.calledWith('signup.success'));
+
+          assert.isTrue(view.invokeBrokerMethod.calledOnce);
+          const args = view.invokeBrokerMethod.args[0];
+          assert.lengthOf(args, 2);
+          assert.equal(args[0], 'afterSignUp');
+          assert.deepEqual(args[1], account);
         });
       });
     });


### PR DESCRIPTION
Spotted by @ryanfeeley, starting with train-97.

The problem is the submit handler of CWTS finishes by calling `onSubmitComplete` and
propagating that functions return value. `this.onSubmitComplete` is set in the SignupMixin.
`onSignUpSuccess` will delegate to the `afterSignUp` method in the broker, which returns a
`NavigateBehavior` to `/confirm`. A `NavigateBehavior` returns a promise which never resolves,
causing `working` to be logged.

`signup`, `choose_what_to_sync`, and `signup_permissions` should all have the same
increase in "working" errors.

fixes #5655 

@mozilla/fxa-devs - r?