### PR TITLE
fix(logo): use new logo on terms and privacy pages

### DIFF
--- a/server/templates/pages/src/privacy.html
+++ b/server/templates/pages/src/privacy.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--[if lt IE 10]>       <html class="lt-ie10" dir="{{ lang_dir }}" lang="{{ lang }}"> <![endif]-->
-<!--[if gte IE 10]><!--> <html dir="{{ lang_dir }}" lang="{{ lang }}"> <!--<![endif]-->
+<!--[if gte IE 10]><!--> <html dir="{{ lang_dir }}" class="fx-57" lang="{{ lang }}"> <!--<![endif]-->
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/server/templates/pages/src/terms.html
+++ b/server/templates/pages/src/terms.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--[if lt IE 10]>       <html class="lt-ie10" dir="{{ lang_dir }}" lang="{{ lang }}"> <![endif]-->
-<!--[if gte IE 10]><!--> <html dir="{{ lang_dir }}" lang="{{ lang }}"> <!--<![endif]-->
+<!--[if gte IE 10]><!--> <html dir="{{ lang_dir }}" class="fx-57" lang="{{ lang }}"> <!--<![endif]-->
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Fixes #5709

@philbooth @vbudhram r? or anyone else

Quick fix for this until we switch to the new logo all the time