### PR TITLE
fix(test): Fix the checkbox clicking functional tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "start-production": "NODE_ENV=production grunt build && CONFIG_FILES=server/config/local.json,server/config/production.json grunt serverproc:dist",
     "start-remote": "scripts/run_remote_dev.sh",
     "test": "node tests/intern.js --unit=true",
-    "test-circle": "node tests/intern.js --suites=circle --fxaAuthRoot=https://fxaci.dev.lcip.org/auth --fxaEmailRoot=http://restmail.net --fxaOauthApp=https://oauth-fxaci.dev.lcip.org --fxaUntrustedOauthApp=https://321done-fxaci.dev.lcip.org --fxaProduction=true --bailAfterFirstFailure=true",
+    "test-circle": "node tests/intern.js --suites=circle --fxaAuthRoot=https://fxaci.dev.lcip.org/auth --fxaEmailRoot=http://restmail.net --fxaOAuthApp=https://oauth-fxaci.dev.lcip.org --fxaUntrustedOauthApp=https://321done-fxaci.dev.lcip.org --fxaProduction=true --bailAfterFirstFailure=true",
     "test-functional": "node tests/intern.js",
     "test-functional-oauth": "node tests/intern.js --suites=oauth",
-    "test-latest": "node tests/intern.js --fxaAuthRoot=https://latest.dev.lcip.org/auth/v1 --fxaContentRoot=https://latest.dev.lcip.org/ --fxaEmailRoot=http://restmail.net --fxaOauthApp=https://123done-latest.dev.lcip.org/ --fxaUntrustedOauthApp=https://321done-latest.dev.lcip.org/ --fxaProduction=true --fxaToken=https://token.dev.lcip.org/1.0/sync/1.5",
+    "test-latest": "node tests/intern.js --fxaAuthRoot=https://latest.dev.lcip.org/auth/v1 --fxaContentRoot=https://latest.dev.lcip.org/ --fxaEmailRoot=http://restmail.net --fxaOAuthApp=https://123done-latest.dev.lcip.org/ --fxaUntrustedOauthApp=https://321done-latest.dev.lcip.org/ --fxaProduction=true --fxaToken=https://token.dev.lcip.org/1.0/sync/1.5",
     "test-server": "node tests/intern.js --suites=server",
     "test-travis": "node tests/intern.js --suites=travis"
   },

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -105,7 +105,7 @@ module.exports = {
     HEADER: '.header-content'
   },
   OAUTH_PERMISSIONS: {
-    CHECKBOX_DISPLAY_NAME: 'input[name="profile:display_name"] + span',
+    CHECKBOX_DISPLAY_NAME: 'input[name="profile:display_name"]',
     HEADER: '#fxa-permissions-header',
     SUBMIT: '#accept'
   },
@@ -206,10 +206,7 @@ module.exports = {
   },
   SIGNUP: {
     AGE: '#age',
-    // The original checkbox is not clickable after the material conversion. The span
-    // next to the element holds the label text, click it instead. See #5425
-    CUSTOMIZE_SYNC_CHECKBOX: '#customize-sync + span',
-    CUSTOMIZE_SYNC_INPUT: '#customize-sync',
+    CUSTOMIZE_SYNC_CHECKBOX: '#customize-sync',
     EMAIL: 'input[type=email]',
     ERROR: '.error',
     HEADER: '#fxa-signup-header',
@@ -217,7 +214,7 @@ module.exports = {
     LINK_SUGGEST_EMAIL_DOMAIN_CORRECTION: '#email-suggestion',
     LINK_SUGGEST_SIGN_IN: '.error a[href="/signin"]',
     LINK_SUGGEST_SYNC: '#suggest-sync a',
-    MARKETING_EMAIL_OPTIN: 'input.marketing-email-optin + span',
+    MARKETING_EMAIL_OPTIN: 'input.marketing-email-optin',
     MIGRATING_USER: '#suggest-sync',
     PASSWORD: '#password',
     SUBMIT: 'button[type="submit"]',

--- a/tests/functional/sync_sign_up.js
+++ b/tests/functional/sync_sign_up.js
@@ -144,7 +144,7 @@ registerSuite('Firefox Desktop Sync sign_up', {
         .then(openPage(PAGE_URL, selectors.SIGNUP.HEADER))
         .execute(listenForFxaCommands)
 
-        .then(testAttributeEquals(selectors.SIGNUP.CUSTOMIZE_SYNC_INPUT, 'checked', null))
+        .then(testAttributeEquals(selectors.SIGNUP.CUSTOMIZE_SYNC_CHECKBOX, 'checked', null))
         .then(fillOutSignUp(email, PASSWORD, {customizeSync: true}))
 
         .then(testIsBrowserNotifiedOfLogin(email))
@@ -158,7 +158,7 @@ registerSuite('Firefox Desktop Sync sign_up', {
       return this.remote
         .then(openPage(url, selectors.SIGNUP.HEADER))
 
-        .then(testAttributeEquals(selectors.SIGNUP.CUSTOMIZE_SYNC_INPUT, 'checked', 'checked'));
+        .then(testAttributeEquals(selectors.SIGNUP.CUSTOMIZE_SYNC_CHECKBOX, 'checked', 'checked'));
     }
   }
 });


### PR DESCRIPTION
* With the Photon checkbox style the label is no longer in a span next to the element,
  just click on the input instead.
* In package.json, test-latest defined fxaOauthApp but the app import fxaOAuthApp.

fixes #6380 

@vladikoff - r?