### PR TITLE
fix(modules): Use Webpack compatible module define statements.

### DIFF
--- a/app/scripts/lib/country-telephone-info.js
+++ b/app/scripts/lib/country-telephone-info.js
@@ -5,7 +5,7 @@
 /**
  * Country->phone number info.
  */
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   /**

--- a/app/scripts/lib/experiments/grouping-rules/TEMPLATE.js
+++ b/app/scripts/lib/experiments/grouping-rules/TEMPLATE.js
@@ -13,7 +13,7 @@
  * 6. Access in views via `this.experiments.choose('name from 3')`
  *    or `this.isInExperimentGroup('name from 3', 'group name')`.
  */
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');

--- a/app/scripts/lib/experiments/grouping-rules/base.js
+++ b/app/scripts/lib/experiments/grouping-rules/base.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const md5 = require('md5');

--- a/app/scripts/lib/experiments/grouping-rules/communication-prefs.js
+++ b/app/scripts/lib/experiments/grouping-rules/communication-prefs.js
@@ -6,7 +6,7 @@
  * Decide if communication preferences are visible for the user.
  */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');

--- a/app/scripts/lib/experiments/grouping-rules/connect-another-device-on-signin.js
+++ b/app/scripts/lib/experiments/grouping-rules/connect-another-device-on-signin.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');

--- a/app/scripts/lib/experiments/grouping-rules/email-first.js
+++ b/app/scripts/lib/experiments/grouping-rules/email-first.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');

--- a/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/app/scripts/lib/experiments/grouping-rules/index.js
@@ -6,7 +6,7 @@
  * Interface to experiment choices.
  */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const _ = require('underscore');

--- a/app/scripts/lib/experiments/grouping-rules/is-sampled-user.js
+++ b/app/scripts/lib/experiments/grouping-rules/is-sampled-user.js
@@ -5,7 +5,7 @@
 /**
  * Are DataDog metrics enabled for the user?
  */
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');

--- a/app/scripts/lib/experiments/grouping-rules/q3-form-changes.js
+++ b/app/scripts/lib/experiments/grouping-rules/q3-form-changes.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');

--- a/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
+++ b/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
@@ -5,7 +5,7 @@
 /**
  * Should the user be part of the SMS experiment?
  */
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');

--- a/app/scripts/lib/experiments/grouping-rules/sentry.js
+++ b/app/scripts/lib/experiments/grouping-rules/sentry.js
@@ -5,7 +5,7 @@
 /**
  * Is Sentry error reporting enabled for the user?
  */
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');

--- a/app/scripts/lib/experiments/grouping-rules/sessions.js
+++ b/app/scripts/lib/experiments/grouping-rules/sessions.js
@@ -5,7 +5,7 @@
 /**
  * Should the user see web sessions in the apps and devices list in settings
  */
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');

--- a/app/scripts/lib/experiments/grouping-rules/signup-password-confirm.js
+++ b/app/scripts/lib/experiments/grouping-rules/signup-password-confirm.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');

--- a/app/scripts/lib/sms-errors.js
+++ b/app/scripts/lib/sms-errors.js
@@ -6,7 +6,7 @@
  * List of SMS error codes.
  * From https://docs.nexmo.com/messaging/sms-api/api-reference#status-codes
  */
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const _ = require('underscore');

--- a/app/scripts/lib/sms-message-ids.js
+++ b/app/scripts/lib/sms-message-ids.js
@@ -5,7 +5,7 @@
 /**
  * List of SMS message IDs
  */
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   module.exports = {

--- a/app/scripts/lib/user-agent-mixin.js
+++ b/app/scripts/lib/user-agent-mixin.js
@@ -8,7 +8,7 @@
  * Requires `this.window` to be set.
  */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const SearchParamMixin = require('./search-param-mixin');

--- a/app/scripts/models/sync-engines.js
+++ b/app/scripts/models/sync-engines.js
@@ -7,7 +7,7 @@
  * in the Choose What to Sync screen.
  */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const _ = require('underscore');

--- a/app/scripts/views/behaviors/connect-another-device-on-signin.js
+++ b/app/scripts/views/behaviors/connect-another-device-on-signin.js
@@ -13,7 +13,7 @@
  * Requires the view to mixin the ConnectAnotherDeviceMixin
  */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const Cocktail = require('cocktail');

--- a/app/scripts/views/behaviors/connect-another-device.js
+++ b/app/scripts/views/behaviors/connect-another-device.js
@@ -12,7 +12,7 @@
  * Requires the view to mixin the ConnectAnotherDeviceMixin
  */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const Cocktail = require('cocktail');

--- a/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -16,7 +16,7 @@
  * }
  */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const p = require('../../lib/promise');

