### PR TITLE
fix(devices): use initial capital letter on strings

### DIFF
--- a/app/scripts/templates/settings/clients.mustache
+++ b/app/scripts/templates/settings/clients.mustache
@@ -26,7 +26,7 @@
                 id="{{id}}">
                 <div class="client-name">{{name}}</div>
                 {{#isCurrentDevice}}
-                    <div class="device-current">{{#t}}current device{{/t}}</div>
+                    <div class="device-current">{{#t}}Current device{{/t}}</div>
                 {{/isCurrentDevice}}
                 {{^isCurrentDevice}}
                     <div class="last-connected">{{lastAccessTimeFormatted}}</div>
@@ -43,7 +43,7 @@
                     id="{{id}}">
                     <div class="client-name" title="{{title}}">{{title}}</div>
                   {{#isCurrentDevice}}
-                    <div class="device-current">{{#t}}current session{{/t}}</div>
+                    <div class="device-current">{{#t}}Current session{{/t}}</div>
                   {{/isCurrentDevice}}
                   {{^isCurrentDevice}}
                     <div class="last-connected">{{lastAccessTimeFormatted}}</div>
@@ -65,12 +65,12 @@
         {{#showMobileApps}}
           <li class="client mobile" data-os="iOS">
             <div class="client-name">{{#t}}Firefox for iOS{{/t}}</div>
-            <div class="last-connected">{{#t}}none connected{{/t}}</div>
+            <div class="last-connected">{{#t}}None connected{{/t}}</div>
             <a target="_blank" href="{{ linkIOS }}" class="settings-button secondary" data-get-app="ios">{{#t}}Download{{/t}}</a>
           </li>
           <li class="client mobile" data-os="Android">
             <div class="client-name">{{#t}}Firefox for Android{{/t}}</div>
-            <div class="last-connected">{{#t}}none connected{{/t}}</div>
+            <div class="last-connected">{{#t}}None connected{{/t}}</div>
             <a target="_blank" href="{{ linkAndroid }}" class="settings-button secondary" data-get-app="android">{{#t}}Download{{/t}}</a>
           </li>
         {{/showMobileApps}}

--- a/tests/functional/settings_clients.js
+++ b/tests/functional/settings_clients.js
@@ -68,7 +68,7 @@ define([
         // current session has the text `current session`
         .then(FunctionalHelpers.testElementTextEquals(
           '.client-webSession:nth-child(1) .client-name + .device-current',
-          'current session'
+          'Current session'
         ))
 
         // first session has the user agent
@@ -176,7 +176,7 @@ define([
         // current device has the text `current device`
         .then(FunctionalHelpers.testElementTextEquals(
           '.client-device:nth-child(1) .client-name + .device-current',
-          'current device'
+          'Current device'
         ))
 
         // external update should show in the device list


### PR DESCRIPTION
Fixes #5691.

<img width="495" alt="Screen shot showing device manager strings with an initial uppercase letter" src="https://user-images.githubusercontent.com/64367/32550171-0255e3a6-c484-11e7-8013-9de0fe3a20e5.png" />

@mozilla/fxa-devs r?
