### PR TITLE
fix(image): use smaller 2FA images on sign-in

### DIFF
--- a/app/styles/modules/_graphic.scss
+++ b/app/styles/modules/_graphic.scss
@@ -63,12 +63,20 @@
   background-image: url('/images/graphic_two_factor_auth.svg');
   height: 138px;
   margin-top: 20px;
+
+  @include respond-to('small') {
+    height: 70px;
+  }
 }
 
 .graphic-recovery-codes {
   background-image: url('/images/graphic_recovery_codes.svg');
   height: 138px;
   margin-top: 20px;
+
+  @include respond-to('small') {
+    height: 70px;
+  }
 }
 
 .graphic-recovery-codes-download {


### PR DESCRIPTION
Fixes #6347 

I could only reproduce this bug in the Lockbox login flow. That flow adds a 20px navigation panel at the top that pushes the web view down causing the buttons to not show. This PR reduces the images when viewed in the `small` resolution.

Updated image
<img width="362" alt="screen shot 2018-07-16 at 3 10 40 pm" src="https://user-images.githubusercontent.com/1295288/42778638-c7321e32-890b-11e8-9b38-1248b403a0ef.png">
