### PR TITLE
revert(csp): revert removing csp support for gravatar

### DIFF
--- a/server/lib/csp/blocking.js
+++ b/server/lib/csp/blocking.js
@@ -23,6 +23,7 @@ module.exports = function (config) {
   const BLOB = 'blob:';
   const CDN_URL = config.get('static_resource_url');
   const DATA = 'data:';
+  const GRAVATAR = 'https://secure.gravatar.com';
   const MARKETING_EMAIL_SERVER = getOrigin(config.get('marketing_email.api_url'));
   const OAUTH_SERVER = getOrigin(config.get('oauth_url'));
   const PROFILE_SERVER = getOrigin(config.get('profile_url'));
@@ -65,6 +66,10 @@ module.exports = function (config) {
       imgSrc: addCdnRuleIfRequired([
         SELF,
         DATA,
+        // Gravatar support was removed in #4927, but we don't want
+        // to break the site for users who already use a Gravatar as
+        // their profile image.
+        GRAVATAR,
         PROFILE_IMAGES_SERVER
       ]),
       mediaSrc: [BLOB],
@@ -86,6 +91,7 @@ module.exports = function (config) {
       CDN_URL,
       DATA,
       EMBEDDED_STYLE_SHA,
+      GRAVATAR,
       MARKETING_EMAIL_SERVER,
       NONE,
       OAUTH_SERVER,

--- a/tests/server/csp.js
+++ b/tests/server/csp.js
@@ -63,9 +63,10 @@ suite.tests['blockingRules'] = function () {
   assert.include(fontSrc, CDN_SERVER);
 
   const imgSrc = directives.imgSrc;
-  assert.lengthOf(imgSrc, 4);
+  assert.lengthOf(imgSrc, 5);
   assert.include(imgSrc, Sources.SELF);
   assert.include(imgSrc, Sources.DATA);
+  assert.include(imgSrc, Sources.GRAVATAR);
   assert.include(imgSrc, Sources.PROFILE_IMAGES_SERVER);
   assert.include(imgSrc, CDN_SERVER);
 


### PR DESCRIPTION
Fixes #6127 

Github complained when I tried to revert https://github.com/mozilla/fxa-content-server/pull/6015 (contents have changed). This manually reverts the changes.