### PR TITLE
fix(ui): ensure that long lines wrap in device manager

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -522,7 +522,7 @@ section.modal-panel {
   background-repeat: no-repeat;
   background-size: 32px 32px;
 
-  height: 40px;
+  min-height: 40px;
   list-style: none;
   margin: 10px 0;
   position: relative;
@@ -576,8 +576,13 @@ section.modal-panel {
   }
 
   .last-connected {
+    margin-right: 120px;
     color: $color-grey;
     font-size: 12px;
+
+    @include respond-to('small') {
+      max-width: 78%;
+    }
   }
 
   &[data-os='Windows'] {


### PR DESCRIPTION
Fixes #5690.

Works in the default layout:

![Screen shot showing wrapped text line in the device manager](https://user-images.githubusercontent.com/64367/32550249-538eab0e-c484-11e7-93db-1364679cc004.png)

And at reduced width:

![Screen shot showing heavily-wrapped text line in the device manager](https://user-images.githubusercontent.com/64367/32550259-5cb5c488-c484-11e7-9e29-fb4e42acdf85.png)

And with the `small` breakpoint (where buttons are variably-sized):

![Screen shot showing wrapped text line in the device manager next to a wide button](https://user-images.githubusercontent.com/64367/32550279-6d01b1d0-c484-11e7-9eb2-ce86890fe9f2.png)

@mozilla/fxa-devs r?