### PR TITLE
fix(metrics): ensure metrics always has a uid

### DIFF
--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -59,7 +59,8 @@ define(function (require, exports, module) {
       this._createView = options.createView;
       this._experimentGroupingRules = options.experimentGroupingRules;
 
-      var uid = this.relier.get('uid');
+      const uid = this.relier.get('uid');
+      this.notifier.trigger('set-uid', uid);
 
       // A uid param is set by RPs linking directly to the settings
       // page for a particular account.

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -88,6 +88,7 @@ define(function (require, exports, module) {
       metrics = new Metrics({ notifier });
       profileClient = new ProfileClient();
       relier = new Relier();
+      relier.set('uid', 'wibble');
 
       user = new User({
         notifier: notifier,
@@ -103,6 +104,7 @@ define(function (require, exports, module) {
       sinon.stub(account, 'fetchProfile').callsFake(function () {
         return p();
       });
+      sinon.spy(notifier, 'trigger');
 
       createSettingsView();
 
@@ -115,6 +117,13 @@ define(function (require, exports, module) {
       $(view.el).remove();
       view.destroy();
       view = null;
+    });
+
+    it('emits set-uid event correctly', () => {
+      assert.equal(notifier.trigger.callCount, 1);
+      const args = notifier.trigger.args[0];
+      assert.equal(args[0], 'set-uid');
+      assert.equal(args[1], 'wibble');
     });
 
     describe('with uid', function () {


### PR DESCRIPTION
Fixes #5762. Replaces #5763.

Missing `uid` was messing up some charts in Amplitude, this fixes it. Opened for a prospective 100.2 tag.

@mozilla/fxa-devs r?