### PR TITLE
feat(recovery): update view when low on recovery codes

### DIFF
--- a/app/scripts/templates/settings/recovery_codes.mustache
+++ b/app/scripts/templates/settings/recovery_codes.mustache
@@ -1,18 +1,30 @@
 <div id="recovery-codes">
     <section class="modal-panel">
-        <p class="success modal-success">{{modalSuccessMsg}}</p>
+        {{#modalSuccessMsg}}
+            <p class="success modal-success">{{modalSuccessMsg}}</p>
+        {{/modalSuccessMsg}}
         <div class="error"></div>
 
         <h2>{{#t}}Recovery codes{{/t}}</h2>
 
-        <p class="description">
-            <span class="note">{{#t}}NOTE:{{/t}}</span>
-            {{#t}}
-                These codes will only be shown and can only be used once. Store them in a safe place in the event you lose access to your mobile device.
-            {{/t}}
-        </p>
+    <form novalidate>
+        {{^hasRecoveryCodes}}
+            <p class="description">
+                <span class="note">{{#t}}NOTE:{{/t}}</span>
+                {{#t}}By generating new recovery codes, all previous codes will become invalid. Please store new codes in a safe location.{{/t}}
+            </p>
 
-        <form novalidate>
+            <div class="recovery-code-generate">
+                <a class="replace-codes-link">{{#t}}Generate new recovery codes{{/t}}</a>
+            </div>
+        {{/hasRecoveryCodes}}
+
+        {{#hasRecoveryCodes}}
+            <p class="description">
+                <span class="note">{{#t}}NOTE:{{/t}}</span>
+                {{#t}}These are your one time use recovery codes. Store them in a safe place in the event you lose access to your mobile device. You will not be able to see these codes again.{{/t}}
+            </p>
+
             <div id="recovery-code-container">
                 {{#recoveryCodes}}
                     <div class="recovery-code">{{code}}</div>
@@ -35,9 +47,11 @@
                     <p class="name">{{#t}}Print{{/t}}</p>
                 </a>
             </div>
-            <div class="button-row">
-                <button class="settings-button secondary-button two-step-authentication-done">{{#t}}Done{{/t}}</button>
-            </div>
-        </form>
+        {{/hasRecoveryCodes}}
+
+        <div class="button-row">
+            <button class="settings-button secondary-button two-step-authentication-done">{{#t}}Done{{/t}}</button>
+        </div>
+    </form>
     </section>
 </div>

--- a/app/scripts/templates/settings/recovery_codes.mustache
+++ b/app/scripts/templates/settings/recovery_codes.mustache
@@ -8,7 +8,7 @@
         <h2>{{#t}}Recovery codes{{/t}}</h2>
 
     <form novalidate>
-        {{^hasRecoveryCodes}}
+        {{^showRecoveryCodes}}
             <p class="description">
                 <span class="note">{{#t}}NOTE:{{/t}}</span>
                 {{#t}}By generating new recovery codes, all previous codes will become invalid. Please store new codes in a safe location.{{/t}}
@@ -17,9 +17,9 @@
             <div class="recovery-code-generate">
                 <a class="replace-codes-link">{{#t}}Generate new recovery codes{{/t}}</a>
             </div>
-        {{/hasRecoveryCodes}}
+        {{/showRecoveryCodes}}
 
-        {{#hasRecoveryCodes}}
+        {{#showRecoveryCodes}}
             <p class="description">
                 <span class="note">{{#t}}NOTE:{{/t}}</span>
                 {{#t}}These are your one time use recovery codes. Store them in a safe place in the event you lose access to your mobile device. You will not be able to see these codes again.{{/t}}
@@ -47,7 +47,7 @@
                     <p class="name">{{#t}}Print{{/t}}</p>
                 </a>
             </div>
-        {{/hasRecoveryCodes}}
+        {{/showRecoveryCodes}}
 
         <div class="button-row">
             <button class="settings-button secondary-button two-step-authentication-done">{{#t}}Done{{/t}}</button>

--- a/app/scripts/views/settings/recovery_codes.js
+++ b/app/scripts/views/settings/recovery_codes.js
@@ -133,9 +133,9 @@ const View = FormView.extend({
     }
 
     context.set({
-      hasRecoveryCodes: recoveryCodes.length > 0,
       modalSuccessMsg,
-      recoveryCodes
+      recoveryCodes,
+      showRecoveryCodes: recoveryCodes.length > 0
     });
   }
 });

--- a/app/scripts/views/settings/recovery_codes.js
+++ b/app/scripts/views/settings/recovery_codes.js
@@ -127,10 +127,13 @@ const View = FormView.extend({
 
     let modalSuccessMsg = this.model.get('modalSuccessMsg');
     if (! modalSuccessMsg) {
-      modalSuccessMsg = t('Two-step authentication enabled');
+      if (recoveryCodes.length > 0) {
+        modalSuccessMsg = t('Two-step authentication enabled');
+      }
     }
 
     context.set({
+      hasRecoveryCodes: recoveryCodes.length > 0,
       modalSuccessMsg,
       recoveryCodes
     });

--- a/app/styles/modules/_settings-totp.scss
+++ b/app/styles/modules/_settings-totp.scss
@@ -132,6 +132,10 @@
     }
   }
 
+  .recovery-code-generate {
+    margin: 40px 0px 40px 0px;
+  }
+
   .two-step-authentication-done {
     float: none;
     width: 100%;

--- a/app/tests/spec/views/settings/recovery_codes.js
+++ b/app/tests/spec/views/settings/recovery_codes.js
@@ -171,4 +171,17 @@ describe('views/settings/recovery_codes', () => {
       assert.equal(args[0], 'settings/two_step_authentication', 'correct path set');
     });
   });
+
+  describe('should only show `generate recovery codes` if model does not have recovery codes', () => {
+    beforeEach(() => {
+      model.set('recoveryCodes', null);
+      return view.render()
+        .then(() => $('#container').html(view.$el));
+    });
+
+    it('only show `generate recovery codes`', () => {
+      assert.equal(view.$('.replace-codes-link').length, 1);
+      assert.equal(view.$('#recovery-code-container').length, 0);
+    });
+  });
 });

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -277,6 +277,8 @@ module.exports = {
     MANUAL_CODE: '.code',
     MENU_BUTTON: '#totp-section .settings-unit-toggle',
     QR_CODE: '.qr-image',
+    RECOVERY_CODES_DESCRIPTION: '#recovery-codes .description',
+    RECOVERY_CODES_DONE: '#recovery-codes .description',
     SHOW_CODE_LINK: '.show-code-link',
     STATUS_DISABLED: '.two-step-authentication .disabled',
     STATUS_ENABLED: '.two-step-authentication .enabled',

--- a/tests/functional/sign_in_totp.js
+++ b/tests/functional/sign_in_totp.js
@@ -16,6 +16,7 @@ const SETTINGS_URL = `${config.fxaContentRoot}settings?showTwoStepAuthentication
 const PASSWORD = 'password';
 const SYNC_SIGNIN_URL = `${config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync`;
 const SIGNIN_URL = `${config.fxaContentRoot}signin?showTwoStepAuthentication=true`;
+const RECOVERY_CODES_URL = `${config.fxaContentRoot}settings/two_step_authentication/recovery_codes?showTwoStepAuthentication=true`;
 
 const SUCCESS_MESSAGE_DELAY_MS = 5000;
 
@@ -170,7 +171,14 @@ registerSuite('TOTP', {
         .then(testIsBrowserNotified('fxaccounts:delete'))
 
         .then(testElementExists(selectors.SIGNUP.HEADER));
-    }
+    },
+
+    'can navigate directly to recovery codes': function () {
+      return this.remote
+        .then(confirmTotpCode(secret))
+        .then(openPage(RECOVERY_CODES_URL, selectors.TOTP.RECOVERY_CODES_DESCRIPTION))
+        .then(click(selectors.TOTP.RECOVERY_CODES_DONE));
+    },
   }
 });
 


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-auth-server/issues/2409

This PR continas some tweaks to the recovery codes modal (when navigated directly too it). Previously it would show options to download/copy/print codes even though there wasn't any. I also updated the messaging to make it more clear that this action invalidates previous codes.

Before:
<img width="532" alt="screen shot 2018-05-11 at 10 53 39 am" src="https://user-images.githubusercontent.com/1295288/39930793-a85d1664-5509-11e8-8728-bd9fcbc17244.png">

After:
<img width="532" alt="screen shot 2018-05-11 at 10 52 34 am" src="https://user-images.githubusercontent.com/1295288/39930805-adb18578-5509-11e8-93f9-15c251e091ed.png">

@mozilla/fxa-devs r?