### PR TITLE
Add TOTP experiment to manual experiment group

### DIFF
--- a/app/scripts/lib/experiment.js
+++ b/app/scripts/lib/experiment.js
@@ -28,7 +28,8 @@ define(function (require, exports, module) {
     // For now, the send SMS experiment only needs to log "enrolled", so
     // no special experiment is created.
     'sendSms': BaseExperiment,
-    'tokenCode': BaseExperiment
+    'tokenCode': BaseExperiment,
+    'totp': BaseExperiment,
   };
 
   const ALL_EXPERIMENTS = _.extend({}, STARTUP_EXPERIMENTS, MANUAL_EXPERIMENTS);

--- a/app/scripts/views/sign_in_totp_code.js
+++ b/app/scripts/views/sign_in_totp_code.js
@@ -9,6 +9,8 @@ const SignInMixin = require('./mixins/signin-mixin');
 const ServiceMixin = require('./mixins/service-mixin');
 const Template = require('templates/sign_in_totp_code.mustache');
 const VerificationReasonMixin = require('./mixins/verification-reason-mixin');
+const FlowEventsMixin = require('./mixins/flow-events-mixin');
+const TotpExperimentMixin = require('./mixins/totp-experiment-mixin');
 
 const CODE_INPUT_SELECTOR = 'input.totp-code';
 
@@ -30,7 +32,7 @@ const View = FormView.extend({
     return account.verifyTotpCode(code, this.relier.get('service'))
       .then((result) => {
         if (result.success) {
-          this.logViewEvent('success');
+          this.logFlowEvent('success', this.viewName);
           return this.invokeBrokerMethod('afterCompleteSignInWithCode', account);
         } else {
           throw AuthErrors.toError('INVALID_TOTP_CODE');
@@ -55,8 +57,10 @@ const View = FormView.extend({
 
 Cocktail.mixin(
   View,
+  FlowEventsMixin,
   SignInMixin,
   ServiceMixin,
+  TotpExperimentMixin,
   VerificationReasonMixin
 );
 


### PR DESCRIPTION
This fixes https://github.com/mozilla/fxa-amplitude-send/issues/64 by adding TOTP as a manual experiment. This is needed to properly initialize the experiment. After speaking with Phil, he mentioned that I could also use the `FlowEventMixin` to automatically emit engagement metrics.

If there isn't any objections, I would like to target this as a point release on train 114 since this is metrics related fix.

Sample output
```
3|content- | {"event":"flow.enter-email.engage","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":4093,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:08.315Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.enter-email.submit","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":5449,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:09.671Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.signin.view","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":5495,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:09.717Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.signin.engage","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":6183,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:10.405Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.signin.submit","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":7343,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:11.565Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.signin.attempt","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":7351,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:11.573Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.experiment.totp.control","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":7587,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:11.809Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.signin-totp-code.view","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":7599,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:11.821Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.signin-totp-code.engage","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":11244,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:15.466Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.signin-totp-code.submit","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":30973,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:35.195Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.signin-totp-code.success","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":31007,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:35.229Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
3|content- | {"event":"flow.signin.sms.view","flow_id":"fff87e3a485c453fe7e5866d418ac6f782a76ee45d2f87f725f9d7b9af27ef4d","flow_time":31161,"hostname":"vijaybudhram-ms.local","locale":"en","op":"flowEvent","pid":37186,"time":"2018-06-21T15:31:35.383Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
```