### PR TITLE
refactor(deps): Remove SearchParamMixin where unneeded.

### DIFF
--- a/app/scripts/views/index.js
+++ b/app/scripts/views/index.js
@@ -15,7 +15,6 @@ import TokenCodeExperimentMixin from './mixins/token-code-experiment-mixin';
 import FlowBeginMixin from './mixins/flow-begin-mixin';
 import FormPrefillMixin from './mixins/form-prefill-mixin';
 import FormView from './form';
-import SearchParamMixin from '../lib/search-param-mixin';
 import ServiceMixin from './mixins/service-mixin';
 import Template from 'templates/index.mustache';
 
@@ -113,7 +112,6 @@ Cocktail.mixin(
   TokenCodeExperimentMixin,
   FlowBeginMixin,
   FormPrefillMixin,
-  SearchParamMixin,
   ServiceMixin
 );
 

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -10,7 +10,6 @@ define(function (require, exports, module) {
   const AuthErrors = require('../../lib/auth-errors');
   const NavigateBehavior = require('../behaviors/navigate');
   const ResumeTokenMixin = require('./resume-token-mixin');
-  const SearchParamMixin = require('../../lib/search-param-mixin');
   const VerificationMethods = require('../../lib/verification-methods');
   const VerificationReasons = require('../../lib/verification-reasons');
   const TokenCodeExperimentMixin = require('../mixins/token-code-experiment-mixin');
@@ -18,7 +17,6 @@ define(function (require, exports, module) {
   module.exports = {
     dependsOn: [
       ResumeTokenMixin,
-      SearchParamMixin,
       TokenCodeExperimentMixin
     ],
 

--- a/app/scripts/views/settings/emails.js
+++ b/app/scripts/views/settings/emails.js
@@ -15,7 +15,6 @@ define(function (require, exports, module) {
   const preventDefaultThen = require('../base').preventDefaultThen;
   const SettingsPanelMixin = require('../mixins/settings-panel-mixin');
   const UpgradeSessionMixin = require('../mixins/upgrade-session-mixin');
-  const SearchParamMixin = require('../../lib/search-param-mixin');
   const Strings = require('../../lib/strings');
   const showProgressIndicator = require('../decorators/progress_indicator');
   const Template = require('templates/settings/emails.mustache');
@@ -162,8 +161,7 @@ define(function (require, exports, module) {
     }),
     AvatarMixin,
     LastCheckedTimeMixin,
-    SettingsPanelMixin,
-    SearchParamMixin
+    SettingsPanelMixin
   );
 
   module.exports = View;


### PR DESCRIPTION
SearchParamMixin is already added to the BaseView, no need
to add it to other views.

Not part of any issue.

@mozilla/fxa-devs - r?