### PR TITLE
refactor(experiment): Remove the q3FormChanges experiment.

### DIFF
--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -17,7 +17,6 @@ define(function (require, exports, module) {
    * Experiments that are created on startup in `chooseExperiments`.
    */
   const STARTUP_EXPERIMENTS = {
-    'q3FormChanges': BaseExperiment
   };
 
   /**

--- a/app/scripts/lib/experiments/grouping-rules/base.js
+++ b/app/scripts/lib/experiments/grouping-rules/base.js
@@ -60,6 +60,9 @@ module.exports = class BaseGroupingRule {
    * @param {Object} subject data used to decide
    */
   choose (subject) {
+    if (this.deprecated) {
+      throw new Error(`Experiment deprecated: ${this.name}`);
+    }
     throw new Error('choose must be overridden');
   }
 };

--- a/app/scripts/lib/experiments/grouping-rules/email-first.js
+++ b/app/scripts/lib/experiments/grouping-rules/email-first.js
@@ -28,8 +28,6 @@ class EmailFirstGroupingRule extends BaseGroupingRule {
     } else if (! subject.isEmailFirstSupported) {
       // isEmailFirstSupported is `true` for brokers that support the email-first flow.
       return false;
-    } else if (subject.experimentGroupingRules.choose('q3FormChanges', subject) !== this.name) {
-      return  false;
     } else if (! this._isSampledUser(subject)) {
       return false;
     }
@@ -58,9 +56,6 @@ class EmailFirstGroupingRule extends BaseGroupingRule {
   _isSampledUser (subject) {
     // All users that make it to this point that also report metrics are
     // sampled users.
-    // There are 4 experiments in q3FormChanges, and 10% of users report metrics.
-    // 100% / 4 = 25% in each of the 4 experiments.
-    // 25% * .1 = 2.5% overall sample rate for this experiment.
     return subject.experimentGroupingRules.choose('isSampledUser', subject);
   }
 }

--- a/app/scripts/lib/experiments/grouping-rules/q3-form-changes.js
+++ b/app/scripts/lib/experiments/grouping-rules/q3-form-changes.js
@@ -2,6 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/**
+ * q3FormChanges is deprecated but kept around so that the experiment name
+ * still validate in the weeks after train-112 rolls out.
+ * The experiment can be removed in train-113 once the numbers of people
+ * reporting q3FormChanges are sufficiently low.
+ */
 'use strict';
 
 const BaseGroupingRule = require('./base');
@@ -9,22 +15,7 @@ const BaseGroupingRule = require('./base');
 module.exports = class Q3FormChanges extends BaseGroupingRule {
   constructor () {
     super();
+    this.deprecated = true;
     this.name = 'q3FormChanges';
-  }
-
-  /**
-   * Use `subject` data to make a choice.
-   *
-   * @param {Object} subject data used to decide
-   * @returns {Any}
-   */
-  choose (subject) {
-    const EXPERIMENTS = ['emailFirst'];
-
-    if (! subject || ! subject.uniqueUserId) {
-      return false;
-    }
-
-    return this.uniformChoice(EXPERIMENTS, subject.uniqueUserId);
   }
 };

--- a/app/tests/spec/lib/experiments/grouping-rules/base.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/base.js
@@ -112,6 +112,14 @@ define(function (require, exports, module) {
           experiment.choose();
         }, 'choose must be overridden');
       });
+
+      it('throws if deprecated', () => {
+        assert.throws(() => {
+          experiment.name = 'oldExperiment';
+          experiment.deprecated = true;
+          experiment.choose();
+        }, 'Experiment deprecated: oldExperiment');
+      });
     });
 
     describe('one experiment choose another', () => {

--- a/app/tests/spec/lib/experiments/grouping-rules/email-first.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/email-first.js
@@ -12,7 +12,6 @@ define(function (require, exports, module) {
   describe('lib/experiments/grouping-rules/email-first', () => {
     let experiment;
     let experimentGroupingRules;
-    let q3FormChangesChoice;
     let sandbox;
 
     before(() => {
@@ -20,9 +19,7 @@ define(function (require, exports, module) {
 
       experimentGroupingRules = {
         choose (experimentName) {
-          if (experimentName === 'q3FormChanges') {
-            return q3FormChangesChoice;
-          } else if (experimentName === 'isSampledUser') {
+          if (experimentName === 'isSampledUser') {
             return true;
           }
           return false;
@@ -31,7 +28,6 @@ define(function (require, exports, module) {
     });
 
     beforeEach(() => {
-      q3FormChangesChoice = 'emailFirst';
       sandbox = sinon.sandbox.create();
     });
 
@@ -56,7 +52,6 @@ define(function (require, exports, module) {
 
       it('returns chooses some experiment ', () => {
         sandbox.stub(experiment, 'bernoulliTrial').callsFake(() => true);
-        q3FormChangesChoice = 'emailFirst';
 
         assert.ok(experiment.choose({
           env: 'development',

--- a/app/tests/spec/lib/experiments/grouping-rules/q3-form-changes.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/q3-form-changes.js
@@ -2,35 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define(function (require, exports, module) {
-  'use strict';
+'use strict';
 
-  const { assert } = require('chai');
-  const Account = require('models/account');
-  const Experiment = require('lib/experiments/grouping-rules/q3-form-changes');
+const { assert } = require('chai');
+const Account = require('models/account');
+const Experiment = require('lib/experiments/grouping-rules/q3-form-changes');
 
-  describe('lib/experiments/grouping-rules/q3-form-changes', () => {
-    let account;
-    let experiment;
+describe('lib/experiments/grouping-rules/q3-form-changes', () => {
+  let account;
+  let experiment;
 
-    before(() => {
-      account = new Account();
-      experiment = new Experiment();
-    });
+  before(() => {
+    account = new Account();
+    experiment = new Experiment();
+  });
 
-    describe('choose', () => {
-      it('returns false if no subject or uniqueUserId', () => {
-        assert.isFalse(experiment.choose());
-        assert.isFalse(experiment.choose({}));
-      });
-
-      it('returns chooses some group ', () => {
-        assert.ok(experiment.choose({
+  describe('choose', () => {
+    it('throws', () => {
+      assert.throws(() => {
+        experiment.choose({
           account,
           uniqueUserId: 'user-id'
-        }));
+        });
       });
-
     });
   });
 });


### PR DESCRIPTION
The experiment has been marked `deprecated`. The experiment
grouping rule is left in tree for a train so that metrics
with the q3FormChanges experiment still pass. This handles
users that loaded FxA before the train was updated but
report metrics after the update.

fixes #5872 

@vladikoff - r?
@irrationalagent - Is the approach to metrics validation reasonable? Is one train sufficient to allow stragglers to report metrics without erroring?