### PR TITLE
fix(pw-strength): Make the pw-strength balloon more a11y friendly. 

### DIFF
--- a/app/scripts/templates/partial/password-strength-balloon.mustache
+++ b/app/scripts/templates/partial/password-strength-balloon.mustache
@@ -1,18 +1,18 @@
-<aside class="input-help input-help-balloon password-strength-balloon">
+<aside id="password-strength-balloon" class="input-help input-help-balloon password-strength-balloon">
   <h3 class="big-only">{{#t}}Your Firefox Account password{{/t}}</h3>
   <ul>
-    <li
+    <li id="password-too-short"
       {{^hasEnteredPassword}}class="min-length unmet"{{/hasEnteredPassword}}
       {{#isTooShort}}class="min-length fail"{{/isTooShort}}
       {{^isTooShort}}class="min-length met"{{/isTooShort}}
     >{{#t}}Must be at least 8 characters{{/t}}</li>
-    <li
+    <li id="password-same-as-email"
       {{^hasEnteredPassword}}class="not-email unmet"{{/hasEnteredPassword}}
       {{#isTooShort}}class="not-email unmet"{{/isTooShort}}
       {{#isSameAsEmail}}class="not-email fail"{{/isSameAsEmail}}
       {{^isSameAsEmail}}class="not-email met"{{/isSameAsEmail}}
     >{{#t}}Must not be your email address{{/t}}</li>
-    <li
+    <li id="password-too-common"
       {{^hasEnteredPassword}}class="not-common unmet"{{/hasEnteredPassword}}
       {{#isTooShort}}class="not-common unmet"{{/isTooShort}}
       {{#isSameAsEmail}}class="not-common unmet"{{/isSameAsEmail}}

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -362,20 +362,26 @@ var FormView = BaseView.extend({
   showValidationError (el, err) {
     this.logError(err);
 
-    var invalidEl = this.$(el);
-    var message = AuthErrors.toMessage(err);
+    const $invalidEl = this.$(el);
+    const message = AuthErrors.toMessage(err);
+
+    // tooltipId is used to bind the invalid element
+    // with the tooltip using `aria-described-by`
+    const tooltipId = `error-tooltip-${err.errno}`;
 
     var tooltip = new Tooltip({
-      invalidEl: invalidEl,
-      message: message
+      id: tooltipId,
+      invalidEl: $invalidEl,
+      message
     });
 
     tooltip.on('destroyed', () => {
-      invalidEl.removeClass('invalid');
+      this.markElementValid($invalidEl);
       this.trigger('validation_error_removed', el);
     }).render().then(() => {
+      this.markElementInvalid($invalidEl, tooltipId);
       try {
-        invalidEl.addClass('invalid').get(0).focus();
+        $invalidEl.get(0).focus();
       } catch (e) {
         // IE can blow up if the element is not visible.
       }
@@ -387,6 +393,28 @@ var FormView = BaseView.extend({
     this.trackChildView(tooltip);
 
     return message;
+  },
+
+  /**
+   * Mark an element as invalid
+   *
+   * @param {Element} $el to mark invalid
+   * @param {String} [describedById] if set, sets 'aria-described-by' attribute on `$el`
+   */
+  markElementInvalid($el, describedById) {
+    $el.addClass('invalid').attr('aria-invalid', 'true');
+    if (describedById) {
+      $el.attr('aria-described-by', describedById);
+    }
+  },
+
+  /**
+   * Mark an element as valid
+   *
+   * @param {Element} $el to mark valid
+   */
+  markElementValid($el) {
+    $el.removeClass('invalid').attr('aria-invalid', null).attr('aria-described-by', null);
   },
 
   /**

--- a/app/scripts/views/mixins/password-strength-experiment-mixin.js
+++ b/app/scripts/views/mixins/password-strength-experiment-mixin.js
@@ -89,7 +89,8 @@ export default function (config = {}) {
     showValidationErrorsStart () {
       const experimentGroup = this._getPasswordStrengthExperimentGroup();
       if (experimentGroup === DESIGN_F_GROUP && this.passwordModel.validate()) {
-        // does not show any additional tooltips if the model says there are any errors
+        this.focus(passwordEl);
+        // do not show any additional tooltips if the model says there are any errors
         // under the assumption our PasswordStrengthBalloonView will display errors.
         return true;
       }

--- a/app/scripts/views/password_strength/password_with_strength_balloon.js
+++ b/app/scripts/views/password_strength/password_with_strength_balloon.js
@@ -56,13 +56,10 @@ const PasswordWithStrengthBalloonView = FormView.extend({
     const { hasEnteredPassword, isValid } = this.model.toJSON();
 
     if (hasEnteredPassword && ! isValid) {
-      this.$el.addClass('invalid').attr('aria-invalid', 'true');
       const describedById = this._getDescribedById();
-      if (describedById) {
-        this.$el.attr('aria-described-by', describedById);
-      }
+      this.markElementInvalid(this.$el, describedById);
     } else {
-      this.$el.removeClass('invalid').attr('aria-invalid', null).attr('aria-described-by', null);
+      this.markElementValid(this.$el);
     }
   },
 

--- a/app/scripts/views/password_strength/password_with_strength_balloon.js
+++ b/app/scripts/views/password_strength/password_with_strength_balloon.js
@@ -15,9 +15,9 @@
 
 import FormView from '../form';
 import PasswordStrengthBalloonView from './password_strength_balloon';
+
 const PasswordWithStrengthBalloonView = FormView.extend({
   events: {
-    blur: 'focusIfInvalidPassword',
     change: 'updateModelForPassword',
     keyup: 'updateModelForPassword',
   },
@@ -43,20 +43,9 @@ const PasswordWithStrengthBalloonView = FormView.extend({
       this.listenTo(this.passwordHelperBalloon, 'rendered', () => this.updateStyles());
 
       return this.passwordHelperBalloon.render();
+    }).then(() => {
+      this.$el.attr('aria-described-by', 'password-strength-balloon');
     });
-  },
-
-  focusIfInvalidPassword () {
-    const { hasEnteredPassword, isValid } = this.model.toJSON();
-
-    if (hasEnteredPassword && ! isValid) {
-      // A timeout is needed so that the focus occurs after the cursor is placed
-      // into the next element. Without the timeout, the focus occurs and then
-      // is immediately taken away.
-      this.setTimeout(() => {
-        this.$el.focus();
-      }, 50);
-    }
   },
 
   updateModelForPassword () {
@@ -67,11 +56,31 @@ const PasswordWithStrengthBalloonView = FormView.extend({
     const { hasEnteredPassword, isValid } = this.model.toJSON();
 
     if (hasEnteredPassword && ! isValid) {
-      this.$el.addClass('invalid');
+      this.$el.addClass('invalid').attr('aria-invalid', 'true');
+      const describedById = this._getDescribedById();
+      if (describedById) {
+        this.$el.attr('aria-described-by', describedById);
+      }
     } else {
-      this.$el.removeClass('invalid');
+      this.$el.removeClass('invalid').attr('aria-invalid', null).attr('aria-described-by', null);
     }
   },
+
+  _getDescribedById () {
+    const {
+      isCommon,
+      isSameAsEmail,
+      isTooShort,
+    } = this.model.toJSON();
+
+    if (isTooShort) {
+      return 'password-too-short';
+    } else if (isSameAsEmail) {
+      return 'password-same-as-email';
+    } else if (isCommon) {
+      return 'password-too-common';
+    }
+  }
 });
 
 

--- a/app/tests/spec/views/mixins/password-strength-experiment-mixin.js
+++ b/app/tests/spec/views/mixins/password-strength-experiment-mixin.js
@@ -32,6 +32,7 @@ Cocktail.mixin(
   PasswordStrenghExperimentMixin(mixinConfig)
 );
 
+
 describe('views/mixins/password-strength-experiment-mixin', () => {
   let account;
   let view;
@@ -166,6 +167,7 @@ describe('views/mixins/password-strength-experiment-mixin', () => {
   describe('showValidationErrorsStart', () => {
     it('designF treatment', () => {
       sinon.stub(view, '_getPasswordStrengthExperimentGroup').callsFake(() => 'designF');
+      sinon.stub(view, 'focus');
       let validationError = undefined;
       view.passwordModel = {
         validate: sinon.spy(() => validationError)
@@ -176,6 +178,8 @@ describe('views/mixins/password-strength-experiment-mixin', () => {
       validationError = new Error('uh oh');
       assert.isTrue(view.showValidationErrorsStart());
       assert.isTrue(view.passwordModel.validate.calledTwice);
+
+      assert.isTrue(view.focus.calledOnceWith('#password'));
     });
 
     it('control', () => {
@@ -212,5 +216,4 @@ describe('views/mixins/password-strength-experiment-mixin', () => {
 
     assert.isTrue(view.notifier.trigger.calledOnceWith('password.error', error));
   });
-
 });

--- a/app/tests/spec/views/password_strength/password_with_strength_balloon.js
+++ b/app/tests/spec/views/password_strength/password_with_strength_balloon.js
@@ -63,26 +63,27 @@ describe('views/password_strength/password_with_strength_ballon', () => {
     assert.isTrue(model.updateForPassword.calledOnceWith('password'));
   });
 
-  it('the invalid class is added and aria attributes set if password has been entered and is invalid', () => {
+  it('the element is marked as invalid if password has been entered and is invalid', () => {
+    sinon.stub(view, 'markElementValid');
+    sinon.stub(view, 'markElementInvalid');
     model.set({
       hasEnteredPassword: false,
       isValid: false
     }, { silent: true });
+
     view.updateStyles();
-    assert.isFalse($('#password').hasClass('invalid'));
+    assert.isFalse(view.markElementInvalid.called);
+    assert.isTrue(view.markElementValid.calledOnceWith(view.$el));
 
     model.set('hasEnteredPassword', true, { silent: true });
     sinon.stub(view, '_getDescribedById').callsFake(() => 'password-too-short');
     view.updateStyles();
-    assert.isTrue($('#password').hasClass('invalid'));
-    assert.equal(view.$el.attr('aria-invalid'), 'true');
-    assert.equal(view.$el.attr('aria-described-by'), 'password-too-short');
+    assert.isTrue(view.markElementInvalid.calledOnceWith(view.$el, 'password-too-short'));
 
     model.set('isValid', true, { silent: true });
     view.updateStyles();
-    assert.isFalse($('#password').hasClass('invalid'));
-    assert.isUndefined(view.$el.attr('aria-invalid'));
-    assert.isUndefined(view.$el.attr('aria-described-by'));
+    assert.isTrue(view.markElementValid.calledTwice);
+    assert.equal(view.markElementValid.args[1][0], view.$el);
   });
 
   it('passwordHelperBalloon updates cause updateStyles', (done) => {

--- a/app/tests/spec/views/password_strength/password_with_strength_balloon.js
+++ b/app/tests/spec/views/password_strength/password_with_strength_balloon.js
@@ -8,7 +8,6 @@ import { assign } from 'underscore';
 import { Events } from 'backbone';
 import Model from 'models/password_strength/password_strength_balloon';
 import PasswordWithStrengthBalloon from 'views/password_strength/password_with_strength_balloon';
-import { requiresFocus } from '../../../lib/helpers';
 import sinon from 'sinon';
 
 const template = `
@@ -42,8 +41,9 @@ describe('views/password_strength/password_with_strength_ballon', () => {
     return view.afterRender();
   });
 
-  it('renders the pw balloon in afterRender', () => {
+  it('renders the pw balloon in afterRender, sets the aria field', () => {
     assert.isTrue(view.passwordHelperBalloon.render.calledOnce);
+    assert.equal(view.$el.attr('aria-described-by'), 'password-strength-balloon');
   });
 
   it('updates the model for the password element value', () => {
@@ -63,7 +63,7 @@ describe('views/password_strength/password_with_strength_ballon', () => {
     assert.isTrue(model.updateForPassword.calledOnceWith('password'));
   });
 
-  it('the invalid class is added if password has been entered and is invalid', () => {
+  it('the invalid class is added and aria attributes set if password has been entered and is invalid', () => {
     model.set({
       hasEnteredPassword: false,
       isValid: false
@@ -72,12 +72,17 @@ describe('views/password_strength/password_with_strength_ballon', () => {
     assert.isFalse($('#password').hasClass('invalid'));
 
     model.set('hasEnteredPassword', true, { silent: true });
+    sinon.stub(view, '_getDescribedById').callsFake(() => 'password-too-short');
     view.updateStyles();
     assert.isTrue($('#password').hasClass('invalid'));
+    assert.equal(view.$el.attr('aria-invalid'), 'true');
+    assert.equal(view.$el.attr('aria-described-by'), 'password-too-short');
 
     model.set('isValid', true, { silent: true });
     view.updateStyles();
     assert.isFalse($('#password').hasClass('invalid'));
+    assert.isUndefined(view.$el.attr('aria-invalid'));
+    assert.isUndefined(view.$el.attr('aria-described-by'));
   });
 
   it('passwordHelperBalloon updates cause updateStyles', (done) => {
@@ -85,16 +90,28 @@ describe('views/password_strength/password_with_strength_ballon', () => {
     passwordHelperBalloon.trigger('rendered');
   });
 
-  it('focusIfInvalid focuses the password if an invalid one has been entered', (done) => {
-    requiresFocus(() => {
+  describe('_getDescribedById', () => {
+    beforeEach(() => {
       model.set({
-        hasEnteredPassword: true,
-        isValid: false
-      }, { silent: true });
+        isCommon: false,
+        isSameAsEmail: false,
+        isTooShort: false,
+      });
+    });
 
-      $('#password').one('focus', () => done());
+    it('returns `password-too-short` if password is too short', () => {
+      model.set('isTooShort', true);
+      assert.equal(view._getDescribedById(), 'password-too-short');
+    });
 
-      view.focusIfInvalidPassword();
-    }, done);
+    it('returns `password-same-as-email` if same as email', () => {
+      model.set('isSameAsEmail', true);
+      assert.equal(view._getDescribedById(), 'password-same-as-email');
+    });
+
+    it('returns `password-too-common` when too common', () => {
+      model.set('isCommon', true);
+      assert.equal(view._getDescribedById(), 'password-too-common');
+    });
   });
 });


### PR DESCRIPTION
fix(pw-strength): Make the pw-strength balloon more a11y friendly.

* Use `aria-invalid` on the input element whenever the element is invalid
* Use `aria-described-by` to point to the criterion that failed when invalid
* Remove the focus on blur behavior, instead focus on submit if a validation error

fixes #6299