### PR TITLE
fix(config): if "10 minutes" then duration not Number

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -523,7 +523,7 @@ const conf = module.exports = convict({
     default: '10 minutes',
     doc: 'Cache max age for static assets, in ms',
     env: 'STATIC_MAX_AGE',
-    format: Number
+    format: 'duration'
   },
   static_resource_url: {
     default: undefined,


### PR DESCRIPTION
This was being interpreted as 10ms if Number, truncated to 0 by other code.

Local/dev config already sets this to explicitly 0. So this just allows fxa-dev instances to use the '10 minutes' intended.

