### PR TITLE
feat(CAD): /connect_another_device redirects to /sms for eligible users.

### DIFF
--- a/app/tests/spec/views/mixins/connect-another-device-mixin.js
+++ b/app/tests/spec/views/mixins/connect-another-device-mixin.js
@@ -303,95 +303,99 @@ define(function (require, exports, module) {
         beforeEach(() => {
           sinon.stub(view, 'isEligibleForConnectAnotherDevice').callsFake(() => true);
           sinon.stub(view, 'navigate').callsFake(() => {});
-          sinon.stub(view, 'createExperiment').callsFake(() => {});
-          sinon.spy(notifier, 'trigger');
         });
 
         describe('not eligible for SMS', () => {
           it('redirects to /connect_another_device without additional logging', () => {
-            sinon.stub(view, '_isEligibleForSms').callsFake(() => Promise.resolve({ ok: false }));
-
             return view.navigateToConnectAnotherDeviceScreen(account)
               .then(() => {
-                assert.isFalse(view.createExperiment.called);
-
-                assert.isTrue(notifier.trigger.calledOnce);
-                assert.isTrue(notifier.trigger.calledWith('flow.initialize'));
-
                 assert.isTrue(view.navigate.calledOnce);
                 assert.isTrue(view.navigate.calledWith('connect_another_device', { account, type: 'signin' }));
-
-                assert.isFalse(view.logFlowEvent.called);
               });
           });
         });
+      });
 
