### PR TITLE
fix(errors): Ensure all server returned errors have entries.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -178,10 +178,34 @@ define(function (require, exports, module) {
       errno: 146,
       message: t('Invalid signin code')
     },
+    CHANGE_EMAIL_TO_UNVERIFIED_EMAIL: {
+      errno: 147,
+      message: t('Can not change primary email to an unverified email')
+    },
+    CHANGE_EMAIL_TO_UNOWNED_EMAIL: {
+      errno: 148,
+      message: t('Can not change primary email to an email that does not belong to this account')
+    },
+    LOGIN_WITH_INVALID_EMAIL: {
+      errno: 149,
+      message: t('This email can not currently be used to login')
+    },
+    RESEND_EMAIL_CODE_TO_UNOWNED_EMAIL: {
+      errno: 150,
+      message: t('Can not change primary email to an email that does not belong to this account')
+    },
+    FAILED_TO_SEND_EMAIL: {
+      errno: 151,
+      message: t('Failed to send email')
+    },
     // Secondary Email errors end
     SERVER_BUSY: {
       errno: 201,
       message: t('Server busy, try again soon')
+    },
+    FEATURE_NOT_ENABLED: {
+      errno: 202,
+      message: t('Feature not enabled')
     },
     ENDPOINT_NOT_SUPPORTED: {
       errno: 116,

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -75,6 +75,22 @@ define(function (require, exports, module) {
         // `scope` should not be translated, so interpolate it in.
         t('Invalid OAuth parameter: %(param)s'), { param: 'scope' })
     },
+    EXPIRED_TOKEN: {
+      errno: 115,
+      message: t('Expired token')
+    },
+    NOT_PUBLIC_CLIENT: {
+      errno: 116,
+      message: 'Not a public client'
+    },
+    INCORRECT_CODE_CHALLENGE: {
+      errno: 117,
+      message: 'Incorrect code_challenge'
+    },
+    MISSING_PKCE_PARAMETERS: {
+      errno: 118,
+      message: 'PKCE parameters missing'
+    },
     SERVICE_UNAVAILABLE: {
       errno: 998,
       message: t('System unavailable, try again soon')

--- a/app/scripts/lib/profile-errors.js
+++ b/app/scripts/lib/profile-errors.js
@@ -12,15 +12,13 @@ define(function (require, exports, module) {
     return msg;
   };
 
+  const THROTTLED_ERROR_MESSAGE = t('You\'ve tried too many times. Try again later.');
+
   /*eslint-disable sorting/sort-object-props*/
   var ERRORS = {
     UNAUTHORIZED: {
       errno: 100,
       message: t('Unauthorized')
-    },
-    INVALID_TOKEN: {
-      errno: 110,
-      message: t('Invalid Token')
     },
     INVALID_PARAMETER: {
       errno: 101,
@@ -33,6 +31,26 @@ define(function (require, exports, module) {
     IMAGE_PROCESSING_ERROR: {
       errno: 103,
       message: t('Image processing error')
+    },
+    OAUTH_ERROR: {
+      errno: 104,
+      message: t('System unavailable, try again soon')
+    },
+    AUTH_ERROR: {
+      errno: 105,
+      message: t('System unavailable, try again soon')
+    },
+    INVALID_TOKEN: {
+      errno: 110,
+      message: t('Invalid Token')
+    },
+    THROTTLED: {
+      errno: 114,
+      message: THROTTLED_ERROR_MESSAGE
+    },
+    REQUEST_BLOCKED: {
+      errno: 125,
+      message: t('The request was blocked for security reasons')
     },
     IMAGE_LOAD_ERROR: {
       errno: 997,


### PR DESCRIPTION
This does not fix #4906, but should reduce the number of
errors reported as invalid.

ref https://github.com/mozilla/fxa-amplitude-send/issues/27
issue #4906 

@mozilla/fxa-devs - r?

I realize this is after the string extraction deadline, but we are seeing a ton of errors being rejected with the error type "error.unknown context.unknown namespace.[object Object]" - this should help reduce those numbers.

