### PR TITLE
feat(sms): Enable SMS to 50% of Germany (DE)

### DIFF
--- a/app/scripts/lib/country-telephone-info.js
+++ b/app/scripts/lib/country-telephone-info.js
@@ -100,7 +100,7 @@ define((require, exports, module) => {
       normalize: ensurePrefix('+49'),
       pattern: /^(?:\+49)?\d{6,13}$/,
       prefix: '+49',
-      rolloutRate: 0 // being soft launched. Testers will need to open `/sms?service=sync&country=DE`
+      rolloutRate: 0.5
     },
     // France
     // https://en.wikipedia.org/wiki/Telephone_numbers_in_France


### PR DESCRIPTION
@mozilla/fxa-devs - r?

I received confirmation that SMS works in Germany! I pointed this at train-100 so we can get it on the next train.