### PR TITLE
fix(ui): move device manager buttons to new row on mobile

### DIFF
--- a/app/scripts/templates/settings/clients.mustache
+++ b/app/scripts/templates/settings/clients.mustache
@@ -66,12 +66,12 @@
           <li class="client mobile" data-os="iOS">
             <div class="client-name">{{#t}}Firefox for iOS{{/t}}</div>
             <div class="last-connected">{{#t}}None connected{{/t}}</div>
-            <a target="_blank" href="{{ linkIOS }}" class="settings-button secondary" data-get-app="ios">{{#t}}Download{{/t}}</a>
+            <a target="_blank" href="{{ linkIOS }}" class="button settings-button secondary" data-get-app="ios">{{#t}}Download{{/t}}</a>
           </li>
           <li class="client mobile" data-os="Android">
             <div class="client-name">{{#t}}Firefox for Android{{/t}}</div>
             <div class="last-connected">{{#t}}None connected{{/t}}</div>
-            <a target="_blank" href="{{ linkAndroid }}" class="settings-button secondary" data-get-app="android">{{#t}}Download{{/t}}</a>
+            <a target="_blank" href="{{ linkAndroid }}" class="button settings-button secondary" data-get-app="android">{{#t}}Download{{/t}}</a>
           </li>
         {{/showMobileApps}}
         <a href="{{devicesSupportUrl}}" target="_blank" class="device-support">{{#t}}Missing or duplicate items?{{/t}}</a>

--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -200,6 +200,12 @@ body.settings #main-content.card {
         }
       }
 
+      html[dir] .clients & {
+        @include respond-to('small') {
+          float: none;
+          margin: 10px 0;
+        }
+      }
     }
   }
 
@@ -542,7 +548,7 @@ section.modal-panel {
     margin-right: 110px;
 
     @include respond-to('small') {
-      max-width: 78%;
+      margin-right: 0;
     }
   }
 
@@ -563,6 +569,10 @@ section.modal-panel {
     html[dir='rtl'] & {
       left: 0;
     }
+
+    @include respond-to('small') {
+      position: relative;
+    }
   }
 
   a.settings-button {
@@ -580,7 +590,7 @@ section.modal-panel {
     margin-right: 110px;
 
     @include respond-to('small') {
-      max-width: 78%;
+      margin-right: 0;
     }
   }
 

--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -539,12 +539,11 @@ section.modal-panel {
 
   .client-name {
     line-height: 1.2;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    /*allows 5% gutter between device-name and .device-disconnected button*/
-    /*reduce by 95px to accomodate the width of the .device-disconnected button*/
-    white-space: nowrap;
-    width: calc(95% - 95px);
+    margin-right: 110px;
+
+    @include respond-to('small') {
+      max-width: 78%;
+    }
   }
 
   .settings-button {
@@ -578,7 +577,7 @@ section.modal-panel {
   .last-connected {
     color: $color-grey;
     font-size: 12px;
-    margin-right: 120px;
+    margin-right: 110px;
 
     @include respond-to('small') {
       max-width: 78%;


### PR DESCRIPTION
Fixes #5712. Includes and supercedes #5713.

Screenshots taken at various widths:

![](https://user-images.githubusercontent.com/64367/32777445-0c921980-c92e-11e7-98a6-4c73315f3fa5.png)

![](https://user-images.githubusercontent.com/64367/32777456-13627570-c92e-11e7-8da4-0f10f0e27c0f.png)

![](https://user-images.githubusercontent.com/64367/32777457-16bda7bc-c92e-11e7-85ce-1d6a80dfcf53.png)

@mozilla/fxa-devs r?
