### PR TITLE
fix(copy): Added a hyphen to Sign-in confirmed

### DIFF
--- a/app/scripts/templates/connect_another_device.mustache
+++ b/app/scripts/templates/connect_another_device.mustache
@@ -8,7 +8,7 @@
       <div class="success success-not-authenticated visible">{{#t}}Email verified{{/t}}</div>
     {{/isSignUp}}
     {{#isSignIn}}
-      <div class="success success-not-authenticated visible">{{#t}}Signin confirmed{{/t}}</div>
+      <div class="success success-not-authenticated visible">{{#t}}Sign-in confirmed{{/t}}</div>
     {{/isSignIn}}
   {{/isSignedIn}}
   <section>


### PR DESCRIPTION
When a verb we say "sign in" and when a noun we say "sign-in".