### PR TITLE
fix(back-mixin): Fix the "New broker method needed for click" error.

### DIFF
--- a/app/scripts/views/mixins/back-mixin.js
+++ b/app/scripts/views/mixins/back-mixin.js
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
     },
 
     events: {
-      'click #back,.back': preventDefaultThen('back'),
+      'click #back,.back': preventDefaultThen('onClick'),
       'keyup #back,.back': 'backOnEnter'
     },
 
@@ -33,6 +33,13 @@ define(function (require, exports, module) {
       if (! context.has('canGoBack')) {
         context.set('canGoBack', this.canGoBack());
       }
+    },
+
+    onClick () {
+      // The `onClick` delegate function is used to prevent the event
+      // from being used as `nextViewData` for the `back` method.
+      // See #5515
+      this.back();
     },
 
     /**

--- a/app/tests/spec/views/mixins/back-mixin.js
+++ b/app/tests/spec/views/mixins/back-mixin.js
@@ -67,7 +67,8 @@ define(function (require, exports, module) {
       });
 
       describe('clicks on `#back`', () => {
-        it('calls `event.preventDefault`', () => {
+        it('calls `event.preventDefault`, does not propagate event as nextViewData', () => {
+          sinon.spy(notifier, 'trigger');
           $('#container').html(view.el);
 
           const clickEvent = $.Event('click');
@@ -75,6 +76,12 @@ define(function (require, exports, module) {
 
           view.$('#back').trigger(clickEvent);
           assert.isTrue(clickEvent.isDefaultPrevented());
+
+          assert.isTrue(notifier.trigger.calledOnce);
+          assert.isTrue(
+            notifier.trigger.calledWith('navigate-back', {
+              nextViewData: undefined
+            }));
         });
       });
     });


### PR DESCRIPTION
The back-mixin erroneously passed the back button click event
as `nextViewData` when it invoked the `back` method.

The fix is to use a delegate method that invoked `back`
without the event.

fixes #5515 

@vladikoff - r?