### PR TITLE
fix(SMS): soft-launch LU. Change default rolloutRate to 0.

### DIFF
--- a/app/scripts/lib/country-telephone-info.js
+++ b/app/scripts/lib/country-telephone-info.js
@@ -91,7 +91,7 @@ define((require, exports, module) => {
       normalize: ensurePrefix('+32'),
       pattern: /^(?:\+32\d{9}|\d{10})$/,
       prefix: '+32',
-      rolloutRate: 0 // being soft launched. Testers will need to open `/sms?service=sync&country=DE`
+      rolloutRate: 0 // being soft launched. Testers will need to open `/sms?service=sync&country=BE`
     },
     // Germany
     // https://en.wikipedia.org/wiki/Telephone_numbers_in_Germany
@@ -109,13 +109,14 @@ define((require, exports, module) => {
       normalize: ensurePrefix('+33'),
       pattern: /^(?:\+33\d{9}|\d{10})$/,
       prefix: '+33',
-      rolloutRate: 0 // being soft launched. Testers will need to open `/sms?service=sync&country=DE`
+      rolloutRate: 0 // being soft launched. Testers will need to open `/sms?service=sync&country=FR`
     },
     GB: {
       format: formatter('+44 ${serverPhoneNumber}'),
       normalize: ensurePrefix('+44'),
       pattern: /^(?:\+44\d{10}|\d{11})$/,
-      prefix: '+44'
+      prefix: '+44',
+      rolloutRate: 1
     },
     // Luxembourg
     // https://en.wikipedia.org/wiki/Telephone_numbers_in_Luxembourg
@@ -123,7 +124,8 @@ define((require, exports, module) => {
       format: formatter('+352 ${serverPhoneNumber}'),
       normalize: ensurePrefix('+352'),
       pattern: /^(?:\+352)?\d{9}$/,
-      prefix: '+352'
+      prefix: '+352',
+      rolloutRate: 0 // being soft launched. Testers will need to open `/sms?service=sync&country=LU`
     },
     RO: {
       format: formatter('+40 ${serverPhoneNumber}'),
@@ -154,7 +156,8 @@ define((require, exports, module) => {
         return `+1${num}`;
       },
       pattern: /^(\+?1)?[2-9]\d{9,9}$/, // allow for a +1 or 1 prefix before the area code, area codes are all 2-9
-      prefix: '+1'
+      prefix: '+1',
+      rolloutRate: 1
     }
   };
 

--- a/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
+++ b/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
@@ -8,7 +8,6 @@
 define((require, exports, module) => {
   'use strict';
 
-  const _ = require('underscore');
   const BaseGroupingRule = require('./base');
   const CountryTelephoneInfo = require('../../country-telephone-info');
 
@@ -36,11 +35,12 @@ define((require, exports, module) => {
       }
 
       let choice = false;
-      const { rolloutRate } = CountryTelephoneInfo[subject.country];
+      // If rolloutRate is not specified, assume 0.
+      const { rolloutRate } = CountryTelephoneInfo[subject.country] || 0;
 
       if (isEmailInSigninCodesGroup(subject.account.get('email'))) {
         choice = 'signinCodes';
-      } else if (_.isUndefined(rolloutRate) || rolloutRate >= 1) {
+      } else if (rolloutRate >= 1) {
         // country is fully rolled out.
         choice = true;
       } else if (this.bernoulliTrial(rolloutRate, subject.uniqueUserId)) {

--- a/app/tests/spec/lib/experiments/grouping-rules/send-sms-install-link.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/send-sms-install-link.js
@@ -39,6 +39,13 @@ define(function (require, exports, module) {
         assert.equal(experiment.choose({ account, country, uniqueUserId: 'user-id' }), 'signinCodes');
       });
 
+      describe('country does not have a `rolloutRate`', () => {
+        it('returns `false', () => {
+          delete CountryTelephoneInfo.GB.rolloutRate;
+          assert.isFalse(experiment.choose({ account, country, uniqueUserId: 'user-id' }));
+        });
+      });
+
       describe('country has a `rolloutRate`', () => {
         beforeEach(() => {
           sinon.stub(experiment, 'uniformChoice').callsFake(() => 'choice');
@@ -67,14 +74,11 @@ define(function (require, exports, module) {
           assert.isTrue(experiment.uniformChoice.called);
           assert.isTrue(experiment.uniformChoice.calledWith(['control', 'signinCodes'], 'user-id'));
         });
-      });
 
-      it('fully rolled out countries return `true`', () => {
-        CountryTelephoneInfo.GB.rolloutRate = 1.0;
-        assert.isTrue(experiment.choose({ account, country, uniqueUserId: 'user-id' }));
-
-        delete CountryTelephoneInfo.GB.rolloutRate;
-        assert.isTrue(experiment.choose({ account, country, uniqueUserId: 'user-id' }));
+        it('fully rolled out countries return `true`', () => {
+          CountryTelephoneInfo.GB.rolloutRate = 1.0;
+          assert.isTrue(experiment.choose({ account, country, uniqueUserId: 'user-id' }));
+        });
       });
     });
   });


### PR DESCRIPTION
I forgot to add a `rolloutRate` to Luxembourg (LU) which meant
it was being shipped fully rolled out. This is an easy mistake
to make. Instead of setting the default rolloutRate to 1, this
PR changes that to be 0 to avoid this problem. If a country is
fully rolled out, it's rolloutRate must be set to 1.

fixes #5727 

This is against train-100 too so that we don't ship with Luxembourg fully enabled w/o first testing it!

@mozilla/fxa-devs - r?