### PR TITLE
fix(style): disable 'clear' button for default avatar(#5935)

### DIFF
--- a/app/scripts/templates/settings/avatar_change.mustache
+++ b/app/scripts/templates/settings/avatar_change.mustache
@@ -15,7 +15,9 @@
       <a href="#" id="file">{{#t}}Upload{{/t}}</a>
       <a href="/settings/avatar/camera" id="camera">{{#t}}Camera{{/t}}</a>
       {{#hasProfileImage}}
+      {{^avatarDefault}}
       <a href="#" class="remove">{{#t}}Clear{{/t}}</a>
+      {{/avatarDefault}}
       {{/hasProfileImage}}
     </nav>
 

--- a/app/scripts/views/settings/avatar_change.js
+++ b/app/scripts/views/settings/avatar_change.js
@@ -48,6 +48,7 @@ define(function (require, exports, module) {
     setInitialContext (context) {
       var account = this.getSignedInAccount();
       context.set({
+        'avatarDefault': account.get('profileImageUrlDefault'),
         'hasProfileImage': account.has('profileImageUrl')
       });
     },


### PR DESCRIPTION
When the default avatar is present, the 'clear' button should not be displayed and when the profile image is present the 'clear' button should be displayed.

@vladikoff please review my changes.