### PR TITLE
feat(test): Show more helpful error messages for the route check.

### DIFF
--- a/tests/server/helpers/routesHelpers.js
+++ b/tests/server/helpers/routesHelpers.js
@@ -68,11 +68,11 @@ function checkHeaders(routes, route, res) {
  * each URL exists, responds with a 200, and in the case of JS, CSS
  * and fonts, that the correct CORS headers are set.
  */
-function extractAndCheckUrls(res) {
+function extractAndCheckUrls(res, testName) {
   var href = url.parse(res.url);
   var origin = [ href.protocol, '//', href.host ].join('');
   return extractUrls(res.body)
-    .then(checkUrls.bind(null, origin));
+    .then((resources) => checkUrls(origin, resources, testName));
 }
 
 function extractUrls(body) {
@@ -145,7 +145,7 @@ function isUrlIgnored (url) {
   return IGNORE_URL_REGEXPS.find(domainRegExp => domainRegExp.test(url));
 }
 
-function checkUrls(origin, resources) {
+function checkUrls(origin, resources, testName = '') {
   findCssSubResources(origin, resources)
     .then((cssSubResources) => {
       resources = resources.concat(cssSubResources);
@@ -170,7 +170,7 @@ function checkUrls(origin, resources) {
               return;
             }
 
-            assert.equal(res.statusCode, 200);
+            assert.equal(res.statusCode, 200, `${testName}: ${resource.url}`);
 
             // If prod-like, Check all CSS and JS (except experiments.bundle.js)
             // for SRI `integrity=` attribute on the link, and that the checksum

--- a/tests/server/l10n-entrained.js
+++ b/tests/server/l10n-entrained.js
@@ -85,7 +85,8 @@ Object.keys(routes).forEach(function (key) {
 registerSuite('check resources entrained by /signin in all locales', suite);
 
 function routeTest(route, expectedStatusCode, requestOptions) {
-  suite.tests['#https get ' + httpsUrl + route + ' ' + requestOptions.headers['Accept-Language']] = function () {
+  const testName = `#https get ${httpsUrl}${route} ${requestOptions.headers['Accept-Language']}`;
+  suite.tests[testName] = function () {
     var dfd = this.async(intern._config.asyncTimeout);
 
     makeRequest(httpsUrl + route, requestOptions)
@@ -93,9 +94,8 @@ function routeTest(route, expectedStatusCode, requestOptions) {
         assert.equal(res.statusCode, expectedStatusCode);
         checkHeaders(routes, route, res);
 
-        return res;
+        return extractAndCheckUrls(res, testName);
       })
-      .then(extractAndCheckUrls)
       .then(dfd.resolve.bind(dfd), dfd.reject.bind(dfd));
 
     return dfd;

--- a/tests/server/routes.js
+++ b/tests/server/routes.js
@@ -141,7 +141,8 @@ Object.keys(redirectedRoutes).forEach(redirectTest);
 registerSuite('front end routes', suite.tests);
 
 function routeTest(route, expectedStatusCode, requestOptions) {
-  suite.tests['#https get ' + httpsUrl + route] = function () {
+  const testName = `#https get ${httpsUrl}${route}`;
+  suite.tests[testName] = function () {
     var dfd = this.async(intern._config.asyncTimeout);
 
     makeRequest(httpsUrl + route, requestOptions)
@@ -149,9 +150,8 @@ function routeTest(route, expectedStatusCode, requestOptions) {
         assert.equal(res.statusCode, expectedStatusCode);
         checkHeaders(routes, route, res);
 
-        return res;
+        return extractAndCheckUrls(res, testName);
       })
-      .then(extractAndCheckUrls)
       .then(dfd.resolve.bind(dfd), dfd.reject.bind(dfd));
 
     return dfd;


### PR DESCRIPTION
The URL checking code printed neither the test name nor the URL
if a test fails. If a URL within a page does not exist, say
which test and which URL is failing.

issue #6330

@mozilla/fxa-devs - r?

The tests are going to fail because of #6330