### PR TITLE
fix(css): correctly wrap button for secondary emails

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -702,7 +702,7 @@ section.modal-panel {
       }
 
       @media screen and (max-width: 400px) {
-        width: 100%
+        width: 100%;
       }
     }
 

--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -696,7 +696,14 @@ section.modal-panel {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-      width: calc(95% - 95px);
+
+      @media screen and (min-width: 400px) {
+        width: calc(95% - 95px);
+      }
+
+      @media screen and (max-width: 400px) {
+        width: 100%
+      }
     }
 
     .details {
@@ -713,14 +720,6 @@ section.modal-panel {
 
       & .verified {
         color: $color-green;
-      }
-    }
-
-    @media screen and (max-width: 400px) {
-      .settings-button-group {
-        /*!important is used here because on small screens these options are displayed*/
-        /*in another area of the panel. They are to the right of the email.*/
-        display: none !important;
       }
     }
 
@@ -745,14 +744,10 @@ section.modal-panel {
         text-align: center;
         width: 20%;
       }
-    }
-  }
 
-  @media screen and (min-width: 400px) {
-    .email-options {
-      /*!important is used here because on large screens these options are not displayed.*/
-      /*They sit below the email address.*/
-      display: none !important;
+      @media screen and (max-width: 400px) {
+        display: none;
+      }
     }
   }
 
@@ -794,6 +789,10 @@ section.modal-panel {
           margin-right: 10px;
         }
       }
+    }
+
+    @media screen and (min-width: 400px) {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
Fixes #5508 and also removes `! important`.

![screen shot 2017-11-02 at 1 06 50 pm](https://user-images.githubusercontent.com/1295288/32339616-b865d0c6-bfce-11e7-8471-988693827903.png)
