### PR TITLE
fix(token): Fix token code experiment to correctly use service

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/token-code.js
+++ b/app/scripts/lib/experiments/grouping-rules/token-code.js
@@ -6,6 +6,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const BaseGroupingRule = require('./base');
+  const Constants = require('../../../lib/constants');
   const GROUPS = ['control', 'treatment-code', 'treatment-link'];
   const ROLLOUT_CLIENTS = {
     '3a1f53aabe17ba32': {
@@ -45,7 +46,7 @@ define(function (require, exports, module) {
         return false;
       }
 
-      if (this.get && this.get('service') === 'Sync') {
+      if (subject.service && subject.service === Constants.SYNC_SERVICE) {
         if (this.bernoulliTrial(this.SYNC_ROLLOUT_RATE, subject.uniqueUserId)) {
           return this.uniformChoice(GROUPS, subject.uniqueUserId);
         }

--- a/app/scripts/views/mixins/token-code-experiment-mixin.js
+++ b/app/scripts/views/mixins/token-code-experiment-mixin.js
@@ -57,6 +57,7 @@ define(function (require, exports, module) {
       const subject = {
         clientId: this.relier.get('clientId'),
         isTokenCodeSupported: this.broker.getCapability('tokenCode'),
+        service: this.relier.get('service'),
       };
       return subject;
     }

--- a/app/tests/spec/lib/experiments/grouping-rules/token-code.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/token-code.js
@@ -19,6 +19,7 @@ define(function (require, exports, module) {
         subject = {
           experimentGroupingRules: {},
           isTokenCodeSupported: true,
+          service: null,
           uniqueUserId: 'user-id'
         };
       });
@@ -52,11 +53,11 @@ define(function (require, exports, module) {
 
       describe('with sync', () => {
         beforeEach(() => {
-          experiment.get = () => 'Sync';
+          subject.service = 'sync';
         });
 
         it('returns false if not Sync', () => {
-          experiment.get = () => 'notSync';
+          subject.service = 'notSync';
           assert.equal(experiment.choose(subject), false);
         });
 


### PR DESCRIPTION
Fixes the token code experiment to correctly accept and use a reliers service. Targeted for a point release on train 106 since it is metrics related.

To test, [set the sync rollout to 1](https://github.com/mozilla/fxa-content-server/blob/ec624a1693e5f87de501cf076707017035d583a4/app/scripts/lib/experiments/grouping-rules/token-code.js#L30), create a new sync account and login. In session storage, you should be enrolled in the `tokenCode` experiment.

<img width="783" alt="screen shot 2018-03-06 at 5 37 09 pm" src="https://user-images.githubusercontent.com/1295288/37062851-9d0fee30-2165-11e8-8d35-741f3572b26d.png">
