### PR TITLE
refactor(l10n): Make translation fetch Webpack compatible.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -74,6 +74,7 @@ define(function (require, exports, module) {
     this._router = options.router;
     this._sentryMetrics = options.sentryMetrics;
     this._storage = options.storage || Storage;
+    this._translator = options.translator;
     this._user = options.user;
     this._window = options.window || window;
   }
@@ -179,7 +180,10 @@ define(function (require, exports, module) {
     },
 
     initializeL10n () {
-      this._translator = this._window.translator = new Translator();
+      if (! this._translator) {
+        this._translator = new Translator();
+      }
+      return this._translator.fetch();
     },
 
     initializeMetrics () {
@@ -488,6 +492,7 @@ define(function (require, exports, module) {
         relier: this._relier,
         sentryMetrics: this._sentryMetrics,
         session: Session,
+        translator: this._translator,
         user: this._user,
         window: this._window
       }, this._router.getViewOptions(options));
@@ -517,6 +522,7 @@ define(function (require, exports, module) {
           environment: new Environment(this._window),
           notifier: this._notifier,
           router: this._router,
+          translator: this._translator,
           window: this._window
         });
       }

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -44,6 +44,7 @@ define(function (require, exports, module) {
     let brokerMock;
     let notifier;
     let routerMock;
+    let translator;
     let userMock;
     let windowMock;
 
@@ -52,6 +53,10 @@ define(function (require, exports, module) {
       backboneHistoryMock = new HistoryMock();
       notifier = new Notifier();
       routerMock = { navigate: sinon.spy() };
+      translator = {
+        fetch: sinon.spy(() => Promise.resolve())
+      };
+
       userMock = new User();
 
       windowMock = new WindowMock();
@@ -75,6 +80,7 @@ define(function (require, exports, module) {
           history: backboneHistoryMock,
           router: routerMock,
           storage: Storage,
+          translator,
           user: userMock,
           window: windowMock
         });
@@ -106,19 +112,12 @@ define(function (require, exports, module) {
           history: backboneHistoryMock,
           router: routerMock,
           storage: Storage,
+          translator,
           user: userMock,
           window: windowMock
         });
 
         appStart.useConfig({});
-      });
-
-      it('starts the app', () => {
-        return appStart.startApp()
-          .then(() => {
-            // translator is put on the global object.
-            assert.isDefined(windowMock.translator);
-          });
       });
 
       it('does not redirect', () => {
@@ -244,6 +243,18 @@ define(function (require, exports, module) {
             });
         });
 
+      });
+    });
+
+    describe('initializeL10n', () => {
+      it('fetches translations', () => {
+        appStart = new AppStart({
+          translator
+        });
+        return appStart.initializeL10n()
+          .then(() => {
+            assert.ok(appStart._translator.fetch.calledOnce);
+          });
       });
     });
 

--- a/grunttasks/l10n-localize-js.js
+++ b/grunttasks/l10n-localize-js.js
@@ -30,7 +30,7 @@ module.exports = function (grunt) {
         process: (contents) => {
           // `__translations__:{},` is written in
           // the replace:fetch_translations task.
-          return contents.replace(/__translations__:{},/, '__translations__:' + JSON.stringify(translations) + ',');
+          return contents.replace(/__translations__:\s*{},/, '__translations__:' + JSON.stringify(translations) + ',');
         }
       });
     });


### PR DESCRIPTION
Using `require('/i18n/clients.json');` works perfectly
in RequireJS because it makes a network request for the
resource, but not in Webpack where the bundler
attempts to read that file from disk.

Instead of leaning on RequireJS to fetch the resource
using an XHR request, use an XHR request directly.

Note: this only affects dev mode, translations
are still built into the final bundle in prod mode.