### PR TITLE
fix(tests): install fxa-js-client for teamcity tests

### DIFF
--- a/tests/teamcity/run.sh
+++ b/tests/teamcity/run.sh
@@ -75,6 +75,7 @@ node ./tests/teamcity/install-npm-deps.js \
   bower                           \
   convict                         \
   firefox-profile                 \
+  fxa-js-client                   \
   fxa-shared                      \
   got                             \
   intern                          \


### PR DESCRIPTION
@vladikoff 

Here also.

(Yeah, should refactor this to be clearer. Could just install everything, but that's a time sink).