### PR TITLE
fix(validation): Stricter utm_ parameter metrics validation

### DIFF
--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -40,7 +40,7 @@ const TYPES = {
   STRING: joi.string().max(1024), // 1024 is arbitrary, seems like it should give CSP reports plenty of space.
   TIME: joi.number().integer().min(0),
   URL: joi.string().max(2048).uri({ scheme: [ 'http', 'https' ]}), // 2048 is also arbitrary, the same limit we use on the front end.
-  UTM: joi.string().max(128).regex(/^[\w\/.%-]+/) // values here can be 'firefox/sync'
+  UTM: joi.string().max(128).regex(/^[\w\/.%-]+$/) // values here can be 'firefox/sync'
 };
 
 module.exports = {

--- a/tests/server/metrics.js
+++ b/tests/server/metrics.js
@@ -117,6 +117,7 @@ suite.tests['#post /metrics - returns 400 with invalid data'] = {
   'invalid timers ([])': testInvalidMetricsField('timers', []),
   'invalid uniqueUserId': testInvalidMetricsField('uniqueUserId', '123-123-123-123-123-123-123-123-123-123-123-123-123-123-123-123-123-123-123'),
   'invalid utm_campaign (#)': testInvalidMetricsField('utm_campaign', '#'),
+  'invalid utm_campaign (asdf#)': testInvalidMetricsField('utm_campaign', '123#'),
   'invalid utm_content (!)': testInvalidMetricsField('utm_content', '!'),
   'invalid utm_medium (,)': testInvalidMetricsField('utm_medium', ','),
   'invalid utm_source (>)': testInvalidMetricsField('utm_source', '>'),


### PR DESCRIPTION
The validation regexp did not contain a $ and only matched the first
portion of the UTM param.

Not attached to an issue.

@philbooth - r?