### PR TITLE
fix(code): disable token code experiment for 123done

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/token-code.js
+++ b/app/scripts/lib/experiments/grouping-rules/token-code.js
@@ -14,7 +14,7 @@ const ROLLOUT_CLIENTS = {
   },
   'dcdb5ae7add825d2': {
     name: '123Done',
-    rolloutRate: 1.0
+    rolloutRate: 0.0
   },
   'ecdb5ae7add825d4': {
     name: 'TestClient',
@@ -27,6 +27,7 @@ module.exports = class TokenCodeGroupingRule extends BaseGroupingRule {
     super();
     this.name = 'tokenCode';
     this.SYNC_ROLLOUT_RATE = 0.00;
+    this.ROLLOUT_CLIENTS = ROLLOUT_CLIENTS;
   }
 
   choose(subject) {
@@ -35,7 +36,7 @@ module.exports = class TokenCodeGroupingRule extends BaseGroupingRule {
     }
 
     if (subject.clientId) {
-      const client = ROLLOUT_CLIENTS[subject.clientId];
+      const client = this.ROLLOUT_CLIENTS[subject.clientId];
       if (client && this.bernoulliTrial(client.rolloutRate, subject.uniqueUserId)) {
         return this.uniformChoice(GROUPS, subject.uniqueUserId);
       }

--- a/app/tests/spec/lib/experiments/grouping-rules/token-code.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/token-code.js
@@ -9,6 +9,21 @@ define(function (require, exports, module) {
   const Experiment = require('lib/experiments/grouping-rules/token-code');
   const sinon = require('sinon');
 
+  const ROLLOUT_CLIENTS = {
+    '3a1f53aabe17ba32': {
+      name: 'Firefox Add-ons',
+      rolloutRate: 0.0 // Rollout rate between 0..1
+    },
+    'dcdb5ae7add825d2': {
+      name: '123Done',
+      rolloutRate: 1.0
+    },
+    'ecdb5ae7add825d4': {
+      name: 'TestClient',
+      rolloutRate: 0.0
+    }
+  };
+
   describe('lib/experiments/grouping-rules/token-code', () => {
     describe('choose', () => {
       let experiment;
@@ -16,6 +31,7 @@ define(function (require, exports, module) {
 
       beforeEach(() => {
         experiment = new Experiment();
+        experiment.ROLLOUT_CLIENTS = ROLLOUT_CLIENTS;
         subject = {
           experimentGroupingRules: {},
           isTokenCodeSupported: true,


### PR DESCRIPTION
Fixes #6102 

Disables token code experiment for 123done and updated experiment to use an override-able config.