### PR TITLE
fix(pw-strength): Style updates to the pw strength balloon

### DIFF
--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -177,7 +177,7 @@
 
   .password-strength-balloon {
     font-size: 14px;
-    font-weight: 400;
+    font-weight: 300;
     line-height: 1.3;
     opacity: 1;
     padding: 28px 14px;
@@ -258,7 +258,14 @@
       }
     }
   }
+
+  #password-too-common {
+    @include respond-to('balloonBig') {
+      margin-bottom: 21px;
+    }
+  }
 }
+
 
 /**
  * IE8 blows up when changing the type of the password field


### PR DESCRIPTION


Use a font weight of 300, add a 21px margin between the list items
and the first "lock" item.

fixes #6448 

@ryanfeeley - r?

<img width="367" alt="screen shot 2018-08-16 at 16 08 59" src="https://user-images.githubusercontent.com/848085/44217163-bd58fb80-a16e-11e8-9349-2f9afaada469.png">
