### PR TITLE
fix(test): Force clear localStorage for the handshake tests.

### DIFF
--- a/tests/functional/oauth_handshake.js
+++ b/tests/functional/oauth_handshake.js
@@ -64,6 +64,7 @@ registerSuite('Firefox desktop user info handshake - OAuth flows', {
   beforeEach: function () {
     return this.remote.then(clearBrowserState({
       '123done': true,
+      force: true,
     }))
       .then(ensureUsers());
   },


### PR DESCRIPTION
This is another stab in the dark, I'm not sure whether this will
fix the problem. Whenever the "OAuth signin page - user signed
into browser, user signed in locally" test fails, on line 110 when
"fillOutSignIn" is called, we do not expect any user to be signed
in. The screen capture shows that a user *is* signed in.

The theory is that the first other tests cause a user to be
written into localStorage and this is not being properly
cleared. This forces the browser state to be cleared
by visiting the /clear page.

This same change fixed the desktop tests, hopefully
it fixes the OAuth test too.

issue #6182

@mozilla/fxa-devs - r?