### PR TITLE
fix(test): Fix the sign_up->afterVisible test

### DIFF
--- a/app/tests/lib/helpers.js
+++ b/app/tests/lib/helpers.js
@@ -66,11 +66,10 @@ define(function (require, exports, module) {
   function wrapAssertion(fn, done) {
     try {
       fn();
+      done();
     } catch (e) {
       done(e);
-      return;
     }
-    done();
   }
 
   function createRandomString(length, base = 36) {

--- a/app/tests/lib/helpers.js
+++ b/app/tests/lib/helpers.js
@@ -68,6 +68,7 @@ define(function (require, exports, module) {
       fn();
     } catch (e) {
       done(e);
+      return;
     }
     done();
   }

--- a/app/tests/spec/views/sign_up.js
+++ b/app/tests/spec/views/sign_up.js
@@ -287,10 +287,11 @@ define(function (require, exports, module) {
         view.render()
           .then(() => view.afterVisible())
           .then(function () {
-            assert.isTrue(view.showValidationError.called);
-            setTimeout(function () {
-              assert.isTrue(view.$('input[type="email"]').hasClass('invalid'));
-              done();
+            setTimeout(() => {
+              TestHelpers.wrapAssertion(function () {
+                assert.isTrue(view.showValidationError.called);
+                assert.isTrue(view.$('input[type="email"]').hasClass('invalid'));
+              }, done);
             }, 50);
           });
       });


### PR DESCRIPTION
There were two problems, the first is that the assertion needed to be wrapped to ensure
failures were always surfaced. The second problem was TestHelpers.wrapAssertion would
call `done` twice if a test failed.

fixes #6290 

@mozilla/fxa-devs - r?