### PR TITLE
fix(scripts): Fix the run_remote_dev.sh script

### DIFF
--- a/scripts/run_remote_dev.sh
+++ b/scripts/run_remote_dev.sh
@@ -4,9 +4,4 @@ set -euo pipefail
 
 node scripts/check-local-config
 
-CONFIG_FILES=server/config/local.json,server/config/fxaci.json grunt server &
-MH=$!
-
-grunt sass watch
-
-kill $MH
+CONFIG_FILES=server/config/local.json,server/config/fxaci.json grunt server


### PR DESCRIPTION
scripts/run_remote_dev.sh tried to run `grunt watch sass` which no longer exists because of which the server didn't stop listening even after exiting by CTRL+C.
Problem found in #6439