### PR TITLE
fix(sms): Ensure the SMS form for both AT and DE are tested. 

### DIFF
--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -37,21 +37,34 @@
    let testPhoneNumber;
    let formattedPhoneNumber;
 
-   const click = FunctionalHelpers.click;
-   const closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-   const deleteAllSms = FunctionalHelpers.deleteAllSms;
-   const disableInProd = FunctionalHelpers.disableInProd;
-   const fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-   const getSms = FunctionalHelpers.getSms;
-   const getSmsSigninCode = FunctionalHelpers.getSmsSigninCode;
-   const openPage = FunctionalHelpers.openPage;
-   const switchToWindow = FunctionalHelpers.switchToWindow;
-   const testAttributeEquals = FunctionalHelpers.testAttributeEquals;
-   const testElementExists = FunctionalHelpers.testElementExists;
-   const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
-   const testElementValueEquals = FunctionalHelpers.testElementValueEquals;
-   const testHrefEquals = FunctionalHelpers.testHrefEquals;
-   const type = FunctionalHelpers.type;
+   const {
+     click,
+     closeCurrentWindow,
+     deleteAllSms,
+     disableInProd,
+     fillOutSignUp,
+     getSms,
+     getSmsSigninCode,
+     openPage,
+     switchToWindow,
+     testAttributeEquals,
+     testElementExists,
+     testElementTextInclude,
+     testElementValueEquals,
+     testHrefEquals,
+     type,
+   } = FunctionalHelpers;
+
+   function testSmsSupportedCountryForm (country, expectedPrefix) {
+     return function () {
+       return this.remote
+         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER, {
+           query: { country },
+         }))
+         .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, expectedPrefix))
+         .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', country));
+     };
+   }
 
    const suite = {
      name: 'send_sms',
@@ -95,49 +108,12 @@
          .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'US'));
      },
 
-     'with `country=CA`': function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER, {
-           query: {
-             country: 'CA'
-           }
-         }))
-         .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, ''))
-         .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'CA'));
-     },
-
-     'with `country=RO`': function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER, {
-           query: {
-             country: 'RO'
-           }
-         }))
-         .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, '+40'))
-         .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'RO'));
-     },
-
-     'with `country=GB`': function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER, {
-           query: {
-             country: 'GB'
-           }
-         }))
-         .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, '+44'))
-         .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'GB'));
-     },
-
-     'with `country=US`': function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER, {
-           query: {
-             country: 'US'
-           }
-         }))
-         .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, ''))
-         .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'US'));
-     },
+     'with `country=AT`': testSmsSupportedCountryForm('AT', '+43'),
+     'with `country=CA`': testSmsSupportedCountryForm('CA', ''),
+     'with `country=DE`': testSmsSupportedCountryForm('DE', '+49'),
+     'with `country=GB`': testSmsSupportedCountryForm('GB', '+44'),
+     'with `country=RO`': testSmsSupportedCountryForm('RO', '+40'),
+     'with `country=US`': testSmsSupportedCountryForm('US', ''),
 
      'with an unsupported `country`': function () {
        return this.remote

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -3,273 +3,273 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
- define([
-   'intern',
-   'intern!object',
-   'tests/lib/helpers',
-   'tests/functional/lib/helpers',
-   'tests/functional/lib/selectors',
-   'app/scripts/lib/country-telephone-info'
- ], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors, CountryTelephoneInfo) {
-   'use strict';
+define([
+  'intern',
+  'intern!object',
+  'tests/lib/helpers',
+  'tests/functional/lib/helpers',
+  'tests/functional/lib/selectors',
+  'app/scripts/lib/country-telephone-info'
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors, CountryTelephoneInfo) {
+  'use strict';
 
-   const config = intern.config;
+  const config = intern.config;
 
-   const ADJUST_LINK_ANDROID =
-    'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +
-    'creative=button-autumn-2016-connect-another-device&adgroup=android';
+  const ADJUST_LINK_ANDROID =
+   'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +
+   'creative=button-autumn-2016-connect-another-device&adgroup=android';
 
-   const ADJUST_LINK_IOS =
-    'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +
-    'creative=button-autumn-2016-connect-another-device&adgroup=ios&' +
-    'fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&' +
-    'ct=adjust_tracker&mt=8';
-
-
-   const SEND_SMS_URL = `${config.fxaContentRoot}sms?service=sync&country=US`;
-   const SEND_SMS_SIGNIN_CODE_URL = `${SEND_SMS_URL}&forceExperiment=sendSms&forceExperimentGroup=signinCodes`;
-   const SEND_SMS_NO_QUERY_URL = `${config.fxaContentRoot}sms`;
+  const ADJUST_LINK_IOS =
+   'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +
+   'creative=button-autumn-2016-connect-another-device&adgroup=ios&' +
+   'fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&' +
+   'ct=adjust_tracker&mt=8';
 
 
-   let email;
-   const PASSWORD = 'password';
+  const SEND_SMS_URL = `${config.fxaContentRoot}sms?service=sync&country=US`;
+  const SEND_SMS_SIGNIN_CODE_URL = `${SEND_SMS_URL}&forceExperiment=sendSms&forceExperimentGroup=signinCodes`;
+  const SEND_SMS_NO_QUERY_URL = `${config.fxaContentRoot}sms`;
 
-   let testPhoneNumber;
-   let formattedPhoneNumber;
 
-   const {
-     click,
-     closeCurrentWindow,
-     deleteAllSms,
-     disableInProd,
-     fillOutSignUp,
-     getSms,
-     getSmsSigninCode,
-     openPage,
-     switchToWindow,
-     testAttributeEquals,
-     testElementExists,
-     testElementTextInclude,
-     testElementValueEquals,
-     testHrefEquals,
-     type,
-   } = FunctionalHelpers;
+  let email;
+  const PASSWORD = 'password';
 
-   function testSmsSupportedCountryForm (country, expectedPrefix) {
-     return function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER, {
-           query: { country },
-         }))
-         .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, expectedPrefix))
-         .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', country));
-     };
-   }
+  let testPhoneNumber;
+  let formattedPhoneNumber;
 
