### PR TITLE
fix(pw-strength): Immediately update pw balloon on submit 

### DIFF
--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -215,6 +215,9 @@ var FormView = BaseView.extend({
           .then(() => {
             return this.afterSubmit();
           });
+      })
+      .finally(() => {
+        this.trigger('submitEnd');
       });
   }),
 

--- a/app/scripts/views/mixins/password-strength-experiment-mixin.js
+++ b/app/scripts/views/mixins/password-strength-experiment-mixin.js
@@ -50,6 +50,9 @@ export default function (config = {}) {
       // chances of spurious warnings being logged as us helping the user.
       this.listenTo(passwordModel, 'change', debounce(() => this._logErrorIfInvalid(), delayBeforeLogReasonMS));
 
+      this.on('submitStart', () => passwordModel.set('isSubmitting', true));
+      this.on('submitEnd', () => passwordModel.set('isSubmitting', false));
+
       const passwordView = this._createPasswordWithStrengthBalloonView(passwordModel);
       this.trackChildView(passwordView);
 

--- a/app/scripts/views/password_strength/password_with_strength_balloon.js
+++ b/app/scripts/views/password_strength/password_with_strength_balloon.js
@@ -49,7 +49,7 @@ const PasswordWithStrengthBalloonView = FormView.extend({
   },
 
   updateModelForPassword () {
-    this.model.updateForPassword(this.$el.val());
+    this.model.set('password', this.$el.val());
   },
 
   updateStyles () {

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -193,10 +193,20 @@ describe('views/form', function () {
   });
 
   describe('validateAndSubmit', function () {
-    it('triggers a `submitStart` event', (done) => {
-      view.on('submitStart', () => done());
+    it('triggers a `submitStart` and `submitEnd` event', () => {
+      const submitStartSpy = sinon.spy();
+      view.on('submitStart', submitStartSpy);
+      const submitEndSpy = sinon.spy();
+      view.on('submitEnd', submitEndSpy);
 
-      view.validateAndSubmit();
+      return view.validateAndSubmit()
+        .then(assert.fail, (err) => {
+          // the form is invalid, swallow the error
+        })
+        .then(() => {
+          assert.isTrue(submitStartSpy.calledOnce);
+          assert.isTrue(submitEndSpy.calledOnce);
+        });
     });
 
     it('submits form if isValid returns true', function () {

--- a/app/tests/spec/views/mixins/password-strength-experiment-mixin.js
+++ b/app/tests/spec/views/mixins/password-strength-experiment-mixin.js
@@ -94,6 +94,7 @@ describe('views/mixins/password-strength-experiment-mixin', () => {
     sinon.stub(view, '_createPasswordWithStrengthBalloonView').callsFake(() => passwordView);
     sinon.stub(view, 'trackChildView');
     sinon.stub(view, 'listenTo');
+    sinon.stub(view, 'on');
 
     return view._setupDesignF()
       .then((result) => {
@@ -101,10 +102,30 @@ describe('views/mixins/password-strength-experiment-mixin', () => {
 
         assert.isTrue(view._createPasswordStrengthBalloonModel.calledOnce);
         assert.isTrue(view.listenTo.calledOnceWith(passwordModel, 'change'));
+        assert.isTrue(view.on.calledTwice);
 
         assert.isTrue(view._createPasswordWithStrengthBalloonView.calledOnce);
         assert.isTrue(view.trackChildView.calledOnceWith(passwordView));
         assert.isTrue(passwordView.afterRender.calledOnce);
+      });
+  });
+
+  it('submitStart and submitEnd update the passwordModel', () => {
+    const passwordModel = new Model({});
+    const passwordView = {
+      afterRender: sinon.spy(() => Promise.resolve('heyo')),
+      on: sinon.spy()
+    };
+
+    sinon.stub(view, '_createPasswordStrengthBalloonModel').callsFake(() => passwordModel);
+    sinon.stub(view, '_createPasswordWithStrengthBalloonView').callsFake(() => passwordView);
+
+    return view._setupDesignF()
+      .then(() => {
+        view.trigger('submitStart');
+        assert.isTrue(passwordModel.get('isSubmitting'));
+        view.trigger('submitEnd');
+        assert.isFalse(passwordModel.get('isSubmitting'));
       });
   });
 

--- a/app/tests/spec/views/password_strength/password_strength_balloon.js
+++ b/app/tests/spec/views/password_strength/password_strength_balloon.js
@@ -94,25 +94,41 @@ describe('views/password_strength/password_strength_balloon', () => {
 
   it('hides if the model is valid', () => {
     sinon.spy(view, 'hideAfterDelay');
-    model.trigger('valid');
+    model.set('isValid', true);
 
     assert.isTrue(view.hideAfterDelay.calledOnce);
   });
 
-  it('renders if the model is invalid', () => {
-    // Use a stub for render because it's asynchronous
-    // and its promises are not completed before the
-    // view is destroyed in `afterEach`
-    sinon.stub(view, 'render');
-    model.trigger('invalid');
+  [
+    'hasEnteredPassword',
+    'isCommon',
+    'isSameAsEmail',
+    'isTooShort'
+  ].forEach(attributeName => {
+    it(`updates when ${attributeName} changes`, () => {
+      model.set(attributeName, false, { silent: true });
 
-    assert.isTrue(view.render.calledOnce);
+      sinon.stub(view, 'update');
+      model.set(attributeName, true);
+
+      assert.isTrue(view.update.calledOnce);
+    });
   });
 
-  it('renders after a delay on change', () => {
-    sinon.spy(view, 'renderAfterDelay');
-    model.trigger('change');
+  it('hideAfterDelay re-renders and then hides if the view is supposed to be visible', () => {
+    sinon.stub(view, 'setTimeout').callsFake((callback) => callback.call(view));
+    sinon.stub(view, 'renderAfterDelay');
+    sinon.stub(view, 'hide');
+
+    model.set('isVisible', false);
+    view.hideAfterDelay();
+    assert.isFalse(view.renderAfterDelay.called);
+
+    model.set('isVisible', true);
+    view.hideAfterDelay();
 
     assert.isTrue(view.renderAfterDelay.calledOnce);
+    assert.isTrue(view.setTimeout.calledOnce);
+    assert.isTrue(view.hide.calledOnce);
   });
 });

--- a/app/tests/spec/views/password_strength/password_with_strength_balloon.js
+++ b/app/tests/spec/views/password_strength/password_with_strength_balloon.js
@@ -58,9 +58,9 @@ describe('views/password_strength/password_with_strength_ballon', () => {
 
   it('updateModelForPassword updates delegates to the model', () => {
     $('#password').val('password');
-    sinon.spy(model, 'updateForPassword');
+    sinon.spy(model, 'set');
     view.updateModelForPassword();
-    assert.isTrue(model.updateForPassword.calledOnceWith('password'));
+    assert.isTrue(model.set.calledOnceWith('password', 'password'));
   });
 
   it('the element is marked as invalid if password has been entered and is invalid', () => {

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -297,7 +297,10 @@ const type = thenify(function (selector, text, options) {
       // focus it will just type 1 number, split the type
       // commands for each character to avoid issues with the
       // test runner
-      if (type === 'number') {
+      // password is added because of the password_strength_experiment.
+      // calling `type` with more than one character on the "signup_password"
+      // screen causes nothing to be written on the second attempt.
+      if (type === 'number' || type === 'password') {
         var index = 0;
         var parent = this.parent;
 

--- a/tests/functional/password_strength_experiment.js
+++ b/tests/functional/password_strength_experiment.js
@@ -27,50 +27,73 @@ registerSuite('password strength experiment', {
     email = TestHelpers.createEmail('sync{id}');
 
     return this.remote
-      .then(clearBrowserState({ force: true }));
+      .then(clearBrowserState({ force: true }))
+      .then(openPage(PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
+        webChannelResponses: {
+          'fxaccounts:can_link_account': {ok: true}
+        }
+      }))
+      .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+      .then(click(selectors.ENTER_EMAIL.SUBMIT, selectors.SIGNUP_PASSWORD.HEADER));
   },
 
   tests: {
-
-    'signup': function () {
+    'submit w/o a password': function () {
       return this.remote
-        .then(openPage(PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-          webChannelResponses: {
-            'fxaccounts:can_link_account': {ok: true}
-          }
-        }))
-        .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-        .then(click(selectors.ENTER_EMAIL.SUBMIT, selectors.SIGNUP_PASSWORD.HEADER))
-
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.BALLOON))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_UNMET))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_EMAIL_UNMET))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_UNMET))
 
+        .then(click(selectors.SIGNUP_PASSWORD.SUBMIT))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_FAIL))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_EMAIL_UNMET))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_UNMET));
+    },
+
+    'too short of a password': function () {
+      return this.remote
         .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, 'p'))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_FAIL))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_EMAIL_UNMET))
-        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_UNMET))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_UNMET));
+    },
 
