### PR TITLE
feat(ua-parser): Add a `genericDeviceType` method.

### DIFF
--- a/app/scripts/lib/user-agent.js
+++ b/app/scripts/lib/user-agent.js
@@ -143,6 +143,36 @@ const UserAgent = function (userAgent) {
         minor: parseInt(osVersion[1] || 0, 10),
         patch: parseInt(osVersion[2] || 0, 10)
       };
+    },
+
+    /**
+     * Get the generic operating system name.
+     *
+     * @param {String} [os=this.os.name] Full Operating System name
+     * @returns {String} generic operating system name
+     */
+    genericOSName (os = this.os.name) {
+      return UserAgent.toGenericOSName(os);
+    },
+
+    /**
+     * Get the generic device type, one of `mobile`, `tablet`, or `desktop`.
+     *
+     * @param {String} [type=this.device.type] Full device type
+     * @returns {String} generic device type.
+     */
+    genericDeviceType (type = this.device.type) {
+      switch (type) {
+      case 'mobile':
+      case 'tablet':
+        return type;
+      case 'smarttv':
+      case 'wearable':
+      case 'embedded':
+        return 'mobile';
+      default:
+        return 'desktop';
+      }
     }
   });
 

--- a/app/tests/spec/lib/user-agent.js
+++ b/app/tests/spec/lib/user-agent.js
@@ -458,6 +458,25 @@ describe('lib/user-agent', () => {
     });
   });
 
+  describe('genericDeviceType', () => {
+    const typeToGenericType = {
+      desktop: 'desktop',
+      embedded: 'mobile',
+      mobile: 'mobile',
+      smarttv: 'mobile',
+      tablet: 'tablet',
+      wearable: 'mobile',
+    };
+
+    Object.keys(typeToGenericType).forEach(type => {
+      const genericType = typeToGenericType[type];
+      it(`converts ${type} to ${genericType}`, () => {
+        const uap = new UserAgent();
+        assert.equal(uap.genericDeviceType(type), genericType);
+      });
+    });
+  });
+
   describe('toGenericOSName', function () {
     function eq(os, expected) {
       assert.equal(UserAgent.toGenericOSName(os), expected);


### PR DESCRIPTION
Converts the `type` returned by the user-agent parser
to one we have an icon for, either `mobile`, `tablet`,
or `desktop`.

Extraction from #6404 

@mozilla/fxa-devs - r?