### PR TITLE
fix(tests): fix PKCE tests for token-code experiment

### DIFF
--- a/tests/functional/sign_in_token_code.js
+++ b/tests/functional/sign_in_token_code.js
@@ -26,9 +26,13 @@ const testElementTextInclude = FunctionalHelpers.testElementTextInclude;
 const type = FunctionalHelpers.type;
 const visibleByQSA = FunctionalHelpers.visibleByQSA;
 
+const NOTES_REDIRECT_PAGE_SELECTOR = '#notes-by-firefox';
+const NOTES_PAGE_TEXT_SELECTOR = 'Notes by Firefox';
 const experimentParams = {
   query: {
     client_id: '7f368c6886429f19', // eslint-disable-line camelcase
+    code_challenge: 'aSOwsmuRBE1ZIVtiW6bzKMaf47kCFl7duD6ZWAXdnJo', // eslint-disable-line camelcase
+    code_challenge_method: 'S256', // eslint-disable-line camelcase
     forceUA: 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36',
     // eslint-disable-next-line camelcase
     keys_jwk: 'eyJrdHkiOiJFQyIsImtpZCI6Im9DNGFudFBBSFZRX1pmQ09RRUYycTRaQlZYblVNZ2xISGpVRzdtSjZHOEEiLCJjcnYiOi' +
@@ -91,7 +95,7 @@ registerSuite('signin token code', {
         .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
         .then(fillOutSignInTokenCode(email, 0))
 
-        .then(testElementTextInclude(selectors.SIGNIN_COMPLETE.SERVICE_NAME, 'notes'));
+        .then(testElementTextInclude(NOTES_REDIRECT_PAGE_SELECTOR, NOTES_PAGE_TEXT_SELECTOR));
     },
 
     'verified - treatment-code - valid code then click back': function () {
@@ -105,7 +109,7 @@ registerSuite('signin token code', {
         .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
         .then(fillOutSignInTokenCode(email, 0))
 
-        .then(testElementTextInclude(selectors.SIGNIN_COMPLETE.SERVICE_NAME, 'notes'))
+        .then(testElementTextInclude(NOTES_REDIRECT_PAGE_SELECTOR, NOTES_PAGE_TEXT_SELECTOR))
 
         .goBack()
         .then(testElementExists(selectors.SIGNIN.HEADER));


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-oauth-server/issues/592

test with 

```
npm run test -- --suites=oauth --grep="signin token code"

```