### PR TITLE
feat(email-first): Report email-first metrics to amplitude.

### DIFF
--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -31,6 +31,7 @@ const APP_VERSION = /^[0-9]+\.([0-9]+)\./.exec(require('../../package.json').ver
 
 const GROUPS = {
   email: 'fxa_email',
+  'email-first': 'fxa_email_first',
   login: 'fxa_login',
   registration: 'fxa_reg',
   settings: 'fxa_pref',
@@ -38,12 +39,14 @@ const GROUPS = {
 };
 
 const ENGAGE_SUBMIT_EVENT_GROUPS = {
+  'enter-email': GROUPS['email-first'],
   'force-auth': GROUPS.login,
   signin: GROUPS.login,
   signup: GROUPS.registration
 };
 
 const VIEW_EVENT_GROUPS = {
+  'enter-email': GROUPS['email-first'],
   'force-auth': GROUPS.login,
   settings: GROUPS.settings,
   signin: GROUPS.login,
@@ -120,6 +123,7 @@ const NOP = () => {};
 
 const EVENT_PROPERTIES = {
   [GROUPS.email]: mixProperties(mapEmailType, mapService),
+  [GROUPS['email-first']]: mapService,
   [GROUPS.login]: mapService,
   [GROUPS.registration]: mapService,
   [GROUPS.settings]: mapDisconnectReason,
@@ -128,6 +132,7 @@ const EVENT_PROPERTIES = {
 
 const USER_PROPERTIES = {
   [GROUPS.email]: mapFlowId,
+  [GROUPS['email-first']]: mixProperties(mapFlowId, mapUtmProperties),
   [GROUPS.login]: mixProperties(mapFlowId, mapUtmProperties),
   [GROUPS.registration]: mixProperties(mapFlowId, mapUtmProperties),
   [GROUPS.settings]: mapNewsletterState,

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -271,6 +271,26 @@ define([
       });
     },
 
+    'flow.enter-email.engage': () => {
+      return amplitude({
+        time: 'a',
+        type: 'flow.enter-email.engage'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '194.12.187.0'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      }).then(() => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0]);
+        assert.equal(arg.event_type, 'fxa_email_first - engage');
+      });
+    },
+
     'flow.force-auth.engage': () => {
       return amplitude({
         time: 'a',
@@ -422,6 +442,26 @@ define([
       });
     },
 
+    'flow.enter-email.submit': () => {
+      return amplitude({
+        time: 'a',
+        type: 'flow.enter-email.submit'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '194.12.187.0'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      }).then(() => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0]);
+        assert.equal(arg.event_type, 'fxa_email_first - submit');
+      });
+    },
+
     'flow.force-auth.submit': () => {
       return amplitude({
         time: 'a',
@@ -496,6 +536,26 @@ define([
         flowId: 'c',
         uid: 'd'
       }).then(() => assert.equal(process.stderr.write.callCount, 0));
+    },
+
+    'screen.enter-email': () => {
+      return amplitude({
+        time: 'a',
+        type: 'screen.enter-email'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '194.12.187.0'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      }).then(() => {
+        assert.equal(process.stderr.write.callCount, 1);
+        const arg = JSON.parse(process.stderr.write.args[0]);
+        assert.equal(arg.event_type, 'fxa_email_first - view');
+      });
     },
 
     'screen.force-auth': () => {


### PR DESCRIPTION
Report:

* fxa_email_first - view
* fxa_email_first - engage
* fxa_email_first - submit

fixes #5788 
Re-opened against train-102 from https://github.com/mozilla/fxa-content-server/pull/5795 which was already given an r+. This uses a slightly different name, `fxa_email_first` rather than `fxa_enter_email`.