### PR TITLE
fix(test): A signup test mixed `done` and promises.

### DIFF
--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -330,10 +330,8 @@ define(function (require, exports, module) {
         sinon.spy(view, 'showValidationError');
         model.set('bouncedEmail', 'testuser@testuser.com');
 
-        return view.render()
-          .then(function () {
-            return view.afterVisible();
-          })
+        view.render()
+          .then(() => view.afterVisible())
           .then(function () {
             assert.isTrue(view.showValidationError.called);
             setTimeout(function () {


### PR DESCRIPTION
Stop returning the promise, only use `done` for this test.

Part of the webpack work.

@mozilla/fxa-devs - r?