### PR TITLE
feat(router): Groundwork to load views on demand.

### DIFF
--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -30,43 +30,61 @@ import DisplayNameView from '../views/settings/display_name';
 import EmailsView from '../views/settings/emails';
 import ForceAuthView from '../views/force_auth';
 import IndexView from '../views/index';
-import LegalView from '../views/legal';
 import OAuthIndexView from '../views/oauth_index';
 import PermissionsView from '../views/permissions';
-import PpView from '../views/pp';
 import ReadyView from '../views/ready';
+import RecoveryCodesView from '../views/settings/recovery_codes';
+import RedirectAuthView from '../views/authorization';
 import ReportSignInView from '../views/report_sign_in';
 import ResetPasswordView from '../views/reset_password';
 import SettingsView from '../views/settings';
 import SignInBouncedView from '../views/sign_in_bounced';
+import SignInPasswordView from '../views/sign_in_password';
 import SignInRecoveryCodeView from '../views/sign_in_recovery_code';
+import SignInReportedView from '../views/sign_in_reported';
 import SignInTokenCodeView from '../views/sign_in_token_code';
 import SignInTotpCodeView from '../views/sign_in_totp_code';
-import SignInPasswordView from '../views/sign_in_password';
-import SignInReportedView from '../views/sign_in_reported';
 import SignInUnblockView from '../views/sign_in_unblock';
 import SignInView from '../views/sign_in';
-import SignUpView from '../views/sign_up';
 import SignUpPasswordView from '../views/sign_up_password';
+import SignUpView from '../views/sign_up';
 import SmsSendView from '../views/sms_send';
 import SmsSentView from '../views/sms_sent';
 import Storage from './storage';
-import TosView from '../views/tos';
 import TwoStepAuthenticationView from '../views/settings/two_step_authentication';
-import RecoveryCodesView from '../views/settings/recovery_codes';
 import VerificationReasons from './verification-reasons';
 import WhyConnectAnotherDeviceView from '../views/why_connect_another_device';
-import RedirectAuthView from '../views/authorization';
 
