### PR TITLE
fix(timers): Always destroy timers created in view.setTimeout.

### DIFF
--- a/app/scripts/views/mixins/timer-mixin.js
+++ b/app/scripts/views/mixins/timer-mixin.js
@@ -15,8 +15,12 @@ import { each, without } from 'underscore';
 const Mixin = {
   setTimeout (callback, timeoutMS) {
     if (! this._timeouts) {
-      this.on('destroy', clearAllTimeouts.bind(this));
       this._timeouts = [];
+    }
+
+    if (! this._isListeningForDestroy) {
+      this._isListeningForDestroy = true;
+      this.on('destroy', clearAllTimeouts.bind(this));
     }
 
     const win = this.window || window;

--- a/app/scripts/views/mixins/timer-mixin.js
+++ b/app/scripts/views/mixins/timer-mixin.js
@@ -10,48 +10,44 @@
  * the view.
  */
 
-define(function (require, exports, module) {
-  'use strict';
+import { each, without } from 'underscore';
 
-  const _ = require('underscore');
-
-  var Mixin = {
-    setTimeout (callback, timeoutMS) {
-      if (! this._timeouts) {
-        this._timeouts = [];
-        // clear all timeouts when the view is destroyed.
-        this.on('destroy', clearAllTimeouts.bind(this));
-      }
-
-      var win = this.window || window;
-      var timeout = win.setTimeout(() => {
-        this.clearTimeout(timeout);
-        callback.call(this);
-      }, timeoutMS);
-
-      this._timeouts.push(timeout);
-
-      return timeout;
-    },
-
-    clearTimeout (timeout) {
-      var win = this.window || window;
-      win.clearTimeout(timeout);
-
-      this._timeouts = _.without(this._timeouts, timeout);
+const Mixin = {
+  setTimeout (callback, timeoutMS) {
+    if (! this._timeouts) {
+      this.on('destroy', clearAllTimeouts.bind(this));
+      this._timeouts = [];
     }
-  };
 
-  function clearAllTimeouts() {
-    var win = this.window || window;
+    const win = this.window || window;
+    const timeout = win.setTimeout(() => {
+      this.clearTimeout(timeout);
+      callback.call(this);
+    }, timeoutMS);
 
-    _.each(this._timeouts, function (timeout) {
-      win.clearTimeout(timeout);
-    });
+    this._timeouts.push(timeout);
 
-    this._timeouts = null;
+    return timeout;
+  },
+
+  clearTimeout (timeout) {
+    if (! timeout) {
+      return;
+    }
+    const win = this.window || window;
+    win.clearTimeout(timeout);
+    this._timeouts = without(this._timeouts, timeout);
   }
+};
 
-  module.exports = Mixin;
-});
+function clearAllTimeouts() {
+  const win = this.window || window;
 
+  each(this._timeouts, function (timeout) {
+    win.clearTimeout(timeout);
+  });
+
+  this._timeouts = null;
+}
+
+module.exports = Mixin;

--- a/app/tests/spec/views/mixins/timer-mixin.js
+++ b/app/tests/spec/views/mixins/timer-mixin.js
@@ -2,82 +2,77 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define(function (require, exports, module) {
-  'use strict';
+import { assert } from 'chai';
+const BaseView = require('views/base');
+const Cocktail = require('cocktail');
+const TestHelpers = require('../../../lib/helpers');
+const TimerMixin = require('views/mixins/timer-mixin');
 
-  const BaseView = require('views/base');
-  const Chai = require('chai');
-  const Cocktail = require('cocktail');
-  const TestHelpers = require('../../../lib/helpers');
-  const TimerMixin = require('views/mixins/timer-mixin');
 
-  var assert = Chai.assert;
+const TimerView = BaseView.extend({});
 
-  var TimerView = BaseView.extend({});
+Cocktail.mixin(
+  TimerView,
+  TimerMixin
+);
 
-  Cocktail.mixin(
-    TimerView,
-    TimerMixin
-  );
+describe('views/mixins/timer-mixin', function () {
+  let view;
 
-  describe('views/mixins/timer-mixin', function () {
-    var view;
+  beforeEach(function () {
+    view = new TimerView();
+  });
 
-    beforeEach(function () {
-      view = new TimerView();
+  describe('setTimeout', function () {
+    it('returns a handle that can be used to call clearTimeout', function (done) {
+      const timeout = view.setTimeout(done, 1);
+      assert.ok(timeout);
     });
 
-    describe('setTimeout', function () {
-      it('returns a handle that can be used to call clearTimeout', function (done) {
-        var timeout = view.setTimeout(done, 1);
-        assert.ok(timeout);
-      });
-
-      it('calls a function after time has elapsed', function (done) {
-        view.setTimeout(done, 1);
-      });
-
-      it('calls a function in the context of the view', function (done) {
-        view.setTimeout(function () {
-          TestHelpers.wrapAssertion(() => {
-            assert.strictEqual(this, view);
-          }, done);
-        }, 1);
-      });
+    it('calls a function after time has elapsed', function (done) {
+      view.setTimeout(done, 1);
     });
 
-    describe('clearTimeout', function () {
-      it('clears an outstanding timeout', function (done) {
-        var isTimeoutCalled = false;
-        var timeout = view.setTimeout(function () {
-          isTimeoutCalled = true;
-        }, 10);
-
-        setTimeout(function () {
-          TestHelpers.wrapAssertion(function () {
-            assert.isFalse(isTimeoutCalled);
-          }, done);
-        }, 20);
-
-        view.clearTimeout(timeout);
-      });
+    it('calls a function in the context of the view', function (done) {
+      view.setTimeout(function () {
+        TestHelpers.wrapAssertion(() => {
+          assert.strictEqual(this, view);
+        }, done);
+      }, 1);
     });
+  });
 
-    describe('destroying the view', function () {
-      it('removes any outstanding timeouts', function (done) {
-        var isTimeoutCalled = false;
-        view.setTimeout(function () {
-          isTimeoutCalled = true;
-        }, 10);
+  describe('clearTimeout', function () {
+    it('clears an outstanding timeout', function (done) {
+      let isTimeoutCalled = false;
+      const timeout = view.setTimeout(function () {
+        isTimeoutCalled = true;
+      }, 10);
 
-        setTimeout(function () {
-          TestHelpers.wrapAssertion(function () {
-            assert.isFalse(isTimeoutCalled);
-          }, done);
-        }, 20);
+      setTimeout(function () {
+        TestHelpers.wrapAssertion(function () {
+          assert.isFalse(isTimeoutCalled);
+        }, done);
+      }, 20);
 
-        view.destroy();
-      });
+      view.clearTimeout(timeout);
+    });
+  });
+
+  describe('destroying the view', function () {
+    it('removes any outstanding timeouts', function (done) {
+      let isTimeoutCalled = false;
+      view.setTimeout(function () {
+        isTimeoutCalled = true;
+      }, 10);
+
+      setTimeout(function () {
+        TestHelpers.wrapAssertion(function () {
+          assert.isFalse(isTimeoutCalled);
+        }, done);
+      }, 20);
+
+      view.destroy();
     });
   });
 });

--- a/app/tests/spec/views/mixins/timer-mixin.js
+++ b/app/tests/spec/views/mixins/timer-mixin.js
@@ -60,7 +60,10 @@ describe('views/mixins/timer-mixin', function () {
   });
 
   describe('destroying the view', function () {
-    it('removes any outstanding timeouts', function (done) {
+    it('removes any outstanding timeouts even if clearTimeout called before setTimeout', function (done) {
+      view.clearTimeout('invalid timer');
+      view.clearTimeout();
+
       let isTimeoutCalled = false;
       view.setTimeout(function () {
         isTimeoutCalled = true;


### PR DESCRIPTION
clearTimeout did not check whether `timeout` was defined
before trying to clear the timer and update the list of timers.

The fix is to check for a `timeout` reference in clearTimeout
before updating `this._timers`

fixes #6291

@mozilla/fxa-devs - r?