### PR TITLE
fix(pw-strength): "password_missing" no longer emit when view is shown

### DIFF
--- a/app/scripts/models/password_strength/password_strength_balloon.js
+++ b/app/scripts/models/password_strength/password_strength_balloon.js
@@ -37,6 +37,7 @@ const BANNED_URL_REGEXP = /^(?:firefox|mozilla)\.(?:com|org)$/;
 export default class PasswordStrengthBalloonModel extends Model {
   constructor (attrs = {}, config = {}) {
     const attrsWithDefaults = assign({
+      hasCheckedPassword: false,
       hasEnteredPassword: false,
       hasSubmit: false,
       isCommon: false,
@@ -82,6 +83,7 @@ export default class PasswordStrengthBalloonModel extends Model {
       const isValid = hasEnteredPassword && ! isTooShort && ! isSameAsEmail && ! isCommon;
 
       this.set({
+        hasCheckedPassword: true,
         hasEnteredPassword,
         isCommon,
         isSameAsEmail,
@@ -135,7 +137,7 @@ export default class PasswordStrengthBalloonModel extends Model {
   }
 
   validate () {
-    if (! this.get('hasEnteredPassword')) {
+    if (! this.get('password')) {
       return AuthErrors.toError('PASSWORD_REQUIRED');
     } else if (this.get('isTooShort')) {
       return AuthErrors.toError('PASSWORD_TOO_SHORT');

--- a/app/scripts/views/mixins/password-strength-experiment-mixin.js
+++ b/app/scripts/views/mixins/password-strength-experiment-mixin.js
@@ -120,6 +120,15 @@ export default function (config = {}) {
     },
 
     _logErrorIfInvalid () {
+      // The model's `change` event occurs when any of the attributes are
+      // updated. Because the model's `updateForPassword` method is
+      // asynchronous, it's possible for a `change` event to be triggered
+      // and the model be considered invalid before the password has
+      // been checked. Only log errors after the password has been checked.
+      if (! this.passwordModel.get('hasCheckedPassword')) {
+        return;
+      }
+
       const error = this.passwordModel.validate();
       if (error) {
         this.logError(error);

--- a/app/tests/spec/models/password_strength/password_strength_balloon.js
+++ b/app/tests/spec/models/password_strength/password_strength_balloon.js
@@ -18,6 +18,7 @@ describe('models/password_strength/password_strength_balloon', () => {
   it('has the expected defaults', () => {
     assert.deepEqual(model.toJSON(), {
       email: 'testuser@testuser.com',
+      hasCheckedPassword: false,
       hasEnteredPassword: false,
       hasSubmit: false,
       isCommon: false,
@@ -35,6 +36,7 @@ describe('models/password_strength/password_strength_balloon', () => {
       return model.updateForPassword().then(() => {
         assert.deepEqual(model.toJSON(), {
           email: 'testuser@testuser.com',
+          hasCheckedPassword: true,
           hasEnteredPassword: true,
           hasSubmit: false,
           isCommon: false,
@@ -61,6 +63,7 @@ describe('models/password_strength/password_strength_balloon', () => {
           .then(() => {
             assert.deepEqual(model.toJSON(), {
               email: 'testuser@testuser.com',
+              hasCheckedPassword: true,
               hasEnteredPassword: true,
               hasSubmit: false,
               isCommon: false,
@@ -84,6 +87,7 @@ describe('models/password_strength/password_strength_balloon', () => {
           .then(() => {
             assert.deepEqual(model.toJSON(), {
               email: 'testuser@testuser.com',
+              hasCheckedPassword: true,
               hasEnteredPassword: true,
               hasSubmit: false,
               isCommon: false,
@@ -121,6 +125,7 @@ describe('models/password_strength/password_strength_balloon', () => {
           .then(() => {
             assert.deepEqual(model.toJSON(), {
               email: 'testuser@testuser.com',
+              hasCheckedPassword: true,
               hasEnteredPassword: true,
               hasSubmit: false,
               isCommon: true,
@@ -143,6 +148,7 @@ describe('models/password_strength/password_strength_balloon', () => {
         .then(() => {
           assert.deepEqual(model.toJSON(), {
             email: 'testuser@testuser.com',
+            hasCheckedPassword: true,
             hasEnteredPassword: true,
             hasSubmit: false,
             isCommon: false,
@@ -162,6 +168,7 @@ describe('models/password_strength/password_strength_balloon', () => {
         .then(() => {
           assert.deepEqual(model.toJSON(), {
             email: 'testuser@testuser.com',
+            hasCheckedPassword: true,
             hasEnteredPassword: true,
             hasSubmit: false,
             isCommon: false,
@@ -187,6 +194,7 @@ describe('models/password_strength/password_strength_balloon', () => {
         isCommon: false,
         isSameAsEmail: false,
         isTooShort: true,
+        password: 'pass',
       });
       assert.isTrue(AuthErrors.is(model.validate(), 'PASSWORD_TOO_SHORT'));
     });
@@ -197,6 +205,7 @@ describe('models/password_strength/password_strength_balloon', () => {
         isCommon: false,
         isSameAsEmail: true,
         isTooShort: false,
+        password: 'testuser',
       });
       assert.isTrue(AuthErrors.is(model.validate(), 'PASSWORD_SAME_AS_EMAIL'));
     });
@@ -207,6 +216,7 @@ describe('models/password_strength/password_strength_balloon', () => {
         isCommon: true,
         isSameAsEmail: false,
         isTooShort: false,
+        password: 'password',
       });
       assert.isTrue(AuthErrors.is(model.validate(), 'PASSWORD_TOO_COMMON'));
     });
@@ -217,6 +227,7 @@ describe('models/password_strength/password_strength_balloon', () => {
         isCommon: false,
         isSameAsEmail: false,
         isTooShort: false,
+        password: 'password123123',
       });
       assert.isUndefined(model.validate());
     });

--- a/app/tests/spec/views/mixins/password-strength-experiment-mixin.js
+++ b/app/tests/spec/views/mixins/password-strength-experiment-mixin.js
@@ -216,13 +216,19 @@ describe('views/mixins/password-strength-experiment-mixin', () => {
     });
   });
 
-  it('_logErrorIfInvalid logs the validation error', () => {
+  it('_logErrorIfInvalid only logs validation errors if the password has been checked', () => {
     const error = new Error('uh oh');
+    let hasCheckedPassword = false;
     view.passwordModel = {
+      get: () => hasCheckedPassword,
       validate: sinon.spy(() => error)
     };
     sinon.stub(view, 'logError');
 
+    view._logErrorIfInvalid();
+    assert.isFalse(view.logError.called);
+
+    hasCheckedPassword = true;
     view._logErrorIfInvalid();
     assert.isTrue(view.logError.calledOnceWith(error));
   });


### PR DESCRIPTION
`fxa_reg - password_missing` was being emit as soon as the pw strength
balloon was displayed because `logErrorIfInvalid` is called any time
the model changes. On startup, the `isVisible` attribute of the model
changes when the balloon becomes visible. Since the model is invalid
on startup because no password has been entered, a password_missing
error is emit.

This changes the behavior to only log errors if the password has
actually been checked.

A 2nd more subtle error was fixed where if the user entered a password
then erased it, a "password_too_short" event was emit instead of
a "password_missing"

fixes #6375 

@mozilla/fxa-devs - r?