### PR TITLE
fix(errors): ensure that toError always behaves sanely

### DIFF
--- a/app/scripts/lib/errors.js
+++ b/app/scripts/lib/errors.js
@@ -17,6 +17,10 @@ define(function (require, exports, module) {
      * @returns {Object}
      */
     find (searchFor) {
+      if (searchFor === undefined || searchFor === null) {
+        return;
+      }
+
       var found;
       if (typeof searchFor.errno === 'number') {
         found = this.find(searchFor.errno);
@@ -116,10 +120,9 @@ define(function (require, exports, module) {
      * @returns {Error}
      */
     toError (type, context) {
-      var errno = this.toErrno(type);
-      var message = this.toMessage(errno);
-
-      var err = new Error(message);
+      const errno = this.toErrno(type);
+      const message = this.toMessage(errno);
+      const err = _.isString(message) ? new Error(message) : message;
 
       if (typeof type === 'object') {
         // copy over any fields from the original object,

--- a/app/tests/spec/lib/auth-errors.js
+++ b/app/tests/spec/lib/auth-errors.js
@@ -30,6 +30,31 @@ define(function (require, exports, module) {
 
         assert.equal(err.context, 'the context');
       });
+
+      it('handles undefined', () => {
+        const err = AuthErrors.toError();
+        assert.equal(err.message, 'System unavailable, try again soon');
+      });
+
+      it('handles null', () => {
+        const err = AuthErrors.toError(null);
+        assert.equal(err.message, 'System unavailable, try again soon');
+      });
+
+      it('handles empty string', () => {
+        const err = AuthErrors.toError('');
+        assert.equal(err.message, 'System unavailable, try again soon');
+      });
+
+      it('handles empty object', () => {
+        const err = AuthErrors.toError({});
+        assert.equal(err.message, 'Unexpected error');
+      });
+
+      it('propagates existing message', () => {
+        const err = AuthErrors.toError(new Error('wibble'));
+        assert.equal(err.message, 'wibble');
+      });
     });
 
     describe('toInvalidParameterError', function () {


### PR DESCRIPTION
While digging in to #5364, I noticed a couple of small assumptions that meant the `toError` method in `app/scripts/lib/errors.js` doesn't behave sanely for all inputs. They're probably not the cause of the `[object Object]` error messages I'm looking in to, but maybe they're still worth plugging?

The first one is that `find` (called from `toErrno`) throws when `searchFor` is `undefined` or `null`.

The second is that `toError` assumes `toMessage` will always return a string but the doc comment says it can return a string or an error object, although I couldn't find a reasonable way to make that happen from the tests, so maybe the comment is out of date. But if you look at the implementation there, you'll notice it doesn't check  the type of `err.forceMessage` or `err.message` before returning, so it seems possible that we might end up doing the equivalent of a `new Error({})` back inside `toError`, which does produce the `[object Object]` error message.

Anyway, I'll leave it up to you guys to decide whether both, either or neither of them are worth keeping.

@mozilla/fxa-devs r?