### PR TITLE
fix(deps): Forbid use of $ w/o requiring jquery.

### DIFF
--- a/app/.eslintrc
+++ b/app/.eslintrc
@@ -1,6 +1,5 @@
 {
   "env": {
-    "jquery": true
   },
 
   "rules": {

--- a/app/scripts/lib/dom-writer.js
+++ b/app/scripts/lib/dom-writer.js
@@ -5,6 +5,8 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
+
   module.exports = {
     /**
      * Write content to the DOM

--- a/app/scripts/lib/mailcheck.js
+++ b/app/scripts/lib/mailcheck.js
@@ -8,6 +8,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const _ = require('underscore');
+  const $ = require('jquery');
   const KeyCodes = require('./key-codes');
   const mailcheck = require('mailcheck'); //eslint-disable-line no-unused-vars
   const Tooltip = require('../views/tooltip');

--- a/app/scripts/views/choose_what_to_sync.js
+++ b/app/scripts/views/choose_what_to_sync.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const _ = require('underscore');
+  const $ = require('jquery');
   const BackMixin = require('./mixins/back-mixin');
   const CheckboxMixin = require('./mixins/checkbox-mixin');
   const Cocktail = require('cocktail');

--- a/app/scripts/views/mixins/avatar-mixin.js
+++ b/app/scripts/views/mixins/avatar-mixin.js
@@ -8,6 +8,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const _ = require('underscore');
+  const $ = require('jquery');
   const AuthErrors = require('../../lib/auth-errors');
   const Notifier = require('../../lib/channels/notifier');
   const p = require('../../lib/promise');

--- a/app/tests/spec/lib/config-loader.js
+++ b/app/tests/spec/lib/config-loader.js
@@ -5,7 +5,8 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const {assert} = require('chai');
+  const $ = require('jquery');
+  const { assert } = require('chai');
   const ConfigLoader = require('lib/config-loader');
   const ConfigLoaderErrors = ConfigLoader.Errors;
   const sinon = require('sinon');

--- a/app/tests/spec/lib/cropper.js
+++ b/app/tests/spec/lib/cropper.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const Backbone = require('backbone');
   const CanvasMock = require('../../mocks/canvas');
   const chai = require('chai');

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const { assert } = require('chai');
   const AuthErrors = require('lib/auth-errors');
   const Broker = require('models/auth_brokers/base');

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const { assert } = require('chai');
   const AuthErrors = require('lib/auth-errors');
   const Backbone = require('backbone');

--- a/app/tests/spec/views/cookies_disabled.js
+++ b/app/tests/spec/views/cookies_disabled.js
@@ -25,7 +25,7 @@ define(function (require, exports, module) {
       // the backend and can control the return value.
 
       $.getJSON = function () {
-        var deferred = jQuery.Deferred();
+        var deferred = $.Deferred();
         deferred.resolve(serverConfig);
         return deferred.promise();
       };

--- a/app/tests/spec/views/force_auth.js
+++ b/app/tests/spec/views/force_auth.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const Account = require('models/account');
   const { assert } = require('chai');
   const AuthErrors = require('lib/auth-errors');

--- a/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/app/tests/spec/views/mixins/avatar-mixin.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const Account = require('models/account');
   const { assert } = require('chai');
   const AuthErrors = require('lib/auth-errors');
@@ -158,7 +159,7 @@ define(function (require, exports, module) {
           spinnerEl.trigger('transitionend');
           // And another for the spinner's pseudo element, using jQuery.Event
           // this time, so we can set originalEvent
-          spinnerEl.trigger(jQuery.Event('transitionend', {
+          spinnerEl.trigger($.Event('transitionend', {
             originalEvent: {
               pseudoElement: '::after'
             }

--- a/app/tests/spec/views/mixins/back-mixin.js
+++ b/app/tests/spec/views/mixins/back-mixin.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const { assert } = require('chai');
   const BackMixin = require('views/mixins/back-mixin');
   const BaseView = require('views/base');

--- a/app/tests/spec/views/mixins/checkbox-mixin.js
+++ b/app/tests/spec/views/mixins/checkbox-mixin.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const BaseView = require('views/base');
   const Chai = require('chai');
   const CheckboxMixin = require('views/mixins/checkbox-mixin');

--- a/app/tests/spec/views/mixins/coppa-mixin.js
+++ b/app/tests/spec/views/mixins/coppa-mixin.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const { assert } = require('chai');
   const FormView = require('views/form');
   const Cocktail = require('cocktail');
@@ -87,21 +88,21 @@ define(function (require, exports, module) {
 
     describe('onCoppaKeyDown', function () {
       it('accept digits', function () {
-        const event = jQuery.Event('keydown', { which: KeyCodes.NUM_1 });
+        const event = $.Event('keydown', { which: KeyCodes.NUM_1 });
         sinon.spy(event, 'preventDefault');
         view.onCoppaKeyDown(event);
         assert.isFalse(event.preventDefault.called);
       });
 
       it('accept ENTER', function () {
-        const event = jQuery.Event('keydown', { which: KeyCodes.ENTER });
+        const event = $.Event('keydown', { which: KeyCodes.ENTER });
         sinon.spy(event, 'preventDefault');
         view.onCoppaKeyDown(event);
         assert.isFalse(event.preventDefault.called);
       });
 
       it('does not allow non-digits', function () {
-        const event = jQuery.Event('keydown', {which: KeyCodes.NUM_PERIOD});
+        const event = $.Event('keydown', {which: KeyCodes.NUM_PERIOD});
         sinon.spy(event, 'preventDefault');
         view.onCoppaKeyDown(event);
         assert.isTrue(event.preventDefault.called);

--- a/app/tests/spec/views/mixins/modal-settings-panel-mixin.js
+++ b/app/tests/spec/views/mixins/modal-settings-panel-mixin.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const { assert } = require('chai');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');

--- a/app/tests/spec/views/mixins/open-webmail-mixin.js
+++ b/app/tests/spec/views/mixins/open-webmail-mixin.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const { assert } = require('chai');
   const BaseView = require('views/base');
   const Broker = require('models/auth_brokers/base');

--- a/app/tests/spec/views/mixins/resume-token-mixin.js
+++ b/app/tests/spec/views/mixins/resume-token-mixin.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const { assert } = require('chai');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');

--- a/app/tests/spec/views/mixins/sync-suggestion-mixin.js
+++ b/app/tests/spec/views/mixins/sync-suggestion-mixin.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const { assert } = require('chai');
   const BaseView = require('views/base');
   const Cocktail = require('cocktail');

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -5,6 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
+  const $ = require('jquery');
   const { assert } = require('chai');
   const VerificationReasons = require('lib/verification-reasons');
   const FxaClient = require('lib/fxa-client');

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const _ = require('underscore');
+  const $ = require('jquery');
   const { assert } = require('chai');
   const AuthErrors = require('lib/auth-errors');
   const Backbone = require('backbone');


### PR DESCRIPTION
This is in preparation for Webpack. Webpack cannot
use the global `$` reference, the reference must
be made explicit.

@mozilla/fxa-devs - r?