### PR TITLE
fix(emails): open correct email for reset password

### DIFF
--- a/tests/functional/settings_change_email.js
+++ b/tests/functional/settings_change_email.js
@@ -144,7 +144,7 @@ define([
         // reset password
         .then(fillOutResetPassword(secondaryEmail))
         .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
-        .then(openVerificationLinkInNewTab(secondaryEmail, 1))
+        .then(openVerificationLinkInNewTab(secondaryEmail, 2))
 
         // complete the reset password in the new tab
         .then(switchToWindow(1))


### PR DESCRIPTION
Fixes #5673 , introduced because we now send an email notifying user that they changed their primary address. Ref: https://github.com/mozilla/fxa-auth-server/pull/2194