### PR TITLE
refactor(experiment): Extract a common `isTestEmail` function for all experiments.

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/base.js
+++ b/app/scripts/lib/experiments/grouping-rules/base.js
@@ -65,4 +65,14 @@ module.exports = class BaseGroupingRule {
     }
     throw new Error('choose must be overridden');
   }
+
+  /**
+   * Is this a test email?
+   *
+   * @param {String} email
+   * @returns {Boolean}
+   */
+  isTestEmail (email) {
+    return /(.+@mozilla\.(com|org)$)|(.+@softvision\.(com|ro)$)/.test(email);
+  }
 };

--- a/app/scripts/lib/experiments/grouping-rules/base.js
+++ b/app/scripts/lib/experiments/grouping-rules/base.js
@@ -73,6 +73,7 @@ module.exports = class BaseGroupingRule {
    * @returns {Boolean}
    */
   isTestEmail (email) {
-    return /(.+@mozilla\.(com|org)$)|(.+@softvision\.(com|ro)$)/.test(email);
+    return /.+@softvision\.(com|ro)$/.test(email) ||
+           /.+@mozilla\.(com|org)$/.test(email);
   }
 };

--- a/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
+++ b/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
@@ -17,11 +17,6 @@ const CountryTelephoneInfo = require('../../country-telephone-info');
 // `control` fares worse.
 const GROUPS_FOR_PARTIAL_ROLLOUT = ['control', 'signinCodes'];
 
-function isEmailInSigninCodesGroup (email) {
-  return /@softvision\.(com|ro)$/.test(email) ||
-          /@mozilla\.(com|org)$/.test(email);
-}
-
 module.exports = class SmsGroupingRule extends BaseGroupingRule {
   constructor () {
     super();
@@ -37,7 +32,7 @@ module.exports = class SmsGroupingRule extends BaseGroupingRule {
     // If rolloutRate is not specified, assume 0.
     const { rolloutRate } = CountryTelephoneInfo[subject.country] || 0;
 
-    if (isEmailInSigninCodesGroup(subject.account.get('email'))) {
+    if (this.isTestEmail(subject.account.get('email'))) {
       choice = 'signinCodes';
     } else if (rolloutRate >= 1) {
       // country is fully rolled out.

--- a/app/scripts/lib/experiments/grouping-rules/totp.js
+++ b/app/scripts/lib/experiments/grouping-rules/totp.js
@@ -24,9 +24,7 @@ module.exports = class TotpGroupingRule extends BaseGroupingRule {
       return true;
     }
 
-    // Is this a test email?
-    const email = subject.account.get('email');
-    if (this.isTestEmail(email)) {
+    if (this.isTestEmail(subject.account.get('email'))) {
       return true;
     }
 

--- a/app/scripts/lib/experiments/grouping-rules/totp.js
+++ b/app/scripts/lib/experiments/grouping-rules/totp.js
@@ -6,7 +6,6 @@
 
 const BaseGroupingRule = require('./base');
 const GROUPS = ['control', 'treatment'];
-const ENABLED_EMAIL_REGEX = /(.+@mozilla\.(com|org)$)|(.+@softvision\.(com|ro)$)/;
 
 module.exports = class TotpGroupingRule extends BaseGroupingRule {
   constructor() {
@@ -25,9 +24,9 @@ module.exports = class TotpGroupingRule extends BaseGroupingRule {
       return true;
     }
 
-    // Is this a Mozilla/Softvision based email?
+    // Is this a test email?
     const email = subject.account.get('email');
-    if (ENABLED_EMAIL_REGEX.test(email)) {
+    if (this.isTestEmail(email)) {
       return true;
     }
 

--- a/app/tests/spec/lib/experiments/grouping-rules/base.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/base.js
@@ -122,6 +122,20 @@ define(function (require, exports, module) {
       });
     });
 
+    describe('isTestEmail', () => {
+      ['tester@mozilla.com', 'testuser@mozilla.org', 'tester@softvision.ro', 'tester@softvision.com'].forEach((email) => {
+        it(`returns 'true' for test email: ${email}`, () => {
+          assert.isTrue(experiment.isTestEmail(email));
+        });
+      });
+
+      ['tester@google.com', 'tester@mozilla.es'].forEach((email) => {
+        it(`returns false for other non-test email: ${email}`, () => {
+          assert.isFalse(experiment.isTestEmail(email));
+        });
+      });
+    });
+
     describe('one experiment choose another', () => {
       /**
        * See #5378. This test is to ensure the hashing function has a uniform distribution


### PR DESCRIPTION
mozilla.com, mozilla.org, softvision.ro and softvision.com are test emails.
We had tests for those emails in several locations and more will add more.

Extraction from #6273 

@mozilla/fxa-devs - r?