### PR TITLE
fix(oauth): handle '+' in scope normalization

### DIFF
--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -321,7 +321,8 @@ define(function (require, exports, module) {
 
     var trimmedScopes = scopes.trim();
     if (trimmedScopes.length) {
-      return _.uniq(scopes.split(/\s+/g));
+      // matches any whitespace character OR matches the character '+' literally
+      return _.uniq(scopes.split(/\s+|\++/g));
     } else {
       return [];
     }

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -350,6 +350,23 @@ define(function (require, exports, module) {
             it('transforms to permissions', function () {
               assert.deepEqual(relier.get('permissions'), PERMISSIONS);
             });
+
+            it('transforms plus scopes to permissions', function () {
+              const SCOPE = 'profile:email+profile:uid';
+
+              windowMock.location.search = TestHelpers.toSearchString({
+                action: ACTION,
+                client_id: CLIENT_ID,
+                redirect_uri: QUERY_REDIRECT_URI,
+                scope: SCOPE,
+                state: STATE
+              });
+
+              return relier.fetch()
+                .then(() => {
+                  assert.deepEqual(relier.get('permissions'), PERMISSIONS);
+                });
+            });
           });
 
           describe('untrusted reliers', function () {


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-oauth-server/issues/552

@rfk r?