### PR TITLE
feat(totp): add experiment logic for TOTP

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/app/scripts/lib/experiments/grouping-rules/index.js
@@ -18,7 +18,8 @@ const experimentGroupingRules = [
   require('./send-sms-install-link'),
   require('./sentry'),
   require('./sessions'),
-  require('./token-code')
+  require('./token-code'),
+  require('./totp'),
 ].map(ExperimentGroupingRule => new ExperimentGroupingRule());
 
 class ExperimentChoiceIndex {

--- a/app/scripts/lib/experiments/grouping-rules/totp.js
+++ b/app/scripts/lib/experiments/grouping-rules/totp.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const BaseGroupingRule = require('./base');
+const GROUPS = ['control', 'treatment'];
+const ENABLED_EMAIL_REGEX = /(.+@mozilla\.(com|org)$)|(.+@softvision\.(com|ro)$)/;
+
+module.exports = class TotpGroupingRule extends BaseGroupingRule {
+  constructor() {
+    super();
+    this.name = 'totp';
+    this.ROLLOUT_RATE = 0.00;
+  }
+
+  choose(subject) {
+    if (! subject || ! subject.account || ! subject.uniqueUserId) {
+      return false;
+    }
+
+    // Is feature enabled explicitly? ex. from `?showTwoStepAuthentication=true` feature flag?
+    if (subject.showTwoStepAuthentication) {
+      return true;
+    }
+
+    // Is this a Mozilla/Softvision based email?
+    const email = subject.account.get('email');
+    if (ENABLED_EMAIL_REGEX.test(email)) {
+      return true;
+    }
+
+    // Are they apart of rollout?
+    if (this.bernoulliTrial(this.ROLLOUT_RATE, subject.uniqueUserId)) {
+      return this.uniformChoice(GROUPS, subject.uniqueUserId);
+    }
+
+    // Otherwise don't show panel
+    return false;
+  }
+};

--- a/app/scripts/views/mixins/totp-experiment-mixin.js
+++ b/app/scripts/views/mixins/totp-experiment-mixin.js
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * An TotpExperimentMixin factory.
+ *
+ * @mixin TotpExperimentMixin
+ */
+'use strict';
+
+const ExperimentMixin = require('./experiment-mixin');
+const EXPERIMENT_NAME = 'totp';
+
+/**
+ * Creates the mixin
+ *
+ * @returns {Object} mixin
+ */
+module.exports = {
+  dependsOn: [ExperimentMixin],
+
+  beforeRender() {
+    if (this.isInTotpExperiment()) {
+      const experimentGroup = this.getTotpExperimentGroup();
+      this.createExperiment(EXPERIMENT_NAME, experimentGroup);
+    }
+  },
+
+  /**
+   * Get TOTP experiment group
+   *
+   * @returns {String}
+   */
+  getTotpExperimentGroup() {
+    return this.getExperimentGroup(EXPERIMENT_NAME, this._getTotpExperimentSubject());
+  },
+
+
+  /**
+   * Is the user in the TOTP experiment?
+   *
+   * @returns {Boolean}
+   */
+  isInTotpExperiment() {
+    return this.isInExperiment(EXPERIMENT_NAME, this._getTotpExperimentSubject());
+  },
+
+  /**
+   * Get the TOTP experiment choice subject
+   *
+   * @returns {Object}
+   * @private
+   */
+  _getTotpExperimentSubject() {
+    const subject = {
+      account: this.getSignedInAccount(),
+      showTwoStepAuthentication: this.broker.getCapability('showTwoStepAuthentication'),
+    };
+    return subject;
+  }
+};

--- a/app/scripts/views/settings/two_step_authentication.js
+++ b/app/scripts/views/settings/two_step_authentication.js
@@ -15,6 +15,7 @@ const UpgradeSessionMixin = require('../mixins/upgrade-session-mixin');
 const Template = require('templates/settings/two_step_authentication.mustache');
 const preventDefaultThen = require('../base').preventDefaultThen;
 const showProgressIndicator = require('../decorators/progress_indicator');
+const TotpExperimentMixin = require('../mixins/totp-experiment-mixin');
 
 var t = BaseView.t;
 
@@ -66,6 +67,11 @@ const View = FormView.extend({
     if (this.broker.hasCapability('showTwoStepAuthentication')) {
       return true;
     }
+
+    if (this.isInTotpExperiment()) {
+      return true;
+    }
+
     return false;
   },
 
@@ -175,7 +181,8 @@ Cocktail.mixin(
   }),
   AvatarMixin,
   SettingsPanelMixin,
-  FloatingPlaceholderMixin
+  FloatingPlaceholderMixin,
+  TotpExperimentMixin
 );
 
 module.exports = View;

--- a/app/tests/spec/lib/experiments/grouping-rules/index.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/index.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
 
   describe('lib/experiments/grouping-rules/index', () => {
     it('EXPERIMENT_NAMES is exported', () => {
-      assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 8);
+      assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 9);
     });
 
     describe('choose', () => {

--- a/app/tests/spec/lib/experiments/grouping-rules/totp.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/totp.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const {assert} = require('chai');
+const Account = require('models/account');
+const Experiment = require('lib/experiments/grouping-rules/totp');
+const sinon = require('sinon');
+
+describe('lib/experiments/grouping-rules/totp', () => {
+  describe('choose', () => {
+    let account;
+    let experiment;
+    let subject;
+
+    beforeEach(() => {
+      account = new Account();
+      experiment = new Experiment();
+      subject = {
+        account: account,
+        experimentGroupingRules: {},
+        showTwoStepAuthentication: false,
+        uniqueUserId: 'user-id'
+      };
+    });
+
+    it('returns true experiment if broker has capability', () => {
+      subject.showTwoStepAuthentication = true;
+      assert.equal(experiment.choose(subject), true);
+    });
+
+    ['a@mozilla.org', 'a@softvision.com', 'a@softvision.ro', 'a@softvision.com'].forEach((email) => {
+      it(`returns true experiment for ${email} email`, () => {
+        subject.account.set('email', email);
+        assert.equal(experiment.choose(subject), true);
+      });
+    });
+
+    it('delegates to uniformChoice if in rollout', () => {
+      experiment.ROLLOUT_RATE = 1.0;
+      sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
+      experiment.choose(subject);
+      assert.isTrue(experiment.uniformChoice.calledOnce);
+      assert.isTrue(experiment.uniformChoice.calledWith(['control', 'treatment'], 'user-id'));
+    });
+
+    it('returns false if not in rollout', () => {
+      experiment.ROLLOUT_RATE = 0.0;
+      assert.equal(experiment.choose(subject), false);
+    });
+  });
+});

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -47,6 +47,7 @@ require('./spec/lib/experiments/grouping-rules/send-sms-install-link');
 require('./spec/lib/experiments/grouping-rules/sentry');
 require('./spec/lib/experiments/grouping-rules/sessions');
 require('./spec/lib/experiments/grouping-rules/token-code');
+require('./spec/lib/experiments/grouping-rules/totp');
 require('./spec/lib/fxa-client');
 require('./spec/lib/height-observer');
 require('./spec/lib/image-loader');


### PR DESCRIPTION
From mtg: enable two step authentication panel for Mozilla emails for train 111. This should be done as a point release once train 111 is deployed.