### PR TITLE
fix(password-reset): Update the password reset text for clarity.

### DIFF
--- a/app/scripts/templates/complete_reset_password.mustache
+++ b/app/scripts/templates/complete_reset_password.mustache
@@ -41,7 +41,7 @@
     <form novalidate>
       {{#showSyncWarning}}
       <p class="reset-warning">
-        {{#unsafeTranslate}}<span>REMEMBER:</span> If you reset your password, some of your data will be erased (including synced server data like history and bookmarks). That’s because we encrypt your data with your password to protect your privacy.{{/unsafeTranslate}}
+        {{#unsafeTranslate}}<span>REMEMBER:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy.{{/unsafeTranslate}}
       </p>
       {{/showSyncWarning}}
 

--- a/app/scripts/templates/reset_password.mustache
+++ b/app/scripts/templates/reset_password.mustache
@@ -16,7 +16,7 @@
 
     <form novalidate>
       <p class="reset-warning">
-        {{#unsafeTranslate}}<span>NOTE:</span> If you reset your password, some of your data will be erased (including synced server data like history and bookmarks). That’s because we encrypt your data with your password to protect your privacy.{{/unsafeTranslate}}
+        {{#unsafeTranslate}}<span>NOTE:</span> When you reset your password, you reset your account. You may lose some of your personal information (including history, bookmarks, and passwords). That’s because we encrypt your data with your password to protect your privacy.{{/unsafeTranslate}}
       </p>
       <div class="input-row">
         {{#forceEmail}}


### PR DESCRIPTION
We have had several reports of users being confused by our password
reset text and were surprised whenever they lost their Sync data.
This tries to mitigate some of that confusion by making the
repercussions of resetting a password much more clear.

fixes #6213 

Since the strings have already been cut for train-115, this should be merged with train-116.

@mozilla/fxa-devs - r?