### PR TITLE
fix(tests): fix websession test

### DIFF
--- a/tests/functional/settings_clients.js
+++ b/tests/functional/settings_clients.js
@@ -71,7 +71,7 @@ registerSuite('settings clients', {
         // first session has the user agent
         .then(testElementTextEquals(
           '.client-webSession:nth-child(1) .client-name',
-          'Web Session, Firefox 40'
+          'Web Session, Firefox 40.0'
         ))
 
         // second session is the node.js session from test setup


### PR DESCRIPTION
Fixes:

```
× firefox on linux 3.13.0-143-generic - settings clients - sessions are listed in clients view (4.888s)
    AssertionError: expected 'Web Session, Firefox 40.0' to equal 'Web Session, Firefox 40'
      at Command.<anonymous>  <tests/functional/lib/helpers.js:1789:14>
      at Command.<anonymous>  <tests/functional/lib/helpers.js:1788:6>
      at Command.<anonymous>  <tests/functional/lib/helpers.js:52:23>
      at Test.sessions are listed in clients view [as test]  <tests/functional/settings_clients.js:72:10>
      at <src/lib/Test.ts:260:47>
```

@philbooth does it make sense that this changed?