### PR TITLE
feat(signin): Re-authenticate an existing session if possible.

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -299,6 +299,76 @@ define(function (require, exports, module) {
     }),
 
     /**
+     * Re-authenticate a user.
+     *
+     * @method sessionReauth
+     * @param {String} sessionToken
+     * @param {String} originalEmail
+     * @param {String} password
+     * @param {Relier} relier
+     * @param {Object} [options]
+     *   @param {String} [options.metricsContext] - context metadata for use in
+     *                   flow events
+     *   @param {String} [options.reason] - Reason for the sign in. See definitions
+     *                   in sign-in-reasons.js. Defaults to SIGN_IN_REASONS.SIGN_IN.
+     *   @param {String} [options.resume] - Resume token, passed in the
+     *                   verification link if the user must verify their email.
+     *   @param {Boolean} [options.skipCaseError] - if set to true, INCORRECT_EMAIL_CASE
+     *                   errors will be returned to be handled locally instead of automatically
+     *                   being retried in the fxa-js-client.
+     *   @param {String} [options.unblockCode] - Unblock code.
+     *   @param {String} [options.originalLoginEmail] - the original email address as entered
+     *                   by the user, if different from the one used for login.
+     *   @param {String} [options.verificationMethod] - the method to use to verify the
+     *                   session, if it is not already verified.
+     * @returns {Promise}
+     */
+    sessionReauth: withClient((client, sessionToken, originalEmail, password, relier, options = {}) => {
+      var email = trim(originalEmail);
+
+      var reauthOptions = {
+        keys: wantsKeys(relier),
+        reason: options.reason || SignInReasons.SIGN_IN
+      };
+
+      if (relier.has('service')) {
+        reauthOptions.service = relier.get('service');
+      }
+
+      if (relier.has('redirectTo')) {
+        reauthOptions.redirectTo = relier.get('redirectTo');
+      }
+
+      if (options.unblockCode) {
+        reauthOptions.unblockCode = options.unblockCode;
+      }
+
+      if (options.resume) {
+        reauthOptions.resume = options.resume;
+      }
+
+      if (options.skipCaseError) {
+        reauthOptions.skipCaseError = options.skipCaseError;
+      }
+
+      if (options.originalLoginEmail) {
+        reauthOptions.originalLoginEmail = options.originalLoginEmail;
+      }
+
+      if (options.verificationMethod) {
+        reauthOptions.verificationMethod = options.verificationMethod;
+      }
+
+      setMetricsContext(reauthOptions, options);
+
+      return client.sessionReauth(sessionToken, email, password, reauthOptions)
+        .then(function (accountData) {
+          accountData.sessionToken = sessionToken;
+          return getUpdatedSessionData(email, relier, accountData, options);
+        });
+    }),
+
+    /**
      * Sign up a user
      *
      * @method signUp

--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -324,9 +324,9 @@ define(function (require, exports, module) {
      * @returns {Promise}
      */
     sessionReauth: withClient((client, sessionToken, originalEmail, password, relier, options = {}) => {
-      var email = trim(originalEmail);
+      const email = trim(originalEmail);
 
-      var reauthOptions = {
+      const reauthOptions = {
         keys: wantsKeys(relier),
         reason: options.reason || SignInReasons.SIGN_IN
       };
@@ -362,7 +362,7 @@ define(function (require, exports, module) {
       setMetricsContext(reauthOptions, options);
 
       return client.sessionReauth(sessionToken, email, password, reauthOptions)
-        .then(function (accountData) {
+        .then(accountData => {
           accountData.sessionToken = sessionToken;
           return getUpdatedSessionData(email, relier, accountData, options);
         });

--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -128,7 +128,7 @@ define(function (require, exports, module) {
         .catch((err) => {
           // if invalid token then invalidate session
           if (AuthErrors.is(err, 'INVALID_TOKEN')) {
-            return this._invalidateSession();
+            this.discardSessionToken();
           }
 
           // Ignore UNAUTHORIZED errors; we'll just fetch again when needed
@@ -139,10 +139,8 @@ define(function (require, exports, module) {
         });
     },
 
-    _invalidateSession () {
-      // Invalid token can happen if user uses 'Disconnect'
-      // in Firefox Desktop. Only 'set' will trigger model
-      // change, using 'unset' will not.
+    discardSessionToken () {
+      // Only 'set' will trigger model change, using 'unset' will not.
       //
       // Details:
       // github.com/jashkenas/backbone/issues/949 and
@@ -455,7 +453,7 @@ define(function (require, exports, module) {
                 if (! AuthErrors.is(err, 'INVALID_TOKEN')) {
                   throw err;
                 }
-                this._invalidateSession();
+                this.discardSessionToken();
                 return this._fxaClient.signIn(email, password, relier, signinOptions);
               });
           }
@@ -1254,7 +1252,7 @@ define(function (require, exports, module) {
           })
           .catch((err) => {
             if (ProfileErrors.is(err, 'INVALID_TOKEN')) {
-              this._invalidateSession();
+              this.discardSessionToken();
             } else if (ProfileErrors.is(err, 'UNAUTHORIZED')) {
               // If no oauth token existed, or it has gone stale,
               // get a new one and retry.

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -482,6 +482,11 @@ define(function (require, exports, module) {
        */
       handleSignedInNotification: true,
       /**
+       * If the user has an existing sessionToken, can we safely re-use it
+       * on subsequent signin attempts rather than generating a new token each time?
+       */
+      reuseExistingSession: false,
+      /**
        * Is signup supported? the fx_ios_v1 broker can disable it.
        */
       signup: true,

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -64,6 +64,7 @@ define(function (require, exports, module) {
       // unintended consequences from redirecting to a relier URL more than
       // once.
       handleSignedInNotification: false,
+      reuseExistingSession: true,
       tokenCode: true
     }),
 

--- a/app/scripts/models/auth_brokers/web.js
+++ b/app/scripts/models/auth_brokers/web.js
@@ -39,6 +39,10 @@ define(function (require, exports, module) {
       afterSignUpConfirmationPoll: redirectToSettingsBehavior
     }),
 
+    defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
+      reuseExistingSession: true
+    }),
+
     type: CONTENT_SERVER_CONTEXT
   });
 });

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -61,6 +61,12 @@ define(function (require, exports, module) {
             }
           }
 
+          // Some brokers (e.g. Sync) hand off control of the sessionToken, and hence expect
+          // each signin to generate a fresh token.  Make sure that will happen.
+          if (account.has('sessionToken') && ! this.broker.hasCapability('reuseExistingSession')) {
+            account.discardSessionToken();
+          }
+
           return this.user.signInAccount(account, password, this.relier, {
             // a resume token is passed in to allow
             // unverified account or session users to complete

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -113,13 +113,13 @@ define(function (require, exports, module) {
     },
 
     submit () {
-      var account = this.getAccount();
-      var email = this.getElementValue('.email');
-      var password = this.getElementValue('.password');
+      const email = this.getElementValue('.email');
+      const password = this.getElementValue('.password');
 
       // Re-authenticate the current account if we're signing in
       // with the same email address; otherwise start afresh.
-      if (! account || account.get('email') !== email) {
+      let account = this.getAccount();
+      if (! account || ! account.has('email') || account.get('email').toLowerCase() !== email.toLowerCase()) {
         account = this.user.initAccount({
           email: email
         });

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -113,11 +113,17 @@ define(function (require, exports, module) {
     },
 
     submit () {
-      var account = this.user.initAccount({
-        email: this.getElementValue('.email')
-      });
-
+      var account = this.getAccount();
+      var email = this.getElementValue('.email');
       var password = this.getElementValue('.password');
+
+      // Re-authenticate the current account if we're signing in
+      // with the same email address; otherwise start afresh.
+      if (! account || account.get('email') !== email) {
+        account = this.user.initAccount({
+          email: email
+        });
+      }
 
       return this._signIn(account, password);
     },

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -278,11 +278,11 @@ define(function (require, exports, module) {
       });
     });
 
-    describe('signIn', function () {
-      describe('with a password and no sessionToken', function () {
-        describe('unverified, reason === undefined', function () {
-          beforeEach(function () {
-            sinon.stub(fxaClient, 'signIn').callsFake(function () {
+    describe('signIn', () => {
+      describe('with a password and no sessionToken', () => {
+        describe('unverified, reason === undefined', () => {
+          beforeEach(() => {
+            sinon.stub(fxaClient, 'signIn').callsFake(() => {
               return Promise.resolve({
                 sessionToken: SESSION_TOKEN,
                 uid: UID,
@@ -292,7 +292,7 @@ define(function (require, exports, module) {
               });
             });
 
-            sinon.stub(fxaClient, 'signUpResend').callsFake(function () {
+            sinon.stub(fxaClient, 'signUpResend').callsFake(() => {
               return Promise.resolve();
             });
 
@@ -302,7 +302,7 @@ define(function (require, exports, module) {
             });
           });
 
-          it('delegates to the fxaClient', function () {
+          it('delegates to the fxaClient', () => {
             assert.isTrue(fxaClient.signIn.calledWith(EMAIL, PASSWORD, relier, {
               metricsContext: {
                 baz: 'qux',
@@ -315,11 +315,11 @@ define(function (require, exports, module) {
             }));
           });
 
-          it('does not resend a signUp email', function () {
+          it('does not resend a signUp email', () => {
             assert.isFalse(fxaClient.signUpResend.called);
           });
 
-          it('updates the account with the returned data', function () {
+          it('updates the account with the returned data', () => {
             assert.isFalse(account.get('verified'));
             assert.equal(account.get('sessionToken'), SESSION_TOKEN);
             assert.equal(account.get('uid'), UID);
@@ -334,9 +334,9 @@ define(function (require, exports, module) {
           });
         });
 
-        describe('verified account, unverified session', function () {
-          beforeEach(function () {
-            sinon.stub(fxaClient, 'signIn').callsFake(function () {
+        describe('verified account, unverified session', () => {
+          beforeEach(() => {
+            sinon.stub(fxaClient, 'signIn').callsFake(() => {
               return Promise.resolve({
                 sessionToken: SESSION_TOKEN,
                 verificationMethod: VerificationMethods.EMAIL,
@@ -345,22 +345,22 @@ define(function (require, exports, module) {
               });
             });
 
-            sinon.stub(fxaClient, 'signUpResend').callsFake(function () {
+            sinon.stub(fxaClient, 'signUpResend').callsFake(() => {
               return Promise.resolve();
             });
 
             return account.signIn(PASSWORD, relier, { resume: 'resume token' });
           });
 
-          it('delegates to the fxaClient', function () {
+          it('delegates to the fxaClient', () => {
             assert.isTrue(fxaClient.signIn.calledWith(EMAIL, PASSWORD, relier));
           });
 
-          it('does not delegate to the fxaClient to send re-confirmation email', function () {
+          it('does not delegate to the fxaClient to send re-confirmation email', () => {
             assert.isFalse(fxaClient.signUpResend.called);
           });
 
-          it('updates the account with the returned data', function () {
+          it('updates the account with the returned data', () => {
             assert.equal(account.get('verificationMethod'), VerificationMethods.EMAIL);
             assert.equal(account.get('verificationReason'), VerificationReasons.SIGN_IN);
             assert.equal(account.get('sessionToken'), SESSION_TOKEN);
@@ -377,9 +377,9 @@ define(function (require, exports, module) {
           });
         });
 
-        describe('verified account, verified session', function () {
-          beforeEach(function () {
-            sinon.stub(fxaClient, 'signIn').callsFake(function () {
+        describe('verified account, verified session', () => {
+          beforeEach(() => {
+            sinon.stub(fxaClient, 'signIn').callsFake(() => {
               return Promise.resolve({ sessionToken: SESSION_TOKEN, verified: true });
             });
 
@@ -389,7 +389,7 @@ define(function (require, exports, module) {
             });
           });
 
-          it('delegates to the fxaClient', function () {
+          it('delegates to the fxaClient', () => {
             assert.isTrue(fxaClient.signIn.calledWith(EMAIL, PASSWORD, relier, {
               metricsContext: {
                 baz: 'qux',
@@ -402,7 +402,7 @@ define(function (require, exports, module) {
             }));
           });
 
-          it('updates the account with the returned data', function () {
+          it('updates the account with the returned data', () => {
             assert.isTrue(account.get('verified'));
             assert.equal(account.get('sessionToken'), SESSION_TOKEN);
             assert.equal(account.get('uid'), UID);
@@ -420,7 +420,7 @@ define(function (require, exports, module) {
         describe('INCORRECT_EMAIL_CASE', () => {
           let upperCaseEmail;
 
-          beforeEach(function () {
+          beforeEach(() => {
             upperCaseEmail = EMAIL.toUpperCase();
 
             sinon.stub(fxaClient, 'signIn').callsFake(() => {
@@ -440,7 +440,7 @@ define(function (require, exports, module) {
             });
           });
 
-          it('re-tries with the normalized email, updates model with normalized email', function () {
+          it('re-tries with the normalized email, updates model with normalized email', () => {
             const firstExpectedOptions = {
               metricsContext: {
                 baz: 'qux',
@@ -474,28 +474,28 @@ define(function (require, exports, module) {
           });
         });
 
-        describe('error', function () {
-          var err;
+        describe('error', () => {
+          let err;
 
-          beforeEach(function () {
-            sinon.stub(fxaClient, 'signIn').callsFake(function () {
+          beforeEach(() => {
+            sinon.stub(fxaClient, 'signIn').callsFake(() => {
               return Promise.reject(AuthErrors.toError('UNKNOWN_ACCOUNT'));
             });
 
             return account.signIn(PASSWORD, relier)
               .then(
                 assert.fail,
-                function (_err) {
+                _err => {
                   err = _err;
                 });
           });
 
 
-          it('delegates to the fxaClient', function () {
+          it('delegates to the fxaClient', () => {
             assert.isTrue(fxaClient.signIn.calledWith(EMAIL, PASSWORD, relier));
           });
 
-          it('propagates the error', function () {
+          it('propagates the error', () => {
             assert.isTrue(AuthErrors.is(err, 'UNKNOWN_ACCOUNT'));
           });
 
@@ -505,14 +505,14 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('with a password and a sessionToken', function () {
-        beforeEach(function () {
+      describe('with a password and a sessionToken', () => {
+        beforeEach(() => {
           account.set('sessionToken', SESSION_TOKEN);
         });
 
-        describe('unverified, reason === undefined', function () {
-          beforeEach(function () {
-            sinon.stub(fxaClient, 'sessionReauth').callsFake(function () {
+        describe('unverified, reason === undefined', () => {
+          beforeEach(() => {
+            sinon.stub(fxaClient, 'sessionReauth').callsFake(() => {
               return Promise.resolve({
                 uid: UID,
                 verificationMethod: VerificationMethods.EMAIL,
@@ -521,7 +521,7 @@ define(function (require, exports, module) {
               });
             });
 
-            sinon.stub(fxaClient, 'signIn').callsFake(function () {
+            sinon.stub(fxaClient, 'signIn').callsFake(() => {
               return Promise.resolve({});
             });
 
@@ -531,7 +531,7 @@ define(function (require, exports, module) {
             });
           });
 
-          it('delegates to fxaClient.sessionReauth', function () {
+          it('delegates to fxaClient.sessionReauth', () => {
             assert.isTrue(fxaClient.sessionReauth.calledWith(SESSION_TOKEN, EMAIL, PASSWORD, relier, {
               metricsContext: {
                 baz: 'qux',
@@ -544,11 +544,11 @@ define(function (require, exports, module) {
             }));
           });
 
-          it('does not call fxaClient.signIn', function () {
+          it('does not call fxaClient.signIn', () => {
             assert.isFalse(fxaClient.signIn.called);
           });
 
-          it('updates the account with the returned data', function () {
+          it('updates the account with the returned data', () => {
             assert.isFalse(account.get('verified'));
             assert.equal(account.get('sessionToken'), SESSION_TOKEN);
             assert.equal(account.get('uid'), UID);
@@ -563,9 +563,9 @@ define(function (require, exports, module) {
           });
         });
 
-        describe('verified account, unverified session', function () {
-          beforeEach(function () {
-            sinon.stub(fxaClient, 'sessionReauth').callsFake(function () {
+        describe('verified account, unverified session', () => {
+          beforeEach(() => {
+            sinon.stub(fxaClient, 'sessionReauth').callsFake(() => {
               return Promise.resolve({
                 verificationMethod: VerificationMethods.EMAIL,
                 verificationReason: VerificationReasons.SIGN_IN,
@@ -573,22 +573,22 @@ define(function (require, exports, module) {
               });
             });
 
-            sinon.stub(fxaClient, 'signIn').callsFake(function () {
+            sinon.stub(fxaClient, 'signIn').callsFake(() => {
               return Promise.resolve({});
             });
 
             return account.signIn(PASSWORD, relier, { resume: 'resume token' });
           });
 
-          it('delegates to the fxaClient.sessionReauth', function () {
+          it('delegates to the fxaClient.sessionReauth', () => {
             assert.isTrue(fxaClient.sessionReauth.calledWith(SESSION_TOKEN, EMAIL, PASSWORD, relier));
           });
 
-          it('does not call fxaClient.signIn', function () {
+          it('does not call fxaClient.signIn', () => {
             assert.isFalse(fxaClient.signIn.called);
           });
 
-          it('updates the account with the returned data', function () {
+          it('updates the account with the returned data', () => {
             assert.equal(account.get('verificationMethod'), VerificationMethods.EMAIL);
             assert.equal(account.get('verificationReason'), VerificationReasons.SIGN_IN);
             assert.equal(account.get('sessionToken'), SESSION_TOKEN);
@@ -605,13 +605,13 @@ define(function (require, exports, module) {
           });
         });
 
-        describe('verified account, verified session', function () {
-          beforeEach(function () {
-            sinon.stub(fxaClient, 'sessionReauth').callsFake(function () {
+        describe('verified account, verified session', () => {
+          beforeEach(() => {
+            sinon.stub(fxaClient, 'sessionReauth').callsFake(() => {
               return Promise.resolve({ verified: true });
             });
 
-            sinon.stub(fxaClient, 'signIn').callsFake(function () {
+            sinon.stub(fxaClient, 'signIn').callsFake(() => {
               return Promise.resolve({});
             });
 
@@ -621,7 +621,7 @@ define(function (require, exports, module) {
             });
           });
 
-          it('delegates to the fxaClient', function () {
+          it('delegates to the fxaClient', () => {
             assert.isTrue(fxaClient.sessionReauth.calledWith(SESSION_TOKEN, EMAIL, PASSWORD, relier, {
               metricsContext: {
                 baz: 'qux',
@@ -634,11 +634,11 @@ define(function (require, exports, module) {
             }));
           });
 
-          it('does not call fxaClient.signIn', function () {
+          it('does not call fxaClient.signIn', () => {
             assert.isFalse(fxaClient.signIn.called);
           });
 
-          it('updates the account with the returned data', function () {
+          it('updates the account with the returned data', () => {
             assert.isTrue(account.get('verified'));
             assert.equal(account.get('sessionToken'), SESSION_TOKEN);
             assert.equal(account.get('uid'), UID);
@@ -656,7 +656,7 @@ define(function (require, exports, module) {
         describe('INCORRECT_EMAIL_CASE', () => {
           let upperCaseEmail;
 
-          beforeEach(function () {
+          beforeEach(() => {
             upperCaseEmail = EMAIL.toUpperCase();
 
             sinon.stub(fxaClient, 'sessionReauth').callsFake(() => {
@@ -676,7 +676,7 @@ define(function (require, exports, module) {
             });
           });
 
-          it('re-tries with the normalized email, updates model with normalized email', function () {
+          it('re-tries with the normalized email, updates model with normalized email', () => {
             const firstExpectedOptions = {
               metricsContext: {
                 baz: 'qux',
@@ -710,15 +710,15 @@ define(function (require, exports, module) {
           });
         });
 
-        describe('invalid session', function () {
-          var NEW_SESSION_TOKEN = 'new session token';
+        describe('invalid session', () => {
+          const NEW_SESSION_TOKEN = 'new session token';
 
-          beforeEach(function () {
-            sinon.stub(fxaClient, 'sessionReauth').callsFake(function () {
+          beforeEach(() => {
+            sinon.stub(fxaClient, 'sessionReauth').callsFake(() => {
               return Promise.reject(AuthErrors.toError('INVALID_TOKEN'));
             });
 
-            sinon.stub(fxaClient, 'signIn').callsFake(function () {
+            sinon.stub(fxaClient, 'signIn').callsFake(() => {
               return Promise.resolve({
                 sessionToken: NEW_SESSION_TOKEN,
                 verified: true
@@ -730,19 +730,19 @@ define(function (require, exports, module) {
           });
 
 
-          it('delegates to the fxaClient', function () {
+          it('delegates to the fxaClient', () => {
             assert.isTrue(fxaClient.sessionReauth.calledWith(SESSION_TOKEN, EMAIL, PASSWORD, relier));
           });
 
-          it('invalidates the stored session', function () {
+          it('invalidates the stored session', () => {
             assert.isTrue(account._invalidateSession.called);
           });
 
-          it('does a fresh login to get a new session token', function () {
+          it('does a fresh login to get a new session token', () => {
             assert.isTrue(fxaClient.signIn.calledWith(EMAIL, PASSWORD, relier));
           });
 
-          it('updates the account with the new session data', function () {
+          it('updates the account with the new session data', () => {
             assert.isTrue(account.get('verified'));
             assert.equal(account.get('sessionToken'), NEW_SESSION_TOKEN);
             assert.equal(account.get('uid'), UID);
@@ -758,31 +758,31 @@ define(function (require, exports, module) {
 
         });
 
-        describe('error', function () {
-          var err;
+        describe('error', () => {
+          let err;
 
-          beforeEach(function () {
-            sinon.stub(fxaClient, 'sessionReauth').callsFake(function () {
+          beforeEach(() => {
+            sinon.stub(fxaClient, 'sessionReauth').callsFake(() => {
               return Promise.reject(AuthErrors.toError('UNEXPECTED_ERROR'));
             });
 
-            sinon.stub(fxaClient, 'signIn').callsFake(function () {
+            sinon.stub(fxaClient, 'signIn').callsFake(() => {
               return Promise.resolve({});
             });
 
             return account.signIn(PASSWORD, relier)
               .then(
                 assert.fail,
-                function (_err) {
+                _err => {
                   err = _err;
                 });
           });
 
-          it('delegates to the fxaClient', function () {
+          it('delegates to the fxaClient', () => {
             assert.isTrue(fxaClient.sessionReauth.calledWith(SESSION_TOKEN, EMAIL, PASSWORD, relier));
           });
 
-          it('propagates the error', function () {
+          it('propagates the error', () => {
             assert.isTrue(AuthErrors.is(err, 'UNEXPECTED_ERROR'));
           });
 

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -725,7 +725,7 @@ define(function (require, exports, module) {
               });
             });
 
-            sinon.stub(account, '_invalidateSession');
+            sinon.stub(account, 'discardSessionToken');
             return account.signIn(PASSWORD, relier);
           });
 
@@ -735,7 +735,7 @@ define(function (require, exports, module) {
           });
 
           it('invalidates the stored session', () => {
-            assert.isTrue(account._invalidateSession.called);
+            assert.isTrue(account.discardSessionToken.called);
           });
 
           it('does a fresh login to get a new session token', () => {

--- a/app/tests/spec/models/auth_brokers/fx-sync-channel.js
+++ b/app/tests/spec/models/auth_brokers/fx-sync-channel.js
@@ -66,6 +66,10 @@ define(function (require, exports, module) {
       assert.isTrue(broker.hasCapability('signup'));
     });
 
+    it('does not have the `reuseExistingSession` capability by default', () => {
+      assert.isFalse(broker.hasCapability('reuseExistingSession'));
+    });
+
     it('has the `handleSignedInNotification` capability by default', () => {
       assert.isTrue(broker.hasCapability('handleSignedInNotification'));
     });

--- a/app/tests/spec/models/auth_brokers/oauth.js
+++ b/app/tests/spec/models/auth_brokers/oauth.js
@@ -84,6 +84,10 @@ define(function (require, exports, module) {
       assert.isTrue(broker.hasCapability('signup'));
     });
 
+    it('has the `reuseExistingSession` capability by default', () => {
+      assert.isTrue(broker.hasCapability('reuseExistingSession'));
+    });
+
     it('does not have the `handleSignedInNotification` capability by default', function () {
       assert.isFalse(broker.hasCapability('handleSignedInNotification'));
     });

--- a/app/tests/spec/views/mixins/signin-mixin.js
+++ b/app/tests/spec/views/mixins/signin-mixin.js
@@ -244,6 +244,45 @@ define(function (require, exports, module) {
         });
       });
 
+      describe('with existing sessionToken', () => {
+        beforeEach(() => {
+          account.set({
+            sessionToken: 'session token',
+            sessionTokenContext: 'sync context'
+          });
+        });
+
+        describe('with broker that has `reuseExistingSession` capability', () => {
+          beforeEach(() => {
+            broker.setCapability('reuseExistingSession', true);
+            return view.signIn(account, 'password');
+          });
+
+          it('keeps the existing sessionToken', () => {
+            assert.equal(account.get('sessionToken'), 'session token');
+          });
+
+          it('signs in the user', () => {
+            assert.isTrue(user.signInAccount.calledWith(account, 'password', relier));
+          });
+        });
+
+        describe('with broker that does not have `reuseExistingSession` capability', () => {
+          beforeEach(() => {
+            broker.setCapability('reuseExistingSession', false);
+            return view.signIn(account, 'password');
+          });
+
+          it('discards the existing sessionToken', () => {
+            assert.isTrue(! account.has('sessionToken'));
+          });
+
+          it('signs in the user', () => {
+            assert.isTrue(user.signInAccount.calledWith(account, 'password', relier));
+          });
+        });
+      });
+
       describe('blocked', () => {
         let blockedError;
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4187,8 +4187,8 @@
       }
     },
     "fxa-js-client": {
-      "version": "1.0.1",
-      "from": "git://github.com/mozilla/fxa-js-client.git#7ef6a81fb95e89bdd7708c2c21dd8c3013464d06",
+      "version": "1.0.2",
+      "from": "fxa-js-client@1.0.2",
       "dependencies": {
         "sjcl": {
           "version": "1.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4188,7 +4188,7 @@
     },
     "fxa-js-client": {
       "version": "1.0.1",
-      "from": "fxa-js-client@1.0.1",
+      "from": "git://github.com/mozilla/fxa-js-client.git#7ef6a81fb95e89bdd7708c2c21dd8c3013464d06",
       "dependencies": {
         "sjcl": {
           "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fxa-checkbox": "git://github.com/mozilla/fxa-checkbox.git#7f856afffd394a144f718e28e6fb79092d6ccddd",
     "fxa-crypto-relier": "2.1.0",
     "fxa-geodb": "1.0.0",
-    "fxa-js-client": "git://github.com/mozilla/fxa-js-client.git#session-reauth",
+    "fxa-js-client": "1.0.2",
     "fxa-mustache-loader": "0.0.2",
     "fxa-shared": "1.0.4",
     "got": "6.7.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fxa-checkbox": "git://github.com/mozilla/fxa-checkbox.git#7f856afffd394a144f718e28e6fb79092d6ccddd",
     "fxa-crypto-relier": "2.1.0",
     "fxa-geodb": "1.0.0",
-    "fxa-js-client": "1.0.1",
+    "fxa-js-client": "git://github.com/mozilla/fxa-js-client.git#session-reauth",
     "fxa-mustache-loader": "0.0.2",
     "fxa-shared": "1.0.4",
     "got": "6.7.1",


### PR DESCRIPTION
A little trial balloon to use https://github.com/mozilla/fxa-auth-server/pull/2302 to avoid creating a new sessionToken when we already have one.  Currently just for deployment, needs some iteration and some tests before it's ready for review.

Fixes https://github.com/mozilla/fxa-content-server/issues/5703