### PR TITLE
fix(style): don't display firefox logo on small screens for CWTS

### DIFF
--- a/app/styles/modules/_branding.scss
+++ b/app/styles/modules/_branding.scss
@@ -21,6 +21,10 @@
     margin: 10px auto 0 auto;
     top: 0;
     width: 100%;
+
+    .screen-choose-what-to-sync & {
+      display: none;
+    }
   }
 
   @include respond-to('trustedUI') {


### PR DESCRIPTION
Fixes #6314 

This PR removes the firefox logo on small screens when on CWTS. When viewed through a smaller device, the navigation bar pushes down the view causing the `save settings` button not to be shown.

<img width="347" alt="screen shot 2018-08-28 at 3 10 24 pm" src="https://user-images.githubusercontent.com/1295288/44745310-5aa02200-aad5-11e8-81f9-512d068752e8.png">
