### PR TITLE
fix(test): Fix the StaleElementReference error in the SMS resent test.

### DIFF
--- a/app/scripts/templates/sms_sent.mustache
+++ b/app/scripts/templates/sms_sent.mustache
@@ -2,12 +2,12 @@
   <header class="hidden" id="fxa-sms-sent-header"><h1>{{#t}}Install Firefox on your smartphone and sign in to complete set-up{{/t}}</h1></header>
   <section>
     {{^isResend}}
-        <div class="success visible">
+        <div id="send-success" class="success visible">
           {{#unsafeTranslate}}App link sent to %(escapedPhoneNumber)s. <a %(escapedBackLinkAttrs)s>Mistyped&nbsp;number?</a>{{/unsafeTranslate}}
         </div>
       {{/isResend}}
       {{#isResend}}
-        <div class="success visible shake">
+        <div id="resend-success" class="success visible shake">
           {{#unsafeTranslate}}App link resent to %(escapedPhoneNumber)s. <a %(escapedBackLinkAttrs)s>Mistyped&nbsp;number?</a>{{/unsafeTranslate}}
         </div>
       {{/isResend}}

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -242,7 +242,8 @@ define([], function () {
       HEADER: '#fxa-sms-sent-header',
       LINK_BACK: '#back',
       LINK_RESEND: '#resend',
-      PHONE_NUMBER_SENT_TO: '.success'
+      PHONE_NUMBER_SENT_TO: '.success',
+      RESEND_SUCCESS: '.shake'
     },
     SMS_WHY_IS_THIS_REQUIRED: {
       CLOSE: '.connect-another-device button[type="submit"]',

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -242,8 +242,8 @@ define([], function () {
       HEADER: '#fxa-sms-sent-header',
       LINK_BACK: '#back',
       LINK_RESEND: '#resend',
-      PHONE_NUMBER_SENT_TO: '.success',
-      RESEND_SUCCESS: '.shake'
+      PHONE_NUMBER_SENT_TO: '#send-success',
+      RESEND_SUCCESS: '#resend-success'
     },
     SMS_WHY_IS_THIS_REQUIRED: {
       CLOSE: '.connect-another-device button[type="submit"]',

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -209,7 +209,7 @@ define([
        .then(getSms(TEST_PHONE_NUMBER, 0))
 
        .then(click(selectors.SMS_SENT.LINK_RESEND))
-       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, FORMATTED_TEST_PHONE_NUMBER))
+       .then(testElementTextInclude(selectors.SMS_SENT.RESEND_SUCCESS, FORMATTED_TEST_PHONE_NUMBER))
        .then(getSms(TEST_PHONE_NUMBER, 1))
 
        // user realizes they made a mistake


### PR DESCRIPTION
We were looking for the `.success` element, which is overwritten. Look instead for
`.success.shake` which is used as the resent-success message.

fixes #5745

@mozilla/fxa-devs - r?
