### PR TITLE
fix(codes): use new line carriage return and spaces to separate recovery codes

### DIFF
--- a/app/scripts/views/settings/recovery_codes.js
+++ b/app/scripts/views/settings/recovery_codes.js
@@ -127,7 +127,7 @@ const View = FormView.extend({
     this.recoveryCodesText = '';
     if (codes) {
       this.recoveryCodes = codes;
-      this.recoveryCodesText = this.recoveryCodes.join('\n');
+      this.recoveryCodesText = this.recoveryCodes.join(' \r\n');
       this.model.set('recoveryCodes', codes);
 
       if (msg) {


### PR DESCRIPTION
Fixes #6289 

This adds a space, new line and carriage return to recovery codes.

<img width="518" alt="screen shot 2018-06-25 at 3 29 49 pm" src="https://user-images.githubusercontent.com/1295288/41871345-a8d48be4-788c-11e8-8dbf-78b6a9b5cbbc.png">

I haven't verified in windows yet.