### PR TITLE
feat(password): Check old password using sessionReauth if possible.

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -794,7 +794,7 @@ define(function (require, exports, module) {
       var fxaClient = this._fxaClient;
       var email = this.get('email');
 
-      return fxaClient.checkPassword(email, oldPassword)
+      return fxaClient.checkPassword(email, oldPassword, this.get('sessionToken'))
         .then(() => {
           if (oldPassword === newPassword) {
             throw AuthErrors.toError('PASSWORDS_MUST_BE_DIFFERENT');

--- a/app/tests/spec/lib/fxa-client.js
+++ b/app/tests/spec/lib/fxa-client.js
@@ -1063,6 +1063,37 @@ define(function (require, exports, module) {
             assert.isTrue(realClient.sessionDestroy.calledWith('session token'));
           });
       });
+
+      it('re-authenticates an existing sessionToken if provided', () => {
+        const sessionToken = 'session token';
+        email = trim(email);
+
+        sinon.stub(realClient, 'sessionReauth').callsFake(() => {
+          return Promise.resolve({});
+        });
+
+        sinon.stub(realClient, 'signIn').callsFake(() => {
+          return Promise.resolve({});
+        });
+
+        sinon.stub(realClient, 'sessionDestroy').callsFake(() => {
+          return Promise.resolve();
+        });
+
+        return client.checkPassword(email, password, sessionToken)
+          .then(() => {
+            assert.isTrue(realClient.sessionReauth.calledWith(
+              sessionToken,
+              email,
+              password,
+              {
+                reason: SignInReasons.PASSWORD_CHECK
+              }
+            ));
+            assert.isFalse(realClient.signIn.called);
+            assert.isFalse(realClient.sessionDestroy.called);
+          });
+      });
     });
 
     describe('changePassword', function () {

--- a/app/tests/spec/models/account.js
+++ b/app/tests/spec/models/account.js
@@ -1862,7 +1862,7 @@ define(function (require, exports, module) {
         return account.changePassword(oldPassword, newPassword, relier)
           .then(function () {
             assert.isTrue(fxaClient.checkPassword.calledWith(
-              EMAIL, oldPassword));
+              EMAIL, oldPassword, 'sessionToken'));
             assert.isTrue(fxaClient.changePassword.calledWith(
               EMAIL, oldPassword, newPassword, 'sessionToken', 'foo', relier));
 


### PR DESCRIPTION
This avoids having to create and then destroy a short-lived sessionToken just to check the user's password.

Depends on #5899, but separate for easier review.