### PR TITLE
Merge v1.113.4 into train-114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@
 * **websessions:** reenable websessions (#6270) r=@vbudhram ([b4d82d9](https://github.com/mozilla/fxa-content-server/commit/b4d82d9))
 
 
+<a name="1.113.4"></a>
+## 1.113.4 (2018-06-10)
+
+
+### Features
+
+* **oauth:** Allow lockbox to request the "oldsync" OAuth scope. (#6272) r=@vladikoff ([306af32](https://github.com/mozilla/fxa-content-server/commit/306af32))
+
 
 <a name="1.113.3"></a>
 ## 1.113.3 (2018-06-05)

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -429,6 +429,11 @@ const conf = module.exports = convict({
             'https://dee85c67bd72f3de1f0a0fb62a8fe9b9b1a166d7.extensions.allizom.org/',
             'https://mozilla.github.io/notes/fxa/android-redirect.html'
           ]
+        },
+        'https://identity.mozilla.com/apps/oldsync': {
+          redirectUris: [
+            'https://lockbox.firefox.com/fxa/ios-redirect.html'
+          ]
         }
       },
       doc: 'Validates redirect uris for requested scopes',


### PR DESCRIPTION
In the hustle and bustle or all-hands, it looks like the v1.113.4 point-release did not get merged back to master and so did not get onto train-114.  This merges it, bringing https://github.com/mozilla/fxa-content-server/pull/6272 back to life.

We'll need to merge it to master again in turn.