### PR TITLE
fix(test): fix totp test failures

### DIFF
--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -187,6 +187,21 @@ const click = thenify(function (selector, readySelector) {
   // Sometimes clicks do not register if the element is in the middle of an animation.
     .then(visibleByQSA(selector))
     .click()
+    .then(null, (err) => {
+      // If element is obsure (possibly by a verification message covering it), attempt
+      // to scroll to the top of page where it might be visible.
+      if (/obscures it/.test(err.message)) {
+        return this.parent
+          .execute(() => {
+            window.scrollTo(0, 0);
+          })
+          .findByCssSelector(selector)
+          .click()
+          .end();
+      }
+      // re-throw other errors
+      throw err;
+    })
     .end()
     .then(function () {
       if (readySelector) {

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -28,6 +28,7 @@ const thenify = FunctionalHelpers.thenify;
 const {
   clearBrowserState,
   click,
+  confirmTotpCode,
   createUser,
   fillOutSignIn,
   fillOutSignInUnblock,
@@ -271,11 +272,7 @@ registerSuite('oauth - TOTP', {
   tests: {
     'can add TOTP to account and confirm oauth signin': function () {
       return this.remote
-      // Shows success for confirming token
-        .then(type(selectors.TOTP.CONFIRM_CODE_INPUT, generateCode(secret)))
-        .then(click(selectors.TOTP.CONFIRM_CODE_BUTTON))
-        .then(testSuccessWasShown)
-        .then(testElementExists(selectors.TOTP.STATUS_ENABLED))
+        .then(confirmTotpCode(secret))
 
         .then(clearBrowserState({
           '123done': true,
@@ -295,10 +292,7 @@ registerSuite('oauth - TOTP', {
 
     'can remove TOTP from account and skip confirmation': function () {
       return this.remote
-        .then(type(selectors.TOTP.CONFIRM_CODE_INPUT, generateCode(secret)))
-        .then(click(selectors.TOTP.CONFIRM_CODE_BUTTON))
-        .then(testSuccessWasShown)
-        .then(testElementExists(selectors.TOTP.STATUS_ENABLED))
+        .then(confirmTotpCode(secret))
 
         // Remove token
         .then(click(selectors.TOTP.DELETE_BUTTON))


### PR DESCRIPTION
Testing this locally, I get `Unable to locate element: #loggedin` with the failing TOTP oauth test in [team city](https://tc-test.dev.lcip.org/viewLog.html?buildId=37690&tab=buildResultsDiv&buildTypeId=FxaLatest_FunctionalTests). I am testing with train 110 oauth-server, train 110 content-server, and master 123Done.

However, I believe that my setup is busted since the previous error was an `obscures it` error.
