### PR TITLE
feat(metrics): emit an anonymous request.headers.dnt flow event

### DIFF
--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -93,6 +93,9 @@ module.exports = (req, metrics, requestReceivedTime) => {
     if (event.type === FLOW_BEGIN_EVENT) {
       event.time = metrics.flowBeginTime;
       event.flowTime = 0;
+      if (isDNT(req)) {
+        logAnonymousFlowEvent('request.headers.dnt', metrics.flowBeginTime);
+      }
     } else {
       event.time = estimateTime({
         /*eslint-disable sorting/sort-object-props*/
@@ -236,6 +239,16 @@ function logFlowEvent (event, data, request) {
 
   // The data pipeline listens on stderr.
   process.stderr.write(JSON.stringify(eventData) + '\n');
+}
+
+function logAnonymousFlowEvent (type, time) {
+  logFlowEvent({
+    flowTime: 0,
+    time,
+    type
+  }, {
+    flowId: flowMetrics.getAnonymousFlowId(FLOW_ID_KEY),
+  }, { headers: {} });
 }
 
 function pickFlowData (data, request) {

--- a/server/lib/flow-metrics.js
+++ b/server/lib/flow-metrics.js
@@ -7,9 +7,7 @@ const crypto = require('crypto');
 const SALT_SIZE = 16;
 const SALT_STRING_LENGTH = SALT_SIZE * 2;
 
-const ANONYMOUS_SALT = new Array(SALT_STRING_LENGTH).fill('0').join('');
-
-let anonymousFlowId;
+const ANONYMOUS_FLOW_ID = new Array(64).fill('0').join('');
 
 module.exports = {
   /**
@@ -21,7 +19,13 @@ module.exports = {
    */
   create (key, userAgent) {
     const salt = crypto.randomBytes(SALT_SIZE).toString('hex');
-    return createFlowEventData(key, salt, Date.now(), userAgent);
+    const result = createFlowEventData(key, salt, Date.now(), userAgent);
+
+    if (result === ANONYMOUS_FLOW_ID) {
+      return this.create(key, userAgent);
+    }
+
+    return result;
   },
 
   /**
@@ -34,7 +38,7 @@ module.exports = {
    * @returns Boolean
    */
   validate (key, flowId, flowBeginTime, userAgent) {
-    if (flowId === this.getAnonymousFlowId(key)) {
+    if (flowId === ANONYMOUS_FLOW_ID) {
       return false;
     }
 
@@ -51,11 +55,7 @@ module.exports = {
    * @returns flowId
    */
   getAnonymousFlowId (key) {
-    if (! anonymousFlowId) {
-      anonymousFlowId = createFlowEventData(key, ANONYMOUS_SALT, 0, '').flowId;
-    }
-
-    return anonymousFlowId;
+    return ANONYMOUS_FLOW_ID;
   }
 };
 

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -16,8 +16,11 @@ define([
     'tests/server/ver.json.js',
     'tests/server/amplitude',
     'tests/server/csp',
-    'tests/server/flow-event',
+    // HACK: Force flow-metrics tests before flow-event because the anonymous flow id
+    //       is cached in server/lib/flow-metrics and the tests need to assert against
+    //       a value that was initialised using a known salt.
     'tests/server/flow-metrics',
+    'tests/server/flow-event',
     'tests/server/frame-guard',
     'tests/server/geo-locate',
     'tests/server/hpkp',

--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -16,11 +16,8 @@ define([
     'tests/server/ver.json.js',
     'tests/server/amplitude',
     'tests/server/csp',
-    // HACK: Force flow-metrics tests before flow-event because the anonymous flow id
-    //       is cached in server/lib/flow-metrics and the tests need to assert against
-    //       a value that was initialised using a known salt.
-    'tests/server/flow-metrics',
     'tests/server/flow-event',
+    'tests/server/flow-metrics',
     'tests/server/frame-guard',
     'tests/server/geo-locate',
     'tests/server/hpkp',

--- a/tests/server/flow-metrics.js
+++ b/tests/server/flow-metrics.js
@@ -119,16 +119,6 @@ define([
     assert.notEqual(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
   };
 
-  suite['getAnonymousFlowId returns the correct flowId'] = () => {
-    mockDateNow = 0;
-    mockRandomBytes = Buffer.from('00000000000000000000000000000000', 'hex');
-
-    assert.equal(
-      flowMetrics.getAnonymousFlowId(mockFlowIdKey),
-      flowMetrics.create(mockFlowIdKey, '').flowId
-    );
-  };
-
   suite['validate returns true for good data'] = () => {
     // Force the mocks to return bad data to be sure it really works
     mockDateNow = 1478626838531;
@@ -206,18 +196,21 @@ define([
   };
 
   suite['validate returns false for the anonymous flow id'] = () => {
-    // Force the mocks to return good data to be sure it really works
-    mockDateNow = 0;
-    mockRandomBytes = 'MozillaFirefox!!';
-
     const result = flowMetrics.validate(
-      mockFlowIdKey,
+      'S3CR37',
       flowMetrics.getAnonymousFlowId(mockFlowIdKey),
       0,
       ''
     );
 
     assert.strictEqual(result, false);
+  };
+
+  suite['getAnonymousFlowId returns the correct flowId'] = () => {
+    assert.equal(
+      flowMetrics.getAnonymousFlowId(mockFlowIdKey),
+      '0000000000000000000000000000000000000000000000000000000000000000'
+    );
   };
 
   registerSuite(suite);


### PR DESCRIPTION
Fixes #5744.

We want the ability to count how many `DNT` headers we encounter, to give us a feel for the proportion of "missing" utm params that are due to that. But of course, we want to do this in a way that is completely anonymised.

We could just log it and count them in Kibana but I thought it would be nicer if we could have them as anonymous flow events in Redshift, so that we can plot their numbers on the same charts as everything else. What I've done here is a stab at that.

It may not be the best approach but it's one that requires no extra help from the metrics pipeline folks. Essentially it boils down to defining an anonymous flow id, which can never clash with proper flow ids out in the wild, and emitting the new events using that.

I've actually implemented two different versions of this change and present them both here as separate commits, so it's easy to go with whichever is preferred (if any):

1. In d7bbbe6, I generate an id using our standard hash key and the epoch timestamp.

2. In 49463ad, I simplify that to a static value and add an extra check in `flowMetrics.create` to make sure we don't accidentally create a real flow id that clashes (I also took the precaution of checking redshift for any pre-existing clashes, there are none).

In both cases, `flowMetrics.validate` will return `false` if you pass it the anonymous flow id.

I'm ambivalent about which implementation we use, either is fine with me. I'm also fine if people think the whole approach is wrong and we should do something else instead. @rfk, I got the sense you might not be a huge fan of it in IRC this morning.

Potential alternative approaches include:

* Changing the current metrics pipeline to accept null flow ids and then sending these events without any flow id at all.

* Emitting these as a new type of event and setting up a new pipeline to store them in a new table in Redshift.

Neither of those is likely to happen quickly though, I suspect, and one reason I'm doing this change now is in the hope of getting further insight on mozilla/fxa-amplitude-send#27.

Sorry, that's a lot of writing for such a small change!

@mozilla/fxa-devs r?