### PR TITLE
fix(tests): auto-download nightly, and config to run tests with nightly

### DIFF
--- a/tests/teamcity/latest-nightly
+++ b/tests/teamcity/latest-nightly
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+CHANNELS_DIR="$HOME/firefox-channels"
+
+source $(dirname $0)/latest
+FXA_FIREFOX_BINARY="${CHANNELS_DIR}/latest-nightly/en-US/firefox/firefox-bin"

--- a/tests/teamcity/stage-nightly
+++ b/tests/teamcity/stage-nightly
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+CHANNELS_DIR="$HOME/firefox-channels"
+
+source $(dirname $0)/stage
+FXA_FIREFOX_BINARY="${CHANNELS_DIR}/latest-nightly/en-US/firefox/firefox-bin"

--- a/tests/teamcity/update-builds.sh
+++ b/tests/teamcity/update-builds.sh
@@ -27,7 +27,7 @@ function update_needed() {
 
 function show_firefox_versions() {
   echo "Available firefox versions:"
-  for d in latest-beta latest latest-esr; do
+  for d in latest-nightly latest-beta latest latest-esr; do
     echo -n "  "
     $CHANNELS_DIR/$d/en-US/firefox/firefox-bin --version 2>/dev/null
   done
@@ -62,7 +62,7 @@ fi
 
 cd $FXDOWNLOAD_DIR && npm install
 
-for d in beta release esr; do
+for d in nightly beta release esr; do
   ./fetch.js --install-dir $CHANNELS_DIR --channel $d
 done
 


### PR DESCRIPTION
Makes it possible to run teamcity with Nightly builds on stage and latest