### PR TITLE
chore(ci): Use release version of Fx 57 for CI tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - redis-server
 
 addons:
-  firefox: "57.0b5"
+  firefox: "57.0"
   apt:
     sources:
       - ubuntu-toolchain-r-test

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 dependencies:
   pre:
     - pip install mozdownload mozinstall
-    - mozdownload --version 57.0b5 --destination firefox.tar.bz2
+    - mozdownload --version 57.0 --destination firefox.tar.bz2
     - mozinstall firefox.tar.bz2
     - sudo apt-get install expect tightvncserver
     - ulimit -S -n 2048;


### PR DESCRIPTION
@mozilla/fxa-devs - r?