### PR TITLE
fix(server): fix undefined dereference

### DIFF
--- a/server/lib/user-agent.js
+++ b/server/lib/user-agent.js
@@ -34,7 +34,7 @@ function safeFamily (parent) {
 }
 
 function safeVersion (parent) {
-  if (! VALID_VERSION.test(parent.toVersionString())) {
+  if (parent && parent.toVersionString && ! VALID_VERSION.test(parent.toVersionString())) {
     parent.major = parent.minor = parent.patch = parent.patchMinor = null;
   }
 }


### PR DESCRIPTION
Fixes #6085, maybe.

Sentry says:

```
TypeError: parent.toVersionString is not a function
  File "/app/node_modules/express/lib/router/index.js", line 284, in null.<anonymous>
    trim_prefix(layer, layerError, layerPath, path);
  File "/app/node_modules/express/lib/router/index.js", line 335, in Function.process_params
    return done();
  File "/app/node_modules/express/lib/router/index.js", line 275, in next
    self.process_params(layer, paramcalled, req, res, function (err) {
  File "/app/node_modules/express/lib/router/index.js", line 174, in Function.handle
    next();
  File "/app/node_modules/express/lib/application.js", line 174, in EventEmitter.handle
    router.handle(req, res, done);
...
(5 additional frame(s) were not displayed)
```

This change should fix that, but there are no tests because I couldn't come up with a failing test case.

I tried every possible user-agent string I could think of to reproduce it, without success. Sentry says the failing user-agent string was this:

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0
```

Which surprised me and, sure enough, that works fine locally. I also tried prematurely terminating the string, inserting nulls, newlines, mismatched parentheses, specifying the empty string, strings that only contained whitespace, emojis and other deliberately weird inputs. None of them reproduce the behaviour for me.

So on the one hand, Sentry is really helpful. On the other hand, sometimes I get the impression that it isn't always truthful.

Was the stack trace for this error correct? The user-agent string? Was there really an error?

No idea, but hopefully this makes it go away.

@mozilla/fxa-devs r?