### PR TITLE
fix(email-first): Handle email-first refresh on /signup, /signin

### DIFF
--- a/app/scripts/views/mixins/email-first-experiment-mixin.js
+++ b/app/scripts/views/mixins/email-first-experiment-mixin.js
@@ -9,73 +9,71 @@
  *
  * @mixin EmailFirstExperimentMixin
  */
-define(function (require, exports, module) {
-  'use strict';
+const ExperimentMixin = require('./experiment-mixin');
+const EXPERIMENT_NAME = 'emailFirst';
 
-  const ExperimentMixin = require('./experiment-mixin');
-  const EXPERIMENT_NAME = 'emailFirst';
+/**
+ * Creates the mixin
+ *
+ * @param {Object} [options={}]
+ *   @param {String} [treatmentPathname] pathname to redirect to if the user is in `treatment`
+ * @returns {Object} mixin
+ */
+module.exports = (options = {}) => {
+  return {
+    dependsOn: [ ExperimentMixin ],
 
-  /**
-   * Creates the mixin
-   *
-   * @param {Object} [options={}]
-   *   @param {String} [treatmentPathname] pathname to redirect to if the user is in `treatment`
-   * @returns {Object} mixin
-   */
-  module.exports = (options = {}) => {
-    return {
-      dependsOn: [ ExperimentMixin ],
-
-      beforeRender () {
-        if (this.isInEmailFirstExperiment()) {
-          const experimentGroup = this.getEmailFirstExperimentGroup();
-          this.createExperiment(EXPERIMENT_NAME, experimentGroup);
-          if (experimentGroup === 'treatment' && options.treatmentPathname) {
-            this.replaceCurrentPage(options.treatmentPathname);
-          }
+    beforeRender () {
+      if (this.relier.get('action') === 'email' && options.treatmentPathname) {
+        this.replaceCurrentPage(options.treatmentPathname);
+      } else if (this.isInEmailFirstExperiment()) {
+        const experimentGroup = this.getEmailFirstExperimentGroup();
+        this.createExperiment(EXPERIMENT_NAME, experimentGroup);
+        if (experimentGroup === 'treatment' && options.treatmentPathname) {
+          this.replaceCurrentPage(options.treatmentPathname);
         }
-      },
-
-      /**
-       * Get the email first experiment group
-       *
-       * @returns {String}
-       */
-      getEmailFirstExperimentGroup () {
-        return this.getExperimentGroup(EXPERIMENT_NAME, this._getEmailFirstExperimentSubject());
-      },
-
-      /**
-       * Is the user in the email-first experiment?
-       *
-       * @returns {Boolean}
-       */
-      isInEmailFirstExperiment () {
-        return this.isInExperiment(EXPERIMENT_NAME, this._getEmailFirstExperimentSubject());
-      },
-
-      /**
-       * Is the user in email-first experiment's `groupName` group?
-       *
-       * @param {String} groupName
-       * @returns {Boolean}
-       */
-      isInEmailFirstExperimentGroup (groupName) {
-        return this.isInExperimentGroup(EXPERIMENT_NAME, groupName, this._getEmailFirstExperimentSubject());
-      },
-
-      /**
-       * Get the email-first experiment choice subject
-       *
-       * @returns {Object}
-       * @private
-       */
-      _getEmailFirstExperimentSubject () {
-        const subject = {
-          isEmailFirstSupported: this.broker.getCapability('emailFirst')
-        };
-        return subject;
       }
-    };
+    },
+
+    /**
+     * Get the email first experiment group
+     *
+     * @returns {String}
+     */
+    getEmailFirstExperimentGroup () {
+      return this.getExperimentGroup(EXPERIMENT_NAME, this._getEmailFirstExperimentSubject());
+    },
+
+    /**
+     * Is the user in the email-first experiment?
+     *
+     * @returns {Boolean}
+     */
+    isInEmailFirstExperiment () {
+      return this.isInExperiment(EXPERIMENT_NAME, this._getEmailFirstExperimentSubject());
+    },
+
+    /**
+     * Is the user in email-first experiment's `groupName` group?
+     *
+     * @param {String} groupName
+     * @returns {Boolean}
+     */
+    isInEmailFirstExperimentGroup (groupName) {
+      return this.isInExperimentGroup(EXPERIMENT_NAME, groupName, this._getEmailFirstExperimentSubject());
+    },
+
+    /**
+     * Get the email-first experiment choice subject
+     *
+     * @returns {Object}
+     * @private
+     */
+    _getEmailFirstExperimentSubject () {
+      const subject = {
+        isEmailFirstSupported: this.broker.getCapability('emailFirst')
+      };
+      return subject;
+    }
   };
-});
+};

--- a/app/tests/spec/views/mixins/email-first-experiment-mixin.js
+++ b/app/tests/spec/views/mixins/email-first-experiment-mixin.js
@@ -11,6 +11,7 @@ define(function(require, exports, module) {
   const Cocktail = require('cocktail');
   const EmailFirstExperimentMixin = require('views/mixins/email-first-experiment-mixin');
   const Notifier = require('lib/channels/notifier');
+  const Relier = require('models/reliers/relier');
   const sinon = require('sinon');
 
   class View extends BaseView {
@@ -28,6 +29,7 @@ define(function(require, exports, module) {
   describe('views/mixins/email-first-experiment-mixin', () => {
     let broker;
     let notifier;
+    let relier;
     let sandbox;
     let view;
 
@@ -37,16 +39,19 @@ define(function(require, exports, module) {
       broker = new AuthBroker();
       broker.setCapability('emailFirst', true);
       notifier = new Notifier();
+      relier = new Relier();
 
       view = new View({
         broker,
         notifier,
+        relier,
         viewName: 'email'
       });
     });
 
     afterEach(() => {
       sandbox.restore();
+      relier.unset('action');
     });
 
     after(() => {
@@ -106,6 +111,14 @@ define(function(require, exports, module) {
       beforeEach(() => {
         sandbox.spy(view, 'createExperiment');
         sandbox.spy(view, 'replaceCurrentPage');
+      });
+
+      it('redirects to the treatment page if `action=email`', () => {
+        relier.set('action', 'email');
+
+        view.beforeRender();
+
+        assert.isTrue(view.replaceCurrentPage.calledOnceWith('/'));
       });
 
       it('does nothing for users not in the experiment', () => {

--- a/tests/functional/fx_firstrun_v2_email_first.js
+++ b/tests/functional/fx_firstrun_v2_email_first.js
@@ -79,6 +79,37 @@ registerSuite('Firstrun Sync v2 email first', {
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
     },
 
+    'signup - refresh when entering password': function () {
+      return this.remote
+        .then(openPage(PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:can_link_account': {ok: true}
+          }
+        }))
+        .then(visibleByQSA(selectors.ENTER_EMAIL.SUB_HEADER))
+        .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+        .then(click(selectors.ENTER_EMAIL.SUBMIT, selectors.SIGNUP_PASSWORD.HEADER))
+        .refresh()
+
+        .then(testElementExists(selectors.ENTER_EMAIL.HEADER));
+    },
+
+    'signin - refresh when entering password': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, {preVerified: true}))
+        .then(openPage(PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
+          webChannelResponses: {
+            'fxaccounts:can_link_account': {ok: true}
+          }
+        }))
+        .then(visibleByQSA(selectors.ENTER_EMAIL.SUB_HEADER))
+        .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+        .then(click(selectors.ENTER_EMAIL.SUBMIT, selectors.SIGNIN_PASSWORD.HEADER))
+        .refresh()
+
+        .then(testElementExists(selectors.ENTER_EMAIL.HEADER));
+    },
+
     'signin - merge cancelled': function () {
       return this.remote
         .then(createUser(email, PASSWORD, {preVerified: true}))


### PR DESCRIPTION
If users are in the email-first flow via `action=email` instead
of being in the experiment and they refreshed on /signin or
/signup, the legacy /signin or /signup pages would be displayed.

In beforeRender, if `action=email`, redirect back to `/`

fixes #6243 

Easiest to review with `?w=1`

@mozilla/fxa-devs - r?