### PR TITLE
Allow lockbox to request the "oldsync" OAuth scope.

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -429,6 +429,11 @@ const conf = module.exports = convict({
             'https://dee85c67bd72f3de1f0a0fb62a8fe9b9b1a166d7.extensions.allizom.org/',
             'https://mozilla.github.io/notes/fxa/android-redirect.html'
           ]
+        },
+        'https://identity.mozilla.com/apps/oldsync': {
+          redirectUris: [
+            'https://lockbox.firefox.com/fxa/ios-redirect.html'
+          ]
         }
       },
       doc: 'Validates redirect uris for requested scopes',


### PR DESCRIPTION
This is a config change that prefs on the ability for Lockbox to request sync keys via the OAuth flow, and receive them at its production redirect URL.  For a train-113 point-release if we want to use production for the lockbox+oauth dev session on Thursday.