-   const suite = {
-     name: 'send_sms',
+  const {
+    click,
+    closeCurrentWindow,
+    deleteAllSms,
+    disableInProd,
+    fillOutSignUp,
+    getSms,
+    getSmsSigninCode,
+    openPage,
+    switchToWindow,
+    testAttributeEquals,
+    testElementExists,
+    testElementTextInclude,
+    testElementValueEquals,
+    testHrefEquals,
+    type,
+  } = FunctionalHelpers;
 
-     beforeEach: function () {
-       email = TestHelpers.createEmail();
-       testPhoneNumber = TestHelpers.createPhoneNumber();
-       const countryInfo = CountryTelephoneInfo['US'];
-       formattedPhoneNumber =
-          countryInfo.format(countryInfo.normalize(testPhoneNumber));
+  function testSmsSupportedCountryForm (country, expectedPrefix) {
+    return function () {
+      return this.remote
+        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER, {
+          query: { country },
+        }))
+        .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, expectedPrefix))
+        .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', country));
+    };
+  }
 
-       // User needs a sessionToken to be able to send an SMS. Sign up,
-       // no need to verify.
-       return this.remote
-         .then(fillOutSignUp(email, PASSWORD))
-         .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
-         // The phoneNumber can be reused by different tests, delete all
-         // of its SMS messages to ensure a clean slate.
-         .then(deleteAllSms(testPhoneNumber));
-     },
+  const suite = {
+    name: 'send_sms',
 
-     'with no query parameters': function () {
-       return this.remote
-         .then(openPage(SEND_SMS_NO_QUERY_URL, selectors.SMS_SEND.HEADER))
-         .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, ''))
-         .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'US'))
-         .then(testHrefEquals(selectors.SMS_SEND.LINK_MARKETING_IOS, ADJUST_LINK_IOS))
-         .then(testHrefEquals(selectors.SMS_SEND.LINK_MARKETING_ANDROID, ADJUST_LINK_ANDROID));
-     },
+    beforeEach: function () {
+      email = TestHelpers.createEmail();
+      testPhoneNumber = TestHelpers.createPhoneNumber();
+      const countryInfo = CountryTelephoneInfo['US'];
+      formattedPhoneNumber =
+         countryInfo.format(countryInfo.normalize(testPhoneNumber));
 
-     'with no service, unsupported country': function () {
-       return this.remote
-         .then(openPage(SEND_SMS_NO_QUERY_URL, selectors.SMS_SEND.HEADER, {
-           query: {
-             country: 'KZ'
-           }
-         }))
-         // The Sync relier validates `country`, this uses the base relier
-         // so country is ignored.
-         .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, ''))
-         .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'US'));
-     },
+      // User needs a sessionToken to be able to send an SMS. Sign up,
+      // no need to verify.
+      return this.remote
+        .then(fillOutSignUp(email, PASSWORD))
+        .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
+        // The phoneNumber can be reused by different tests, delete all
+        // of its SMS messages to ensure a clean slate.
+        .then(deleteAllSms(testPhoneNumber));
+    },
 
