### PR TITLE
fix(pw-reset): Ensure pw reset completes w/ uid & email specified in email

### DIFF
--- a/app/scripts/models/verification/same-browser.js
+++ b/app/scripts/models/verification/same-browser.js
@@ -70,7 +70,16 @@ define(function (require, exports, module) {
     load () {
       var id = this._getUsersStorageId();
       if (id) {
-        var usersStoredInfo = (this._storage.get(STORAGE_KEY) || {})[id];
+        const allStoredInfo = this._storage.get(STORAGE_KEY) || {};
+        // During password reset, SameBrowserVerificationModel will persist
+        // info keyed by email since the uid is not known when the flow is
+        // initiated. All other flows key by uid.
+        // As of train-117 links in the password reset emails contain
+        // both a uid and an email.
+        // First, try fetching the info using uid since that'll cover all
+        // flows except password reset. If that fails, try email to
+        // handle password reset.
+        const usersStoredInfo = allStoredInfo[this._uid] || allStoredInfo[this._email];
         if (usersStoredInfo) {
           this.set(usersStoredInfo[this._namespace] || {});
         }

--- a/app/tests/spec/models/verification/same-browser.js
+++ b/app/tests/spec/models/verification/same-browser.js
@@ -75,21 +75,6 @@ define(function (require, exports, module) {
         });
       });
 
-      describe('load', function () {
-        beforeEach(function () {
-          model.persist();
-
-          model.unset('context');
-          sinon.spy(model, 'set');
-          model.load();
-        });
-
-        it('loads verification info from localStorage', function () {
-          assert.isTrue(storage.get.calledWith(model._STORAGE_KEY));
-          assert.equal(model.get('context'), 'fx_desktop_v1');
-        });
-      });
-
       describe('clear', function () {
         beforeEach(function () {
           model.persist();
@@ -106,6 +91,82 @@ define(function (require, exports, module) {
         it('does not reload erased data', function () {
           assert.isFalse(model.has('context'));
         });
+      });
+    });
+
+    describe('persist/load', function () {
+      let storage;
+
+      this.beforeEach(() => {
+        storage = new Storage();
+      });
+
+      it('signup, stores and loads verification keyed by uid', function () {
+        const persistModel = new SameBrowserVerificationModel({
+          context: 'fx_desktop_v1'
+        }, {
+          namespace: 'context',
+          storage: storage,
+          uid: 'a-uid',
+        });
+
+        persistModel.persist();
+
+        const loadModel = new SameBrowserVerificationModel({
+        }, {
+          namespace: 'context',
+          storage: storage,
+          uid: 'a-uid',
+        });
+
+        loadModel.load();
+
+        assert.equal(loadModel.get('context'), 'fx_desktop_v1');
+      });
+
+      it('password reset, stores and loads verification keyed by email (pre-train-117)', function () {
+        const persistModel = new SameBrowserVerificationModel({
+          context: 'fx_desktop_v2'
+        }, {
+          email: 'testuser@testuser.com',
+          namespace: 'context',
+          storage: storage,
+        });
+
+        persistModel.persist();
+
+        const loadModel = new SameBrowserVerificationModel({
+        }, {
+          email: 'testuser@testuser.com',
+          namespace: 'context',
+          storage: storage,
+        });
+
+        loadModel.load();
+        assert.equal(loadModel.get('context'), 'fx_desktop_v2');
+      });
+
+      it('password reset, stores and loads verification keyed by email, both uid and email specified in load (>= train-117)', function () {
+        const persistModel = new SameBrowserVerificationModel({
+          context: 'fx_desktop_v3'
+        }, {
+          email: 'testuser@testuser.com',
+          namespace: 'context',
+          storage: storage,
+        });
+
+        persistModel.persist();
+
+        const loadModel = new SameBrowserVerificationModel({
+        }, {
+          email: 'testuser@testuser.com',
+          namespace: 'context',
+          storage: storage,
+          uid: 'a-uid'
+        });
+
+        loadModel.load();
+        assert.equal(loadModel.get('context'), 'fx_desktop_v3');
       });
     });
   });


### PR DESCRIPTION
With https://github.com/mozilla/fxa-auth-server/pull/2518 a password
reset verification email contains both a uid and an email, the
expectation has always been password resets would only contain
an email.

In a password reset flow, the same browser verification info
must be stored using the email as a key because the uid
is unknown.

Now that password reset emails contain both a uid and
an email, we have to check stored verification info
first by uid, then by email.

fixes #6368

@vbudhram and @vladikoff - r?