### PR TITLE
chore(codes): update clients for token code experiment

### DIFF
--- a/app/scripts/views/mixins/token-code-experiment-mixin.js
+++ b/app/scripts/views/mixins/token-code-experiment-mixin.js
@@ -55,6 +55,7 @@ define(function (require, exports, module) {
      */
     _getTokenCodeExperimentSubject () {
       const subject = {
+        account: this.model.get('account'),
         clientId: this.relier.get('clientId'),
         isTokenCodeSupported: this.broker.getCapability('tokenCode'),
         service: this.relier.get('service'),

--- a/app/tests/spec/lib/experiments/grouping-rules/token-code.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/token-code.js
@@ -2,92 +2,102 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define(function (require, exports, module) {
-  'use strict';
+import {assert} from 'chai';
+import Account from 'models/account';
+import Experiment from 'lib/experiments/grouping-rules/token-code';
+import sinon from 'sinon';
 
-  const {assert} = require('chai');
-  const Experiment = require('lib/experiments/grouping-rules/token-code');
-  const sinon = require('sinon');
+const ROLLOUT_CLIENTS = {
+  '3a1f53aabe17ba32': {
+    name: 'Firefox Add-ons',
+    rolloutRate: 0.0 // Rollout rate between 0..1
+  },
+  'dcdb5ae7add825d2': {
+    name: '123Done',
+    rolloutRate: 1.0
+  },
+  'ecdb5ae7add825d4': {
+    enableTestEmails: true,
+    name: 'TestClient',
+    rolloutRate: 0.0
+  },
+};
 
-  const ROLLOUT_CLIENTS = {
-    '3a1f53aabe17ba32': {
-      name: 'Firefox Add-ons',
-      rolloutRate: 0.0 // Rollout rate between 0..1
-    },
-    'dcdb5ae7add825d2': {
-      name: '123Done',
-      rolloutRate: 1.0
-    },
-    'ecdb5ae7add825d4': {
-      name: 'TestClient',
-      rolloutRate: 0.0
-    }
-  };
+describe('lib/experiments/grouping-rules/token-code', () => {
+  describe('choose', () => {
+    let account;
+    let experiment;
+    let subject;
 
-  describe('lib/experiments/grouping-rules/token-code', () => {
-    describe('choose', () => {
-      let experiment;
-      let subject;
+    beforeEach(() => {
+      account = new Account();
+      experiment = new Experiment();
+      experiment.ROLLOUT_CLIENTS = ROLLOUT_CLIENTS;
+      subject = {
+        account: account,
+        experimentGroupingRules: {},
+        isTokenCodeSupported: true,
+        service: null,
+        uniqueUserId: 'user-id'
+      };
+    });
 
-      beforeEach(() => {
-        experiment = new Experiment();
-        experiment.ROLLOUT_CLIENTS = ROLLOUT_CLIENTS;
-        subject = {
-          experimentGroupingRules: {},
-          isTokenCodeSupported: true,
-          service: null,
-          uniqueUserId: 'user-id'
-        };
-      });
+    it('returns false experiment not enabled', () => {
+      subject = {
+        isTokenCodeSupported: false
+      };
+      assert.equal(experiment.choose(subject), false);
+    });
 
-      it('returns false experiment not enabled', () => {
-        subject = {
-          isTokenCodeSupported: false
-        };
+    describe('with oauth client', () => {
+      it('returns false if client not defined in config', () => {
+        subject.clientId = 'invalidClientId';
         assert.equal(experiment.choose(subject), false);
       });
 
-      describe('with oauth client', () => {
-        it('returns false if client not defined in config', () => {
-          subject.clientId = 'invalidClientId';
-          assert.equal(experiment.choose(subject), false);
-        });
-
-        it('returns false if client rollout is 0', () => {
-          subject.clientId = '3a1f53aabe17ba32';
-          assert.equal(experiment.choose(subject), false);
-        });
-
-        it('delegates to uniformChoice', () => {
-          subject.clientId = 'dcdb5ae7add825d2';
-          sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
-          experiment.choose(subject);
-          assert.isTrue(experiment.uniformChoice.calledOnce);
-          assert.isTrue(experiment.uniformChoice.calledWith(['control', 'treatment-code', 'treatment-link'], 'user-id'));
-        });
+      it('returns false if client rollout is 0', () => {
+        subject.clientId = '3a1f53aabe17ba32';
+        assert.equal(experiment.choose(subject), false);
       });
 
-      describe('with sync', () => {
-        beforeEach(() => {
-          subject.service = 'sync';
-        });
+      it('delegates to uniformChoice', () => {
+        subject.clientId = 'dcdb5ae7add825d2';
+        sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
+        experiment.choose(subject);
+        assert.isTrue(experiment.uniformChoice.calledOnce);
+        assert.isTrue(experiment.uniformChoice.calledWith(['control', 'treatment-code', 'treatment-link'], 'user-id'));
+      });
 
-        it('returns false if not Sync', () => {
-          subject.service = 'notSync';
-          assert.equal(experiment.choose(subject), false);
-        });
+      it('delegates to uniformChoice when `enableTestEmails` is true and using test email', () => {
+        subject.clientId = 'ecdb5ae7add825d4';
+        subject.account.set('email', 'a@mozilla.org');
+        sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
+        experiment.choose(subject);
+        assert.isTrue(experiment.uniformChoice.calledOnce);
+        assert.isTrue(experiment.uniformChoice.calledWith(['control', 'treatment-code', 'treatment-link'], 'user-id'));
+      });
+    });
 
-        it('returns false if rollout is 0', () => {
-          assert.equal(experiment.choose(subject), false);
-        });
+    describe('with sync', () => {
+      beforeEach(() => {
+        subject.service = 'sync';
+      });
 
-        it('delegates to uniformChoice', () => {
-          experiment.SYNC_ROLLOUT_RATE = 1.0;
-          sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
-          experiment.choose(subject);
-          assert.isTrue(experiment.uniformChoice.calledOnce, 'called once');
-          assert.isTrue(experiment.uniformChoice.calledWith(['control', 'treatment-code', 'treatment-link'], 'user-id'));
-        });
+      it('returns false if not Sync', () => {
+        subject.service = 'notSync';
+        assert.equal(experiment.choose(subject), false);
+      });
+
+      it('returns false if rollout is 0', () => {
+        assert.equal(experiment.choose(subject), false);
+      });
+
+      it('delegates to uniformChoice', () => {
+        experiment.SYNC_ROLLOUT_RATE = 1.0;
+        sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
+        experiment.choose(subject);
+        assert.isTrue(experiment.uniformChoice.calledOnce, 'called once');
+        assert.isTrue(experiment.uniformChoice.calledWith(['control', 'treatment-code', 'treatment-link'], 'user-id'));
       });
     });
   });


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-content-server/issues/5990

This PR adds some extra clients that might want to use codes instead of sign-in links. It also adds the ability to have different experiment groups for each client. 