### PR TITLE
fix(metrics): stop sending raw client ids to amplitude

### DIFF
--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -26,10 +26,6 @@ const P = require('bluebird');
 const ua = require('node-uap');
 
 const SERVICES = require('./configuration').get('oauth_client_id_map');
-if (! SERVICES.sync) {
-  // Ensure there is an entry for Sync, which isn't identified by client id
-  SERVICES.sync = 'sync';
-}
 
 const APP_VERSION = /^[0-9]+\.([0-9]+)\./.exec(require('../../package.json').version)[1];
 
@@ -315,7 +311,16 @@ function mapEmailType (event, eventCategory) {
 function mapService (event, eventCategory, data) {
   const service = marshallOptionalValue(data.service);
   if (service) {
-    return { service: SERVICES[service] || 'undefined_oauth' };
+    let serviceName, clientId;
+
+    if (service === 'sync') {
+      serviceName = service;
+    } else {
+      serviceName = SERVICES[service] || 'undefined_oauth';
+      clientId = service;
+    }
+
+    return { service: serviceName, oauth_client_id: clientId };
   }
 }
 

--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -26,6 +26,10 @@ const P = require('bluebird');
 const ua = require('node-uap');
 
 const SERVICES = require('./configuration').get('oauth_client_id_map');
+if (! SERVICES.sync) {
+  // Ensure there is an entry for Sync, which isn't identified by client id
+  SERVICES.sync = 'sync';
+}
 
 const APP_VERSION = /^[0-9]+\.([0-9]+)\./.exec(require('../../package.json').version)[1];
 
@@ -311,7 +315,7 @@ function mapEmailType (event, eventCategory) {
 function mapService (event, eventCategory, data) {
   const service = marshallOptionalValue(data.service);
   if (service) {
-    return { service: SERVICES[service] || service };
+    return { service: SERVICES[service] || 'undefined_oauth' };
   }
 }
 

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -79,7 +79,7 @@ define([
         flowBeginTime: 'qux',
         flowId: 'wibble',
         lang: 'blee',
-        service: '0',
+        service: '1',
         uid: 'soop',
         utm_campaign: 'melm',
         utm_content: 'florg',
@@ -98,7 +98,7 @@ define([
           device_id: 'bar',
           event_properties: {
             device_id: 'bar',
-            service: 'amo'
+            service: 'pocket'
           },
           event_type: 'fxa_login - forgot_submit',
           language: 'blee',
@@ -325,7 +325,7 @@ define([
         flowBeginTime: 'd',
         flowId: 'e',
         lang: 'f',
-        service: '1',
+        service: '2',
         uid: 'h',
         utm_campaign: 'i',
         utm_content: 'j',
@@ -342,7 +342,7 @@ define([
           device_id: 'b',
           event_properties: {
             device_id: 'b',
-            service: 'pocket'
+            service: 'undefined_oauth'
           },
           event_type: 'fxa_reg - engage',
           language: 'f',
@@ -712,7 +712,7 @@ define([
         flowBeginTime: 'd',
         flowId: 'e',
         lang: 'f',
-        service: 'g',
+        service: 'sync',
         uid: 'h',
         utm_campaign: 'i',
         utm_content: 'j',
@@ -729,7 +729,7 @@ define([
           event_properties: {
             device_id: 'b',
             email_type: 'reset_password',
-            service: 'g'
+            service: 'sync'
           },
           event_type: 'fxa_email - click',
           language: 'f',

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -98,6 +98,7 @@ define([
           device_id: 'bar',
           event_properties: {
             device_id: 'bar',
+            oauth_client_id: '1',
             service: 'pocket'
           },
           event_type: 'fxa_login - forgot_submit',
@@ -342,6 +343,7 @@ define([
           device_id: 'b',
           event_properties: {
             device_id: 'b',
+            oauth_client_id: '2',
             service: 'undefined_oauth'
           },
           event_type: 'fxa_reg - engage',


### PR DESCRIPTION
Related to mozilla/fxa-amplitude-send#28 (equivalent fix for the auth server also coming).

Having raw client ids in Amplitude isn't helpful. This change replaces them with a fallback string, `undefined_oauth`.

@mozilla/fxa-devs r?