### PR TITLE
fix(oauth): fix password reset for scoped reliers verifying in same b…

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -1032,6 +1032,14 @@ define(function (require, exports, module) {
     },
 
     /**
+     * Returns `true` if `keyFetchToken` and `unwrapBKey` are set.
+     * @returns {boolean}
+     */
+    canFetchKeys() {
+      return this.has('keyFetchToken') && this.has('unwrapBKey');
+    },
+
+    /**
      * Fetch keys for the account. Requires account to have
      * `keyFetchToken` and `unwrapBKey`
      *
@@ -1039,7 +1047,7 @@ define(function (require, exports, module) {
      *   can be generated, resolves with null otherwise.
      */
     accountKeys () {
-      if (! this.has('keyFetchToken') || ! this.has('unwrapBKey')) {
+      if (! this.canFetchKeys()) {
         return Promise.resolve(null);
       }
 

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -124,12 +124,10 @@ define(function (require, exports, module) {
      */
     _provisionScopedKeys (account, assertion) {
       const relier = this.relier;
-      const keyFetchToken = account.get('keyFetchToken');
-      const unwrapBKey = account.get('unwrapBKey');
       const uid = account.get('uid');
 
       return Promise.resolve().then(() => {
-        if (unwrapBKey && keyFetchToken) {
+        if (account.canFetchKeys()) {
           // check if requested scopes provide scoped keys
           return this._oAuthClient.getClientKeyData({
             assertion: assertion,

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
     },
 
     afterVisible () {
-      var account = this.user.initAccount({ email: this.model.get('email') });
+      const account = this.user.initAccount({ email: this.model.get('email') });
       return this.broker.persistVerificationData(account)
         .then(() => {
           return this._waitForConfirmation()
@@ -58,6 +58,12 @@ define(function (require, exports, module) {
               this.logViewEvent('verification.success');
               // The password was reset, future attempts should ask confirmation.
               this.relier.set('resetPasswordConfirm', true);
+
+              // for scoped key OAuth reliers, if key tokens are missing, ask the user to login again
+              // and get those tokens
+              if (! account.canFetchKeys() && this.relier.wantsKeys() && this.relier.isOAuth()) {
+                return this._finishPasswordResetDifferentBrowser();
+              }
               // The original window should finish the flow if the user
               // completes verification in the same browser and has sessionInfo
               // passed over from tab 2.

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -197,6 +197,33 @@ define(function (require, exports, module) {
         destroyView();
       });
 
+      it('calls `_finishPasswordResetSameBrowser` for scoped-key reliers with missing key tokens', function () {
+        const sessionInfo = { sessionToken: 'sessiontoken' };
+
+        sinon.stub(view, '_waitForConfirmation').callsFake(function () {
+          return Promise.resolve(sessionInfo);
+        });
+
+        sinon.stub(view, '_finishPasswordResetDifferentBrowser').callsFake(function () {
+          return Promise.resolve();
+        });
+
+        sinon.stub(relier, 'isOAuth').callsFake(() => {
+          return true;
+        });
+
+        sinon.stub(relier, 'wantsKeys').callsFake(() => {
+          return true;
+        });
+
+        return view.afterVisible()
+          .then(function () {
+            assert.isTrue(broker.persistVerificationData.called);
+            assert.isTrue(view._finishPasswordResetDifferentBrowser.called);
+            assert.isTrue(TestHelpers.isEventLogged(metrics, 'confirm_reset_password.verification.success'));
+          });
+      });
+
       it('calls `_finishPasswordResetSameBrowser` if `_waitForConfirmation` returns session info', function () {
         var sessionInfo = { sessionToken: 'sessiontoken' };
 


### PR DESCRIPTION
…rowser

Fixes #5934 


@rfk r?

you can test locally with fxa-local-dev and local Notes login:

https://github.com/mozilla/notes/tree/local (`nvm use 8 && npm i && npm start`)