### PR TITLE
fix(metrics): prevent reset-password from clobbering mixed-in events

### DIFF
--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
   const FlowEventsMixin = require('./mixins/flow-events-mixin');
   const FormView = require('./form');
   const PasswordResetMixin = require('./mixins/password-reset-mixin');
+  const preventDefaultThen = require('./base').preventDefaultThen;
   const ServiceMixin = require('./mixins/service-mixin');
   const Session = require('../lib/session');
   const Template = require('templates/reset_password.mustache');
@@ -19,7 +20,7 @@ define(function (require, exports, module) {
 
   const ResetPasswordView = FormView.extend({
     events: {
-      'click .remember-password': '_rememberPassword'
+      'click .remember-password': preventDefaultThen('_rememberPassword')
     },
 
     initialize (options) {

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -31,12 +31,15 @@ define(function (require, exports, module) {
       // address clears the email field in the formPrefill model if
       // the user doesn't enter an address. See comment in beforeDestroy
       this._formPrefill = options.formPrefill;
+
+      FormView.prototype.initialize.call(this, options);
     },
 
     setInitialContext (context) {
       context.set({
         forceEmail: this.model.get('forceEmail')
       });
+      FormView.prototype.setInitialContext.call(this, context);
     },
 
     beforeRender () {
@@ -49,6 +52,7 @@ define(function (require, exports, module) {
             this.model.set('error', err);
           });
       }
+      FormView.prototype.beforeRender.call(this);
     },
 
     beforeDestroy () {

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -11,14 +11,17 @@ define(function (require, exports, module) {
   const FlowEventsMixin = require('./mixins/flow-events-mixin');
   const FormView = require('./form');
   const PasswordResetMixin = require('./mixins/password-reset-mixin');
-  const preventDefaultThen = require('./base').preventDefaultThen;
   const ServiceMixin = require('./mixins/service-mixin');
   const Session = require('../lib/session');
   const Template = require('templates/reset_password.mustache');
 
   const t = (msg) => msg;
 
-  class ResetPasswordView extends FormView {
+  const ResetPasswordView = FormView.extend({
+    events: {
+      'click .remember-password': '_rememberPassword'
+    },
+
     initialize (options) {
       this.template = Template;
       this.className = 'reset_password';
@@ -27,22 +30,13 @@ define(function (require, exports, module) {
       // address clears the email field in the formPrefill model if
       // the user doesn't enter an address. See comment in beforeDestroy
       this._formPrefill = options.formPrefill;
-
-      this.events = {
-        'click .remember-password': preventDefaultThen('_rememberPassword')
-      };
-
-      super.initialize(options);
-    }
-
+    },
 
     setInitialContext (context) {
-      super.setInitialContext(context);
-
       context.set({
         forceEmail: this.model.get('forceEmail')
       });
-    }
+    },
 
     beforeRender () {
       var email = this.relier.get('email');
@@ -54,9 +48,7 @@ define(function (require, exports, module) {
             this.model.set('error', err);
           });
       }
-
-      return super.beforeRender();
-    }
+    },
 
     beforeDestroy () {
       const email = this.getElementValue('.email');
@@ -70,11 +62,11 @@ define(function (require, exports, module) {
       if (email) {
         this._formPrefill.set({ email });
       }
-    }
+    },
 
     submit () {
       return this._resetPassword(this.getElementValue('.email'));
-    }
+    },
 
     /**
      *
@@ -86,7 +78,7 @@ define(function (require, exports, module) {
       } else {
         this.navigate('signin');
       }
-    }
+    },
 
     _resetPassword (email) {
       return this.resetPassword(email)
@@ -105,7 +97,7 @@ define(function (require, exports, module) {
           throw err;
         });
     }
-  }
+  });
 
   Cocktail.mixin(
     ResetPasswordView,

--- a/app/tests/spec/views/reset_password.js
+++ b/app/tests/spec/views/reset_password.js
@@ -72,6 +72,15 @@ define(function (require, exports, module) {
       view = metrics = null;
     });
 
+    it('registers for the expected events', () => {
+      assert.isFunction(view.events['click .remember-password']);
+      assert.isFunction(view.events['click a']);
+      assert.isFunction(view.events['click input']);
+      assert.isFunction(view.events['input input']);
+      assert.isFunction(view.events['keyup input']);
+      assert.isFunction(view.events['submit']);
+    });
+
     describe('render', function () {
       it('renders template', function () {
         assert.ok($('#fxa-reset-password-header').length);


### PR DESCRIPTION
Fixes mozilla/fxa-amplitude-send#65.

The reset password view was clobbering the events that it was mixing in from the flow events mixin, by assigning directly to `this.events`.  This change sorts that out, and adds some tests that all of the expected events are registered for.

@mozilla/fxa-devs r?