### PR TITLE
feat(devices): include location in the last sync/active string

### DIFF
--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -34,6 +34,53 @@ define(function (require, exports, module) {
     creative: 'button'
   });
 
+  const LAST_ACTIVITY_FORMATS = {
+    /* eslint-disable sorting/sort-object-props */
+    device: {
+      withoutLocation: {
+        precise: t('Last sync %(translatedTimeAgo)s'),
+        approximate: t('Last sync over %(translatedTimeAgo)s')
+      },
+      withCountry: {
+        precise: t('Last sync %(translatedTimeAgo)s in %(translatedCountry)s'),
+        approximate: t('Last sync over %(translatedTimeAgo)s in %(translatedCountry)s')
+      },
+      withCityStateCountry: {
+        precise: t('Last sync %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'),
+        approximate: t('Last sync over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s')
+      }
+    },
+    oauth: {
+      withoutLocation: {
+        precise: t('Last active %(translatedTimeAgo)s'),
+        approximate: t('Last active over %(translatedTimeAgo)s')
+      },
+      withCountry: {
+        precise: t('Last active %(translatedTimeAgo)s in %(translatedCountry)s'),
+        approximate: t('Last active over %(translatedTimeAgo)s in %(translatedCountry)s')
+      },
+      withCityStateCountry: {
+        precise: t('Last active %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'),
+        approximate: t('Last active over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s')
+      }
+    },
+    web: {
+      withoutLocation: {
+        precise: t('%(translatedTimeAgo)s'),
+        approximate: t('Over %(translatedTimeAgo)s')
+      },
+      withCountry: {
+        precise: t('%(translatedTimeAgo)s in %(translatedCountry)s'),
+        approximate: t('Over %(translatedTimeAgo)s in %(translatedCountry)s')
+      },
+      withCityStateCountry: {
+        precise: t('%(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'),
+        approximate: t('Over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s')
+      }
+    }
+    /* eslint-enable sorting/sort-object-props */
+  };
+
   const proto = FormView.prototype;
   const View = FormView.extend({
     template: Template,
@@ -69,39 +116,15 @@ define(function (require, exports, module) {
               item.title = t('Web Session');
             }
 
-            this._setLastAccessTimeFormatted(
-              item,
-              t('%(translatedTimeAgo)s'),
-              t('Over %(translatedTimeAgo)s'),
-              t('%(translatedTimeAgo)s in %(translatedCountry)s'),
-              t('Over %(translatedTimeAgo)s in %(translatedCountry)s'),
-              t('%(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'),
-              t('Over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s')
-            );
+            this._setLastAccessTimeFormatted(item, LAST_ACTIVITY_FORMATS.web);
           }
 
           if (item.isDevice) {
-            this._setLastAccessTimeFormatted(
-              item,
-              t('Last sync %(translatedTimeAgo)s'),
-              t('Last sync over %(translatedTimeAgo)s'),
-              t('Last sync %(translatedTimeAgo)s in %(translatedCountry)s'),
-              t('Last sync over %(translatedTimeAgo)s in %(translatedCountry)s'),
-              t('Last sync %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'),
-              t('Last sync over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s')
-            );
+            this._setLastAccessTimeFormatted(item, LAST_ACTIVITY_FORMATS.device);
           }
 
           if (item.clientType === Constants.CLIENT_TYPE_OAUTH_APP) {
-            this._setLastAccessTimeFormatted(
-              item,
-              t('Last active %(translatedTimeAgo)s'),
-              t('Last active over %(translatedTimeAgo)s'),
-              t('Last active %(translatedTimeAgo)s in %(translatedCountry)s'),
-              t('Last active over %(translatedTimeAgo)s in %(translatedCountry)s'),
-              t('Last active %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'),
-              t('Last active over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s')
-            );
+            this._setLastAccessTimeFormatted(item, LAST_ACTIVITY_FORMATS.oauth);
           }
         } else {
           if (item.isDevice) {
@@ -115,8 +138,7 @@ define(function (require, exports, module) {
       });
     },
 
-    _setLastAccessTimeFormatted (item, ...formats) {
-      let formatIndex;
+    _setLastAccessTimeFormatted (item, format) {
       let translatedCity;
       let translatedCountry;
       let translatedState;
@@ -127,20 +149,22 @@ define(function (require, exports, module) {
         if (item.location.city && item.location.stateCode) {
           translatedCity = item.location.city;
           translatedState = item.location.stateCode;
-          formatIndex = 4;
+          format = format.withCityStateCountry;
         } else {
-          formatIndex = 2;
+          format = format.withCountry;
         }
       } else {
-        formatIndex = 0;
+        format = format.withoutLocation;
       }
 
       if (item.approximateLastAccessTime > item.lastAccessTime) {
         translatedTimeAgo = item.approximateLastAccessTimeFormatted;
-        ++formatIndex;
+        format = format.approximate;
+      } else {
+        format = format.precise;
       }
 
-      item.lastAccessTimeFormatted = this.translate(formats[formatIndex], {
+      item.lastAccessTimeFormatted = this.translate(format, {
         translatedCity, translatedCountry, translatedState, translatedTimeAgo
       });
     },

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -56,14 +56,6 @@ define(function (require, exports, module) {
       return _.map(items, (item) => {
         item.title = item.name;
 
-        if (item.location) {
-          if (item.location.country && item.location.state) {
-            item.title += ' - ' + item.location.state + ', ' + item.location.country;
-          } else if (item.location.country) {
-            item.title += ' - ' + item.location.country;
-          }
-        }
-
         if (item.scope) {
           item.title += ' - ' + item.scope;
         }
@@ -80,28 +72,40 @@ define(function (require, exports, module) {
             this._setLastAccessTimeFormatted(
               item,
               t('%(translatedTimeAgo)s'),
-              t('over %(translatedTimeAgo)s')
+              t('Over %(translatedTimeAgo)s'),
+              t('%(translatedTimeAgo)s in %(translatedCountry)s'),
+              t('Over %(translatedTimeAgo)s in %(translatedCountry)s'),
+              t('%(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'),
+              t('Over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s')
             );
           }
 
           if (item.isDevice) {
             this._setLastAccessTimeFormatted(
               item,
-              t('last sync %(translatedTimeAgo)s'),
-              t('last sync over %(translatedTimeAgo)s')
+              t('Last sync %(translatedTimeAgo)s'),
+              t('Last sync over %(translatedTimeAgo)s'),
+              t('Last sync %(translatedTimeAgo)s in %(translatedCountry)s'),
+              t('Last sync over %(translatedTimeAgo)s in %(translatedCountry)s'),
+              t('Last sync %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'),
+              t('Last sync over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s')
             );
           }
 
           if (item.clientType === Constants.CLIENT_TYPE_OAUTH_APP) {
             this._setLastAccessTimeFormatted(
               item,
-              t('last active %(translatedTimeAgo)s'),
-              t('last active over %(translatedTimeAgo)s')
+              t('Last active %(translatedTimeAgo)s'),
+              t('Last active over %(translatedTimeAgo)s'),
+              t('Last active %(translatedTimeAgo)s in %(translatedCountry)s'),
+              t('Last active over %(translatedTimeAgo)s in %(translatedCountry)s'),
+              t('Last active %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'),
+              t('Last active over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s')
             );
           }
         } else {
           if (item.isDevice) {
-            item.lastAccessTimeFormatted = t('last sync time unknown');
+            item.lastAccessTimeFormatted = t('Last sync time unknown');
           } else {
             // unknown lastAccessTimeFormatted or not possible to format.
             item.lastAccessTimeFormatted = '';
@@ -111,16 +115,34 @@ define(function (require, exports, module) {
       });
     },
 
-    _setLastAccessTimeFormatted (item, format, approximateFormat) {
+    _setLastAccessTimeFormatted (item, ...formats) {
+      let formatIndex;
+      let translatedCity;
+      let translatedCountry;
+      let translatedState;
       let translatedTimeAgo = item.lastAccessTimeFormatted;
-      let correctFormat = format;
+
+      if (item.location && item.location.country) {
+        translatedCountry = item.location.country;
+        if (item.location.city && item.location.stateCode) {
+          translatedCity = item.location.city;
+          translatedState = item.location.stateCode;
+          formatIndex = 4;
+        } else {
+          formatIndex = 2;
+        }
+      } else {
+        formatIndex = 0;
+      }
 
       if (item.approximateLastAccessTime > item.lastAccessTime) {
         translatedTimeAgo = item.approximateLastAccessTimeFormatted;
-        correctFormat = approximateFormat;
+        ++formatIndex;
       }
 
-      item.lastAccessTimeFormatted = this.translate(correctFormat, { translatedTimeAgo });
+      item.lastAccessTimeFormatted = this.translate(formats[formatIndex], {
+        translatedCity, translatedCountry, translatedState, translatedTimeAgo
+      });
     },
 
     setInitialContext (context) {

--- a/app/tests/spec/views/settings/clients.js
+++ b/app/tests/spec/views/settings/clients.js
@@ -508,7 +508,7 @@ define(function (require, exports, module) {
           .then(() => {
             view.translator = {
               get: (untranslatedText) => {
-                if (untranslatedText === 'last sync %(translatedTimeAgo)s') {
+                if (untranslatedText === 'Last sync %(translatedTimeAgo)s') {
                   return 'Translated %(translatedTimeAgo)s';
                 }
 
@@ -543,6 +543,11 @@ define(function (require, exports, module) {
                 isDevice: true,
                 lastAccessTime: now,
                 lastAccessTimeFormatted: '32 minutes ago',
+                location: {
+                  city: 'Bournemouth',
+                  country: 'United Kingdom',
+                  stateCode: 'EN'
+                },
                 type: 'desktop'
               },
               {
@@ -554,6 +559,10 @@ define(function (require, exports, module) {
                 isDevice: true,
                 lastAccessTime: now - 1,
                 lastAccessTimeFormatted: '2 days ago',
+                location: {
+                  city: 'Bournemouth',
+                  country: 'United Kingdom'
+                },
                 type: 'mobile'
               },
               {
@@ -565,6 +574,10 @@ define(function (require, exports, module) {
                 isDevice: true,
                 lastAccessTime: now,
                 lastAccessTimeFormatted: '4 months ago',
+                location: {
+                  country: 'United Kingdom',
+                  stateCode: 'EN'
+                },
                 type: 'mobile'
               },
               {
@@ -573,7 +586,11 @@ define(function (require, exports, module) {
                 id: 'session-1',
                 isWebSession: true,
                 lastAccessTime: now,
-                lastAccessTimeFormatted: '1 day ago'
+                lastAccessTimeFormatted: '1 day ago',
+                location: {
+                  city: 'Bournemouth',
+                  stateCode: 'EN'
+                }
               },
               {
                 approximateLastAccessTime: now,
@@ -582,6 +599,9 @@ define(function (require, exports, module) {
                 isWebSession: true,
                 lastAccessTime: now - 1,
                 lastAccessTimeFormatted: '4 months ago',
+                location: {
+                  country: 'United Kingdom'
+                }
               },
               {
                 approximateLastAccessTime: now,
@@ -590,6 +610,7 @@ define(function (require, exports, module) {
                 isWebSession: true,
                 lastAccessTime: now,
                 lastAccessTimeFormatted: '6 decades ago',
+                location: {}
               },
               {
                 clientType: 'oAuthApp',
@@ -614,18 +635,23 @@ define(function (require, exports, module) {
                 id: 'oauth-3',
                 lastAccessTime: now,
                 lastAccessTimeFormatted: 'blee',
+                location: {
+                  city: 'Mountain View',
+                  country: 'United States',
+                  stateCode: 'CA'
+                }
               },
             ]);
 
-            assert.equal(formatted[0].lastAccessTimeFormatted, 'last sync 32 minutes ago');
-            assert.equal(formatted[1].lastAccessTimeFormatted, 'last sync over 1 hour ago');
-            assert.equal(formatted[2].lastAccessTimeFormatted, 'last sync 4 months ago');
+            assert.equal(formatted[0].lastAccessTimeFormatted, 'Last sync 32 minutes ago near Bournemouth, EN, United Kingdom');
+            assert.equal(formatted[1].lastAccessTimeFormatted, 'Last sync over 1 hour ago in United Kingdom');
+            assert.equal(formatted[2].lastAccessTimeFormatted, 'Last sync 4 months ago in United Kingdom');
             assert.equal(formatted[3].lastAccessTimeFormatted, '1 day ago');
-            assert.equal(formatted[4].lastAccessTimeFormatted, 'over 3 weeks ago');
+            assert.equal(formatted[4].lastAccessTimeFormatted, 'Over 3 weeks ago in United Kingdom');
             assert.equal(formatted[5].lastAccessTimeFormatted, '6 decades ago');
-            assert.equal(formatted[6].lastAccessTimeFormatted, 'last active blee');
-            assert.equal(formatted[7].lastAccessTimeFormatted, 'last active over wibble');
-            assert.equal(formatted[8].lastAccessTimeFormatted, 'last active blee');
+            assert.equal(formatted[6].lastAccessTimeFormatted, 'Last active blee');
+            assert.equal(formatted[7].lastAccessTimeFormatted, 'Last active over wibble');
+            assert.equal(formatted[8].lastAccessTimeFormatted, 'Last active blee near Mountain View, CA, United States');
           });
       });
 
@@ -697,15 +723,15 @@ define(function (require, exports, module) {
             ]);
 
             assert.equal(formatted[0].title, '123Done - profile');
-            assert.equal(formatted[0].lastAccessTimeFormatted, 'last active a few seconds ago');
+            assert.equal(formatted[0].lastAccessTimeFormatted, 'Last active a few seconds ago');
             assert.equal(formatted[1].title, 'Pocket - profile,profile:write');
             assert.equal(formatted[2].title, 'Add-ons');
             assert.equal(formatted[3].title, 'Web Session, Firefox 40');
             assert.equal(formatted[4].title, 'Web Session');
-            assert.equal(formatted[5].title, 'device-1 - Ontario, Canada');
-            assert.equal(formatted[5].lastAccessTimeFormatted, 'last sync 30 minutes ago');
+            assert.equal(formatted[5].title, 'device-1');
+            assert.equal(formatted[5].lastAccessTimeFormatted, 'Last sync 30 minutes ago in Canada');
             assert.equal(formatted[6].title, 'device-2');
-            assert.equal(formatted[6].lastAccessTimeFormatted, 'last sync time unknown');
+            assert.equal(formatted[6].lastAccessTimeFormatted, 'Last sync time unknown');
           });
       });
     });


### PR DESCRIPTION
Fixes #5597.

Moves location into the formatted time string. Translation was added to the back-end in mozilla/fxa-auth-server#2188, so no worries on that front.

There's logic to test for the existence of `city` and `stateCode` because we don't know how to translate those yet. And I opted to pull the format strings up to a constant dictionary object, because all the different variations were an unwieldy mess inline in the function. Here they're labelled with an appropriate name, which I think is an improvement.

~~Tests are failing on circleci but they are on `master` too, I don't think it has anything to do with these changes.~~

@mozilla/fxa-devs r?