### PR TITLE
chore(totp): enable totp for 100% of users

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/totp.js
+++ b/app/scripts/lib/experiments/grouping-rules/totp.js
@@ -12,7 +12,7 @@ module.exports = class TotpGroupingRule extends BaseGroupingRule {
   constructor() {
     super();
     this.name = 'totp';
-    this.ROLLOUT_RATE = 0.10;
+    this.ROLLOUT_RATE = 1;
   }
 
   choose(subject) {


### PR DESCRIPTION
Per [test plan](https://wiki.mozilla.org/QA/Multi-Factor_Authentication_for_Firefox_Accounts), we were opening TOTP for 100% of users. This is against train 113.

Depends on https://github.com/mozilla/fxa-content-server/pull/6232

