### PR TITLE
fix(tests): update token code experiment tests

### DIFF
--- a/tests/functional/sync_v3_sign_in.js
+++ b/tests/functional/sync_v3_sign_in.js
@@ -232,7 +232,7 @@ registerSuite('Firefox Desktop Sync v3 signin', {
 
 registerSuite('Firefox Desktop Sync v3 signin - token code', {
   beforeEach: function () {
-    email = TestHelpers.createEmail();
+    email = TestHelpers.createEmail('sync{id}');
 
     return this.remote
       .then(clearBrowserState({force: true}))


### PR DESCRIPTION
This PR fixes some of the tests that https://github.com/mozilla/fxa-auth-server/pull/2564 will break.

blocked by https://github.com/mozilla/fxa-auth-server/pull/2564.