### PR TITLE
fix(recovery): add account recovery reason property for metrics

### DIFF
--- a/app/scripts/lib/fxa-client.js
+++ b/app/scripts/lib/fxa-client.js
@@ -1052,7 +1052,7 @@ define(function (require, exports, module) {
     createRecoveryBundle: withClient((client, email, password, sessionToken, uid) => {
       let recoveryKey, keys, recoveryJwk;
 
-      return client.sessionReauth(sessionToken, email, password, {keys: true})
+      return client.sessionReauth(sessionToken, email, password, {keys: true, reason: VerificationReasons.RECOVERY_KEY})
         .then((res) => client.accountKeys(res.keyFetchToken, res.unwrapBKey))
         .then((result) => {
           keys = result;

--- a/app/scripts/lib/verification-reasons.js
+++ b/app/scripts/lib/verification-reasons.js
@@ -6,17 +6,13 @@
  * List of reasons a user must perform some form of verification.
  */
 
-define(function (require, exports, module) {
-  'use strict';
-
-  return {
-    FORCE_AUTH: 'force_auth',
-    PASSWORD_RESET: 'reset_password',
-    PASSWORD_RESET_WITH_RECOVERY_KEY: 'reset_password_with_recovery_key',
-    PRIMARY_EMAIL_VERIFIED: 'primary_email_verified',
-    SECONDARY_EMAIL_VERIFIED: 'secondary_email_verified',
-    SIGN_IN: 'login',
-    SIGN_UP: 'signup'
-  };
-});
-
+module.exports = {
+  FORCE_AUTH: 'force_auth',
+  PASSWORD_RESET: 'reset_password',
+  PASSWORD_RESET_WITH_RECOVERY_KEY: 'reset_password_with_recovery_key',
+  PRIMARY_EMAIL_VERIFIED: 'primary_email_verified',
+  RECOVERY_KEY: 'recovery_key',
+  SECONDARY_EMAIL_VERIFIED: 'secondary_email_verified',
+  SIGN_IN: 'login',
+  SIGN_UP: 'signup'
+};


### PR DESCRIPTION
This PR specifies a verificationReason `recovery_key` when setting up account recovery. It will give us more metrics data on users that setup account recovery. Targeted as a point release for train 120.

Pair programming Friday's with @shane-tomlinson.