### PR TITLE
fix(metrics): remove flow_id on fxa_pref amplitude events

### DIFF
--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -127,11 +127,11 @@ const EVENT_PROPERTIES = {
 };
 
 const USER_PROPERTIES = {
-  [GROUPS.email]: NOP,
-  [GROUPS.login]: mapUtmProperties,
-  [GROUPS.registration]: mapUtmProperties,
+  [GROUPS.email]: mapFlowId,
+  [GROUPS.login]: mixProperties(mapFlowId, mapUtmProperties),
+  [GROUPS.registration]: mixProperties(mapFlowId, mapUtmProperties),
   [GROUPS.settings]: mapNewsletterState,
-  [GROUPS.sms]: NOP
+  [GROUPS.sms]: mapFlowId
 };
 
 module.exports = receiveEvent;
@@ -202,7 +202,7 @@ function mapEventProperties (group, event, eventCategory, data) {
 
 function mapUserProperties (group, eventCategory, data, userAgent) {
   return Object.assign(
-    { flow_id: marshallOptionalValue(data.flowId), },
+    {},
     mapBrowser(userAgent),
     mapExperiments(data),
     USER_PROPERTIES[group](eventCategory, data)
@@ -311,6 +311,13 @@ function mapService (event, eventCategory, data) {
   const service = marshallOptionalValue(data.service);
   if (service) {
     return { service: SERVICES[service] || service };
+  }
+}
+
+function mapFlowId (eventCategory, data) {
+  const flow_id = marshallOptionalValue(data.flowId);
+  if (flow_id) {
+    return { flow_id };
   }
 }
 

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -176,7 +176,6 @@ define([
           time: 'a',
           user_id: 'h',
           user_properties: {
-            flow_id: 'e',
             ua_browser: 'Mobile Safari',
             ua_version: '6'
           }


### PR DESCRIPTION
Fixes #5669.

@rfk pointed out that `flow_id` doesn't make sense on `fxa_pref - ...` events because they're not part of a flow. And actually it's redundant anyway because it's a user property, so will already have been set by earlier events if the user arrived at `/settings` from a login flow.

Ergo, I deleted it.

@mozilla/fxa-devs r?