### PR TITLE
feat(scripts): force registry links in shrinkwrap to use tls

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build-production": "NODE_ENV=production grunt build",
     "postinstall": "scripts/download_l10n.sh",
     "prepush": "npm run lint && grunt sasslint",
-    "shrink": "npmshrink",
+    "shrink": "npmshrink && scripts/tls-shrink.sh",
     "lint": "eslint app server tests --cache",
     "start": "node scripts/check-local-config && grunt server",
     "start-circle": "CONFIG_FILES=server/config/local.json,server/config/production.json,tests/ci/config_circleci.json node_modules/.bin/grunt build && CONFIG_FILES=server/config/local.json,server/config/production.json,tests/ci/config_circleci.json node_modules/.bin/grunt serverproc:dist",

--- a/scripts/tls-shrink.sh
+++ b/scripts/tls-shrink.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sed -i '' 's/"resolved": "http:\/\/registry\.npmjs\.org\//"resolved": "https:\/\/registry.npmjs.org\//' npm-shrinkwrap.json


### PR DESCRIPTION
Content server corollary to mozilla/fxa-auth-server#2641.

@mozilla/fxa-devs r?