+    'password is too common': function () {
+      return this.remote
         .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, 'password'))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_MET))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_EMAIL_MET))
-        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_FAIL))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_FAIL));
+    },
 
+    'password is the same as the full email': function () {
+      return this.remote
         .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, email))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_MET))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_EMAIL_FAIL))
-        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_UNMET))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_UNMET));
+    },
 
-        .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, ''))
-        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_FAIL))
-        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_EMAIL_UNMET))
-        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_UNMET))
+    'password is same as the local part of the email': function () {
+      return this.remote
+        .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, email.split('@')[0]))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_MET))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_EMAIL_FAIL))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_UNMET));
+    },
 
+    'good password, then back to too short': function () {
+      return this.remote
         .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, 'password123123'))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_MET))
         .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_EMAIL_MET))
-        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_MET));
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_MET))
+
+        .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, 'pass'))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_FAIL))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_EMAIL_UNMET))
+        .then(testElementExists(selectors.SIGNUP_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_UNMET));
     }
   }
 });


### PR DESCRIPTION
To do this, the balloon needs to know when a form is being submitted.

I ended up leaning on MVC principals more to (IMHO) make the logic
a bit simpler to follow. "Field X was updated? Yup, need to redraw"
"Field Y was updated? No need to redraw"

Because updates only occur when certain model fields are updated,
I was able to toss more data into the model w/o worrying about whether
it'd cause a redraw, and I could ditch the homegrown "isValid"
change check.

fixes #6339 