### PR TITLE
fix(tests): do not override intern.reporters if already set

### DIFF
--- a/tests/intern_server.js
+++ b/tests/intern_server.js
@@ -9,7 +9,11 @@ define([
   intern.webdriver = {};
   intern.environments = [];
   intern.functionalSuites = [];
-  intern.reporters = [ 'Pretty' ];
+
+  if (! intern.reporters) {
+    intern.reporters = [ 'Pretty' ];
+  }
+
   intern.suites = [
     'tests/server/routes',
     'tests/server/l10n-entrained',


### PR DESCRIPTION
Currently, this overwrites the teamcity reporter here: https://github.com/mozilla/fxa-content-server/blob/master/tests/intern.js#L97-L99

So, only set it if not already set.

r? - @philbooth 