### PR TITLE
fix(ui): wrap long device names rather than truncate

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -539,12 +539,11 @@ section.modal-panel {
 
   .client-name {
     line-height: 1.2;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    /*allows 5% gutter between device-name and .device-disconnected button*/
-    /*reduce by 95px to accomodate the width of the .device-disconnected button*/
-    white-space: nowrap;
-    width: calc(95% - 95px);
+    margin-right: 110px;
+
+    @include respond-to('small') {
+      max-width: 78%;
+    }
   }
 
   .settings-button {
@@ -578,7 +577,7 @@ section.modal-panel {
   .last-connected {
     color: $color-grey;
     font-size: 12px;
-    margin-right: 120px;
+    margin-right: 110px;
 
     @include respond-to('small') {
       max-width: 78%;


### PR DESCRIPTION
Related to #5712, this just makes the device name wrap without sorting out the button placement on mobile. Opened separately in the hope of sneaking it on to train 100, as the button placement is taxing my CSS-fu a little bit more.

Some screenshots of it in action at various widths:

<img width="495" alt="" src="https://user-images.githubusercontent.com/64367/32771269-1c1e2bd2-c91a-11e7-8a1b-248af58df94a.png" />

<img width="436" alt="" src="https://user-images.githubusercontent.com/64367/32771283-227ecee6-c91a-11e7-8020-4012d513327e.png" />

<img width="314" alt="" src="https://user-images.githubusercontent.com/64367/32771344-4f3c32d4-c91a-11e7-820f-e887121ded88.png" />

Has the happy side-effect of removing the ugly `calc` we were using to set the variable width for truncation.

@mozilla/fxa-devs r?
