### PR TITLE
fix(metrics): remove temporary flow validation fallback code

### DIFF
--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -200,7 +200,7 @@ function isValidFlowData (metrics, requestReceivedTime) {
     return false;
   }
 
-  return flowMetrics.validate(FLOW_ID_KEY, metrics.flowId, metrics.flowBeginTime, metrics.agent);
+  return flowMetrics.validate(FLOW_ID_KEY, metrics.flowId, metrics.flowBeginTime);
 }
 
 function isValidTime (time, requestReceivedTime) {

--- a/server/lib/flow-metrics.js
+++ b/server/lib/flow-metrics.js
@@ -26,20 +26,12 @@ module.exports = {
    * @param key String
    * @param flowId String
    * @param flowBeginTime Number
-   * @param userAgent String
    * @returns Boolean
    */
-  validate (key, flowId, flowBeginTime, userAgent) {
+  validate (key, flowId, flowBeginTime) {
     const salt = flowId.substr(0, SALT_STRING_LENGTH);
-    let expected = createFlowEventData(key, salt, flowBeginTime);
+    const expected = createFlowEventData(key, salt, flowBeginTime);
 
-    if (getFlowSignature(flowId) === getFlowSignature(expected.flowId)) {
-      return true;
-    }
-
-    // HACK: We're transitioning between flow id recipes so, just for one train,
-    //       fall back to trying the old way if the preceding check failed.
-    expected = createFlowEventData(key, salt, flowBeginTime, userAgent);
     return getFlowSignature(flowId) === getFlowSignature(expected.flowId);
   }
 };

--- a/tests/server/flow-metrics.js
+++ b/tests/server/flow-metrics.js
@@ -114,7 +114,7 @@ suite.tests['create generates different flowIds for different timestamps'] = () 
   assert.notEqual(flowEventData1.flowBeginTime, flowEventData2.flowBeginTime);
 };
 
-suite.tests['validate returns true for good data with user-agent'] = () => {
+suite.tests['validate returns false for data with user-agent'] = () => {
   // Force the mocks to return bad data to be sure it really works
   mockDateNow = 1478626838531;
   mockFlowIdKey = 'foo';
@@ -128,7 +128,7 @@ suite.tests['validate returns true for good data with user-agent'] = () => {
     'Firefox'
   );
 
-  assert.strictEqual(result, true);
+  assert.strictEqual(result, false);
 };
 
 suite.tests['validate returns true for good data without user-agent'] = () => {
@@ -158,8 +158,7 @@ suite.tests['validate returns false for a bad flow id'] = () => {
   const result = flowMetrics.validate(
     'S3CR37',
     'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
-    1451566800000,
-    'Firefox'
+    1451566800000
   );
 
   assert.strictEqual(result, false);
@@ -174,9 +173,8 @@ suite.tests['validate returns false for a bad key'] = () => {
 
   const result = flowMetrics.validate(
     'foo',
-    '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
-    1451566800000,
-    'Firefox'
+    '4d6f7a696c6c6146697265666f7821212a204a6d26b009b26b3116f643d84c6f',
+    1451566800000
   );
 
   assert.strictEqual(result, false);
@@ -191,26 +189,8 @@ suite.tests['validate returns false for a bad flow begin time'] = () => {
 
   const result = flowMetrics.validate(
     'S3CR37',
-    '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
-    1478626838531,
-    'Firefox'
-  );
-
-  assert.strictEqual(result, false);
-};
-
-suite.tests['validate returns false for a bad user agent string'] = () => {
-  // Force the mocks to return good data to be sure it really works
-  mockDateNow = 1451566800000;
-  mockFlowIdKey = 'S3CR37';
-  mockUserAgent = 'Firefox';
-  mockRandomBytes = 'MozillaFirefox!!';
-
-  const result = flowMetrics.validate(
-    'S3CR37',
-    '4d6f7a696c6c6146697265666f782121c89d56556d22039fbbf54d34e0baf206',
-    1451566800000,
-    'foo'
+    '4d6f7a696c6c6146697265666f7821212a204a6d26b009b26b3116f643d84c6f',
+    1478626838531
   );
 
   assert.strictEqual(result, false);


### PR DESCRIPTION
See #6044. Related auth server change in mozilla/fxa-auth-server#2420.

I would have opened it against against the `train-111` branch but it looks like some blocking point release stuff got merged already and I don't want to interfere with anyone's feature rollout plans or whatever. It's fine to wait a train.

@mozilla/fxa-devs r?