### PR TITLE
fix(recovery): use `enable` instead of `add` button

### DIFF
--- a/app/scripts/templates/settings/account_recovery/account_recovery.mustache
+++ b/app/scripts/templates/settings/account_recovery/account_recovery.mustache
@@ -6,7 +6,7 @@
 
         {{^hasRecoveryKey}}
             <button class="settings-button primary-button settings-unit-toggle" data-href="settings/account_recovery">
-                {{#t}}Add…{{/t}}
+                {{#t}}Enable…{{/t}}
             </button>
         {{/hasRecoveryKey}}
 


### PR DESCRIPTION
Fixes #6452