### PR TITLE
feat(totp): enable totp for 10% of all users

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/totp.js
+++ b/app/scripts/lib/experiments/grouping-rules/totp.js
@@ -12,7 +12,7 @@ module.exports = class TotpGroupingRule extends BaseGroupingRule {
   constructor() {
     super();
     this.name = 'totp';
-    this.ROLLOUT_RATE = 0.00;
+    this.ROLLOUT_RATE = 0.10;
   }
 
   choose(subject) {


### PR DESCRIPTION
Reverted https://github.com/mozilla/fxa-content-server/pull/6205 on train 112 (accidentally squashed and merged and lost commit history). I re-based train 112 against master so now it will have correct history when I make point release.