### PR TITLE
fix(metrics): reinstate bespoke code for emitting amplitude events

### DIFF
--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -3,8 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // This module contains mappings from content server event names to
-// amplitude event definitions. A module in fxa-shared is responsible
-// for performing the actual transformations.
+// amplitude event definitions. The intention is for the returned
+// `receiveEvent` function to be invoked for every event and the
+// mappings determine which of those will be transformed into an
+// amplitude event.
+//
+// You can read more about the amplitude event
+// structure here:
+//
+// https://amplitude.zendesk.com/hc/en-us/articles/204771828-HTTP-API
 //
 // You can see the event taxonomy here:
 //
@@ -14,11 +21,49 @@
 
 'use strict';
 
-const { EMAIL_TYPES, GROUPS, initialize } = require('fxa-shared/metrics/amplitude');
 const geolocate = require('./geo-locate');
 const ua = require('./user-agent');
 
 const SERVICES = require('./configuration').get('oauth_client_id_map');
+
+const APP_VERSION = /^[0-9]+\.([0-9]+)\./.exec(require('../../package.json').version)[1];
+
+const GROUPS = {
+  connectDevice: 'fxa_connect_device',
+  email: 'fxa_email',
+  emailFirst: 'fxa_email_first',
+  login: 'fxa_login',
+  registration: 'fxa_reg',
+  settings: 'fxa_pref',
+  sms: 'fxa_sms'
+};
+
+const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {
+  'enter-email': GROUPS.emailFirst,
+  'force-auth': GROUPS.login,
+  settings: GROUPS.settings,
+  signin: GROUPS.login,
+  signup: GROUPS.registration,
+  sms: GROUPS.connectDevice
+};
+
+const CONNECT_DEVICE_FLOWS = {
+  'app-store': 'store_buttons',
+  install_from: 'store_buttons',
+  signin_from: 'signin',
+  sms: 'sms'
+};
+
+const EMAIL_TYPES = {
+  'complete-reset-password': 'reset_password',
+  'complete-signin': 'login',
+  'verify-email': 'registration'
+};
+
+const NEWSLETTER_STATES = {
+  optIn: 'subscribed',
+  optOut: 'unsubscribed',
+};
 
 const EVENTS = {
   'flow.reset-password.submit': {
@@ -35,19 +80,11 @@ const EVENTS = {
   },
 };
 
-const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {
-  'enter-email': GROUPS.emailFirst,
-  'force-auth': GROUPS.login,
-  settings: GROUPS.settings,
-  signin: GROUPS.login,
-  signup: GROUPS.registration,
-  sms: GROUPS.connectDevice
-};
-
-// In the following regular expressions, the first match group is
-// exposed as `eventCategory` and the second as `eventTarget`.
+// In the following regular expressions, the first match group is exposed to
+// the rest of the code as `eventCategory` and the second as `eventTarget`.
 const FUZZY_EVENTS = new Map([
   [ /^flow\.([\w-]+)\.engage$/, {
+    isDynamicGroup: true,
     group: eventCategory => VIEW_ENGAGE_SUBMIT_EVENT_GROUPS[eventCategory],
     event: 'engage'
   } ],
@@ -68,10 +105,12 @@ const FUZZY_EVENTS = new Map([
     event: 'engage'
   } ],
   [ /^flow\.([\w-]+)\.submit$/, {
+    isDynamicGroup: true,
     group: eventCategory => VIEW_ENGAGE_SUBMIT_EVENT_GROUPS[eventCategory],
     event: 'submit'
   } ],
   [ /^screen\.([\w-]+)$/, {
+    isDynamicGroup: true,
     group: eventCategory => VIEW_ENGAGE_SUBMIT_EVENT_GROUPS[eventCategory],
     event: 'view'
   } ],
@@ -84,59 +123,116 @@ const FUZZY_EVENTS = new Map([
     event: 'disconnect_device'
   } ],
   [ /^([\w-]+).verification.clicked$/, {
+    isDynamicGroup: true,
     group: eventCategory => eventCategory in EMAIL_TYPES ? GROUPS.email : null,
     event: 'click'
   } ]
 ]);
 
-const transform = initialize(SERVICES, EVENTS, FUZZY_EVENTS);
+const EVENT_PROPERTIES = {
+  [GROUPS.connectDevice]: mapConnectDeviceFlow,
+  [GROUPS.email]: mixProperties(mapEmailType, mapService),
+  [GROUPS.emailFirst]: mapService,
+  [GROUPS.login]: mapService,
+  [GROUPS.registration]: mapService,
+  [GROUPS.settings]: mapDisconnectReason
+};
+
+const USER_PROPERTIES = {
+  [GROUPS.connectDevice]: mapFlowId,
+  [GROUPS.email]: mapFlowId,
+  [GROUPS.emailFirst]: mixProperties(mapFlowId, mapUtmProperties),
+  [GROUPS.login]: mixProperties(mapFlowId, mapUtmProperties),
+  [GROUPS.registration]: mixProperties(mapFlowId, mapUtmProperties),
+  [GROUPS.settings]: mapNewsletterState
+};
 
 module.exports = receiveEvent;
 
 function receiveEvent (event, request, data) {
-  if (! event || ! request || ! data) {
+  if (! event || ! data) {
     return;
   }
 
-  const location = geolocate(request);
-  const userAgent = ua.parse(request.headers['user-agent']);
+  const eventType = event.type;
+  let mapping = EVENTS[eventType];
+  let eventCategory, eventTarget;
 
-  const amplitudeEvent = transform(
-    event,
-    Object.assign(
-      {},
-      pruneUnsetValues(data),
-      mapBrowser(userAgent),
-      mapOs(userAgent),
-      mapFormFactor(userAgent),
-      mapLocation(location)
-    )
-  );
+  if (! mapping) {
+    for (const [ key, value ] of FUZZY_EVENTS.entries()) {
+      const match = key.exec(eventType);
+      if (match) {
+        mapping = value;
+        if (match.length >= 2) {
+          eventCategory = match[1];
+          if (match.length === 3) {
+            eventTarget = match[2];
+          }
+        }
+        break;
+      }
+    }
+  }
 
-  if (amplitudeEvent) {
-    process.stderr.write(`${JSON.stringify(amplitudeEvent)}\n`);
+  if (mapping) {
+    let group = mapping.group;
+    if (mapping.isDynamicGroup) {
+      group = group(eventCategory);
+      if (! group) {
+        return;
+      }
+    }
+
+    const location = geolocate(request);
+    const userAgent = ua.parse(request.headers['user-agent']);
+
+    process.stderr.write(`${
+      JSON.stringify(
+        Object.assign({
+          op: 'amplitudeEvent',
+          time: event.time,
+          user_id: marshallOptionalValue(data.uid),
+          device_id: marshallOptionalValue(data.deviceId),
+          event_type: `${group} - ${mapping.event}`,
+          session_id: data.flowBeginTime,
+          event_properties: mapEventProperties(group, mapping.event, eventCategory, eventTarget, data),
+          user_properties: mapUserProperties(group, eventCategory, data, userAgent),
+          app_version: APP_VERSION,
+          language: data.lang
+        }, mapOs(userAgent), mapDevice(userAgent), mapLocation(location))
+      )
+    }\n`);
   }
 }
 
-function pruneUnsetValues (data) {
-  const result = {};
-
-  Object.keys(data).forEach(key => {
-    const value = data[key];
-    if (value && value !== 'none') {
-      result[key] = value;
-    }
-  });
-
-  return result;
+function mapEventProperties (group, event, eventCategory, eventTarget, data) {
+  return Object.assign({
+    device_id: marshallOptionalValue(data.deviceId)
+  }, EVENT_PROPERTIES[group](event, eventCategory, eventTarget, data));
 }
 
-function mapBrowser (userAgent) {
-  return mapUserAgentProperties(userAgent, 'ua', 'browser', 'browserVersion');
+function mapUserProperties (group, eventCategory, data, userAgent) {
+  return Object.assign(
+    {},
+    mapBrowser(userAgent),
+    mapEntrypoint(data),
+    mapExperiments(data),
+    USER_PROPERTIES[group](eventCategory, data)
+  );
+}
+
+function marshallOptionalValue (value) {
+  if (value && value !== 'none') {
+    return value;
+  }
 }
 
 function mapOs (userAgent) {
-  return mapUserAgentProperties(userAgent, 'os', 'os', 'osVersion');
+  return mapUserAgentProperties(userAgent, 'os', 'os_name', 'os_version');
+}
+
+function mapBrowser (userAgent) {
+  return mapUserAgentProperties(userAgent, 'ua', 'ua_browser', 'ua_version');
 }
 
 function mapUserAgentProperties (userAgent, key, familyProperty, versionProperty) {
@@ -150,13 +246,6 @@ function mapUserAgentProperties (userAgent, key, familyProperty, versionProperty
   }
 }
 
-function mapFormFactor (userAgent) {
-  const { brand, family: formFactor } =  userAgent.device;
-  if (brand && formFactor && brand !== 'Generic') {
-    return { formFactor };
-  }
-}
-
 function mapLocation (location) {
   if (location && (location.country || location.state)) {
     return {
@@ -165,3 +254,105 @@ function mapLocation (location) {
     };
   }
 }
+
+function mapDevice (userAgent) {
+  const { brand, family: device_model } =  userAgent.device;
+  if (brand && device_model && brand !== 'Generic') {
+    return { device_model };
+  }
+}
+
+function mixProperties (...mappers) {
+  return (...args) => Object.assign({}, ...mappers.map(m => m(...args)));
+}
+
+function mapEntrypoint (data) {
+  const entrypoint = marshallOptionalValue(data.entrypoint);
+  if (entrypoint) {
+    return { entrypoint };
+  }
+}
+
+function mapExperiments (data) {
+  if (data.experiments && data.experiments.length > 0) {
+    return {
+      '$append': {
+        experiments: data.experiments.map(e => `${toSnakeCase(e.choice)}_${toSnakeCase(e.group)}`)
+      }
+    };
+  }
+}
+
+function toSnakeCase (string) {
+  return string.replace(/([a-z])([A-Z])/g, (s, c1, c2) => `${c1}_${c2.toLowerCase()}`)
+    .replace(/([A-Z])/g, c => c.toLowerCase())
+    .replace(/\./g, '_')
+    .replace(/-/g, '_');
+}
+
+function mapDisconnectReason (event, eventCategory) {
+  if (event === 'disconnect_device' && eventCategory) {
+    return { reason: eventCategory };
+  }
+}
+
+function mapConnectDeviceFlow (event, eventCategory, eventTarget) {
+  const connect_device_flow = CONNECT_DEVICE_FLOWS[eventCategory];
+  if (connect_device_flow) {
+    const result = { connect_device_flow };
+
+    if (eventTarget) {
+      result.connect_device_os = eventTarget;
+    }
+
+    return result;
+  }
+}
+
+function mapEmailType (event, eventCategory, eventTarget, data) {
+  const email_type = EMAIL_TYPES[eventCategory];
+  if (email_type) {
+    return { email_type, email_domain: marshallOptionalValue(data.emailDomain) };
+  }
+}
+
+function mapService (event, eventCategory, eventTarget, data) {
+  const service = marshallOptionalValue(data.service);
+  if (service) {
+    let serviceName, clientId;
+
+    if (service === 'sync') {
+      serviceName = service;
+    } else {
+      serviceName = SERVICES[service] || 'undefined_oauth';
+      clientId = service;
+    }
+
+    return { service: serviceName, oauth_client_id: clientId };
+  }
+}
+
+function mapFlowId (eventCategory, data) {
+  const flow_id = marshallOptionalValue(data.flowId);
+  if (flow_id) {
+    return { flow_id };
+  }
+}
+
+function mapNewsletterState (eventCategory) {
+  const newsletter_state = NEWSLETTER_STATES[eventCategory];
+  if (newsletter_state) {
+    return { newsletter_state };
+  }
+}
+
+function mapUtmProperties (eventCategory, data) {
+  return {
+    utm_campaign: marshallOptionalValue(data.utm_campaign),
+    utm_content: marshallOptionalValue(data.utm_content),
+    utm_medium: marshallOptionalValue(data.utm_medium),
+    utm_source: marshallOptionalValue(data.utm_source),
+    utm_term: marshallOptionalValue(data.utm_term)
+  };
+}
+

--- a/tests/server/amplitude.js
+++ b/tests/server/amplitude.js
@@ -88,6 +88,7 @@ registerSuite('amplitude', {
         country: 'United States',
         device_id: 'bar',
         event_properties: {
+          device_id: 'bar',
           oauth_client_id: '1',
           service: 'pocket'
         },
@@ -116,8 +117,7 @@ registerSuite('amplitude', {
               'second_experiment_group_two',
               'third_experiment_group_three',
               'fourth_experiment_group_four'
-            ],
-            fxa_services_used: 'pocket'
+            ]
           }
         }
       });
@@ -157,8 +157,7 @@ registerSuite('amplitude', {
         device_id: 'b',
         device_model: 'iPad',
         event_properties: {
-          oauth_client_id: 'g',
-          service: 'undefined_oauth'
+          device_id: 'b'
         },
         event_type: 'fxa_pref - password',
         language: 'f',
@@ -170,18 +169,9 @@ registerSuite('amplitude', {
         time: 'a',
         user_id: 'h',
         user_properties: {
-          '$append': {
-            fxa_services_used: 'undefined_oauth'
-          },
           entrypoint: 'c',
-          flow_id: 'e',
           ua_browser: 'Mobile Safari',
-          ua_version: '6.0',
-          utm_campaign: 'i',
-          utm_content: 'j',
-          utm_medium: 'k',
-          utm_source: 'l',
-          utm_term: 'm'
+          ua_version: '6.0'
         }
       });
     },
@@ -227,6 +217,7 @@ registerSuite('amplitude', {
       assert.equal(arg.event_type, 'fxa_pref - disconnect_device');
       assert.equal(arg.event_properties.reason, 'suspicious');
       assert.isUndefined(arg.device_id);
+      assert.isUndefined(arg.event_properties.device_id);
       assert.isUndefined(arg.user_id);
     },
 
@@ -365,6 +356,7 @@ registerSuite('amplitude', {
         country: 'United States',
         device_id: 'b',
         event_properties: {
+          device_id: 'b',
           oauth_client_id: '2',
           service: 'undefined_oauth'
         },
@@ -376,9 +368,6 @@ registerSuite('amplitude', {
         time: 'a',
         user_id: 'h',
         user_properties: {
-          '$append': {
-            fxa_services_used: 'undefined_oauth'
-          },
           entrypoint: 'c',
           flow_id: 'e',
           utm_campaign: 'i',
@@ -786,8 +775,7 @@ registerSuite('amplitude', {
         device_id: 'b',
         event_properties: {
           connect_device_flow: 'sms',
-          oauth_client_id: 'g',
-          service: 'undefined_oauth'
+          device_id: 'b'
         },
         event_type: 'fxa_connect_device - view',
         language: 'f',
@@ -797,16 +785,8 @@ registerSuite('amplitude', {
         time: 'a',
         user_id: 'h',
         user_properties: {
-          '$append': {
-            fxa_services_used: 'undefined_oauth'
-          },
           entrypoint: 'c',
-          flow_id: 'e',
-          utm_campaign: 'i',
-          utm_content: 'j',
-          utm_medium: 'k',
-          utm_source: 'l',
-          utm_term: 'm'
+          flow_id: 'e'
         }
       });
     },
@@ -919,7 +899,8 @@ registerSuite('amplitude', {
         country: 'United States',
         device_id: 'b',
         event_properties: {
-          email_provider: 'other',
+          device_id: 'b',
+          email_domain: 'other',
           email_type: 'reset_password',
           service: 'sync'
         },
@@ -931,16 +912,8 @@ registerSuite('amplitude', {
         time: 'a',
         user_id: 'h',
         user_properties: {
-          '$append': {
-            fxa_services_used: 'sync'
-          },
           entrypoint: 'c',
-          flow_id: 'e',
-          utm_campaign: 'i',
-          utm_content: 'j',
-          utm_medium: 'k',
-          utm_source: 'l',
-          utm_term: 'm'
+          flow_id: 'e'
         }
       });
     },
@@ -964,7 +937,7 @@ registerSuite('amplitude', {
       assert.equal(process.stderr.write.callCount, 1);
       const arg = JSON.parse(process.stderr.write.args[0]);
       assert.equal(arg.event_type, 'fxa_email - click');
-      assert.equal(arg.event_properties.email_provider, undefined);
+      assert.equal(arg.event_properties.email_domain, undefined);
       assert.equal(arg.event_properties.email_type, 'login');
     },
 
@@ -986,7 +959,7 @@ registerSuite('amplitude', {
       assert.equal(process.stderr.write.callCount, 1);
       const arg = JSON.parse(process.stderr.write.args[0]);
       assert.equal(arg.event_type, 'fxa_email - click');
-      assert.equal(arg.event_properties.email_provider, undefined);
+      assert.equal(arg.event_properties.email_domain, undefined);
       assert.equal(arg.event_properties.email_type, 'registration');
     },
 


### PR DESCRIPTION
Reverts a5ab8370ff50af3b536b4665b0723c655fe423b8, in case we want to try a point release for train 110 with the refactored Amplitude code reverted.

I couldn't reproduce anything that seemed wrong locally but one of the biggest metrics-related changes from that train was the refactor to use common code in `fxa-shared` for the Amplitude events. This is a speculative fix that reinstates the old code for logging Amplitude events.

Maybe it will or maybe it won't fix the problem, but we can be sure it won't break anything because this is the exact same code that's running in prod from train 109 (I've even consciously left some warts in so that `git diff train-109 -- server/lib/amplitude.js` returns nothing). And even if it doesn't fix the issue, at least is narrows down the list of culprits that may have caused the breakage.

@mozilla/fxa-devs r?