### PR TITLE
fix(metrics): force utm_source=email when signing in from CAD

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -127,6 +127,8 @@ module.exports = {
     return map;
   }, {}),
 
-  OTHER_EMAIL_DOMAIN: 'other'
+  OTHER_EMAIL_DOMAIN: 'other',
+
+  UTM_SOURCE_EMAIL: 'email'
 };
 /*eslint-enable sorting/sort-object-props*/

--- a/app/scripts/views/connect_another_device.js
+++ b/app/scripts/views/connect_another_device.js
@@ -16,7 +16,11 @@ define(function (require, exports, module) {
   const ExperimentMixin = require('./mixins/experiment-mixin');
   const FlowEventsMixin = require('./mixins/flow-events-mixin');
   const FormView = require('./form');
-  const { MARKETING_ID_AUTUMN_2016, SYNC_SERVICE } = require('../lib/constants');
+  const {
+    MARKETING_ID_AUTUMN_2016,
+    SYNC_SERVICE,
+    UTM_SOURCE_EMAIL
+  } = require('../lib/constants');
   const MarketingMixin = require('./mixins/marketing-mixin');
   const MarketingSnippet = require('./marketing_snippet');
   const SyncAuthMixin = require('./mixins/sync-auth-mixin');
@@ -231,7 +235,19 @@ define(function (require, exports, module) {
      * @private
      */
     _getEscapedSignInUrl (email) {
-      return this.getEscapedSyncUrl('signin', ConnectAnotherDeviceView.ENTRYPOINT, { email: email });
+      return this.getEscapedSyncUrl('signin', ConnectAnotherDeviceView.ENTRYPOINT, {
+        email,
+        // Users will only reach this view from a verification email, so we can
+        // hard-code an appropriate utm_source. The utm_source can't be set on
+        // the originating link because we don't want to clobber the existing
+        // utm_source for that flow. Related issues:
+        //
+        //   * https://github.com/mozilla/fxa-content-server/issues/6258
+        //   * https://github.com/mozilla/fxa-auth-server/issues/2496
+        //
+        //eslint-disable-next-line camelcase
+        utm_source: UTM_SOURCE_EMAIL
+      });
     }
 
     static get ENTRYPOINT () {

--- a/app/tests/spec/views/connect_another_device.js
+++ b/app/tests/spec/views/connect_another_device.js
@@ -441,7 +441,11 @@ define(function (require, exports, module) {
 
         assert.isTrue(view.getEscapedSyncUrl.calledOnce);
         assert.isTrue(view.getEscapedSyncUrl.calledWith(
-          'signin', View.ENTRYPOINT, { email: 'testuser@testuser.com' }));
+          'signin', View.ENTRYPOINT, {
+            email: 'testuser@testuser.com',
+            //eslint-disable-next-line camelcase
+            utm_source: 'email'
+          }));
       });
     });
 


### PR DESCRIPTION
Related to: #6258, mozilla/fxa-auth-server#2496

Currently, the vast majority of our `fxa_reg - complete` events in Amplitude are incorrectly showing up with `utm_source` set to `email`. This is because the auth server forces it on all links in email addresses, so when the user clicks the verification link the original `utm_source` for that flow is overwritten.

A [separate PR for the auth server](https://github.com/mozilla/fxa-auth-server/pull/2505) has been opened to prevent this from happening. But in order for that PR not to break legitimate cases where we want `utm_source` set to `email`, we must first handle those legitimate cases elsewhere. Hence this PR.

The connect-another-device view can only be reached from a verification email. When a user signs in from that view, we always want the new flow to have `utm_source` set to `email`. This change simply hard-codes the `utm_source` on signin links in that view.

@shane-tomlinson this is what I took out of our meeting with Alex and Leif just now, does it match up with what you're thinking?