### PR TITLE
fix(tests): fix attempt for flaky gated session test

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,6 +2,8 @@
   "exceptions": [
     // uglify-js
     "https://nodesecurity.io/advisories/39",
-    "https://nodesecurity.io/advisories/48"
+    "https://nodesecurity.io/advisories/48",
+    // moment
+    "https://nodesecurity.io/advisories/532"
   ]
 }

--- a/tests/functional/settings_secondary_emails.js
+++ b/tests/functional/settings_secondary_emails.js
@@ -83,8 +83,8 @@ define([
 
     'gated in unverified session open verification new tab': function () {
       return this.remote
-      // when an account is created, the original session is verified
-      // re-login to destroy original session and created an unverified one
+        // when an account is created, the original session is verified
+        // re-login to destroy original session and created an unverified one
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
         .then(fillOutSignIn(email, PASSWORD))
@@ -99,10 +99,12 @@ define([
         .then(openVerificationLinkInNewTab(email, 0))
         .then(switchToWindow(1))
           // panel becomes verified and opens add secondary panel
+          .then(testElementExists(selectors.EMAIL.INPUT))
           .then(visibleByQSA(selectors.EMAIL.INPUT))
           .then(closeCurrentWindow())
 
         .then(switchToWindow(0))
+          .then(testElementExists(selectors.EMAIL.UNLOCK_REFRESH_BUTTON))
           .then(click(selectors.EMAIL.UNLOCK_REFRESH_BUTTON))
           .then(visibleByQSA(selectors.EMAIL.INPUT));
     },


### PR DESCRIPTION
Team city reports that multiple selectors are visible. This doesn't really make sense because there is only one element with that ID. Putting in some delays before launching switching windows just to see what what happens.

 Ref #5748 