-     'with `country=AT`': testSmsSupportedCountryForm('AT', '+43'),
-     'with `country=CA`': testSmsSupportedCountryForm('CA', ''),
-     'with `country=DE`': testSmsSupportedCountryForm('DE', '+49'),
-     'with `country=GB`': testSmsSupportedCountryForm('GB', '+44'),
-     'with `country=RO`': testSmsSupportedCountryForm('RO', '+40'),
-     'with `country=US`': testSmsSupportedCountryForm('US', ''),
+    'with no query parameters': function () {
+      return this.remote
+        .then(openPage(SEND_SMS_NO_QUERY_URL, selectors.SMS_SEND.HEADER))
+        .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, ''))
+        .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'US'))
+        .then(testHrefEquals(selectors.SMS_SEND.LINK_MARKETING_IOS, ADJUST_LINK_IOS))
+        .then(testHrefEquals(selectors.SMS_SEND.LINK_MARKETING_ANDROID, ADJUST_LINK_ANDROID));
+    },
 
-     'with an unsupported `country`': function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, selectors['400'].HEADER, {
-           query: {
-             country: 'KZ'
-           }
-         }))
-         .then(testElementTextInclude(selectors['400'].ERROR, 'country'));
-     },
+    'with no service, unsupported country': function () {
+      return this.remote
+        .then(openPage(SEND_SMS_NO_QUERY_URL, selectors.SMS_SEND.HEADER, {
+          query: {
+            country: 'KZ'
+          }
+        }))
+        // The Sync relier validates `country`, this uses the base relier
+        // so country is ignored.
+        .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, ''))
+        .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'US'));
+    },
 
-     'learn more': function () {
-       return this.remote
+    'with `country=AT`': testSmsSupportedCountryForm('AT', '+43'),
+    'with `country=CA`': testSmsSupportedCountryForm('CA', ''),
+    'with `country=DE`': testSmsSupportedCountryForm('DE', '+49'),
+    'with `country=GB`': testSmsSupportedCountryForm('GB', '+44'),
+    'with `country=RO`': testSmsSupportedCountryForm('RO', '+40'),
+    'with `country=US`': testSmsSupportedCountryForm('US', ''),
+
+    'with an unsupported `country`': function () {
+      return this.remote
+        .then(openPage(SEND_SMS_URL, selectors['400'].HEADER, {
+          query: {
+            country: 'KZ'
+          }
+        }))
+        .then(testElementTextInclude(selectors['400'].ERROR, 'country'));
+    },
+
+    'learn more': function () {
+      return this.remote
+       .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
+       .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
+       .then(click(selectors.SMS_SEND.LINK_LEARN_MORE))
+       .then(switchToWindow(1))
+
+       .then(testElementExists(selectors.SMS_LEARN_MORE.HEADER))
+       .then(closeCurrentWindow());
+
+    },
+
+    'why is this required': function () {
+      return this.remote
+       .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
+       .then(click(selectors.SMS_SEND.LINK_WHY_IS_THIS_REQUIRED))
+
+       .then(testElementExists(selectors.SMS_WHY_IS_THIS_REQUIRED.HEADER))
+       .then(click(selectors.SMS_WHY_IS_THIS_REQUIRED.CLOSE))
+
+       .then(testElementExists(selectors.SMS_SEND.HEADER));
+    },
+
+    'empty phone number': function () {
+      return this.remote
+       .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
+       .then(click(selectors.SMS_SEND.SUBMIT))
+       .then(testElementExists(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP))
+       .then(testElementTextInclude(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP, 'required'));
+    },
+
+    'invalid phone number (too short)': function () {
+      return this.remote
         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
-        .then(click(selectors.SMS_SEND.LINK_LEARN_MORE))
-        .then(switchToWindow(1))
-
-        .then(testElementExists(selectors.SMS_LEARN_MORE.HEADER))
-        .then(closeCurrentWindow());
-
-     },
-
-     'why is this required': function () {
-       return this.remote
-        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(click(selectors.SMS_SEND.LINK_WHY_IS_THIS_REQUIRED))
-
-        .then(testElementExists(selectors.SMS_WHY_IS_THIS_REQUIRED.HEADER))
-        .then(click(selectors.SMS_WHY_IS_THIS_REQUIRED.CLOSE))
-
-        .then(testElementExists(selectors.SMS_SEND.HEADER));
-     },
-
-     'empty phone number': function () {
-       return this.remote
-        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(click(selectors.SMS_SEND.SUBMIT))
-        .then(testElementExists(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP))
-        .then(testElementTextInclude(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP, 'required'));
-     },
-
-     'invalid phone number (too short)': function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-         .then(type(selectors.SMS_SEND.PHONE_NUMBER, '2134567'))
-         .then(click(selectors.SMS_SEND.SUBMIT))
-         .then(testElementExists(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP))
-         .then(testElementTextInclude(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP, 'invalid'));
-     },
-
-     'invalid phone number (too long)': function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-         .then(type(selectors.SMS_SEND.PHONE_NUMBER, '21345678901'))
-         .then(click(selectors.SMS_SEND.SUBMIT))
-         .then(testElementExists(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP))
-         .then(testElementTextInclude(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP, 'invalid'));
-     },
-
-     'invalid phone number (contains letters)': function () {
-       return this.remote
-        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, '2134567a890'))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, '2134567'))
         .then(click(selectors.SMS_SEND.SUBMIT))
         .then(testElementExists(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP))
         .then(testElementTextInclude(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP, 'invalid'));
