### PR TITLE
fix(permissions): Allow untrusted reliers to request 'openid' scope.

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -65,6 +65,7 @@ module.exports = {
   // We only grant permissions that our UI currently prompts for. Others
   // will be stripped.
   OAUTH_UNTRUSTED_ALLOWED_PERMISSIONS: [
+    'openid',
     'profile:display_name',
     'profile:email',
     'profile:uid'

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
     var SCOPE_PROFILE_EXPANDED = Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION.join(' ');
     var PERMISSIONS = ['profile:email', 'profile:uid'];
     var SCOPE_WITH_EXTRAS = 'profile:email profile:uid profile:non_whitelisted';
+    var SCOPE_WITH_OPENID = 'profile:email profile:uid openid';
     var SERVER_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
     var SERVICE = 'service';
     var SERVICE_NAME = '123Done';
@@ -342,8 +343,8 @@ define(function (require, exports, module) {
               });
             });
 
-            var validValues = [SCOPE_WITH_EXTRAS];
-            var expectedValues = [SCOPE];
+            var validValues = [SCOPE_WITH_EXTRAS, SCOPE_WITH_OPENID];
+            var expectedValues = [SCOPE, SCOPE_WITH_OPENID];
             testValidQueryParams('scope', validValues, 'scope', expectedValues);
 
             var invalidValues = ['profile', 'profile:unrecognized'];


### PR DESCRIPTION
This aligns our list with what the oauth-server allows: https://github.com/mozilla/fxa-oauth-server/blob/7ad1e56f95ec54dd5096937a5cb3b42585841105/lib/routes/authorization.js#L30

Should resolve the recent test issues with 321done, such as https://github.com/mozilla/fxa-content-server/issues/6106.  I'm making a point-release of train-110 to hopefully unbreak stage tests.