### PR TITLE
fix(image):Descaled icons for snappier rendering

### DIFF
--- a/app/styles/modules/_avatar.scss
+++ b/app/styles/modules/_avatar.scss
@@ -183,8 +183,7 @@
       &#camera,
       &#file,
       &.remove {
-        background-position: 50% 22%;
-        background-size: 41%;
+        background-position: 50% 0%;
 
         &:hover {
           filter: hue-rotate(3deg) saturate(1.1) brightness(.85);


### PR DESCRIPTION
Noticed that on a low-resolution screen that these images were being scaled and were not pixel snapped (a + should render with no anti-aliasing on right angles). I hope this fixes it, give it a try before accepting please.