### PR TITLE
feat(signin): Show a user "card" for the email-first signin flow. 

### DIFF
--- a/app/scripts/templates/partial/user-card.mustache
+++ b/app/scripts/templates/partial/user-card.mustache
@@ -1,0 +1,9 @@
+<div class="user-card">
+  <div class="avatar-wrapper card-view"></div>
+  <div class="user-info">
+    <div>
+      <div class="prefillEmail">{{ email }}</div>
+      <a href="#" id="back" class="use-different" data-flow-event="use-different-account">{{#t}}Use a different email address{{/t}}</a>
+    </div>
+  </div>
+</div>

--- a/app/scripts/templates/sign_in_password.mustache
+++ b/app/scripts/templates/sign_in_password.mustache
@@ -15,8 +15,10 @@
     <div class="error"></div>
     <div class="success"></div>
 
+    {{{ userCardHTML }}}
+
+
     <form novalidate>
-      <p class="prefillEmail">{{ email }}</p>
       <input type="email" class="email hidden" value="{{ email }}" disabled />
 
       <div class="input-row password-row">
@@ -28,8 +30,7 @@
       </div>
 
       <div class="links">
-        <a href="#" id="back" class="left">{{#t}}Mistyped email?{{/t}}</a>
-        <a href="/reset_password" class="right reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>
+        <a href="/reset_password" class="center reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>
       </div>
     </form>
   </section>

--- a/app/scripts/views/index.js
+++ b/app/scripts/views/index.js
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
      * @returns {Promise}
      */
     checkEmail (email) {
-      const account = this.user.initAccount({
+      let account = this.user.initAccount({
         email
       });
 
@@ -95,6 +95,15 @@ define(function (require, exports, module) {
         .then(() => this.user.checkAccountEmailExists(account))
         .then((exists) => {
           const nextEndpoint = this.broker.transformLink(exists ? 'signin' : 'signup');
+          if (exists) {
+            // If the account exists, use the stored account
+            // so that any stored avatars are displayed on
+            // the next page.
+            account = this.user.getAccountByEmail(email);
+            // the returned account could be the default,
+            // ensure it's email is set.
+            account.set('email', email);
+          }
           this.navigate(nextEndpoint, { account });
         });
     }

--- a/app/scripts/views/mixins/user-card-mixin.js
+++ b/app/scripts/views/mixins/user-card-mixin.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import AvatarMixin from './avatar-mixin';
+import UserCardTemplate from 'templates/partial/user-card.mustache';
+
+export default {
+  dependsOn: [
+    AvatarMixin
+  ],
+
+  afterVisible () {
+    // this.displayAccountProfileImage could cause the existing
+    // accessToken to be invalidated, in which case the view
+    // should be re-rendered with the default avatar.
+    const account = this.getAccount();
+    this.listenTo(account, 'change:accessToken', () => this._onAccessTokenChange());
+    return this.displayAccountProfileImage(account, { spinner: true });
+  },
+
+  setInitialContext (context) {
+    context.set({
+      userCardHTML: this.renderTemplate(UserCardTemplate, {
+        email: this.getAccount().get('email')
+      })
+    });
+  },
+
+  _onAccessTokenChange () {
+    // if no access token and password is not visible we need to show the password field.
+    if (! this.getAccount().has('accessToken')) {
+      // accessToken could be changed async by an external request after render
+      // If the ProfileClient fails to get an OAuth token with the current token then reset the view
+      this.setDefaultPlaceholderAvatar();
+    }
+  }
+};

--- a/app/scripts/views/sign_in_password.js
+++ b/app/scripts/views/sign_in_password.js
@@ -2,56 +2,56 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define(function (require, exports, module) {
-  'use strict';
+'use strict';
 
-  const BackMixin = require('./mixins/back-mixin');
-  const Cocktail = require('cocktail');
-  const FlowEventsMixin = require('./mixins/flow-events-mixin');
-  const FormPrefillMixin = require('./mixins/form-prefill-mixin');
-  const FormView = require('./form');
-  const PasswordMixin = require('./mixins/password-mixin');
-  const ServiceMixin = require('./mixins/service-mixin');
-  const SignInMixin = require('./mixins/signin-mixin');
-  const Template = require('templates/sign_in_password.mustache');
+const BackMixin = require('./mixins/back-mixin');
+const Cocktail = require('cocktail');
+const FlowEventsMixin = require('./mixins/flow-events-mixin');
+const FormPrefillMixin = require('./mixins/form-prefill-mixin');
+const FormView = require('./form');
+const PasswordMixin = require('./mixins/password-mixin');
+const ServiceMixin = require('./mixins/service-mixin');
+const SignInMixin = require('./mixins/signin-mixin');
+const Template = require('templates/sign_in_password.mustache');
+import UserCardMixin from './mixins/user-card-mixin';
 
-  class SignInPasswordView extends FormView {
-    constructor (options) {
-      super(options);
+class SignInPasswordView extends FormView {
+  constructor (options) {
+    super(options);
 
-      this.template = Template;
-    }
+    this.template = Template;
+  }
 
-    getAccount () {
-      return this.model.get('account');
-    }
+  getAccount () {
+    return this.model.get('account');
+  }
 
-    beforeRender () {
-      if (! this.getAccount()) {
-        this.navigate('/');
-      }
-    }
-
-    setInitialContext (context) {
-      context.set(this.getAccount().pick('email'));
-    }
-
-    submit () {
-      const password = this.getElementValue('input[type=password]');
-
-      return this.signIn(this.getAccount(), password);
+  beforeRender () {
+    if (! this.getAccount()) {
+      this.navigate('/');
     }
   }
 
-  Cocktail.mixin(
-    SignInPasswordView,
-    BackMixin,
-    FlowEventsMixin,
-    FormPrefillMixin,
-    PasswordMixin,
-    ServiceMixin,
-    SignInMixin
-  );
+  setInitialContext (context) {
+    context.set(this.getAccount().pick('email'));
+  }
 
-  module.exports = SignInPasswordView;
-});
+  submit () {
+    const password = this.getElementValue('input[type=password]');
+
+    return this.signIn(this.getAccount(), password);
+  }
+}
+
+Cocktail.mixin(
+  SignInPasswordView,
+  BackMixin,
+  FlowEventsMixin,
+  FormPrefillMixin,
+  PasswordMixin,
+  ServiceMixin,
+  SignInMixin,
+  UserCardMixin,
+);
+
+module.exports = SignInPasswordView;

--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -145,15 +145,15 @@ input[type='radio'] {
     }
 }
 
+.prefillEmail {
+  color: $grey-60;
+  font-size: 15px;
+  font-weight: 500;
+  word-wrap: break-word;
+}
+
 section p {
   margin: 0 auto 25px 0;
-
-  &.prefillEmail {
-    color: $grey-60;
-    font-size: 15px;
-    font-weight: 500;
-    word-wrap: break-word;
-  }
 }
 
 .email {

--- a/app/styles/modules/_avatar.scss
+++ b/app/styles/modules/_avatar.scss
@@ -1,3 +1,41 @@
+.user-card {
+  display: block;
+  line-height: 1.5;
+  margin-bottom: 20px;
+  overflow: hidden;
+  padding: 0 0 0 91px;
+  text-align: left;
+  text-overflow: ellipsis;
+  width: 100%;
+
+  @include respond-to('small') {
+    background-color: #fff;
+    border-radius: 4px;
+    box-shadow: 0 1px 4px 0 rgba(12, 12, 13, 0.1);
+  }
+
+  @include respond-to('trustedUI') {
+    box-shadow: none;
+    height: 65px;
+    padding: 0 0 0 55px;
+  }
+
+  .user-info {
+    align-items: center;
+    display: flex;
+    height: 111px;
+    padding-left: 16px;
+
+    @include respond-to('trustedUI') {
+      height: 55px;
+    }
+  }
+
+  a {
+    font-size: 13px;
+  }
+}
+
 .avatar-wrapper {
   border-radius: 50%;
   border-width: 0;
@@ -8,6 +46,31 @@
   overflow: hidden;
   position: relative;
   width: $avatar-size;
+
+  &.card-view {
+    float: left;
+    height: 71px;
+    margin: 20px 0 0 -71px;
+    width: 71px;
+
+    @include respond-to('trustedUI') {
+      height: 55px;
+      margin-left: -55px;
+      margin-top: 0;
+      width: 55px;
+    }
+
+    img {
+      display: block;
+      height: 71px;
+      width: 71px;
+
+      @include respond-to('trustedUI') {
+        height: 55px;
+        width: 55px;
+      }
+    }
+  }
 
   &.avatar-view {
     display: block;

--- a/app/tests/spec/views/mixins/user-card-mixin.js
+++ b/app/tests/spec/views/mixins/user-card-mixin.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+import Account from 'models/account';
+import { assert } from 'chai';
+import BaseView from 'views/base';
+import Cocktail from 'cocktail';
+import { Model } from 'backbone';
+import UserCardMixin from 'views/mixins/user-card-mixin';
+import sinon from 'sinon';
+
+class View extends BaseView {
+}
+
+Cocktail.mixin(
+  View,
+  UserCardMixin
+);
+
+describe('views/mixins/user-card-mixin', () => {
+  let account;
+  let view;
+
+  beforeEach(() => {
+    account = new Account({ email: 'testuser@testuser.com' });
+    view = new View({});
+
+    sinon.stub(view, 'getAccount').callsFake(() => account);
+    sinon.stub(view, 'displayAccountProfileImage').callsFake(() => {});
+  });
+
+  describe('afterVisible', () => {
+    it('hooks up a `change:accessToken` listener, displays account profile photo', () => {
+      sinon.spy(view, 'listenTo');
+
+      view.afterVisible();
+
+      assert.isTrue(view.listenTo.calledOnceWith(account, 'change:accessToken'));
+      assert.isTrue(view.displayAccountProfileImage.calledOnceWith(account, { spinner: true }));
+    });
+  });
+
+  describe('setInitialContext', () => {
+    it('sets userCardHTML', () => {
+      const context = new Model({});
+      view.setInitialContext(context);
+      assert.ok(context.get('userCardHTML'));
+    });
+  });
+
+  describe('_onAccessTokenChange', () => {
+    it('sets the default placeholder if the account has no access token', () => {
+      sinon.stub(view, 'setDefaultPlaceholderAvatar');
+
+      account.set('accessToken', 'token');
+      view._onAccessTokenChange();
+      assert.isFalse(view.setDefaultPlaceholderAvatar.called);
+
+      account.unset('accessToken');
+      view._onAccessTokenChange();
+      assert.isTrue(view.setDefaultPlaceholderAvatar.calledOnce);
+    });
+  });
+});

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -186,6 +186,7 @@ require('./spec/views/mixins/sms-mixin');
 require('./spec/views/mixins/sync-auth-mixin');
 require('./spec/views/mixins/sync-suggestion-mixin');
 require('./spec/views/mixins/timer-mixin');
+require('./spec/views/mixins/user-card-mixin');
 require('./spec/views/mixins/verification-reason-mixin');
 require('./spec/views/oauth_index');
 require('./spec/views/oauth_sign_in');


### PR DESCRIPTION
I only added this to the email-first flow because it was tricky
to get this to work for the legacy signin flow and I want to
get this merged before the train cut.

I'll open a follow-on PR to add this behavior to the legacy flow.

builds on #6185 and should be reviewed afterwards (that's the first commit of this PR)
issue #6083
fixes #6052
fixes #6126 

## Desktop, default avatar

<img width="484" alt="screen shot 2018-05-14 at 14 58 43" src="https://user-images.githubusercontent.com/848085/40002539-f692bd08-5788-11e8-8f35-24f9a122634a.png">

## Mobile, default avatar

<img width="330" alt="screen shot 2018-05-14 at 14 58 49" src="https://user-images.githubusercontent.com/848085/40002558-00e7b394-5789-11e8-849e-a3753b3c8770.png">

## Firstrun, default avatar
<img width="325" alt="screen shot 2018-05-14 at 15 07 14" src="https://user-images.githubusercontent.com/848085/40002567-071d3266-5789-11e8-8f34-15522ad5c38c.png">

## Desktop OAuth email-first, with avatar
<img width="435" alt="screen shot 2018-05-14 at 15 06 36" src="https://user-images.githubusercontent.com/848085/40002579-10827eec-5789-11e8-8dcb-03e6711e506d.png">

## Mobile OAuth email-first, with avatar
<img width="355" alt="screen shot 2018-05-14 at 15 06 45" src="https://user-images.githubusercontent.com/848085/40002585-1628aad8-5789-11e8-9ea3-295e6f084872.png">

@mozilla/fxa-devs - r?