### PR TITLE
feat(logging): log an error when validation fails

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.100.5",
+  "version": "1.102.0",
   "dependencies": {
     "babel-middleware": {
       "version": "0.3.4",
@@ -134,9 +134,9 @@
               "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.5.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "home-or-tmp": {
                   "version": "2.0.0",
@@ -168,14 +168,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             },
@@ -238,9 +238,9 @@
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz"
             },
             "convert-source-map": {
-              "version": "1.5.0",
+              "version": "1.5.1",
               "from": "convert-source-map@>=1.5.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz"
             },
             "debug": {
               "version": "2.6.9",
@@ -354,7 +354,7 @@
                           "dependencies": {
                             "isarray": {
                               "version": "1.0.0",
-                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "from": "isarray@1.0.0",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             }
                           }
@@ -638,14 +638,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -662,14 +662,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -686,14 +686,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -706,18 +706,18 @@
           "dependencies": {
             "babel-runtime": {
               "version": "6.26.0",
-              "from": "babel-runtime@>=6.26.0 <7.0.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             },
@@ -735,7 +735,7 @@
             },
             "babel-traverse": {
               "version": "6.26.0",
-              "from": "babel-traverse@>=6.26.0 <7.0.0",
+              "from": "babel-traverse@>=6.24.1 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
               "dependencies": {
                 "babel-code-frame": {
@@ -851,7 +851,7 @@
             },
             "babel-types": {
               "version": "6.26.0",
-              "from": "babel-types@>=6.26.0 <7.0.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
               "dependencies": {
                 "esutils": {
@@ -909,7 +909,7 @@
             },
             "babel-traverse": {
               "version": "6.26.0",
-              "from": "babel-traverse@>=6.26.0 <7.0.0",
+              "from": "babel-traverse@>=6.24.1 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
               "dependencies": {
                 "babel-code-frame": {
@@ -1034,14 +1034,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             },
@@ -1215,14 +1215,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -1239,14 +1239,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -1263,14 +1263,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             },
@@ -1304,14 +1304,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -1485,14 +1485,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -1509,14 +1509,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -1673,14 +1673,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -1702,14 +1702,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             },
@@ -2030,14 +2030,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -2194,14 +2194,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -2375,14 +2375,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -2395,7 +2395,7 @@
           "dependencies": {
             "babel-traverse": {
               "version": "6.26.0",
-              "from": "babel-traverse@>=6.26.0 <7.0.0",
+              "from": "babel-traverse@>=6.24.1 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
               "dependencies": {
                 "babel-code-frame": {
@@ -2561,14 +2561,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -2602,14 +2602,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -2626,14 +2626,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -2672,14 +2672,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -2696,14 +2696,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -2720,14 +2720,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             }
@@ -2768,14 +2768,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             },
@@ -2822,18 +2822,18 @@
               "dependencies": {
                 "babel-runtime": {
                   "version": "6.26.0",
-                  "from": "babel-runtime@>=6.26.0 <7.0.0",
+                  "from": "babel-runtime@>=6.18.0 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
                   "dependencies": {
                     "core-js": {
-                      "version": "2.5.1",
+                      "version": "2.5.3",
                       "from": "core-js@>=2.4.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                     },
                     "regenerator-runtime": {
-                      "version": "0.11.0",
+                      "version": "0.11.1",
                       "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                     }
                   }
                 },
@@ -2990,9 +2990,9 @@
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz"
     },
     "celebrate": {
-      "version": "4.0.1",
-      "from": "celebrate@4.0.1",
-      "resolved": "https://registry.npmjs.org/celebrate/-/celebrate-4.0.1.tgz",
+      "version": "7.0.3",
+      "from": "celebrate@7.0.3",
+      "resolved": "https://registry.npmjs.org/celebrate/-/celebrate-7.0.3.tgz",
       "dependencies": {
         "escape-html": {
           "version": "1.0.3",
@@ -3015,6 +3015,35 @@
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
+        },
+        "joi": {
+          "version": "12.0.0",
+          "from": "joi@>=12.0.0 <13.0.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
+          "dependencies": {
+            "hoek": {
+              "version": "4.2.0",
+              "from": "hoek@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
+            },
+            "isemail": {
+              "version": "3.0.0",
+              "from": "isemail@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "2.1.0",
+                  "from": "punycode@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz"
+                }
+              }
+            },
+            "topo": {
+              "version": "2.0.2",
+              "from": "topo@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz"
+            }
+          }
         }
       }
     },
@@ -3025,7 +3054,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.3.1",
+          "from": "underscore@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
@@ -3125,12 +3154,12 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "from": "object-assign@>=4.0.0 <5.0.0",
+          "from": "object-assign@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
         },
         "vary": {
           "version": "1.1.2",
-          "from": "vary@>=1.0.0 <2.0.0",
+          "from": "vary@>=1.1.2 <1.2.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
         }
       }
@@ -3382,7 +3411,7 @@
         },
         "vary": {
           "version": "1.1.2",
-          "from": "vary@>=1.0.0 <2.0.0",
+          "from": "vary@>=1.1.2 <1.2.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
         }
       }
@@ -3413,9 +3442,9 @@
               "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.3.1.tgz",
               "dependencies": {
                 "moment": {
-                  "version": "2.19.2",
+                  "version": "2.19.4",
                   "from": "moment@>=2.6.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz"
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.4.tgz"
                 }
               }
             }
@@ -3567,7 +3596,7 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
@@ -3685,9 +3714,9 @@
                   }
                 },
                 "commander": {
-                  "version": "2.11.0",
+                  "version": "2.12.2",
                   "from": "commander@>=2.9.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz"
                 },
                 "is-my-json-valid": {
                   "version": "2.16.1",
@@ -4367,7 +4396,7 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "once": {
@@ -4604,7 +4633,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "from": "minimatch@>=3.0.0 <3.1.0",
+          "from": "minimatch@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dependencies": {
             "brace-expansion": {
@@ -4671,9 +4700,9 @@
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000769",
+              "version": "1.0.30000783",
               "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000769.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz"
             }
           }
         },
@@ -4684,12 +4713,12 @@
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -4716,7 +4745,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
@@ -4771,7 +4800,7 @@
       "dependencies": {
         "babel-core": {
           "version": "6.26.0",
-          "from": "babel-core@>=6.0.12 <7.0.0",
+          "from": "babel-core@>=6.9.1 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
           "dependencies": {
             "babel-code-frame": {
@@ -4896,9 +4925,9 @@
               "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.5.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "home-or-tmp": {
                   "version": "2.0.0",
@@ -4930,14 +4959,14 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.5.1",
+                  "version": "2.5.3",
                   "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz"
                 },
                 "regenerator-runtime": {
-                  "version": "0.11.0",
+                  "version": "0.11.1",
                   "from": "regenerator-runtime@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
                 }
               }
             },
@@ -4979,7 +5008,7 @@
             },
             "babel-types": {
               "version": "6.26.0",
-              "from": "babel-types@>=6.19.0 <7.0.0",
+              "from": "babel-types@>=6.26.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
               "dependencies": {
                 "esutils": {
@@ -5000,9 +5029,9 @@
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz"
             },
             "convert-source-map": {
-              "version": "1.5.0",
+              "version": "1.5.1",
               "from": "convert-source-map@>=1.5.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz"
             },
             "debug": {
               "version": "2.6.9",
@@ -5081,12 +5110,12 @@
       "dependencies": {
         "arrify": {
           "version": "1.0.1",
-          "from": "arrify@>=1.0.0 <2.0.0",
+          "from": "arrify@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
         },
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
+          "from": "async@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "indent-string": {
@@ -5173,7 +5202,7 @@
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
@@ -5399,7 +5428,7 @@
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                      "from": "end-of-stream@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
                       "dependencies": {
                         "once": {
@@ -5462,7 +5491,7 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "pump": {
@@ -5472,7 +5501,7 @@
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                      "from": "end-of-stream@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz"
                     },
                     "once": {
@@ -5641,7 +5670,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
+          "from": "async@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "rimraf": {
@@ -5788,7 +5817,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -5846,12 +5875,12 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
@@ -5919,7 +5948,7 @@
                 },
                 "object-assign": {
                   "version": "4.1.1",
-                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
                 }
               }
@@ -5959,7 +5988,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -6004,9 +6033,9 @@
           }
         },
         "html-minifier": {
-          "version": "3.5.6",
+          "version": "3.5.7",
           "from": "html-minifier@>=3.5.0 <3.6.0",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.6.tgz",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.7.tgz",
           "dependencies": {
             "camel-case": {
               "version": "3.0.0",
@@ -6045,9 +6074,9 @@
               }
             },
             "commander": {
-              "version": "2.11.0",
-              "from": "commander@>=2.11.0 <2.12.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+              "version": "2.12.2",
+              "from": "commander@>=2.12.0 <2.13.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz"
             },
             "he": {
               "version": "1.1.1",
@@ -6091,9 +6120,9 @@
               "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
             },
             "uglify-js": {
-              "version": "3.1.10",
-              "from": "uglify-js@>=3.1.0 <3.2.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.10.tgz",
+              "version": "3.2.2",
+              "from": "uglify-js@>=3.2.0 <3.3.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.2.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.6.1",
@@ -6118,7 +6147,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -6179,7 +6208,7 @@
                 },
                 "object-assign": {
                   "version": "4.1.1",
-                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
                 }
               }
@@ -6618,7 +6647,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.3 <0.2.0",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -6659,7 +6688,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.3 <0.2.0",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -7808,9 +7837,9 @@
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                   "dependencies": {
                     "commander": {
-                      "version": "2.11.0",
+                      "version": "2.12.2",
                       "from": "commander@>=2.9.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz"
                     },
                     "is-my-json-valid": {
                       "version": "2.16.1",
@@ -8057,9 +8086,9 @@
                   "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
                   "dependencies": {
                     "js-base64": {
-                      "version": "2.3.2",
+                      "version": "2.4.0",
                       "from": "js-base64@>=2.1.8 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz"
+                      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz"
                     },
                     "source-map": {
                       "version": "0.4.4",
@@ -8685,9 +8714,9 @@
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
                   "dependencies": {
                     "ajv": {
-                      "version": "5.4.0",
+                      "version": "5.5.1",
                       "from": "ajv@>=5.1.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
@@ -9290,7 +9319,7 @@
             },
             "gettext-parser": {
               "version": "1.3.0",
-              "from": "gettext-parser@>=1.1.2 <2.0.0",
+              "from": "gettext-parser@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.0.tgz",
               "dependencies": {
                 "encoding": {
@@ -9733,9 +9762,9 @@
               "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
             },
             "commander": {
-              "version": "2.11.0",
+              "version": "2.12.2",
               "from": "commander@>=2.9.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
@@ -9768,7 +9797,7 @@
             },
             "jade": {
               "version": "1.11.0",
-              "from": "jade@>=1.0.0 <2.0.0",
+              "from": "jade@>=1.11.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
               "dependencies": {
                 "character-parser": {
@@ -10097,7 +10126,7 @@
       "dependencies": {
         "arrify": {
           "version": "1.0.1",
-          "from": "arrify@>=1.0.0 <2.0.0",
+          "from": "arrify@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
         },
         "multimatch": {
@@ -10124,7 +10153,7 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "from": "minimatch@>=3.0.0 <3.1.0",
+              "from": "minimatch@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "dependencies": {
                 "brace-expansion": {
@@ -10381,9 +10410,9 @@
               }
             },
             "es-abstract": {
-              "version": "1.9.0",
+              "version": "1.10.0",
               "from": "es-abstract@>=1.5.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
               "dependencies": {
                 "es-to-primitive": {
                   "version": "1.1.1",
@@ -10429,7 +10458,7 @@
         "uap-core": {
           "version": "0.5.0",
           "from": "git://github.com/ua-parser/uap-core.git",
-          "resolved": "git://github.com/ua-parser/uap-core.git#157160ae0830a49297c58430917c59a355fc2961"
+          "resolved": "git://github.com/ua-parser/uap-core.git#aad0412268f877ff9d5e806d2ac0a7256210a72b"
         },
         "uap-ref-impl": {
           "version": "0.2.0",
@@ -10595,7 +10624,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -10663,7 +10692,7 @@
             },
             "object-assign": {
               "version": "4.1.1",
-              "from": "object-assign@>=4.0.0 <5.0.0",
+              "from": "object-assign@>=4.1.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
             }
           }
@@ -10772,9 +10801,9 @@
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
               "dependencies": {
                 "ajv": {
-                  "version": "5.4.0",
+                  "version": "5.5.1",
                   "from": "ajv@>=5.1.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
@@ -10995,7 +11024,7 @@
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.3.1",
+          "from": "underscore@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         },
         "uuid": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bluebird": "3.5.0",
     "body-parser": "1.18.2",
     "bower": "1.8.2",
-    "celebrate": "4.0.1",
+    "celebrate": "7.0.3",
     "connect-cachify": "0.0.17",
     "connect-fonts-firasans": "0.0.6",
     "consolidate": "0.14.5",

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 'use strict';
-const celebrate = require('celebrate');
+const { celebrate } = require('celebrate');
 const cors = require('cors');
 const logger = require('./logging/log')('server.routes');
 

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 'use strict';
-const { celebrate } = require('celebrate');
+
+const { celebrate, isCelebrate, errors: celebrateErrors } = require('celebrate');
 const cors = require('cors');
 const logger = require('./logging/log')('server.routes');
 
@@ -119,6 +120,14 @@ module.exports = function (config, i18n) {
 
       routeHandlers.push(route.process);
       app[route.method].apply(app, [route.path].concat(routeHandlers));
+    });
+
+    const defaultErrorHandler = celebrateErrors();
+    app.use((err, req, res, next) => {
+      if (err && isCelebrate(err)) {
+        logger.error(`validation.failed.${req.url}`, { err });
+      }
+      defaultErrorHandler(err, req, res, next);
     });
   };
 };

--- a/server/lib/routes.js
+++ b/server/lib/routes.js
@@ -125,7 +125,7 @@ module.exports = function (config, i18n) {
     const defaultErrorHandler = celebrateErrors();
     app.use((err, req, res, next) => {
       if (err && isCelebrate(err)) {
-        logger.error(`validation.failed.${req.url}`, { err });
+        logger.error('validation.failed', { err, method: req.method, path: req.url });
       }
       defaultErrorHandler(err, req, res, next);
     });


### PR DESCRIPTION
This will enable us to see how many requests to `POST /metrics` are being rejected due to invalid data. I also took the opportunity to update `celebrate` while I was at it.

I tested it locally by hacking the metrics module to send bad data:

```
diff --git a/app/scripts/lib/metrics.js b/app/scripts/lib/metrics.js
index 6c257fa2..3e8ff163 100644
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -268,6 +268,7 @@ define(function (require, exports, module) {
       // reported again.
       this._numStoredAccounts = '';

+      filteredData.entrypoint = 'illegal value';
       const send = () => this._send(filteredData, isPageUnloading);
       return send()
         // Retry once in case of failure, then give up
```

...and then just loading one of our views in the browser so that it sends metrics. That logs an error message to the console, which looks like this:

```
3|content- | fxa-content-server.server.routes.ERROR: validation.failed {"err":"ValidationError: child \"entrypoint\" fails because [\"entrypoint\" with value \"illegal value\" fails to match the required pattern: /^[\\w.:-]+$/]","method":"POST","path":"/metrics"}
```

@mozilla/fxa-devs r?