### PR TITLE
refactor(decorators): change color of 'Working...' error message

### DIFF
--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -87,7 +87,7 @@ define(function (require, exports, module) {
     var $error = this.$('.error');
 
     if (err.errno === 1005) {
-      $error = this.$('.info');
+      $error.addClass('working-error');
     }
 
     if (translated) {

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -81,11 +81,15 @@ define(function (require, exports, module) {
     this.hideSuccess();
 
     err = this._normalizeError(err);
-
     this.logError(err);
     var translated = this.translateError(err);
 
     var $error = this.$('.error');
+
+    if (err.errno === 1005) {
+      $error = this.$('.info');
+    }
+
     if (translated) {
       $error[displayStrategy](translated);
     }

--- a/app/scripts/views/decorators/notify_delayed_request.js
+++ b/app/scripts/views/decorators/notify_delayed_request.js
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
       return Promise.resolve().then(() => this.invokeHandler(handler, args))
         .then((value) => {
           this.clearTimeout(this._workingTimeout);
-          if (workingText === this.$('.error').text()) {
+          if (workingText === this.$('.info').text()) {
             this.hideError();
           }
           return value;

--- a/app/scripts/views/decorators/notify_delayed_request.js
+++ b/app/scripts/views/decorators/notify_delayed_request.js
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
       return Promise.resolve().then(() => this.invokeHandler(handler, args))
         .then((value) => {
           this.clearTimeout(this._workingTimeout);
-          if (workingText === this.$('.info').text()) {
+          if (workingText === this.$('.working-error').text()) {
             this.hideError();
           }
           return value;

--- a/app/styles/_state.scss
+++ b/app/styles/_state.scss
@@ -48,6 +48,10 @@
   }
 }
 
+.working-error {
+  background: $info-background-color !important;
+}
+
 .success {
   background: $success-background-color;
   display: none;


### PR DESCRIPTION
In this PR I have:

- Modified the baseView in order to filter out the error displaying the text '**Working...**' and give it the class of `info` so that it will display blue instead of red.

- Refactored the notifyDelayedRequest function to reflect the change of class made in the baseView.

fixes #5354