### PR TITLE
fix(sms): If SMS is enabled, always send a signinCode.

### DIFF
--- a/app/scripts/views/mixins/sms-mixin.js
+++ b/app/scripts/views/mixins/sms-mixin.js
@@ -22,11 +22,8 @@ define((require, exports, module) => {
      * @returns {String[]}
      */
     getSmsFeatures () {
-      const features = [];
-      if (this.isInExperimentGroup('sendSms', 'signinCodes')) {
-        features.push('signinCodes');
-      }
-      return features;
+      // If SMS is enabled for a user, always send a signinCode.
+      return ['signinCodes'];
     }
   };
 });

--- a/app/tests/spec/views/mixins/sms-mixin.js
+++ b/app/tests/spec/views/mixins/sms-mixin.js
@@ -30,20 +30,9 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('getSmsFeatures', () => {
-      describe('user in `signinCodes` experiment group', () => {
-        it('returns an array with `signinCodes`', () => {
-          sinon.stub(view, 'isInExperimentGroup').callsFake(() => true);
-          assert.isTrue(view.getSmsFeatures().indexOf('signinCodes') > -1);
-        });
-      });
-
-      describe('user not in `signinCodes` experiment group', () => {
-        it('returns an empty array', () => {
-          sinon.stub(view, 'isInExperimentGroup').callsFake(() => false);
-          assert.deepEqual(view.getSmsFeatures(), []);
-        });
-      });
+    it('getSmsFeatures returns an array with `signinCodes`', () => {
+      sinon.stub(view, 'isInExperimentGroup').callsFake(() => true);
+      assert.isTrue(view.getSmsFeatures().indexOf('signinCodes') > -1);
     });
   });
 });

--- a/app/tests/spec/views/mixins/sms-mixin.js
+++ b/app/tests/spec/views/mixins/sms-mixin.js
@@ -9,7 +9,6 @@ define(function (require, exports, module) {
   const { assert } = require('chai');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');
-  const sinon = require('sinon');
   const Template = require('stache!templates/test_template');
 
   const SmsView = BaseView.extend({
@@ -31,7 +30,6 @@ define(function (require, exports, module) {
     });
 
     it('getSmsFeatures returns an array with `signinCodes`', () => {
-      sinon.stub(view, 'isInExperimentGroup').callsFake(() => true);
       assert.isTrue(view.getSmsFeatures().indexOf('signinCodes') > -1);
     });
   });


### PR DESCRIPTION
We know that SMS with signinCodes perform better than SMS w/o signinCodes.
Always use a signinCode if SMS is enabled.

The second half of the fix for #5685

issue #5685 

@vladikoff, @vbudhram - could I get another r on this?
