### PR TITLE
fix(email): on password reset, hash email with the `emailToHashWith` value

### DIFF
--- a/app/scripts/models/account.js
+++ b/app/scripts/models/account.js
@@ -870,9 +870,10 @@ const Account = Backbone.Model.extend({
      * @param {String} token - email verification token
      * @param {String} code - email verification code
      * @param {Object} relier - relier being signed in to.
+     * @param {String} emailToHashWith - use this email to hash password with.
      * @returns {Promise} - resolves when complete
      */
-  completePasswordReset (password, token, code, relier) {
+  completePasswordReset (password, token, code, relier, emailToHashWith) {
     return this._fxaClient.completePasswordReset(
       this.get('email'),
       password,
@@ -880,7 +881,8 @@ const Account = Backbone.Model.extend({
       code,
       relier,
       {
-        metricsContext: this._metrics.getFlowEventMetadata()
+        emailToHashWith,
+        metricsContext: this._metrics.getFlowEventMetadata(),
       }
     ).then(this.set.bind(this));
   },
@@ -1444,9 +1446,10 @@ const Account = Backbone.Model.extend({
      * @param {String} recoveryKeyId - recoveryKeyId that maps to recovery key
      * @param {String} kB - original kB
      * @param {Object} relier - relier being signed in to.
+     * @param {String} emailToHashWith - has password with this email address
      * @returns {Promise} resolves with response when complete.
      */
-  resetPasswordWithRecoveryKey(accountResetToken, password, recoveryKeyId, kB, relier) {
+  resetPasswordWithRecoveryKey(accountResetToken, password, recoveryKeyId, kB, relier, emailToHashWith) {
     return this._fxaClient.resetPasswordWithRecoveryKey(
       accountResetToken,
       this.get('email'),
@@ -1455,6 +1458,7 @@ const Account = Backbone.Model.extend({
       kB,
       relier,
       {
+        emailToHashWith,
         metricsContext: this._metrics.getFlowEventMetadata()
       })
       .then(this.set.bind(this));

--- a/app/scripts/models/user.js
+++ b/app/scripts/models/user.js
@@ -615,10 +615,11 @@ define(function (require, exports, module) {
      * @param {String} token - email verification token
      * @param {String} code - email verification code
      * @param {Object} relier - relier being signed in to
+     * @param {String} emailToHashWith - use this email to hash password with
      * @returns {Promise} - resolves when complete
      */
-    completeAccountPasswordReset (account, password, token, code, relier) {
-      return account.completePasswordReset(password, token, code, relier)
+    completeAccountPasswordReset (account, password, token, code, relier, emailToHashWith) {
+      return account.completePasswordReset(password, token, code, relier, emailToHashWith)
         .then(() => {
           this._notifyOfAccountSignIn(account);
           return this.setSignedInAccount(account);
@@ -635,10 +636,11 @@ define(function (require, exports, module) {
      * @param {String} recoveryKeyId - recoveryKeyId that maps to recovery code
      * @param {String} kB - original kB
      * @param {Object} relier - relier being signed in to
+     * @param {String} emailToHashWith - hash password with this email
      * @returns {Promise} - resolves when complete
      */
-    completeAccountPasswordResetWithRecoveryKey (account, password, accountResetToken, recoveryKeyId, kB, relier) {
-      return account.resetPasswordWithRecoveryKey(accountResetToken, password, recoveryKeyId, kB, relier)
+    completeAccountPasswordResetWithRecoveryKey (account, password, accountResetToken, recoveryKeyId, kB, relier, emailToHashWith) {
+      return account.resetPasswordWithRecoveryKey(accountResetToken, password, recoveryKeyId, kB, relier, emailToHashWith)
         .then(() => {
           this._notifyOfAccountSignIn(account);
           return this.setSignedInAccount(account);

--- a/app/scripts/views/complete_reset_password.js
+++ b/app/scripts/views/complete_reset_password.js
@@ -150,6 +150,7 @@ define(function (require, exports, module) {
       var password = this._getPassword();
       var token = verificationInfo.get('token');
       var code = verificationInfo.get('code');
+      const emailToHashWith = verificationInfo.get('emailToHashWith');
 
       // If the user verifies in the same browser and the original tab
       // is still open, we want the original tab to redirect back to
@@ -174,7 +175,8 @@ define(function (require, exports, module) {
               accountRecoveryVerificationInfo.get('accountResetToken'),
               accountRecoveryVerificationInfo.get('recoveryKeyId'),
               accountRecoveryVerificationInfo.get('kB'),
-              this.relier);
+              this.relier,
+              emailToHashWith);
           }
 
           return this.user.completeAccountPasswordReset(
@@ -182,7 +184,8 @@ define(function (require, exports, module) {
             password,
             token,
             code,
-            this.relier);
+            this.relier,
+            emailToHashWith);
         })
         .then((updatedAccount) => {
           // The password was reset, future attempts should ask confirmation.

--- a/app/tests/spec/models/user.js
+++ b/app/tests/spec/models/user.js
@@ -1152,7 +1152,7 @@ define(function (require, exports, module) {
         sinon.spy(notifier, 'triggerRemote');
 
         return user.completeAccountPasswordReset(
-          account, 'password', 'token', 'code', relierMock);
+          account, 'password', 'token', 'code', relierMock, EMAIL);
       });
 
       it('delegates to the account', function () {
@@ -1160,7 +1160,8 @@ define(function (require, exports, module) {
           'password',
           'token',
           'code',
-          relierMock
+          relierMock,
+          EMAIL
         ));
       });
 
@@ -1169,6 +1170,47 @@ define(function (require, exports, module) {
       });
 
       it('notifies remote listeners', function () {
+        testRemoteSignInMessageSent(account);
+      });
+    });
+
+    describe('completeAccountPasswordResetWithRecoveryKey', () => {
+      let account;
+      const relierMock = {};
+      const recoveryKeyId = 'recoveryKeyId';
+      const kB = 'kB';
+
+      beforeEach(() => {
+        account = user.initAccount({
+          email: EMAIL,
+          sessionToken: 'sessionToken',
+          sessionTokenContext: 'sessionTokenContext',
+          uid: createUid()
+        });
+
+        sinon.stub(account, 'resetPasswordWithRecoveryKey').callsFake(() => Promise.resolve());
+        sinon.stub(user, 'setSignedInAccount').callsFake((account) => Promise.resolve(account));
+        sinon.spy(notifier, 'triggerRemote');
+
+        return user.completeAccountPasswordResetWithRecoveryKey(account, 'password', 'token', recoveryKeyId, kB, relierMock, EMAIL);
+      });
+
+      it('delegates to the account', () => {
+        assert.isTrue(account.resetPasswordWithRecoveryKey.calledWith(
+          'token',
+          'password',
+          recoveryKeyId,
+          kB,
+          relierMock,
+          EMAIL
+        ));
+      });
+
+      it('saves the updated account data', () => {
+        assert.isTrue(user.setSignedInAccount.calledWith(account));
+      });
+
+      it('notifies remote listeners', () => {
         testRemoteSignInMessageSent(account);
       });
     });

--- a/tests/functional/settings_change_email.js
+++ b/tests/functional/settings_change_email.js
@@ -146,7 +146,7 @@ registerSuite('settings change email', {
 
     'can change primary email, change password, login, change email and login': function () {
       return this.remote
-        // change password
+      // change password
         .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
         .then(fillOutChangePassword(PASSWORD, NEW_PASSWORD))
 
@@ -157,6 +157,47 @@ registerSuite('settings change email', {
         .then(visibleByQSA(selectors.SIGNIN.TOOLTIP))
 
         // sign in with new password
+        .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
+        .then(fillOutSignIn(secondaryEmail, NEW_PASSWORD))
+        .then(testElementTextEquals(selectors.SETTINGS.PROFILE_HEADER, secondaryEmail))
+
+        // set primary email to original email
+        .then(click(selectors.EMAIL.MENU_BUTTON))
+        .then(testElementTextEquals(selectors.EMAIL.ADDRESS_LABEL, email))
+        .then(testElementExists(selectors.EMAIL.VERIFIED_LABEL))
+        .then(click(selectors.EMAIL.SET_PRIMARY_EMAIL_BUTTON))
+
+        // sign out and login with new password
+        .then(click(selectors.SETTINGS.SIGNOUT))
+        .then(testElementExists(selectors.SIGNIN.HEADER))
+        .then(fillOutSignIn(email, NEW_PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER));
+    },
+
+    'can change primary email, reset password, login, change email and login': function () {
+      return this.remote
+        .then(click(selectors.SETTINGS.SIGNOUT))
+        .then(testElementExists(selectors.SIGNIN.HEADER))
+
+        .then(click(selectors.CHANGE_PASSWORD.LINK_RESET_PASSWORD))
+
+        .then(fillOutResetPassword(secondaryEmail))
+        .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
+
+        // user browses to another site.
+        .then(openVerificationLinkInNewTab(secondaryEmail, 2))
+
+        .then(switchToWindow(1))
+
+        .then(fillOutCompleteResetPassword(NEW_PASSWORD, NEW_PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+        .then(testSuccessWasShown())
+
+        // switch to the original window
+        .then(closeCurrentWindow())
+
+        // sign in with new password
+        .then(click(selectors.SETTINGS.SIGNOUT))
         .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
         .then(fillOutSignIn(secondaryEmail, NEW_PASSWORD))
         .then(testElementTextEquals(selectors.SETTINGS.PROFILE_HEADER, secondaryEmail))


### PR DESCRIPTION
Fixes #6571 

After some investigating and head scratching, it turns out that the password reset is not using the correct email address to hash the password when the password is reset. I am not sure when this got regressed but suspect it might have been with account recovery.

This PR pdates the `completePasswordReset` and `resetPasswordWithRecoveryKey` functions to correctly pass the email that should be hashed with password (`emailToHashWith`). This value ensures that passwords are always hashed with the original email the account was created with. 

Unfortunately, with this bug, we can't have that guarantee anymore because there might be some users that reset their passwords (after performing a primary email change), so their password would be hashed with the new email.

In practice, I don't believe this is an issue because the auth-server will only compare the `authPW` that the content-server passes to it.