### PR TITLE
fix(tests): return promise so on error it's not unhandled rejection

### DIFF
--- a/tests/server/helpers/routesHelpers.js
+++ b/tests/server/helpers/routesHelpers.js
@@ -143,7 +143,7 @@ function isUrlIgnored (url) {
 }
 
 function checkUrls(origin, resources, testName = '') {
-  findCssSubResources(origin, resources)
+  return findCssSubResources(origin, resources)
     .then((cssSubResources) => {
       resources = resources.concat(cssSubResources);
 


### PR DESCRIPTION
In https://github.com/mozilla/legal-docs/issues/1157, two links on the privacy page are returning 404.

When the server tests are run, `Unhandled rejection` is logged and the test runner at the end notes ` Error: An error was emitted` and turns the test red, but without noting a failed test.

With this fix, the rejection is handled and reported as a failed test.

r? - @vladikoff @shane-tomlinson 