### PR TITLE
fix(style): Fix the link focusring style.

### DIFF
--- a/app/scripts/templates/confirm_reset_password.mustache
+++ b/app/scripts/templates/confirm_reset_password.mustache
@@ -17,25 +17,19 @@
       </div>
     {{/isOpenWebmailButtonVisible}}
 
-    <ul class="links">
-      <li>
-        <a id="resend" class="resend-email" href="#">{{#t}}Not in inbox or spam folder? Resend{{/t}}</a>
-      </li>
+    <div class="links centered">
+      <a id="resend" class="resend-email" href="#">{{#t}}Not in inbox or spam folder? Resend{{/t}}</a>
 
       {{#isSignInEnabled}}
         {{#forceAuth}}
-        <li>
           <a href="/force_auth?email={{ encodedEmail }}" class="sign-in">{{#t}}Remember password? Sign in{{/t}}</a>
-        </li>
         {{/forceAuth}}
 
         {{^forceAuth}}
-        <li>
           <a href="/signin" class="sign-in">{{#t}}Remember password? Sign in{{/t}}</a>
-        </li>
         {{/forceAuth}}
       {{/isSignInEnabled}}
-    </ul>
+    </div>
 
   </section>
 </div>

--- a/app/scripts/templates/cookies_disabled.mustache
+++ b/app/scripts/templates/cookies_disabled.mustache
@@ -10,7 +10,7 @@
       {{#t}}Please enable cookies and local storage in your browser to access Firefox Accounts. Doing so will enable functionality such as remembering you between sessions.{{/t}}
     </p>
 
-    <p class="links centered">
+    <p class="links">
       <a href="https://support.mozilla.org/kb/cookies-information-websites-store-on-your-computer" target="_blank">{{#t}}Learn more{{/t}}</a>
     </p>
 

--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -58,6 +58,7 @@ noscript,
 
 
 a {
+  border-radius: 2px; // Give the focusring rounded corners
   color: $link-color-default;
   cursor: pointer; // Use the correct cursor for anchors without an href
   text-decoration: none;

--- a/app/styles/_mixins.scss
+++ b/app/styles/_mixins.scss
@@ -66,21 +66,32 @@
 }
 
 @mixin anchor-default-pseudo-classes($color-hover: $link-color-hover, $color-box-shadow: $blue-60, $color-focus: $link-color-focus, $color-active: $link-color-active) {
-  &:hover {
-    color: $color-hover;
-    text-decoration: underline;
-  }
-
   &:focus {
     box-shadow: 0 0 0 2px $color-box-shadow, 0 0 0 6px rgba($color-box-shadow, 0.3);
     color: $color-focus;
     outline: none;
   }
 
+  &:hover {
+    color: $color-hover;
+    text-decoration: underline;
+  }
+
   &:active {
     box-shadow: none;
     color: $color-active;
     outline: none;
+  }
+
+  &:focus:hover {
+    // remove the underline on hover if already focused to
+    // avoid a double underline. See #6204
+    text-decoration: none;
+  }
+
+  &:focus:active {
+    // while depressed, always show the underline.
+    text-decoration: underline;
   }
 }
 

--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -5,21 +5,17 @@
 
 .links {
   clear: both;
-  overflow: auto;
-  // the 1px of padding allows the :focus outline on anchors to show.
-  padding: 1px;
-  text-align: center;
-
-  .left {
-    float: left;
-    max-width: 50%;
-    text-align: left;
-  }
+  display: flex;
+  justify-content: center;
 
   .right {
-    float: right;
-    max-width: 50%;
-    text-align: right;
+    html[dir='ltr'] & {
+      margin-left: auto;  // Forces the two links as far apart as can be.
+    }
+
+    html[dir='rtl'] & {
+      margin-right: auto; // Forces the two links as far apart as can be.
+    }
   }
 
   .delayed-fadein {
@@ -27,14 +23,12 @@
     opacity: 0;
   }
 
-  &.centered a:not(:only-child) {
-    display: block;
-    float: none;
-    margin: 5px auto;
-    max-width: 100%;
-    padding-bottom: 10px;
-    text-align: center;
-    width: fit-content;
+  &.centered {
+    flex-direction: column;
+
+    a:not(:only-child) {
+      margin: 0 auto 12px;
+    }
   }
 }
 


### PR DESCRIPTION
`.links` uses flexbox to center elements by default, and a margin
to push right links to the far side of the content.

The focusrings are more consistent now, they always show.

Also removes the list item bullets on /confirm_reset_password

fixes #6204 

@philbooth - r?