### PR TITLE
fix(totp): Fix the "can add TOTP to account and confirm web signin" test

### DIFF
--- a/app/scripts/templates/settings/two_step_authentication.mustache
+++ b/app/scripts/templates/settings/two_step_authentication.mustache
@@ -78,7 +78,7 @@
                 </div>
 
                 <div class="button-row">
-                    <button type="submit" class="settings-button primary">{{#t}}Confirm{{/t}}</button>
+                    <button type="submit" class="settings-button primary totp-confirm-code">{{#t}}Confirm{{/t}}</button>
                     <button class="settings-button cancel secondary enabled totp-cancel">{{#t}}Cancel{{/t}}</button>
                 </div>
             </div>


### PR DESCRIPTION
The selector `.totp-confirm-code` was not added to the submit button as a class.

fixes #6068

@philbooth - r?