### PR TITLE
feat(metrics): emit view, engage & submit events for CAD

### DIFF
--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -43,6 +43,7 @@ const ENGAGE_SUBMIT_EVENT_GROUPS = {
   'enter-email': GROUPS.emailFirst,
   'force-auth': GROUPS.login,
   install_from: GROUPS.connectDevice,
+  signin_from: GROUPS.connectDevice,
   signin: GROUPS.login,
   signup: GROUPS.registration,
   sms: GROUPS.connectDevice
@@ -59,8 +60,9 @@ const VIEW_EVENT_GROUPS = {
 };
 
 const CONNECT_DEVICE_FLOWS = {
-  'connect-another-device': 'store_buttons',
+  'connect-another-device': 'cad',
   install_from: 'store_buttons',
+  signin_from: 'signin',
   sms: 'sms'
 };
 
@@ -104,7 +106,7 @@ const FUZZY_EVENTS = new Map([
     group: GROUPS.registration,
     event: 'have_account'
   } ],
-  [ /^flow\.(install_from)\.\w+$/, {
+  [ /^flow\.((?:install|signin)_from)\.\w+$/, {
     group: GROUPS.connectDevice,
     event: 'engage'
   } ],

--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -30,7 +30,7 @@ const APP_VERSION = /^[0-9]+\.([0-9]+)\./.exec(require('../../package.json').ver
 
 const GROUPS = {
   email: 'fxa_email',
-  'email-first': 'fxa_email_first',
+  emailFirst: 'fxa_email_first',
   login: 'fxa_login',
   registration: 'fxa_reg',
   settings: 'fxa_pref',
@@ -38,14 +38,14 @@ const GROUPS = {
 };
 
 const ENGAGE_SUBMIT_EVENT_GROUPS = {
-  'enter-email': GROUPS['email-first'],
+  'enter-email': GROUPS.emailFirst,
   'force-auth': GROUPS.login,
   signin: GROUPS.login,
   signup: GROUPS.registration
 };
 
 const VIEW_EVENT_GROUPS = {
-  'enter-email': GROUPS['email-first'],
+  'enter-email': GROUPS.emailFirst,
   'force-auth': GROUPS.login,
   settings: GROUPS.settings,
   signin: GROUPS.login,
@@ -122,7 +122,7 @@ const NOP = () => {};
 
 const EVENT_PROPERTIES = {
   [GROUPS.email]: mixProperties(mapEmailType, mapService),
-  [GROUPS['email-first']]: mapService,
+  [GROUPS.emailFirst]: mapService,
   [GROUPS.login]: mapService,
   [GROUPS.registration]: mapService,
   [GROUPS.settings]: mapDisconnectReason,
@@ -131,7 +131,7 @@ const EVENT_PROPERTIES = {
 
 const USER_PROPERTIES = {
   [GROUPS.email]: mapFlowId,
-  [GROUPS['email-first']]: mixProperties(mapFlowId, mapUtmProperties),
+  [GROUPS.emailFirst]: mixProperties(mapFlowId, mapUtmProperties),
   [GROUPS.login]: mixProperties(mapFlowId, mapUtmProperties),
   [GROUPS.registration]: mixProperties(mapFlowId, mapUtmProperties),
   [GROUPS.settings]: mapNewsletterState,

--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -59,8 +59,8 @@ const VIEW_EVENT_GROUPS = {
 };
 
 const CONNECT_DEVICE_FLOWS = {
-  'connect-another-device': 'cad',
-  install_from: 'cad',
+  'connect-another-device': 'store_buttons',
+  install_from: 'store_buttons',
   sms: 'sms'
 };
 

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -436,6 +436,27 @@ registerSuite('amplitude', {
       assert.equal(arg.event_properties.connect_device_flow, 'store_buttons');
     },
 
+    'flow.signin_from.bar': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.signin_from.bar'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(process.stderr.write.callCount, 1);
+      const arg = JSON.parse(process.stderr.write.args[0]);
+      assert.equal(arg.event_type, 'fxa_connect_device - engage');
+      assert.equal(arg.event_properties.connect_device_flow, 'signin');
+    },
+
     'flow.signin.forgot-password': () => {
       amplitude({
         time: 'a',
@@ -760,7 +781,7 @@ registerSuite('amplitude', {
       assert.equal(process.stderr.write.callCount, 1);
       const arg = JSON.parse(process.stderr.write.args[0]);
       assert.equal(arg.event_type, 'fxa_connect_device - view');
-      assert.equal(arg.event_properties.connect_device_flow, 'store_buttons');
+      assert.equal(arg.event_properties.connect_device_flow, 'cad');
     },
 
     'screen.reset-password': () => {

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -377,6 +377,27 @@ registerSuite('amplitude', {
       });
     },
 
+    'flow.sms.engage': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.sms.engage'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(process.stderr.write.callCount, 1);
+      const arg = JSON.parse(process.stderr.write.args[0]);
+      assert.equal(arg.event_type, 'fxa_connect_device - engage');
+      assert.equal(arg.event_properties.connect_device_flow, 'sms');
+    },
+
     'flow.reset-password.engage': () => {
       amplitude({
         time: 'a',
@@ -392,6 +413,27 @@ registerSuite('amplitude', {
         uid: 'd'
       });
       assert.equal(process.stderr.write.callCount, 0);
+    },
+
+    'flow.install_from.foo': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.install_from.foo'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(process.stderr.write.callCount, 1);
+      const arg = JSON.parse(process.stderr.write.args[0]);
+      assert.equal(arg.event_type, 'fxa_connect_device - engage');
+      assert.equal(arg.event_properties.connect_device_flow, 'cad');
     },
 
     'flow.signin.forgot-password': () => {
@@ -512,6 +554,27 @@ registerSuite('amplitude', {
       assert.equal(process.stderr.write.callCount, 1);
       const arg = JSON.parse(process.stderr.write.args[0]);
       assert.equal(arg.event_type, 'fxa_reg - submit');
+    },
+
+    'flow.sms.submit': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.sms.submit'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(process.stderr.write.callCount, 1);
+      const arg = JSON.parse(process.stderr.write.args[0]);
+      assert.equal(arg.event_type, 'fxa_connect_device - submit');
+      assert.equal(arg.event_properties.connect_device_flow, 'sms');
     },
 
     'flow.wibble.submit': () => {
@@ -662,9 +725,10 @@ registerSuite('amplitude', {
         country: 'United States',
         device_id: 'b',
         event_properties: {
+          connect_device_flow: 'sms',
           device_id: 'b'
         },
-        event_type: 'fxa_sms - view',
+        event_type: 'fxa_connect_device - view',
         language: 'f',
         op: 'amplitudeEvent',
         region: 'California',
@@ -676,6 +740,27 @@ registerSuite('amplitude', {
           flow_id: 'e'
         }
       });
+    },
+
+    'screen.connect-another-device': () => {
+      amplitude({
+        time: 'a',
+        type: 'screen.connect-another-device'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(process.stderr.write.callCount, 1);
+      const arg = JSON.parse(process.stderr.write.args[0]);
+      assert.equal(arg.event_type, 'fxa_connect_device - view');
+      assert.equal(arg.event_properties.connect_device_flow, 'cad');
     },
 
     'screen.reset-password': () => {

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -433,7 +433,7 @@ registerSuite('amplitude', {
       assert.equal(process.stderr.write.callCount, 1);
       const arg = JSON.parse(process.stderr.write.args[0]);
       assert.equal(arg.event_type, 'fxa_connect_device - engage');
-      assert.equal(arg.event_properties.connect_device_flow, 'cad');
+      assert.equal(arg.event_properties.connect_device_flow, 'store_buttons');
     },
 
     'flow.signin.forgot-password': () => {
@@ -760,7 +760,7 @@ registerSuite('amplitude', {
       assert.equal(process.stderr.write.callCount, 1);
       const arg = JSON.parse(process.stderr.write.args[0]);
       assert.equal(arg.event_type, 'fxa_connect_device - view');
-      assert.equal(arg.event_properties.connect_device_flow, 'cad');
+      assert.equal(arg.event_properties.connect_device_flow, 'store_buttons');
     },
 
     'screen.reset-password': () => {


### PR DESCRIPTION
Fixes mozilla/fxa-amplitude-send#50.

Ditches the `fxa_sms - view` Amplitude event in favour of three new events:

* `fxa_connect_device - view`
* `fxa_connect_device - engage`
* `fxa_connect_device - submit`

These new events are emitted from both the old CAD screen and the new SMS screen. An extra event property, `connect_device_flow`, is used to distinguish between the screens and can be used to distinguish between further variations in the future.

I also included another tiny little tweak to `lib/server/amplitude.js`, preferring a camelCased key for one of the properties to make dereferencing it more readable.

Example log lines showing the new events:

* `/connect_another_device`

  ```
  {"op":"amplitudeEvent","time":1521122118766,"device_id":"42d31696f62c4465be8fd4aa817f57d5","event_type":"fxa_connect_device - view","session_id":1521122118195,"event_properties":{"device_id":"42d31696f62c4465be8fd4aa817f57d5","connect_device_flow":"cad"},"user_properties":{"ua_browser":"Firefox","ua_version":"61","experiments":["q3form_changes_email_first"],"flow_id":"ca8d3a20ac9e3d3ad4e8a5875b7fc35ee0f386766bba5f8a17f5002f21503cfa"},"app_version":"107","language":"en","os_name":"Mac OS X","os_version":"10.11"}
  {"op":"amplitudeEvent","time":1521122118766,"device_id":"42d31696f62c4465be8fd4aa817f57d5","event_type":"fxa_connect_device - engage","session_id":1521122118195,"event_properties":{"device_id":"42d31696f62c4465be8fd4aa817f57d5","connect_device_flow":"cad"},"user_properties":{"ua_browser":"Firefox","ua_version":"61","experiments":["q3form_changes_email_first"],"flow_id":"ca8d3a20ac9e3d3ad4e8a5875b7fc35ee0f386766bba5f8a17f5002f21503cfa"},"app_version":"107","language":"en","os_name":"Mac OS X","os_version":"10.11"}
  ```

* `/sms`

  ```
  {"op":"amplitudeEvent","time":1521122643922,"device_id":"cca3bb5712ba4296999c8313960569fd","event_type":"fxa_connect_device - view","session_id":1521122643469,"event_properties":{"device_id":"cca3bb5712ba4296999c8313960569fd","connect_device_flow":"sms"},"user_properties":{"ua_browser":"Firefox","ua_version":"58","entrypoint":"preferences","experiments":["q3form_changes_email_first"],"flow_id":"bb4815492734de8bd09f4612cb144d6ed1ddd7c400259fd90e0a6cd8de6a72ee"},"app_version":"107","language":"en","os_name":"Mac OS X","os_version":"10.11"}
  {"op":"amplitudeEvent","time":1521122648147,"device_id":"cca3bb5712ba4296999c8313960569fd","event_type":"fxa_connect_device - engage","session_id":1521122643469,"event_properties":{"device_id":"cca3bb5712ba4296999c8313960569fd","connect_device_flow":"sms"},"user_properties":{"ua_browser":"Firefox","ua_version":"58","entrypoint":"preferences","experiments":["q3form_changes_email_first"],"flow_id":"bb4815492734de8bd09f4612cb144d6ed1ddd7c400259fd90e0a6cd8de6a72ee"},"app_version":"107","language":"en","os_name":"Mac OS X","os_version":"10.11"}
  {"op":"amplitudeEvent","time":1521122655433,"device_id":"cca3bb5712ba4296999c8313960569fd","event_type":"fxa_connect_device - submit","session_id":1521122643469,"event_properties":{"device_id":"cca3bb5712ba4296999c8313960569fd","connect_device_flow":"sms"},"user_properties":{"ua_browser":"Firefox","ua_version":"58","entrypoint":"preferences","experiments":["q3form_changes_email_first"],"flow_id":"bb4815492734de8bd09f4612cb144d6ed1ddd7c400259fd90e0a6cd8de6a72ee"},"app_version":"107","language":"en","os_name":"Mac OS X","os_version":"10.11"}
  ```

Note there is no `submit` event for the old CAD screen, because there is no form on that view.

Also note, I don't have the green light for these changes from @davismtl and @irrationalagent yet, so let's not merge them until we get that. I had the changes locally though, so figured it was still worth getting the review.

@mozilla/fxa-devs r?