### PR TITLE
fix(cad): hide the success message after direct navigation

### DIFF
--- a/app/scripts/templates/connect_another_device.mustache
+++ b/app/scripts/templates/connect_another_device.mustache
@@ -1,16 +1,18 @@
 <div id="main-content" class="card">
   <header class="hidden" id="fxa-connect-another-device-header"><h1>{{#t}}Connect another device{{/t}}</h1></header>
-  {{#isSignedIn}}
-    <div class="success success-authenticated visible">{{#t}}This Firefox is connected{{/t}}</div>
-  {{/isSignedIn}}
-  {{^isSignedIn}}
-    {{#isSignUp}}
-      <div class="success success-not-authenticated visible">{{#t}}Email verified{{/t}}</div>
-    {{/isSignUp}}
-    {{#isSignIn}}
-      <div class="success success-not-authenticated visible">{{#t}}Sign-in confirmed{{/t}}</div>
-    {{/isSignIn}}
-  {{/isSignedIn}}
+  {{#showSuccessMessage}}
+    {{#isSignedIn}}
+      <div class="success success-authenticated visible">{{#t}}This Firefox is connected{{/t}}</div>
+    {{/isSignedIn}}
+    {{^isSignedIn}}
+      {{#isSignUp}}
+        <div class="success success-not-authenticated visible">{{#t}}Email verified{{/t}}</div>
+      {{/isSignUp}}
+      {{#isSignIn}}
+        <div class="success success-not-authenticated visible">{{#t}}Sign-in confirmed{{/t}}</div>
+      {{/isSignIn}}
+    {{/isSignedIn}}
+  {{/showSuccessMessage}}
   <section>
     <div class="graphic graphic-connect-another-device">{{#t}}Success{{/t}}</div>
 

--- a/app/scripts/templates/sms_send.mustache
+++ b/app/scripts/templates/sms_send.mustache
@@ -1,6 +1,8 @@
 <div id="main-content" class="card">
     <header class="hidden" id="fxa-send-sms-header"><h1>{{#t}}Send Firefox directly to your smartphone and sign in to complete set-up{{/t}}</h1></header>
-    <div class="success visible">{{#t}}This Firefox is connected{{/t}}</div>
+	{{#showSuccessMessage}}
+      <div class="success visible">{{#t}}This Firefox is connected{{/t}}</div>
+	{{/showSuccessMessage}}
     <div class="error"></div>
 
     <section class="send-sms">

--- a/app/scripts/views/connect_another_device.js
+++ b/app/scripts/views/connect_another_device.js
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
       return this.getEligibleSmsCountry(account)
         .then((country) => {
           if (country) {
-            return this.replaceCurrentPageWithSmsScreen(account, country);
+            return this.replaceCurrentPageWithSmsScreen(account, country, this._showSuccessMessage());
           }
         });
     }
@@ -156,6 +156,7 @@ define(function (require, exports, module) {
       const isOther = ! isAndroid && ! isIos && ! isFirefoxDesktop;
       const isSignIn = this.isSignIn();
       const isSignUp = this.isSignUp();
+      const showSuccessMessage = this._showSuccessMessage();
 
       context.set({
         canSignIn,
@@ -169,7 +170,8 @@ define(function (require, exports, module) {
         isOtherIos,
         isSignIn,
         isSignUp,
-        isSignedIn
+        isSignedIn,
+        showSuccessMessage
       });
     }
 
@@ -203,6 +205,19 @@ define(function (require, exports, module) {
     _canSignIn () {
       // Only users that are not signed in can do so.
       return ! this._isSignedIn() && this.isSyncAuthSupported();
+    }
+
+    /**
+     * Check whether to render the success message at the top of the view.
+     * This enables Firefox code to link directly to this view without a
+     * misleading status message being displayed. When navigating internally,
+     * the connect-another-device-mixin ensures it gets set to true.
+     *
+     * @returns {Boolean}
+     * @private
+     */
+    _showSuccessMessage () {
+      return !! this.model.get('showSuccessMessage');
     }
 
     /**

--- a/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -68,7 +68,7 @@ define(function(require, exports, module) {
         }
 
         const type = this.model.get('type');
-        this.navigate('connect_another_device', { account, type });
+        this.navigate('connect_another_device', { account, showSuccessMessage: true, type });
       });
     },
 
@@ -77,10 +77,11 @@ define(function(require, exports, module) {
      *
      * @param {Object} account
      * @param {String} country
+     * @param {Boolean} showSuccessMessage
      */
-    replaceCurrentPageWithSmsScreen (account, country) {
+    replaceCurrentPageWithSmsScreen (account, country, showSuccessMessage) {
       const type = this.model.get('type');
-      this.replaceCurrentPage('sms', { account, country, type });
+      this.replaceCurrentPage('sms', { account, country, showSuccessMessage, type });
     },
 
     /**

--- a/app/scripts/views/sms_send.js
+++ b/app/scripts/views/sms_send.js
@@ -68,6 +68,7 @@ define(function (require, exports, module) {
         escapedLearnMoreAttributes,
         isSignIn,
         phoneNumber,
+        showSuccessMessage: this.model.get('showSuccessMessage')
       });
     }
 

--- a/app/tests/spec/views/connect_another_device.js
+++ b/app/tests/spec/views/connect_another_device.js
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
       broker = new AuthBroker( { relier });
       broker.setCapability('emailVerificationMarketingSnippet', true);
 
-      model = new Backbone.Model({ account });
+      model = new Backbone.Model({ account, showSuccessMessage: true });
       windowMock = new WindowMock();
 
       notifier = new Notifier();
@@ -79,7 +79,7 @@ define(function (require, exports, module) {
 
         it('redirects the user to the /sms page', () => {
           assert.isTrue(view.replaceCurrentPageWithSmsScreen.calledOnce);
-          assert.isTrue(view.replaceCurrentPageWithSmsScreen.calledWith(account, 'GB'));
+          assert.isTrue(view.replaceCurrentPageWithSmsScreen.calledWith(account, 'GB', true));
         });
       });
 
@@ -103,6 +103,10 @@ define(function (require, exports, module) {
           testIsFlowEventLogged('install_from.fx_desktop');
 
           assert.isFalse(view.replaceCurrentPageWithSmsScreen.called);
+        });
+
+        it('shows the success message', () => {
+          assert.lengthOf(view.$('.success'), 1);
         });
       });
 
@@ -133,6 +137,10 @@ define(function (require, exports, module) {
           testIsFlowEventLogged('signedin.true');
           testIsFlowEventLogged('signin.ineligible');
           testIsFlowEventLogged('install_from.fx_android');
+        });
+
+        it('shows the success message', () => {
+          assert.lengthOf(view.$('.success'), 1);
         });
       });
 
@@ -166,6 +174,10 @@ define(function (require, exports, module) {
           testIsFlowEventLogged('signin.eligible');
           testIsFlowEventLogged('signin_from.fx_desktop');
         });
+
+        it('shows the success message', () => {
+          assert.lengthOf(view.$('.success'), 1);
+        });
       });
 
       describe('with a fennec user that can sign in', () => {
@@ -197,6 +209,10 @@ define(function (require, exports, module) {
           testIsFlowEventLogged('signedin.false');
           testIsFlowEventLogged('signin.eligible');
           testIsFlowEventLogged('signin_from.fx_android');
+        });
+
+        it('shows the success message', () => {
+          assert.lengthOf(view.$('.success'), 1);
         });
       });
 
@@ -315,6 +331,39 @@ define(function (require, exports, module) {
               assert.lengthOf(view.$('.marketing-area'), 1);
               testIsFlowEventLogged('install_from.other');
             });
+        });
+      });
+
+      describe('with showSuccessMessage set to false', () => {
+        beforeEach(() => {
+          model.set('showSuccessMessage', false);
+          sinon.stub(view, '_isSignedIn').callsFake(() => true);
+
+          windowMock.navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
+
+          return view.render()
+            .then(() => {
+              view.afterVisible();
+            });
+        });
+
+        it('does not show the success message', () => {
+          assert.lengthOf(view.$('.success'), 0);
+        });
+      });
+
+      describe('with showSuccessMessage set to false for a user that can send an SMS', () => {
+        beforeEach(() => {
+          model.set('showSuccessMessage', false);
+          smsCountry = 'CA';
+
+          return view.render()
+            .then(() => view.afterVisible());
+        });
+
+        it('redirects the user to the /sms page', () => {
+          assert.isTrue(view.replaceCurrentPageWithSmsScreen.calledOnce);
+          assert.isTrue(view.replaceCurrentPageWithSmsScreen.calledWith(account, 'CA', false));
         });
       });
     });

--- a/app/tests/spec/views/mixins/connect-another-device-mixin.js
+++ b/app/tests/spec/views/mixins/connect-another-device-mixin.js
@@ -310,7 +310,11 @@ define(function (require, exports, module) {
             return view.navigateToConnectAnotherDeviceScreen(account)
               .then(() => {
                 assert.isTrue(view.navigate.calledOnce);
-                assert.isTrue(view.navigate.calledWith('connect_another_device', { account, type: 'signin' }));
+                assert.isTrue(view.navigate.calledWith('connect_another_device', {
+                  account,
+                  showSuccessMessage: true,
+                  type: 'signin'
+                }));
               });
           });
         });
@@ -392,10 +396,15 @@ define(function (require, exports, module) {
           sinon.spy(view, 'replaceCurrentPage');
 
           const account = {};
-          view.replaceCurrentPageWithSmsScreen (account, 'GB');
+          view.replaceCurrentPageWithSmsScreen (account, 'GB', true);
 
           assert.isTrue(view.replaceCurrentPage.calledOnce);
-          assert.isTrue(view.replaceCurrentPage.calledWith('sms', { account, country: 'GB', type: 'signin' }));
+          assert.isTrue(view.replaceCurrentPage.calledWith('sms', {
+            account,
+            country: 'GB',
+            showSuccessMessage: true,
+            type: 'signin'
+          }));
         });
       });
     });

--- a/app/tests/spec/views/sms_send.js
+++ b/app/tests/spec/views/sms_send.js
@@ -47,7 +47,7 @@ define(function(require, exports, module) {
       broker = new Broker();
       formPrefill = new Backbone.Model({});
       metrics = new Metrics();
-      model = new Backbone.Model({ account });
+      model = new Backbone.Model({ account, showSuccessMessage: true });
       notifier = new Notifier();
       relier = new Relier({ service: 'sync' });
 
@@ -69,6 +69,7 @@ define(function(require, exports, module) {
         assert.equal(view.$('input[type=tel]').__val(), '');
         assert.equal(view.$('input[type=tel]').data('country'), 'US');
         assert.lengthOf(view.$('.marketing-link'), 2);
+        assert.lengthOf(view.$('.success'), 1);
 
         // ensure clicks on the marketing links work as expected.
         sinon.spy(metrics, 'logMarketingClick');
@@ -138,6 +139,15 @@ define(function(require, exports, module) {
         return view.render()
           .then(() => {
             assert.include(view.$('.send-sms > p').text().toLowerCase(), 'still adding devices');
+          });
+      });
+
+      it('with showSuccessMessage set to false, no success message is rendered', () => {
+        model.set('showSuccessMessage', false);
+
+        return view.render()
+          .then(() => {
+            assert.lengthOf(view.$('.success'), 0);
           });
       });
     });

--- a/tests/functional/connect_another_device.js
+++ b/tests/functional/connect_another_device.js
@@ -79,7 +79,8 @@ registerSuite('connect_another_device', {
         .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SIGNIN_BUTTON))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.TEXT_INSTALL_FX_DESKTOP))
         .then(testHrefEquals(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_IOS, ADJUST_LINK_IOS))
-        .then(testHrefEquals(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_ANDROID, ADJUST_LINK_ANDROID));
+        .then(testHrefEquals(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_ANDROID, ADJUST_LINK_ANDROID))
+        .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS));
     },
 
     'signup Fx Desktop, load /connect_another_device page, SMS enabled': function () {
@@ -93,7 +94,8 @@ registerSuite('connect_another_device', {
 
         .then(openPage(CONNECT_ANOTHER_DEVICE_SMS_ENABLED_URL, selectors.SMS_SEND.HEADER))
         .then(testHrefEquals(selectors.SMS_SEND.LINK_MARKETING_IOS, ADJUST_LINK_IOS))
-        .then(testHrefEquals(selectors.SMS_SEND.LINK_MARKETING_ANDROID, ADJUST_LINK_ANDROID));
+        .then(testHrefEquals(selectors.SMS_SEND.LINK_MARKETING_ANDROID, ADJUST_LINK_ANDROID))
+        .then(noSuchElement(selectors.SMS_SEND.SUCCESS));
     },
 
     'signup Fx Desktop, verify same browser': function () {
@@ -114,7 +116,8 @@ registerSuite('connect_another_device', {
         .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SIGNIN_BUTTON))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.TEXT_INSTALL_FX_DESKTOP))
         .then(testHrefEquals(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_IOS, ADJUST_LINK_IOS))
-        .then(testHrefEquals(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_ANDROID, ADJUST_LINK_ANDROID));
+        .then(testHrefEquals(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_ANDROID, ADJUST_LINK_ANDROID))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS));
     },
 
     'signup Fx Desktop, verify different Fx Desktop': function () {
@@ -134,6 +137,7 @@ registerSuite('connect_another_device', {
         .then(clearBrowserState())
 
         .then(openVerificationLinkInSameTab(email, 0, {query: {forceUA}}))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS_DIFFERENT_BROWSER))
 
         // ask "why must I do this?"
@@ -164,9 +168,11 @@ registerSuite('connect_another_device', {
         .then(openVerificationLinkInNewTab(email, 0, { query }))
         .then(switchToWindow(1))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         .then(closeCurrentWindow())
 
-        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS));
     },
 
     'signup Fx Desktop, verify different Fx Desktop with another user already signed in': function () {
@@ -188,6 +194,7 @@ registerSuite('connect_another_device', {
 
 
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
 
         // NOW - go back and open the verification link for the signup user in a
         // browser where another user is already signed in.
@@ -219,6 +226,7 @@ registerSuite('connect_another_device', {
             forceUA: UA_STRINGS['android_firefox']
           }
         }))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS_DIFFERENT_BROWSER))
 
         // ask "why must I do this?"
@@ -257,6 +265,7 @@ registerSuite('connect_another_device', {
             forceUA: UA_STRINGS['ios_firefox']
           }
         }))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS_DIFFERENT_BROWSER))
 
         // ask "why must I do this?"
@@ -292,6 +301,7 @@ registerSuite('connect_another_device', {
             forceUA: UA_STRINGS['android_chrome']
           }
         }))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS_DIFFERENT_BROWSER))
         .then(testElementTextInclude(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS_DIFFERENT_BROWSER, 'email verified'))
 
@@ -304,12 +314,7 @@ registerSuite('connect_another_device', {
         .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SIGNIN_BUTTON))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.TEXT_INSTALL_FX_ANDROID))
         .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_IOS))
-        .then(testHrefEquals(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_ANDROID, ADJUST_LINK_ANDROID))
-
-        .refresh()
-
-        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS_DIFFERENT_BROWSER))
-        .then(testElementTextInclude(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS_DIFFERENT_BROWSER, 'email verified'));
+        .then(testHrefEquals(selectors.CONNECT_ANOTHER_DEVICE.LINK_INSTALL_ANDROID, ADJUST_LINK_ANDROID));
     },
 
     'signup Fx Desktop, verify in Chrome Desktop': function () {
@@ -333,6 +338,7 @@ registerSuite('connect_another_device', {
             forceUA: UA_STRINGS['desktop_chrome']
           }
         }))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS_DIFFERENT_BROWSER))
 
         // ask "why must I do this?"
@@ -366,6 +372,7 @@ registerSuite('connect_another_device', {
             forceUA: UA_STRINGS['ios_safari']
           }
         }))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS_DIFFERENT_BROWSER))
 
         // ask "why must I do this?"
@@ -401,6 +408,7 @@ registerSuite('connect_another_device', {
           }
         }))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS_SAME_BROWSER))
 
         .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SIGNIN_BUTTON))

--- a/tests/functional/fx_firstrun_v2_sign_up.js
+++ b/tests/functional/fx_firstrun_v2_sign_up.js
@@ -87,11 +87,13 @@ const verifyMobileTest = thenify(function (verificationUaString) {
     // mobile users are ineligible to send an SMS, they should be redirected
     // to the "connect another device" screen
     .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+    .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
 
     // switch back to the original window, user should be
     // able to send an SMS.
     .then(closeCurrentWindow())
-    .then(testElementExists(selectors.SMS_SEND.HEADER));
+    .then(testElementExists(selectors.SMS_SEND.HEADER))
+    .then(testElementExists(selectors.SMS_SEND.SUCCESS));
 });
 
 registerSuite('Firstrun Sync v2 signup', {
@@ -181,13 +183,15 @@ registerSuite('Firstrun Sync v2 signup', {
         // synthesize what the other browser sees.
         .then(openVerificationLinkInDifferentBrowser(email, 0))
         .then(testElementExists(selectors.SMS_SEND.HEADER))
+        .then(testElementExists(selectors.SMS_SEND.SUCCESS))
 
         // clear browser state to synthesize opening in a different browser
         .then(clearBrowserState({force: true}))
         // verify the user in a different browser, they should see the
         // "connect another device" screen.
         .then(openVerificationLinkInSameTab(email, 0, options))
-        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS));
     },
 
     'verify same browser, force SMS, force supported country': function () {
@@ -208,11 +212,13 @@ registerSuite('Firstrun Sync v2 signup', {
 
         // user should be redirected to "Send SMS" screen.
         .then(testElementExists(selectors.SMS_SEND.HEADER))
+        .then(testElementExists(selectors.SMS_SEND.SUCCESS))
         .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', 'CA'))
 
         // switch back to the original window, it should transition to the verification tab.
         .then(closeCurrentWindow())
-        .then(testElementExists(selectors.SMS_SEND.HEADER));
+        .then(testElementExists(selectors.SMS_SEND.HEADER))
+        .then(testElementExists(selectors.SMS_SEND.SUCCESS));
     },
 
     'force SMS, force unsupported country in signup tab': function () {

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -59,6 +59,7 @@ module.exports = {
     LINK_INSTALL_IOS: '.marketing-link-ios',
     LINK_WHY_IS_THIS_REQUIRED: 'a[href="/connect_another_device/why"]',
     SIGNIN_BUTTON: 'form div a',
+    SUCCESS: '.success',
     SUCCESS_DIFFERENT_BROWSER: '.success-not-authenticated',
     SUCCESS_SAME_BROWSER: '.success-authenticated',
     TEXT_INSTALL_FROM_OTHER: '#install-mobile-firefox-other',
@@ -235,7 +236,8 @@ module.exports = {
     LINK_WHY_IS_THIS_REQUIRED: 'a[href="/sms/why"]',
     PHONE_NUMBER: 'input[type="tel"]',
     PHONE_NUMBER_TOOLTIP: 'input[type="tel"] ~ .tooltip',
-    SUBMIT: 'button[type="submit"]'
+    SUBMIT: 'button[type="submit"]',
+    SUCCESS: '.success'
   },
   SMS_SENT: {
     HEADER: '#fxa-sms-sent-header',

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -43,6 +43,7 @@ const {
   fillOutSignUp,
   getSms,
   getSmsSigninCode,
+  noSuchElement,
   openPage,
   switchToWindow,
   testAttributeEquals,
@@ -60,7 +61,8 @@ function testSmsSupportedCountryForm (country, expectedPrefix) {
         query: { country },
       }))
       .then(testElementValueEquals(selectors.SMS_SEND.PHONE_NUMBER, expectedPrefix))
-      .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', country));
+      .then(testAttributeEquals(selectors.SMS_SEND.PHONE_NUMBER, 'data-country', country))
+      .then(noSuchElement(selectors.SMS_SEND.SUCCESS));
   };
 }
 

--- a/tests/functional/sync_v3_sign_up.js
+++ b/tests/functional/sync_v3_sign_up.js
@@ -67,6 +67,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
         .then(openVerificationLinkInNewTab(email, 0))
         .then(switchToWindow(1))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SIGNIN_BUTTON))
         // switch back to the original window, it should transition to CAD.
         .then(closeCurrentWindow())
@@ -96,6 +97,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
         .then(openVerificationLinkInNewTab(email, 0))
         .then(switchToWindow(1))
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         .then(noSuchElement(selectors.CONNECT_ANOTHER_DEVICE.SIGNIN_BUTTON))
         // switch back to the original window, it should transition to CAD.
         .then(closeCurrentWindow())
@@ -103,6 +105,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
         // In Fx >= 58, about:accounts does not take over.
         // Expect a screen transition.
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
         // but the login message is sent automatically.
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
@@ -146,6 +149,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
         .then(switchToWindow(1))
 
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.SUCCESS))
 
         .then(closeCurrentWindow())
 
@@ -222,7 +226,8 @@ registerSuite('Firefox Desktop Sync v3 signup', {
                 }
               }
             }));
-        });
+        })
+        .then(testElementExists(selectors.SMS_SEND.SUCCESS));
     },
 
     'Fx >= 56, engines not supported': function () {


### PR DESCRIPTION
Fixes #5852.

Adds a little bit of conditional logic to the templates for `/connect_another_device` and `/sms` so that they don't show a success message when navigated to directly. The success message is still shown when navigation happens internally.

Seeing as this is wanted for Fx 59, I reckon it's worth tagging in to a 105.1 point release if you guys think the approach here is okay. (or no worries if not, we agreed on train 106 last night and I'm happy to change what I've done here if it's not content-servery enough)

Screen shots after navigating directly:

<img width="833" alt="Screenshot of /connect_another_device after direct navigation, without a success message" src="https://user-images.githubusercontent.com/64367/35862032-1b9dd8be-0b42-11e8-82a0-5c53df7204b0.png" />

<img width="820" alt="Screenshot of /sms after direct navigation, without a success message" src="https://user-images.githubusercontent.com/64367/35862068-3d1b57dc-0b42-11e8-9e9f-9704c3ec5ec0.png" />

Screenshots after navigating internally:

<img width="843" alt="Screenshot of /connect_another_device after internal navigation, with a success message" src="https://user-images.githubusercontent.com/64367/35862112-591fb964-0b42-11e8-8824-c141b7ef2233.png" />

<img width="834" alt="Screenshot of /sms after internal navigation, with a success message" src="https://user-images.githubusercontent.com/64367/35862148-6da0dde6-0b42-11e8-954c-60619df2784b.png">

@mozilla/fxa-devs r?