### PR TITLE
fix(css): Update recovery code placeholder text, and recovery code css size

### DIFF
--- a/app/images/recovery_code_copy.svg
+++ b/app/images/recovery_code_copy.svg
@@ -2,6 +2,6 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-    <path fill="#0060DF"
+    <path fill="#0a84ff"
           d="M14.707 8.293l-3-3A1 1 0 0 0 11 5h-1V4a1 1 0 0 0-.293-.707l-3-3A1 1 0 0 0 6 0H3a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3v3a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2V9a1 1 0 0 0-.293-.707zM12.586 9H11V7.414zm-5-5H6V2.414zM6 7v2H3V2h2v2.5a.5.5 0 0 0 .5.5H8a2 2 0 0 0-2 2zm2 7V7h2v2.5a.5.5 0 0 0 .5.5H13v4z"></path>
 </svg>

--- a/app/images/recovery_code_download.svg
+++ b/app/images/recovery_code_download.svg
@@ -2,5 +2,5 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill="#0060DF" d="M7.293 12.707a1 1 0 0 0 1.414 0l5-5a1 1 0 0 0-1.414-1.414L9 9.586V1a1 1 0 1 0-2 0v8.586L3.707 6.293a1 1 0 0 0-1.414 1.414zM13 14H3a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"></path>
+  <path fill="#0a84ff" d="M7.293 12.707a1 1 0 0 0 1.414 0l5-5a1 1 0 0 0-1.414-1.414L9 9.586V1a1 1 0 1 0-2 0v8.586L3.707 6.293a1 1 0 0 0-1.414 1.414zM13 14H3a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"></path>
 </svg>

--- a/app/images/recovery_code_print.svg
+++ b/app/images/recovery_code_print.svg
@@ -2,6 +2,6 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-    <path fill="#0060DF"
+    <path fill="#0a84ff"
           d="M14 5h-1V1a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v4H2a2 2 0 0 0-2 2v5h3v3a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-3h3V7a2 2 0 0 0-2-2zM2.5 8a.5.5 0 1 1 .5-.5.5.5 0 0 1-.5.5zm9.5 7H4v-5h8zm0-10H4V1h8zm-6.5 7h4a.5.5 0 0 0 0-1h-4a.5.5 0 1 0 0 1zm0 2h5a.5.5 0 0 0 0-1h-5a.5.5 0 1 0 0 1z"></path>
 </svg>

--- a/app/images/recovery_code_replace.svg
+++ b/app/images/recovery_code_replace.svg
@@ -2,6 +2,6 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-    <path fill="#0060DF"
+    <path fill="#0a84ff"
           d="M15 1a1 1 0 0 0-1 1v2.418A6.995 6.995 0 1 0 8 15a6.954 6.954 0 0 0 4.95-2.05 1 1 0 0 0-1.414-1.414A5.019 5.019 0 1 1 12.549 6H10a1 1 0 0 0 0 2h5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z"></path>
 </svg>

--- a/app/scripts/templates/sign_in_recovery_code.mustache
+++ b/app/scripts/templates/sign_in_recovery_code.mustache
@@ -19,7 +19,7 @@
 
     <form novalidate>
       <div class="input-row token-code-row">
-        <input type="text" class="tooltip-below recovery-code" placeholder="{{#t}}Enter 8-digit recovery code{{/t}}" required autofocus />
+        <input type="text" class="tooltip-below recovery-code" placeholder="{{#t}}Enter 10-digit recovery code{{/t}}" required autofocus />
       </div>
 
       <div class="button-row">

--- a/app/styles/modules/_settings-totp.scss
+++ b/app/styles/modules/_settings-totp.scss
@@ -128,6 +128,9 @@
       display: inline-block;
       font-family: monospace;
       font-size: 2em;
+      @include respond-to('small') {
+        font-size: 1.5em;
+      }
       text-transform: uppercase;
       width: 49%;
     }


### PR DESCRIPTION
Fixes #6057 
Fixes https://github.com/mozilla/fxa-content-server/issues/6095
Fixes https://github.com/mozilla/fxa-content-server/issues/6057#issuecomment-380899557

<img width="340" alt="screen shot 2018-04-23 at 2 21 16 pm" src="https://user-images.githubusercontent.com/1295288/39145440-a8d2ba38-4701-11e8-8035-62cdb3fdc966.png">

Using `1.5em` seems to provide enough space between codes.

@mozilla/fxa-devs r? cc @ryanfeeley 