### PR TITLE
fix(refresh): adds `Last checked:` as tooltip

### DIFF
--- a/app/scripts/templates/settings/emails.mustache
+++ b/app/scripts/templates/settings/emails.mustache
@@ -70,7 +70,7 @@
 
             <div class="button-row">
                 {{#hasSecondaryEmail}}
-                    <button type="submit" class="settings-button email-refresh primary-button enabled">{{#t}}Refresh{{/t}}</button>
+                    <button type="submit" class="settings-button email-refresh primary-button enabled" title="{{ lastCheckedTime }}">{{#t}}Refresh Status{{/t}}</button>
 
                     <button
                         class="settings-button {{#hasSecondaryVerifiedEmail}}cancel secondary-button enabled{{/hasSecondaryVerifiedEmail}}

--- a/app/scripts/templates/settings/two_step_authentication.mustache
+++ b/app/scripts/templates/settings/two_step_authentication.mustache
@@ -51,7 +51,7 @@
                 </li>
             </ul>
             <div class="button-row">
-                <button class="settings-button primary-button totp-refresh">{{#t}}Refresh{{/t}}</button>
+                <button class="settings-button primary-button totp-refresh" title="{{ lastCheckedTime }}">{{#t}}Refresh Status{{/t}}</button>
                 <button class="settings-button cancel secondary-button enabled totp-cancel">{{#t}}Cancel{{/t}}</button>
             </div>
         </div>

--- a/app/scripts/templates/settings/upgrade_session.mustache
+++ b/app/scripts/templates/settings/upgrade_session.mustache
@@ -32,7 +32,8 @@
             {{#emailSent }}
                 <div class="button-row email-sent-options">
                     <button type="submit" class="settings-button primary-button refresh-verification-state"
-                            data-id="{{ email }}">{{#t}}Refresh{{/t}}</button>
+                            data-id="{{ email }}"
+                            title="{{ lastCheckedTime }}">{{#t}}Refresh Status{{/t}}</button>
                     <button class="settings-button secondary-button cancel">{{#t}}Done{{/t}}</button>
                 </div>
             {{/emailSent }}

--- a/app/scripts/views/mixins/last-checked-time-mixin.js
+++ b/app/scripts/views/mixins/last-checked-time-mixin.js
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Mixin to set the time a panel was refreshed or checked.
+ *
+ * @mixin LastCheckedTimeMixin
+ */
+'use strict';
+
+const {t} = require('../base');
+
+const Mixin = {
+
+  setInitialContext(context) {
+    context.set({
+      lastCheckedTime: this.getLastCheckedTimeString()
+    });
+  },
+
+  setLastCheckedTime(date) {
+    if (! date) {
+      date = new Date();
+    }
+    this.lastCheckedTime = date.toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  },
+
+  getLastCheckedTimeString() {
+    let time = t('none');
+    if (this.lastCheckedTime) {
+      time = this.lastCheckedTime;
+    }
+    return this.translate(t('Last checked: %(lastCheckTime)s'), {lastCheckTime: time});
+  }
+};
+
+module.exports = Mixin;

--- a/app/scripts/views/mixins/upgrade-session-mixin.js
+++ b/app/scripts/views/mixins/upgrade-session-mixin.js
@@ -22,6 +22,7 @@ define(function (require, exports, module) {
   const BaseView = require('../base');
   const { preventDefaultThen } = BaseView;
   const Notifier = require('../../lib/channels/notifier');
+  const LastCheckedTimeMixin = require('./last-checked-time-mixin');
   const SessionVerifiedNotificationMixin = require('./session-verified-notification-mixin');
   const SettingsPanelMixin = require('../mixins/settings-panel-mixin');
   const UpgradeSessionTemplate = require('templates/settings/upgrade_session.mustache');
@@ -43,7 +44,7 @@ define(function (require, exports, module) {
    */
   module.exports = (options = {}) => {
     return {
-      dependsOn: [SettingsPanelMixin, SessionVerifiedNotificationMixin],
+      dependsOn: [LastCheckedTimeMixin, SettingsPanelMixin, SessionVerifiedNotificationMixin],
 
       events: {
         'click .cancel-verification-email': preventDefaultThen('_clickCancelVerificationEmail'),
@@ -58,6 +59,7 @@ define(function (require, exports, module) {
       _clickRefreshVerificationState: showProgressIndicator(function() {
         return this.setupSessionGateIfRequired()
           .then((verified) => {
+            this.setLastCheckedTime();
             if (verified) {
               this.displaySuccess(t('Primary email verified successfully'), {
                 closePanel: false
@@ -65,6 +67,8 @@ define(function (require, exports, module) {
 
               this.notifier.triggerAll(Notifier.SESSION_VERIFIED);
             }
+
+            this.render();
           });
       }, EMAIL_REFRESH_SELECTOR, EMAIL_REFRESH_DELAYMS),
 
@@ -74,6 +78,7 @@ define(function (require, exports, module) {
           redirectTo: this.window.location.href
         })
           .then(() => {
+            this.setLastCheckedTime();
             this.displaySuccess(t('Verification email sent'), {
               closePanel: false
             });

--- a/app/scripts/views/settings/emails.js
+++ b/app/scripts/views/settings/emails.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
   const Cocktail = require('cocktail');
   const Email = require('../../models/email');
   const FormView = require('../form');
+  const LastCheckedTimeMixin = require('../mixins/last-checked-time-mixin');
   const preventDefaultThen = require('../base').preventDefaultThen;
   const SettingsPanelMixin = require('../mixins/settings-panel-mixin');
   const UpgradeSessionMixin = require('../mixins/upgrade-session-mixin');
@@ -61,6 +62,7 @@ define(function (require, exports, module) {
         hasSecondaryEmail: this._hasSecondaryEmail(),
         hasSecondaryVerifiedEmail: this._hasSecondaryVerifiedEmail(),
         isPanelOpen: this.isPanelOpen(),
+        lastCheckedTime: this.getLastCheckedTimeString(),
         newEmail: this.newEmail,
       });
     },
@@ -106,6 +108,7 @@ define(function (require, exports, module) {
     },
 
     refresh: showProgressIndicator(function() {
+      this.setLastCheckedTime();
       return this.render();
     }, EMAIL_REFRESH_SELECTOR, EMAIL_REFRESH_DELAYMS),
 
@@ -158,6 +161,7 @@ define(function (require, exports, module) {
       title: t('Secondary email')
     }),
     AvatarMixin,
+    LastCheckedTimeMixin,
     SettingsPanelMixin,
     SearchParamMixin
   );

--- a/app/scripts/views/settings/two_step_authentication.js
+++ b/app/scripts/views/settings/two_step_authentication.js
@@ -10,6 +10,7 @@ const AuthErrors = require('lib/auth-errors');
 const BaseView = require('../base');
 const Cocktail = require('cocktail');
 const FormView = require('../form');
+const LastCheckedTimeMixin = require('../mixins/last-checked-time-mixin');
 const SettingsPanelMixin = require('../mixins/settings-panel-mixin');
 const UpgradeSessionMixin = require('../mixins/upgrade-session-mixin');
 const Template = require('templates/settings/two_step_authentication.mustache');
@@ -170,6 +171,7 @@ const View = FormView.extend({
   },
 
   refresh: showProgressIndicator(function () {
+    this.setLastCheckedTime();
     return this.render();
   }, CODE_REFRESH_SELECTOR, CODE_REFRESH_DELAY_MS),
 
@@ -182,6 +184,7 @@ Cocktail.mixin(
     title: t('Two-step Authentication')
   }),
   AvatarMixin,
+  LastCheckedTimeMixin,
   SettingsPanelMixin,
   TotpExperimentMixin
 );

--- a/app/tests/spec/views/mixins/last-checked-time-mixin.js
+++ b/app/tests/spec/views/mixins/last-checked-time-mixin.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const {assert} = require('chai');
+const BaseView = require('views/base');
+const Cocktail = require('cocktail');
+const LastCheckedTimeMixin = require('views/mixins/last-checked-time-mixin');
+const sinon = require('sinon');
+
+const View = BaseView.extend({});
+
+Cocktail.mixin(
+  View,
+  LastCheckedTimeMixin
+);
+
+describe('views/mixins/last-checked-time-mixin', () => {
+  let view;
+
+  beforeEach(() => {
+    view = new View({});
+  });
+
+  it('should set last checked time', () => {
+    assert.equal(view.lastCheckedTime, undefined, 'no time set');
+    view.setLastCheckedTime();
+    assert.equal(typeof view.lastCheckedTime, 'string', 'time is set');
+  });
+
+  it('should return `none` if lastCheckTime is not set', () => {
+    assert.equal(view.lastCheckedTime, undefined, 'no time set');
+    const lastCheckString = view.getLastCheckedTimeString();
+    assert.equal(lastCheckString, 'Last checked: none', 'time is set to `none`');
+  });
+
+  it('should return formatted time', () => {
+    const date = new Date();
+    sinon.stub(date, 'toLocaleTimeString').callsFake(() => '4:58 PM');
+    view.setLastCheckedTime(date);
+    const lastCheckString = view.getLastCheckedTimeString();
+    assert.equal(lastCheckString, 'Last checked: 4:58 PM', 'formatted time is set');
+  });
+});

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -165,6 +165,7 @@ require('./spec/views/mixins/external-links-mixin');
 require('./spec/views/mixins/flow-begin-mixin');
 require('./spec/views/mixins/flow-events-mixin');
 require('./spec/views/mixins/form-prefill-mixin');
+require('./spec/views/mixins/last-checked-time-mixin');
 require('./spec/views/mixins/loading-mixin');
 require('./spec/views/mixins/marketing-mixin');
 require('./spec/views/mixins/modal-panel-mixin');


### PR DESCRIPTION
Fixes #6043 

- [x]  Update all panels that use `Refresh` to `Refresh Status`
- [x]  Show a tooltip with a synthesized Last update time.
- [x]  Tooltip shows `none` when panel is first opened
- [x]  Tooltip shows `none` when page is refreshed
- [x]  Tooltip shows `time` when refreshed button was clicked (only locally)

WIP for tests