### PR TITLE
fix(metrics): ensure metrics always has a uid

### DIFF
--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -91,6 +91,7 @@ define(function (require, exports, module) {
 
     _setSignedInAccountUid (uid) {
       this._storage.set('currentAccountUid', uid);
+      this._notifier.trigger('set-uid', uid);
       // Clear the in-memory cache if the uid has changed
       if (this._cachedSignedInAccount && this._cachedSignedInAccount.get('uid') !== uid) {
         this._cachedSignedInAccount = null;

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -424,10 +424,17 @@ define(function (require, exports, module) {
 
     it('setSignedInAccount', function () {
       sinon.spy(notifier, 'triggerRemote');
+      sinon.spy(notifier, 'trigger');
       return user.setSignedInAccount({ email: EMAIL, uid: 'uid' })
         .then(function () {
           assert.equal(user.getSignedInAccount().get('uid'), 'uid');
           assert.equal(notifier.triggerRemote.callCount, 0);
+
+          assert.equal(notifier.trigger.callCount, 1);
+          const args = notifier.trigger.args[0];
+          assert.equal(args.length, 2);
+          assert.equal(args[0], 'set-uid');
+          assert.equal(args[1], 'uid');
         });
     });
 


### PR DESCRIPTION
Fixes #5762.

I noticed that some sign-in paths don't set the uid in metrics. This change fixes that, although I'm not sure if it's the right place for it.

@mozilla/fxa-devs r?