-     },
+    },
 
-     'valid phone number, back': disableInProd(function () {
-       return this.remote
+    'invalid phone number (too long)': function () {
+      return this.remote
         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, '21345678901'))
+        .then(click(selectors.SMS_SEND.SUBMIT))
+        .then(testElementExists(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP))
+        .then(testElementTextInclude(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP, 'invalid'));
+    },
+
+    'invalid phone number (contains letters)': function () {
+      return this.remote
+       .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, '2134567a890'))
+       .then(click(selectors.SMS_SEND.SUBMIT))
+       .then(testElementExists(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP))
+       .then(testElementTextInclude(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP, 'invalid'));
+    },
+
+    'valid phone number, back': disableInProd(function () {
+      return this.remote
+       .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+       .then(click(selectors.SMS_SEND.SUBMIT))
+       .then(testElementExists(selectors.SMS_SENT.HEADER))
+       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
+       .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
+       .then(getSms(testPhoneNumber, 0))
+
+       // user realizes they made a mistake
+       .then(click(selectors.SMS_SENT.LINK_BACK))
+       .then(testElementExists(selectors.SMS_SEND.HEADER))
+
+       // original phone number should still be in place
+       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber));
+    }),
+
+    'valid phone number, resend': disableInProd(function () {
+      return this.remote
+       .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+       .then(click(selectors.SMS_SEND.SUBMIT))
+       .then(testElementExists(selectors.SMS_SENT.HEADER))
+       .then(getSms(testPhoneNumber, 0))
+
+       .then(click(selectors.SMS_SENT.LINK_RESEND))
+       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
+       .then(getSms(testPhoneNumber, 1))
+
+       // user realizes they made a mistake
+       .then(click(selectors.SMS_SENT.LINK_BACK))
+       .then(testElementExists(selectors.SMS_SEND.HEADER))
+
+       // original phone number should still be in place
+       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber));
+    }),
+
+    'valid phone number, enable signinCode': disableInProd(function () {
+      return this.remote
+       .then(openPage(SEND_SMS_SIGNIN_CODE_URL, selectors.SMS_SEND.HEADER))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+       .then(click(selectors.SMS_SEND.SUBMIT))
+       .then(testElementExists(selectors.SMS_SENT.HEADER))
+       .then(getSmsSigninCode(testPhoneNumber, 0));
+    }),
+
+    'valid phone number w/ country code of 1': disableInProd(function () {
+      return this.remote
+        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, `1${testPhoneNumber}`))
         .then(click(selectors.SMS_SEND.SUBMIT))
         .then(testElementExists(selectors.SMS_SENT.HEADER))
         .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
         .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
