### PR TITLE
fix(tooltip): Show tooltips above the input on mobile

### DIFF
--- a/app/scripts/views/tooltip.js
+++ b/app/scripts/views/tooltip.js
@@ -4,138 +4,154 @@
 
 // It's a tooltip!
 
-define(function (require, exports, module) {
-  'use strict';
+'use strict';
 
-  const $ = require('jquery');
-  const _ = require('underscore');
-  const BaseView = require('./base');
-  const KeyCodes = require('../lib/key-codes');
+import $ from 'jquery';
+import _ from 'underscore';
+import BaseView from './base';
+import KeyCodes from '../lib/key-codes';
+import ScreenInfo from '../lib/screen-info';
 
-  var displayedTooltip;
-  var PADDING_BELOW_TOOLTIP_PX = 2;
-  var PADDING_ABOVE_TOOLTIP_PX = 4;
+let displayedTooltip;
+const PADDING_BELOW_TOOLTIP_PX = 2;
+const PADDING_ABOVE_TOOLTIP_PX = 4;
 
-  const proto = BaseView.prototype;
-  const Tooltip = BaseView.extend({
-    tagName: 'aside',
-    className: 'tooltip',
-    // tracks the type of a tooltip, used for metrics purposes
-    type: 'generic',
+// These values should be the same as
+// https://github.com/mozilla/fxa-content-server/blob/0eab619612897dcda43e8074dafdf55e8cbe11ee/app/styles/_breakpoints.scss#L6
+const MIN_HEIGHT_TO_SHOW_TOOLTIP_BELOW = 480;
+const MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW = 520;
 
-    initialize (options = {}) {
-      this.message = options.message || '';
-      this.unsafeMessage = options.unsafeMessage || '';
+const proto = BaseView.prototype;
+const Tooltip = BaseView.extend({
+  tagName: 'aside',
+  className: 'tooltip',
+  // tracks the type of a tooltip, used for metrics purposes
+  type: 'generic',
 
-      this.dismissible  = options.dismissible || false;
-      this.extraClassNames = options.extraClassNames || '';
+  initialize (options = {}) {
+    this.message = options.message || '';
+    this.unsafeMessage = options.unsafeMessage || '';
 
-      // the tooltip has to be attached to an element.
-      // By default, the tooltip is displayed just above the
-      // element. If the element has the 'tooltip-below' class, the
-      // tooltip is displayed just below it.
-      this.invalidEl = $(options.invalidEl);
-    },
+    this.dismissible  = options.dismissible || false;
+    this.extraClassNames = options.extraClassNames || '';
 
-    template () {
-      // If both `message` and `unsafeMessage` are set, prefer `message`
-      // since it'll be HTML escaped.
-      if (this.message) {
-        return this.translate(this.message);
-      } else if (this.unsafeMessage) {
-        return this.unsafeTranslate(this.unsafeMessage);
-      }
+    // the tooltip has to be attached to an element.
+    // By default, the tooltip is displayed just above the
+    // element. If the element has the 'tooltip-below' class, the
+    // tooltip is displayed just below it.
+    this.invalidEl = $(options.invalidEl);
+  },
 
-      return '';
-    },
-
-    afterRender () {
-      // only one tooltip at a time!
-      if (displayedTooltip) {
-        displayedTooltip.destroy(true);
-      }
-      displayedTooltip = this;
-
-      var tooltipContainer = this.invalidEl.closest('.input-row,.select-row-wrapper');
-
-      this.$el.addClass(this.extraClassNames);
-      this.$el.appendTo(tooltipContainer);
-
-      this.setPosition();
-
-      if (this.dismissible) {
-        this.$el.append('<span class="dismiss" tabindex="2">&#10005;</span>');
-      }
-
-      this.bindDOMEvents();
-
-      return proto.afterRender.call(this);
-    },
-
-    beforeDestroy () {
-      displayedTooltip = null;
-
-      // ditch the events we manually added to reduce interference
-      // between tooltips.
-      var invalidEl = this.invalidEl;
-      invalidEl.off('keyup change', this._destroy);
-      invalidEl.find('option').off('click', this._destroy);
-    },
-
-    setPosition () {
-      // by default, the position is above the input/select element
-      // to show the tooltip below the element, we use JS to set
-      // the top of the tooltip to be just below the element it is
-      // attached to.
-      var tooltipEl = this.$el;
-      var invalidEl = this.invalidEl;
-      if (invalidEl.hasClass('tooltip-below')) {
-        tooltipEl.addClass('tooltip-below fade-up-tt');
-        tooltipEl.css({
-          top: invalidEl.outerHeight() + PADDING_ABOVE_TOOLTIP_PX
-        });
-      } else {
-        tooltipEl.css({
-          top: -tooltipEl.outerHeight() - PADDING_BELOW_TOOLTIP_PX
-        });
-        tooltipEl.addClass('fade-down-tt');
-      }
-    },
-
-    bindDOMEvents () {
-      var invalidEl = this.invalidEl;
-
-      // destroy the tooltip any time the user
-      // interacts with the invalid element.
-      this._destroy = _.bind(this.destroy, this, true);
-      // keyboard input for input/select elements.
-      invalidEl.one('change', this._destroy);
-
-      // destroy the tooltip only if it's value has changed.
-      var originalValue = $(invalidEl).val().trim();
-      var closeIfInvalidElementValueHasChanged = function () {
-        var currValue = $(invalidEl).val().trim();
-        if (currValue !== originalValue) {
-          this._destroy();
-        } else {
-          invalidEl.one('keyup', closeIfInvalidElementValueHasChanged);
-        }
-      }.bind(this);
-
-      invalidEl.one('keyup', closeIfInvalidElementValueHasChanged);
-      // handle selecting an option with the mouse for select elements
-      invalidEl.find('option').one('click', this._destroy);
-
-      // destroy when dismissed
-      this.$el.find('.dismiss').one('click keypress', function (e) {
-        if (e.type === 'click' || e.which === KeyCodes.ENTER) {
-          var metricsEvent = 'tooltip.' + this.type + '-dismissed';
-          this.logEvent(metricsEvent);
-          this._destroy();
-        }
-      }.bind(this));
+  template () {
+    // If both `message` and `unsafeMessage` are set, prefer `message`
+    // since it'll be HTML escaped.
+    if (this.message) {
+      return this.translate(this.message);
+    } else if (this.unsafeMessage) {
+      return this.unsafeTranslate(this.unsafeMessage);
     }
-  });
 
-  module.exports = Tooltip;
+    return '';
+  },
+
+  afterRender () {
+    // only one tooltip at a time!
+    if (displayedTooltip) {
+      displayedTooltip.destroy(true);
+    }
+    displayedTooltip = this;
+
+    const tooltipContainer = this.invalidEl.closest('.input-row,.select-row-wrapper');
+
+    this.$el.addClass(this.extraClassNames);
+    this.$el.appendTo(tooltipContainer);
+
+    this.setPosition();
+
+    if (this.dismissible) {
+      this.$el.append('<span class="dismiss" tabindex="2">&#10005;</span>');
+    }
+
+    this.bindDOMEvents();
+
+    return proto.afterRender.call(this);
+  },
+
+  beforeDestroy () {
+    displayedTooltip = null;
+
+    // ditch the events we manually added to reduce interference
+    // between tooltips.
+    const invalidEl = this.invalidEl;
+    invalidEl.off('keyup change', this._destroy);
+    invalidEl.find('option').off('click', this._destroy);
+  },
+
+  canShowTooltipBelow () {
+    // Virtual keyboards on phones can obscure a tooltip.
+    // To avoid hidden tooltips, tooltips on phones are displayed above
+    // the input element. Tablets show tooltips in their default
+    // locations.
+    // While this heuristic isn't foolproof, it should be good enough.
+    // See issue #6188
+    const screenInfo = new ScreenInfo(this.window);
+    return (screenInfo.clientHeight >= MIN_HEIGHT_TO_SHOW_TOOLTIP_BELOW) &&
+           (screenInfo.clientWidth >= MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW);
+  },
+
+  setPosition () {
+    // by default, the position is above the input/select element
+    // to show the tooltip below the element, we use JS to set
+    // the top of the tooltip to be just below the element it is
+    // attached to.
+    const tooltipEl = this.$el;
+    const invalidEl = this.invalidEl;
+    if (invalidEl.hasClass('tooltip-below') && this.canShowTooltipBelow()) {
+      tooltipEl.addClass('tooltip-below fade-up-tt');
+      tooltipEl.css({
+        top: invalidEl.outerHeight() + PADDING_ABOVE_TOOLTIP_PX
+      });
+    } else {
+      tooltipEl.css({
+        top: -tooltipEl.outerHeight() - PADDING_BELOW_TOOLTIP_PX
+      });
+      tooltipEl.addClass('fade-down-tt');
+    }
+  },
+
+  bindDOMEvents () {
+    const invalidEl = this.invalidEl;
+
+    // destroy the tooltip any time the user
+    // interacts with the invalid element.
+    this._destroy = _.bind(this.destroy, this, true);
+    // keyboard input for input/select elements.
+    invalidEl.one('change', this._destroy);
+
+    // destroy the tooltip only if it's value has changed.
+    const originalValue = $(invalidEl).val().trim();
+    const closeIfInvalidElementValueHasChanged = function () {
+      const currValue = $(invalidEl).val().trim();
+      if (currValue !== originalValue) {
+        this._destroy();
+      } else {
+        invalidEl.one('keyup', closeIfInvalidElementValueHasChanged);
+      }
+    }.bind(this);
+
+    invalidEl.one('keyup', closeIfInvalidElementValueHasChanged);
+    // handle selecting an option with the mouse for select elements
+    invalidEl.find('option').one('click', this._destroy);
+
+    // destroy when dismissed
+    this.$el.find('.dismiss').one('click keypress', function (e) {
+      if (e.type === 'click' || e.which === KeyCodes.ENTER) {
+        const metricsEvent = 'tooltip.' + this.type + '-dismissed';
+        this.logEvent(metricsEvent);
+        this._destroy();
+      }
+    }.bind(this));
+  }
 });
+
+module.exports = Tooltip;

--- a/app/styles/modules/_tooltip.scss
+++ b/app/styles/modules/_tooltip.scss
@@ -96,7 +96,7 @@
  * these are caret's attached to tooltips that hang below the
  * input element. The tooltip's top is set via JS.
  */
-html[dir='rtl'] .tooltip-below::before,
-.tooltip-below::before {
+html[dir='rtl'] .tooltip.tooltip-below::before,
+.tooltip.tooltip-below::before {
   top: -7px;
 }

--- a/app/tests/mocks/window.js
+++ b/app/tests/mocks/window.js
@@ -39,7 +39,8 @@ define(function (require, exports, module) {
       cookie: '',
       documentElement: {
         className: '',
-        clientHeight: window.document.documentElement.clientHeight
+        clientHeight: window.document.documentElement.clientHeight,
+        clientWidth: window.document.documentElement.clientWidth
       },
       referrer: window.document.referrer,
       title: window.document.title

--- a/app/tests/spec/views/tooltip.js
+++ b/app/tests/spec/views/tooltip.js
@@ -2,141 +2,226 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define(function (require, exports, module) {
-  'use strict';
+'use strict';
 
-  const _ = require('underscore');
-  const $ = require('jquery');
-  const { assert } = require('chai');
-  const KeyCodes = require('lib/key-codes');
-  const Tooltip = require('views/tooltip');
+import _ from 'underscore';
+import $ from 'jquery';
+import { assert } from 'chai';
+import KeyCodes from 'lib/key-codes';
+import sinon from 'sinon';
+import Tooltip from 'views/tooltip';
+import WindowMock from '../../mocks/window';
 
-  function _createEvent(keyCode) {
-    var keyEvent = $.Event('keydown');
-    keyEvent.which = keyCode;
+function _createEvent(keyCode) {
+  var keyEvent = $.Event('keydown');
+  keyEvent.which = keyCode;
 
-    return keyEvent;
-  }
+  return keyEvent;
+}
 
-  describe('views/tooltip', function () {
-    let tooltip;
-    const htmlMessage = 'this is an <span>HTML tooltip</span>';
+describe('views/tooltip', function () {
+  let tooltip;
+  let windowMock;
 
-    beforeEach(function () {
-      $('#container').html('<div class="input-row"><input id="focusMe" /></div>');
-      tooltip = new Tooltip({
+  const htmlMessage = 'this is an <span>HTML tooltip</span>';
+
+  beforeEach(function () {
+    $('#container').html('<div class="input-row"><input id="focusMe" /></div>');
+    windowMock = new WindowMock();
+
+    tooltip = new Tooltip({
+      invalidEl: '#focusMe',
+      message: htmlMessage,
+      window: windowMock
+    });
+  });
+
+  afterEach(function () {
+    tooltip.destroy();
+    $('#container').empty();
+  });
+
+  describe('render', function () {
+    beforeEach(() => {
+      return tooltip.render();
+    });
+
+    it('HTML escapes and renders and attaches the tooltip', function () {
+      assert.equal(tooltip.$el.html(), _.escape(htmlMessage));
+      assert.equal($('.tooltip').length, 1);
+    });
+
+    it('only one tooltip can be rendered at a time', function () {
+      const tooltip2 = new Tooltip({
         invalidEl: '#focusMe',
-        message: htmlMessage
+        message: 'this is a second tooltip',
+        window: windowMock
       });
+
+      return tooltip2.render()
+        .then(function () {
+          assert.equal($('.tooltip').length, 1);
+        });
     });
 
-    afterEach(function () {
-      tooltip.destroy();
-      $('#container').empty();
-    });
 
-    describe('render', function () {
+    describe('with `unsafeMessage`', () => {
       beforeEach(() => {
+        $('#container').html('<div class="input-row"><input id="focusMe" /></div>');
+        tooltip = new Tooltip({
+          invalidEl: '#focusMe',
+          unsafeMessage: htmlMessage,
+          window: windowMock
+        });
+
         return tooltip.render();
       });
 
-      it('HTML escapes and renders and attaches the tooltip', function () {
-        assert.equal(tooltip.$el.html(), _.escape(htmlMessage));
+      it('renders the tooltip as HTML', () => {
+        assert.equal(tooltip.$el.html(), htmlMessage);
         assert.equal($('.tooltip').length, 1);
       });
+    });
+  });
 
-      it('only one tooltip can be rendered at a time', function () {
-        const tooltip2 = new Tooltip({
-          invalidEl: '#focusMe',
-          message: 'this is a second tooltip'
-        });
-
-        return tooltip2.render()
-          .then(function () {
-            assert.equal($('.tooltip').length, 1);
-          });
-      });
-
-
-      describe('with `unsafeMessage`', () => {
-        beforeEach(() => {
-          $('#container').html('<div class="input-row"><input id="focusMe" /></div>');
-          tooltip = new Tooltip({
-            invalidEl: '#focusMe',
-            unsafeMessage: htmlMessage
-          });
-
-          return tooltip.render();
-        });
-
-        it('renders the tooltip as HTML', () => {
-          assert.equal(tooltip.$el.html(), htmlMessage);
-          assert.equal($('.tooltip').length, 1);
-        });
+  describe('keyboard events', function () {
+    it('does not close on down arrow key press', function () {
+      return tooltip.render().then(function () {
+        $('#focusMe').trigger(_createEvent(KeyCodes.DOWN_ARROW));
+      }).then(function () {
+        assert.equal($('.tooltip').length, 1);
       });
     });
 
-    describe('keyboard events', function () {
-      it('does not close on down arrow key press', function () {
-        return tooltip.render().then(function () {
-          $('#focusMe').trigger(_createEvent(KeyCodes.DOWN_ARROW));
-        }).then(function () {
-          assert.equal($('.tooltip').length, 1);
-        });
-      });
-
-      it('does not close on left arrow key press', function () {
-        return tooltip.render().then(function () {
-          $('#focusMe').trigger(_createEvent(KeyCodes.LEFT_ARROW));
-        }).then(function () {
-          assert.equal($('.tooltip').length, 1);
-        });
-      });
-
-      it('does not close on right arrow key press', function () {
-        return tooltip.render().then(function () {
-          $('#focusMe').trigger(_createEvent(KeyCodes.RIGHT_ARROW));
-        }).then(function () {
-          assert.equal($('.tooltip').length, 1);
-        });
-      });
-
-      it('does not close on tab key press', function () {
-        return tooltip.render().then(function () {
-          $('#focusMe').trigger(_createEvent(KeyCodes.TAB));
-        }).then(function () {
-          assert.equal($('.tooltip').length, 1);
-        });
-      });
-
-      it('does not close on up arrow key press', function () {
-        return tooltip.render().then(function () {
-          $('#focusMe').trigger(_createEvent(KeyCodes.UP_ARROW));
-        }).then(function () {
-          assert.equal($('.tooltip').length, 1);
-        });
+    it('does not close on left arrow key press', function () {
+      return tooltip.render().then(function () {
+        $('#focusMe').trigger(_createEvent(KeyCodes.LEFT_ARROW));
+      }).then(function () {
+        assert.equal($('.tooltip').length, 1);
       });
     });
 
-    describe('self destruct', function () {
-      it('when invalid element is changed', function (done) {
-        tooltip.once('destroyed', function () {
-          done();
-        });
+    it('does not close on right arrow key press', function () {
+      return tooltip.render().then(function () {
+        $('#focusMe').trigger(_createEvent(KeyCodes.RIGHT_ARROW));
+      }).then(function () {
+        assert.equal($('.tooltip').length, 1);
+      });
+    });
 
-        tooltip.render().then(function () {
-          $('#focusMe').val('heyya!');
-          $('#focusMe').trigger('keyup');
-        });
+    it('does not close on tab key press', function () {
+      return tooltip.render().then(function () {
+        $('#focusMe').trigger(_createEvent(KeyCodes.TAB));
+      }).then(function () {
+        assert.equal($('.tooltip').length, 1);
+      });
+    });
+
+    it('does not close on up arrow key press', function () {
+      return tooltip.render().then(function () {
+        $('#focusMe').trigger(_createEvent(KeyCodes.UP_ARROW));
+      }).then(function () {
+        assert.equal($('.tooltip').length, 1);
+      });
+    });
+  });
+
+  describe('self destruct', function () {
+    it('when invalid element is changed', function (done) {
+      tooltip.once('destroyed', function () {
+        done();
       });
 
-      it('when invalid element is not changed (should not destroy)', function () {
-        return tooltip.render().then(function () {
-          $('#focusMe').trigger('keyup');
-        }).then(function () {
-          assert.equal($('.tooltip').length, 1);
-        });
+      tooltip.render().then(function () {
+        $('#focusMe').val('heyya!');
+        $('#focusMe').trigger('keyup');
       });
+    });
+
+    it('when invalid element is not changed (should not destroy)', function () {
+      return tooltip.render().then(function () {
+        $('#focusMe').trigger('keyup');
+      }).then(function () {
+        assert.equal($('.tooltip').length, 1);
+      });
+    });
+  });
+
+  describe('canShowTooltipBelow', () => {
+    function setScreenSize (widthPx, heightPx) {
+      windowMock.document.documentElement.clientHeight = heightPx;
+      windowMock.document.documentElement.clientWidth = widthPx;
+    }
+
+    it('returns true if screen is large enough', () => {
+      setScreenSize(520, 480);
+
+      assert.isTrue(tooltip.canShowTooltipBelow());
+    });
+
+    it('returns false if screen is not wide enough', () => {
+      setScreenSize(519, 480);
+
+      assert.isFalse(tooltip.canShowTooltipBelow());
+    });
+
+    it('returns false if the screen is not tall enough', () => {
+      setScreenSize(520, 479);
+
+      assert.isFalse(tooltip.canShowTooltipBelow());
+    });
+  });
+
+  describe('setPosition', () => {
+    let invalidEl;
+    let tooltipEl;
+
+    beforeEach(() => {
+      invalidEl = tooltip.invalidEl;
+      tooltipEl = tooltip.$el;
+
+      sinon.spy(invalidEl, 'css');
+      sinon.stub(invalidEl, 'outerHeight').callsFake(() => 20);
+
+      sinon.spy(tooltipEl, 'addClass');
+      sinon.spy(tooltipEl, 'css');
+      sinon.stub(tooltipEl, 'outerHeight').callsFake(() => 16);
+    });
+
+    it('does not allow tooltips on the bottom if `canShowTooltipBelow` returns false', () => {
+      sinon.stub(tooltip, 'canShowTooltipBelow').callsFake(() => false);
+      sinon.stub(invalidEl, 'hasClass').callsFake((className) => className === 'tooltip-below');
+
+      tooltip.setPosition();
+
+      assert.isTrue(invalidEl.hasClass.calledOnceWith('tooltip-below'));
+      assert.isTrue(tooltip.canShowTooltipBelow.calledOnce);
+
+      assert.isTrue(tooltipEl.css.calledOnceWith({ top: -18 }));
+      assert.isTrue(tooltipEl.addClass.calledOnceWith('fade-down-tt'));
+    });
+
+    it('allows tooltips on the bottom if `canShowTooltipBelow` returns false', () => {
+      sinon.stub(tooltip, 'canShowTooltipBelow').callsFake(() => true);
+      sinon.stub(invalidEl, 'hasClass').callsFake((className) => className === 'tooltip-below');
+
+      tooltip.setPosition();
+
+      assert.isTrue(invalidEl.hasClass.calledOnceWith('tooltip-below'));
+      assert.isTrue(tooltip.canShowTooltipBelow.calledOnce);
+
+      assert.isTrue(tooltipEl.css.calledOnceWith({ top: 24 }));
+      assert.isTrue(tooltipEl.addClass.calledOnceWith('tooltip-below fade-up-tt'));
+    });
+
+    it('shows tooltips on top by default', () => {
+      sinon.stub(tooltip, 'canShowTooltipBelow').callsFake(() => true);
+      sinon.stub(invalidEl, 'hasClass').callsFake(() => false);
+
+      tooltip.setPosition();
+
+      assert.isTrue(tooltipEl.css.calledOnceWith({ top: -18 }));
+      assert.isTrue(tooltipEl.addClass.calledOnceWith('fade-down-tt'));
     });
   });
 });


### PR DESCRIPTION
Tooltips can be obscured by a phone's virtual keyboard.
To avoid hidden tooltips, show tooltips above the
input element on mobile phones.

The check for mobile is rudimentary, the screen
size is checked. If it's width or height is smaller
than the breakpoints used in the CSS, consider
the user on a mobile device.

Note, tablets are not affected.

fixes #6188 

@mozilla/fxa-devs - r?

This is pretty easy to test using the iOS simulator. Open Safari and give it a try.
This is probably easiest to review using ?w=1 because I removed the AMD wrappers.