### PR TITLE
fix(client): improve messaging before delete account

### DIFF
--- a/app/scripts/templates/settings/delete_account.mustache
+++ b/app/scripts/templates/settings/delete_account.mustache
@@ -11,7 +11,7 @@
     <div class="error"></div>
 
     <form novalidate>
-      <p>{{#t}}Are you sure you want to delete your account? This action cannot be undone.{{/t}}</p>
+      <p>{{#t}}If you use this account for Mozilla apps and services like AMO, Pocket, and Screenshots you should first log in and remove any saved personal information. Once you delete your account here you may lose access to it everywhere.{{/t}}</p>
 
       <div class="input-row password-row">
         <label class="label-helper"></label>


### PR DESCRIPTION
As a first step to GDPR compliance, this change improves the messaging around account deletion so that the user knows to separately delete their pocket/AMO/whatever account first.

This is the text in place, as approved by legal [here](https://docs.google.com/presentation/d/1MUuna5kDVLolHlJIH_tXPKtXIVzxn5pbYBaPN4QARlw):

![Screenshot showing the updated message before a user deletes their account](https://user-images.githubusercontent.com/64367/39769402-041154d4-52e4-11e8-8ee0-124b97881868.png)

@mozilla/fxa-devs r?