### PR TITLE
fix(tokenCode): Add support for tokenCode sync experiment

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/token-code.js
+++ b/app/scripts/lib/experiments/grouping-rules/token-code.js
@@ -26,6 +26,7 @@ define(function (require, exports, module) {
     constructor() {
       super();
       this.name = 'tokenCode';
+      this.SYNC_ROLLOUT_RATE = 0.0;
     }
 
     choose(subject) {
@@ -35,6 +36,10 @@ define(function (require, exports, module) {
 
       const client = ROLLOUT_CLIENTS[subject.clientId];
       if (client && this.bernoulliTrial(client.rolloutRate, subject.uniqueUserId)) {
+        return this.uniformChoice(GROUPS, subject.uniqueUserId);
+      }
+      const isSync = this.get('service') === 'Sync';
+      if (isSync && this.bernoulliTrial(this.SYNC_ROLLOUT_RATE, subject.uniqueUserId)) {
         return this.uniformChoice(GROUPS, subject.uniqueUserId);
       }
 

--- a/app/scripts/models/auth_brokers/fx-sync-web-channel.js
+++ b/app/scripts/models/auth_brokers/fx-sync-web-channel.js
@@ -40,7 +40,12 @@ define(function (require, exports, module) {
       });
 
       return channel;
-    }
+    },
+
+    afterCompleteSignInTokenCode (account) {
+      return this._notifyRelierOfLogin(account)
+        .then(() => proto.afterSignInConfirmationPoll.call(this, account));
+    },
   });
 
   module.exports = FxSyncWebChannelAuthenticationBroker;

--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -41,7 +41,8 @@ define(function (require, exports, module) {
     defaults: _.extend({}, Relier.prototype.defaults, {
       action: undefined,
       customizeSync: false,
-      signinCode: undefined
+      signinCode: undefined,
+      tokenCode: true
     }),
 
     initialize (attributes, options = {}) {


### PR DESCRIPTION
Fixes #5886 

This PR adds support to perform tokenCode experiment on sync users. WIP Until https://github.com/mozilla/fxa-auth-db-mysql/pull/303 and https://github.com/mozilla/fxa-auth-server/pull/2287 are merged.