### PR TITLE
refactor(router): Do all link transformation from the router.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -491,6 +491,7 @@ Start.prototype = {
   initializeRouter () {
     if (! this._router) {
       this._router = new Router({
+        broker: this._authenticationBroker,
         createView: this.createView.bind(this),
         metrics: this._metrics,
         notifier: this._notifier,

--- a/app/scripts/models/auth_brokers/oauth.js
+++ b/app/scripts/models/auth_brokers/oauth.js
@@ -219,7 +219,7 @@ var OAuthAuthenticationBroker = BaseAuthenticationBroker.extend({
       link = '/' + link;
     }
 
-    if (/^\/(signin|signup)/.test(link)) {
+    if (/^\/(force_auth|signin|signup)$/.test(link)) {
       link = '/oauth' + link;
     }
 

--- a/app/scripts/views/authorization.js
+++ b/app/scripts/views/authorization.js
@@ -11,8 +11,8 @@ class AuthorizationView extends BaseView {
   beforeRender () {
     const action = this.relier.get('action');
     if (action) {
-      const pathname = action === 'email' ? '/' : action;
-      this.replaceCurrentPage(this.broker.transformLink(pathname));
+      const pathname = action === 'email' ? '/oauth/' : action;
+      this.replaceCurrentPage(pathname);
     } else {
       // if no action is specified, let oauth-index decide based on
       // current user signed in state.

--- a/app/scripts/views/confirm.js
+++ b/app/scripts/views/confirm.js
@@ -53,8 +53,7 @@ const View = BaseView.extend({
   },
 
   _getMissingSessionTokenScreen () {
-    var screenUrl = this.isSignUp() ? 'signup' : 'signin';
-    return this.broker.transformLink(screenUrl);
+    return this.isSignUp() ? 'signup' : 'signin';
   },
 
   beforeRender () {

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -166,16 +166,12 @@ const View = BaseView.extend({
       });
   },
 
-  _getSignInRoute () {
-    return this.broker.transformLink('/signin').replace(/^\//, '');
-  },
-
   _finishPasswordResetDifferentBrowser () {
     // user verified in a different browser, make them sign in. OAuth
     // users will be redirected back to the RP, Sync users will be
     // taken to the Sync controlled completion page.
     Session.clear();
-    this.navigate(this._getSignInRoute(), {
+    this.navigate('signin', {
       success: t('Password reset successfully. Sign in to continue.')
     });
   },

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -132,14 +132,14 @@ var View = SignInView.extend({
     this.broker.setBehavior(
       'beforeSignUpConfirmationPoll', new NullBehavior());
 
-    return this.navigate(this.broker.transformLink('signup'), {
+    return this.navigate('signup', {
       error: AuthErrors.toError('DELETED_ACCOUNT'),
       forceEmail: account.get('email')
     });
   },
 
   _navigateToForceResetPassword () {
-    return this.navigate(this.broker.transformLink('reset_password'), {
+    return this.navigate('reset_password', {
       forceEmail: this.relier.get('email')
     });
   },

--- a/app/scripts/views/index.js
+++ b/app/scripts/views/index.js
@@ -91,7 +91,7 @@ class IndexView extends FormView {
     return this.invokeBrokerMethod('beforeSignIn', account)
       .then(() => this.user.checkAccountEmailExists(account))
       .then((exists) => {
-        const nextEndpoint = this.broker.transformLink(exists ? 'signin' : 'signup');
+        const nextEndpoint = exists ? 'signin' : 'signup';
         if (exists) {
           // If the account exists, use the stored account
           // so that any stored avatars are displayed on

--- a/app/scripts/views/oauth_index.js
+++ b/app/scripts/views/oauth_index.js
@@ -9,6 +9,7 @@
  *
  * @module views/oauth_index
  */
+
 import IndexView from './index';
 
 class OAuthIndexView extends IndexView {
@@ -41,9 +42,9 @@ class OAuthIndexView extends IndexView {
       return this.user.checkAccountEmailExists(account)
         .then(function (exists) {
           if (exists) {
-            return 'oauth/signin';
+            return 'signin';
           } else {
-            return 'oauth/signup';
+            return 'signup';
           }
         }, (err) => {
           // The error here is a throttling error or server error (500).
@@ -56,14 +57,15 @@ class OAuthIndexView extends IndexView {
     }).then((url) => {
       if (! url) {
         if (this.user.getChooserAccount().isDefault()) {
-          url = 'oauth/signup';
+          url = 'signup';
         } else {
-          url = 'oauth/signin';
+          url = 'signin';
         }
       }
 
       this.replaceCurrentPage(url);
     });
+
   }
 }
 

--- a/app/scripts/views/permissions.js
+++ b/app/scripts/views/permissions.js
@@ -5,17 +5,15 @@
 import _ from 'underscore';
 import Account from '../models/account';
 import BackMixin from './mixins/back-mixin';
-import BaseView from './base';
 import Cocktail from 'cocktail';
 import FormView from './form';
 import OAuthErrors from '../lib/oauth-errors';
 import PermissionTemplate from 'templates/partial/permission.mustache';
 import ServiceMixin from './mixins/service-mixin';
 import Strings from '../lib/strings';
+import { t } from './base';
 import Template from 'templates/permissions.mustache';
 import VerificationReasonMixin from './mixins/verification-reason-mixin';
-
-var t = BaseView.t;
 
 // Reduce the number of strings to translate by interpolating
 // to create the required variant of a label.
@@ -262,8 +260,7 @@ var View = FormView.extend({
   },
 
   _previousView () {
-    var page = this.isSignUp() ? '/signup' : '/signin';
-    return this.broker.transformLink(page);
+    return this.isSignUp() ? '/signup' : '/signin';
   }
 }, {
   PERMISSIONS: PERMISSIONS

--- a/app/scripts/views/sign_in_recovery_code.js
+++ b/app/scripts/views/sign_in_recovery_code.js
@@ -51,10 +51,7 @@ const View = FormView.extend({
    * @returns {String}
    */
   _getAuthPage() {
-    const authPage =
-      this.model.get('lastPage') === 'force_auth' ? 'force_auth' : 'signin';
-
-    return this.broker.transformLink(authPage);
+    return this.model.get('lastPage') === 'force_auth' ? 'force_auth' : 'signin';
   }
 });
 

--- a/app/scripts/views/sign_in_token_code.js
+++ b/app/scripts/views/sign_in_token_code.js
@@ -61,10 +61,7 @@ const View = FormView.extend({
      * @returns {String}
      */
   _getAuthPage () {
-    const authPage =
-        this.model.get('lastPage') === 'force_auth' ? 'force_auth' : 'signin';
-
-    return this.broker.transformLink(authPage);
+    return this.model.get('lastPage') === 'force_auth' ? 'force_auth' : 'signin';
   }
 });
 

--- a/app/scripts/views/sign_in_totp_code.js
+++ b/app/scripts/views/sign_in_totp_code.js
@@ -48,10 +48,7 @@ const View = FormView.extend({
    * @returns {String}
    */
   _getAuthPage () {
-    const authPage =
-      this.model.get('lastPage') === 'force_auth' ? 'force_auth' : 'signin';
-
-    return this.broker.transformLink(authPage);
+    return this.model.get('lastPage') === 'force_auth' ? 'force_auth' : 'signin';
   }
 });
 

--- a/app/scripts/views/sign_in_unblock.js
+++ b/app/scripts/views/sign_in_unblock.js
@@ -80,10 +80,7 @@ const View = FormView.extend({
      * @returns {String}
      */
   _getAuthPage () {
-    const authPage =
-        this.model.get('lastPage') === 'force_auth' ? 'force_auth' : 'signin';
-
-    return this.broker.transformLink(authPage);
+    return this.model.get('lastPage') === 'force_auth' ? 'force_auth' : 'signin';
   },
 
   /**

--- a/app/tests/spec/views/authorization.js
+++ b/app/tests/spec/views/authorization.js
@@ -89,7 +89,7 @@ describe('views/authorization', function () {
 
       return view.render()
         .then(() => {
-          assert.ok(view.replaceCurrentPage.calledOnceWith(broker.transformLink('signin')), 'called with proper signin action');
+          assert.ok(view.replaceCurrentPage.calledOnceWith('signin'), 'called with proper signin action');
         });
     });
 
@@ -107,7 +107,7 @@ describe('views/authorization', function () {
 
       return view.render()
         .then(() => {
-          assert.ok(view.replaceCurrentPage.calledOnceWith(broker.transformLink('/')), 'called default action for action=email');
+          assert.ok(view.replaceCurrentPage.calledOnceWith('/oauth/'), 'called default action for action=email');
         });
     });
   });

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -383,17 +383,11 @@ describe('views/confirm_reset_password', function () {
 
   describe('_finishPasswordResetDifferentBrowser', function () {
     it('redirects to page specified by broker if user verifies in a second browser', function () {
-      sinon.stub(broker, 'transformLink').callsFake(function () {
-        // synthesize the OAuth broker.
-        return '/oauth/signin';
-      });
-
       sinon.spy(view, 'navigate');
 
       view._finishPasswordResetDifferentBrowser();
 
-      // leading slash should be removed from the url.
-      assert(view.navigate.calledWith('oauth/signin'));
+      assert(view.navigate.calledOnceWith('signin'));
     });
   });
 

--- a/app/tests/spec/views/index.js
+++ b/app/tests/spec/views/index.js
@@ -235,7 +235,6 @@ describe('views/index', () => {
 
         sinon.stub(user, 'checkAccountEmailExists').callsFake(() => Promise.resolve(true));
         sinon.stub(user, 'getAccountByEmail').callsFake(() => storedAccount);
-        sinon.stub(broker, 'transformLink').callsFake(link => `oauth/${link}`);
 
         return view.checkEmail(EMAIL)
           .then(() => {
@@ -243,8 +242,7 @@ describe('views/index', () => {
             const brokerAccount = broker.beforeSignIn.args[0][0];
             assert.equal(brokerAccount.get('email'), EMAIL);
 
-            // test ensures `transformLink` is called to handle OAuth flow.
-            assert.isTrue(view.navigate.calledOnceWith('oauth/signin'));
+            assert.isTrue(view.navigate.calledOnceWith('signin'));
             const { account } = view.navigate.args[0][1];
             assert.strictEqual(account, storedAccount);
             // Ensure the email is added to the stored account.

--- a/app/tests/spec/views/oauth_index.js
+++ b/app/tests/spec/views/oauth_index.js
@@ -70,7 +70,7 @@ describe('views/oauth_index', () => {
       it('navigates to signup page if there is no current account', () => {
         return view.render()
           .then(() => {
-            assert.isTrue(view.replaceCurrentPage.calledOnceWith('oauth/signup'));
+            assert.isTrue(view.replaceCurrentPage.calledOnceWith('signup'));
           });
       });
 
@@ -81,7 +81,7 @@ describe('views/oauth_index', () => {
 
         return view.render()
           .then(() => {
-            assert.isTrue(view.replaceCurrentPage.calledOnceWith('oauth/signin'));
+            assert.isTrue(view.replaceCurrentPage.calledOnceWith('signin'));
           });
       });
     });
@@ -96,7 +96,7 @@ describe('views/oauth_index', () => {
 
         return view.render()
           .then(() => {
-            assert.isTrue(view.replaceCurrentPage.calledOnceWith('oauth/signup'));
+            assert.isTrue(view.replaceCurrentPage.calledOnceWith('signup'));
           });
       });
 
@@ -105,7 +105,7 @@ describe('views/oauth_index', () => {
 
         return view.render()
           .then(() => {
-            assert.isTrue(view.replaceCurrentPage.calledOnceWith('oauth/signin'));
+            assert.isTrue(view.replaceCurrentPage.calledOnceWith('signin'));
           });
       });
 
@@ -120,7 +120,7 @@ describe('views/oauth_index', () => {
         return view.render()
           .then(() => {
             assert.isTrue(view.logError.calledWith(err));
-            assert.isTrue(view.replaceCurrentPage.calledOnceWith('oauth/signup'));
+            assert.isTrue(view.replaceCurrentPage.calledOnceWith('signup'));
           });
       });
     });

--- a/app/tests/spec/views/sign_in_unblock.js
+++ b/app/tests/spec/views/sign_in_unblock.js
@@ -247,18 +247,8 @@ describe('views/sign_in_unblock', () => {
         model.set('lastPage', 'force_auth');
       });
 
-      it('returns `force_auth`', () => {
+      it('returns `force_auth', () => {
         assert.equal(view._getAuthPage(), 'force_auth');
-      });
-    });
-
-    describe('broker modifies URL', () => {
-      beforeEach(() => {
-        sinon.stub(broker, 'transformLink').callsFake((url) => `/oauth/${url}`);
-      });
-
-      it('returns URL the broker returns', () => {
-        assert.equal(view._getAuthPage(), '/oauth/signin');
       });
     });
   });


### PR DESCRIPTION
`broker.transformLink` was called from a bunch of different views
and it was easy to forget when it should be called.

This pushes the logic to the router where view developers
no longer need to think about it.

blocks #6360