### PR TITLE
Enable recovery key experiment for test emails

### DIFF
--- a/app/scripts/views/mixins/recovery-key-experiment-mixin.js
+++ b/app/scripts/views/mixins/recovery-key-experiment-mixin.js
@@ -54,7 +54,7 @@ module.exports = {
   _getRecoveryKeyExperimentSubject() {
     const subject = {
       account: this.getSignedInAccount(),
-      showTwoStepAuthentication: this.broker.getCapability('showAccountRecovery'),
+      showAccountRecovery: this.broker.getCapability('showAccountRecovery'),
     };
     return subject;
   }

--- a/app/scripts/views/settings/account_recovery/account_recovery.js
+++ b/app/scripts/views/settings/account_recovery/account_recovery.js
@@ -9,6 +9,7 @@ import Template from 'templates/settings/account_recovery/account_recovery.musta
 import showProgressIndicator from '../../decorators/progress_indicator';
 import LastCheckedTimeMixin from '../../mixins/last-checked-time-mixin';
 import UpgradeSessionMixin from '../../mixins/upgrade-session-mixin';
+import RecoveryKeyExperimentMixin from '../../mixins/recovery-key-experiment-mixin';
 
 const CODE_REFRESH_SELECTOR = 'button.settings-button.refresh-status';
 const CODE_REFRESH_DELAY_MS = 350;
@@ -44,6 +45,11 @@ const View = BaseView.extend({
     if (this.broker.hasCapability('showAccountRecovery')) {
       return true;
     }
+
+    if (this.getRecoveryKeyExperimentGroup() === 'treatment') {
+      return true;
+    }
+
     return false;
   },
 
@@ -89,7 +95,8 @@ Cocktail.mixin(
     title: t('Account Recovery')
   }),
   SettingsPanelMixin,
-  LastCheckedTimeMixin
+  LastCheckedTimeMixin,
+  RecoveryKeyExperimentMixin
 );
 
 module.exports = View;

--- a/app/tests/spec/views/settings/account_recovery/account_recovery.js
+++ b/app/tests/spec/views/settings/account_recovery/account_recovery.js
@@ -88,6 +88,17 @@ describe('views/settings/account_recovery/account_recovery', () => {
       });
     });
 
+    describe('should show panel when using test email', () => {
+      it('should show panel when user has supported email', () => {
+        showAccountRecovery = true;
+        email = Math.random() + '@mozilla.com';
+        return initView()
+          .then(() => {
+            assert.equal(view.remove.callCount, 0);
+          });
+      });
+    });
+
     describe('should show support link', () => {
       it('should show support link', () => {
         assert.lengthOf(view.$('.account-recovery-support-link'), 1);

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -208,6 +208,22 @@ const click = thenify(function (selector, readySelector) {
           })
           .end();
       }
+
+      // Check to see if the error is a `stale element exception` and
+      // retry clicking if it is. This could happen if a panel on
+      // the page is re-rendered causing the element to be removed
+      // from the DOM.
+      if (/either the element is no longer attached to the DOM/.test(err.message)) {
+        return this.parent
+          .sleep(2000)
+          .findByCssSelector(selector)
+          .click()
+          .then(null, (err) => {
+            throw err;
+          })
+          .end();
+      }
+
       // re-throw other errors
       throw err;
     })


### PR DESCRIPTION
Didn't get a chance to mention this in yesterday meeting but wanted to enable account recovery for Mozilla and Softvision emails this train.

This is targeted as a point release so we can rollback if needed.