### PR TITLE
fix(oauth): Fix `login_hint` support

### DIFF
--- a/app/scripts/models/reliers/oauth.js
+++ b/app/scripts/models/reliers/oauth.js
@@ -6,187 +6,184 @@
  * An OAuth Relier - holds OAuth information.
  */
 
-define(function (require, exports, module) {
-  'use strict';
+import _ from 'underscore';
+import Constants from '../../lib/constants';
+import OAuthErrors from '../../lib/oauth-errors';
+import Relier from './relier';
+import Transform from '../../lib/transform';
+import Vat from '../../lib/vat';
 
-  const _ = require('underscore');
-  const Constants = require('../../lib/constants');
-  const OAuthErrors = require('../../lib/oauth-errors');
-  const Relier = require('./relier');
-  const Transform = require('../../lib/transform');
-  const Vat = require('../../lib/vat');
+/*eslint-disable camelcase*/
+var CLIENT_INFO_SCHEMA = {
+  id: Vat.hex().required().renameTo('clientId'),
+  image_uri: Vat.url().allow('').renameTo('imageUri'),
+  name: Vat.string().required().min(1).renameTo('serviceName'),
+  redirect_uri: Vat.url().required().renameTo('redirectUri'),
+  trusted: Vat.boolean().required()
+};
 
-  /*eslint-disable camelcase*/
-  var CLIENT_INFO_SCHEMA = {
-    id: Vat.hex().required().renameTo('clientId'),
-    image_uri: Vat.url().allow('').renameTo('imageUri'),
-    name: Vat.string().required().min(1).renameTo('serviceName'),
-    redirect_uri: Vat.url().required().renameTo('redirectUri'),
-    trusted: Vat.boolean().required()
-  };
+var SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA = {
+  access_type: Vat.accessType().renameTo('accessType'),
+  action: Vat.action(),
+  client_id: Vat.clientId().required().renameTo('clientId'),
+  code_challenge: Vat.codeChallenge().renameTo('codeChallenge'),
+  code_challenge_method: Vat.codeChallengeMethod().renameTo('codeChallengeMethod'),
+  keys_jwk: Vat.keysJwk().renameTo('keysJwk'),
+  login_hint: Vat.email().renameTo('loginHint'),
+  prompt: Vat.prompt(),
+  redirectTo: Vat.url(),
+  redirect_uri: Vat.url().renameTo('redirectUri'),
+  scope: Vat.string().required().min(1),
+  state: Vat.string()
+};
 
-  var SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA = {
-    access_type: Vat.accessType().renameTo('accessType'),
-    action: Vat.action(),
-    client_id: Vat.clientId().required().renameTo('clientId'),
-    code_challenge: Vat.codeChallenge().renameTo('codeChallenge'),
-    code_challenge_method: Vat.codeChallengeMethod().renameTo('codeChallengeMethod'),
-    keys_jwk: Vat.keysJwk().renameTo('keysJwk'),
-    login_hint: Vat.email().renameTo('loginHint'),
-    prompt: Vat.prompt(),
-    redirectTo: Vat.url(),
-    redirect_uri: Vat.url().renameTo('redirectUri'),
-    scope: Vat.string().required().min(1),
-    state: Vat.string()
-  };
-
-  var VERIFICATION_INFO_SCHEMA = {
-    access_type: Vat.accessType().renameTo('accessType'),
-    action: Vat.string().min(1),
-    client_id: Vat.clientId().required().renameTo('clientId'),
-    prompt: Vat.prompt(),
-    redirect_uri: Vat.url().renameTo('redirectUri'),
-    // scopes are optional when verifying, user could be verifying in a 2nd browser
-    scope: Vat.string().min(1),
-    // `service` for OAuth verification is a clientId
-    service: Vat.clientId(),
-    state: Vat.string().min(1)
-  };
+var VERIFICATION_INFO_SCHEMA = {
+  access_type: Vat.accessType().renameTo('accessType'),
+  action: Vat.string().min(1),
+  client_id: Vat.clientId().required().renameTo('clientId'),
+  prompt: Vat.prompt(),
+  redirect_uri: Vat.url().renameTo('redirectUri'),
+  // scopes are optional when verifying, user could be verifying in a 2nd browser
+  scope: Vat.string().min(1),
+  // `service` for OAuth verification is a clientId
+  service: Vat.clientId(),
+  state: Vat.string().min(1)
+};
 
   /*eslint-enable camelcase*/
 
-  var OAuthRelier = Relier.extend({
-    defaults: _.extend({}, Relier.prototype.defaults, {
-      accessType: null,
-      clientId: null,
-      context: Constants.OAUTH_CONTEXT,
-      keysJwk: null,
-      // permissions are individual scopes
-      permissions: null,
-      // whether the permissions prompt will be shown to trusted reliers
-      prompt: null,
-      // redirectTo is for future use by the oauth flow. redirectTo
-      // would have redirectUri as its base.
-      redirectTo: null,
-      // redirectUri is used by the oauth flow
-      redirectUri: null,
-      // a rollup of all the permissions
-      scope: null,
-      // standard oauth parameters.
-      state: null
-    }),
+var OAuthRelier = Relier.extend({
+  defaults: _.extend({}, Relier.prototype.defaults, {
+    accessType: null,
+    clientId: null,
+    context: Constants.OAUTH_CONTEXT,
+    keysJwk: null,
+    // permissions are individual scopes
+    permissions: null,
+    // whether the permissions prompt will be shown to trusted reliers
+    prompt: null,
+    // redirectTo is for future use by the oauth flow. redirectTo
+    // would have redirectUri as its base.
+    redirectTo: null,
+    // redirectUri is used by the oauth flow
+    redirectUri: null,
+    // a rollup of all the permissions
+    scope: null,
+    // standard oauth parameters.
+    state: null
+  }),
 
-    initialize (attributes, options = {}) {
-      Relier.prototype.initialize.call(this, attributes, options);
+  initialize (attributes, options = {}) {
+    Relier.prototype.initialize.call(this, attributes, options);
 
-      this._config = options.config;
-      this._oAuthClient = options.oAuthClient;
-      this._session = options.session;
-    },
+    this._config = options.config;
+    this._oAuthClient = options.oAuthClient;
+    this._session = options.session;
+  },
 
-    fetch () {
-      return Relier.prototype.fetch.call(this)
-        .then(() => {
-          if (this._isVerificationFlow()) {
-            this._setupVerificationFlow();
-          } else {
-            this._setupSignInSignUpFlow();
-          }
-
-          if (! this.has('service')) {
-            this.set('service', this.get('clientId'));
-          }
-
-          return this._setupOAuthRPInfo();
-        })
-        .then(() => {
-          if (this.has('scope')) {
-            // normalization depends on `trusted` field set in
-            // setupOAuthRPInfo.
-            this._normalizeScopesAndPermissions();
-          }
-        })
-        .then(() => {
-          this._validateKeyScopeRequest();
-        });
-    },
-
-    _normalizeScopesAndPermissions () {
-      var permissions = scopeStrToArray(this.get('scope'));
-      if (this.isTrusted()) {
-        // We have to normalize `profile` into is expanded sub-scopes
-        // in order to show the consent screen.
-        if (this.wantsConsent()) {
-          permissions = replaceItemInArray(
-            permissions,
-            Constants.OAUTH_TRUSTED_PROFILE_SCOPE,
-            Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION
-          );
+  fetch () {
+    return Relier.prototype.fetch.call(this)
+      .then(() => {
+        if (this._isVerificationFlow()) {
+          this._setupVerificationFlow();
+        } else {
+          this._setupSignInSignUpFlow();
         }
-      } else {
-        permissions = sanitizeUntrustedPermissions(permissions);
+
+        if (! this.has('service')) {
+          this.set('service', this.get('clientId'));
+        }
+
+        return this._setupOAuthRPInfo();
+      })
+      .then(() => {
+        if (this.has('scope')) {
+          // normalization depends on `trusted` field set in
+          // setupOAuthRPInfo.
+          this._normalizeScopesAndPermissions();
+        }
+      })
+      .then(() => {
+        this._validateKeyScopeRequest();
+      });
+  },
+
+  _normalizeScopesAndPermissions () {
+    var permissions = scopeStrToArray(this.get('scope'));
+    if (this.isTrusted()) {
+      // We have to normalize `profile` into is expanded sub-scopes
+      // in order to show the consent screen.
+      if (this.wantsConsent()) {
+        permissions = replaceItemInArray(
+          permissions,
+          Constants.OAUTH_TRUSTED_PROFILE_SCOPE,
+          Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION
+        );
       }
+    } else {
+      permissions = sanitizeUntrustedPermissions(permissions);
+    }
 
-      if (! permissions.length) {
-        throw OAuthErrors.toInvalidParameterError('scope');
-      }
+    if (! permissions.length) {
+      throw OAuthErrors.toInvalidParameterError('scope');
+    }
 
-      this.set('scope', permissions.join(' '));
-      this.set('permissions', permissions);
-    },
+    this.set('scope', permissions.join(' '));
+    this.set('permissions', permissions);
+  },
 
-    isOAuth () {
-      return true;
-    },
+  isOAuth () {
+    return true;
+  },
 
-    _isVerificationFlow () {
-      return !! this.getSearchParam('code');
-    },
+  _isVerificationFlow () {
+    return !! this.getSearchParam('code');
+  },
 
-    _setupVerificationFlow () {
-      var resumeObj = this._session.oauth;
-      if (! resumeObj) {
-        // The user is verifying in a second browser. `service` is
-        // available in the link. Use it to populate the `service`
-        // and `clientId` fields which will allow the user to
-        // redirect back to the RP but not sign in.
-        resumeObj = {
-          client_id: this.getSearchParam('service'), //eslint-disable-line camelcase
-          service: this.getSearchParam('service')
-        };
-      }
+  _setupVerificationFlow () {
+    var resumeObj = this._session.oauth;
+    if (! resumeObj) {
+      // The user is verifying in a second browser. `service` is
+      // available in the link. Use it to populate the `service`
+      // and `clientId` fields which will allow the user to
+      // redirect back to the RP but not sign in.
+      resumeObj = {
+        client_id: this.getSearchParam('service'), //eslint-disable-line camelcase
+        service: this.getSearchParam('service')
+      };
+    }
 
-      var result = Transform.transformUsingSchema(
-        resumeObj, VERIFICATION_INFO_SCHEMA, OAuthErrors);
+    var result = Transform.transformUsingSchema(
+      resumeObj, VERIFICATION_INFO_SCHEMA, OAuthErrors);
 
-      this.set(result);
-    },
+    this.set(result);
+  },
 
-    _setupSignInSignUpFlow () {
-      // params listed in:
-      // https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1authorization
-      this.importSearchParamsUsingSchema(
-        SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA, OAuthErrors);
+  _setupSignInSignUpFlow () {
+    // params listed in:
+    // https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1authorization
+    this.importSearchParamsUsingSchema(
+      SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA, OAuthErrors);
 
-      if (! this.get('email')) {
-        this.set('email', this.get('login_hint'));
-      }
-      // OAuth reliers are not allowed to specify a service. `service`
-      // is used in the verification flow, it'll be set to the `client_id`.
-      if (this.getSearchParam('service')) {
-        throw OAuthErrors.toInvalidParameterError('service');
-      }
-    },
+    if (! this.get('email')) {
+      this.set('email', this.get('loginHint'));
+    }
+    // OAuth reliers are not allowed to specify a service. `service`
+    // is used in the verification flow, it'll be set to the `client_id`.
+    if (this.getSearchParam('service')) {
+      throw OAuthErrors.toInvalidParameterError('service');
+    }
+  },
 
-    _setupOAuthRPInfo () {
-      const clientId = this.get('clientId');
-      // get the app provided redirect uri
-      const queryRedirectUri = this.get('redirectUri');
+  _setupOAuthRPInfo () {
+    const clientId = this.get('clientId');
+    // get the app provided redirect uri
+    const queryRedirectUri = this.get('redirectUri');
 
-      return this._oAuthClient.getClientInfo(clientId)
-        .then((serviceInfo) => {
-          const result = Transform.transformUsingSchema(
-            serviceInfo, CLIENT_INFO_SCHEMA, OAuthErrors);
+    return this._oAuthClient.getClientInfo(clientId)
+      .then((serviceInfo) => {
+        const result = Transform.transformUsingSchema(
+          serviceInfo, CLIENT_INFO_SCHEMA, OAuthErrors);
 
           /**
            * If redirect_uri was specified in the query we must validate it
@@ -194,51 +191,51 @@ define(function (require, exports, module) {
            *
            * Verification (email) flows do not have a redirect uri, nothing to validate
            */
-          if (queryRedirectUri && result.redirectUri !== queryRedirectUri) {
-            // if provided redirect uri doesn't match with client info then throw
-            throw OAuthErrors.toError('INCORRECT_REDIRECT');
-          }
+        if (queryRedirectUri && result.redirectUri !== queryRedirectUri) {
+          // if provided redirect uri doesn't match with client info then throw
+          throw OAuthErrors.toError('INCORRECT_REDIRECT');
+        }
 
-          this.set(result);
-        }, function (err) {
-          // the server returns an invalid request parameter for an
-          // invalid/unknown client_id
-          if (OAuthErrors.is(err, 'INVALID_PARAMETER') &&
+        this.set(result);
+      }, function (err) {
+        // the server returns an invalid request parameter for an
+        // invalid/unknown client_id
+        if (OAuthErrors.is(err, 'INVALID_PARAMETER') &&
               err.validation &&
               err.validation.keys &&
               err.validation.keys[0] === 'client_id') {
-            err = OAuthErrors.toError('UNKNOWN_CLIENT');
-            // used for logging the error on the server.
-            err.client_id = clientId; //eslint-disable-line camelcase
-          }
-          throw err;
-        });
-    },
+          err = OAuthErrors.toError('UNKNOWN_CLIENT');
+          // used for logging the error on the server.
+          err.client_id = clientId; //eslint-disable-line camelcase
+        }
+        throw err;
+      });
+  },
 
-    isTrusted () {
-      return this.get('trusted');
-    },
+  isTrusted () {
+    return this.get('trusted');
+  },
 
-    /**
+  /**
      * Return `true` if the relier sets `prompt=consent`
      *
      * @returns {Boolean} `true` if relier asks for consent, false otw.
      */
-    wantsConsent () {
-      return this.get('prompt') === Constants.OAUTH_PROMPT_CONSENT;
-    },
+  wantsConsent () {
+    return this.get('prompt') === Constants.OAUTH_PROMPT_CONSENT;
+  },
 
-    /**
+  /**
      * Check if the relier wants access to the account encryption keys.
      *
      * @returns {Boolean}
      */
-    wantsKeys () {
-      return !! (this._config && this._config.scopedKeysEnabled && this.has('keysJwk'));
-    },
+  wantsKeys () {
+    return !! (this._config && this._config.scopedKeysEnabled && this.has('keysJwk'));
+  },
 
 
-    /**
+  /**
      * Perform additional validation for scopes that have encryption keys.
      *
      * If the relier is requesting keys, we check their redirect URI against
@@ -252,39 +249,39 @@ define(function (require, exports, module) {
      * @returns {boolean}
      * @private
      */
-    _validateKeyScopeRequest () {
-      if (! this.has('keysJwk')) {
-        return false;
-      }
+  _validateKeyScopeRequest () {
+    if (! this.has('keysJwk')) {
+      return false;
+    }
 
-      const validation = this._config.scopedKeysValidation || {};
-      let foundRedirectScopeMatch = false;
+    const validation = this._config.scopedKeysValidation || {};
+    let foundRedirectScopeMatch = false;
 
-      // Requesting keys, but not specifying a scope?  That's unexpected.
-      if (! this.get('scope')) {
-        throw new Error('Invalid scope parameter');
-      }
+    // Requesting keys, but not specifying a scope?  That's unexpected.
+    if (! this.get('scope')) {
+      throw new Error('Invalid scope parameter');
+    }
 
-      scopeStrToArray(this.get('scope')).forEach((scope) => {
-        if (validation.hasOwnProperty(scope)) {
-          if (validation[scope].redirectUris.includes(this.get('redirectUri'))) {
-            foundRedirectScopeMatch = true;
-          } else {
-            // Requesting keys, but trying to deliver them to an unexpected uri? Nope.
-            throw new Error('Invalid redirect parameter');
-          }
+    scopeStrToArray(this.get('scope')).forEach((scope) => {
+      if (validation.hasOwnProperty(scope)) {
+        if (validation[scope].redirectUris.includes(this.get('redirectUri'))) {
+          foundRedirectScopeMatch = true;
+        } else {
+          // Requesting keys, but trying to deliver them to an unexpected uri? Nope.
+          throw new Error('Invalid redirect parameter');
         }
-      });
-
-      // Requesting keys, but no key-bearing scopes? That's unexpected.
-      if (! foundRedirectScopeMatch) {
-        throw new Error('No key-bearing scopes requested');
       }
+    });
 
-      return true;
-    },
+    // Requesting keys, but no key-bearing scopes? That's unexpected.
+    if (! foundRedirectScopeMatch) {
+      throw new Error('No key-bearing scopes requested');
+    }
 
-    /**
+    return true;
+  },
+
+  /**
      * Check whether additional permissions are requested from
      * the given account
      *
@@ -292,45 +289,44 @@ define(function (require, exports, module) {
      * @returns {Boolean} `true` if additional permissions
      *   are needed, false otw.
      */
-    accountNeedsPermissions (account) {
-      if (this.isTrusted() && ! this.wantsConsent()) {
-        return false;
-      }
+  accountNeedsPermissions (account) {
+    if (this.isTrusted() && ! this.wantsConsent()) {
+      return false;
+    }
 
-      // only check permissions for which the account has a value.
-      var applicableProfilePermissions =
+    // only check permissions for which the account has a value.
+    var applicableProfilePermissions =
         account.getPermissionsWithValues(this.get('permissions'));
 
-      return ! account.hasSeenPermissions(
-        this.get('clientId'), applicableProfilePermissions);
-    }
-  });
-
-  function replaceItemInArray(array, itemToReplace, replaceWith) {
-    var without = _.without(array, itemToReplace);
-    if (without.length !== array.length) {
-      return _.union(without, replaceWith);
-    }
-    return array;
+    return ! account.hasSeenPermissions(
+      this.get('clientId'), applicableProfilePermissions);
   }
-
-  function scopeStrToArray(scopes) {
-    if (! _.isString) {
-      return [];
-    }
-
-    var trimmedScopes = scopes.trim();
-    if (trimmedScopes.length) {
-      // matches any whitespace character OR matches the character '+' literally
-      return _.uniq(scopes.split(/\s+|\++/g));
-    } else {
-      return [];
-    }
-  }
-
-  function sanitizeUntrustedPermissions(permissions) {
-    return _.intersection(permissions, Constants.OAUTH_UNTRUSTED_ALLOWED_PERMISSIONS);
-  }
-
-  module.exports = OAuthRelier;
 });
+
+function replaceItemInArray(array, itemToReplace, replaceWith) {
+  var without = _.without(array, itemToReplace);
+  if (without.length !== array.length) {
+    return _.union(without, replaceWith);
+  }
+  return array;
+}
+
+function scopeStrToArray(scopes) {
+  if (! _.isString) {
+    return [];
+  }
+
+  var trimmedScopes = scopes.trim();
+  if (trimmedScopes.length) {
+    // matches any whitespace character OR matches the character '+' literally
+    return _.uniq(scopes.split(/\s+|\++/g));
+  } else {
+    return [];
+  }
+}
+
+function sanitizeUntrustedPermissions(permissions) {
+  return _.intersection(permissions, Constants.OAUTH_UNTRUSTED_ALLOWED_PERMISSIONS);
+}
+
+module.exports = OAuthRelier;

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -2,981 +2,990 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define(function (require, exports, module) {
-  'use strict';
+import _ from 'underscore';
+import { assert } from 'chai';
+import Constants from 'lib/constants';
+import OAuthClient from 'lib/oauth-client';
+import OAuthErrors from 'lib/oauth-errors';
+import OAuthRelier from 'models/reliers/oauth';
+import Session from 'lib/session';
+import sinon from 'sinon';
+import TestHelpers from '../../../lib/helpers';
+import User from 'models/user';
+import WindowMock from '../../../mocks/window';
 
-  const _ = require('underscore');
-  const { assert } = require('chai');
-  const Constants = require('lib/constants');
-  const OAuthClient = require('lib/oauth-client');
-  const OAuthErrors = require('lib/oauth-errors');
-  const OAuthRelier = require('models/reliers/oauth');
-  const Session = require('lib/session');
-  const sinon = require('sinon');
-  const TestHelpers = require('../../../lib/helpers');
-  const User = require('models/user');
-  const WindowMock = require('../../../mocks/window');
+/*eslint-disable camelcase */
+var getValueLabel = TestHelpers.getValueLabel;
 
-  /*eslint-disable camelcase */
-  var getValueLabel = TestHelpers.getValueLabel;
+describe('models/reliers/oauth', () => {
+  var err;
+  var isTrusted;
+  var oAuthClient;
+  var relier;
+  var user;
+  var windowMock;
 
-  describe('models/reliers/oauth', function () {
-    var err;
-    var isTrusted;
-    var oAuthClient;
-    var relier;
-    var user;
-    var windowMock;
+  var ACCESS_TYPE = 'offline';
+  var ACTION = 'email';
+  var CLIENT_ID = 'dcdb5ae7add825d2';
+  var CLIENT_IMAGE_URI = 'https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.pngx';
+  var PROMPT = Constants.OAUTH_PROMPT_CONSENT;
+  var QUERY_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
+  var SCOPE = 'profile:email profile:uid';
+  var SCOPE_PROFILE = Constants.OAUTH_TRUSTED_PROFILE_SCOPE;
+  var SCOPE_PROFILE_EXPANDED = Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION.join(' ');
+  var PERMISSIONS = ['profile:email', 'profile:uid'];
+  var SCOPE_WITH_EXTRAS = 'profile:email profile:uid profile:non_whitelisted';
+  var SCOPE_WITH_OPENID = 'profile:email profile:uid openid';
+  var SERVER_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
+  var SERVICE = 'service';
+  var SERVICE_NAME = '123Done';
+  var STATE = 'fakestatetoken';
+  var CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+  var CODE_CHALLENGE_METHOD = 'S256';
 
-    var ACCESS_TYPE = 'offline';
-    var ACTION = 'email';
-    var CLIENT_ID = 'dcdb5ae7add825d2';
-    var CLIENT_IMAGE_URI = 'https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.pngx';
-    var PROMPT = Constants.OAUTH_PROMPT_CONSENT;
-    var QUERY_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
-    var SCOPE = 'profile:email profile:uid';
-    var SCOPE_PROFILE = Constants.OAUTH_TRUSTED_PROFILE_SCOPE;
-    var SCOPE_PROFILE_EXPANDED = Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION.join(' ');
-    var PERMISSIONS = ['profile:email', 'profile:uid'];
-    var SCOPE_WITH_EXTRAS = 'profile:email profile:uid profile:non_whitelisted';
-    var SCOPE_WITH_OPENID = 'profile:email profile:uid openid';
-    var SERVER_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
-    var SERVICE = 'service';
-    var SERVICE_NAME = '123Done';
-    var STATE = 'fakestatetoken';
-    var CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
-    var CODE_CHALLENGE_METHOD = 'S256';
+  var RESUME_INFO = {
+    access_type: ACCESS_TYPE,
+    action: ACTION,
+    client_id: CLIENT_ID,
+    redirect_uri: QUERY_REDIRECT_URI,
+    scope: SCOPE,
+    state: STATE
+  };
 
-    var RESUME_INFO = {
-      access_type: ACCESS_TYPE,
-      action: ACTION,
-      client_id: CLIENT_ID,
-      redirect_uri: QUERY_REDIRECT_URI,
-      scope: SCOPE,
-      state: STATE
-    };
+  beforeEach(() => {
+    isTrusted = false;
+    oAuthClient = new OAuthClient();
+    windowMock = new WindowMock();
 
-    beforeEach(function () {
-      isTrusted = false;
-      oAuthClient = new OAuthClient();
-      windowMock = new WindowMock();
+    mockGetClientInfo();
 
-      mockGetClientInfo();
+    user = new User();
 
-      user = new User();
-
-      relier = new OAuthRelier({}, {
-        config: {},
-        oAuthClient: oAuthClient,
-        session: Session,
-        window: windowMock
-      });
+    relier = new OAuthRelier({}, {
+      config: {},
+      oAuthClient: oAuthClient,
+      session: Session,
+      window: windowMock
     });
+  });
 
-    describe('fetch', function () {
-      describe('signin/signup flow', () => {
-        it('populates expected fields from the search parameters', function () {
-          windowMock.location.search = TestHelpers.toSearchString({
-            access_type: ACCESS_TYPE,
-            action: ACTION,
-            client_id: CLIENT_ID,
-            code_challenge: CODE_CHALLENGE,
-            code_challenge_method: CODE_CHALLENGE_METHOD,
-            prompt: PROMPT,
-            redirect_uri: QUERY_REDIRECT_URI,
-            scope: SCOPE,
-            state: STATE
-          });
-
-          return relier.fetch()
-            .then(function () {
-              // context is not imported from query params
-              assert.equal(relier.get('context'), Constants.OAUTH_CONTEXT);
-
-              assert.equal(relier.get('action'), ACTION);
-
-              assert.equal(relier.get('prompt'), PROMPT);
-
-              // service will be the client_id in the signin/up flow
-              assert.equal(relier.get('service'), CLIENT_ID);
-              assert.equal(relier.get('state'), STATE);
-
-              // client_id and redirect_uri are converted to camelCase
-              // for consistency with other variables in the app.
-              assert.equal(relier.get('clientId'), CLIENT_ID);
-              assert.equal(relier.get('accessType'), ACCESS_TYPE);
-
-              // The redirect_uri is matched with the server, if no match then we throw
-              assert.equal(relier.get('redirectUri'), SERVER_REDIRECT_URI);
-
-              // PKCE parameters
-              assert.equal(relier.get('codeChallenge'), CODE_CHALLENGE);
-              assert.equal(relier.get('codeChallengeMethod'), CODE_CHALLENGE_METHOD);
-            });
-        });
-
-        it('throws if `service` is specified', () => {
-          windowMock.location.search = TestHelpers.toSearchString({
-            access_type: ACCESS_TYPE,
-            action: ACTION,
-            client_id: CLIENT_ID,
-            prompt: PROMPT,
-            redirect_uri: QUERY_REDIRECT_URI,
-            scope: SCOPE,
-            service: SERVICE,
-            state: STATE
-          });
-
-          return relier.fetch()
-            .then(assert.fail, (err) => {
-              assert.isTrue(OAuthErrors.is(err, 'INVALID_PARAMETER'));
-            });
-        });
-
-        it('throws if invalid PKCE code_challenge is specified', () => {
-          windowMock.location.search = TestHelpers.toSearchString({
-            access_type: ACCESS_TYPE,
-            action: ACTION,
-            client_id: CLIENT_ID,
-            code_challenge: 'foo',
-            prompt: PROMPT,
-            redirect_uri: QUERY_REDIRECT_URI,
-            scope: SCOPE,
-            state: STATE
-          });
-
-          return relier.fetch()
-            .then(assert.fail, (err) => {
-              assert.isTrue(OAuthErrors.is(err, 'INVALID_PARAMETER'));
-              assert.equal(err.param, 'code_challenge');
-            });
-        });
-
-        it('throws if invalid PKCE code_challenge_method is specified', () => {
-          windowMock.location.search = TestHelpers.toSearchString({
-            access_type: ACCESS_TYPE,
-            action: ACTION,
-            client_id: CLIENT_ID,
-            code_challenge_method: 'foo',
-            prompt: PROMPT,
-            redirect_uri: QUERY_REDIRECT_URI,
-            scope: SCOPE,
-            state: STATE
-          });
-
-          return relier.fetch()
-            .then(assert.fail, (err) => {
-              assert.isTrue(OAuthErrors.is(err, 'INVALID_PARAMETER'));
-              assert.equal(err.param, 'code_challenge_method');
-            });
-        });
-      });
-
-      describe('verification flow', () => {
-        it('populates OAuth information from Session if verifying in the same browser', function () {
-          windowMock.location.search = TestHelpers.toSearchString({
-            client_id: CLIENT_ID,
-            code: '123',
-            redirect_uri: QUERY_REDIRECT_URI
-          });
-          Session.set('oauth', RESUME_INFO);
-
-          return relier.fetch()
-            .then(function () {
-              assert.equal(relier.get('state'), STATE);
-              // both clientId and service are populated from the stored info.
-              assert.equal(relier.get('clientId'), CLIENT_ID);
-              assert.equal(relier.get('service'), CLIENT_ID);
-              assert.equal(relier.get('scope'), SCOPE);
-              assert.equal(relier.get('accessType'), ACCESS_TYPE);
-            });
-        });
-
-        it('populates OAuth information from from the `service` query params if verifying in a second browser', function () {
-          windowMock.location.search = TestHelpers.toSearchString({
-            code: '123',
-            redirect_uri: QUERY_REDIRECT_URI,
-            scope: SCOPE,
-            service: CLIENT_ID
-          });
-
-          return relier.fetch()
-            .then(function () {
-              assert.equal(relier.get('clientId'), CLIENT_ID);
-              assert.equal(relier.get('service'), CLIENT_ID);
-            });
-        });
-      });
-
-      it('sets serviceName, and redirectUri from parameters returned by the server', function () {
+  describe('fetch', () => {
+    describe('signin/signup flow', () => {
+      it('populates expected fields from the search parameters', () => {
         windowMock.location.search = TestHelpers.toSearchString({
+          access_type: ACCESS_TYPE,
           action: ACTION,
           client_id: CLIENT_ID,
+          code_challenge: CODE_CHALLENGE,
+          code_challenge_method: CODE_CHALLENGE_METHOD,
+          prompt: PROMPT,
           redirect_uri: QUERY_REDIRECT_URI,
           scope: SCOPE,
           state: STATE
         });
 
         return relier.fetch()
-          .then(function () {
-            assert.equal(relier.get('serviceName'), SERVICE_NAME);
+          .then(() => {
+            // context is not imported from query params
+            assert.equal(relier.get('context'), Constants.OAUTH_CONTEXT);
+
+            assert.equal(relier.get('action'), ACTION);
+
+            assert.equal(relier.get('prompt'), PROMPT);
+
+            // service will be the client_id in the signin/up flow
+            assert.equal(relier.get('service'), CLIENT_ID);
+            assert.equal(relier.get('state'), STATE);
+
+            // client_id and redirect_uri are converted to camelCase
+            // for consistency with other variables in the app.
+            assert.equal(relier.get('clientId'), CLIENT_ID);
+            assert.equal(relier.get('accessType'), ACCESS_TYPE);
+
+            // The redirect_uri is matched with the server, if no match then we throw
             assert.equal(relier.get('redirectUri'), SERVER_REDIRECT_URI);
+
+            // PKCE parameters
+            assert.equal(relier.get('codeChallenge'), CODE_CHALLENGE);
+            assert.equal(relier.get('codeChallengeMethod'), CODE_CHALLENGE_METHOD);
           });
       });
 
-      describe('query parameter validation', function () {
-        describe('access_type', function () {
-          var validValues = [undefined, 'offline', 'online'];
-          testValidQueryParams('access_type', validValues, 'accessType', validValues);
-
-          var invalidValues = ['', ' ', 'invalid'];
-          testInvalidQueryParams('access_type', invalidValues);
+      it('throws if `service` is specified', () => {
+        windowMock.location.search = TestHelpers.toSearchString({
+          access_type: ACCESS_TYPE,
+          action: ACTION,
+          client_id: CLIENT_ID,
+          prompt: PROMPT,
+          redirect_uri: QUERY_REDIRECT_URI,
+          scope: SCOPE,
+          service: SERVICE,
+          state: STATE
         });
 
-        describe('action', function () {
-          var validValues = [undefined, 'email', 'signin', 'signup', 'force_auth'];
-          testValidQueryParams('action', validValues, 'action', validValues);
-
-          var invalidValues = ['', ' ', 'invalid'];
-          testInvalidQueryParams('action', invalidValues);
-        });
-
-        describe('login_hint', function () {
-          var validValues = [undefined, 'test@example.com'];
-          testValidQueryParams('login_hint', validValues, 'loginHint', validValues);
-
-          var invalidValues = ['', ' ', 'invalid'];
-          testInvalidQueryParams('login_hint', invalidValues);
-        });
-
-        describe('client_id', function () {
-          testMissingRequiredQueryParam('client_id');
-
-          var invalidValues = ['', ' ', 'not-hex'];
-          testInvalidQueryParams('client_id', invalidValues);
-
-          describe('is unknown', function () {
-            beforeEach(function () {
-              oAuthClient.getClientInfo.restore();
-              sinon.stub(oAuthClient, 'getClientInfo').callsFake(function () {
-                var err = OAuthErrors.toError('INVALID_PARAMETER');
-                err.validation = {
-                  keys: ['client_id']
-                };
-                return Promise.reject(err);
-              });
-
-              return fetchExpectError({
-                client_id: '1234567abcde', // Invalid client
-                scope: SCOPE
-              });
-            });
-
-            it('errors correctly', function () {
-              // INVALID_PARAMETER should be converted to UNKNOWN_CLIENT
-              assert.isTrue(OAuthErrors.is(err, 'UNKNOWN_CLIENT'));
-            });
+        return relier.fetch()
+          .then(assert.fail, (err) => {
+            assert.isTrue(OAuthErrors.is(err, 'INVALID_PARAMETER'));
           });
+      });
 
-          describe('is missing in verification flow', function () {
-            beforeEach(function () {
-              Session.set('oauth', {
-                action: ACTION,
-                scope: SCOPE,
-                state: STATE
-              });
-
-              return fetchExpectError({
-                code: '123'
-              });
-            });
-
-            it('errors correctly', function () {
-              assert.isTrue(OAuthErrors.is(err, 'MISSING_PARAMETER'));
-              assert.equal(err.param, 'client_id');
-            });
-          });
-
-          describe('is valid', function () {
-            beforeEach(function () {
-              return fetchExpectSuccess({
-                client_id: CLIENT_ID,
-                redirect_uri: QUERY_REDIRECT_URI,
-                scope: SCOPE
-              });
-            });
-
-            it('populates service with client_id', function () {
-              assert.equal(relier.get('service'), CLIENT_ID);
-            });
-          });
+      it('throws if invalid PKCE code_challenge is specified', () => {
+        windowMock.location.search = TestHelpers.toSearchString({
+          access_type: ACCESS_TYPE,
+          action: ACTION,
+          client_id: CLIENT_ID,
+          code_challenge: 'foo',
+          prompt: PROMPT,
+          redirect_uri: QUERY_REDIRECT_URI,
+          scope: SCOPE,
+          state: STATE
         });
 
-        describe('prompt', function () {
-          var invalidValues = ['', ' ', 'invalid'];
-          testInvalidQueryParams('prompt', invalidValues);
+        return relier.fetch()
+          .then(assert.fail, (err) => {
+            assert.isTrue(OAuthErrors.is(err, 'INVALID_PARAMETER'));
+            assert.equal(err.param, 'code_challenge');
+          });
+      });
 
-          var validValues = [undefined, Constants.OAUTH_PROMPT_CONSENT];
-          testValidQueryParams('prompt', validValues, 'prompt', validValues);
+      it('throws if invalid PKCE code_challenge_method is specified', () => {
+        windowMock.location.search = TestHelpers.toSearchString({
+          access_type: ACCESS_TYPE,
+          action: ACTION,
+          client_id: CLIENT_ID,
+          code_challenge_method: 'foo',
+          prompt: PROMPT,
+          redirect_uri: QUERY_REDIRECT_URI,
+          scope: SCOPE,
+          state: STATE
         });
 
-        describe('redirectTo', function () {
-          var invalidValues = ['', ' '];
-          testInvalidQueryParams('redirectTo', invalidValues);
+        return relier.fetch()
+          .then(assert.fail, (err) => {
+            assert.isTrue(OAuthErrors.is(err, 'INVALID_PARAMETER'));
+            assert.equal(err.param, 'code_challenge_method');
+          });
+      });
+    });
 
-          var validValues = [undefined, 'http://testdomain.com'];
-          testValidQueryParams('redirectTo', validValues, 'redirectTo', validValues);
+    describe('verification flow', () => {
+      it('populates OAuth information from Session if verifying in the same browser', () => {
+        windowMock.location.search = TestHelpers.toSearchString({
+          client_id: CLIENT_ID,
+          code: '123',
+          redirect_uri: QUERY_REDIRECT_URI
+        });
+        Session.set('oauth', RESUME_INFO);
+
+        return relier.fetch()
+          .then(() => {
+            assert.equal(relier.get('state'), STATE);
+            // both clientId and service are populated from the stored info.
+            assert.equal(relier.get('clientId'), CLIENT_ID);
+            assert.equal(relier.get('service'), CLIENT_ID);
+            assert.equal(relier.get('scope'), SCOPE);
+            assert.equal(relier.get('accessType'), ACCESS_TYPE);
+          });
+      });
+
+      it('populates OAuth information from from the `service` query params if verifying in a second browser', () => {
+        windowMock.location.search = TestHelpers.toSearchString({
+          code: '123',
+          redirect_uri: QUERY_REDIRECT_URI,
+          scope: SCOPE,
+          service: CLIENT_ID
         });
 
-        describe('redirect_uri', function () {
-          var validQueryParamValues = [QUERY_REDIRECT_URI];
-          // redirectUri will always be loaded from the server
-          var expectedValues = [SERVER_REDIRECT_URI, SERVER_REDIRECT_URI];
-          testValidQueryParams('redirect_uri', validQueryParamValues, 'redirectUri', expectedValues);
+        return relier.fetch()
+          .then(() => {
+            assert.equal(relier.get('clientId'), CLIENT_ID);
+            assert.equal(relier.get('service'), CLIENT_ID);
+          });
+      });
+    });
 
-          var invalidQueryParamValues = ['', ' ', 'not-a-url'];
-          testInvalidQueryParams('redirect_uri', invalidQueryParamValues);
+    it('sets serviceName, and redirectUri from parameters returned by the server', () => {
+      windowMock.location.search = TestHelpers.toSearchString({
+        action: ACTION,
+        client_id: CLIENT_ID,
+        redirect_uri: QUERY_REDIRECT_URI,
+        scope: SCOPE,
+        state: STATE
+      });
+
+      return relier.fetch()
+        .then(() => {
+          assert.equal(relier.get('serviceName'), SERVICE_NAME);
+          assert.equal(relier.get('redirectUri'), SERVER_REDIRECT_URI);
         });
+    });
 
-        describe('scope', function () {
-          testMissingRequiredQueryParam('scope');
+    describe('query parameter validation', () => {
+      describe('access_type', () => {
+        var validValues = [undefined, 'offline', 'online'];
+        testValidQueryParams('access_type', validValues, 'accessType', validValues);
 
-          var invalidValues = ['', ' '];
-          testInvalidQueryParams('scope', invalidValues);
+        var invalidValues = ['', ' ', 'invalid'];
+        testInvalidQueryParams('access_type', invalidValues);
+      });
 
-          describe('is valid', function () {
-            testValidQueryParam('scope', SCOPE, 'scope', SCOPE);
+      describe('action', () => {
+        var validValues = [undefined, 'email', 'signin', 'signup', 'force_auth'];
+        testValidQueryParams('action', validValues, 'action', validValues);
 
-            it('transforms to permissions', function () {
-              assert.deepEqual(relier.get('permissions'), PERMISSIONS);
-            });
+        var invalidValues = ['', ' ', 'invalid'];
+        testInvalidQueryParams('action', invalidValues);
+      });
 
-            it('transforms plus scopes to permissions', function () {
-              const SCOPE = 'profile:email+profile:uid';
+      describe('login_hint', () => {
+        var validValues = [undefined, 'test@example.com'];
+        // login_hint is translated to email if no email is set.
+        testValidQueryParams('login_hint', validValues, 'email', validValues);
 
-              windowMock.location.search = TestHelpers.toSearchString({
-                action: ACTION,
-                client_id: CLIENT_ID,
-                redirect_uri: QUERY_REDIRECT_URI,
-                scope: SCOPE,
-                state: STATE
-              });
+        var invalidValues = ['', ' ', 'invalid'];
+        testInvalidQueryParams('login_hint', invalidValues);
 
-              return relier.fetch()
-                .then(() => {
-                  assert.deepEqual(relier.get('permissions'), PERMISSIONS);
-                });
-            });
-          });
-
-          describe('untrusted reliers', function () {
-            beforeEach(function () {
-              sinon.stub(relier, 'isTrusted').callsFake(function () {
-                return false;
-              });
-            });
-
-            var validValues = [SCOPE_WITH_EXTRAS, SCOPE_WITH_OPENID];
-            var expectedValues = [SCOPE, SCOPE_WITH_OPENID];
-            testValidQueryParams('scope', validValues, 'scope', expectedValues);
-
-            var invalidValues = ['profile', 'profile:unrecognized'];
-            testInvalidQueryParams('scope', invalidValues);
-          });
-
-          describe('trusted reliers that dont ask for consent', function () {
-            beforeEach(function () {
-              sinon.stub(relier, 'isTrusted').callsFake(function () {
-                return true;
-              });
-              sinon.stub(relier, 'wantsConsent').callsFake(function () {
-                return false;
-              });
-            });
-
-            var validValues = [SCOPE_WITH_EXTRAS, SCOPE_PROFILE, 'profile:unrecognized'];
-            var expectedValues = [SCOPE_WITH_EXTRAS, SCOPE_PROFILE, 'profile:unrecognized'];
-            testValidQueryParams('scope', validValues, 'scope', expectedValues);
-          });
-
-          describe('trusted reliers that ask for consent', function () {
-            beforeEach(function () {
-              sinon.stub(relier, 'isTrusted').callsFake(function () {
-                return true;
-              });
-              sinon.stub(relier, 'wantsConsent').callsFake(function () {
-                return true;
-              });
-            });
-
-            var validValues = [SCOPE_WITH_EXTRAS, SCOPE_PROFILE, 'profile:unrecognized'];
-            var expectedValues = [SCOPE_WITH_EXTRAS, SCOPE_PROFILE_EXPANDED, 'profile:unrecognized'];
-            testValidQueryParams('scope', validValues, 'scope', expectedValues);
+        it('email takes precedence with both sent', () => {
+          return fetchExpectSuccess({
+            client_id: CLIENT_ID,
+            email: 'test@example.com',
+            login_hint: 'does_not_overwrite@example.com', //eslint_disable_line camelcase
+            redirect_uri: QUERY_REDIRECT_URI,
+            scope: SCOPE,
+          }).then(() => {
+            assert.equal(relier.get('email'), 'test@example.com');
           });
         });
       });
 
-      describe('client info validation', function () {
+      describe('client_id', () => {
+        testMissingRequiredQueryParam('client_id');
 
-        describe('image_uri', function () {
-          // leading & trailing whitespace will be trimmed
-          var validValues = ['', ' ', CLIENT_IMAGE_URI, ' ' + CLIENT_IMAGE_URI];
-          var expectedValues = ['', '', CLIENT_IMAGE_URI, CLIENT_IMAGE_URI];
-          testValidClientInfoValues(
-            'image_uri', validValues, 'imageUri', expectedValues);
+        var invalidValues = ['', ' ', 'not-hex'];
+        testInvalidQueryParams('client_id', invalidValues);
 
-          var invalidValues = ['not-a-url'];
-          testInvalidClientInfoValues('image_uri', invalidValues);
-        });
-
-        describe('name', function () {
-          var validValues = ['client name'];
-          testValidClientInfoValues('name', validValues, 'serviceName', validValues);
-
-          var invalidValues = ['', ' '];
-          testInvalidClientInfoValues('name', invalidValues);
-        });
-
-        describe('redirect_uri', function () {
-          describe('is missing on the server', function () {
-            testMissingClientInfoValue('redirect_uri');
-          });
-
-          var invalidClientInfoValues = ['', ' '];
-          testInvalidClientInfoValues('redirect_uri', invalidClientInfoValues);
-        });
-
-        describe('trusted', function () {
-          var validValues = ['true', true, 'false', false];
-          var expected = [true, true, false, false];
-          testValidClientInfoValues('trusted', validValues, 'trusted', expected);
-          var invalidValues = ['', 'not-a-boolean'];
-          testInvalidClientInfoValues('trusted', invalidValues);
-        });
-      });
-
-      describe('scoped-keys request validation', function () {
-
-        describe('fails', function () {
-          beforeEach(function () {
-            sinon.stub(relier, '_validateKeyScopeRequest').callsFake(function () {
-              throw new Error('Invalid redirect parameter');
+        describe('is unknown', () => {
+          beforeEach(() => {
+            oAuthClient.getClientInfo.restore();
+            sinon.stub(oAuthClient, 'getClientInfo').callsFake(() => {
+              var err = OAuthErrors.toError('INVALID_PARAMETER');
+              err.validation = {
+                keys: ['client_id']
+              };
+              return Promise.reject(err);
             });
 
             return fetchExpectError({
-              client_id: CLIENT_ID,
+              client_id: '1234567abcde', // Invalid client
               scope: SCOPE
             });
           });
 
-          it('errors correctly', function () {
-            assert.equal(err.message, 'Invalid redirect parameter');
+          it('errors correctly', () => {
+            // INVALID_PARAMETER should be converted to UNKNOWN_CLIENT
+            assert.isTrue(OAuthErrors.is(err, 'UNKNOWN_CLIENT'));
           });
         });
 
-        describe('succeeds', function () {
-          beforeEach(function () {
-            sinon.stub(relier, '_validateKeyScopeRequest').callsFake(function () {
-              return true;
+        describe('is missing in verification flow', () => {
+          beforeEach(() => {
+            Session.set('oauth', {
+              action: ACTION,
+              scope: SCOPE,
+              state: STATE
             });
 
+            return fetchExpectError({
+              code: '123'
+            });
+          });
+
+          it('errors correctly', () => {
+            assert.isTrue(OAuthErrors.is(err, 'MISSING_PARAMETER'));
+            assert.equal(err.param, 'client_id');
+          });
+        });
+
+        describe('is valid', () => {
+          beforeEach(() => {
             return fetchExpectSuccess({
               client_id: CLIENT_ID,
-              keys_jwk: 'keysJwk',
+              redirect_uri: QUERY_REDIRECT_URI,
               scope: SCOPE
             });
           });
 
-          it('returns correctly', function () {
-            assert.equal(relier.get('keysJwk'), 'keysJwk');
+          it('populates service with client_id', () => {
+            assert.equal(relier.get('service'), CLIENT_ID);
           });
         });
       });
+
+      describe('prompt', () => {
+        var invalidValues = ['', ' ', 'invalid'];
+        testInvalidQueryParams('prompt', invalidValues);
+
+        var validValues = [undefined, Constants.OAUTH_PROMPT_CONSENT];
+        testValidQueryParams('prompt', validValues, 'prompt', validValues);
+      });
+
+      describe('redirectTo', () => {
+        var invalidValues = ['', ' '];
+        testInvalidQueryParams('redirectTo', invalidValues);
+
+        var validValues = [undefined, 'http://testdomain.com'];
+        testValidQueryParams('redirectTo', validValues, 'redirectTo', validValues);
+      });
+
+      describe('redirect_uri', () => {
+        var validQueryParamValues = [QUERY_REDIRECT_URI];
+        // redirectUri will always be loaded from the server
+        var expectedValues = [SERVER_REDIRECT_URI, SERVER_REDIRECT_URI];
+        testValidQueryParams('redirect_uri', validQueryParamValues, 'redirectUri', expectedValues);
+
+        var invalidQueryParamValues = ['', ' ', 'not-a-url'];
+        testInvalidQueryParams('redirect_uri', invalidQueryParamValues);
+      });
+
+      describe('scope', () => {
+        testMissingRequiredQueryParam('scope');
+
+        var invalidValues = ['', ' '];
+        testInvalidQueryParams('scope', invalidValues);
+
+        describe('is valid', () => {
+          testValidQueryParam('scope', SCOPE, 'scope', SCOPE);
+
+          it('transforms to permissions', () => {
+            assert.deepEqual(relier.get('permissions'), PERMISSIONS);
+          });
+
+          it('transforms plus scopes to permissions', () => {
+            const SCOPE = 'profile:email+profile:uid';
+
+            windowMock.location.search = TestHelpers.toSearchString({
+              action: ACTION,
+              client_id: CLIENT_ID,
+              redirect_uri: QUERY_REDIRECT_URI,
+              scope: SCOPE,
+              state: STATE
+            });
+
+            return relier.fetch()
+              .then(() => {
+                assert.deepEqual(relier.get('permissions'), PERMISSIONS);
+              });
+          });
+        });
+
+        describe('untrusted reliers', () => {
+          beforeEach(() => {
+            sinon.stub(relier, 'isTrusted').callsFake(() => {
+              return false;
+            });
+          });
+
+          var validValues = [SCOPE_WITH_EXTRAS, SCOPE_WITH_OPENID];
+          var expectedValues = [SCOPE, SCOPE_WITH_OPENID];
+          testValidQueryParams('scope', validValues, 'scope', expectedValues);
+
+          var invalidValues = ['profile', 'profile:unrecognized'];
+          testInvalidQueryParams('scope', invalidValues);
+        });
+
+        describe('trusted reliers that dont ask for consent', () => {
+          beforeEach(() => {
+            sinon.stub(relier, 'isTrusted').callsFake(() => {
+              return true;
+            });
+            sinon.stub(relier, 'wantsConsent').callsFake(() => {
+              return false;
+            });
+          });
+
+          var validValues = [SCOPE_WITH_EXTRAS, SCOPE_PROFILE, 'profile:unrecognized'];
+          var expectedValues = [SCOPE_WITH_EXTRAS, SCOPE_PROFILE, 'profile:unrecognized'];
+          testValidQueryParams('scope', validValues, 'scope', expectedValues);
+        });
+
+        describe('trusted reliers that ask for consent', () => {
+          beforeEach(() => {
+            sinon.stub(relier, 'isTrusted').callsFake(() => {
+              return true;
+            });
+            sinon.stub(relier, 'wantsConsent').callsFake(() => {
+              return true;
+            });
+          });
+
+          var validValues = [SCOPE_WITH_EXTRAS, SCOPE_PROFILE, 'profile:unrecognized'];
+          var expectedValues = [SCOPE_WITH_EXTRAS, SCOPE_PROFILE_EXPANDED, 'profile:unrecognized'];
+          testValidQueryParams('scope', validValues, 'scope', expectedValues);
+        });
+      });
     });
 
-    describe('isTrusted', function () {
-      beforeEach(function () {
-        windowMock.location.search = TestHelpers.toSearchString({
-          client_id: CLIENT_ID,
-          redirect_uri: QUERY_REDIRECT_URI,
-          scope: SCOPE
-        });
+    describe('client info validation', () => {
+
+      describe('image_uri', () => {
+        // leading & trailing whitespace will be trimmed
+        var validValues = ['', ' ', CLIENT_IMAGE_URI, ' ' + CLIENT_IMAGE_URI];
+        var expectedValues = ['', '', CLIENT_IMAGE_URI, CLIENT_IMAGE_URI];
+        testValidClientInfoValues(
+          'image_uri', validValues, 'imageUri', expectedValues);
+
+        var invalidValues = ['not-a-url'];
+        testInvalidClientInfoValues('image_uri', invalidValues);
       });
 
-      describe('when `trusted` is true', function () {
-        beforeEach(function () {
-          isTrusted = true;
-          return relier.fetch();
-        });
+      describe('name', () => {
+        var validValues = ['client name'];
+        testValidClientInfoValues('name', validValues, 'serviceName', validValues);
 
-        it('returns `true`', function () {
-          assert.isTrue(relier.isTrusted());
-        });
+        var invalidValues = ['', ' '];
+        testInvalidClientInfoValues('name', invalidValues);
       });
 
-      describe('when `trusted` is false', function () {
-        beforeEach(function () {
-          isTrusted = false;
-          return relier.fetch();
+      describe('redirect_uri', () => {
+        describe('is missing on the server', () => {
+          testMissingClientInfoValue('redirect_uri');
         });
 
-        it('returns `false`', function () {
-          assert.isFalse(relier.isTrusted());
-        });
+        var invalidClientInfoValues = ['', ' '];
+        testInvalidClientInfoValues('redirect_uri', invalidClientInfoValues);
+      });
+
+      describe('trusted', () => {
+        var validValues = ['true', true, 'false', false];
+        var expected = [true, true, false, false];
+        testValidClientInfoValues('trusted', validValues, 'trusted', expected);
+        var invalidValues = ['', 'not-a-boolean'];
+        testInvalidClientInfoValues('trusted', invalidValues);
       });
     });
 
-    describe('isOAuth', function () {
-      it('returns `true`', function () {
-        assert.isTrue(relier.isOAuth());
-      });
-    });
+    describe('scoped-keys request validation', () => {
 
-    describe('pickResumeTokenInfo', function () {
-      it('returns an object with info to be passed along with email verification links', function () {
-        var UTM_CAMPAIGN = 'campaign id';
-        var ITEM = 'item';
-        var ENTRYPOINT = 'entry point';
-        var STATE = 'some long opaque state token';
+      describe('fails', () => {
+        beforeEach(() => {
+          sinon.stub(relier, '_validateKeyScopeRequest').callsFake(() => {
+            throw new Error('Invalid redirect parameter');
+          });
 
-        relier.set({
-          entrypoint: ENTRYPOINT,
-          notPassed: 'this should not be picked',
-          resetPasswordConfirm: false,
-          state: STATE,
-          utmCampaign: UTM_CAMPAIGN,
-          utmContent: ITEM,
-          utmMedium: ITEM,
-          utmSource: ITEM,
-          utmTerm: ITEM
+          return fetchExpectError({
+            client_id: CLIENT_ID,
+            scope: SCOPE
+          });
         });
 
-        assert.deepEqual(relier.pickResumeTokenInfo(), {
-          // ensure campaign and entrypoint from
-          // the Relier are still passed.
-          entrypoint: ENTRYPOINT,
-          resetPasswordConfirm: false,
-          utmCampaign: UTM_CAMPAIGN,
-          utmContent: ITEM,
-          utmMedium: ITEM,
-          utmSource: ITEM,
-          utmTerm: ITEM
-        });
-      });
-    });
-
-    describe('_validateKeyScopeRequest', () => {
-      const scopeApp1 = 'profile openid https://identity.mozilla.com/apps/lockbox';
-      const scopeApp1Redirect = 'https://dee85c67bd72f3de1f0a0fb62a8fe9b9b1a166d7.extensions.allizom.org';
-      const scopeApp1Redirect2 = 'lockbox://redirect.ios';
-      const scopeApp2Redirect = 'https://2aa95473a5115d5f3deb36bb6875cf76f05e4c4d.extensions.allizom.org';
-      const scopeNormal = 'profile';
-
-      beforeEach(() => {
-        relier._config.scopedKeysValidation = {
-          'https://identity.mozilla.com/apps/lockbox': {
-            redirectUris: [
-              scopeApp1Redirect,
-              scopeApp1Redirect2
-            ]
-          },
-          'https://identity.mozilla.com/apps/notes': {
-            redirectUris: [
-              scopeApp2Redirect
-            ]
-          }
-        };
-      });
-
-      it('returns false by default', () => {
-        relier.set('scope', scopeNormal);
-        assert.isFalse(relier._validateKeyScopeRequest());
-      });
-
-      it('returns true if scopes match at least one redirect uri', () => {
-        relier.set('keysJwk', 'jwk');
-        relier.set('scope', scopeApp1);
-        relier.set('redirectUri', scopeApp1Redirect);
-        assert.isTrue(relier._validateKeyScopeRequest());
-
-        relier.set('scope', scopeApp1);
-        relier.set('redirectUri', scopeApp1Redirect2);
-        assert.isTrue(relier._validateKeyScopeRequest());
-      });
-
-      it('throws if a client requests keys for an unknown scoped key scope', (done) => {
-        relier.set('keysJwk', 'jwk');
-        relier.set('scope', 'https://identity.mozilla.org/not-found');
-        relier.set('redirectUri', scopeApp2Redirect);
-
-        try {
-          relier._validateKeyScopeRequest();
-        } catch (err) {
-          assert.equal(err.message, 'No key-bearing scopes requested');
-          done();
-        }
-      });
-
-      it('throws if a client requests a scope that does not belong to it', (done) => {
-        relier.set('keysJwk', 'jwk');
-        relier.set('scope', scopeApp1);
-        relier.set('redirectUri', scopeApp2Redirect);
-
-        try {
-          relier._validateKeyScopeRequest();
-        } catch (err) {
+        it('errors correctly', () => {
           assert.equal(err.message, 'Invalid redirect parameter');
-          done();
+        });
+      });
+
+      describe('succeeds', () => {
+        beforeEach(() => {
+          sinon.stub(relier, '_validateKeyScopeRequest').callsFake(() => {
+            return true;
+          });
+
+          return fetchExpectSuccess({
+            client_id: CLIENT_ID,
+            keys_jwk: 'keysJwk',
+            scope: SCOPE
+          });
+        });
+
+        it('returns correctly', () => {
+          assert.equal(relier.get('keysJwk'), 'keysJwk');
+        });
+      });
+    });
+  });
+
+  describe('isTrusted', () => {
+    beforeEach(() => {
+      windowMock.location.search = TestHelpers.toSearchString({
+        client_id: CLIENT_ID,
+        redirect_uri: QUERY_REDIRECT_URI,
+        scope: SCOPE
+      });
+    });
+
+    describe('when `trusted` is true', () => {
+      beforeEach(() => {
+        isTrusted = true;
+        return relier.fetch();
+      });
+
+      it('returns `true`', () => {
+        assert.isTrue(relier.isTrusted());
+      });
+    });
+
+    describe('when `trusted` is false', () => {
+      beforeEach(() => {
+        isTrusted = false;
+        return relier.fetch();
+      });
+
+      it('returns `false`', () => {
+        assert.isFalse(relier.isTrusted());
+      });
+    });
+  });
+
+  describe('isOAuth', () => {
+    it('returns `true`', () => {
+      assert.isTrue(relier.isOAuth());
+    });
+  });
+
+  describe('pickResumeTokenInfo', () => {
+    it('returns an object with info to be passed along with email verification links', () => {
+      var UTM_CAMPAIGN = 'campaign id';
+      var ITEM = 'item';
+      var ENTRYPOINT = 'entry point';
+      var STATE = 'some long opaque state token';
+
+      relier.set({
+        entrypoint: ENTRYPOINT,
+        notPassed: 'this should not be picked',
+        resetPasswordConfirm: false,
+        state: STATE,
+        utmCampaign: UTM_CAMPAIGN,
+        utmContent: ITEM,
+        utmMedium: ITEM,
+        utmSource: ITEM,
+        utmTerm: ITEM
+      });
+
+      assert.deepEqual(relier.pickResumeTokenInfo(), {
+        // ensure campaign and entrypoint from
+        // the Relier are still passed.
+        entrypoint: ENTRYPOINT,
+        resetPasswordConfirm: false,
+        utmCampaign: UTM_CAMPAIGN,
+        utmContent: ITEM,
+        utmMedium: ITEM,
+        utmSource: ITEM,
+        utmTerm: ITEM
+      });
+    });
+  });
+
+  describe('_validateKeyScopeRequest', () => {
+    const scopeApp1 = 'profile openid https://identity.mozilla.com/apps/lockbox';
+    const scopeApp1Redirect = 'https://dee85c67bd72f3de1f0a0fb62a8fe9b9b1a166d7.extensions.allizom.org';
+    const scopeApp1Redirect2 = 'lockbox://redirect.ios';
+    const scopeApp2Redirect = 'https://2aa95473a5115d5f3deb36bb6875cf76f05e4c4d.extensions.allizom.org';
+    const scopeNormal = 'profile';
+
+    beforeEach(() => {
+      relier._config.scopedKeysValidation = {
+        'https://identity.mozilla.com/apps/lockbox': {
+          redirectUris: [
+            scopeApp1Redirect,
+            scopeApp1Redirect2
+          ]
+        },
+        'https://identity.mozilla.com/apps/notes': {
+          redirectUris: [
+            scopeApp2Redirect
+          ]
         }
+      };
+    });
+
+    it('returns false by default', () => {
+      relier.set('scope', scopeNormal);
+      assert.isFalse(relier._validateKeyScopeRequest());
+    });
+
+    it('returns true if scopes match at least one redirect uri', () => {
+      relier.set('keysJwk', 'jwk');
+      relier.set('scope', scopeApp1);
+      relier.set('redirectUri', scopeApp1Redirect);
+      assert.isTrue(relier._validateKeyScopeRequest());
+
+      relier.set('scope', scopeApp1);
+      relier.set('redirectUri', scopeApp1Redirect2);
+      assert.isTrue(relier._validateKeyScopeRequest());
+    });
+
+    it('throws if a client requests keys for an unknown scoped key scope', (done) => {
+      relier.set('keysJwk', 'jwk');
+      relier.set('scope', 'https://identity.mozilla.org/not-found');
+      relier.set('redirectUri', scopeApp2Redirect);
+
+      try {
+        relier._validateKeyScopeRequest();
+      } catch (err) {
+        assert.equal(err.message, 'No key-bearing scopes requested');
+        done();
+      }
+    });
+
+    it('throws if a client requests a scope that does not belong to it', (done) => {
+      relier.set('keysJwk', 'jwk');
+      relier.set('scope', scopeApp1);
+      relier.set('redirectUri', scopeApp2Redirect);
+
+      try {
+        relier._validateKeyScopeRequest();
+      } catch (err) {
+        assert.equal(err.message, 'Invalid redirect parameter');
+        done();
+      }
+    });
+  });
+
+  describe('wantsKeys', () => {
+    it('returns false by default', () => {
+      assert.isFalse(relier.wantsKeys());
+    });
+
+    it('returns false when scopedKeysEnabled is configured to false', () => {
+      relier._config.scopedKeysEnabled = false;
+      relier.set('keysJwk', 'jwk');
+      assert.isFalse(relier.wantsKeys());
+    });
+
+    it('returns false when relier did not specify keysJwk', () => {
+      relier._config.scopedKeysEnabled = true;
+      assert.isFalse(relier.wantsKeys());
+    });
+
+    it('returns true with keysJwk and enabled scoped keys', () => {
+      relier._config.scopedKeysEnabled = true;
+      relier.set('keysJwk', 'jwk');
+      assert.isTrue(relier.wantsKeys());
+    });
+  });
+
+  describe('wantsConsent', () => {
+    describe('prompt=consent', () => {
+      beforeEach(() => {
+        relier.set('prompt', 'consent');
+      });
+
+      it('returns true', () => {
+        assert.isTrue(relier.wantsConsent());
       });
     });
 
-    describe('wantsKeys', () => {
-      it('returns false by default', () => {
-        assert.isFalse(relier.wantsKeys());
+    describe('otherwise', () => {
+      beforeEach(() => {
+        relier.unset('prompt');
       });
 
-      it('returns false when scopedKeysEnabled is configured to false', () => {
-        relier._config.scopedKeysEnabled = false;
-        relier.set('keysJwk', 'jwk');
-        assert.isFalse(relier.wantsKeys());
+      it('returns false', () => {
+        assert.isFalse(relier.wantsConsent());
+      });
+    });
+  });
+
+  describe('accountNeedsPermissions', () => {
+    var account;
+    var hasSeenPermissions;
+
+    beforeEach(() => {
+      account = user.initAccount();
+      account.set('email', 'testuser@testuser.com');
+
+      hasSeenPermissions = false;
+
+      sinon.stub(account, 'hasSeenPermissions').callsFake(() => {
+        return hasSeenPermissions;
       });
 
-      it('returns false when relier did not specify keysJwk', () => {
-        relier._config.scopedKeysEnabled = true;
-        assert.isFalse(relier.wantsKeys());
-      });
-
-      it('returns true with keysJwk and enabled scoped keys', () => {
-        relier._config.scopedKeysEnabled = true;
-        relier.set('keysJwk', 'jwk');
-        assert.isTrue(relier.wantsKeys());
+      relier.set({
+        clientId: CLIENT_ID,
+        permissions: ['profile:email', 'profile:display_name']
       });
     });
 
-    describe('wantsConsent', function () {
-      describe('prompt=consent', function () {
-        beforeEach(function () {
-          relier.set('prompt', 'consent');
-        });
-
-        it('returns true', function () {
-          assert.isTrue(relier.wantsConsent());
-        });
+    describe('a trusted relier', () => {
+      beforeEach(() => {
+        relier.set('trusted', true);
       });
 
-      describe('otherwise', function () {
-        beforeEach(function () {
+      describe('without prompt=consent', () => {
+        beforeEach(() => {
           relier.unset('prompt');
         });
 
-        it('returns false', function () {
-          assert.isFalse(relier.wantsConsent());
-        });
-      });
-    });
-
-    describe('accountNeedsPermissions', function () {
-      var account;
-      var hasSeenPermissions;
-
-      beforeEach(function () {
-        account = user.initAccount();
-        account.set('email', 'testuser@testuser.com');
-
-        hasSeenPermissions = false;
-
-        sinon.stub(account, 'hasSeenPermissions').callsFake(function () {
-          return hasSeenPermissions;
-        });
-
-        relier.set({
-          clientId: CLIENT_ID,
-          permissions: ['profile:email', 'profile:display_name']
+        it('returns false', () => {
+          assert.isFalse(relier.accountNeedsPermissions(account));
         });
       });
 
-      describe('a trusted relier', function () {
-        beforeEach(function () {
-          relier.set('trusted', true);
+      describe('with prompt=consent', () => {
+        beforeEach(() => {
+          relier.set('prompt', 'consent');
         });
 
-        describe('without prompt=consent', function () {
-          beforeEach(function () {
-            relier.unset('prompt');
-          });
-
-          it('returns false', function () {
-            assert.isFalse(relier.accountNeedsPermissions(account));
-          });
-        });
-
-        describe('with prompt=consent', function () {
-          beforeEach(function () {
-            relier.set('prompt', 'consent');
-          });
-
-          describe('account does not need additional permissions', function () {
-            beforeEach(function () {
-              hasSeenPermissions = true;
-            });
-
-            it('returns false', function () {
-              assert.isFalse(relier.accountNeedsPermissions(account));
-            });
-          });
-
-          describe('account needs additional permissions', function () {
-            beforeEach(function () {
-              hasSeenPermissions = false;
-            });
-
-            it('returns true', function () {
-              assert.isTrue(relier.accountNeedsPermissions(account));
-            });
-          });
-        });
-      });
-
-      describe('an untrusted relier', function () {
-        beforeEach(function () {
-          relier.set('trusted', false);
-        });
-
-        describe('account has seen all the permissions', function () {
-          beforeEach(function () {
+        describe('account does not need additional permissions', () => {
+          beforeEach(() => {
             hasSeenPermissions = true;
           });
 
-          it('should return false', function () {
+          it('returns false', () => {
             assert.isFalse(relier.accountNeedsPermissions(account));
-          });
-
-          it('should filter any permissions for which the account has no value', function () {
-            relier.accountNeedsPermissions(account);
-            assert.isTrue(account.hasSeenPermissions.calledWith(CLIENT_ID, ['profile:email']));
           });
         });
 
-        describe('account has not seen all permissions', function () {
-          beforeEach(function () {
+        describe('account needs additional permissions', () => {
+          beforeEach(() => {
             hasSeenPermissions = false;
           });
 
-          it('should return true', function () {
+          it('returns true', () => {
             assert.isTrue(relier.accountNeedsPermissions(account));
-          });
-
-          it('should filter any permissions for which the account has no value', function () {
-            relier.accountNeedsPermissions(account);
-            assert.isTrue(account.hasSeenPermissions.calledWith(CLIENT_ID, ['profile:email']));
           });
         });
       });
     });
 
-    function mockGetClientInfo(paramName, paramValue) {
-      if (oAuthClient.getClientInfo.restore) {
-        oAuthClient.getClientInfo.restore();
+    describe('an untrusted relier', () => {
+      beforeEach(() => {
+        relier.set('trusted', false);
+      });
+
+      describe('account has seen all the permissions', () => {
+        beforeEach(() => {
+          hasSeenPermissions = true;
+        });
+
+        it('should return false', () => {
+          assert.isFalse(relier.accountNeedsPermissions(account));
+        });
+
+        it('should filter any permissions for which the account has no value', () => {
+          relier.accountNeedsPermissions(account);
+          assert.isTrue(account.hasSeenPermissions.calledWith(CLIENT_ID, ['profile:email']));
+        });
+      });
+
+      describe('account has not seen all permissions', () => {
+        beforeEach(() => {
+          hasSeenPermissions = false;
+        });
+
+        it('should return true', () => {
+          assert.isTrue(relier.accountNeedsPermissions(account));
+        });
+
+        it('should filter any permissions for which the account has no value', () => {
+          relier.accountNeedsPermissions(account);
+          assert.isTrue(account.hasSeenPermissions.calledWith(CLIENT_ID, ['profile:email']));
+        });
+      });
+    });
+  });
+
+  function mockGetClientInfo(paramName, paramValue) {
+    if (oAuthClient.getClientInfo.restore) {
+      oAuthClient.getClientInfo.restore();
+    }
+
+    sinon.stub(oAuthClient, 'getClientInfo').callsFake(() => {
+      var clientInfo = {
+        id: CLIENT_ID,
+        name: SERVICE_NAME,
+        redirect_uri: SERVER_REDIRECT_URI,
+        trusted: isTrusted
+      };
+
+      if (! _.isUndefined(paramName)) {
+        if (_.isUndefined(paramValue)) {
+          delete clientInfo[paramName];
+        } else {
+          clientInfo[paramName] = paramValue;
+        }
       }
 
-      sinon.stub(oAuthClient, 'getClientInfo').callsFake(function () {
-        var clientInfo = {
-          id: CLIENT_ID,
-          name: SERVICE_NAME,
-          redirect_uri: SERVER_REDIRECT_URI,
-          trusted: isTrusted
-        };
+      return Promise.resolve(clientInfo);
+    });
+  }
 
-        if (! _.isUndefined(paramName)) {
-          if (_.isUndefined(paramValue)) {
-            delete clientInfo[paramName];
-          } else {
-            clientInfo[paramName] = paramValue;
-          }
-        }
+  function fetchExpectError(params) {
+    windowMock.location.search = TestHelpers.toSearchString(params);
 
-        return Promise.resolve(clientInfo);
+    return relier.fetch()
+      .then(assert.fail, function (_err) {
+        err = _err;
       });
-    }
+  }
 
-    function fetchExpectError(params) {
-      windowMock.location.search = TestHelpers.toSearchString(params);
+  function fetchExpectSuccess(params) {
+    windowMock.location.search = TestHelpers.toSearchString(params);
 
-      return relier.fetch()
-        .then(assert.fail, function (_err) {
-          err = _err;
-        });
-    }
+    return relier.fetch();
+  }
 
-    function fetchExpectSuccess(params) {
-      windowMock.location.search = TestHelpers.toSearchString(params);
-
-      return relier.fetch();
-    }
-
-    function testInvalidQueryParams(paramName, values) {
-      describe('invalid', function () {
-        values.forEach(function (value) {
-          var description = 'is ' + getValueLabel(value);
-          describe(description, function () {
-            testInvalidQueryParam(paramName, value);
-          });
+  function testInvalidQueryParams(paramName, values) {
+    describe('invalid', () => {
+      values.forEach(function (value) {
+        var description = 'is ' + getValueLabel(value);
+        describe(description, () => {
+          testInvalidQueryParam(paramName, value);
         });
       });
-    }
+    });
+  }
 
-    function testInvalidQueryParam(paramName, value) {
-      beforeEach(function () {
+  function testInvalidQueryParam(paramName, value) {
+    beforeEach(() => {
+      var params = {
+        client_id: CLIENT_ID,
+        redirect_uri: QUERY_REDIRECT_URI,
+        scope: SCOPE
+      };
+
+      if (! _.isUndefined(value)) {
+        params[paramName] = value;
+      } else {
+        delete params[paramName];
+      }
+
+      return fetchExpectError(params);
+    });
+
+    it('errors correctly', () => {
+      assert.isTrue(OAuthErrors.is(err, 'INVALID_PARAMETER'));
+      assert.equal(err.param, paramName);
+    });
+  }
+
+  function testMissingRequiredQueryParam(paramName) {
+    describe('is missing', () => {
+      beforeEach(() => {
         var params = {
           client_id: CLIENT_ID,
           redirect_uri: QUERY_REDIRECT_URI,
           scope: SCOPE
         };
 
-        if (! _.isUndefined(value)) {
-          params[paramName] = value;
-        } else {
-          delete params[paramName];
-        }
+        delete params[paramName];
 
         return fetchExpectError(params);
       });
 
-      it('errors correctly', function () {
-        assert.isTrue(OAuthErrors.is(err, 'INVALID_PARAMETER'));
-        assert.equal(err.param, paramName);
-      });
-    }
-
-    function testMissingRequiredQueryParam(paramName) {
-      describe('is missing', function () {
-        beforeEach(function () {
-          var params = {
-            client_id: CLIENT_ID,
-            redirect_uri: QUERY_REDIRECT_URI,
-            scope: SCOPE
-          };
-
-          delete params[paramName];
-
-          return fetchExpectError(params);
-        });
-
-        it('errors correctly', function () {
-          assert.isTrue(OAuthErrors.is(err, 'MISSING_PARAMETER'));
-          assert.equal(err.param, paramName);
-        });
-      });
-    }
-
-    function testValidQueryParams(paramName, values, modelName, expectedValues) {
-      describe('valid', function () {
-        values.forEach(function (value, index) {
-          var description = 'is ' + getValueLabel(value);
-          describe(description, function () {
-            var expectedValue = expectedValues[index];
-            testValidQueryParam(paramName, value, modelName, expectedValue);
-          });
-        });
-      });
-    }
-
-    function testValidQueryParam(paramName, paramValue, modelName, expectedValue) {
-      beforeEach(function () {
-        var params = {
-          client_id: CLIENT_ID,
-          redirect_uri: QUERY_REDIRECT_URI,
-          scope: SCOPE
-        };
-
-        if (! _.isUndefined(paramValue)) {
-          params[paramName] = paramValue;
-        } else {
-          delete params[paramName];
-        }
-
-        return fetchExpectSuccess(params);
-      });
-
-      it('is successful', function () {
-        if (_.isUndefined(expectedValue)) {
-          assert.isFalse(relier.has(modelName));
-        } else {
-          assert.equal(relier.get(modelName), expectedValue);
-        }
-      });
-    }
-
-    function testMissingClientInfoValue(paramName) {
-      beforeEach(function () {
-        mockGetClientInfo(paramName, undefined);
-
-        return fetchExpectError({
-          client_id: CLIENT_ID,
-          scope: SCOPE
-        });
-      });
-
-      it('errors correctly', function () {
+      it('errors correctly', () => {
         assert.isTrue(OAuthErrors.is(err, 'MISSING_PARAMETER'));
         assert.equal(err.param, paramName);
       });
-    }
+    });
+  }
 
-    function testInvalidClientInfoValues(paramName, values) {
-      values.forEach(function (value) {
-        var description = 'is ' + getValueLabel(value);
-        describe(description, function () {
-          testInvalidClientInfoValue(paramName, value);
-        });
-      });
-    }
-
-    function testInvalidClientInfoValue(paramName, paramValue) {
-      beforeEach(function () {
-        mockGetClientInfo(paramName, paramValue);
-
-        return fetchExpectError({
-          client_id: CLIENT_ID,
-          scope: SCOPE
-        });
-      });
-
-      it('errors correctly', function () {
-        assert.isTrue(OAuthErrors.is(err, 'INVALID_PARAMETER'));
-        assert.equal(err.param, paramName);
-      });
-    }
-
-    function testValidClientInfo(paramName, paramValue, modelName, expectedValue) {
-      beforeEach(function () {
-        mockGetClientInfo(paramName, paramValue);
-
-        return fetchExpectSuccess({
-          client_id: CLIENT_ID,
-          redirect_uri: QUERY_REDIRECT_URI,
-          scope: SCOPE
-        });
-      });
-
-      it('is successful', function () {
-        if (_.isUndefined(expectedValue)) {
-          assert.isFalse(relier.has(modelName));
-        } else {
-          assert.equal(relier.get(modelName), expectedValue);
-        }
-      });
-    }
-
-    function testValidClientInfoValues(paramName, values, modelName, expectedValues) {
+  function testValidQueryParams(paramName, values, modelName, expectedValues) {
+    describe('valid', () => {
       values.forEach(function (value, index) {
         var description = 'is ' + getValueLabel(value);
-        describe(description, function () {
+        describe(description, () => {
           var expectedValue = expectedValues[index];
-          testValidClientInfo(paramName, value, modelName, expectedValue);
+          testValidQueryParam(paramName, value, modelName, expectedValue);
         });
       });
-    }
-  });
+    });
+  }
+
+  function testValidQueryParam(paramName, paramValue, modelName, expectedValue) {
+    beforeEach(() => {
+      var params = {
+        client_id: CLIENT_ID,
+        redirect_uri: QUERY_REDIRECT_URI,
+        scope: SCOPE
+      };
+
+      if (! _.isUndefined(paramValue)) {
+        params[paramName] = paramValue;
+      } else {
+        delete params[paramName];
+      }
+
+      return fetchExpectSuccess(params);
+    });
+
+    it('is successful', () => {
+      if (_.isUndefined(expectedValue)) {
+        assert.isFalse(relier.has(modelName));
+      } else {
+        assert.equal(relier.get(modelName), expectedValue);
+      }
+    });
+  }
+
+  function testMissingClientInfoValue(paramName) {
+    beforeEach(() => {
+      mockGetClientInfo(paramName, undefined);
+
+      return fetchExpectError({
+        client_id: CLIENT_ID,
+        scope: SCOPE
+      });
+    });
+
+    it('errors correctly', () => {
+      assert.isTrue(OAuthErrors.is(err, 'MISSING_PARAMETER'));
+      assert.equal(err.param, paramName);
+    });
+  }
+
+  function testInvalidClientInfoValues(paramName, values) {
+    values.forEach(function (value) {
+      var description = 'is ' + getValueLabel(value);
+      describe(description, () => {
+        testInvalidClientInfoValue(paramName, value);
+      });
+    });
+  }
+
+  function testInvalidClientInfoValue(paramName, paramValue) {
+    beforeEach(() => {
+      mockGetClientInfo(paramName, paramValue);
+
+      return fetchExpectError({
+        client_id: CLIENT_ID,
+        scope: SCOPE
+      });
+    });
+
+    it('errors correctly', () => {
+      assert.isTrue(OAuthErrors.is(err, 'INVALID_PARAMETER'));
+      assert.equal(err.param, paramName);
+    });
+  }
+
+  function testValidClientInfo(paramName, paramValue, modelName, expectedValue) {
+    beforeEach(() => {
+      mockGetClientInfo(paramName, paramValue);
+
+      return fetchExpectSuccess({
+        client_id: CLIENT_ID,
+        redirect_uri: QUERY_REDIRECT_URI,
+        scope: SCOPE
+      });
+    });
+
+    it('is successful', () => {
+      if (_.isUndefined(expectedValue)) {
+        assert.isFalse(relier.has(modelName));
+      } else {
+        assert.equal(relier.get(modelName), expectedValue);
+      }
+    });
+  }
+
+  function testValidClientInfoValues(paramName, values, modelName, expectedValues) {
+    values.forEach(function (value, index) {
+      var description = 'is ' + getValueLabel(value);
+      describe(description, () => {
+        var expectedValue = expectedValues[index];
+        testValidClientInfo(paramName, value, modelName, expectedValue);
+      });
+    });
+  }
 });

--- a/tests/functional/oauth_email_first.js
+++ b/tests/functional/oauth_email_first.js
@@ -102,7 +102,6 @@ registerSuite('oauth email first', {
         .then(testAtOAuthApp());
     },
 
-
     'email specified by relier, not registered': function () {
       return this.remote
         .then(openFxaFromRp('email-first', { header: selectors.ENTER_EMAIL.HEADER }))
@@ -115,6 +114,16 @@ registerSuite('oauth email first', {
 
     },
 
+    'login_hint specified by relier, not registered': function () {
+      return this.remote
+        .then(openFxaFromRp('email-first', { header: selectors.ENTER_EMAIL.HEADER }))
+        .then(reOpenWithAdditionalQueryParams({
+          'login_hint': email
+        }, selectors.SIGNUP_PASSWORD.HEADER))
+
+        .then(testElementValueEquals(selectors.SIGNUP_PASSWORD.EMAIL, email));
+    },
+
     'email specified by relier, registered': function () {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
@@ -125,6 +134,16 @@ registerSuite('oauth email first', {
         .then(click(selectors.SIGNIN_PASSWORD.LINK_MISTYPED_EMAIL, selectors.ENTER_EMAIL.HEADER))
 
         .then(testElementValueEquals(selectors.ENTER_EMAIL.EMAIL, email));
+    },
+
+    'login_hint specified by relier, registered': function () {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openFxaFromRp('email-first', { header: selectors.ENTER_EMAIL.HEADER }))
+        .then(reOpenWithAdditionalQueryParams({
+          'login_hint': email
+        }, selectors.SIGNIN_PASSWORD.HEADER ))
+        .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.EMAIL, email));
     }
   }
 });


### PR DESCRIPTION
`login_hint` is renamed to `loginHint` when importing from
the query parameters. When we tried to set the relier's email,
the email was pulled from `login_hint` which didn't exist.

Also ES6'ify the affected modules.

fixes #6383

This is easiest to review with `?w=1`.

@mozilla/fxa-devs - r?