### PR TITLE
fix(css): make qr code padding consistent

### DIFF
--- a/app/styles/modules/_settings-totp.scss
+++ b/app/styles/modules/_settings-totp.scss
@@ -80,8 +80,7 @@
   .totp-details {
     .qr-image-container {
       height: 228px;
-      margin: auto;
-      padding-bottom: 10px;
+      margin: auto auto 24px auto;
       width: 228px;
     }
 


### PR DESCRIPTION
Fixes the margin for QR code

Before:

<img width="210" alt="screen shot 2018-04-11 at 7 42 27 pm" src="https://user-images.githubusercontent.com/1295288/38649268-9793823a-3dc3-11e8-9415-4e0ebd3b018e.png">

After:
<img width="199" alt="screen shot 2018-04-11 at 7 42 05 pm" src="https://user-images.githubusercontent.com/1295288/38649280-a1b1981a-3dc3-11e8-96fb-2a8f2b0d5a23.png">
