### PR TITLE
fix(tests): teamcity server tests now need underscore and js-md5

### DIFF
--- a/tests/teamcity/install-npm-deps.sh
+++ b/tests/teamcity/install-npm-deps.sh
@@ -20,6 +20,7 @@ node ./tests/teamcity/install-npm-deps.js \
   htmlparser2                     \
   intern                          \
   joi                             \
+  js-md5                          \
   leadfoot                        \
   lodash                          \
   morgan                          \
@@ -32,6 +33,7 @@ node ./tests/teamcity/install-npm-deps.js \
   raven                           \
   sinon                           \
   sync-exec                       \
+  underscore                      \
   universal-analytics             \
   xmlhttprequest                  \
   yargs


### PR DESCRIPTION
These modules are now required to run the serverside tests. r? @mozilla/fxa-devs 