### PR TITLE
fix(style): Fix the error message/heading styles in settings

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -280,11 +280,6 @@ body.settings #main-content.card {
   @include respond-to('small') {
     padding: 10px 0;
   }
-
-  .error {
-    padding: 5px 10px;
-    top: 0;
-  }
 }
 
 .settings-unit-stub {
@@ -292,6 +287,7 @@ body.settings #main-content.card {
 
   .settings-unit-summary {
     display: inline-block;
+    margin-bottom: 0;
     margin-top: 2px;
     overflow: hidden;
 
@@ -365,6 +361,7 @@ body.settings #main-content.card {
 }
 
 .settings-unit-details {
+  clear: both;
   display: none;
 
   p {


### PR DESCRIPTION
* Remove the bottom-margin of the headings in settings-panels.
* Ensure the error message clears the heading floated content.
* Remove the padding on the error content, that's handled universally.

fixes #6206 

Result:

<img width="490" alt="screen shot 2018-05-21 at 13 04 26" src="https://user-images.githubusercontent.com/848085/40306760-cbd04b34-5cf7-11e8-8936-c2813e001b4e.png">

@philbooth - r?