### PR TITLE
fix(sms): Allow SMS sending again.

### DIFF
--- a/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -121,6 +121,13 @@ define((require, exports, module) => {
           const type = this.model.get('type');
           const group = this.getExperimentGroup('sendSms', { account, country });
 
+          if (ok && ! group) {
+            // Auth server said "OK" but user was not selected
+            // for the experiment, this mode is not logged in
+            // `_areSmsRequirementsMet`
+            this.logFlowEvent(REASON_NOT_IN_EXPERIMENT);
+          }
+
           if (ok && group) {
             // User is eligible and a member of the experiment.
             this.createExperiment('sendSms', group);
@@ -183,8 +190,6 @@ define((require, exports, module) => {
         // If a user is already signed in to Sync which is different to the
         // user that just verified, show them the old "Account verified!" screen.
         reason = REASON_OTHER_USER_SIGNED_IN;
-      } else if (! this.isInExperiment('sendSms', { account })) {
-        reason = REASON_NOT_IN_EXPERIMENT;
       }
 
       if (reason) {


### PR DESCRIPTION
In `_areSmsRequirementsMet`, `isInExperiment` was called
w/o a `country`. The experiment itself requires a country,
so it returned that the user was not a member of the experiment.
Because of this, all users were sent to /connect_another_device,
even if in a country where SMS is was supported.

This fixes that by *not* calling `isInExperiment` in
`_areSmsRequirementsMet` and instead depends on the
call to `getExperimentGroup` in
`navigateToConnectAnotherDeviceScreen` to determine whether
the user is in an experiment group. The user's country is
known at this point and the correct answer will be returned.
If the user is not a member of the experiment, log
it there instead of in `_areSmsRequirementsMet`

Note, there are no functional test updates for this. We
are in a bit of a pickle here because the user is not
enrolled in any experiments within the functional tests
unless the `forceExperiment` query parameter is specified.

This is going to need some manual testing.

fixes #5685

@vladikoff and @vbudhram - r?