-        .then(getSms(testPhoneNumber, 0))
+        .then(getSms(testPhoneNumber, 0));
+    }),
 
-        // user realizes they made a mistake
-        .then(click(selectors.SMS_SENT.LINK_BACK))
-        .then(testElementExists(selectors.SMS_SEND.HEADER))
-
-        // original phone number should still be in place
-        .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber));
-     }),
-
-     'valid phone number, resend': disableInProd(function () {
-       return this.remote
+    'valid phone number w/ country code of +1': disableInProd(function () {
+      return this.remote
         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
-        .then(click(selectors.SMS_SEND.SUBMIT))
-        .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(getSms(testPhoneNumber, 0))
-
-        .then(click(selectors.SMS_SENT.LINK_RESEND))
-        .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
-        .then(getSms(testPhoneNumber, 1))
-
-        // user realizes they made a mistake
-        .then(click(selectors.SMS_SENT.LINK_BACK))
-        .then(testElementExists(selectors.SMS_SEND.HEADER))
-
-        // original phone number should still be in place
-        .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber));
-     }),
-
-     'valid phone number, enable signinCode': disableInProd(function () {
-       return this.remote
-        .then(openPage(SEND_SMS_SIGNIN_CODE_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
-        .then(click(selectors.SMS_SEND.SUBMIT))
-        .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(getSmsSigninCode(testPhoneNumber, 0));
-     }),
-
-     'valid phone number w/ country code of 1': disableInProd(function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-         .then(type(selectors.SMS_SEND.PHONE_NUMBER, `1${testPhoneNumber}`))
-         .then(click(selectors.SMS_SEND.SUBMIT))
-         .then(testElementExists(selectors.SMS_SENT.HEADER))
-         .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
-         .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
-         .then(getSms(testPhoneNumber, 0));
-     }),
-
-     'valid phone number w/ country code of +1': disableInProd(function () {
-       return this.remote
-         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-         .then(type(selectors.SMS_SEND.PHONE_NUMBER, `+1${testPhoneNumber}`))
-         .then(click(selectors.SMS_SEND.SUBMIT))
-         .then(testElementExists(selectors.SMS_SENT.HEADER))
-         .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
-         .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
-         .then(getSms(testPhoneNumber, 0));
-     }),
-
-     'valid phone number (contains spaces and punctuation)': disableInProd(function () {
-       const unformattedPhoneNumber = ` ${testPhoneNumber.slice(0,3)} .,- ${testPhoneNumber.slice(3)} `;
-       return this.remote
-        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, unformattedPhoneNumber))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, `+1${testPhoneNumber}`))
         .then(click(selectors.SMS_SEND.SUBMIT))
         .then(testElementExists(selectors.SMS_SENT.HEADER))
         .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
-        .then(getSms(testPhoneNumber, 0))
+        .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
+        .then(getSms(testPhoneNumber, 0));
+    }),
 
-        // user realizes they made a mistake
-        .then(click(selectors.SMS_SENT.LINK_BACK))
-        .then(testElementExists(selectors.SMS_SEND.HEADER))
+    'valid phone number (contains spaces and punctuation)': disableInProd(function () {
+      const unformattedPhoneNumber = ` ${testPhoneNumber.slice(0,3)} .,- ${testPhoneNumber.slice(3)} `;
+      return this.remote
+       .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, unformattedPhoneNumber))
+       .then(click(selectors.SMS_SEND.SUBMIT))
+       .then(testElementExists(selectors.SMS_SENT.HEADER))
+       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
+       .then(getSms(testPhoneNumber, 0))
 
-        // original phone number should still be in place
-        .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, unformattedPhoneNumber));
-     })
-   };
+       // user realizes they made a mistake
+       .then(click(selectors.SMS_SENT.LINK_BACK))
+       .then(testElementExists(selectors.SMS_SEND.HEADER))
 
-   registerSuite(suite);
- });
+       // original phone number should still be in place
+       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, unformattedPhoneNumber));
+    })
+  };
+
+  registerSuite(suite);
+});


### PR DESCRIPTION
This PR is 2 commits, the first is the meat of the PR, the 2nd is to remove an extra leading space on each line.

The common logic to test the form for a given country is extracted into a helper function, testSmsSupportedCountryForm

Not attached to an issue, but I noticed neither AT nor DE were tested while digging into [yesterday's issue](https://github.com/mozilla/fxa-content-server/issues/5685).

