### PR TITLE
fix(tests): scroll to top of page before clicking item

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -182,6 +182,9 @@ const testElementExists = thenify(function (selector) {
  */
 const click = thenify(function (selector, readySelector) {
   return this.parent
+    .execute(() => {
+      window.scrollTo(0,0);
+    })
     .findByCssSelector(selector)
   // Ensure the element is visible and not animating before attempting to click.
   // Sometimes clicks do not register if the element is in the middle of an animation.


### PR DESCRIPTION
This might fix part of the flaky tests in https://github.com/mozilla/fxa-content-server/issues/6078 and [team city](https://tc-test.dev.lcip.org/viewLog.html?buildId=37597&tab=buildResultsDiv&buildTypeId=fxa_LatestFirefoxBetaTests).

For some TOTP tests, the green verification message blocks the sign out button which causes the `is not clickable at point (1191.5999755859375,2.25) because another element <div class="success settings-success"> obscures it`

```
    UnknownError: [POST http://localhost:4444/wd/hub/session/fa10ff4e-23b2-9e45-a055-a04038978e58/element/e3d797e8-90d2-fe48-a9a4-ca17cd018b0b/click / {}] Element <button id="signout" class="settings-button secondary"> is not clickable at point (1191.5999755859375,2.25) because another element <div class="success settings-success"> obscures it
    Build info: version: '3.5.2', revision: '10229a9020', time: '2017-08-21T17:54:21.164Z'
    System info: host: 'vijaybudhram-ms.local', ip: '192.168.0.6', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.13.4', java.version: '1.8.0_161'
    Driver info: driver.version: unknown
      at Command.<anonymous>  <tests/functional/lib/helpers.js:189:6>
      at Command.<anonymous>  <tests/functional/lib/helpers.js:57:23>
      at Test.can remove TOTP from account and skip confirmation [as test]  <tests/functional/sign_in_totp.js:140:10>
      at <src/lib/Test.ts:260:47>
```