--- a/app/scripts/views/mixins/pulse-graphic-mixin.js
+++ b/app/scripts/views/mixins/pulse-graphic-mixin.js
@@ -5,7 +5,7 @@
 /**
  * A mixin to pulse the primary graphic on the view.
  */
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   return {

--- a/app/scripts/views/mixins/sms-mixin.js
+++ b/app/scripts/views/mixins/sms-mixin.js
@@ -8,7 +8,7 @@
  * @mixin SmsMixin
  */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const ExperimentMixin = require('./experiment-mixin');

--- a/app/scripts/views/mixins/sync-auth-mixin.js
+++ b/app/scripts/views/mixins/sync-auth-mixin.js
@@ -7,7 +7,7 @@
  * current tab, and if so, which URL should be used to do so.
  */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const _ = require('underscore');

--- a/app/scripts/views/mixins/sync-suggestion-mixin.js
+++ b/app/scripts/views/mixins/sync-suggestion-mixin.js
@@ -10,7 +10,7 @@
  * which contains the HTML to display.
  */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const Constants = require('../../lib/constants');

--- a/app/tests/spec/lib/country-telephone-info.js
+++ b/app/tests/spec/lib/country-telephone-info.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/lib/experiments/grouping-rules/signup-password-confirm.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/signup-password-confirm.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/models/auth_brokers/index.js
+++ b/app/tests/spec/models/auth_brokers/index.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/models/auth_brokers/mob-android-v1.js
+++ b/app/tests/spec/models/auth_brokers/mob-android-v1.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/models/auth_brokers/mob-ios-v1.js
+++ b/app/tests/spec/models/auth_brokers/mob-ios-v1.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/models/sync-engines.js
+++ b/app/tests/spec/models/sync-engines.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/views/behaviors/connect-another-device-on-signin.js
+++ b/app/tests/spec/views/behaviors/connect-another-device-on-signin.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/views/behaviors/connect-another-device.js
+++ b/app/tests/spec/views/behaviors/connect-another-device.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/views/behaviors/settings.js
+++ b/app/tests/spec/views/behaviors/settings.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const Account = require('models/account');

--- a/app/tests/spec/views/index.js
+++ b/app/tests/spec/views/index.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const $ = require('jquery');

--- a/app/tests/spec/views/mixins/email-first-experiment-mixin.js
+++ b/app/tests/spec/views/mixins/email-first-experiment-mixin.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/views/mixins/flow-begin-mixin.js
+++ b/app/tests/spec/views/mixins/flow-begin-mixin.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/views/mixins/flow-events-mixin.js
+++ b/app/tests/spec/views/mixins/flow-events-mixin.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/views/mixins/pulse-graphic-mixin.js
+++ b/app/tests/spec/views/mixins/pulse-graphic-mixin.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/views/mixins/signed-out-notification-mixin.js
+++ b/app/tests/spec/views/mixins/signed-out-notification-mixin.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/views/oauth_index.js
+++ b/app/tests/spec/views/oauth_index.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/views/sign_in_bounced.js
+++ b/app/tests/spec/views/sign_in_bounced.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const { assert } = require('chai');

--- a/app/tests/spec/views/sms_send.js
+++ b/app/tests/spec/views/sms_send.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const $ = require('jquery');

--- a/app/tests/spec/views/sms_sent.js
+++ b/app/tests/spec/views/sms_sent.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define((require, exports, module) => {
+define(function(require, exports, module) {
   'use strict';
 
   const $ = require('jquery');


### PR DESCRIPTION
Webpack chokes on `define((require, exports, module) => {`.
Instead, it needs `define(function(require, exports, module) {`

Part of the drive to replace RequireJS with Webpack.

@philbooth - r?