### PR TITLE
fix(metrics): stop sending unused performance flow events

### DIFF
--- a/server/lib/flow-event.js
+++ b/server/lib/flow-event.js
@@ -60,6 +60,7 @@ const PERFORMANCE_TIMINGS = [
   {
     event: 'network',
     timings: [
+      { from: 'redirectStart', until: 'redirectEnd' },
       { from: 'domainLookupStart', until: 'domainLookupEnd' },
       { from: 'connectStart', until: 'connectEnd' },
       { from: 'responseStart', until: 'responseEnd' }
@@ -75,33 +76,6 @@ const PERFORMANCE_TIMINGS = [
     event: 'client',
     timings: [
       { from: 'domLoading', until: 'domComplete' }
-    ]
-  },
-  // These timings were identified as strongly correlating with user behaviour,
-  // specifically whether the user completes the flow. We're not entirely sure
-  // what that means yet, so they're retained for further analysis.
-  {
-    event: 'connectStart',
-    timings: [
-      { from: 'navigationStart', until: 'connectStart' }
-    ]
-  },
-  {
-    event: 'domainLookupEnd',
-    timings: [
-      { from: 'navigationStart', until: 'domainLookupEnd' }
-    ]
-  },
-  {
-    event: 'redirectEnd',
-    timings: [
-      { from: 'navigationStart', until: 'redirectEnd' }
-    ]
-  },
-  {
-    event: 'requestStart',
-    timings: [
-      { from: 'navigationStart', until: 'requestStart' }
     ]
   }
 ];

--- a/tests/server/flow-event.js
+++ b/tests/server/flow-event.js
@@ -223,7 +223,7 @@ registerSuite('flow-event', {
 
       tests: {
         'process.stderr.write was called seven times': () => {
-          assert.equal(process.stderr.write.callCount, 7);
+          assert.equal(process.stderr.write.callCount, 4);
         },
 
         'first call to process.stderr.write was correct': () => {
@@ -252,24 +252,6 @@ registerSuite('flow-event', {
           assert.equal(arg.event, 'flow.performance.auth.client');
           assert.equal(arg.time, new Date(mocks.time - 2000 + 200).toISOString());
           assert.equal(arg.flow_time, 200);
-        },
-
-        'fifth call to process.stderr.write was correct': () => {
-          const arg = JSON.parse(process.stderr.write.args[4][0]);
-          assert.equal(arg.event, 'flow.performance.auth.connectStart');
-          assert.equal(arg.flow_time, 300);
-        },
-
-        'sixth call to process.stderr.write was correct': () => {
-          const arg = JSON.parse(process.stderr.write.args[5][0]);
-          assert.equal(arg.event, 'flow.performance.auth.domainLookupEnd');
-          assert.equal(arg.flow_time, 200);
-        },
-
-        'seventh call to process.stderr.write was correct': () => {
-          const arg = JSON.parse(process.stderr.write.args[6][0]);
-          assert.equal(arg.event, 'flow.performance.auth.requestStart');
-          assert.equal(arg.flow_time, 500);
         },
 
         'amplitude was called once': () => {
@@ -888,7 +870,7 @@ registerSuite('flow-event', {
 
       tests: {
         'process.stderr.write was called 6 times': () => {
-          assert.equal(process.stderr.write.callCount, 6);
+          assert.equal(process.stderr.write.callCount, 3);
         },
 
         'first call to process.stderr.write was correct': () => {
@@ -904,24 +886,6 @@ registerSuite('flow-event', {
         'third call to process.stderr.write was correct': () => {
           const arg = JSON.parse(process.stderr.write.args[2][0]);
           assert.equal(arg.event, 'flow.performance.other.client');
-        },
-
-        'fourth call to process.stderr.write was correct': () => {
-          const arg = JSON.parse(process.stderr.write.args[3][0]);
-          assert.equal(arg.event, 'flow.performance.other.connectStart');
-          assert.equal(arg.flow_time, 300);
-        },
-
-        'fifth call to process.stderr.write was correct': () => {
-          const arg = JSON.parse(process.stderr.write.args[4][0]);
-          assert.equal(arg.event, 'flow.performance.other.domainLookupEnd');
-          assert.equal(arg.flow_time, 200);
-        },
-
-        'sixth call to process.stderr.write was correct': () => {
-          const arg = JSON.parse(process.stderr.write.args[5][0]);
-          assert.equal(arg.event, 'flow.performance.other.requestStart');
-          assert.equal(arg.flow_time, 500);
         }
       }
     },


### PR DESCRIPTION
Related to mozilla/fxa-activity-metrics#104.

We're not using these events so we can delete them. And they all measure the part of the request that we've termed `network` in our charts, so were likely indicative of the same thing as that (people on a slow connection perform worse, quelle surprise). Hence as well as removing them, I also incorporated `redirectStart` and `redirectEnd` with our network timing to make it better representative.

Given there are four of these for every `flow.begin`, deleting them should bring a tangible reduction to the size of our flow event dataset.

@mozilla/fxa-devs r?