### PR TITLE
fix(css): Maximized visible password area

### DIFF
--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -8,11 +8,11 @@
   &.input-row .password {
 
     html[dir='ltr'] & {
-      padding-right: 75px;
+      padding-right: 58px;
     }
 
     html[dir='rtl'] & {
-      padding-left: 75px;
+      padding-left: 58px;
     }
   }
 


### PR DESCRIPTION
Because we now have a 55px wide eyeball for show password, I reduced the right padding on the password field to 58px, so the password field extends right up to the button.