### PR TITLE
fix(metrics): treat enter-email as an "auth" view for flow events

### DIFF
--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -106,7 +106,7 @@ const PERFORMANCE_TIMINGS = [
   }
 ];
 
-const AUTH_VIEWS = new Set([ 'force-auth', 'signin', 'signup' ]);
+const AUTH_VIEWS = new Set([ 'enter-email', 'force-auth', 'signin', 'signup' ]);
 
 module.exports = (req, metrics, requestReceivedTime) => {
   if (IS_DISABLED || ! isValidFlowData(metrics, requestReceivedTime)) {

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -963,6 +963,44 @@ registerSuite('flow-event', {
           assert.equal(arg.event, 'flow.performance.auth');
         }
       }
+    },
+
+    'call flowEvent for enter-email': {
+      beforeEach() {
+        flowMetricsValidateResult = true;
+        setup({
+          events: [
+            { offset: 2000, type: 'loaded' }
+          ],
+          initialView: 'enter-email'
+        }, 2000, true);
+      },
+      tests: {
+        'process.stderr.write was called correctly': () => {
+          assert.equal(process.stderr.write.callCount, 1);
+          const arg = JSON.parse(process.stderr.write.args[0][0]);
+          assert.equal(arg.event, 'flow.performance.auth');
+        }
+      }
+    },
+
+    'call flowEvent for force-auth': {
+      beforeEach() {
+        flowMetricsValidateResult = true;
+        setup({
+          events: [
+            { offset: 2000, type: 'loaded' }
+          ],
+          initialView: 'force-auth'
+        }, 2000, true);
+      },
+      tests: {
+        'process.stderr.write was called correctly': () => {
+          assert.equal(process.stderr.write.callCount, 1);
+          const arg = JSON.parse(process.stderr.write.args[0][0]);
+          assert.equal(arg.event, 'flow.performance.auth');
+        }
+      }
     }
   }
 });


### PR DESCRIPTION
This relates to the perf discrepancies I demoed last night. As mentioned then, we need to explicitly recognise the email-first view as part of the authentication flow, so that those perf events get correctly categorised.

Opened against train 106 for a point release so we can get the dashboard into shape sooner rather than later.

@mozilla/fxa-devs r?