### PR TITLE
fix(authorization): Minor updates for /authorization endpoint

### DIFF
--- a/app/scripts/views/authorization.js
+++ b/app/scripts/views/authorization.js
@@ -14,7 +14,9 @@ class AuthorizationView extends BaseView {
       const pathname = action === 'email' ? '/' : action;
       this.replaceCurrentPage(this.broker.transformLink(pathname));
     } else {
-      this.replaceCurrentPage('/oauth/signup');
+      // if no action is specified, let oauth-index decide based on
+      // current user signed in state.
+      this.replaceCurrentPage('/oauth/');
     }
   }
 }

--- a/app/tests/spec/views/authorization.js
+++ b/app/tests/spec/views/authorization.js
@@ -71,7 +71,7 @@ describe('views/authorization', function () {
     it('handles default action', () => {
       return view.render()
         .then(() => {
-          assert.ok(view.replaceCurrentPage.calledWith('/oauth/signup'), 'called with proper action');
+          assert.ok(view.replaceCurrentPage.calledOnceWith('/oauth/'), 'called with proper action');
         });
     });
 
@@ -89,7 +89,7 @@ describe('views/authorization', function () {
 
       return view.render()
         .then(() => {
-          assert.ok(view.replaceCurrentPage.calledWith(broker.transformLink('signin')), 'called with proper signin action');
+          assert.ok(view.replaceCurrentPage.calledOnceWith(broker.transformLink('signin')), 'called with proper signin action');
         });
     });
 
@@ -107,9 +107,8 @@ describe('views/authorization', function () {
 
       return view.render()
         .then(() => {
-          assert.ok(view.replaceCurrentPage.calledWith(broker.transformLink('/')), 'called default action for action=email');
+          assert.ok(view.replaceCurrentPage.calledOnceWith(broker.transformLink('/')), 'called default action for action=email');
         });
     });
-
   });
 });

--- a/tests/functional/oauth_query_param_validation.js
+++ b/tests/functional/oauth_query_param_validation.js
@@ -7,6 +7,7 @@
 const { registerSuite } = intern.getInterface('object');
 const Querystring = require('querystring');
 const FunctionalHelpers = require('./lib/helpers');
+const { createEmail } = require('../lib/helpers');
 const config = intern._config;
 
 const SIGNUP_ROOT = `${config.fxaContentRoot}oauth/signup`;
@@ -357,7 +358,7 @@ registerSuite('oauth query parameter validation', {
         .then(openAuthorizationWithQueryParams({
           action: 'force_auth',
           client_id: TRUSTED_CLIENT_ID,
-          email: 'test@restmail.net',
+          email: createEmail(),
           redirect_uri: TRUSTED_REDIRECT_URI,
           scope: TRUSTED_SCOPE
         }, '#fxa-signup-header'));
@@ -368,9 +369,10 @@ registerSuite('oauth query parameter validation', {
         .then(openAuthorizationWithQueryParams({
           action: 'email',
           client_id: TRUSTED_CLIENT_ID,
+          email: createEmail(),
           redirect_uri: TRUSTED_REDIRECT_URI,
           scope: TRUSTED_SCOPE
-        }, '#fxa-signup-header'));
+        }, '#fxa-signup-password-header'));
     },
   },
 


### PR DESCRIPTION
The test to see whether /authorization correctly redirects the user
to /signup did not pass an email address and looked for the wrong
selector. The test was fixed by specifying an email address and
updating the selector.

Calling /authorization w/o an `action` query parameter should
default to send users to `/oauth` and allowing the content
server to decide the next step based on whether a user is signed in.

fixes #6250 

@jrgm, @vladikoff - r?