### PR TITLE
fix(metrics): include full version information in amplitude event data

### DIFF
--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -244,7 +244,7 @@ function mapUserAgentProperties (userAgent, key, familyProperty, versionProperty
   if (family && family !== 'Other') {
     return {
       [familyProperty]: family,
-      [versionProperty]: marshallVersion(group)
+      [versionProperty]: group.toVersionString()
     };
   }
 }
@@ -256,23 +256,6 @@ function mapLocation (location) {
       region: location.state
     };
   }
-}
-
-function marshallVersion (version) {
-  // To maintain consistency with metrics emitted by the auth server,
-  // we can't rely on toVersionString() here. Ultimately, this code
-  // should be refactored out of the content server as part of
-  // https://github.com/mozilla/fxa-shared/issues/11
-
-  if (! version.major) {
-    return;
-  }
-
-  if (! version.minor || parseInt(version.minor) === 0) {
-    return version.major;
-  }
-
-  return `${version.major}.${version.minor}`;
 }
 
 function mapDevice (userAgent) {

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -111,7 +111,7 @@ registerSuite('amplitude', {
           ],
           flow_id: 'wibble',
           ua_browser: 'Firefox',
-          ua_version: '58',
+          ua_version: '58.0',
           utm_campaign: 'melm',
           utm_content: 'florg',
           utm_medium: 'derp',
@@ -161,7 +161,7 @@ registerSuite('amplitude', {
         language: 'f',
         op: 'amplitudeEvent',
         os_name: 'iOS',
-        os_version: '6',
+        os_version: '6.0',
         region: 'California',
         session_id: 'd',
         time: 'a',
@@ -169,7 +169,7 @@ registerSuite('amplitude', {
         user_properties: {
           entrypoint: 'c',
           ua_browser: 'Mobile Safari',
-          ua_version: '6'
+          ua_version: '6.0'
         }
       });
     },


### PR DESCRIPTION
Matches the auth server change from mozilla/fxa-auth-server#2356. The same rationale for that PR applies here, and we also want the events to be consistent between servers.

@mozilla/fxa-devs r?