### PR TITLE
fix(metrics): use $append on the experiments user property

### DIFF
--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -280,7 +280,9 @@ function mapEntrypoint (data) {
 function mapExperiments (data) {
   if (data.experiments && data.experiments.length > 0) {
     return {
-      experiments: data.experiments.map(e => `${toSnakeCase(e.choice)}_${toSnakeCase(e.group)}`)
+      '$append': {
+        experiments: data.experiments.map(e => `${toSnakeCase(e.choice)}_${toSnakeCase(e.group)}`)
+      }
     };
   }
 }

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -103,12 +103,6 @@ registerSuite('amplitude', {
         user_id: 'soop',
         user_properties: {
           entrypoint: 'baz',
-          experiments: [
-            'first_experiment_group_one',
-            'second_experiment_group_two',
-            'third_experiment_group_three',
-            'fourth_experiment_group_four'
-          ],
           flow_id: 'wibble',
           ua_browser: 'Firefox',
           ua_version: '58.0',
@@ -116,7 +110,15 @@ registerSuite('amplitude', {
           utm_content: 'florg',
           utm_medium: 'derp',
           utm_source: 'bnag',
-          utm_term: 'plin'
+          utm_term: 'plin',
+          '$append': {
+            experiments: [
+              'first_experiment_group_one',
+              'second_experiment_group_two',
+              'third_experiment_group_three',
+              'fourth_experiment_group_four'
+            ]
+          }
         }
       });
     },


### PR DESCRIPTION
Fixes #5985.

Since `experiments` got promoted to a user property, it's been clobbering old values each time we set it. This change leans on Amplitude's `$append` syntax to ensure that we preserve (and dedupe) old values.

@mozilla/fxa-devs r?