### PR TITLE
Removed Sync from Sync devices

### DIFF
--- a/app/scripts/templates/settings/emails.mustache
+++ b/app/scripts/templates/settings/emails.mustache
@@ -12,7 +12,7 @@
     <div class="settings-unit-details">
         <form novalidate>
             <p>
-                {{#t}}A secondary email is an additional address for receiving security notices and confirming new Sync devices.{{/t}}
+                {{#t}}A secondary email is an additional address for receiving security notices and confirming new devices.{{/t}}
             </p>
             {{#hasSecondaryEmail}}
                 <ul class="email-list button-row">


### PR DESCRIPTION
We are syncing with other things like password manager and Test Pilot, so I think "devices" is sufficient