### PR TITLE
fix(codes): adds more support for assistive technologies

### DIFF
--- a/app/scripts/templates/settings/recovery_codes.mustache
+++ b/app/scripts/templates/settings/recovery_codes.mustache
@@ -36,15 +36,15 @@
 
             {{^isIos}}
                 <div class="button-row recovery-code-options">
-                    <a class="recovery-code-option download-codes">
+                    <a href="#" class="recovery-code-option download-codes">
                         <div class="graphic graphic-recovery-codes-download"></div>
                         <p class="name">{{#t}}Download{{/t}}</p>
                     </a>
-                    <a class="recovery-code-option copy-codes">
+                    <a href="#" class="recovery-code-option copy-codes">
                         <div class="graphic graphic-recovery-codes-copy"></div>
                         <p class="name">{{#t}}Copy{{/t}}</p>
                     </a>
-                    <a class="recovery-code-option print-codes">
+                    <a href="#" class="recovery-code-option print-codes">
                         <div class="graphic graphic-recovery-codes-print"></div>
                         <p class="name">{{#t}}Print{{/t}}</p>
                     </a>
@@ -53,7 +53,7 @@
 
             {{#isIos}}
                 <div class="button-row">
-                    <a class="recovery-code-option copy-codes">
+                    <a href="#" class="recovery-code-option copy-codes">
                         <div class="graphic graphic-recovery-codes-copy"></div>
                         <p class="name">{{#t}}Copy{{/t}}</p>
                     </a>

--- a/app/scripts/templates/settings/two_step_authentication.mustache
+++ b/app/scripts/templates/settings/two_step_authentication.mustache
@@ -59,12 +59,12 @@
         <form novalidate>
             <div id="totp" class="totp-details hidden">
                 <div class="qr-image-container">
-                    <img class="qr-image"/>
+                    <img class="qr-image" alt="{{ qrImageAltText }}"/>
                 </div>
 
                 <p class="setup-description">
                     {{#t}}Scan the QR code in your authentication app and then enter the security code it provides.{{/t}}
-                    <a class="show-code-link">{{#t}}Can’t scan code?{{/t}}</a>
+                    <a href="#" class="show-code-link">{{#t}}Can’t scan code?{{/t}}</a>
                 </p>
 
                 <div class="manual-code hidden">

--- a/app/scripts/views/settings/two_step_authentication.js
+++ b/app/scripts/views/settings/two_step_authentication.js
@@ -129,6 +129,10 @@ const View = FormView.extend({
     return account.createTotpToken()
       .then(result => {
         this.$('.qr-image').attr('src', result.qrCodeUrl);
+
+        const qrImageAltText = t('Use the code %(code)s to set up two-step authentication in supported applications.');
+        this.$('.qr-image').attr('alt', this.translate(qrImageAltText, {code: result.secret}));
+
         this.$('.code').html(this._getFormattedCode(result.secret));
         this._showQrCode();
         this._hideStatus();


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-bugzilla-mirror/issues/504

Exposes recovery code links with `href` tags so they clickable when using assistive technologies. I opted to keep these as links because it was easier to style and vertically center text and image than using a button. This was done in a similar way as avatar [links](https://github.com/mozilla/fxa-content-server/blob/3dd7b778dc91ce4c050c42b3f57cc8b2df77215a/app/scripts/templates/settings/avatar_change.mustache#L15).