### PR TITLE
fix(account): fix [object Object] errors in Sentry

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -134,7 +134,7 @@ define(function (require, exports, module) {
           // Ignore UNAUTHORIZED errors; we'll just fetch again when needed
           // Otherwise report the error
           if (! AuthErrors.is(err, 'UNAUTHORIZED') && this._sentryMetrics) {
-            this._sentryMetrics.captureException(err);
+            this._sentryMetrics.captureException(new Error(_.isEmpty(err) ? 'Something went wrong!' : err));
           }
         });
     },


### PR DESCRIPTION
Fixes #5364 

@philbooth r?

Sentry says this started since v 0.78 where this was merged: https://github.com/mozilla/fxa-content-server/commit/9a429ae22eaa009a3ed168ad36d336919556b701#diff-046db0ab09009f68f513da9058e5be2eR128

Setting `new Error` should fix this up and give us more info if object is empty or if it is something else