### PR TITLE
fix(form): Catch the form validation errors, no more console message.

### DIFF
--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -17,24 +17,20 @@
  * See documentation for an explanation of each.
  */
 
-define(function (require, exports, module) {
-  'use strict';
+require('./elements/jquery-plugin');
 
-  require('./elements/jquery-plugin');
+import _ from 'underscore';
+import allowOnlyOneSubmit from './decorators/allow_only_one_submit';
+import AuthErrors from '../lib/auth-errors';
+import BaseView from './base';
+import Duration from 'duration';
+import notifyDelayedRequest from './decorators/notify_delayed_request';
+import p from '../lib/promise';
+import showButtonProgressIndicator from './decorators/progress_indicator';
+import Tooltip from './tooltip';
+const { cancelEventThen, preventDefaultThen } = BaseView;
 
-  const _ = require('underscore');
-  const allowOnlyOneSubmit = require('./decorators/allow_only_one_submit');
-  const AuthErrors = require('../lib/auth-errors');
-  const BaseView = require('./base');
-  const Duration = require('duration');
-  const notifyDelayedRequest = require('./decorators/notify_delayed_request');
-  const p = require('../lib/promise');
-  const showButtonProgressIndicator = require('./decorators/progress_indicator');
-  const Tooltip = require('./tooltip');
-  const { cancelEventThen, preventDefaultThen } = BaseView;
-
-
-  /**
+/**
    * Decorator that checks whether the form has changed, and if so, call
    * the specified handler.
    * Called if `keypress` or `change` is fired on the form.
@@ -42,113 +38,119 @@ define(function (require, exports, module) {
    * @param {Function} handler
    * @returns {Function}
    */
-  function ifFormValuesChanged(handler) {
-    return function () {
-      if (this.updateFormValueChanges()) {
-        return this.invokeHandler(handler, arguments);
-      }
-    };
-  }
+function ifFormValuesChanged(handler) {
+  return function () {
+    if (this.updateFormValueChanges()) {
+      return this.invokeHandler(handler, arguments);
+    }
+  };
+}
 
-  const proto = BaseView.prototype;
+const proto = BaseView.prototype;
 
-  var FormView = BaseView.extend({
+var FormView = BaseView.extend({
 
-    // Time to wait for a request to finish before showing a notice
-    LONGER_THAN_EXPECTED: new Duration('10s').milliseconds(),
+  // Time to wait for a request to finish before showing a notice
+  LONGER_THAN_EXPECTED: new Duration('10s').milliseconds(),
 
-    constructor: function (options) {
-      BaseView.call(this, options);
+  constructor: function (options) {
+    BaseView.call(this, options);
 
-      // attach events of the descendent view and this view.
-      this.delegateEvents(_.extend({}, FormView.prototype.events, this.events));
-    },
+    // attach events of the descendent view and this view.
+    this.delegateEvents(_.extend({}, FormView.prototype.events, this.events));
+  },
 
-    events: {
-      'change form': ifFormValuesChanged(cancelEventThen('onFormChange')),
-      'input form': ifFormValuesChanged(cancelEventThen('onFormChange')),
-      'keyup form': ifFormValuesChanged(cancelEventThen('onFormChange')),
-      'submit form': preventDefaultThen('validateAndSubmit')
-    },
+  events: {
+    'change form': ifFormValuesChanged(cancelEventThen('onFormChange')),
+    'input form': ifFormValuesChanged(cancelEventThen('onFormChange')),
+    'keyup form': ifFormValuesChanged(cancelEventThen('onFormChange')),
+    'submit form': preventDefaultThen('onFormSubmit')
+  },
 
-    _notifiedOfEngaged: false,
-    onFormChange () {
-      // the change event can be called after the form is already
-      // submitted if the user presses "enter" in the form. If the
-      // form is in the midst of being submitted, bail out now.
-      if (this.isSubmitting() || this.isHalted()) {
-        return;
-      }
+  _notifiedOfEngaged: false,
+  onFormChange () {
+    // the change event can be called after the form is already
+    // submitted if the user presses "enter" in the form. If the
+    // form is in the midst of being submitted, bail out now.
+    if (this.isSubmitting() || this.isHalted()) {
+      return;
+    }
 
-      // hide success and error messages after user changes the form
-      this.hideError();
-      this.hideSuccess();
+    // hide success and error messages after user changes the form
+    this.hideError();
+    this.hideSuccess();
 
-      if (! this._notifiedOfEngaged) {
-        this._notifiedOfEngaged = true;
-        this.notifier.trigger('form.engaged');
-      }
-    },
+    if (! this._notifiedOfEngaged) {
+      this._notifiedOfEngaged = true;
+      this.notifier.trigger('form.engaged');
+    }
+  },
 
-    afterRender () {
-      // Firefox has a strange issue where if the previous
-      // screen was submit using the keyboard, the `enter` key's
-      // `keyup` event fires here on the element that receives
-      // focus. Without seeding the initial form values, any
-      // errors passed from the previous screen are immediately
-      // hidden.
-      this.updateFormValueChanges();
+  afterRender () {
+    // Firefox has a strange issue where if the previous
+    // screen was submit using the keyboard, the `enter` key's
+    // `keyup` event fires here on the element that receives
+    // focus. Without seeding the initial form values, any
+    // errors passed from the previous screen are immediately
+    // hidden.
+    this.updateFormValueChanges();
 
-      return proto.afterRender.call(this);
-    },
+    return proto.afterRender.call(this);
+  },
 
-    /**
+  /**
      * Get the current form values. Does not fetch the value of elements with
      * the `data-novalue` attribute.
      *
      * @method getFormValues
      * @returns {Object}
      */
-    getFormValues () {
-      var values = {};
+  getFormValues () {
+    var values = {};
 
-      this.getFormElements().each((index, el) => {
-        const $el = this.$(el);
-        // If the element has neither a name nor id, use the index as key
-        const key = $el.attr('name') || $el.attr('id') || index;
-        values[key] = this.getElementValue($el);
-      });
+    this.getFormElements().each((index, el) => {
+      const $el = this.$(el);
+      // If the element has neither a name nor id, use the index as key
+      const key = $el.attr('name') || $el.attr('id') || index;
+      values[key] = this.getElementValue($el);
+    });
 
-      return values;
-    },
+    return values;
+  },
 
-    /**
+  /**
      * Get a list of form elements that do not have the `data-novalue` attribute.
      *
      * @method getFormElements
      * @returns {Object}
      */
-    getFormElements () {
-      return this.$('input,textarea,select').filter((index, el) => {
-        const $el = this.$(el);
-        // elements that have data-novalue (like password show fields)
-        // are not added to the values.
-        return _.isUndefined($el.attr('data-novalue'));
-      });
-    },
+  getFormElements () {
+    return this.$('input,textarea,select').filter((index, el) => {
+      const $el = this.$(el);
+      // elements that have data-novalue (like password show fields)
+      // are not added to the values.
+      return _.isUndefined($el.attr('data-novalue'));
+    });
+  },
 
 
-    /**
+  /**
      * Check if the form is enabled
      *
      * @returns {Boolean}
      */
-    isFormEnabled () {
-      const $submitEl = this.$('button[type=submit]');
-      return ! $submitEl.hasClass('disabled') && ! $submitEl.attr('disabled');
-    },
+  isFormEnabled () {
+    const $submitEl = this.$('button[type=submit]');
+    return ! $submitEl.hasClass('disabled') && ! $submitEl.attr('disabled');
+  },
 
-    /**
+  onFormSubmit () {
+    return this.validateAndSubmit()
+      // drop the error on the ground, it'll already be logged.
+      .catch(err => {});
+  },
+
+  /**
      * Validate and if valid, submit the form.
      *
      * If the form is valid, three functions are run in series using
@@ -173,66 +175,66 @@ define(function (require, exports, module) {
      * Minimum artificial delay for the submit to resolve, useful for loading indicators
      * @return {Promise}
      */
-    validateAndSubmit: allowOnlyOneSubmit(function validateAndSubmit (event, options = {}) {
-      const startTime = Date.now();
-      const artificialDelay = options.artificialDelay || 0;
+  validateAndSubmit: allowOnlyOneSubmit(function validateAndSubmit (event, options = {}) {
+    const startTime = Date.now();
+    const artificialDelay = options.artificialDelay || 0;
 
-      if (event) {
-        event.stopImmediatePropagation();
-      }
+    if (event) {
+      event.stopImmediatePropagation();
+    }
 
-      this.trigger('submitStart');
+    this.trigger('submitStart');
 
-      return Promise.resolve()
-        .then(() => {
-          if (this.isHalted()) {
-            return;
-          }
+    return Promise.resolve()
+      .then(() => {
+        if (this.isHalted()) {
+          return;
+        }
 
-          if (! this.isValid()) {
-            // Validation error is surfaced for testing.
-            throw this.showValidationErrors();
-          }
+        if (! this.isValid()) {
+          // Validation error is surfaced for testing.
+          throw this.showValidationErrors();
+        }
 
-          // the form enabled check is done after the validation check
-          // so that the form's `submit` handler is triggered and validation
-          // error tooltips are displayed, even if the form is disabled.
-          if (! this.isFormEnabled()) {
-            // form is disabled, get outta here.
-            return;
-          }
+        // the form enabled check is done after the validation check
+        // so that the form's `submit` handler is triggered and validation
+        // error tooltips are displayed, even if the form is disabled.
+        if (! this.isFormEnabled()) {
+          // form is disabled, get outta here.
+          return;
+        }
 
-          // all good, do the beforeSubmit, submit, and afterSubmit chain.
-          this.logViewEvent('submit');
-          return this._submitForm()
-            .then(() => {
-              const diff = Date.now() - startTime;
-              const extraDelayTimeMS = Math.max(artificialDelay - diff, 0);
-              return p.delay(extraDelayTimeMS);
-            })
-            .then(() => {
-              return this.afterSubmit();
-            });
-        });
-    }),
+        // all good, do the beforeSubmit, submit, and afterSubmit chain.
+        this.logViewEvent('submit');
+        return this._submitForm()
+          .then(() => {
+            const diff = Date.now() - startTime;
+            const extraDelayTimeMS = Math.max(artificialDelay - diff, 0);
+            return p.delay(extraDelayTimeMS);
+          })
+          .then(() => {
+            return this.afterSubmit();
+          });
+      });
+  }),
 
-    _submitForm: notifyDelayedRequest(showButtonProgressIndicator(function () {
-      return Promise.resolve()
-        .then(_.bind(this.beforeSubmit, this))
-        .then((shouldSubmit) => {
-          // submission is opt out, not opt in.
-          if (shouldSubmit !== false) {
-            return this.submit();
-          }
-        })
-        .catch((err) => {
-          // display error and surface for testing.
-          this.displayError(err);
-          throw err;
-        });
-    })),
+  _submitForm: notifyDelayedRequest(showButtonProgressIndicator(function () {
+    return Promise.resolve()
+      .then(_.bind(this.beforeSubmit, this))
+      .then((shouldSubmit) => {
+        // submission is opt out, not opt in.
+        if (shouldSubmit !== false) {
+          return this.submit();
+        }
+      })
+      .catch((err) => {
+        // display error and surface for testing.
+        this.displayError(err);
+        throw err;
+      });
+  })),
 
-    /**
+  /**
      * Checks whether the form is valid. Checks the validitity of each
      * form element. If any elements are invalid, returns false.
      *
@@ -243,25 +245,25 @@ define(function (require, exports, module) {
      *
      * @returns {Boolean}
      */
-    isValid () {
-      if (! this.isValidStart()) {
+  isValid () {
+    if (! this.isValidStart()) {
+      return false;
+    }
+
+    const inputEls = this.$('input');
+    for (var i = 0, length = inputEls.length; i < length; ++i) {
+      var $el = this.$(inputEls[i]);
+      try {
+        $el.validate();
+      } catch (e) {
         return false;
       }
+    }
 
-      const inputEls = this.$('input');
-      for (var i = 0, length = inputEls.length; i < length; ++i) {
-        var $el = this.$(inputEls[i]);
-        try {
-          $el.validate();
-        } catch (e) {
-          return false;
-        }
-      }
+    return this.isValidEnd();
+  },
 
-      return this.isValidEnd();
-    },
-
-    /**
+  /**
      * Check form for validity.  isValidStart is run before
      * input elements are checked. Descendent views only need to
      * override to do any form specific checks that cannot be
@@ -269,11 +271,11 @@ define(function (require, exports, module) {
      *
      * @return {Boolean} true if form is valid, false otw.
      */
-    isValidStart () {
-      return true;
-    },
+  isValidStart () {
+    return true;
+  },
 
-    /**
+  /**
      * Check form for validity.  isValidEnd is run after
      * input elements are checked. Descendent views only need to
      * override to do any form specific checks that cannot be
@@ -281,11 +283,11 @@ define(function (require, exports, module) {
      *
      * @return {Boolean} true if form is valid, false otw.
      */
-    isValidEnd () {
-      return true;
-    },
+  isValidEnd () {
+    return true;
+  },
 
-    /**
+  /**
      * Display form validation errors.
      *
      * Descendent views can override showValidationErrorsStart
@@ -293,42 +295,42 @@ define(function (require, exports, module) {
      *
      * @returns {undefined}
      */
-    showValidationErrors () {
-      this.hideError();
+  showValidationErrors () {
+    this.hideError();
 
-      if (this.showValidationErrorsStart()) {
+    if (this.showValidationErrorsStart()) {
+      // only one message at a time.
+      return;
+    }
+
+    const inputEls = this.$('input');
+    for (var i = 0, length = inputEls.length; i < length; ++i) {
+      const el = inputEls[i];
+      const $el = this.$(el);
+
+      try {
+        $el.validate();
+      } catch (validationError) {
+        this.showValidationError(el, validationError);
         // only one message at a time.
         return;
       }
+    }
 
-      const inputEls = this.$('input');
-      for (var i = 0, length = inputEls.length; i < length; ++i) {
-        const el = inputEls[i];
-        const $el = this.$(el);
+    this.showValidationErrorsEnd();
+  },
 
-        try {
-          $el.validate();
-        } catch (validationError) {
-          this.showValidationError(el, validationError);
-          // only one message at a time.
-          return;
-        }
-      }
-
-      this.showValidationErrorsEnd();
-    },
-
-    /**
+  /**
      * Get an element value, trimming the value of whitespace if necessary
      *
      * @param {String} el
      * @returns {String}
      */
-    getElementValue (el) {
-      return this.$(el).val();
-    },
+  getElementValue (el) {
+    return this.$(el).val();
+  },
 
-    /**
+  /**
      * Display form validation errors. isValidStart is run before
      * input element validation errors are displayed. Descendent
      * views only need to override to show any form specific
@@ -336,10 +338,10 @@ define(function (require, exports, module) {
      *
      * @return {undefined} true if a validation error is displayed.
      */
-    showValidationErrorsStart () {
-    },
+  showValidationErrorsStart () {
+  },
 
-    /**
+  /**
      * Display form validation errors. isValidEnd is run after
      * input element validation errors are displayed. Descendent
      * views only need to override to show any form specific
@@ -347,47 +349,47 @@ define(function (require, exports, module) {
      *
      * @return {undefined} true if a validation error is displayed.
      */
-    showValidationErrorsEnd () {
-    },
+  showValidationErrorsEnd () {
+  },
 
-    /**
+  /**
      * Show a form validation error to the user in the form of a tooltip.
      *
      * @param {String} el
      * @param {Error} err
      * @returns {String}
      */
-    showValidationError (el, err) {
-      this.logError(err);
+  showValidationError (el, err) {
+    this.logError(err);
 
-      var invalidEl = this.$(el);
-      var message = AuthErrors.toMessage(err);
+    var invalidEl = this.$(el);
+    var message = AuthErrors.toMessage(err);
 
-      var tooltip = new Tooltip({
-        invalidEl: invalidEl,
-        message: message
-      });
+    var tooltip = new Tooltip({
+      invalidEl: invalidEl,
+      message: message
+    });
 
-      tooltip.on('destroyed', () => {
-        invalidEl.removeClass('invalid');
-        this.trigger('validation_error_removed', el);
-      }).render().then(() => {
-        try {
-          invalidEl.addClass('invalid').get(0).focus();
-        } catch (e) {
-          // IE can blow up if the element is not visible.
-        }
+    tooltip.on('destroyed', () => {
+      invalidEl.removeClass('invalid');
+      this.trigger('validation_error_removed', el);
+    }).render().then(() => {
+      try {
+        invalidEl.addClass('invalid').get(0).focus();
+      } catch (e) {
+        // IE can blow up if the element is not visible.
+      }
 
-        // used for testing
-        this.trigger('validation_error', el, message);
-      });
+      // used for testing
+      this.trigger('validation_error', el, message);
+    });
 
-      this.trackChildView(tooltip);
+    this.trackChildView(tooltip);
 
-      return message;
-    },
+    return message;
+  },
 
-    /**
+  /**
      * Descendent views can override.
      *
      * Descendent views may want to override this to allow multiple form
@@ -397,21 +399,21 @@ define(function (require, exports, module) {
      * @returns {Promise|Boolean|none} Return a promise if
      *   beforeSubmit is an asynchronous operation.
      */
-    beforeSubmit () {
-      return Promise.resolve();
-    },
+  beforeSubmit () {
+    return Promise.resolve();
+  },
 
-    /**
+  /**
      * Descendent views should override.
      *
      * Submit form data to the server. Only called if isValid returns true
      * and beforeSubmit does not return false.
      *
      */
-    submit () {
-    },
+  submit () {
+  },
 
-    /**
+  /**
      * Descendent views can override.
      *
      * Descendent views may want to override this to allow
@@ -421,81 +423,80 @@ define(function (require, exports, module) {
      * @returns {Promise|none} Return a promise if afterSubmit is
      *   an asynchronous operation.
      */
-    afterSubmit (result) {
-      return Promise.resolve().then(() => {
-        // the flow may be halted by an authentication broker after form
-        // submission. Views may display an error without throwing an exception.
-        // Ensure the flow is not halted and and no errors are visible before
-        // re-enabling the form. The user must modify the form for it to
-        // be re-enabled.
+  afterSubmit (result) {
+    return Promise.resolve().then(() => {
+      // the flow may be halted by an authentication broker after form
+      // submission. Views may display an error without throwing an exception.
+      // Ensure the flow is not halted and and no errors are visible before
+      // re-enabling the form. The user must modify the form for it to
+      // be re-enabled.
 
-        if (result && result.halt) {
-          this.halt();
-        }
+      if (result && result.halt) {
+        this.halt();
+      }
 
-        return result;
-      });
-    },
+      return result;
+    });
+  },
 
-    /**
+  /**
      * Check if the form is currently being submitted
      *
      * @returns {Boolean} true if form is being submitted, false otw.
      */
-    isSubmitting () {
-      return this._isSubmitting;
-    },
+  isSubmitting () {
+    return this._isSubmitting;
+  },
 
-    /**
+  /**
      * Halt! Disable form edits, submission.
      *
      * TODO - this should be named disableForm, but that name is already taken.
      */
-    halt () {
-      this.$('input,textarea,button').attr('disabled', 'disabled').blur();
-      this._isHalted = true;
-    },
+  halt () {
+    this.$('input,textarea,button').attr('disabled', 'disabled').blur();
+    this._isHalted = true;
+  },
 
-    /**
+  /**
      * Check if the view is halted
      *
      * @returns {Boolean} true if the view is halted, false otw.
      */
-    isHalted () {
-      return this._isHalted;
-    },
+  isHalted () {
+    return this._isHalted;
+  },
 
-    /**
+  /**
      * Detect if form values have changed
      *
      * @returns {Object|null} the form values or null if they haven't changed.
      */
-    detectFormValueChanges () {
-      // oldValues will be `undefined` the first time through.
-      var oldValues = this._previousFormValues;
-      var newValues = this.getFormValues();
+  detectFormValueChanges () {
+    // oldValues will be `undefined` the first time through.
+    var oldValues = this._previousFormValues;
+    var newValues = this.getFormValues();
 
-      if (! _.isEqual(oldValues, newValues)) {
-        return newValues;
-      }
+    if (! _.isEqual(oldValues, newValues)) {
+      return newValues;
+    }
 
-      return null;
-    },
+    return null;
+  },
 
-    /**
+  /**
      * Detect if form values have changed and use the new
      * values as the baseline to detect future changes.
      *
      * @returns {Object|null} the form values or null if they haven't changed.
      */
-    updateFormValueChanges () {
-      var newValues = this.detectFormValueChanges();
-      if (newValues) {
-        this._previousFormValues = newValues;
-      }
-      return newValues;
+  updateFormValueChanges () {
+    var newValues = this.detectFormValueChanges();
+    if (newValues) {
+      this._previousFormValues = newValues;
     }
-  });
-
-  module.exports = FormView;
+    return newValues;
+  }
 });
+
+module.exports = FormView;

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -2,692 +2,696 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define(function (require, exports, module) {
-  'use strict';
+import $ from 'jquery';
+import { assert } from 'chai';
+import AuthErrors from 'lib/auth-errors';
+import Backbone from 'backbone';
+import Constants from 'lib/constants';
+import FormView from 'views/form';
+import HaltBehavior from 'views/behaviors/halt';
+import Metrics from 'lib/metrics';
+import Notifier from 'lib/channels/notifier';
+import p from 'lib/promise';
+import sinon from 'sinon';
+import Template from 'templates/test_template.mustache';
+import TestHelpers from '../../lib/helpers';
 
-  const $ = require('jquery');
-  const { assert } = require('chai');
-  const AuthErrors = require('lib/auth-errors');
-  const Backbone = require('backbone');
-  const Constants = require('lib/constants');
-  const FormView = require('views/form');
-  const HaltBehavior = require('views/behaviors/halt');
-  const Metrics = require('lib/metrics');
-  const Notifier = require('lib/channels/notifier');
-  const p = require('lib/promise');
-  const sinon = require('sinon');
-  const Template = require('templates/test_template.mustache');
-  const TestHelpers = require('../../lib/helpers');
+var View = FormView.extend({
+  template: Template,
 
-  var View = FormView.extend({
-    template: Template,
+  // overridden in tests.
+  formIsValid: false,
+  isFormSubmitted: false,
 
-    // overridden in tests.
-    formIsValid: false,
-    isFormSubmitted: false,
+  isValid () {
+    return this.formIsValid;
+  },
 
-    isValid () {
-      return this.formIsValid;
-    },
+  showValidationErrors () {
+    return this.showValidationError('body', 'invalid form');
+  },
 
-    showValidationErrors () {
-      return this.showValidationError('body', 'invalid form');
-    },
+  submit () {
+    this.isFormSubmitted = true;
+  },
 
-    submit () {
-      this.isFormSubmitted = true;
-    },
+  setInitialContext (context) {
+    context.set({
+      error: this.model.get('templateWrittenError'),
+      success: this.model.get('templateWrittenSuccess')
+    });
+  }
+});
 
-    setInitialContext (context) {
-      context.set({
-        error: this.model.get('templateWrittenError'),
-        success: this.model.get('templateWrittenSuccess')
+describe('views/form', function () {
+  let metrics;
+  let model;
+  let notifier;
+  let view;
+
+  function testErrorDisplayed(expectedMessage) {
+    return view.validateAndSubmit()
+      .then(assert.fail, function (err) {
+        assert.equal(err, expectedMessage);
+        assert.isTrue(view.isErrorVisible());
       });
+  }
+
+  function testValidationErrorDisplayed(expectedMessage) {
+    return view.validateAndSubmit()
+      .then(assert.fail, function (err) {
+        assert.equal(err, expectedMessage);
+      });
+  }
+
+  function testFormSubmitted() {
+    return view.validateAndSubmit()
+      .then(function () {
+        assert.isTrue(view.isFormSubmitted);
+      });
+  }
+
+  function testValidationError($el, expectedError) {
+    let validationError;
+
+    try {
+      $el.validate();
+    } catch (e) {
+      validationError = e;
+    }
+
+    assert.isTrue(AuthErrors.is(validationError, expectedError));
+  }
+
+  function testNoValidationError($el) {
+    let validationError;
+
+    try {
+      $el.validate();
+    } catch (e) {
+      validationError = e;
+    }
+
+    assert.isUndefined(validationError);
+  }
+
+
+  beforeEach(function () {
+    notifier = new Notifier();
+    metrics = new Metrics({ notifier });
+    model = new Backbone.Model({});
+    sinon.spy(notifier, 'trigger');
+
+    view = new View({
+      metrics,
+      model,
+      notifier
+    });
+
+    return view.render();
+  });
+
+  afterEach(function () {
+    if (view) {
+      view.remove();
+      view.destroy();
+      view = null;
     }
   });
 
-  describe('views/form', function () {
-    let metrics;
-    let model;
-    let notifier;
-    let view;
-
-    function testErrorDisplayed(expectedMessage) {
-      return view.validateAndSubmit()
-        .then(assert.fail, function (err) {
-          assert.equal(err, expectedMessage);
-          assert.isTrue(view.isErrorVisible());
-        });
-    }
-
-    function testValidationErrorDisplayed(expectedMessage) {
-      return view.validateAndSubmit()
-        .then(assert.fail, function (err) {
-          assert.equal(err, expectedMessage);
-        });
-    }
-
-    function testFormSubmitted() {
-      return view.validateAndSubmit()
-        .then(function () {
-          assert.isTrue(view.isFormSubmitted);
-        });
-    }
-
-    function testValidationError($el, expectedError) {
-      let validationError;
-
-      try {
-        $el.validate();
-      } catch (e) {
-        validationError = e;
-      }
-
-      assert.isTrue(AuthErrors.is(validationError, expectedError));
-    }
-
-    function testNoValidationError($el) {
-      let validationError;
-
-      try {
-        $el.validate();
-      } catch (e) {
-        validationError = e;
-      }
-
-      assert.isUndefined(validationError);
-    }
-
-
-    beforeEach(function () {
-      notifier = new Notifier();
-      metrics = new Metrics({ notifier });
-      model = new Backbone.Model({});
-      sinon.spy(notifier, 'trigger');
-
-      view = new View({
-        metrics,
-        model,
-        notifier
+  describe('render', () => {
+    beforeEach(() => {
+      model.set({
+        templateWrittenError: 'template written error',
+        templateWrittenSuccess: 'template written success'
       });
 
       return view.render();
     });
 
-    afterEach(function () {
-      if (view) {
-        view.remove();
-        view.destroy();
-        view = null;
-      }
+    it('does not hide already visible status messages', () => {
+      assert.lengthOf(view.$('.error.visible'), 1);
+      assert.isTrue(view.isErrorVisible());
+      assert.lengthOf(view.$('.success.visible'), 1);
+      assert.isTrue(view.isSuccessVisible());
+    });
+  });
+
+  describe('onFormChange', () => {
+    it('hides messages', () => {
+      sinon.stub(view, 'isHalted').callsFake(() => false);
+      sinon.stub(view, 'isSubmitting').callsFake(() => false);
+      sinon.spy(view, 'hideError');
+      sinon.spy(view, 'hideSuccess');
+
+      view.onFormChange();
+      assert.isTrue(view.hideError.calledOnce);
+      assert.isTrue(view.hideSuccess.calledOnce);
     });
 
-    describe('render', () => {
-      beforeEach(() => {
-        model.set({
-          templateWrittenError: 'template written error',
-          templateWrittenSuccess: 'template written success'
+    it('does nothing if submitting', function () {
+      sinon.stub(view, 'isHalted').callsFake(() => false);
+      sinon.stub(view, 'isSubmitting').callsFake(() => true);
+      sinon.spy(view, 'hideError');
+      sinon.spy(view, 'hideSuccess');
+
+      view.onFormChange();
+      assert.isFalse(view.hideError.called);
+      assert.isFalse(view.hideSuccess.called);
+    });
+
+    it('does nothing if halted', function () {
+      sinon.stub(view, 'isHalted').callsFake(() => true);
+      sinon.stub(view, 'isSubmitting').callsFake(() => false);
+      sinon.spy(view, 'hideError');
+      sinon.spy(view, 'hideSuccess');
+
+      view.onFormChange();
+      assert.isFalse(view.hideError.called);
+      assert.isFalse(view.hideSuccess.called);
+    });
+
+    it('notifies of `form.engage` for the first change', () => {
+      sinon.stub(view, 'isHalted').callsFake(() => false);
+      sinon.stub(view, 'isSubmitting').callsFake(() => false);
+
+      view.onFormChange();
+      assert.isTrue(notifier.trigger.calledOnce);
+      assert.isTrue(notifier.trigger.calledWith('form.engaged'));
+      view.onFormChange();
+      view.onFormChange();
+      assert.isTrue(notifier.trigger.calledOnce);
+    });
+  });
+
+  it('onFormSubmit swallows errors from validateAndSubmit', () => {
+    sinon.stub(view, 'validateAndSubmit').callsFake(() => Promise.reject(new Error('uh oh')));
+
+    // if the error is not swallowed it'll be propagated to the test runner
+    // and the test will fail.
+    return view.onFormSubmit();
+  });
+
+  describe('validateAndSubmit', function () {
+    it('triggers a `submitStart` event', (done) => {
+      view.on('submitStart', () => done());
+
+      view.validateAndSubmit();
+    });
+
+    it('submits form if isValid returns true', function () {
+      view.formIsValid = true;
+      return testFormSubmitted();
+    });
+
+    it('shows validation errors if isValid returns false', function () {
+      view.formIsValid = false;
+      return testValidationErrorDisplayed('invalid form');
+    });
+
+    it('only allows one submit at a time', function () {
+      view.formIsValid = true;
+      view.validateAndSubmit();
+      return view.validateAndSubmit()
+        .then(function () {
+          assert(false, 'unexpected success');
+        }, function (err) {
+          assert.equal(err.message, 'submit already in progress');
         });
 
-        return view.render();
-      });
-
-      it('does not hide already visible status messages', () => {
-        assert.lengthOf(view.$('.error.visible'), 1);
-        assert.isTrue(view.isErrorVisible());
-        assert.lengthOf(view.$('.success.visible'), 1);
-        assert.isTrue(view.isSuccessVisible());
-      });
     });
 
-    describe('onFormChange', () => {
-      it('hides messages', () => {
-        sinon.stub(view, 'isHalted').callsFake(() => false);
-        sinon.stub(view, 'isSubmitting').callsFake(() => false);
-        sinon.spy(view, 'hideError');
-        sinon.spy(view, 'hideSuccess');
-
-        view.onFormChange();
-        assert.isTrue(view.hideError.calledOnce);
-        assert.isTrue(view.hideSuccess.calledOnce);
-      });
-
-      it('does nothing if submitting', function () {
-        sinon.stub(view, 'isHalted').callsFake(() => false);
-        sinon.stub(view, 'isSubmitting').callsFake(() => true);
-        sinon.spy(view, 'hideError');
-        sinon.spy(view, 'hideSuccess');
-
-        view.onFormChange();
-        assert.isFalse(view.hideError.called);
-        assert.isFalse(view.hideSuccess.called);
-      });
-
-      it('does nothing if halted', function () {
-        sinon.stub(view, 'isHalted').callsFake(() => true);
-        sinon.stub(view, 'isSubmitting').callsFake(() => false);
-        sinon.spy(view, 'hideError');
-        sinon.spy(view, 'hideSuccess');
-
-        view.onFormChange();
-        assert.isFalse(view.hideError.called);
-        assert.isFalse(view.hideSuccess.called);
-      });
-
-      it('notifies of `form.engage` for the first change', () => {
-        sinon.stub(view, 'isHalted').callsFake(() => false);
-        sinon.stub(view, 'isSubmitting').callsFake(() => false);
-
-        view.onFormChange();
-        assert.isTrue(notifier.trigger.calledOnce);
-        assert.isTrue(notifier.trigger.calledWith('form.engaged'));
-        view.onFormChange();
-        view.onFormChange();
-        assert.isTrue(notifier.trigger.calledOnce);
-      });
-    });
-
-    describe('validateAndSubmit', function () {
-      it('triggers a `submitStart` event', (done) => {
-        view.on('submitStart', () => done());
-
-        view.validateAndSubmit();
-      });
-
-      it('submits form if isValid returns true', function () {
-        view.formIsValid = true;
-        return testFormSubmitted();
-      });
-
-      it('shows validation errors if isValid returns false', function () {
-        view.formIsValid = false;
-        return testValidationErrorDisplayed('invalid form');
-      });
-
-      it('only allows one submit at a time', function () {
-        view.formIsValid = true;
-        view.validateAndSubmit();
-        return view.validateAndSubmit()
-          .then(function () {
-            assert(false, 'unexpected success');
-          }, function (err) {
-            assert.equal(err.message, 'submit already in progress');
-          });
-
-      });
-
-      it('does not submit if form is halted', function () {
-        view.formIsValid = true;
-        view.halt();
-        sinon.spy(view, 'submit');
-        return view.validateAndSubmit()
-          .then(function () {
-            assert.isFalse(view.submit.called);
-          });
-      });
-
-      it('displays error message and does not disable form if beforeSubmit throws an error', function () {
-        view.formIsValid = true;
-        view.beforeSubmit = function () {
-          throw 'an error message';
-        };
-
-        return testErrorDisplayed('an error message')
-          .then(function () {
-            assert.isTrue(view.isFormEnabled());
-          });
-      });
-
-      it('beforeSubmit can return a false to stop form submission', function () {
-        view.formIsValid = true;
-        view.beforeSubmit = function () {
-          return false;
-        };
-
-        return view.validateAndSubmit()
-          .then(function () {
-            assert.isFalse(view.isFormSubmitted);
-          });
-      });
-
-      it('beforeSubmit can return a promise for asynchronous operations', function () {
-        view.formIsValid = true;
-        view.beforeSubmit = function () {
-          return p.delay(10);
-        };
-
-        return testFormSubmitted();
-      });
-
-      it('displays error message if submit throws an error', function () {
-        view.formIsValid = true;
-        sinon.stub(view, 'submit').callsFake(() => {
-          throw 'an error message';
+    it('does not submit if form is halted', function () {
+      view.formIsValid = true;
+      view.halt();
+      sinon.spy(view, 'submit');
+      return view.validateAndSubmit()
+        .then(function () {
+          assert.isFalse(view.submit.called);
         });
-
-        return testErrorDisplayed('an error message');
-      });
-
-      it('submit can return a promise for asynchronous operations', function () {
-        view.formIsValid = true;
-        view.submit = function () {
-          return p.delay(10).then(function () {
-            view.isFormSubmitted = true;
-          });
-        };
-
-        return testFormSubmitted();
-      });
     });
 
-    describe('afterSubmit', function () {
-      it('errors in override are not disaplayed', function () {
-        view.formIsValid = true;
-        view.afterSubmit = function () {
-          throw new Error('error that is not displayed');
-        };
+    it('displays error message and does not disable form if beforeSubmit throws an error', function () {
+      view.formIsValid = true;
+      view.beforeSubmit = function () {
+        throw 'an error message';
+      };
 
-        return view.validateAndSubmit()
-          .then(assert.fail, function (err) {
-            assert.equal(err.message, 'error that is not displayed');
-            assert.isFalse(view.isErrorVisible());
-          });
-      });
-
-      it('pass in an object with `halt: true` to disable form', function () {
-        return view.afterSubmit(new HaltBehavior())
-          .then(function () {
-            assert.isTrue(view.isHalted());
-            assert.isFalse(view.isFormEnabled());
-          });
-      });
-    });
-
-    describe('halt', function () {
-      it('prevents input fields from being changed', function () {
-        view.halt();
-
-        view.$('input').each(function (index, el) {
-          assert.ok(view.$(el).attr('disabled'));
+      return testErrorDisplayed('an error message')
+        .then(function () {
+          assert.isTrue(view.isFormEnabled());
         });
+    });
+
+    it('beforeSubmit can return a false to stop form submission', function () {
+      view.formIsValid = true;
+      view.beforeSubmit = function () {
+        return false;
+      };
+
+      return view.validateAndSubmit()
+        .then(function () {
+          assert.isFalse(view.isFormSubmitted);
+        });
+    });
+
+    it('beforeSubmit can return a promise for asynchronous operations', function () {
+      view.formIsValid = true;
+      view.beforeSubmit = function () {
+        return p.delay(10);
+      };
+
+      return testFormSubmitted();
+    });
+
+    it('displays error message if submit throws an error', function () {
+      view.formIsValid = true;
+      sinon.stub(view, 'submit').callsFake(() => {
+        throw 'an error message';
       });
 
-      it('prevents the form from being submitted', function () {
-        view.halt();
+      return testErrorDisplayed('an error message');
+    });
 
-        assert.ok(view.$('button[type="submit"]').attr('disabled'));
-        assert.isFalse(view.isFormEnabled());
+    it('submit can return a promise for asynchronous operations', function () {
+      view.formIsValid = true;
+      view.submit = function () {
+        return p.delay(10).then(function () {
+          view.isFormSubmitted = true;
+        });
+      };
+
+      return testFormSubmitted();
+    });
+  });
+
+  describe('afterSubmit', function () {
+    it('errors in override are not disaplayed', function () {
+      view.formIsValid = true;
+      view.afterSubmit = function () {
+        throw new Error('error that is not displayed');
+      };
+
+      return view.validateAndSubmit()
+        .then(assert.fail, function (err) {
+          assert.equal(err.message, 'error that is not displayed');
+          assert.isFalse(view.isErrorVisible());
+        });
+    });
+
+    it('pass in an object with `halt: true` to disable form', function () {
+      return view.afterSubmit(new HaltBehavior())
+        .then(function () {
+          assert.isTrue(view.isHalted());
+          assert.isFalse(view.isFormEnabled());
+        });
+    });
+  });
+
+  describe('halt', function () {
+    it('prevents input fields from being changed', function () {
+      view.halt();
+
+      view.$('input').each(function (index, el) {
+        assert.ok(view.$(el).attr('disabled'));
       });
     });
 
-    describe('showValidationError', function () {
-      it('creates a tooltip', function () {
-        view.on('validation_error', function (done) {
-          assert.ok(view.$('.tooltip').length);
+    it('prevents the form from being submitted', function () {
+      view.halt();
+
+      assert.ok(view.$('button[type="submit"]').attr('disabled'));
+      assert.isFalse(view.isFormEnabled());
+    });
+  });
+
+  describe('showValidationError', function () {
+    it('creates a tooltip', function () {
+      view.on('validation_error', function (done) {
+        assert.ok(view.$('.tooltip').length);
+        done();
+      });
+      view.showValidationError('#focusMe', 'this is an error');
+    });
+
+    it('focuses the invalid element', function (done) {
+      $('#container').html(view.el);
+
+      // wekbit fails unless focusing another element first.
+      view.$('#otherElement').focus();
+
+      TestHelpers.requiresFocus(function () {
+        view.$('#focusMe').on('focus', function () {
           done();
         });
         view.showValidationError('#focusMe', 'this is an error');
-      });
+      }, done);
+    });
 
-      it('focuses the invalid element', function (done) {
-        $('#container').html(view.el);
-
-        // wekbit fails unless focusing another element first.
-        view.$('#otherElement').focus();
-
-        TestHelpers.requiresFocus(function () {
-          view.$('#focusMe').on('focus', function () {
-            done();
-          });
-          view.showValidationError('#focusMe', 'this is an error');
+    it('logs the error', function (done) {
+      var err = AuthErrors.toError('EMAIL_REQUIRED');
+      view.on('validation_error', function () {
+        TestHelpers.wrapAssertion(function () {
+          assert.isTrue(TestHelpers.isErrorLogged(metrics, err));
         }, done);
       });
+      view.showValidationError('#focusMe', err);
+    });
 
-      it('logs the error', function (done) {
-        var err = AuthErrors.toError('EMAIL_REQUIRED');
-        view.on('validation_error', function () {
-          TestHelpers.wrapAssertion(function () {
-            assert.isTrue(TestHelpers.isErrorLogged(metrics, err));
-          }, done);
+    it('adds invalid class to the invalid element', function (done) {
+      view.showValidationError('#focusMe', 'this is an error');
+      setTimeout(function () {
+        assert.isTrue(view.$('#focusMe').hasClass('invalid'));
+        done();
+      }, 20);
+    });
+
+    it('invalid class is removed as soon as element is valid again', function (done) {
+      view.on('validation_error', function () {
+        assert.isTrue(view.$('#focusMe').hasClass('invalid'));
+
+        // add a value, causing the validation error to be removed.
+        view.$('#focusMe').val('heyya!');
+        view.$('#focusMe').trigger('keyup');
+      });
+
+      view.on('validation_error_removed', function () {
+        assert.isFalse(view.$('#focusMe').hasClass('invalid'));
+        done();
+      });
+
+      // element is required, has no value
+      view.showValidationError('#focusMe', 'Field is required');
+    });
+  });
+
+  describe('getFormElements', () => {
+    it('gets a list of form fields that do not have the `data-novalue` attribute', function () {
+      var $els = view.getFormElements();
+      assert.lengthOf($els, 12);
+
+      $els.each((index, el) => {
+        const $el = view.$(el);
+        assert.isUndefined($el.attr('data-novalue'));
+      });
+    });
+  });
+
+  describe('getFormValues', function () {
+    it('gets the value of form fields that do not have the `data-novalue` attribute', function () {
+      view.$('#focusMe').val('the value');
+      view.$('#otherElement').val('another value');
+
+      var values = view.getFormValues();
+      assert.equal(values.focusMe, 'the value');
+      assert.equal(values.otherElement, 'another value');
+      assert.isUndefined(values.novalue);
+    });
+  });
+
+  describe('validate - mail', function () {
+    it('not valid if an empty email', function () {
+      const $el = view.$('#email');
+      $el.val('');
+
+      testValidationError($el, 'EMAIL_REQUIRED');
+    });
+
+    it('not valid if an invalid email', function () {
+      const $el = view.$('#email');
+      $el.val('invalid');
+
+      testValidationError($el, 'INVALID_EMAIL');
+    });
+
+    it('valid if a valid email', function () {
+      const $el = view.$('#email');
+      $el.val('testuser@testuser.com');
+
+      testNoValidationError($el);
+    });
+  });
+
+  describe('validate - password', function () {
+    it('invalid if an empty password', function () {
+      const $el = view.$('#password');
+      $el.val('');
+
+      testValidationError($el, 'PASSWORD_REQUIRED');
+    });
+
+    it('invalid if too short a password', function () {
+      const $el = view.$('#password');
+      $el.val('1');
+
+      testValidationError($el, 'PASSWORD_TOO_SHORT');
+    });
+
+    it('valid if a valid password', function () {
+      const $el = view.$('#password');
+      $el.val(TestHelpers.createRandomHexString(Constants.PASSWORD_MIN_LENGTH));
+      testNoValidationError($el);
+    });
+  });
+
+  describe('validate - text', function () {
+    it('valid for an empty non-required input', function () {
+      view.$('#notRequired').val('');
+      testNoValidationError(view.$('#notRequired'));
+    });
+
+    it('valid for a filled out non-required input', function () {
+      view.$('#notRequired').val('value');
+      testNoValidationError(view.$('#notRequired'));
+    });
+
+    it('invalid for an empty required input', function () {
+      const $el = view.$('#required');
+      $el.val('');
+
+      testValidationError($el, 'INPUT_REQUIRED');
+    });
+
+    it('valid for a filled out required input', function () {
+      view.$('#required').val('value');
+      testNoValidationError(view.$('#required'));
+    });
+  });
+
+  describe('showValidationErrors', function () {
+    beforeEach(function () {
+      // View overrides showValidationErrors, create a new View type
+      // with the default showValidationErrors
+      var ShowValidationErrorTestView = FormView.extend({
+        template: Template
+      });
+
+      view = new ShowValidationErrorTestView({ notifier });
+
+      return view.render()
+        .then(function () {
+          view.$('#focusMe').val('a value');
+          view.$('#required').val('a value');
+          view.$('input[type="email"]').val('testuser@testuser.com');
+          view.$('input[type="password"]').val('password');
         });
-        view.showValidationError('#focusMe', err);
+    });
+
+    it('shows nothing when all elements are valid', function () {
+      sinon.spy(view, 'showValidationError');
+      view.showValidationErrors();
+      assert.isFalse(view.showValidationError.called);
+    });
+
+    it('shows correct error when an email is missing', function () {
+      view.$('input[type="email"]').val('');
+      sinon.stub(view, 'showValidationError').callsFake(function (el, err) {
+        assert.ok(el);
+        assert.isTrue(AuthErrors.is(err, 'EMAIL_REQUIRED'));
       });
+      view.showValidationErrors();
+      assert.isTrue(view.showValidationError.called);
+    });
 
-      it('adds invalid class to the invalid element', function (done) {
-        view.showValidationError('#focusMe', 'this is an error');
-        setTimeout(function () {
-          assert.isTrue(view.$('#focusMe').hasClass('invalid'));
-          done();
-        }, 20);
+    it('shows correct error when an email is invalid', function () {
+      view.$('input[type="email"]').val('a');
+      sinon.stub(view, 'showValidationError').callsFake(function (el, err) {
+        assert.ok(el);
+        assert.isTrue(AuthErrors.is(err, 'INVALID_EMAIL'));
       });
+      view.showValidationErrors();
+      assert.isTrue(view.showValidationError.called);
+    });
 
-      it('invalid class is removed as soon as element is valid again', function (done) {
-        view.on('validation_error', function () {
-          assert.isTrue(view.$('#focusMe').hasClass('invalid'));
+    it('shows correct error when a password is invalid', function () {
+      view.$('input[type="password"]').val('');
+      sinon.spy(view, 'showValidationError');
+      view.showValidationErrors();
+      assert.isTrue(view.showValidationError.called);
+    });
 
-          // add a value, causing the validation error to be removed.
-          view.$('#focusMe').val('heyya!');
-          view.$('#focusMe').trigger('keyup');
+    it('shows one message at a time', function () {
+      view.$('input[type="email"]').val('a');
+      view.$('input[type="password"]').val('');
+      sinon.spy(view, 'showValidationError');
+      sinon.spy(view, 'showValidationErrorsEnd');
+      view.showValidationErrors();
+      assert.equal(view.showValidationError.callCount, 1);
+      assert.isFalse(view.showValidationErrorsEnd.called);
+    });
+
+    it('shows one message at a time with text inputs', function () {
+      view.$('input[required]').val('');
+      sinon.spy(view, 'showValidationErrorsEnd');
+      view.showValidationErrors();
+      assert.isFalse(view.showValidationErrorsEnd.called);
+    });
+
+    it('gives subclasses the opportunity to show validation errors at the start', function () {
+      sinon.stub(view, 'showValidationErrorsStart').callsFake(function () {
+        return true;
+      });
+      view.showValidationErrors();
+      assert.isTrue(view.showValidationErrorsStart.called);
+    });
+
+    it('gives subclasses the opportunity to show validation errors at the end', function () {
+      sinon.spy(view, 'showValidationErrorsEnd');
+      view.showValidationErrors();
+      assert.isTrue(view.showValidationErrorsEnd.called);
+    });
+  });
+
+  describe('notifyDelayedRequest', function () {
+    it('shows a notification when the response takes too long then hides it', function () {
+      // override expectation
+      view.LONGER_THAN_EXPECTED = 10;
+      view.formIsValid = true;
+
+      view.submit = function () {
+        return new Promise((resolve, reject) => {
+          setTimeout(function () {
+            try {
+              assert.isTrue(view._isErrorVisible);
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
+          }, 20);
         });
+      };
 
-        view.on('validation_error_removed', function () {
-          assert.isFalse(view.$('#focusMe').hasClass('invalid'));
-          done();
+      return view.validateAndSubmit()
+        .then(function () {
+          assert.isFalse(view._isErrorVisible);
         });
-
-        // element is required, has no value
-        view.showValidationError('#focusMe', 'Field is required');
-      });
     });
 
-    describe('getFormElements', () => {
-      it('gets a list of form fields that do not have the `data-novalue` attribute', function () {
-        var $els = view.getFormElements();
-        assert.lengthOf($els, 12);
+    it('shows a notification when the response takes too long, switches when an error is thrown', function () {
+      // override expectation
+      view.LONGER_THAN_EXPECTED = 10;
+      view.formIsValid = true;
 
-        $els.each((index, el) => {
-          const $el = view.$(el);
-          assert.isUndefined($el.attr('data-novalue'));
+      view.submit = function () {
+        return new Promise((resolve, reject) => {
+          setTimeout(function () {
+            try {
+              assert.isTrue(view._isErrorVisible);
+              reject('BOOM');
+            } catch (e) {
+              reject(e);
+            }
+          }, 20);
         });
-      });
-    });
+      };
 
-    describe('getFormValues', function () {
-      it('gets the value of form fields that do not have the `data-novalue` attribute', function () {
-        view.$('#focusMe').val('the value');
-        view.$('#otherElement').val('another value');
-
-        var values = view.getFormValues();
-        assert.equal(values.focusMe, 'the value');
-        assert.equal(values.otherElement, 'another value');
-        assert.isUndefined(values.novalue);
-      });
-    });
-
-    describe('validate - mail', function () {
-      it('not valid if an empty email', function () {
-        const $el = view.$('#email');
-        $el.val('');
-
-        testValidationError($el, 'EMAIL_REQUIRED');
-      });
-
-      it('not valid if an invalid email', function () {
-        const $el = view.$('#email');
-        $el.val('invalid');
-
-        testValidationError($el, 'INVALID_EMAIL');
-      });
-
-      it('valid if a valid email', function () {
-        const $el = view.$('#email');
-        $el.val('testuser@testuser.com');
-
-        testNoValidationError($el);
-      });
-    });
-
-    describe('validate - password', function () {
-      it('invalid if an empty password', function () {
-        const $el = view.$('#password');
-        $el.val('');
-
-        testValidationError($el, 'PASSWORD_REQUIRED');
-      });
-
-      it('invalid if too short a password', function () {
-        const $el = view.$('#password');
-        $el.val('1');
-
-        testValidationError($el, 'PASSWORD_TOO_SHORT');
-      });
-
-      it('valid if a valid password', function () {
-        const $el = view.$('#password');
-        $el.val(TestHelpers.createRandomHexString(Constants.PASSWORD_MIN_LENGTH));
-        testNoValidationError($el);
-      });
-    });
-
-    describe('validate - text', function () {
-      it('valid for an empty non-required input', function () {
-        view.$('#notRequired').val('');
-        testNoValidationError(view.$('#notRequired'));
-      });
-
-      it('valid for a filled out non-required input', function () {
-        view.$('#notRequired').val('value');
-        testNoValidationError(view.$('#notRequired'));
-      });
-
-      it('invalid for an empty required input', function () {
-        const $el = view.$('#required');
-        $el.val('');
-
-        testValidationError($el, 'INPUT_REQUIRED');
-      });
-
-      it('valid for a filled out required input', function () {
-        view.$('#required').val('value');
-        testNoValidationError(view.$('#required'));
-      });
-    });
-
-    describe('showValidationErrors', function () {
-      beforeEach(function () {
-        // View overrides showValidationErrors, create a new View type
-        // with the default showValidationErrors
-        var ShowValidationErrorTestView = FormView.extend({
-          template: Template
+      return view.validateAndSubmit()
+        .then(null, function () {
+          assert.isTrue(view._isErrorVisible);
+          assert.equal(view.$('.error').text(), 'BOOM');
         });
+    });
 
-        view = new ShowValidationErrorTestView({ notifier });
+    it('should not hide forceMessage errors', function () {
+      view.formIsValid = true;
 
-        return view.render()
+      view.submit = function () {
+        return Promise.resolve()
           .then(function () {
-            view.$('#focusMe').val('a value');
-            view.$('#required').val('a value');
-            view.$('input[type="email"]').val('testuser@testuser.com');
-            view.$('input[type="password"]').val('password');
+            return view.displayError({ forceMessage: 'BOOM' });
           });
-      });
+      };
 
-      it('shows nothing when all elements are valid', function () {
-        sinon.spy(view, 'showValidationError');
-        view.showValidationErrors();
-        assert.isFalse(view.showValidationError.called);
-      });
-
-      it('shows correct error when an email is missing', function () {
-        view.$('input[type="email"]').val('');
-        sinon.stub(view, 'showValidationError').callsFake(function (el, err) {
-          assert.ok(el);
-          assert.isTrue(AuthErrors.is(err, 'EMAIL_REQUIRED'));
+      return view.validateAndSubmit()
+        .then(function () {
+          assert.equal(view.$('.error').text(), 'BOOM');
+          assert.isTrue(view._isErrorVisible);
         });
-        view.showValidationErrors();
-        assert.isTrue(view.showValidationError.called);
-      });
+    });
+  });
 
-      it('shows correct error when an email is invalid', function () {
-        view.$('input[type="email"]').val('a');
-        sinon.stub(view, 'showValidationError').callsFake(function (el, err) {
-          assert.ok(el);
-          assert.isTrue(AuthErrors.is(err, 'INVALID_EMAIL'));
-        });
-        view.showValidationErrors();
-        assert.isTrue(view.showValidationError.called);
-      });
-
-      it('shows correct error when a password is invalid', function () {
-        view.$('input[type="password"]').val('');
-        sinon.spy(view, 'showValidationError');
-        view.showValidationErrors();
-        assert.isTrue(view.showValidationError.called);
-      });
-
-      it('shows one message at a time', function () {
-        view.$('input[type="email"]').val('a');
-        view.$('input[type="password"]').val('');
-        sinon.spy(view, 'showValidationError');
-        sinon.spy(view, 'showValidationErrorsEnd');
-        view.showValidationErrors();
-        assert.equal(view.showValidationError.callCount, 1);
-        assert.isFalse(view.showValidationErrorsEnd.called);
-      });
-
-      it('shows one message at a time with text inputs', function () {
-        view.$('input[required]').val('');
-        sinon.spy(view, 'showValidationErrorsEnd');
-        view.showValidationErrors();
-        assert.isFalse(view.showValidationErrorsEnd.called);
-      });
-
-      it('gives subclasses the opportunity to show validation errors at the start', function () {
-        sinon.stub(view, 'showValidationErrorsStart').callsFake(function () {
-          return true;
-        });
-        view.showValidationErrors();
-        assert.isTrue(view.showValidationErrorsStart.called);
-      });
-
-      it('gives subclasses the opportunity to show validation errors at the end', function () {
-        sinon.spy(view, 'showValidationErrorsEnd');
-        view.showValidationErrors();
-        assert.isTrue(view.showValidationErrorsEnd.called);
-      });
+  describe('getElementValue', function () {
+    it('gets an element\'s value, does not trim by default', function () {
+      var elementVal = 'this is the value of an element ';
+      view.$('#required').val(elementVal);
+      assert.equal(view.getElementValue('#required'), elementVal);
     });
 
-    describe('notifyDelayedRequest', function () {
-      it('shows a notification when the response takes too long then hides it', function () {
-        // override expectation
-        view.LONGER_THAN_EXPECTED = 10;
-        view.formIsValid = true;
-
-        view.submit = function () {
-          return new Promise((resolve, reject) => {
-            setTimeout(function () {
-              try {
-                assert.isTrue(view._isErrorVisible);
-                resolve();
-              } catch (e) {
-                reject(e);
-              }
-            }, 20);
-          });
-        };
-
-        return view.validateAndSubmit()
-          .then(function () {
-            assert.isFalse(view._isErrorVisible);
-          });
-      });
-
-      it('shows a notification when the response takes too long, switches when an error is thrown', function () {
-        // override expectation
-        view.LONGER_THAN_EXPECTED = 10;
-        view.formIsValid = true;
-
-        view.submit = function () {
-          return new Promise((resolve, reject) => {
-            setTimeout(function () {
-              try {
-                assert.isTrue(view._isErrorVisible);
-                reject('BOOM');
-              } catch (e) {
-                reject(e);
-              }
-            }, 20);
-          });
-        };
-
-        return view.validateAndSubmit()
-          .then(null, function () {
-            assert.isTrue(view._isErrorVisible);
-            assert.equal(view.$('.error').text(), 'BOOM');
-          });
-      });
-
-      it('should not hide forceMessage errors', function () {
-        view.formIsValid = true;
-
-        view.submit = function () {
-          return Promise.resolve()
-            .then(function () {
-              return view.displayError({ forceMessage: 'BOOM' });
-            });
-        };
-
-        return view.validateAndSubmit()
-          .then(function () {
-            assert.equal(view.$('.error').text(), 'BOOM');
-            assert.isTrue(view._isErrorVisible);
-          });
-      });
+    it('trims the value of an email element', function () {
+      var elementVal = '   testuser@testuser.com ';
+      view.$('#email').val(elementVal);
+      assert.equal(view.getElementValue('#email'), $.trim(elementVal));
     });
 
-    describe('getElementValue', function () {
-      it('gets an element\'s value, does not trim by default', function () {
-        var elementVal = 'this is the value of an element ';
-        view.$('#required').val(elementVal);
-        assert.equal(view.getElementValue('#required'), elementVal);
+    it('does not trim the value of a password element', function () {
+      var elementVal = '  password  ';
+      view.$('#password').val(elementVal);
+      assert.equal(view.getElementValue('#password'), elementVal);
+    });
+  });
+
+  describe('isValid', function () {
+    beforeEach(function () {
+      // View overrides isValid, create a new View type
+      // with the default isValid
+      var IsValidTestView = FormView.extend({
+        template: Template
       });
 
-      it('trims the value of an email element', function () {
-        var elementVal = '   testuser@testuser.com ';
-        view.$('#email').val(elementVal);
-        assert.equal(view.getElementValue('#email'), $.trim(elementVal));
-      });
+      view = new IsValidTestView({ notifier });
 
-      it('does not trim the value of a password element', function () {
-        var elementVal = '  password  ';
-        view.$('#password').val(elementVal);
-        assert.equal(view.getElementValue('#password'), elementVal);
-      });
+      return view.render()
+        .then(function () {
+          view.$('#focusMe').val('a value');
+          view.$('#required').val('a value');
+          view.$('input[type="email"]').val('testuser@testuser.com');
+          view.$('input[type="password"]').val('password');
+        });
     });
 
-    describe('isValid', function () {
-      beforeEach(function () {
-        // View overrides isValid, create a new View type
-        // with the default isValid
-        var IsValidTestView = FormView.extend({
-          template: Template
-        });
+    it('returns true if all elements are valid', function () {
+      assert.isTrue(view.isValid());
+    });
 
-        view = new IsValidTestView({ notifier });
+    it('returns false if one element is invalid', function () {
+      view.$('input[type="email"]').val('not_an_email');
+      assert.isFalse(view.isValid());
+    });
 
-        return view.render()
-          .then(function () {
-            view.$('#focusMe').val('a value');
-            view.$('#required').val('a value');
-            view.$('input[type="email"]').val('testuser@testuser.com');
-            view.$('input[type="password"]').val('password');
-          });
+    it('returns false if isValidStart returns false', function () {
+      sinon.stub(view, 'isValidStart').callsFake(function () {
+        return false;
       });
 
-      it('returns true if all elements are valid', function () {
-        assert.isTrue(view.isValid());
+      assert.isFalse(view.isValid());
+    });
+
+    it('returns false if isValidEnd returns false', function () {
+      sinon.stub(view, 'isValidEnd').callsFake(function () {
+        return false;
       });
 
-      it('returns false if one element is invalid', function () {
-        view.$('input[type="email"]').val('not_an_email');
-        assert.isFalse(view.isValid());
-      });
-
-      it('returns false if isValidStart returns false', function () {
-        sinon.stub(view, 'isValidStart').callsFake(function () {
-          return false;
-        });
-
-        assert.isFalse(view.isValid());
-      });
-
-      it('returns false if isValidEnd returns false', function () {
-        sinon.stub(view, 'isValidEnd').callsFake(function () {
-          return false;
-        });
-
-        assert.isFalse(view.isValid());
-      });
+      assert.isFalse(view.isValid());
     });
   });
 });


### PR DESCRIPTION
Create an `onFormSubmit` function that catches and swallows the error.
The error will already have been logged, no need to do anything else.

fixes #6025 

@mozilla/fxa-devs - r? I reformatted the modules, easiest to review with ?w=1