### PR TITLE
fix(CWTS): Fix CWTS columns when firstrun is 420px.

### DIFF
--- a/app/styles/modules/_branding.scss
+++ b/app/styles/modules/_branding.scss
@@ -95,7 +95,7 @@
     background-position: center top;
     background-repeat: no-repeat;
     height: 100px;
-    margin: 10px auto 0 auto;
+    margin: 10px auto 10px auto;
     width: 200px;
 
     @include respond-to('big') {

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -244,6 +244,10 @@ ul.permission-links {
     color: $color-grey-faint-text;
   }
 
+  @include respond-to('small') {
+    column-width: 150px;
+  }
+
   @include respond-to('trustedUI') {
     column-width: 118px;
 


### PR DESCRIPTION
Set the column width to 150px in the "small" UI.

fixes #5710 

@ryanfeeley - here's how it looks when the iframe is 420px:

<img width="385" alt="screen shot 2017-11-21 at 16 48 09" src="https://user-images.githubusercontent.com/848085/33085163-d189dd92-cedb-11e7-99ac-5af704990a79.png">

@mozilla/fxa-devs - r?