### PR TITLE
fix(metrics): emit amplitude click events earlier

### DIFF
--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -40,6 +40,8 @@ define(function (require, exports, module) {
     // beforeRender is asynchronous and returns a promise. Only render
     // after beforeRender has finished its business.
     beforeRender () {
+      this.logViewEvent('verification.clicked');
+
       var verificationInfo = this._verificationInfo;
       if (! verificationInfo.isValid()) {
         // One or more parameters fails validation. Abort and show an

--- a/app/scripts/views/complete_sign_up.js
+++ b/app/scripts/views/complete_sign_up.js
@@ -58,6 +58,8 @@ define(function (require, exports, module) {
     },
 
     beforeRender () {
+      this.logViewEvent('verification.clicked');
+
       const verificationInfo = this._verificationInfo;
       if (! verificationInfo.isValid()) {
         // One or more parameters fails validation. Abort and show an

--- a/app/tests/spec/views/complete_reset_password.js
+++ b/app/tests/spec/views/complete_reset_password.js
@@ -98,6 +98,20 @@ define(function (require, exports, module) {
       view = windowMock = metrics = null;
     });
 
+    describe('beforeRender', () => {
+      beforeEach(() => {
+        sinon.spy(view, 'logViewEvent');
+        return view.beforeRender();
+      });
+
+      it('emits verification.clicked event correctly', () => {
+        assert.equal(view.logViewEvent.callCount, 1);
+        const args = view.logViewEvent.args[0];
+        assert.equal(args.length, 1);
+        assert.equal(args[0], 'verification.clicked');
+      });
+    });
+
     describe('render', function () {
       it('shows form if token, code and email are all present', function () {
         return view.render()

--- a/app/tests/spec/views/complete_sign_up.js
+++ b/app/tests/spec/views/complete_sign_up.js
@@ -113,6 +113,7 @@ define(function (require, exports, module) {
 
       windowMock.location.search = '?code=' + validCode + '&uid=' + validUid;
       initView(account);
+      sinon.spy(view, 'logViewEvent');
     });
 
     afterEach(function () {
@@ -129,6 +130,19 @@ define(function (require, exports, module) {
       const args = notifier.trigger.args[0];
       assert.equal(args[0], 'set-uid');
       assert.equal(args[1], validUid);
+    });
+
+    describe('beforeRender', () => {
+      beforeEach(() => {
+        view.beforeRender();
+      });
+
+      it('emits verification.clicked event correctly', () => {
+        assert.equal(view.logViewEvent.callCount, 1);
+        const args = view.logViewEvent.args[0];
+        assert.equal(args.length, 1);
+        assert.equal(args[0], 'verification.clicked');
+      });
     });
 
     describe('getAccount', function () {
@@ -556,7 +570,6 @@ define(function (require, exports, module) {
         sinon.stub(view, '_getBrokerMethod').callsFake(() => 'afterCompleteSignIn');
         sinon.stub(view, 'invokeBrokerMethod').callsFake(() => Promise.resolve());
         sinon.stub(view, 'isSignIn').callsFake(() => true);
-        sinon.spy(view, 'logViewEvent');
         sinon.spy(view, 'logEvent');
 
         return view._notifyBrokerAndComplete(account)

--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -111,7 +111,7 @@ const FUZZY_EVENTS = new Map([
     group: GROUPS.settings,
     event: 'disconnect_device'
   } ],
-  [ /^([\w-]+).verification.success$/, {
+  [ /^([\w-]+).verification.clicked$/, {
     isDynamicGroup: true,
     group: eventCategory => eventCategory in EMAIL_TYPES ? GROUPS.email : null,
     event: 'click'

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -754,10 +754,10 @@ registerSuite('amplitude', {
       assert.equal(process.stderr.write.callCount, 0);
     },
 
-    'complete-reset-password.verification.success': () => {
+    'complete-reset-password.verification.clicked': () => {
       amplitude({
         time: 'a',
-        type: 'complete-reset-password.verification.success'
+        type: 'complete-reset-password.verification.clicked'
       }, {
         connection: {},
         headers: {
@@ -803,10 +803,10 @@ registerSuite('amplitude', {
       });
     },
 
-    'complete-signin.verification.success': () => {
+    'complete-signin.verification.clicked': () => {
       amplitude({
         time: 'a',
-        type: 'complete-signin.verification.success'
+        type: 'complete-signin.verification.clicked'
       }, {
         connection: {},
         headers: {
@@ -824,10 +824,10 @@ registerSuite('amplitude', {
       assert.equal(arg.event_properties.email_type, 'login');
     },
 
-    'verify-email.verification.success': () => {
+    'verify-email.verification.clicked': () => {
       amplitude({
         time: 'a',
-        type: 'verify-email.verification.success'
+        type: 'verify-email.verification.clicked'
       }, {
         connection: {},
         headers: {


### PR DESCRIPTION
Fixes #5878.

Previously, amplitude click events were being triggered from the `verification.success` front-end events. As the name suggests, those events don't occur until after verification has succeeded. This change ensures they happen as early as possible after the user has clicked.

Example log line showing the Amplitude event:

```
{"op":"amplitudeEvent","time":1517591889190,"user_id":"728f923b23b44efe9d6f79aa65910c07","device_id":"4f9cac2a627e42bbac71195fd0ada260","event_type":"fxa_email - click","session_id":1517591849700,"event_properties":{"device_id":"4f9cac2a627e42bbac71195fd0ada260","email_type":"registration"},"user_properties":{"ua_browser":"Firefox","ua_version":"60","experiments":["q3form_changes_signup_password_confirm","signup_password_confirm_control"],"flow_id":"fe4d5b37567ab916c93f7ced4610c68b958e3cd1556f570733b41ed1bc981248"},"app_version":"104","language":"en","os_name":"Mac OS X","os_version":"10.11"}
```

@mozilla/fxa-devs r?