### PR TITLE
feat(pw-strength): 50% to Arabic, 100% in German

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/password-strength.js
+++ b/app/scripts/lib/experiments/grouping-rules/password-strength.js
@@ -8,11 +8,12 @@ const GROUPS_FOR_PARTIAL_ROLLOUT = ['control', 'designF'];
 
 // These locales only see designF
 const FULLY_ROLLED_OUT = [
+  'de',
   'en'
 ];
 
 const ROLLOUT_RATES = {
-  'de': 0.2, // german is 10% control, 10% treatment
+  'ar': 0.5, // arabic is 25% control, 25% treatment
 };
 
 const EXPERIMENT_NAME = 'passwordStrength';

--- a/app/scripts/views/mixins/password-strength-experiment-mixin.js
+++ b/app/scripts/views/mixins/password-strength-experiment-mixin.js
@@ -70,7 +70,9 @@ export default function (config = {}) {
       return new PasswordWithStrengthBalloonView({
         balloonEl: this.$(balloonEl),
         el: this.$(passwordEl),
-        model: passwordModel
+        lang: this.lang,
+        model: passwordModel,
+        translator: this.translator
       });
     },
 

--- a/app/scripts/views/password_strength/password_with_strength_balloon.js
+++ b/app/scripts/views/password_strength/password_with_strength_balloon.js
@@ -25,7 +25,9 @@ const PasswordWithStrengthBalloonView = FormView.extend({
   initialize (options = {}) {
     this.passwordHelperBalloon = options.passwordHelperBalloon || new PasswordStrengthBalloonView({
       el: options.balloonEl,
-      model: this.model
+      lang: this.lang,
+      model: this.model,
+      translator: this.translator
     });
     this.trackChildView(this.passwordHelperBalloon);
   },

--- a/app/tests/spec/lib/experiments/grouping-rules/password-strength.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/password-strength.js
@@ -27,11 +27,12 @@ describe('lib/experiments/grouping-rules/password-strength', () => {
     });
 
     it('has the expected locales fully rolled out', () => {
+      assert.include(experiment.FULLY_ROLLED_OUT, 'de');
       assert.include(experiment.FULLY_ROLLED_OUT, 'en');
     });
 
     it('has the expected rollout rates defined', () => {
-      assert.equal(experiment.ROLLOUT_RATES.de, 0.2);
+      assert.equal(experiment.ROLLOUT_RATES.ar, 0.5);
     });
 
     ['a@mozilla.org', 'a@softvision.com', 'a@softvision.ro', 'a@softvision.com'].forEach((email) => {


### PR DESCRIPTION
Also pass in the translator and the lang to the pw-strength
related views so that the strings are translated in dev mode.
This was not a problem when run in prod mode because prod
has all the strings built into the bundle, only in dev mode
do we have to pass around all the extra info.

I opted for Arabic rather than Hebrew because not all
strings are translated in Hebrew.

fixes #6516

@mozilla/fxa-devs - r?