### PR TITLE
fix(sms): Run all SMS tests, all the time

### DIFF
--- a/tests/functional/fx_desktop_handshake.js
+++ b/tests/functional/fx_desktop_handshake.js
@@ -42,7 +42,6 @@ define([
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
   const createUser = FunctionalHelpers.createUser;
   const deleteAllSms = FunctionalHelpers.deleteAllSms;
-  const disableInProd = FunctionalHelpers.disableInProd;
   const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   const getSmsSigninCode = FunctionalHelpers.getSmsSigninCode;
   const openPage = FunctionalHelpers.openPage;
@@ -141,14 +140,14 @@ define([
         .then(testElementValueEquals(selectors.SIGNIN.EMAIL, browserSignedInEmail));
     },
 
-    'Sync signin page w/ signin code - user signed into browser': disableInProd(function () {
-      const testPhoneNumber = TestHelpers.createPhoneNumber();
+    'Sync signin page w/ signin code - user signed into browser': function () {
+      const TEST_PHONE_NUMBER = config.fxaTestPhoneNumber;
       let signinUrlWithSigninCode;
 
       return this.remote
         // The phoneNumber can be reused by different tests, delete all
         // of its SMS messages to ensure a clean slate.
-        .then(deleteAllSms(testPhoneNumber))
+        .then(deleteAllSms(TEST_PHONE_NUMBER))
 
         .then(openPage(SYNC_SMS_PAGE_URL, selectors.SMS_SEND.HEADER, {
           webChannelResponses: {
@@ -157,11 +156,11 @@ define([
             }
           }
         }))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
         .then(click(selectors.SMS_SEND.SUBMIT))
 
         .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(getSmsSigninCode(testPhoneNumber, 0))
+        .then(getSmsSigninCode(TEST_PHONE_NUMBER, 0))
         .then(function (signinCode) {
           signinUrlWithSigninCode = `${SYNC_SIGNIN_PAGE_URL}&signin=${signinCode}`;
           return this.parent
@@ -181,7 +180,7 @@ define([
             // defined so that we are ready when Fennec or iOS adds fxa_status support.
             .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, browserSignedInEmail));
         });
-    }),
+    },
 
     'Non-Sync signin page - user signed into browser, no user signed in locally': function () {
       return this.remote

--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -24,7 +24,6 @@ define([
     closeCurrentWindow,
     createUser,
     deleteAllSms,
-    disableInProd,
     fillOutSignIn,
     fillOutSignInUnblock,
     getSmsSigninCode,
@@ -116,22 +115,22 @@ define([
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
-    'signup in desktop, send an SMS, open deferred deeplink in Fennec': disableInProd(function () {
-      const testPhoneNumber = TestHelpers.createPhoneNumber();
+    'signup in desktop, send an SMS, open deferred deeplink in Fennec': function () {
+      const TEST_PHONE_NUMBER = config.fxaTestPhoneNumber;
       let signinUrlWithSigninCode;
 
       return this.remote
         // The phoneNumber is reused across tests, delete all
         // if its SMS messages to ensure a clean slate.
-        .then(deleteAllSms(testPhoneNumber))
+        .then(deleteAllSms(TEST_PHONE_NUMBER))
         .then(setupTest(selectors.CONFIRM_SIGNUP.HEADER))
 
         .then(openPage(SMS_PAGE_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
         .then(click(selectors.SMS_SEND.SUBMIT))
 
         .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(getSmsSigninCode(testPhoneNumber, 0))
+        .then(getSmsSigninCode(TEST_PHONE_NUMBER, 0))
         .then(function (signinCode) {
           signinUrlWithSigninCode = `${SIGNIN_PAGE_URL}&signin=${signinCode}`;
           return this.parent
@@ -139,6 +138,6 @@ define([
             .then(openPage(signinUrlWithSigninCode, selectors.SIGNIN.HEADER))
             .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email));
         });
-    })
+    }
   });
 });

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -27,7 +27,6 @@ define([
     closeCurrentWindow,
     createUser,
     deleteAllSms,
-    disableInProd,
     fillOutSignIn,
     fillOutSignInUnblock,
     getSmsSigninCode,
@@ -181,23 +180,23 @@ define([
         .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }));
     },
 
-    'signup in desktop, send an SMS, open deferred deeplink in Fx for iOS': disableInProd(function () {
-      const testPhoneNumber = TestHelpers.createPhoneNumber();
+    'signup in desktop, send an SMS, open deferred deeplink in Fx for iOS': function () {
+      const TEST_PHONE_NUMBER = config.fxaTestPhoneNumber;
       const forceUA = UA_STRINGS['ios_firefox_6_1'];
       const query = { forceUA };
 
       return this.remote
         // The phoneNumber is reused across tests, delete all
         // if its SMS messages to ensure a clean slate.
-        .then(deleteAllSms(testPhoneNumber))
+        .then(deleteAllSms(TEST_PHONE_NUMBER))
         .then(setupTest({ preVerified: true, query }))
 
         .then(openPage(SMS_PAGE_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
         .then(click(selectors.SMS_SEND.SUBMIT))
 
         .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(getSmsSigninCode(testPhoneNumber, 0))
+        .then(getSmsSigninCode(TEST_PHONE_NUMBER, 0))
         .then(function (signinCode) {
           query.signin = signinCode;
 
@@ -206,6 +205,6 @@ define([
             .then(openPage(SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, { query }))
             .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email));
         });
-    })
+    }
   });
 });

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -610,23 +610,6 @@ define([
   });
 
   /**
-   * Tests that send an SMS should be wrapped by `disableInProd`. This will
-   * prevent the tests from running in stage/prod where we should not
-   * send SMSs to random people.
-   *
-   * @param {Function} test
-   * @returns {Function}
-   */
-  function disableInProd(test) {
-    if (intern.config.fxaProduction) {
-      return function () {
-      };
-    }
-
-    return test;
-  }
-
-  /**
    * Get SMS message `index` for `phoneNumber`.
    *
    * @param {String} phoneNumber
@@ -2079,7 +2062,6 @@ define([
     deleteAllEmails,
     deleteAllSms,
     denormalizeStoredEmail: denormalizeStoredEmail,
-    disableInProd,
     fetchAllMetrics: fetchAllMetrics,
     fillOutChangePassword: fillOutChangePassword,
     fillOutCompleteResetPassword: fillOutCompleteResetPassword,

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -8,9 +8,8 @@ define([
   'intern!object',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
-  'tests/functional/lib/selectors',
-  'app/scripts/lib/country-telephone-info'
-], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors, CountryTelephoneInfo) {
+  'tests/functional/lib/selectors'
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors) {
   'use strict';
 
   const config = intern.config;
@@ -30,18 +29,16 @@ define([
   const SEND_SMS_SIGNIN_CODE_URL = `${SEND_SMS_URL}&forceExperiment=sendSms&forceExperimentGroup=signinCodes`;
   const SEND_SMS_NO_QUERY_URL = `${config.fxaContentRoot}sms`;
 
+  const TEST_PHONE_NUMBER = config.fxaTestPhoneNumber;
+  const FORMATTED_TEST_PHONE_NUMBER = '916-440-0029';
 
   let email;
   const PASSWORD = 'password';
-
-  let testPhoneNumber;
-  let formattedPhoneNumber;
 
   const {
     click,
     closeCurrentWindow,
     deleteAllSms,
-    disableInProd,
     fillOutSignUp,
     getSms,
     getSmsSigninCode,
@@ -71,10 +68,6 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
-      testPhoneNumber = TestHelpers.createPhoneNumber();
-      const countryInfo = CountryTelephoneInfo['US'];
-      formattedPhoneNumber =
-         countryInfo.format(countryInfo.normalize(testPhoneNumber));
 
       // User needs a sessionToken to be able to send an SMS. Sign up,
       // no need to verify.
@@ -83,7 +76,7 @@ define([
         .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
         // The phoneNumber can be reused by different tests, delete all
         // of its SMS messages to ensure a clean slate.
-        .then(deleteAllSms(testPhoneNumber));
+        .then(deleteAllSms(TEST_PHONE_NUMBER));
     },
 
     'with no query parameters': function () {
@@ -186,92 +179,92 @@ define([
        .then(testElementTextInclude(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP, 'invalid'));
     },
 
-    'valid phone number, back': disableInProd(function () {
+    'valid phone number, back': function () {
       return this.remote
        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-       .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
        .then(click(selectors.SMS_SEND.SUBMIT))
        .then(testElementExists(selectors.SMS_SENT.HEADER))
-       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
+       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, FORMATTED_TEST_PHONE_NUMBER))
        .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
-       .then(getSms(testPhoneNumber, 0))
+       .then(getSms(TEST_PHONE_NUMBER, 0))
 
        // user realizes they made a mistake
        .then(click(selectors.SMS_SENT.LINK_BACK))
        .then(testElementExists(selectors.SMS_SEND.HEADER))
 
        // original phone number should still be in place
-       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber));
-    }),
+       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER));
+    },
 
-    'valid phone number, resend': disableInProd(function () {
+    'valid phone number, resend': function () {
       return this.remote
        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-       .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
        .then(click(selectors.SMS_SEND.SUBMIT))
        .then(testElementExists(selectors.SMS_SENT.HEADER))
-       .then(getSms(testPhoneNumber, 0))
+       .then(getSms(TEST_PHONE_NUMBER, 0))
 
        .then(click(selectors.SMS_SENT.LINK_RESEND))
-       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
-       .then(getSms(testPhoneNumber, 1))
+       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, FORMATTED_TEST_PHONE_NUMBER))
+       .then(getSms(TEST_PHONE_NUMBER, 1))
 
        // user realizes they made a mistake
        .then(click(selectors.SMS_SENT.LINK_BACK))
        .then(testElementExists(selectors.SMS_SEND.HEADER))
 
        // original phone number should still be in place
-       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber));
-    }),
+       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER));
+    },
 
-    'valid phone number, enable signinCode': disableInProd(function () {
+    'valid phone number, enable signinCode': function () {
       return this.remote
        .then(openPage(SEND_SMS_SIGNIN_CODE_URL, selectors.SMS_SEND.HEADER))
-       .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
        .then(click(selectors.SMS_SEND.SUBMIT))
        .then(testElementExists(selectors.SMS_SENT.HEADER))
-       .then(getSmsSigninCode(testPhoneNumber, 0));
-    }),
+       .then(getSmsSigninCode(TEST_PHONE_NUMBER, 0));
+    },
 
-    'valid phone number w/ country code of 1': disableInProd(function () {
+    'valid phone number w/ country code of 1': function () {
       return this.remote
         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, `1${testPhoneNumber}`))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, `1${TEST_PHONE_NUMBER}`))
         .then(click(selectors.SMS_SEND.SUBMIT))
         .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
+        .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, FORMATTED_TEST_PHONE_NUMBER))
         .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
-        .then(getSms(testPhoneNumber, 0));
-    }),
+        .then(getSms(TEST_PHONE_NUMBER, 0));
+    },
 
-    'valid phone number w/ country code of +1': disableInProd(function () {
+    'valid phone number w/ country code of +1': function () {
       return this.remote
         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, `+1${testPhoneNumber}`))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, `+1${TEST_PHONE_NUMBER}`))
         .then(click(selectors.SMS_SEND.SUBMIT))
         .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
+        .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, FORMATTED_TEST_PHONE_NUMBER))
         .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
-        .then(getSms(testPhoneNumber, 0));
-    }),
+        .then(getSms(TEST_PHONE_NUMBER, 0));
+    },
 
-    'valid phone number (contains spaces and punctuation)': disableInProd(function () {
-      const unformattedPhoneNumber = ` ${testPhoneNumber.slice(0,3)} .,- ${testPhoneNumber.slice(3)} `;
+    'valid phone number (contains spaces and punctuation)': function () {
+      const unformattedTestPhoneNumber = ` ${TEST_PHONE_NUMBER.slice(0,3)} .,- ${TEST_PHONE_NUMBER.slice(3)} `;
       return this.remote
        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-       .then(type(selectors.SMS_SEND.PHONE_NUMBER, unformattedPhoneNumber))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, unformattedTestPhoneNumber))
        .then(click(selectors.SMS_SEND.SUBMIT))
        .then(testElementExists(selectors.SMS_SENT.HEADER))
-       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
-       .then(getSms(testPhoneNumber, 0))
+       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, FORMATTED_TEST_PHONE_NUMBER))
+       .then(getSms(TEST_PHONE_NUMBER, 0))
 
        // user realizes they made a mistake
        .then(click(selectors.SMS_SENT.LINK_BACK))
        .then(testElementExists(selectors.SMS_SEND.HEADER))
 
        // original phone number should still be in place
-       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, unformattedPhoneNumber));
-    })
+       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, unformattedTestPhoneNumber));
+    }
   };
 
   registerSuite(suite);

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -20,6 +20,7 @@ function (intern, topic, firefoxProfile) {
   var fxaEmailRoot = args.fxaEmailRoot || 'http://127.0.0.1:9001';
   var fxaOauthApp = args.fxaOauthApp || 'http://127.0.0.1:8080/';
   var fxaUntrustedOauthApp = args.fxaUntrustedOauthApp || 'http://127.0.0.1:10139/';
+  const fxaTestPhoneNumber = args.fxaTestPhoneNumber || '9164400029'; // We're sorry, all circuits are busy now
 
   // "fxaProduction" is a little overloaded in how it is used in the tests.
   // Sometimes it means real "stage" or real production configuration, but
@@ -66,6 +67,7 @@ function (intern, topic, firefoxProfile) {
     fxaOauthApp: fxaOauthApp,
     fxaProduction: fxaProduction,
     fxaProfileRoot: fxaProfileRoot,
+    fxaTestPhoneNumber,
     fxaToken: fxaToken,
     fxaTokenRoot: fxaTokenRoot,
     fxaUntrustedOauthApp: fxaUntrustedOauthApp,

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -31,43 +31,12 @@ define([
     return template.replace('{id}', Math.random()) + '@restmail.net';
   }
 
-  /**
-   * Create a phone number with `prefix` with `length` digits.
-   *
-   * @param {String} [prefix='9164']
-   * @param {Number} [length=10]
-   * @returns {String}
-   */
-  function createPhoneNumber (prefix, length) {
-    if (typeof prefix === 'undefined') {
-      prefix = '9164';
-    }
-    if (typeof length === 'undefined') {
-      length = 10;
-    }
-    // start with an area code and known good first number,
-    // append a 6 character suffix.
-    const suffixLength = length - prefix.length;
-    let suffix = Math.floor(Math.random() * Math.pow(10, suffixLength));
-    suffix = padright(suffix, suffixLength, '0');
-    return `${prefix}${suffix}`;
-  }
-
-  function padright (str, len, filler) {
-    let padded = '' + str;
-    while (padded.length < len) {
-      padded += filler;
-    }
-    return padded;
-  }
-
   function emailToUser(email) {
     return email.split('@')[0];
   }
 
   return {
     createEmail,
-    createPhoneNumber,
     createRandomHexString,
     createUID,
     emailToUser


### PR DESCRIPTION
Use a known test number for SMS tests. When
dialed, the number says "All circuits are busy now..."

Use this number to test sending SMSs.

The phone number is not rate limited on the
back end.

fixes #5689 

BLOCKED BY https://github.com/mozilla/fxa-dev/pull/345