### PR TITLE
fix(tests): adjust mozilla.org link to have www

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -118,7 +118,7 @@ module.exports = {
   DOWNLOAD_LINK_TEMPLATE_ANDROID: 'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=android',
   DOWNLOAD_LINK_TEMPLATE_IOS: 'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=ios&fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&ct=adjust_tracker&mt=8', //eslint-disable-line max-len
 
-  MOZ_ORG_SYNC_GET_STARTED_LINK: 'https://mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started', //eslint-disable-line max-len
+  MOZ_ORG_SYNC_GET_STARTED_LINK: 'https://www.mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started', //eslint-disable-line max-len
 
   // 20 most popular email domains, used for metrics. Matches the list
   // we use in the auth server, converted to a map for faster lookup.


### PR DESCRIPTION
Fixes failing tests , from `#www`:

```
[12:52:25]  <vladikoff>	craigcook, one issue i just found, this doesn't resolve https://mozilla.org/firefox/sync
[12:52:38]  <vladikoff>	but this does https://mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started
[12:52:43]  <vladikoff>	but i think that could be something else
[12:53:51]  <@craigcook>	neither one of those is resolving for me
[12:53:59]  <@craigcook>	pmac: ^^ any ideas?
[12:54:01]  <vladikoff>	O_o
[12:54:20]  <vladikoff>	ok the second stopped working
[12:55:10]  <@craigcook>	there's a series of redirects it has to jump through... like first it'll jump to www, then we detect locale and redirect to /en-US (or whatever) and THEN it loads the page. But somewhere along the way that isn't happening.
[12:55:35]  <vladikoff>	it should end up at https://www.mozilla.org/en-US/firefox/features/sync/?utm_campaign=fx-signup&utm_content=fx-sync-get-started&utm_medium=fx-accounts&utm_source=fx-website
[12:55:43]  <@craigcook>	oh it also redirects to firefox/features/sync
[12:55:49]  <@craigcook>	right
[12:56:00]  <@craigcook>	so yeah I think we may just have a busted redirect somewhere in that chain
[12:56:47]  <@agibson>	it looks like all redirects without the www are not working e.g. https://mozilla.org/firefox/
[12:57:17] vladikoff	adds www to tests
[12:58:10]  <@pmac>	craigcook: jgmize and ericz we’re moving those earlier. Ping.
[12:58:11]  <@craigcook>	hm yeah, nothing is working for me without www... so this may be breaking before it even gets to bedrock.
[12:58:20]  <@craigcook>	ok
[12:58:27]  <ericz>	Yep, something looks wrong, I'm digging
[12:58:29] jgmize	looking
[12:58:34]  <vladikoff>	oh sorry i thought it was bedrock
[12:58:45]  <ericz>	No I think it's my redirects
[12:58:57]  <ericz>	Zeus doesn't show much traffic as of 18 minutes ago
[12:59:33]  <@jgmize>	yeah mozilla.org (the apex domain, not www.mozilla.org) is no longer responding for me
[13:00:22]  <vladikoff>	to correct myself when i said `as of ~12 hours ago ` what i mean is, we had tests pass 12 hours and i ran them ~1 hour ago and it started failing
[13:00:44]  <@jgmize>	ericz: fail back to scl3?
[13:02:32]  <@jgmize>	notified #moc
[13:02:44]  <ericz>	Thanks
[13:02:56]  <ericz>	fox2mike is helping me look, considering that option
[13:03:22]  <fox2mike>	I want to spend a _little_ bit more time to see if this is something on the network 
[13:03:28]  <fox2mike>	before we roll back 
````