### PR TITLE
chore(install): Only clone the l10n repo if needed.

### DIFF
--- a/scripts/download_l10n.sh
+++ b/scripts/download_l10n.sh
@@ -11,14 +11,17 @@ if [ -z "$FXA_L10N_SHA" ]; then
     FXA_L10N_SHA="master"
 fi
 
-rm -rf fxa-content-server-l10n
-
 DOWNLOAD_PATH="https://github.com/mozilla/fxa-content-server-l10n.git"
 
-echo "Downloading L10N files from $DOWNLOAD_PATH..."
 # Download L10N using git
-git clone --depth=20 $DOWNLOAD_PATH
+if [ ! -d "fxa-content-server-l10n" ]; then
+	echo "Downloading L10N files from $DOWNLOAD_PATH..."
+	git clone --depth=20 $DOWNLOAD_PATH
+fi
 cd fxa-content-server-l10n
+echo "Updating L100N files"
+git checkout -- .
 git checkout $FXA_L10N_SHA
+git pull
 git rev-parse $FXA_L10N_SHA >> git-head.txt
 cd ..

--- a/scripts/download_l10n.sh
+++ b/scripts/download_l10n.sh
@@ -19,7 +19,7 @@ if [ ! -d "fxa-content-server-l10n" ]; then
 	git clone --depth=20 $DOWNLOAD_PATH
 fi
 cd fxa-content-server-l10n
-echo "Updating L100N files"
+echo "Updating L10N files"
 git checkout -- .
 git checkout $FXA_L10N_SHA
 git pull


### PR DESCRIPTION
We delete the l10n directory and re-clone
*every time* we do an `npm install`. This takes
a long time on a slow connection.

This change checks if the l10n directory exists,
if it does it reverts any local changes and pulls.

If the directory doens't exist, then clone the
l10n repo.

@vladikoff - I figured we could do this here too - r?