### PR TITLE
feat(OpenID): Enable CORS on the /.well-known/openid-configuration endpoint.

### DIFF
--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -4,6 +4,7 @@
 
 'use strict';
 const celebrate = require('celebrate');
+const cors = require('cors');
 const logger = require('./logging/log')('server.routes');
 
 /**
@@ -91,8 +92,20 @@ module.exports = function (config, i18n) {
       }
 
       // Build a list of route handlers.
-      // `preProcess` and `validate` are optional.
+      // `cors`, preProcess` and `validate` are optional.
       const routeHandlers = [];
+
+      // Enable CORS using https://github.com/expressjs/cors
+      // If defined, `cors` can be truthy or an object.
+      // Objects are passed to the middleware directly.
+      // Other truthy values use the default configuration.
+      if (route.cors) {
+        const corsConfig = typeof route.cors === 'object' ? route.cors : undefined;
+        // Enable the pre-flight OPTIONS request
+        app.options(route.path, cors(corsConfig));
+        routeHandlers.push(cors(corsConfig));
+      }
+
       if (route.preProcess) {
         routeHandlers.push(route.preProcess);
       }

--- a/server/lib/routes/get-openid-configuration.js
+++ b/server/lib/routes/get-openid-configuration.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 'use strict';
+
 const config = require('../configuration');
 
 const authorizationEndpoint = config.get('oauth_url') + '/v1/authorization';
@@ -26,20 +27,23 @@ for (const key in c) {
 }
 
 module.exports = function (config) {
-  const route = {};
-  route.method = 'get';
-  route.path = '/.well-known/openid-configuration';
+  return {
+    cors: {
+      methods: 'GET',
+      origin: '*',
+      preflightContinue: false
+    },
+    method: 'get',
+    path: '/.well-known/openid-configuration',
+    process: function (req, res) {
 
-  route.process = function (req, res) {
+      // taken from https://accounts.google.com/.well-known/openid-configuration
+      res.header('Cache-Control', 'public, max-age=3600');
 
-    // taken from https://accounts.google.com/.well-known/openid-configuration
-    res.header('Cache-Control', 'public, max-age=3600');
+      // charset must be set on json responses.
+      res.charset = 'utf-8';
 
-    // charset must be set on json responses.
-    res.charset = 'utf-8';
-
-    res.json(openidConfig);
+      res.json(openidConfig);
+    }
   };
-
-  return route;
 };

--- a/tests/server/routes/get-openid-configuration.js
+++ b/tests/server/routes/get-openid-configuration.js
@@ -16,6 +16,17 @@ define([
     name: 'openid-configuration'
   };
 
+  suite['#options /.well-known/openid-configuration - CORS enabled'] = function () {
+    const dfd = this.async(intern.config.asyncTimeout);
+
+    got(serverUrl + '/.well-known/openid-configuration', { method: 'options' })
+      .then(function (res) {
+        assert.equal(res.statusCode, 204);
+        assert.equal(res.headers['access-control-allow-origin'], '*');
+        assert.equal(res.headers['access-control-allow-methods'], 'GET');
+      }).then(dfd.resolve, dfd.reject);
+  };
+
   suite['#get /.well-known/openid-configuration - returns a JSON doc with expected values'] = function () {
     var dfd = this.async(intern.config.asyncTimeout);
 
@@ -23,6 +34,7 @@ define([
       .then(function (res) {
         assert.equal(res.statusCode, 200);
         assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
+        assert.equal(res.headers['access-control-allow-origin'], '*');
 
         var result = JSON.parse(res.body);
         assert.equal(Object.keys(result).length, 11);


### PR DESCRIPTION
Allow a route to declare a `cors` property that is used
to create a cors middleware.

fixes #5453

@vladikoff, @rfk - r?

I opened this against train-100 so that @vladikoff has it ready for https://github.com/mozilla/fxa-content-server/pull/5675