### PR TITLE
fix(l10n): Fix the string extraction script

### DIFF
--- a/grunttasks/l10n-extract.js
+++ b/grunttasks/l10n-extract.js
@@ -12,7 +12,7 @@ var execSync = require('child_process').execSync;
 
 // where to place the pot files.
 var messagesOutputPath = path.join(__dirname, '..', 'locale', 'templates', 'LC_MESSAGES');
-var babelCmd = 'node_modules/.bin/babel --plugins=babel-plugin-syntax-dynamic-import,dynamic-import-webpack --presets es2015 app/scripts --out-dir .es5';
+var babelCmd = 'node_modules/.bin/babel --plugins=babel-plugin-syntax-dynamic-import,dynamic-import-webpack,transform-class-properties --presets es2015 app/scripts --out-dir .es5';
 var templateCmd = 'cp -r app/scripts/templates .es5/templates/';
 
 module.exports = function (grunt) {


### PR DESCRIPTION
The `tranform-class-properties` plugin needed to be specified
in l10n-extract.js

fixes #6343 
fixes https://github.com/mozilla/fxa-content-server-l10n/issues/273

@mozilla/fxa-devs - r?

This is a quick fix, adding .babelrc didn't work as easily as I had hoped.