### PR TITLE
fix(style): fix missing recovery code icons

### DIFF
--- a/app/scripts/templates/settings/account_recovery/recovery_key.mustache
+++ b/app/scripts/templates/settings/account_recovery/recovery_key.mustache
@@ -12,8 +12,8 @@
 
         <div class="options">
             <div class="buttons">
-                <button class="print-key"><img alt="{{#t}}Print button image{{/t}}" class="recovery-icon-option" src="/images/recovery_key_print.svg">{{#t}}Print{{/t}}</button>
-                <button class="download-key"><img alt="{{#t}}Download button image{{/t}}" class="recovery-icon-option" src="/images/recovery_key_download.svg">{{#t}}Download{{/t}}</button>
+                <button class="print-key"><img alt="{{#t}}Print button image{{/t}}" class="recovery-icon-option print-image" src="">{{#t}}Print{{/t}}</button>
+                <button class="download-key"><img alt="{{#t}}Download button image{{/t}}" class="recovery-icon-option download-image" src="">{{#t}}Download{{/t}}</button>
             </div>
         </div>
 

--- a/app/styles/modules/_settings-account-recovery.scss
+++ b/app/styles/modules/_settings-account-recovery.scss
@@ -81,7 +81,17 @@
 
         .recovery-icon-option {
           height: 16px;
-          padding-right: 10px;
+          padding-right: 25px;
+        }
+
+        img {
+          &.download-image {
+            background: image-url('recovery_key_download.svg') no-repeat;
+          }
+
+          &.print-image {
+            background: image-url('recovery_key_print.svg') no-repeat;
+          }
         }
       }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-content-server/issues/6440

These images were originally in-lined, removed and updated to use `image-url` property.