### PR TITLE
fix(css): make sign-in confirm button blue

### DIFF
--- a/app/scripts/templates/ready.mustache
+++ b/app/scripts/templates/ready.mustache
@@ -17,7 +17,7 @@
         <p class="account-ready-service">{{#t}}You are now ready to use %(serviceName)s{{/t}}</p>
         {{#showContinueButton}}
         <div class="button-row">
-          <button class="btn-continue">{{#t}}Continue{{/t}}</button>
+          <button class="primary-button btn-continue">{{#t}}Continue{{/t}}</button>
         </div>
         {{/showContinueButton}}
       {{/serviceName}}


### PR DESCRIPTION
Fixes #6229 

Couldn't test with Notes, instead used inspector to verify correct css.

![screen shot 2018-05-24 at 9 27 18 pm](https://user-images.githubusercontent.com/1295288/40521430-9447be32-5f99-11e8-8547-7164f870aa99.png)
