### PR TITLE
[WIP] fix(email-first): Propagate model data from /signin, /signup to /

### DIFF
--- a/app/scripts/views/mixins/email-first-experiment-mixin.js
+++ b/app/scripts/views/mixins/email-first-experiment-mixin.js
@@ -9,7 +9,7 @@
  *
  * @mixin EmailFirstExperimentMixin
  */
-const ExperimentMixin = require('./experiment-mixin');
+import ExperimentMixin from './experiment-mixin';
 const EXPERIMENT_NAME = 'emailFirst';
 
 /**
@@ -24,14 +24,23 @@ module.exports = (options = {}) => {
     dependsOn: [ ExperimentMixin ],
 
     beforeRender () {
+      let redirectTo;
+
       if (this.relier.get('action') === 'email' && options.treatmentPathname) {
-        this.replaceCurrentPage(options.treatmentPathname);
+        redirectTo = options.treatmentPathname;
       } else if (this.isInEmailFirstExperiment()) {
         const experimentGroup = this.getEmailFirstExperimentGroup();
         this.createExperiment(EXPERIMENT_NAME, experimentGroup);
         if (experimentGroup === 'treatment' && options.treatmentPathname) {
-          this.replaceCurrentPage(options.treatmentPathname);
+          redirectTo = options.treatmentPathname;
         }
+      }
+
+      if (redirectTo) {
+        // Pass this view's model data to the page being redirected to. This
+        // allows data like `redirectTo` or `account` to be propagated to
+        // the email-first view.
+        this.replaceCurrentPage(options.treatmentPathname, this.model.toJSON());
       }
     },
 

--- a/app/tests/spec/views/mixins/email-first-experiment-mixin.js
+++ b/app/tests/spec/views/mixins/email-first-experiment-mixin.js
@@ -2,162 +2,160 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define(function(require, exports, module) {
-  'use strict';
+import { assert } from 'chai';
+import AuthBroker from 'models/auth_brokers/base';
+import BaseView from 'views/base';
+import Cocktail from 'cocktail';
+import EmailFirstExperimentMixin from 'views/mixins/email-first-experiment-mixin';
+import { Model } from 'backbone';
+import Notifier from 'lib/channels/notifier';
+import Relier from 'models/reliers/relier';
+import sinon from 'sinon';
 
-  const { assert } = require('chai');
-  const AuthBroker = require('models/auth_brokers/base');
-  const BaseView = require('views/base');
-  const Cocktail = require('cocktail');
-  const EmailFirstExperimentMixin = require('views/mixins/email-first-experiment-mixin');
-  const Notifier = require('lib/channels/notifier');
-  const Relier = require('models/reliers/relier');
-  const sinon = require('sinon');
-
-  class View extends BaseView {
-    constructor (options) {
-      super(options);
-      this.className = 'redirects';
-    }
+class View extends BaseView {
+  constructor (options) {
+    super(options);
+    this.className = 'redirects';
   }
+}
 
-  Cocktail.mixin(
-    View,
-    EmailFirstExperimentMixin({ treatmentPathname: '/' })
-  );
+Cocktail.mixin(
+  View,
+  EmailFirstExperimentMixin({ treatmentPathname: '/' })
+);
 
-  describe('views/mixins/email-first-experiment-mixin', () => {
-    let broker;
-    let notifier;
-    let relier;
-    let sandbox;
-    let view;
+describe('views/mixins/email-first-experiment-mixin', () => {
+  let broker;
+  let model;
+  let notifier;
+  let relier;
+  let sandbox;
+  let view;
 
-    before(() => {
-      sandbox = sinon.sandbox.create();
+  before(() => {
+    sandbox = sinon.sandbox.create();
 
-      broker = new AuthBroker();
-      broker.setCapability('emailFirst', true);
-      notifier = new Notifier();
-      relier = new Relier();
+    broker = new AuthBroker();
+    broker.setCapability('emailFirst', true);
+    model = new Model();
+    notifier = new Notifier();
+    relier = new Relier();
 
-      view = new View({
-        broker,
-        notifier,
-        relier,
-        viewName: 'email'
-      });
+    view = new View({
+      broker,
+      model,
+      notifier,
+      relier,
+      viewName: 'email'
     });
+  });
 
-    afterEach(() => {
-      sandbox.restore();
-      relier.unset('action');
+  afterEach(() => {
+    sandbox.restore();
+    relier.unset('action');
+  });
+
+  after(() => {
+    view.remove();
+    view.destroy();
+
+    view = null;
+  });
+
+  it('exposes the expected interface', () => {
+    const mixin = EmailFirstExperimentMixin();
+    assert.lengthOf(Object.keys(mixin), 6);
+    assert.isArray(mixin.dependsOn);
+    assert.isFunction(mixin.beforeRender);
+    assert.isFunction(mixin.getEmailFirstExperimentGroup);
+    assert.isFunction(mixin.isInEmailFirstExperiment);
+    assert.isFunction(mixin.isInEmailFirstExperimentGroup);
+    assert.isFunction(mixin._getEmailFirstExperimentSubject);
+  });
+
+  it('_getEmailFirstExperimentSubject returns the expected object', () => {
+    assert.deepEqual(view._getEmailFirstExperimentSubject(), {
+      isEmailFirstSupported: true
     });
+  });
 
-    after(() => {
-      view.remove();
-      view.destroy();
+  it('isInEmailFirstExperiment delegates to `isInExperiment` correctly', () => {
+    sandbox.stub(view, 'isInExperiment').callsFake(() => true);
 
-      view = null;
-    });
+    assert.isTrue(view.isInEmailFirstExperiment());
 
-    it('exposes the expected interface', () => {
-      const mixin = EmailFirstExperimentMixin();
-      assert.lengthOf(Object.keys(mixin), 6);
-      assert.isArray(mixin.dependsOn);
-      assert.isFunction(mixin.beforeRender);
-      assert.isFunction(mixin.getEmailFirstExperimentGroup);
-      assert.isFunction(mixin.isInEmailFirstExperiment);
-      assert.isFunction(mixin.isInEmailFirstExperimentGroup);
-      assert.isFunction(mixin._getEmailFirstExperimentSubject);
-    });
-
-    it('_getEmailFirstExperimentSubject returns the expected object', () => {
-      assert.deepEqual(view._getEmailFirstExperimentSubject(), {
+    assert.isTrue(view.isInExperiment.calledOnce);
+    assert.isTrue(view.isInExperiment.calledWith(
+      'emailFirst',
+      {
         isEmailFirstSupported: true
-      });
+      }
+    ));
+  });
+
+  it('isInEmailFirstExperimentGroup delegates to `isInExperimentGroup` correctly', () => {
+    sandbox.stub(view, 'isInExperimentGroup').callsFake(() => true);
+
+    assert.isTrue(view.isInEmailFirstExperimentGroup('treatment'));
+
+    assert.isTrue(view.isInExperimentGroup.calledOnce);
+    assert.isTrue(view.isInExperimentGroup.calledWith(
+      'emailFirst',
+      'treatment',
+      {
+        isEmailFirstSupported: true
+      }
+    ));
+  });
+
+  describe('beforeRender', () => {
+    beforeEach(() => {
+      sandbox.spy(view, 'createExperiment');
+      sandbox.spy(view, 'replaceCurrentPage');
     });
 
-    it('isInEmailFirstExperiment delegates to `isInExperiment` correctly', () => {
-      sandbox.stub(view, 'isInExperiment').callsFake(() => true);
+    it('redirects to the treatment page if `action=email`', () => {
+      relier.set('action', 'email');
 
-      assert.isTrue(view.isInEmailFirstExperiment());
+      view.beforeRender();
 
-      assert.isTrue(view.isInExperiment.calledOnce);
-      assert.isTrue(view.isInExperiment.calledWith(
-        'emailFirst',
-        {
-          isEmailFirstSupported: true
-        }
-      ));
+      assert.isTrue(view.replaceCurrentPage.calledOnceWith('/'));
     });
 
-    it('isInEmailFirstExperimentGroup delegates to `isInExperimentGroup` correctly', () => {
-      sandbox.stub(view, 'isInExperimentGroup').callsFake(() => true);
+    it('does nothing for users not in the experiment', () => {
+      sandbox.stub(view, 'isInEmailFirstExperiment').callsFake(() => false);
+      sandbox.stub(view, 'isInEmailFirstExperimentGroup').callsFake(() => false);
 
-      assert.isTrue(view.isInEmailFirstExperimentGroup('treatment'));
+      view.beforeRender();
 
-      assert.isTrue(view.isInExperimentGroup.calledOnce);
-      assert.isTrue(view.isInExperimentGroup.calledWith(
-        'emailFirst',
-        'treatment',
-        {
-          isEmailFirstSupported: true
-        }
-      ));
+      assert.isTrue(view.isInEmailFirstExperiment.calledOnce);
+      assert.isFalse(view.createExperiment.called);
+      assert.isFalse(view.replaceCurrentPage.called);
     });
 
-    describe('beforeRender', () => {
-      beforeEach(() => {
-        sandbox.spy(view, 'createExperiment');
-        sandbox.spy(view, 'replaceCurrentPage');
-      });
+    it('creates the experiment for users in the control group, does not redirect', () => {
+      sandbox.stub(view, 'isInEmailFirstExperiment').callsFake(() => true);
+      sandbox.stub(view, 'getEmailFirstExperimentGroup').callsFake(() => 'control');
 
-      it('redirects to the treatment page if `action=email`', () => {
-        relier.set('action', 'email');
+      view.beforeRender();
 
-        view.beforeRender();
+      assert.isTrue(view.isInEmailFirstExperiment.calledOnce);
 
-        assert.isTrue(view.replaceCurrentPage.calledOnceWith('/'));
-      });
+      assert.isTrue(view.createExperiment.calledOnce);
+      assert.isTrue(view.createExperiment.calledWith('emailFirst', 'control'));
 
-      it('does nothing for users not in the experiment', () => {
-        sandbox.stub(view, 'isInEmailFirstExperiment').callsFake(() => false);
-        sandbox.stub(view, 'isInEmailFirstExperimentGroup').callsFake(() => false);
+      assert.isFalse(view.replaceCurrentPage.called);
+    });
 
-        view.beforeRender();
+    it('creates the experiment for users in the treatment group, redirects if treatmentPathname specified', () => {
+      sandbox.stub(view, 'isInEmailFirstExperiment').callsFake(() => true);
+      sandbox.stub(view, 'getEmailFirstExperimentGroup').callsFake(() => 'treatment');
+      model.set('foo', 'bar');
 
-        assert.isTrue(view.isInEmailFirstExperiment.calledOnce);
-        assert.isFalse(view.createExperiment.called);
-        assert.isFalse(view.replaceCurrentPage.called);
-      });
+      view.beforeRender();
 
-      it('creates the experiment for users in the control group, does not redirect', () => {
-        sandbox.stub(view, 'isInEmailFirstExperiment').callsFake(() => true);
-        sandbox.stub(view, 'getEmailFirstExperimentGroup').callsFake(() => 'control');
-
-        view.beforeRender();
-
-        assert.isTrue(view.isInEmailFirstExperiment.calledOnce);
-
-        assert.isTrue(view.createExperiment.calledOnce);
-        assert.isTrue(view.createExperiment.calledWith('emailFirst', 'control'));
-
-        assert.isFalse(view.replaceCurrentPage.called);
-      });
-
-      it('creates the experiment for users in the treatment group, redirects if treatmentPathname specified', () => {
-        sandbox.stub(view, 'isInEmailFirstExperiment').callsFake(() => true);
-        sandbox.stub(view, 'getEmailFirstExperimentGroup').callsFake(() => 'treatment');
-
-        view.beforeRender();
-
-        assert.isTrue(view.createExperiment.calledOnce);
-        assert.isTrue(view.createExperiment.calledWith('emailFirst', 'treatment'));
-
-        assert.isTrue(view.replaceCurrentPage.calledOnce);
-        assert.isTrue(view.replaceCurrentPage.calledWith('/'));
-      });
+      assert.isTrue(view.createExperiment.calledOnceWith('emailFirst', 'treatment'));
+      assert.isTrue(view.replaceCurrentPage.calledOnceWith('/', { foo: 'bar' }));
     });
   });
 });


### PR DESCRIPTION
In the email-first flow, model data passed to /signin or /signup
was not being propagated to /. This prevented data like `redirectTo`
from being propagated so if a user had to sign in, they would not
be sent back to the page being signed into.

extraction from #6404 
blocks #6527 