### PR TITLE
fix(metrics): stop using user-agent string in flow id check

### DIFF
--- a/server/lib/flow-metrics.js
+++ b/server/lib/flow-metrics.js
@@ -17,7 +17,7 @@ module.exports = {
    */
   create (key, userAgent) {
     const salt = crypto.randomBytes(SALT_SIZE).toString('hex');
-    return createFlowEventData(key, salt, Date.now(), userAgent);
+    return createFlowEventData(key, salt, Date.now());
   },
 
   /**
@@ -31,26 +31,32 @@ module.exports = {
    */
   validate (key, flowId, flowBeginTime, userAgent) {
     const salt = flowId.substr(0, SALT_STRING_LENGTH);
-    const expected = createFlowEventData(key, salt, flowBeginTime, userAgent);
+    let expected = createFlowEventData(key, salt, flowBeginTime);
 
+    if (getFlowSignature(flowId) === getFlowSignature(expected.flowId)) {
+      return true;
+    }
+
+    // HACK: We're transitioning between flow id recipes so, just for one train,
+    //       fall back to trying the old way if the preceding check failed.
+    expected = createFlowEventData(key, salt, flowBeginTime, userAgent);
     return getFlowSignature(flowId) === getFlowSignature(expected.flowId);
   }
 };
 
-function createFlowEventData(key, salt, flowBeginTime, userAgent) {
+function createFlowEventData (key, ...data) {
+  const [ salt, flowBeginTime ] = data;
+  data[1] = flowBeginTime.toString(16);
+
   // Incorporate a hash of request metadata into the flow id,
   // so that receiving servers can cross-check the metrics bundle.
   const flowSignature = crypto.createHmac('sha256', key)
-    .update([
-      salt,
-      flowBeginTime.toString(16),
-      userAgent
-    ].join('\n'))
+    .update(data.join('\n'))
     .digest('hex')
     .substr(0, SALT_STRING_LENGTH);
 
   return {
-    flowBeginTime: flowBeginTime,
+    flowBeginTime,
     flowId: salt + flowSignature
   };
 }


### PR DESCRIPTION
Fixes mozilla/fxa-amplitude-send#52

We're tweaking the flow id validation a little bit, but we need to do so in a way that doesn't cause any events to be lost during the transition period.

To that end, here the `create` function features the change but the `validate` function employs a dual check. First it tries to check the new way then, if that fails, we try again the old way. In the next train, we can remove the old way entirely and update the tests to match.

There is a related PR for the auth server: mozilla/fxa-auth-server#2391.

The auth server change will need to be deployed before the content server one, so we should hold this PR back for either a train-110 point release or train-111. I'm ambivalent about which, the main thing is let's not merge this for now.

To test it out, run it against the auth server PR and make sure that flow events are emitted sanely from both servers.

@mozilla/fxa-devs r?