### PR TITLE
feat(token): Fix `emailFirst` disabling `tokenCode` experiment 

### DIFF
--- a/app/scripts/models/auth_brokers/fx-desktop-v3.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v3.js
@@ -22,7 +22,8 @@ define(function (require, exports, module) {
   const FxDesktopV3AuthenticationBroker = FxDesktopV2AuthenticationBroker.extend({
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
       allowUidChange: true,
-      emailFirst: true
+      emailFirst: true,
+      tokenCode: true
     }),
 
     type: 'fx-desktop-v3',

--- a/app/scripts/views/index.js
+++ b/app/scripts/views/index.js
@@ -14,6 +14,7 @@ define(function (require, exports, module) {
   const Cocktail = require('cocktail');
   const CoppaMixin = require('./mixins/coppa-mixin');
   const EmailFirstExperimentMixin = require('./mixins/email-first-experiment-mixin');
+  const TokenCodeExperimentMixin = require('./mixins/token-code-experiment-mixin');
   const FlowBeginMixin = require('./mixins/flow-begin-mixin');
   const FormPrefillMixin = require('./mixins/form-prefill-mixin');
   const FormView = require('./form');
@@ -87,6 +88,7 @@ define(function (require, exports, module) {
     IndexView,
     CoppaMixin({}),
     EmailFirstExperimentMixin(),
+    TokenCodeExperimentMixin,
     FlowBeginMixin,
     FormPrefillMixin,
     SearchParamMixin,

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -13,11 +13,13 @@ define(function (require, exports, module) {
   const SearchParamMixin = require('../../lib/search-param-mixin');
   const VerificationMethods = require('../../lib/verification-methods');
   const VerificationReasons = require('../../lib/verification-reasons');
+  const TokenCodeExperimentMixin = require('../mixins/token-code-experiment-mixin');
 
   module.exports = {
     dependsOn: [
       ResumeTokenMixin,
-      SearchParamMixin
+      SearchParamMixin,
+      TokenCodeExperimentMixin
     ],
 
     /**

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -11,7 +11,6 @@ define(function (require, exports, module) {
   const AvatarMixin = require('./mixins/avatar-mixin');
   const Cocktail = require('cocktail');
   const EmailFirstExperimentMixin = require('./mixins/email-first-experiment-mixin');
-  const TokenCodeExperimentMixin = require('./mixins/token-code-experiment-mixin');
   const FlowBeginMixin = require('./mixins/flow-begin-mixin');
   const FormPrefillMixin = require('./mixins/form-prefill-mixin');
   const FormView = require('./form');
@@ -278,7 +277,6 @@ define(function (require, exports, module) {
     AvatarMixin,
     FlowBeginMixin,
     EmailFirstExperimentMixin({ treatmentPathname: '/' }),
-    TokenCodeExperimentMixin,
     FormPrefillMixin,
     MigrationMixin,
     PasswordMixin,

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v3.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v3.js
@@ -26,6 +26,7 @@ define(function (require, exports, module) {
       it('has the expected capabilities', () => {
         assert.isTrue(broker.hasCapability('allowUidChange'));
         assert.isTrue(broker.hasCapability('emailFirst'));
+        assert.isTrue(broker.hasCapability('tokenCode'));
       });
     });
 


### PR DESCRIPTION
After 1.106.4 was deployed, `tokenCode` metrics were still not being emitted even though it said users were enrolled in [experiment](https://github.com/mozilla/fxa-content-server/pull/5955#issue-173304685). After digging into it a bit, it seems that the `emailFirst` experiment needed to include the `TokenCodeExperimentMixin` so that it would properly set the [verification method](https://github.com/mozilla/fxa-content-server/blob/60bb21d8e6374f6bb216c0bcd8aaff64c60f4799/app/scripts/views/mixins/signin-mixin.js#L55). This was overlooked because when testing this with `forceExperiment` query, it excludes all *other* experiments.

This time around, I cross verified with our test datadog environment and the metrics do show up, https://app.datadoghq.com/dash/67160/experiments?live=true&page=0&is_auto=false&from_ts=1520454452682&to_ts=1520468852682&tile_size=m

If it isn't a big hassle, I would like try this in another 106 point release, or I can pull changes to 107 if it makes more sense.

@mozilla/fxa-devs  r? 

cc @jrgm 