### PR TITLE
fix(test): Fix the handshake test.

### DIFF
--- a/tests/functional/fx_desktop_handshake.js
+++ b/tests/functional/fx_desktop_handshake.js
@@ -81,7 +81,7 @@ const ensureUsers = thenify(function () {
 
 registerSuite('Firefox desktop user info handshake', {
   beforeEach: function () {
-    return this.remote.then(clearBrowserState())
+    return this.remote.then(clearBrowserState({ force: true }))
       .then(ensureUsers());
   },
 


### PR DESCRIPTION
This is a bit of a stab in the dark. The recurring
pattern seems to be the failing signin is always
after a "user signed into browser" test, always
when trying to call `fillOutSignIn` which expects
an editable email and password. The failure is
that a non-editable email is displayed.

One example:
https://screencap.co.uk/images/c8473d20b922b94b5feab7b9f13fb3f711c19899.png
from https://tc-test.dev.lcip.org/viewLog.html?buildId=40916&buildTypeId=FxaLatest_FunctionalTests&tab=buildLog

The theory is that the page from the previous test
is still displayed whenever `fillOutSignIn` is called.
`fillOutSignIn` cannot find an editable email and errors
out. This can happen if the `.get` call in `.openPage`
incurrs a lot of latency. The browser will not remove the
old page from view until it starts to receive bytes for
the new page.

This forces a page load to clearing localStorage. By
force loading a page that isn't /signin, this should
re-force /signin to load for the failing test.

issue #6182 

@mozilla/fxa-devs - r?