### PR TITLE
fix(ios): iOS only shows numbers in the keyboard for the age input

### DIFF
--- a/app/scripts/templates/partial/coppa-age-input.mustache
+++ b/app/scripts/templates/partial/coppa-age-input.mustache
@@ -1,4 +1,4 @@
 <div id="coppa" class="input-row input-row-age">
   <label class="label-helper"></label>
-  <input type="number" id="age" placeholder="{{#t}}How old are you?{{/t}}" min="0" max="999" value="{{ age }}" {{#required}}required{{/required}} />
+  <input type="number" pattern="\d*" id="age" placeholder="{{#t}}How old are you?{{/t}}" min="0" max="999" value="{{ age }}" {{#required}}required{{/required}} />
 </div>


### PR DESCRIPTION
For whatever reason, iOS will display the entire keyboard on an
`<input type="number" />` element. Adding `pattern="\d*"` fixes
the problem.

fixes #6132 

@vbudhram or someone else with an iOS device or iOS simulator, mind an r?