### PR TITLE
fix(styles): fix icon overlap in CWTS on iOS

### DIFF
--- a/app/styles/modules/_branding.scss
+++ b/app/styles/modules/_branding.scss
@@ -41,6 +41,9 @@
   }
 
   .screen-choose-what-to-sync & {
+    // in Blink and Webkit it is not enough to use `!important` opacity
+    // also need to add animation:none to avoid overrides from `keyframes`
+    animation: none;
     // the 'choose-what-to-sync' view is a special case view
     // where we want to hide the logo and not animate it
     // it uses `!important` to avoid the fade-in effect and inline styles.


### PR DESCRIPTION
Fixes #5879 

<img src=https://user-images.githubusercontent.com/128755/36229113-3a632dc2-11a4-11e8-9614-acc80425c7f9.png width=300 />


@vbudhram r?