### PR TITLE
fix(server): validate ip addresses before use

### DIFF
--- a/server/lib/remote-address.js
+++ b/server/lib/remote-address.js
@@ -8,12 +8,16 @@
 
 const CLIENT_IP_ADDRESS_DEPTH = require('./configuration').get('clientAddressDepth') || 1;
 
+// Crude IP address validation. Allows invalid IP addresses but is still
+// useful for rejecting unsafe input.
+const IPV4_ADDRESS_FORMAT =  /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/;
+
 module.exports = request => {
   let ipAddresses = (request.headers['x-forwarded-for'] || '')
     .split(',')
     .map(address => address.trim());
   ipAddresses.push(request.ip || request.connection.remoteAddress);
-  ipAddresses = ipAddresses.filter(ipAddress => !! ipAddress);
+  ipAddresses = ipAddresses.filter(ipAddress => IPV4_ADDRESS_FORMAT.test(ipAddress));
 
   let clientAddressIndex = ipAddresses.length - CLIENT_IP_ADDRESS_DEPTH;
   if (clientAddressIndex < 0) {

--- a/server/lib/remote-address.js
+++ b/server/lib/remote-address.js
@@ -6,18 +6,18 @@
 
 'use strict';
 
+const joi = require('joi');
+
 const CLIENT_IP_ADDRESS_DEPTH = require('./configuration').get('clientAddressDepth') || 1;
 
-// Crude IP address validation. Allows invalid IP addresses but is still
-// useful for rejecting unsafe input.
-const IPV4_ADDRESS_FORMAT =  /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/;
+const IP_ADDRESS = joi.string().ip().required();
 
 module.exports = request => {
   let ipAddresses = (request.headers['x-forwarded-for'] || '')
     .split(',')
     .map(address => address.trim());
   ipAddresses.push(request.ip || request.connection.remoteAddress);
-  ipAddresses = ipAddresses.filter(ipAddress => IPV4_ADDRESS_FORMAT.test(ipAddress));
+  ipAddresses = ipAddresses.filter(ipAddress => ! joi.validate(ipAddress, IP_ADDRESS).error);
 
   let clientAddressIndex = ipAddresses.length - CLIENT_IP_ADDRESS_DEPTH;
   if (clientAddressIndex < 0) {

--- a/tests/server/remote-address.js
+++ b/tests/server/remote-address.js
@@ -30,7 +30,7 @@ registerSuite('remote-address', {
     const result = remoteAddress({
       connection: {},
       headers: {
-        'x-forwarded-for': ' 194.12.187.0 , 127.0.0.1,127.0.0.1'
+        'x-forwarded-for': ' 194.12.187.0 , 127.0.0.1,wibble,127.0.0.1'
       }
     });
     assert.deepEqual(result, {
@@ -107,5 +107,33 @@ registerSuite('remote-address', {
       addresses: [ '127.0.0.1', '194.12.187.0', '127.0.0.1', '192.168.1.254' ],
       clientAddress: '194.12.187.0'
     });
-  }
+  },
+
+  'ignores bad request.connection.remoteAddress': () => {
+    const result = remoteAddress({
+      connection: {
+        remoteAddress: 'wibble'
+      },
+      headers: {
+        'x-forwarded-for': '127.0.0.1'
+      }
+    });
+    assert.deepEqual(result, {
+      addresses: [ '127.0.0.1' ],
+      clientAddress: '127.0.0.1'
+    });
+  },
+
+  'ignores bad request.ip': () => {
+    const result = remoteAddress({
+      headers: {
+        'x-forwarded-for': '127.0.0.1'
+      },
+      ip: 'wibble'
+    });
+    assert.deepEqual(result, {
+      addresses: [ '127.0.0.1' ],
+      clientAddress: '127.0.0.1'
+    });
+  },
 });


### PR DESCRIPTION
Ref: [bug 1447452 (comment)](https://bugzilla.mozilla.org/show_bug.cgi?id=1447452#c19)

`X-Forwarded-For` and `request.info.remoteAddress` come from nginx and the load balancer, so should always be sane. But let's validate them anyway.

Equivalent auth server PR: mozilla/fxa-auth-server#2359

@mozilla/fxa-devs r?