### PR TITLE
refactor(l10n): Remove the global `Translator` object.

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -21,6 +21,7 @@ define(function (require, exports, module) {
   const SearchParamMixin = require('../lib/search-param-mixin');
   const Strings = require('../lib/strings');
   const TimerMixin = require('./mixins/timer-mixin');
+  const Translator = require('../lib/translator');
   const VerificationReasons = require('../lib/verification-reasons');
 
   var DEFAULT_TITLE = window.document.title;
@@ -133,7 +134,7 @@ define(function (require, exports, module) {
       this.logger = new Logger(this.window);
 
       this.navigator = options.navigator || this.window.navigator || navigator;
-      this.translator = options.translator || this.window.translator;
+      this.translator = options.translator || new Translator();
 
       // `events` are defined on child views without extending
       // BaseView's events. Defining events on BaseView (or any

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -27,7 +27,6 @@ define(function (require, exports, module) {
   function WindowMock() {
     var win = this;
 
-    this.translator = window.translator;
     this.location = {
       host: window.location.host,
       href: window.location.href,

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -3,11 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 require([
-  'lib/translator',
   'lib/session',
   '../tests/setup'
 ],
-function (Translator, Session) {
+function (Session) {
   'use strict';
 
   var tests = [
@@ -221,9 +220,6 @@ function (Translator, Session) {
     '../tests/spec/views/tos',
     '../tests/spec/views/why_connect_another_device'
   ];
-
-  // The translator is expected to be on the window object.
-  window.translator = new Translator('en-US', ['en-US']);
 
   var runTests = function () {
     /**


### PR DESCRIPTION
Not part of any issue, it's always just been a niggle that I've finally ripped out.

@mozilla/fxa-devs - r?