### PR TITLE
refactor(sync): Remove support for migration=sync11

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -46,7 +46,7 @@ module.exports = {
   CONTENT_SERVER_SERVICE: 'content-server',
   SYNC_SERVICE: 'sync',
 
-  SYNC11_MIGRATION: 'sync11',
+  SYNC11_MIGRATION: 'sync11', // Note, with #6130 this is no longer supported, we accept and ignore the value.
   AMO_MIGRATION: 'amo',
 
   VERIFICATION_POLL_IN_MS: 4000,

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -127,6 +127,13 @@ define(function (require, exports, module) {
           this.unset('email');
           this.set('allowCachedCredentials', false);
         }
+
+        if (this.get('migration') === Constants.SYNC11_MIGRATION) {
+          // Support for the sync1.1 migration message was
+          // removed in #6130, accept the value so
+          // no errors are caused but drop the value on the ground.
+          this.unset('migration');
+        }
       });
     },
 

--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -3,11 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * The Sync for Sync relier. In addition to the fields available on
- * `Relier`, provides the following:
- *
- * - context
- * - migration
+ * The Sync relier.
  */
 
 define(function (require, exports, module) {

--- a/app/scripts/templates/sign_in.mustache
+++ b/app/scripts/templates/sign_in.mustache
@@ -22,9 +22,6 @@
       {{#isAmoMigration}}
         <div class="info nudge pad" id="amo-migration">{{#unsafeTranslate}}Looking for your Add-ons data? <a href="/signup">Sign up</a> for a Firefox Account with your old Add-ons account email address.{{/unsafeTranslate}}</div>
       {{/isAmoMigration}}
-      {{#isSyncMigration}}
-        <div class="info nudge" id="sync-migration">{{#unsafeTranslate}}Migrate your sync data by signing in to your Firefox&nbsp;Account.{{/unsafeTranslate}}</div>
-      {{/isSyncMigration}}
 
       {{#suggestedAccount}}
           <div class="avatar-wrapper avatar-view">

--- a/app/scripts/templates/sign_up.mustache
+++ b/app/scripts/templates/sign_up.mustache
@@ -22,10 +22,6 @@
 
     {{{ syncSuggestionHTML }}}
 
-    {{#isSyncMigration}}
-      <div class="info nudge" id="sync-migration">{{#unsafeTranslate}}Migrate your sync data by creating a new Firefox&nbsp;Account.{{/unsafeTranslate}}</div>
-    {{/isSyncMigration}}
-
     {{#isAmoMigration}}
         <div class="info nudge" id="amo-migration">{{#t}}Looking for your Add-ons data? Sign up for a Firefox Account with your old Add-ons account email address.{{/t}}</div>
     {{/isAmoMigration}}

--- a/app/scripts/views/mixins/migration-mixin.js
+++ b/app/scripts/views/mixins/migration-mixin.js
@@ -11,10 +11,6 @@ define(function (require, exports, module) {
   const Constants = require('../../lib/constants');
 
   module.exports = {
-    isSyncMigration: function isSyncMigration () {
-      return this.relier.get('migration') === Constants.SYNC11_MIGRATION;
-    },
-
     isAmoMigration: function isAmoMigration () {
       return this.relier.get('migration') === Constants.AMO_MIGRATION;
     }

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -100,7 +100,6 @@ define(function (require, exports, module) {
         error: this.error,
         headerSignInText,
         isAmoMigration: this.isAmoMigration(),
-        isSyncMigration: this.isSyncMigration(),
         password: this.formPrefill.get('password'),
         suggestedAccount: hasSuggestedAccount
       });

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -115,8 +115,7 @@ define(function (require, exports, module) {
         isAmoMigration: this.isAmoMigration(),
         isCustomizeSyncChecked: relier.isCustomizeSyncChecked(),
         isSignInEnabled: ! forceEmail,
-        isSync: isSync,
-        isSyncMigration: this.isSyncMigration()
+        isSync: isSync
       });
     },
 

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
         entrypoint: 'menupanel',
         isSampledUser: true,
         lang: 'db_LB',
-        migration: 'sync1.5',
+        migration: 'amo',
         notifier,
         screenHeight: 1200,
         screenWidth: 1600,
@@ -193,7 +193,7 @@ define(function (require, exports, module) {
         assert.equal(filteredData.lang, 'db_LB');
         assert.equal(filteredData.emailDomain, 'none');
         assert.equal(filteredData.entrypoint, 'menupanel');
-        assert.equal(filteredData.migration, 'sync1.5');
+        assert.equal(filteredData.migration, 'amo');
         assert.equal(filteredData.uniqueUserId, '0ae7fe2b-244f-4a78-9857-dff3ae263927');
         assert.equal(filteredData.startTime, 1439233336187);
 

--- a/app/tests/spec/lib/storage-metrics.js
+++ b/app/tests/spec/lib/storage-metrics.js
@@ -7,13 +7,11 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const chai = require('chai');
+  const { assert } = require('chai');
   const Metrics = require('lib/metrics');
   const Storage = require('lib/storage');
   const StorageMetrics = require('lib/storage-metrics');
   const WindowMock = require('../../mocks/window');
-
-  var assert = chai.assert;
 
   describe('lib/storage-metrics', function () {
     var storageMetrics;
@@ -31,7 +29,6 @@ define(function (require, exports, module) {
         devicePixelRatio: 2,
         entrypoint: 'menupanel',
         lang: 'db_LB',
-        migration: 'sync1.5',
         screenHeight: 1200,
         screenWidth: 1600,
         service: 'sync',

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -114,8 +114,19 @@ define(function (require, exports, module) {
       testInvalidQueryParam('migration', token);
     });
 
-    [undefined, Constants.AMO_MIGRATION, Constants.SYNC11_MIGRATION].forEach(function (value) {
+    [undefined, Constants.AMO_MIGRATION].forEach(function (value) {
       testValidQueryParam('migration', value, 'migration', value);
+    });
+
+    describe('sync11 migration', () => {
+      it('accepts the value, but drops it on the ground', () => {
+        windowMock.location.search = TestHelpers.toSearchString({ migration: Constants.SYNC11_MIGRATION });
+
+        return relier.fetch()
+          .then(() => {
+            assert.isFalse(relier.has('migration'));
+          });
+      });
     });
 
     describe('email non-verification flow', function () {

--- a/app/tests/spec/models/reliers/sync.js
+++ b/app/tests/spec/models/reliers/sync.js
@@ -15,7 +15,6 @@ define(function (require, exports, module) {
   const ACTION = 'email';
   const CONTEXT = 'fx_desktop_v1';
   const COUNTRY = 'RO';
-  const SYNC_MIGRATION = 'sync11';
   const SYNC_SERVICE = 'sync';
 
   describe('models/reliers/sync', () => {
@@ -50,7 +49,6 @@ define(function (require, exports, module) {
           context: CONTEXT,
           country: COUNTRY,
           customizeSync: 'true',
-          migration: SYNC_MIGRATION,
           service: SYNC_SERVICE,
           signin: 'signin-code'
         });
@@ -60,7 +58,6 @@ define(function (require, exports, module) {
             assert.equal(relier.get('action'), ACTION);
             assert.equal(relier.get('context'), CONTEXT);
             assert.equal(relier.get('country'), COUNTRY);
-            assert.equal(relier.get('migration'), SYNC_MIGRATION);
             assert.equal(relier.get('service'), SYNC_SERVICE);
             assert.isTrue(relier.get('customizeSync'));
             assert.equal(relier.get('signinCode'), 'signin-code');

--- a/app/tests/spec/views/mixins/migration-mixin.js
+++ b/app/tests/spec/views/mixins/migration-mixin.js
@@ -5,48 +5,18 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const chai = require('chai');
+  const { assert } = require('chai');
   const MigrationMixin = require('views/mixins/migration-mixin');
   const sinon = require('sinon');
 
-  var assert = chai.assert;
-
   describe('views/mixins/migration-mixin', function () {
     it('exports correct interface', function () {
-      assert.lengthOf(Object.keys(MigrationMixin), 2);
-      assert.isFunction(MigrationMixin.isSyncMigration);
+      assert.lengthOf(Object.keys(MigrationMixin), 1);
       assert.isFunction(MigrationMixin.isAmoMigration);
     });
 
-    describe('call isSyncMigration', function () {
-      var relier, result;
-
-      beforeEach(function () {
-        relier = {
-          get: sinon.spy(function () {
-            return 'sync11';
-          }),
-          has: sinon.spy(function () {
-            return 'foo';
-          })
-        };
-        result = MigrationMixin.isSyncMigration.call({ relier: relier });
-      });
-
-      it('calls isSyncMigration correctly', function () {
-        assert.equal(relier.get.callCount, 1);
-        var args = relier.get.getCall(0).args;
-        assert.lengthOf(args, 1);
-        assert.equal(args[0], 'migration');
-      });
-
-      it('returns this.isSyncMigration result', function () {
-        assert.equal(result, true);
-      });
-    });
-
     describe('call isAmoMigration', function () {
-      var relier, result;
+      let relier, result;
 
       beforeEach(function () {
         relier = {
@@ -63,7 +33,7 @@ define(function (require, exports, module) {
 
       it('calls isAmoMigration correctly', function () {
         assert.equal(relier.get.callCount, 1);
-        var args = relier.get.getCall(0).args;
+        const args = relier.get.getCall(0).args;
         assert.lengthOf(args, 1);
         assert.equal(args[0], 'migration');
       });

--- a/app/tests/spec/views/mixins/sync-suggestion-mixin.js
+++ b/app/tests/spec/views/mixins/sync-suggestion-mixin.js
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
     });
 
     describe('sync suggestion', () => {
-      it('displays sync suggestion message if no migration', () => {
+      it('displays sync suggestion message if no service', () => {
         relier.set('service', null);
 
         return view.render()

--- a/app/tests/spec/views/sign_in.js
+++ b/app/tests/spec/views/sign_in.js
@@ -217,34 +217,32 @@ define(function (require, exports, module) {
     });
 
     describe('migration', () => {
+      beforeEach(() => {
+        initView();
+      });
+
       it('does not display migration message if no migration', () => {
-        initView();
-
         return view.render()
           .then(() => {
-            assert.lengthOf(view.$('#sync-migration'), 0);
+            assert.lengthOf(view.$('#amo-migration'), 0);
           });
       });
 
-      it('displays migration message if isSyncMigration returns true', () => {
-        initView();
-        sinon.stub(view, 'isSyncMigration').callsFake(() => true);
+      it('displays migration message if isAmoMigration returns true', () => {
+        sinon.stub(view, 'isAmoMigration').callsFake(() => true);
 
         return view.render()
           .then(() => {
-            assert.equal(view.$('#sync-migration').html(), 'Migrate your sync data by signing in to your Firefox&nbsp;Account.');
-            view.isSyncMigration.restore();
+            assert.lengthOf(view.$('#amo-migration'), 1);
           });
       });
 
-      it('does not display migration message if isSyncMigration returns false', () => {
-        initView();
-        sinon.stub(view, 'isSyncMigration').callsFake(() => false);
+      it('does not display migration message if isAmoMigration returns false', () => {
+        sinon.stub(view, 'isAmoMigration').callsFake(() => false);
 
         return view.render()
           .then(() => {
-            assert.lengthOf(view.$('#sync-migration'), 0);
-            view.isSyncMigration.restore();
+            assert.lengthOf(view.$('#amo-migration'), 0);
           });
       });
     });

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -284,26 +284,7 @@ define(function (require, exports, module) {
         return view.render()
           .then(() => {
             assert.lengthOf(view.$('#amo-migration'), 0);
-            assert.lengthOf(view.$('#sync-migration'), 0);
             assert.lengthOf(view.$('#suggest-sync'), 1);
-          });
-      });
-
-      it('displays migration message if isSyncMigration returns true', function () {
-        sinon.stub(view, 'isSyncMigration').callsFake(() => true);
-
-        return view.render()
-          .then(() => {
-            assert.lengthOf(view.$('#sync-migration'), 1);
-          });
-      });
-
-      it('does not display migration message if isSyncMigration returns false', function () {
-        sinon.stub(view, 'isSyncMigration').callsFake(() => false);
-
-        return view.render()
-          .then(() => {
-            assert.lengthOf(view.$('#sync-migration'), 0);
           });
       });
 

--- a/tests/functional/sync_sign_in.js
+++ b/tests/functional/sync_sign_in.js
@@ -12,7 +12,6 @@ const selectors = require('./lib/selectors');
 const config = intern._config;
 const ROOT_URL = config.fxaContentRoot;
 const PAGE_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
-const PAGE_URL_WITH_MIGRATION = PAGE_URL + '&migration=sync11';
 
 let email;
 const PASSWORD = '12345678';
@@ -126,12 +125,6 @@ registerSuite('Firefox Desktop Sync v1 signin', {
         .then(setupTest({preVerified: false}))
 
         .then(openPage(ROOT_URL, selectors.CONFIRM_SIGNUP.HEADER));
-    },
-
-    'as a migrating user': function () {
-      return this.remote
-        .then(openPage(PAGE_URL_WITH_MIGRATION, selectors.SIGNIN.HEADER))
-        .then(visibleByQSA(selectors.SIGNIN.MIGRATION_NUDGE));
     },
 
     'verified, blocked': function () {

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -11,7 +11,6 @@ const FxDesktopHelpers = require('./lib/fx-desktop');
 const selectors = require('./lib/selectors');
 var config = intern._config;
 var PAGE_URL = config.fxaContentRoot + 'signup?context=fx_desktop_v1&service=sync';
-var PAGE_URL_WITH_MIGRATION = PAGE_URL + '&migration=sync11';
 
 var email;
 var PASSWORD = '12345678';
@@ -29,8 +28,7 @@ const {
   switchToWindow,
   testAttributeEquals,
   testElementExists,
-  testEmailExpected,
-  visibleByQSA,
+  testEmailExpected
 } = FunctionalHelpers;
 
 const {
@@ -161,12 +159,6 @@ registerSuite('Firefox Desktop Sync sign_up', {
         .then(openPage(url, selectors.SIGNUP.HEADER))
 
         .then(testAttributeEquals(selectors.SIGNUP.CUSTOMIZE_SYNC_INPUT, 'checked', 'checked'));
-    },
-
-    'as a migrating user': function () {
-      return this.remote
-        .then(openPage(PAGE_URL_WITH_MIGRATION, selectors.SIGNUP.HEADER))
-        .then(visibleByQSA(selectors.SIGNUP.MIGRATING_USER));
     }
   }
 });

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -94,7 +94,7 @@ registerSuite('flow-event', {
             flow_time: 0,
             hostname: os.hostname(),
             locale: 'en',
-            migration: 'sync11',
+            migration: 'amo',
             op: 'flowEvent',
             pid: process.pid,
             service: '1234567890abcdef',
@@ -363,7 +363,7 @@ registerSuite('flow-event', {
       beforeEach() {
         flowMetricsValidateResult = true;
         setup({
-          migration: 'sync111'
+          migration: 'amo1'
         }, 1000);
       },
 
@@ -1022,7 +1022,7 @@ function setup (data, timeSinceFlowBegin, clobberNavigationTiming, navigationTim
       flowId: data.flowId || '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
       flushTime: flowBeginTime,
       initialView: data.initialView || 'signup',
-      migration: data.migration || 'sync11',
+      migration: data.migration || 'amo',
       navigationTiming: clobberNavigationTiming ? null : {
         /*eslint-disable sorting/sort-object-props*/
         navigationStart: 0,

--- a/tests/server/metrics-collector-stderr.js
+++ b/tests/server/metrics-collector-stderr.js
@@ -74,7 +74,7 @@ suite.tests['writes formatted data to stderr'] = function () {
       assert.equal(loggedMetrics['screen.width'], 1680);
       assert.equal(loggedMetrics['screen.height'], 1050);
       assert.equal(loggedMetrics.entrypoint, 'menupanel');
-      assert.equal(loggedMetrics.migration, 'sync1.5');
+      assert.equal(loggedMetrics.migration, 'amo');
     } else if (loggedMetrics.op === 'client.marketing') {
       assert.equal(loggedMetrics.campaignId, 'survey');
       assert.isFalse(loggedMetrics.clicked, true);
@@ -85,7 +85,7 @@ suite.tests['writes formatted data to stderr'] = function () {
       assert.equal(loggedMetrics.context, 'fx_desktop_v1');
       assert.equal(loggedMetrics.entrypoint, 'menupanel');
       assert.equal(loggedMetrics.service, 'sync');
-      assert.equal(loggedMetrics.migration, 'sync1.5');
+      assert.equal(loggedMetrics.migration, 'amo');
 
       process.stderr.write = _origWrite;
       dfd.resolve();
@@ -117,7 +117,7 @@ suite.tests['writes formatted data to stderr'] = function () {
       clicked: false,
       url: 'http://mzl.la/1oV7jUy'
     }],
-    migration: 'sync1.5',
+    migration: 'amo',
     navigationTiming: {
       included: 0,
       notIncludedNull: null,


### PR DESCRIPTION
This feature has not been used by Firefox release for quite
some time.

The query parameter value is still considered valid because
there are a few dozen people that go through the flow every
month, but the value is dropped on the ground.

fixes #6122