### PR TITLE
revert(sms): "Use a known test number for SMS tests. (#5720)"

### DIFF
--- a/tests/functional/fx_desktop_handshake.js
+++ b/tests/functional/fx_desktop_handshake.js
@@ -42,6 +42,7 @@ define([
   const clearBrowserState = FunctionalHelpers.clearBrowserState;
   const createUser = FunctionalHelpers.createUser;
   const deleteAllSms = FunctionalHelpers.deleteAllSms;
+  const disableInProd = FunctionalHelpers.disableInProd;
   const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
   const getSmsSigninCode = FunctionalHelpers.getSmsSigninCode;
   const openPage = FunctionalHelpers.openPage;
@@ -140,14 +141,14 @@ define([
         .then(testElementValueEquals(selectors.SIGNIN.EMAIL, browserSignedInEmail));
     },
 
-    'Sync signin page w/ signin code - user signed into browser': function () {
-      const TEST_PHONE_NUMBER = config.fxaTestPhoneNumber;
+    'Sync signin page w/ signin code - user signed into browser': disableInProd(function () {
+      const testPhoneNumber = TestHelpers.createPhoneNumber();
       let signinUrlWithSigninCode;
 
       return this.remote
         // The phoneNumber can be reused by different tests, delete all
         // of its SMS messages to ensure a clean slate.
-        .then(deleteAllSms(TEST_PHONE_NUMBER))
+        .then(deleteAllSms(testPhoneNumber))
 
         .then(openPage(SYNC_SMS_PAGE_URL, selectors.SMS_SEND.HEADER, {
           webChannelResponses: {
@@ -156,11 +157,11 @@ define([
             }
           }
         }))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
         .then(click(selectors.SMS_SEND.SUBMIT))
 
         .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(getSmsSigninCode(TEST_PHONE_NUMBER, 0))
+        .then(getSmsSigninCode(testPhoneNumber, 0))
         .then(function (signinCode) {
           signinUrlWithSigninCode = `${SYNC_SIGNIN_PAGE_URL}&signin=${signinCode}`;
           return this.parent
@@ -180,7 +181,7 @@ define([
             // defined so that we are ready when Fennec or iOS adds fxa_status support.
             .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, browserSignedInEmail));
         });
-    },
+    }),
 
     'Non-Sync signin page - user signed into browser, no user signed in locally': function () {
       return this.remote

--- a/tests/functional/fx_fennec_v1_sign_in.js
+++ b/tests/functional/fx_fennec_v1_sign_in.js
@@ -24,6 +24,7 @@ define([
     closeCurrentWindow,
     createUser,
     deleteAllSms,
+    disableInProd,
     fillOutSignIn,
     fillOutSignInUnblock,
     getSmsSigninCode,
@@ -115,22 +116,22 @@ define([
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
-    'signup in desktop, send an SMS, open deferred deeplink in Fennec': function () {
-      const TEST_PHONE_NUMBER = config.fxaTestPhoneNumber;
+    'signup in desktop, send an SMS, open deferred deeplink in Fennec': disableInProd(function () {
+      const testPhoneNumber = TestHelpers.createPhoneNumber();
       let signinUrlWithSigninCode;
 
       return this.remote
         // The phoneNumber is reused across tests, delete all
         // if its SMS messages to ensure a clean slate.
-        .then(deleteAllSms(TEST_PHONE_NUMBER))
+        .then(deleteAllSms(testPhoneNumber))
         .then(setupTest(selectors.CONFIRM_SIGNUP.HEADER))
 
         .then(openPage(SMS_PAGE_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
         .then(click(selectors.SMS_SEND.SUBMIT))
 
         .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(getSmsSigninCode(TEST_PHONE_NUMBER, 0))
+        .then(getSmsSigninCode(testPhoneNumber, 0))
         .then(function (signinCode) {
           signinUrlWithSigninCode = `${SIGNIN_PAGE_URL}&signin=${signinCode}`;
           return this.parent
@@ -138,6 +139,6 @@ define([
             .then(openPage(signinUrlWithSigninCode, selectors.SIGNIN.HEADER))
             .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email));
         });
-    }
+    })
   });
 });

--- a/tests/functional/fx_ios_v1_sign_in.js
+++ b/tests/functional/fx_ios_v1_sign_in.js
@@ -27,6 +27,7 @@ define([
     closeCurrentWindow,
     createUser,
     deleteAllSms,
+    disableInProd,
     fillOutSignIn,
     fillOutSignInUnblock,
     getSmsSigninCode,
@@ -180,23 +181,23 @@ define([
         .then(testIsBrowserNotifiedOfLogin(email, { expectVerified: true }));
     },
 
-    'signup in desktop, send an SMS, open deferred deeplink in Fx for iOS': function () {
-      const TEST_PHONE_NUMBER = config.fxaTestPhoneNumber;
+    'signup in desktop, send an SMS, open deferred deeplink in Fx for iOS': disableInProd(function () {
+      const testPhoneNumber = TestHelpers.createPhoneNumber();
       const forceUA = UA_STRINGS['ios_firefox_6_1'];
       const query = { forceUA };
 
       return this.remote
         // The phoneNumber is reused across tests, delete all
         // if its SMS messages to ensure a clean slate.
-        .then(deleteAllSms(TEST_PHONE_NUMBER))
+        .then(deleteAllSms(testPhoneNumber))
         .then(setupTest({ preVerified: true, query }))
 
         .then(openPage(SMS_PAGE_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
         .then(click(selectors.SMS_SEND.SUBMIT))
 
         .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(getSmsSigninCode(TEST_PHONE_NUMBER, 0))
+        .then(getSmsSigninCode(testPhoneNumber, 0))
         .then(function (signinCode) {
           query.signin = signinCode;
 
@@ -205,6 +206,6 @@ define([
             .then(openPage(SIGNIN_PAGE_URL, selectors.SIGNIN.HEADER, { query }))
             .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email));
         });
-    }
+    })
   });
 });

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -610,6 +610,23 @@ define([
   });
 
   /**
+   * Tests that send an SMS should be wrapped by `disableInProd`. This will
+   * prevent the tests from running in stage/prod where we should not
+   * send SMSs to random people.
+   *
+   * @param {Function} test
+   * @returns {Function}
+   */
+  function disableInProd(test) {
+    if (intern.config.fxaProduction) {
+      return function () {
+      };
+    }
+
+    return test;
+  }
+
+  /**
    * Get SMS message `index` for `phoneNumber`.
    *
    * @param {String} phoneNumber
@@ -2062,6 +2079,7 @@ define([
     deleteAllEmails,
     deleteAllSms,
     denormalizeStoredEmail: denormalizeStoredEmail,
+    disableInProd,
     fetchAllMetrics: fetchAllMetrics,
     fillOutChangePassword: fillOutChangePassword,
     fillOutCompleteResetPassword: fillOutCompleteResetPassword,

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -8,8 +8,9 @@ define([
   'intern!object',
   'tests/lib/helpers',
   'tests/functional/lib/helpers',
-  'tests/functional/lib/selectors'
-], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors) {
+  'tests/functional/lib/selectors',
+  'app/scripts/lib/country-telephone-info'
+], function (intern, registerSuite, TestHelpers, FunctionalHelpers, selectors, CountryTelephoneInfo) {
   'use strict';
 
   const config = intern.config;
@@ -29,16 +30,18 @@ define([
   const SEND_SMS_SIGNIN_CODE_URL = `${SEND_SMS_URL}&forceExperiment=sendSms&forceExperimentGroup=signinCodes`;
   const SEND_SMS_NO_QUERY_URL = `${config.fxaContentRoot}sms`;
 
-  const TEST_PHONE_NUMBER = config.fxaTestPhoneNumber;
-  const FORMATTED_TEST_PHONE_NUMBER = '916-440-0029';
 
   let email;
   const PASSWORD = 'password';
+
+  let testPhoneNumber;
+  let formattedPhoneNumber;
 
   const {
     click,
     closeCurrentWindow,
     deleteAllSms,
+    disableInProd,
     fillOutSignUp,
     getSms,
     getSmsSigninCode,
@@ -68,6 +71,10 @@ define([
 
     beforeEach: function () {
       email = TestHelpers.createEmail();
+      testPhoneNumber = TestHelpers.createPhoneNumber();
+      const countryInfo = CountryTelephoneInfo['US'];
+      formattedPhoneNumber =
+         countryInfo.format(countryInfo.normalize(testPhoneNumber));
 
       // User needs a sessionToken to be able to send an SMS. Sign up,
       // no need to verify.
@@ -76,7 +83,7 @@ define([
         .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
         // The phoneNumber can be reused by different tests, delete all
         // of its SMS messages to ensure a clean slate.
-        .then(deleteAllSms(TEST_PHONE_NUMBER));
+        .then(deleteAllSms(testPhoneNumber));
     },
 
     'with no query parameters': function () {
@@ -182,92 +189,92 @@ define([
        .then(testElementTextInclude(selectors.SMS_SEND.PHONE_NUMBER_TOOLTIP, 'invalid'));
     },
 
-    'valid phone number, back': function () {
+    'valid phone number, back': disableInProd(function () {
       return this.remote
        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-       .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
        .then(click(selectors.SMS_SEND.SUBMIT))
        .then(testElementExists(selectors.SMS_SENT.HEADER))
-       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, FORMATTED_TEST_PHONE_NUMBER))
+       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
        .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
-       .then(getSms(TEST_PHONE_NUMBER, 0))
+       .then(getSms(testPhoneNumber, 0))
 
        // user realizes they made a mistake
        .then(click(selectors.SMS_SENT.LINK_BACK))
        .then(testElementExists(selectors.SMS_SEND.HEADER))
 
        // original phone number should still be in place
-       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER));
-    },
+       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber));
+    }),
 
-    'valid phone number, resend': function () {
+    'valid phone number, resend': disableInProd(function () {
       return this.remote
        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-       .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
        .then(click(selectors.SMS_SEND.SUBMIT))
        .then(testElementExists(selectors.SMS_SENT.HEADER))
-       .then(getSms(TEST_PHONE_NUMBER, 0))
+       .then(getSms(testPhoneNumber, 0))
 
        .then(click(selectors.SMS_SENT.LINK_RESEND))
-       .then(testElementTextInclude(selectors.SMS_SENT.RESEND_SUCCESS, FORMATTED_TEST_PHONE_NUMBER))
-       .then(getSms(TEST_PHONE_NUMBER, 1))
+       .then(testElementTextInclude(selectors.SMS_SENT.RESEND_SUCCESS, formattedPhoneNumber))
+       .then(getSms(testPhoneNumber, 1))
 
        // user realizes they made a mistake
        .then(click(selectors.SMS_SENT.LINK_BACK))
        .then(testElementExists(selectors.SMS_SEND.HEADER))
 
        // original phone number should still be in place
-       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER));
-    },
+       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber));
+    }),
 
-    'valid phone number, enable signinCode': function () {
+    'valid phone number, enable signinCode': disableInProd(function () {
       return this.remote
        .then(openPage(SEND_SMS_SIGNIN_CODE_URL, selectors.SMS_SEND.HEADER))
-       .then(type(selectors.SMS_SEND.PHONE_NUMBER, TEST_PHONE_NUMBER))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, testPhoneNumber))
        .then(click(selectors.SMS_SEND.SUBMIT))
        .then(testElementExists(selectors.SMS_SENT.HEADER))
-       .then(getSmsSigninCode(TEST_PHONE_NUMBER, 0));
-    },
+       .then(getSmsSigninCode(testPhoneNumber, 0));
+    }),
 
-    'valid phone number w/ country code of 1': function () {
+    'valid phone number w/ country code of 1': disableInProd(function () {
       return this.remote
         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, `1${TEST_PHONE_NUMBER}`))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, `1${testPhoneNumber}`))
         .then(click(selectors.SMS_SEND.SUBMIT))
         .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, FORMATTED_TEST_PHONE_NUMBER))
+        .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
         .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
-        .then(getSms(TEST_PHONE_NUMBER, 0));
-    },
+        .then(getSms(testPhoneNumber, 0));
+    }),
 
-    'valid phone number w/ country code of +1': function () {
+    'valid phone number w/ country code of +1': disableInProd(function () {
       return this.remote
         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-        .then(type(selectors.SMS_SEND.PHONE_NUMBER, `+1${TEST_PHONE_NUMBER}`))
+        .then(type(selectors.SMS_SEND.PHONE_NUMBER, `+1${testPhoneNumber}`))
         .then(click(selectors.SMS_SEND.SUBMIT))
         .then(testElementExists(selectors.SMS_SENT.HEADER))
-        .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, FORMATTED_TEST_PHONE_NUMBER))
+        .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
         .then(testElementExists(selectors.SMS_SEND.LINK_MARKETING))
-        .then(getSms(TEST_PHONE_NUMBER, 0));
-    },
+        .then(getSms(testPhoneNumber, 0));
+    }),
 
-    'valid phone number (contains spaces and punctuation)': function () {
-      const unformattedTestPhoneNumber = ` ${TEST_PHONE_NUMBER.slice(0,3)} .,- ${TEST_PHONE_NUMBER.slice(3)} `;
+    'valid phone number (contains spaces and punctuation)': disableInProd(function () {
+      const unformattedPhoneNumber = ` ${testPhoneNumber.slice(0,3)} .,- ${testPhoneNumber.slice(3)} `;
       return this.remote
        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
-       .then(type(selectors.SMS_SEND.PHONE_NUMBER, unformattedTestPhoneNumber))
+       .then(type(selectors.SMS_SEND.PHONE_NUMBER, unformattedPhoneNumber))
        .then(click(selectors.SMS_SEND.SUBMIT))
        .then(testElementExists(selectors.SMS_SENT.HEADER))
-       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, FORMATTED_TEST_PHONE_NUMBER))
-       .then(getSms(TEST_PHONE_NUMBER, 0))
+       .then(testElementTextInclude(selectors.SMS_SENT.PHONE_NUMBER_SENT_TO, formattedPhoneNumber))
+       .then(getSms(testPhoneNumber, 0))
 
        // user realizes they made a mistake
        .then(click(selectors.SMS_SENT.LINK_BACK))
        .then(testElementExists(selectors.SMS_SEND.HEADER))
 
        // original phone number should still be in place
-       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, unformattedTestPhoneNumber));
-    }
+       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, unformattedPhoneNumber));
+    })
   };
 
   registerSuite(suite);

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -20,7 +20,6 @@ function (intern, topic, firefoxProfile) {
   var fxaEmailRoot = args.fxaEmailRoot || 'http://127.0.0.1:9001';
   var fxaOauthApp = args.fxaOauthApp || 'http://127.0.0.1:8080/';
   var fxaUntrustedOauthApp = args.fxaUntrustedOauthApp || 'http://127.0.0.1:10139/';
-  const fxaTestPhoneNumber = args.fxaTestPhoneNumber || '9164400029'; // We're sorry, all circuits are busy now
 
   // "fxaProduction" is a little overloaded in how it is used in the tests.
   // Sometimes it means real "stage" or real production configuration, but
@@ -67,7 +66,6 @@ function (intern, topic, firefoxProfile) {
     fxaOauthApp: fxaOauthApp,
     fxaProduction: fxaProduction,
     fxaProfileRoot: fxaProfileRoot,
-    fxaTestPhoneNumber,
     fxaToken: fxaToken,
     fxaTokenRoot: fxaTokenRoot,
     fxaUntrustedOauthApp: fxaUntrustedOauthApp,

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -31,12 +31,43 @@ define([
     return template.replace('{id}', Math.random()) + '@restmail.net';
   }
 
+  /**
+   * Create a phone number with `prefix` with `length` digits.
+   *
+   * @param {String} [prefix='9164']
+   * @param {Number} [length=10]
+   * @returns {String}
+   */
+  function createPhoneNumber (prefix, length) {
+    if (typeof prefix === 'undefined') {
+      prefix = '9164';
+    }
+    if (typeof length === 'undefined') {
+      length = 10;
+    }
+    // start with an area code and known good first number,
+    // append a 6 character suffix.
+    const suffixLength = length - prefix.length;
+    let suffix = Math.floor(Math.random() * Math.pow(10, suffixLength));
+    suffix = padright(suffix, suffixLength, '0');
+    return `${prefix}${suffix}`;
+  }
+
+  function padright (str, len, filler) {
+    let padded = '' + str;
+    while (padded.length < len) {
+      padded += filler;
+    }
+    return padded;
+  }
+
   function emailToUser(email) {
     return email.split('@')[0];
   }
 
   return {
     createEmail,
+    createPhoneNumber,
     createRandomHexString,
     createUID,
     emailToUser


### PR DESCRIPTION
This reverts commit 8e8d2d712423f0c64c04320f556c1492fff38501.

There were multiple problems with approach to the original PR:

* stage actually sends SMS, we cannot fetch the contents of
  the SMS message from restmail.
* All tests use the same phone number - if multiple runners
  run SMS tests at the same time, one runner can cause all
  messages to be wiped that another runner is looking for.

This goes back to the former state and disables SMS sending
tests on "prod-like" environments - meaning all CI & stage.