### PR TITLE
chore(logs): log an anonymous event when we see the DNT header

### DIFF
--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 'use strict';
+
 const flowMetrics = require('../flow-metrics');
+const logger = require('../logging/log')('routes.index');
 
 module.exports = function (config) {
   const AUTH_SERVER_URL = config.get('fxaccount_url');
@@ -47,6 +49,10 @@ module.exports = function (config) {
       // Note that staticResourceUrl is added to templates as a build step
       staticResourceUrl: STATIC_RESOURCE_URL
     });
+
+    if (req.headers.dnt === '1') {
+      logger.info('request.headers.dnt');
+    }
   };
 
   return route;


### PR DESCRIPTION
Fixes #5744. Supercedes #5756.

As per yesterday's meeting, the flow event wasn't going to happen in time for train 101 so let's just log something we can count in Kibana instead.

@mozilla/fxa-devs r?