-function createViewHandler(View, options) {
+function getView(ViewOrPath) {
+  if (typeof ViewOrPath === 'string') {
+    return import(`../views/${ViewOrPath}`)
+      .then((result) => {
+        if (result.default) {
+          return result.default;
+        }
+        return result;
+      });
+  } else {
+    return Promise.resolve(ViewOrPath);
+  }
+}
+
+function createViewHandler(ViewOrPath, options) {
   return function () {
-    return this.showView(View, options);
+    return getView(ViewOrPath).then(View => {
+      return this.showView(View, options);
+    });
   };
 }
 
-function createChildViewHandler(ChildView, ParentView, options) {
+function createChildViewHandler(ChildViewOrPath, ParentViewOrPath, options) {
   return function () {
-    return this.showChildView(ChildView, ParentView, options);
+    return Promise.all([
+      getView(ChildViewOrPath),
+      getView(ParentViewOrPath)
+    ]).then(([ ChildView, ParentView ]) => {
+      return this.showChildView(ChildView, ParentView, options);
+    });
   };
 }
 
@@ -92,9 +110,9 @@ const Router = Backbone.Router.extend({
     'connect_another_device/why(/)': createChildViewHandler(WhyConnectAnotherDeviceView, ConnectAnotherDeviceView),
     'cookies_disabled(/)': createViewHandler(CookiesDisabledView),
     'force_auth(/)': createViewHandler(ForceAuthView),
-    'legal(/)': createViewHandler(LegalView),
-    'legal/privacy(/)': createViewHandler(PpView),
-    'legal/terms(/)': createViewHandler(TosView),
+    'legal(/)': createViewHandler('legal'),
+    'legal/privacy(/)': createViewHandler('pp'),
+    'legal/terms(/)': createViewHandler('tos'),
     'oauth(/)': createViewHandler(OAuthIndexView),
     'oauth/force_auth(/)': createViewHandler(ForceAuthView),
     'oauth/signin(/)': 'onSignIn',

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -823,12 +823,12 @@ define(function (require, exports, module) {
         this.logError(nextViewData.error);
       }
 
+      this._hasNavigated = true;
       this.notifier.trigger('navigate', {
         nextViewData: nextViewData,
         routerOptions: routerOptions,
         url: url
       });
-      this._hasNavigated = true;
     },
 
     /**
@@ -837,11 +837,11 @@ define(function (require, exports, module) {
      * @param {String} url
      */
     navigateAway (url) {
+      this._hasNavigated = true;
       this.notifier.trigger('navigate', {
         server: true,
         url
       });
-      this._hasNavigated = true;
     },
 
     /**

--- a/app/scripts/views/mixins/modal-settings-panel-mixin.js
+++ b/app/scripts/views/mixins/modal-settings-panel-mixin.js
@@ -6,84 +6,88 @@
 // This is a mixin used by Modal views that are childViews of Settings
 // Non-modal childViews of Settings use settings-panel-mixin instead.
 
-define(function (require, exports, module) {
-  'use strict';
+import { assign } from 'underscore';
+import { preventDefaultThen } from '../base';
+import ModalPanelMixin from './modal-panel-mixin';
 
-  const _ = require('underscore');
-  const BaseView = require('../base');
-  const ModalPanelMixin = require('./modal-panel-mixin');
-  const preventDefaultThen = BaseView.preventDefaultThen;
+const Mixin = assign({}, ModalPanelMixin, {
+  initialize (options = {}) {
+    this.parentView = options.parentView;
+    this.on('modal-cancel', () => this.onModalCancel());
+  },
 
-  const Mixin = _.extend({}, ModalPanelMixin, {
-    initialize (options = {}) {
-      this.parentView = options.parentView;
-      this.on('modal-cancel', () => this.onModalCancel());
-    },
+  events: {
+    'click .cancel': preventDefaultThen('_returnToSettings'),
+    'click .modal-panel #back': preventDefaultThen('_returnToAvatarChange')
+  },
 
-    events: {
-      'click .cancel': preventDefaultThen('_returnToSettings'),
-      'click .modal-panel #back': preventDefaultThen('_returnToAvatarChange')
-    },
+  _returnToAvatarChange () {
+    this.navigate('settings/avatar/change');
+  },
 
-    _returnToAvatarChange () {
-      this.navigate('settings/avatar/change');
-    },
+  _returnToClients () {
+    this.navigate('settings/clients');
+  },
 
-    _returnToClients () {
-      this.navigate('settings/clients');
-    },
+  _returnToTwoFactorAuthentication () {
+    this.navigate('settings/two_step_authentication');
+  },
 
-    _returnToTwoFactorAuthentication () {
-      this.navigate('settings/two_step_authentication');
-    },
+  _returnToAccountRecovery (hasRecoveryKey) {
+    this.navigate('settings/account_recovery', { hasRecoveryKey });
+  },
 
-    _returnToAccountRecovery (hasRecoveryKey) {
-      this.navigate('settings/account_recovery', {hasRecoveryKey});
-    },
+  _showAccountRecoveryKey () {
+    this.navigate('settings/account_recovery/recovery_key', {
+      hasRecoveryKey: true
+    });
+  },
 
-    _showAccountRecoveryKey () {
-      this.navigate('settings/account_recovery/recovery_key', {
-        hasRecoveryKey: true
-      });
-    },
+  _returnToSettings () {
+    this.navigate('settings');
+  },
 
-    _returnToSettings () {
-      this.navigate('settings');
-    },
-
-    onModalCancel() {
-      switch (this.currentPage) {
-      case 'settings/clients/disconnect':
-        this._returnToClients();
-        break;
-      case 'settings/two_step_authentication/recovery_codes':
-        if (this.model.get('previousViewName') === 'sign_in_recovery_code') {
-          const account = this.getSignedInAccount();
-          return this.invokeBrokerMethod('afterCompleteSignInWithCode', account);
-        }
-        this._returnToTwoFactorAuthentication();
-        break;
-      case 'settings/account_recovery/recovery_key' :
-        this._returnToAccountRecovery(true);
-        break;
-      case 'settings/account_recovery/confirm_revoke' :
-        this._returnToAccountRecovery(false);
-        break;
-      case 'settings/account_recovery/confirm_password' :
-        if (this.showRecoveryKeyView) {
-          this._showAccountRecoveryKey();
-        } else {
-          this._returnToAccountRecovery(false);
-        }
-        break;
-      default:
-        this._returnToSettings();
-      }
-    },
-
-    displaySuccess (msg) {
-      this.parentView.displaySuccess(msg);
+  onModalCancel() {
+    // modal-cancel is called whenever the modal is closed because the
+    // page has navigated, causing two navigate's to occur. If a navigate
+    // has already happened, do not try to navigate again when the
+    // modal-cancel event occurs.
+    if (this.hasNavigated()) {
+      return;
     }
-  });
-  module.exports = Mixin;
+
+    switch (this.currentPage) {
+    case 'settings/clients/disconnect':
+      this._returnToClients();
+      break;
+    case 'settings/two_step_authentication/recovery_codes':
+      if (this.model.get('previousViewName') === 'sign_in_recovery_code') {
+        const account = this.getSignedInAccount();
+        return this.invokeBrokerMethod('afterCompleteSignInWithCode', account);
+      }
+      this._returnToTwoFactorAuthentication();
+      break;
+    case 'settings/account_recovery/recovery_key' :
+      this._returnToAccountRecovery(true);
+      break;
+    case 'settings/account_recovery/confirm_revoke' :
+      this._returnToAccountRecovery(false);
+      break;
+    case 'settings/account_recovery/confirm_password' :
+      if (this.showRecoveryKeyView) {
+        this._showAccountRecoveryKey();
+      } else {
+        this._returnToAccountRecovery(false);
+      }
+      break;
+    default:
+      this._returnToSettings();
+    }
+  },
+
+  displaySuccess (msg) {
+    this.parentView.displaySuccess(msg);
+  }
 });
+
+module.exports = Mixin;

--- a/app/tests/spec/lib/router.js
+++ b/app/tests/spec/lib/router.js
@@ -21,7 +21,7 @@ import sinon from 'sinon';
 import User from 'models/user';
 import WindowMock from '../../mocks/window';
 
-describe('lib/router', function () {
+describe('lib/router', () => {
   let broker;
   var metrics;
   var navigateOptions;
@@ -32,7 +32,7 @@ describe('lib/router', function () {
   var user;
   var windowMock;
 
-  beforeEach(function () {
+  beforeEach(() => {
     navigateUrl = navigateOptions = null;
 
     notifier = new Notifier();
@@ -61,14 +61,14 @@ describe('lib/router', function () {
     });
   });
 
-  afterEach(function () {
+  afterEach(() => {
     metrics.destroy();
     windowMock = router = navigateUrl = navigateOptions = metrics = null;
     Backbone.Router.prototype.navigate.restore();
   });
 
-  describe('navigate', function () {
-    it('tells the router to navigate to a page', function () {
+  describe('navigate', () => {
+    it('tells the router to navigate to a page', () => {
       sinon.stub(broker, 'transformLink').callsFake((url) => `/oauth/${url}`);
       windowMock.location.search = '';
       router.navigate('signin');
@@ -79,8 +79,8 @@ describe('lib/router', function () {
     });
   });
 
-  describe('`navigate` notifier message', function () {
-    beforeEach(function () {
+  describe('`navigate` notifier message', () => {
+    beforeEach(() => {
       sinon.spy(router, 'navigate');
 
       notifier.trigger('navigate', {
@@ -95,7 +95,7 @@ describe('lib/router', function () {
       });
     });
 
-    it('calls `navigate` correctly', function () {
+    it('calls `navigate` correctly', () => {
       assert.isTrue(router.navigate.calledWith('signin', {
         key: 'value'
       }, {
@@ -139,15 +139,15 @@ describe('lib/router', function () {
       assert.lengthOf(metrics.flush.args[0], 0);
     });
 
-    it('navigated correctly', function () {
+    it('navigated correctly', () => {
       assert.isTrue(broker.transformLink.calledOnceWith('blee'));
       assert.equal(router.navigate.callCount, 0);
       assert.equal(windowMock.location.href, '/oauth/blee');
     });
   });
 
-  describe('`navigate-back` notifier message', function () {
-    beforeEach(function () {
+  describe('`navigate-back` notifier message', () => {
+    beforeEach(() => {
       sinon.spy(router, 'navigateBack');
 
       notifier.trigger('navigate-back', {
@@ -157,48 +157,48 @@ describe('lib/router', function () {
       });
     });
 
-    it('calls `navigateBack` correctly', function () {
+    it('calls `navigateBack` correctly', () => {
       assert.isTrue(router.navigateBack.called);
     });
   });
 
-  describe('set query params', function () {
-    beforeEach(function () {
+  describe('set query params', () => {
+    beforeEach(() => {
       windowMock.location.search = '?context=' + Constants.FX_DESKTOP_V1_CONTEXT;
     });
 
-    describe('navigate with default options', function () {
-      beforeEach(function () {
+    describe('navigate with default options', () => {
+      beforeEach(() => {
         router.navigate('/forgot');
       });
 
-      it('preserves query params', function () {
+      it('preserves query params', () => {
         assert.equal(navigateUrl, '/forgot?context=' + Constants.FX_DESKTOP_V1_CONTEXT);
         assert.deepEqual(navigateOptions, { trigger: true });
       });
     });
 
-    describe('navigate with clearQueryParams option set', function () {
-      beforeEach(function () {
+    describe('navigate with clearQueryParams option set', () => {
+      beforeEach(() => {
         router.navigate('/forgot?context=' + Constants.FX_DESKTOP_V1_CONTEXT, {}, { clearQueryParams: true });
       });
 
-      it('clears the query params if clearQueryString option is set', function () {
+      it('clears the query params if clearQueryString option is set', () => {
         assert.equal(navigateUrl, '/forgot');
         assert.deepEqual(navigateOptions, { clearQueryParams: true, trigger: true });
       });
     });
   });
 
-  describe('navigateBack', function () {
-    beforeEach(function () {
+  describe('navigateBack', () => {
+    beforeEach(() => {
       sinon.spy(windowMock.history, 'back');
       sinon.stub(router, 'canGoBack').callsFake(() => true);
 
       router.navigateBack();
     });
 
-    it('calls `window.history.back`', function () {
+    it('calls `window.history.back`', () => {
       assert.isTrue(windowMock.history.back.called);
     });
   });
@@ -275,41 +275,41 @@ describe('lib/router', function () {
     });
   });
 
-  describe('_afterFirstViewHasRendered', function () {
-    it('sets `canGoBack`', function () {
+  describe('_afterFirstViewHasRendered', () => {
+    it('sets `canGoBack`', () => {
       router._afterFirstViewHasRendered();
 
       assert.isTrue(router.storage.get('canGoBack'));
     });
   });
 
-  describe('pathToViewName', function () {
-    it('strips leading /', function () {
+  describe('pathToViewName', () => {
+    it('strips leading /', () => {
       assert.equal(router.fragmentToViewName('/signin'), 'signin');
     });
 
-    it('strips trailing /', function () {
+    it('strips trailing /', () => {
       assert.equal(router.fragmentToViewName('signup/'), 'signup');
     });
 
-    it('converts middle / to .', function () {
+    it('converts middle / to .', () => {
       assert.equal(router.fragmentToViewName('/legal/tos/'), 'legal.tos');
     });
 
-    it('converts _ to -', function () {
+    it('converts _ to -', () => {
       assert.equal(router.fragmentToViewName('complete_sign_up'),
         'complete-sign-up');
     });
 
-    it('strips search parameters', function () {
+    it('strips search parameters', () => {
       assert.equal(router.fragmentToViewName('complete_sign_up?email=testuser@testuser.com'),
         'complete-sign-up');
     });
 
   });
 
-  describe('showView', function () {
-    it('triggers a `show-view` notification', function () {
+  describe('showView', () => {
+    it('triggers a `show-view` notification', () => {
       sinon.spy(notifier, 'trigger');
 
       var options = { key: 'value' };
@@ -320,8 +320,8 @@ describe('lib/router', function () {
     });
   });
 
-  describe('showChildView', function () {
-    it('triggers a `show-child-view` notification', function () {
+  describe('showChildView', () => {
+    it('triggers a `show-child-view` notification', () => {
       sinon.spy(notifier, 'trigger');
 
       var options = { key: 'value' };
@@ -332,12 +332,12 @@ describe('lib/router', function () {
     });
   });
 
-  describe('canGoBack initial value', function () {
-    it('is `false` if sessionStorage.canGoBack is not set', function () {
+  describe('canGoBack initial value', () => {
+    it('is `false` if sessionStorage.canGoBack is not set', () => {
       assert.isUndefined(router.storage._backend.getItem('canGoBack'));
     });
 
-    it('is `true` if sessionStorage.canGoBack is set', function () {
+    it('is `true` if sessionStorage.canGoBack is set', () => {
       windowMock.sessionStorage.setItem('canGoBack', true);
       router = new Router({
         metrics: metrics,
@@ -350,8 +350,8 @@ describe('lib/router', function () {
     });
   });
 
-  describe('getCurrentPage', function () {
-    it('returns the current screen URL based on Backbone.history.fragment', function () {
+  describe('getCurrentPage', () => {
+    it('returns the current screen URL based on Backbone.history.fragment', () => {
       Backbone.history.fragment = 'settings';
       assert.equal(router.getCurrentPage(), 'settings');
     });
@@ -372,26 +372,42 @@ describe('lib/router', function () {
     });
   });
 
-  describe('createViewHandler', function () {
+  describe('createViewHandler', () => {
     function View() {
     }
     var viewConstructorOptions = {};
 
-    it('returns a function that can be used by the router to show a View', function () {
+    beforeEach(() => {
       sinon.spy(router, 'showView');
+    });
+
+    it('returns a function that can be used by the router to show a View', () => {
 
       var routeHandler = router.createViewHandler(View, viewConstructorOptions);
       assert.isFunction(routeHandler);
       assert.isFalse(router.showView.called);
 
-      routeHandler.call(router);
+      return routeHandler.call(router)
+        .then(() => {
+          assert.isTrue(
+            router.showView.calledWith(View, viewConstructorOptions));
+        });
+    });
 
-      assert.isTrue(
-        router.showView.calledWith(View, viewConstructorOptions));
+    it('handles module names for the view', () => {
+      var routeHandler = router.createViewHandler('sign_in', viewConstructorOptions);
+      assert.isFunction(routeHandler);
+      assert.isFalse(router.showView.called);
+
+      return routeHandler.call(router)
+        .then(() => {
+          assert.isTrue(
+            router.showView.calledWith(SignInView, viewConstructorOptions));
+        });
     });
   });
 
-  describe('createChildViewHandler', function () {
+  describe('createChildViewHandler', () => {
     function ParentView() {
     }
     function ChildView() {
@@ -399,8 +415,11 @@ describe('lib/router', function () {
 
     var viewConstructorOptions = {};
 
-    it('returns a function that can be used by the router to show a ChildView within a ParentView', function () {
+    beforeEach(() => {
       sinon.spy(router, 'showChildView');
+    });
+
+    it('returns a function that can be used by the router to show a ChildView within a ParentView', () => {
 
       var routeHandler = router.createChildViewHandler(
         ChildView, ParentView, viewConstructorOptions);
@@ -408,11 +427,25 @@ describe('lib/router', function () {
       assert.isFunction(routeHandler);
       assert.isFalse(router.showChildView.called);
 
-      routeHandler.call(router);
-
-      assert.isTrue(router.showChildView.calledWith(
-        ChildView, ParentView, viewConstructorOptions));
+      return routeHandler.call(router)
+        .then(() => {
+          assert.isTrue(router.showChildView.calledWith(
+            ChildView, ParentView, viewConstructorOptions));
+        });
     });
+
+    it('handles module names for the view', () => {
+      var routeHandler = router.createChildViewHandler('sign_in', ParentView, viewConstructorOptions);
+      assert.isFunction(routeHandler);
+      assert.isFalse(router.showChildView.called);
+
+      return routeHandler.call(router)
+        .then(() => {
+          assert.isTrue(
+            router.showChildView.calledWith(SignInView, ParentView, viewConstructorOptions));
+        });
+    });
+
   });
 
   describe('signup flow', () => {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "shrink": "npmshrink",
     "lint": "eslint app server tests --cache",
     "start": "node scripts/check-local-config && grunt server",
-    "start-circle": "NODE_ENV=production grunt build && CONFIG_FILES=server/config/fxaci.json,server/config/production.json grunt serverproc:dist",
+    "start-circle": "CONFIG_FILES=server/config/local.json,server/config/production.json,tests/ci/config_circleci.json node_modules/.bin/grunt build && CONFIG_FILES=server/config/local.json,server/config/production.json,tests/ci/config_circleci.json node_modules/.bin/grunt serverproc:dist",
     "start-production": "NODE_ENV=production grunt build && CONFIG_FILES=server/config/local.json,server/config/production.json grunt serverproc:dist",
     "start-remote": "scripts/run_remote_dev.sh",
     "test": "node tests/intern.js --unit=true",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -170,6 +170,9 @@ const webpackConfig = {
       threads: 4,
       debug: false
     }),
+    // dynamically loaded routes cause the .md file to be read and a
+    // warning to be displayed on the console. Just ignore them.
+    new webpack.IgnorePlugin(/\.md$/)
   ]),
 
   stats: { colors: true },


### PR DESCRIPTION
The app is becoming a big heavy beast. This lays the groundwork
to load views on demand. The first views to use this are the legal
templates.

Loading views asynchronously uncovered a bug in the
modal-settings-panel-mixin where the panels would call
`navigate` twice, the first time when expected, the 2nd
when the panel closes and the `modal-cancel` event is
triggered. This PR updates to ignore modal-cancel
if `navigate` has previously been called.

The Fenix pairing flows will make use of this.

This can be tested by visiting https://lod.dev.lcip.org and then clicking the TOS/PP links.

extraction from #6404