### PR TITLE
fix(metrics): promote entrypoint to amplitude user properties

### DIFF
--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -120,9 +120,9 @@ const NOP = () => {};
 
 const EVENT_PROPERTIES = {
   [GROUPS.email]: mixProperties(mapEmailType, mapService),
-  [GROUPS.login]: mixProperties(mapEntrypoint, mapService),
-  [GROUPS.registration]: mixProperties(mapEntrypoint, mapService),
-  [GROUPS.settings]: mixProperties(mapEntrypoint, mapDisconnectReason),
+  [GROUPS.login]: mapService,
+  [GROUPS.registration]: mapService,
+  [GROUPS.settings]: mapDisconnectReason,
   [GROUPS.sms]: NOP
 };
 
@@ -204,6 +204,7 @@ function mapUserProperties (group, eventCategory, data, userAgent) {
   return Object.assign(
     {},
     mapBrowser(userAgent),
+    mapEntrypoint(data),
     mapExperiments(data),
     USER_PROPERTIES[group](eventCategory, data)
   );
@@ -272,6 +273,13 @@ function mixProperties (...mappers) {
     Object.assign({}, ...mappers.map(m => m(event, eventCategory, data)));
 }
 
+function mapEntrypoint (data) {
+  const entrypoint = marshallOptionalValue(data.entrypoint);
+  if (entrypoint) {
+    return { entrypoint };
+  }
+}
+
 function mapExperiments (data) {
   if (data.experiments && data.experiments.length > 0) {
     return {
@@ -297,13 +305,6 @@ function mapEmailType (event, eventCategory) {
   const email_type = EMAIL_TYPES[eventCategory];
   if (email_type) {
     return { email_type };
-  }
-}
-
-function mapEntrypoint (event, eventCategory, data) {
-  const entrypoint = marshallOptionalValue(data.entrypoint);
-  if (entrypoint) {
-    return { entrypoint };
   }
 }
 

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -98,7 +98,6 @@ define([
           device_id: 'bar',
           event_properties: {
             device_id: 'bar',
-            entrypoint: 'baz',
             service: 'amo'
           },
           event_type: 'fxa_login - forgot_submit',
@@ -111,6 +110,7 @@ define([
           time: 'foo',
           user_id: 'soop',
           user_properties: {
+            entrypoint: 'baz',
             experiments: [
               'first_experiment_group_one',
               'second_experiment_group_two',
@@ -163,8 +163,7 @@ define([
           device_id: 'b',
           device_model: 'iPad',
           event_properties: {
-            device_id: 'b',
-            entrypoint: 'c'
+            device_id: 'b'
           },
           event_type: 'fxa_pref - password',
           language: 'f',
@@ -176,6 +175,7 @@ define([
           time: 'a',
           user_id: 'h',
           user_properties: {
+            entrypoint: 'c',
             ua_browser: 'Mobile Safari',
             ua_version: '6'
           }
@@ -342,7 +342,6 @@ define([
           device_id: 'b',
           event_properties: {
             device_id: 'b',
-            entrypoint: 'c',
             service: 'pocket'
           },
           event_type: 'fxa_reg - engage',
@@ -353,6 +352,7 @@ define([
           time: 'a',
           user_id: 'h',
           user_properties: {
+            entrypoint: 'c',
             flow_id: 'e',
             utm_campaign: 'i',
             utm_content: 'j',
@@ -616,6 +616,7 @@ define([
           time: 'a',
           user_id: 'h',
           user_properties: {
+            entrypoint: 'c',
             flow_id: 'e'
           }
         });
@@ -738,6 +739,7 @@ define([
           time: 'a',
           user_id: 'h',
           user_properties: {
+            entrypoint: 'c',
             flow_id: 'e'
           }
         });


### PR DESCRIPTION
Fixes mozilla/fxa-amplitude-send#26.

To save us having to propagate `entrypoint` to the auth server and store it in memcached with the rest of the metrics context, this change promotes it to a user property so that it's available on all subsequent events in Amplitude.

Sample events:

```
{"op":"amplitudeEvent","time":1510063899198,"device_id":"fb35bc2cef5b4abe8a26e150a4cb62f7","event_type":"fxa_reg - view","session_id":1510063895204,"event_properties":{"device_id":"fb35bc2cef5b4abe8a26e150a4cb62f7","service":"sync"},"user_properties":{"ua_browser":"Firefox","ua_version":"58","entrypoint":"menupanel","experiments":["q3form_changes_signup_password_confirm","signup_password_confirm_control"],"flow_id":"9868fd8902fdcf3d91ba77604ec13582ed3387f1cdfbbac5bfa786f24b03c647"},"app_version":"99","language":"fr","os_name":"Mac OS X","os_version":"10.11"}
{"op":"amplitudeEvent","time":1510063904160,"device_id":"fb35bc2cef5b4abe8a26e150a4cb62f7","event_type":"fxa_reg - engage","session_id":1510063895204,"event_properties":{"device_id":"fb35bc2cef5b4abe8a26e150a4cb62f7","service":"sync"},"user_properties":{"ua_browser":"Firefox","ua_version":"58","entrypoint":"menupanel","experiments":["q3form_changes_signup_password_confirm","signup_password_confirm_control"],"flow_id":"9868fd8902fdcf3d91ba77604ec13582ed3387f1cdfbbac5bfa786f24b03c647"},"app_version":"99","language":"fr","os_name":"Mac OS X","os_version":"10.11"}
{"op":"amplitudeEvent","time":1510063965607,"device_id":"fb35bc2cef5b4abe8a26e150a4cb62f7","event_type":"fxa_reg - submit","session_id":1510063895204,"event_properties":{"device_id":"fb35bc2cef5b4abe8a26e150a4cb62f7","service":"sync"},"user_properties":{"ua_browser":"Firefox","ua_version":"58","entrypoint":"menupanel","experiments":["q3form_changes_signup_password_confirm","signup_password_confirm_control"],"flow_id":"9868fd8902fdcf3d91ba77604ec13582ed3387f1cdfbbac5bfa786f24b03c647"},"app_version":"99","language":"fr","os_name":"Mac OS X","os_version":"10.11"}
{"op":"amplitudeEvent","time":1510063990877,"user_id":"289d14364646422ab5f33c491b564aaf","device_id":"b4c531d00294404c98fff44e3f80a2a5","event_type":"fxa_email - click","session_id":1510063895204,"event_properties":{"device_id":"b4c531d00294404c98fff44e3f80a2a5","email_type":"registration","service":"sync"},"user_properties":{"ua_browser":"Firefox","ua_version":"58","entrypoint":"menupanel","experiments":["q3form_changes_signup_password_confirm","signup_password_confirm_control"],"flow_id":"9868fd8902fdcf3d91ba77604ec13582ed3387f1cdfbbac5bfa786f24b03c647"},"app_version":"99","language":"fr","os_name":"Mac OS X","os_version":"10.11"}
```

@mozilla/fxa-devs r?