+      describe('getEligibleSmsCountry', () => {
         describe('eligible for SMS', () => {
           beforeEach(() => {
             sinon.stub(view, '_isEligibleForSms').callsFake(() => Promise.resolve({ country: 'GB', ok: true }));
+            sinon.stub(view, 'createExperiment').callsFake(() => {});
+            sinon.spy(notifier, 'trigger');
           });
 
           describe('user is not part of experiment', () => {
-            it('does not enroll the user in an experiment, logs a flow event, navigates to connect_another_device', () => {
+            it('does not enroll the user in an experiment, logs a flow event', () => {
               sinon.stub(view, 'getExperimentGroup').callsFake(() => false);
-              return view.navigateToConnectAnotherDeviceScreen(account)
-                .then(() => {
+              return view.getEligibleSmsCountry(account)
+                .then((country) => {
+                  assert.isUndefined(country);
+
+                  assert.isTrue(notifier.trigger.calledOnce);
+                  assert.isTrue(notifier.trigger.calledWith('flow.initialize'));
+
                   assert.isFalse(view.createExperiment.called);
 
                   assert.isTrue(view.logFlowEvent.calledOnce);
                   assert.isTrue(view.logFlowEvent.calledWith('sms.ineligible.not_in_experiment'));
-
-                  assert.isTrue(view.navigate.calledOnce);
-                  assert.isTrue(view.navigate.calledWith('connect_another_device', { account, type: 'signin' }));
                 });
             });
           });
 
           describe('country is fully rolled out', () => {
-            it('creates the experiment, redirects to /sms', () => {
+            it('does not create the experiment, returns the country', () => {
               sinon.stub(view, 'getExperimentGroup').callsFake(() => true);
-              return view.navigateToConnectAnotherDeviceScreen(account)
-                .then(() => {
+              return view.getEligibleSmsCountry(account)
+                .then((country) => {
+                  assert.equal(country, 'GB');
+
                   assert.isFalse(view.createExperiment.called);
 
                   assert.isFalse(view.logFlowEvent.called);
-
-                  assert.isTrue(view.navigate.calledOnce);
-                  assert.isTrue(view.navigate.calledWith('sms', { account, country: 'GB', type: 'signin' }));
                 });
             });
           });
 
           describe('in treatment group', () => {
-            it('creates the experiment, redirects to /sms', () => {
+            it('creates the experiment, returns the country', () => {
               sinon.stub(view, 'getExperimentGroup').callsFake(() => 'treatment');
-              return view.navigateToConnectAnotherDeviceScreen(account)
-                .then(() => {
+              return view.getEligibleSmsCountry(account)
+                .then((country) => {
+                  assert.equal(country, 'GB');
+
                   assert.isTrue(view.createExperiment.calledOnce);
                   assert.isTrue(view.createExperiment.calledWith('sendSms', 'treatment'));
-
-                  assert.isTrue(view.navigate.calledOnce);
-                  assert.isTrue(view.navigate.calledWith('sms', { account, country: 'GB', type: 'signin' }));
                 });
             });
           });
 
           describe('in control group', () => {
-            it('creates the experiment, redirects to /connect_another_device', () => {
+            it('creates the experiment, does not return a country', () => {
               sinon.stub(view, 'getExperimentGroup').callsFake(() => 'control');
-              return view.navigateToConnectAnotherDeviceScreen(account)
-                .then(() => {
+              return view.getEligibleSmsCountry(account)
+                .then((country) => {
+                  assert.isUndefined(country);
+
                   assert.isTrue(view.createExperiment.calledOnce);
                   assert.isTrue(view.createExperiment.calledWith('sendSms', 'control'));
-
-                  assert.isTrue(view.navigate.calledOnce);
-                  assert.isTrue(view.navigate.calledWith('connect_another_device', { account, type: 'signin' }));
 
                   assert.isTrue(view.logFlowEvent.calledOnce);
                   assert.isTrue(view.logFlowEvent.calledWith('sms.ineligible.control_group'));
                 });
             });
           });
+        });
+      });
+
+      describe('replaceCurrentPageWithSmsScreen', () => {
+        it('delegates to replaceCurrentPage', () => {
+          sinon.spy(view, 'replaceCurrentPage');
+
+          const account = {};
+          view.replaceCurrentPageWithSmsScreen (account, 'GB');
+
+          assert.isTrue(view.replaceCurrentPage.calledOnce);
+          assert.isTrue(view.replaceCurrentPage.calledWith('sms', { account, country: 'GB', type: 'signin' }));
         });
       });
     });

--- a/tests/functional/connect_another_device.js
+++ b/tests/functional/connect_another_device.js
@@ -25,6 +25,7 @@ define([
     'ct=adjust_tracker&mt=8';
 
   const CONNECT_ANOTHER_DEVICE_URL = `${config.fxaContentRoot}connect_another_device`;
+  const CONNECT_ANOTHER_DEVICE_SMS_ENABLED_URL = `${config.fxaContentRoot}connect_another_device?forceExperiment=sendSms&forceExperimentGroup=signinCodes`;
   const SIGNIN_DESKTOP_URL = `${config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync`;
   const SIGNUP_FENNEC_URL = `${config.fxaContentRoot}signup?context=fx_fennec_v1&service=sync`;
   const SIGNUP_DESKTOP_URL = `${config.fxaContentRoot}signup?context=fx_desktop_v3&service=sync`;
@@ -83,6 +84,20 @@ define([
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.TEXT_INSTALL_FX_DESKTOP))
         .then(testHrefEquals(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_IOS, ADJUST_LINK_IOS))
         .then(testHrefEquals(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_ANDROID, ADJUST_LINK_ANDROID));
+    },
+
+    'signup Fx Desktop, load /connect_another_device page, SMS enabled': function () {
+      // should have both links to mobile apps
+      const forceUA = UA_STRINGS['desktop_firefox'];
+      return this.remote
+        .then(openPage(SIGNUP_DESKTOP_URL, selectors.SIGNUP.HEADER, { query: { forceUA } }))
+        .then(respondToWebChannelMessage(CHANNEL_COMMAND_CAN_LINK_ACCOUNT, { ok: true } ))
+        .then(fillOutSignUp(email, PASSWORD))
+        .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
+
+        .then(openPage(CONNECT_ANOTHER_DEVICE_SMS_ENABLED_URL, selectors.SMS_SEND.HEADER))
+        .then(testHrefEquals(selectors.SMS_SEND.LINK_MARKETING_IOS, ADJUST_LINK_IOS))
+        .then(testHrefEquals(selectors.SMS_SEND.LINK_MARKETING_ANDROID, ADJUST_LINK_ANDROID));
     },
 
     'signup Fx Desktop, verify same browser': function () {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1418466 introduces a feature where users
can open /connect_another_device from within Firefox Desktop. We want users eligible
to send an SMS to be redirected to the /sms page. This makes it so.

fixes #5737 