### PR TITLE
fix(metrics): ensure CAD view and engage events are correct

### DIFF
--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -398,6 +398,7 @@ registerSuite('amplitude', {
       const arg = JSON.parse(process.stderr.write.args[0]);
       assert.equal(arg.event_type, 'fxa_connect_device - engage');
       assert.equal(arg.event_properties.connect_device_flow, 'sms');
+      assert.equal(arg.event_properties.connect_device_os, undefined);
     },
 
     'flow.reset-password.engage': () => {
@@ -434,8 +435,9 @@ registerSuite('amplitude', {
 
       assert.equal(process.stderr.write.callCount, 1);
       const arg = JSON.parse(process.stderr.write.args[0]);
-      assert.equal(arg.event_type, 'fxa_connect_device - engage');
+      assert.equal(arg.event_type, 'fxa_connect_device - view');
       assert.equal(arg.event_properties.connect_device_flow, 'store_buttons');
+      assert.equal(arg.event_properties.connect_device_os, undefined);
     },
 
     'flow.signin_from.bar': () => {
@@ -455,8 +457,31 @@ registerSuite('amplitude', {
 
       assert.equal(process.stderr.write.callCount, 1);
       const arg = JSON.parse(process.stderr.write.args[0]);
-      assert.equal(arg.event_type, 'fxa_connect_device - engage');
+      assert.equal(arg.event_type, 'fxa_connect_device - view');
       assert.equal(arg.event_properties.connect_device_flow, 'signin');
+      assert.equal(arg.event_properties.connect_device_os, undefined);
+    },
+
+    'flow.connect-another-device.link.app-store.foo': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.connect-another-device.link.app-store.foo'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(process.stderr.write.callCount, 1);
+      const arg = JSON.parse(process.stderr.write.args[0]);
+      assert.equal(arg.event_type, 'fxa_connect_device - engage');
+      assert.equal(arg.event_properties.connect_device_flow, 'store_buttons');
+      assert.equal(arg.event_properties.connect_device_os, 'foo');
     },
 
     'flow.signin.forgot-password': () => {
@@ -598,6 +623,7 @@ registerSuite('amplitude', {
       const arg = JSON.parse(process.stderr.write.args[0]);
       assert.equal(arg.event_type, 'fxa_connect_device - submit');
       assert.equal(arg.event_properties.connect_device_flow, 'sms');
+      assert.equal(arg.event_properties.connect_device_os, undefined);
     },
 
     'flow.wibble.submit': () => {
@@ -763,27 +789,6 @@ registerSuite('amplitude', {
           flow_id: 'e'
         }
       });
-    },
-
-    'screen.connect-another-device': () => {
-      amplitude({
-        time: 'a',
-        type: 'screen.connect-another-device'
-      }, {
-        connection: {},
-        headers: {
-          'x-forwarded-for': '63.245.221.32'
-        }
-      }, {
-        flowBeginTime: 'b',
-        flowId: 'c',
-        uid: 'd'
-      });
-
-      assert.equal(process.stderr.write.callCount, 1);
-      const arg = JSON.parse(process.stderr.write.args[0]);
-      assert.equal(arg.event_type, 'fxa_connect_device - view');
-      assert.equal(arg.event_properties.connect_device_flow, 'cad');
     },
 
     'screen.reset-password': () => {


### PR DESCRIPTION
Fixes #5987.

When I added new Amplitude events for connect-another-device in #5982, I used the wrong trigger event for `engage` so ended up emitting it right after the `view` event instead. And stupidly, because I was testing the two events one-after-the-other, it looked like they were working correctly in the logs.

In addition to fixing that bug so that the `engage` events are now sane, this change adds a new `connect_device_os` event property, so that we can see which app-store buttons are being clicked on.

Here are some sample `engage` events showing the new property in the logs:

```
{"op":"amplitudeEvent","time":1522248388824,"device_id":"8acf53afea5d4741ac5ee27ff13a8bc7","event_type":"fxa_connect_device - engage","session_id":1522248290811,"event_properties":{"device_id":"8acf53afea5d4741ac5ee27ff13a8bc7","connect_device_flow":"store_buttons","connect_device_os":"ios"},"user_properties":{"ua_browser":"Firefox","ua_version":"61.0","$append":{"experiments":["q3form_changes_email_first"]},"flow_id":"5b6bc13a7b2fe73a8dd5849fae5e3f5456074124809149667f5664482344d3c5"},"app_version":"108","language":"en","os_name":"Mac OS X","os_version":"10.11"}
{"op":"amplitudeEvent","time":1522248395414,"device_id":"8acf53afea5d4741ac5ee27ff13a8bc7","event_type":"fxa_connect_device - engage","session_id":1522248290811,"event_properties":{"device_id":"8acf53afea5d4741ac5ee27ff13a8bc7","connect_device_flow":"store_buttons","connect_device_os":"android"},"user_properties":{"ua_browser":"Firefox","ua_version":"61.0","$append":{"experiments":["q3form_changes_email_first"]},"flow_id":"5b6bc13a7b2fe73a8dd5849fae5e3f5456074124809149667f5664482344d3c5"},"app_version":"108","language":"en","os_name":"Mac OS X","os_version":"10.11"}
```

@mozilla/fxa-devs r?