### PR TITLE
fix(css): make "show password" button background white on blur

### DIFF
--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -201,19 +201,13 @@
 
 .show-password-label:hover,
 .show-password-label:active,
-.show-password-label:focus,
-.show-password:hover + .show-password-label,
-.show-password:active + .show-password-label,
-.show-password:focus + .show-password-label {
+.show-password-label:focus {
   background-color: #d9d9d9;
 }
 
 input[type='text'] {
   // Hover over the show password label in its dark state
   ~ .show-password-label,
-  ~ .show-password:focus + .show-password-label,
-  ~ .show-password:active + .show-password-label,
-  ~ .show-password:hover + .show-password-label,
   ~ .show-password-label:focus,
   ~ .show-password-label:active,
   ~ .show-password-label:hover {


### PR DESCRIPTION
Fixes #6196 

I explained what I did here on https://github.com/mozilla/fxa-content-server/issues/6196#issuecomment-394891321

r? @vladikoff 