### PR TITLE
fix(copy):Change passwords to logins 

### DIFF
--- a/app/scripts/models/sync-engines.js
+++ b/app/scripts/models/sync-engines.js
@@ -45,7 +45,7 @@ define(function(require, exports, module) {
     {
       checked: true,
       id: 'passwords',
-      text: t('Passwords')
+      text: t('Logins')
     },
     {
       checked: true,


### PR DESCRIPTION
This is my first commit made in conjunction with @ryanfeeley. Please replace"Passwords" with "Logins" to be consistent with Firefox client.