### PR TITLE
feat(metrics): log 'enter-email.view' in metrics-flow

### DIFF
--- a/server/lib/routes/get-metrics-flow.js
+++ b/server/lib/routes/get-metrics-flow.js
@@ -11,6 +11,8 @@ const logger = require('../logging/log')('server.get-metrics-flow');
 module.exports = function (config) {
   const FLOW_ID_KEY = config.get('flow_id_key');
   const FLOW_EVENT_NAME = 'flow.begin';
+  const FLOW_ENTER_EMAIL_EVENT_NAME = 'flow.enter-email.view';
+  const FORM_TYPE_EMAIL = 'email';
   const ALLOWED_CORS_ORIGINS = config.get('allowed_metrics_flow_cors_origins');
   const CORS_OPTIONS = {
     methods: 'GET',
@@ -43,6 +45,14 @@ module.exports = function (config) {
       time: flowBeingTime,
       type: FLOW_EVENT_NAME
     }, metricsData, req);
+
+    if (metricsData.form_type === FORM_TYPE_EMAIL) {
+      logFlowEvent({
+        flowTime: flowBeingTime,
+        time: flowBeingTime,
+        type: FLOW_ENTER_EMAIL_EVENT_NAME
+      }, metricsData, req);
+    }
 
     // charset must be set on json responses.
     res.charset = 'utf-8';

--- a/tests/server/routes/get-metrics-flow.js
+++ b/tests/server/routes/get-metrics-flow.js
@@ -72,6 +72,7 @@ registerSuite('routes/get-metrics-flow', {
       const argsFlowEvent = mocks.flowEvent.logFlowEvent.args[0];
       assert.equal(argsFlowEvent.length, 3);
     },
+
     'supports query params': function () {
       request = {
         headers: {},
@@ -89,6 +90,27 @@ registerSuite('routes/get-metrics-flow', {
       assert.ok(eventData.time);
       assert.equal(eventData.type, 'flow.begin');
       assert.equal(metricsData.entrypoint, 'zoo');
+      assert.ok(metricsData.flowId);
+    },
+
+    'logs enter-email.view event if form_type email is set': function () {
+      request = {
+        headers: {},
+        query: {
+          entrypoint: 'bar',
+          form_type: 'email' // eslint-disable-line camelcase
+        }
+      };
+      instance.process(request, response);
+
+      assert.equal(mocks.flowEvent.logFlowEvent.callCount, 2);
+      const argsFlowEmailEvent = mocks.flowEvent.logFlowEvent.args[1];
+      const eventData = argsFlowEmailEvent[0];
+      const metricsData = argsFlowEmailEvent[1];
+      assert.ok(eventData.flowTime);
+      assert.ok(eventData.time);
+      assert.equal(eventData.type, 'flow.enter-email.view');
+      assert.equal(metricsData.entrypoint, 'bar');
       assert.ok(metricsData.flowId);
     },
 


### PR DESCRIPTION
Fixes #6395