### PR TITLE
fix(email-first): Fix FxA resizing in the firstrun page for email-first

### DIFF
--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -61,6 +61,7 @@
     border: 0;
     box-shadow: none;
     margin-top: 0;
+    min-height: 0 !important;
   }
 }
 


### PR DESCRIPTION
The min-height forced the iframe to be too large on the firstrun page
in the email-first flow. In chromeless, it doesn't really matter
how big the #main-content is, there's no shadow, etc, to display.

Remove the min-height: 300 declaration for chromeless.