### PR TITLE
refactor(metrics): move amplitude email types back here from fxa-shared

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5388,9 +5388,9 @@
       }
     },
     "fxa-shared": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.7.tgz",
-      "integrity": "sha512-aKCVdLh6e0eKNOswAQ0o9vp40AZ9YvfkGr0sSxjGRCMLN+4XinAZrg2BCtvyTFClJPAFsWfvXYFX7etL1o0V8g==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.9.tgz",
+      "integrity": "sha512-H8ECHQG/V7yqU5vAJFBbcS7IcEona0qj8xE+K8LAtMvcEr4QR2jlr3Q/DE139r3/CzKc3ocQRRpJ/nFIv1Yo6g==",
       "requires": {
         "accept-language": "2.0.17",
         "moment": "2.20.1"
@@ -11699,9 +11699,9 @@
       }
     },
     "pumpify": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
-      "integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "requires": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fxa-geodb": "1.0.0",
     "fxa-js-client": "1.0.4",
     "fxa-mustache-loader": "0.0.2",
-    "fxa-shared": "1.0.7",
+    "fxa-shared": "1.0.9",
     "got": "6.7.1",
     "grunt": "1.0.1",
     "grunt-autoprefixer": "3.0.4",

--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -20,6 +20,7 @@ const ua = require('./user-agent');
 
 const SERVICES = require('./configuration').get('oauth_client_id_map');
 
+// Maps view name to email type
 const EMAIL_TYPES = {
   'complete-reset-password': 'reset_password',
   'complete-signin': 'login',

--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -14,11 +14,17 @@
 
 'use strict';
 
-const { EMAIL_TYPES, GROUPS, initialize } = require('fxa-shared/metrics/amplitude');
+const { GROUPS, initialize } = require('fxa-shared/metrics/amplitude');
 const geolocate = require('./geo-locate');
 const ua = require('./user-agent');
 
 const SERVICES = require('./configuration').get('oauth_client_id_map');
+
+const EMAIL_TYPES = {
+  'complete-reset-password': 'reset_password',
+  'complete-signin': 'login',
+  'verify-email': 'registration'
+};
 
 const EVENTS = {
   'flow.reset-password.submit': {
@@ -104,7 +110,7 @@ function receiveEvent (event, request, data) {
   const amplitudeEvent = transform(
     event,
     Object.assign(
-      {},
+      { emailTypes: EMAIL_TYPES },
       pruneUnsetValues(data),
       mapBrowser(userAgent),
       mapOs(userAgent),


### PR DESCRIPTION
Fixes mozilla/fxa-shared#23.

Moves `EMAIL_TYPES` back into this repo for easier maintenance when new email types get added (more for the auth server's benefit, but what's good for the goose is good for the gander).

@mozilla/fxa-devs r?