### PR TITLE
fix(style): Fix styling for 2nd password experiment.

### DIFF
--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -52,7 +52,7 @@
            as the username. -->
       <input type="email" value="{{email}}" class="hidden" />
 
-      <div class="input-row password-row">
+      <div class="input-row password-row label-helper-top">
         <label class="label-helper"></label>
         <input type="password" class="password check-password tooltip-below" id="password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" required autofocus data-synchronize-show="true"/>
 
@@ -60,7 +60,7 @@
       </div>
 
 
-      <div class="input-row password-row">
+      <div class="input-row password-row label-helper-top">
         <label class="label-helper"></label>
         <input type="password" class="password tooltip-below" id="vpassword" placeholder="{{#t}}Repeat password{{/t}}" required pattern=".{8,}" data-synchronize-show="true"/>
       </div>

--- a/app/scripts/templates/settings/change_password.mustache
+++ b/app/scripts/templates/settings/change_password.mustache
@@ -19,14 +19,14 @@
            the password manager saves the old_password
            as the username. -->
       <input type="email" value="{{email}}" class="hidden" />
-      <div class="input-row password-row">
+      <div class="input-row password-row label-helper-top">
         <label class="label-helper"></label>
         <input type="password" class="password" id="old_password" placeholder="{{#t}}Old password{{/t}}" required pattern=".{8,}" autofocus />
 
         <div class="input-help input-help-forgot-pw links"><a href="/reset_password" class="reset-password">{{#t}}Forgot password?{{/t}}</a></div>
       </div>
 
-      <div class="input-row password-row">
+      <div class="input-row password-row label-helper-top">
         <label class="label-helper"></label>
         <input type="password" class="password check-password tooltip-below" id="new_password" placeholder="{{#t}}New password{{/t}}" required pattern=".{8,}" />
 

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -41,15 +41,23 @@
         {{/forceEmail}}
       </div>
 
-      <div class="input-row password-row">
-        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#showPasswordConfirm}}data-synchronize-show="true"{{/showPasswordConfirm}} />
-        <div class="input-help input-help-focused input-help-signup">{{#t}}A strong, unique password will keep your Firefox data safe from intruders.{{/t}}</div>
-      </div>
+      {{^showPasswordConfirm}}
+        <div class="input-row password-row">
+          <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#showPasswordConfirm}}data-synchronize-show="true"{{/showPasswordConfirm}} />
+          <div class="input-help input-help-focused input-help-signup">{{#t}}A strong, unique password will keep your Firefox data safe from intruders.{{/t}}</div>
+        </div>
+      {{/showPasswordConfirm}}
 
       {{#showPasswordConfirm}}
-      <div class="input-row password-row">
+      <div class="input-row password-row label-helper-top">
+        <label class="label-helper"></label>
+        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" pattern=".{8,}" required {{#showPasswordConfirm}}data-synchronize-show="true"{{/showPasswordConfirm}} />
+      </div>
+
+      <div class="input-row password-row label-helper-top">
         <label class="label-helper"></label>
         <input id="vpassword" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Repeat password{{/t}}" pattern=".{8,}" required data-synchronize-show="true" />
+        <div class="input-help input-help-focused input-help-signup">{{#t}}A strong, unique password will keep your Firefox data safe from intruders.{{/t}}</div>
       </div>
       {{/showPasswordConfirm}}
 

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -31,12 +31,15 @@
     {{/isAmoMigration}}
 
     <form novalidate>
-      <div class="input-row">
+      <div class="input-row {{^forceEmail}}{{#showPasswordConfirm}}label-helper-top{{/showPasswordConfirm}}{{/forceEmail}}">
         {{#forceEmail}}
           <p class="prefillEmail">{{ forceEmail }}</p>
           <input type="email" class="email hidden tooltip-below" value="{{ forceEmail }}" disabled />
         {{/forceEmail}}
         {{^forceEmail}}
+          {{#showPasswordConfirm}}
+            <label class="label-helper"></label>
+          {{/showPasswordConfirm}}
           <input name="email" type="email" class="email tooltip-below" placeholder="{{#t}}Email{{/t}}" value="{{ email }}" spellcheck="false" required />
         {{/forceEmail}}
       </div>

--- a/app/scripts/views/mixins/password-mixin.js
+++ b/app/scripts/views/mixins/password-mixin.js
@@ -12,9 +12,13 @@ define(function (require, exports, module) {
   const Constants = require('../../lib/constants');
   const showPasswordTemplate = require('stache!templates/partial/show-password');
 
+  const SELECTOR_SIGNUP_PASSWORD_HELPER = '.input-help-signup';
+
   module.exports = {
     events: {
+      'blur input.password': 'unhighlightSignupPasswordHelper',
       'change input.password': 'onPasswordChanged',
+      'focus input.password': 'highlightSignupPasswordHelper',
       'keyup input.password': 'onPasswordChanged',
       'mousedown .show-password-label': 'onShowPasswordMouseDown',
       'touchstart .show-password-label': 'onShowPasswordMouseDown'
@@ -220,6 +224,22 @@ define(function (require, exports, module) {
     hidePasswordHelper () {
       // Hide all input-help classes except input-help-forgot-pw
       this.$('.input-help:not(.input-help-forgot-pw)').css('opacity', '0');
+    },
+
+    /**
+     * Add the `highlight` class to the signup password helper. This is
+     * used to make the "A strong, unique..." text blue if either
+     * password field is focused.
+     */
+    highlightSignupPasswordHelper () {
+      this.$(SELECTOR_SIGNUP_PASSWORD_HELPER).addClass('highlight');
+    },
+
+    /**
+     * Remove the `highlight` class from the signup password helper
+     */
+    unhighlightSignupPasswordHelper () {
+      this.$(SELECTOR_SIGNUP_PASSWORD_HELPER).removeClass('highlight');
     }
   };
 });

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -122,16 +122,6 @@ ul.links {
   }
 }
 
-.change-password .password-row,
-.complete-reset-password .password-row {
-  margin-bottom: 15px;
-}
-
-.change-password .password-row:first-of-type,
-.complete-reset-password .password-row:first-of-type {
-  margin-bottom: 30px;
-}
-
 @include respond-to('small') {
   .extra-links,
   .links + .extra-links {

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -184,6 +184,7 @@ ul.links {
 }
 
 .label-helper {
+  left: 0;
   position: absolute;
   top: 0;
   transition: top 400ms,

--- a/app/styles/modules/_input-row.scss
+++ b/app/styles/modules/_input-row.scss
@@ -117,9 +117,23 @@
 
   input:focus ~ .input-help-focused,
   label:active ~ .input-help-focused,
-  label:focus ~ .input-help-focused {
+  label:focus ~ .input-help-focused,
+  .input-help-focused.highlight {
     color: $input-row-focus-border-color;
     opacity: 1;
+  }
+
+  &.label-helper-top {
+    // input rows with a label on the top need a bit more space
+    // than the 12px margin-bottom given from the element above it,
+    // except for the first row, which only needs 15px.
+    &:first-of-type {
+      margin-top: 15px;
+    }
+
+    &:not(:first-of-type) {
+      margin-top: 30px;
+    }
   }
 
   .label-helper {

--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -5,14 +5,6 @@
 .password-row {
   position: relative;
 
-  + .password-row {
-    /**
-     * The extra padding is so the "repeat password" floating placeholder
-     * does not overlap the "A string unique password..." help text.
-     */
-    margin-top: 15px;
-  }
-
   &.input-row .password {
 
     html[dir='ltr'] & {

--- a/app/tests/spec/views/mixins/password-mixin.js
+++ b/app/tests/spec/views/mixins/password-mixin.js
@@ -296,5 +296,13 @@ define(function (require, exports, module) {
         assert.equal(err.type, 'password');
       });
     });
+
+    it('highlightSignupPasswordHelper adds `hightlight` class, unhighlightSignupPasswordHelper removes it', () => {
+      assert.isFalse(view.$('.input-help-signup').hasClass('highlight'));
+      view.highlightSignupPasswordHelper();
+      assert.isTrue(view.$('.input-help-signup').hasClass('highlight'));
+      view.unhighlightSignupPasswordHelper();
+      assert.isFalse(view.$('.input-help-signup').hasClass('highlight'));
+    });
   });
 });


### PR DESCRIPTION
* fix 1 - place strong password warning below 2nd password
* fix 2 - place password placeholders above password fields

For fix 1, the "A strong, unique" text is highlight if
either password field is focused.

fixes #5580
fixes #5581 

Here's what it looks like:

#### Nothing focused

<img width="384" alt="screen shot 2017-11-13 at 14 05 17" src="https://user-images.githubusercontent.com/848085/32729571-24955950-c87c-11e7-8434-9e1af685bdb4.png">

A little more space is needed between the rows to accommodate the floating placeholder helper.

#### First password field focused - helper text is still blue!

<img width="386" alt="screen shot 2017-11-13 at 14 06 02" src="https://user-images.githubusercontent.com/848085/32729599-3f6621d8-c87c-11e7-9fd1-e96407a08e2c.png">

#### Second password field focused

<img width="371" alt="screen shot 2017-11-13 at 14 05 24" src="https://user-images.githubusercontent.com/848085/32729605-49506c80-c87c-11e7-977f-8afa49f7ce1d.png">

@ryanfeeley - r?