### PR TITLE
fix(sms): Fix the failing send_sms tests

### DIFF
--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -8,7 +8,6 @@ const { registerSuite } = intern.getInterface('object');
 const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
-const CountryTelephoneInfo = require('../../app/scripts/lib/country-telephone-info');
 
 const config = intern._config;
 
@@ -69,9 +68,7 @@ const suite = {
   beforeEach: function () {
     email = TestHelpers.createEmail();
     testPhoneNumber = TestHelpers.createPhoneNumber();
-    const countryInfo = CountryTelephoneInfo['US'];
-    formattedPhoneNumber =
-      countryInfo.format(countryInfo.normalize(testPhoneNumber));
+    formattedPhoneNumber = `${testPhoneNumber.substr(0, 3)}-${testPhoneNumber.substr(3, 3)}-${testPhoneNumber.substr(6)}`;
 
     // User needs a sessionToken to be able to send an SMS. Sign up,
     // no need to verify.


### PR DESCRIPTION
The SMS tests used the internal `format` function to format
phone numbers, but we started relying upon the server to
return the correct format for the country.

The internal format function stopped doing any real local
formatting, and the tests became out of sync with reality.

Unfortunately we don't run SMS tests on CI because we
never figured out how to make it work correctly. These
tests only fail locally.

To fix, format the expected numbers locally before
testing the phone number format.

fixes #6384

To run the tests locally:

> npm run test-functional -- --grep="send_sms"

@mozilla/fxa-devs - r?