### PR TITLE
feat(email-first): Allow invalid emails in query params.

### DIFF
--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -16,7 +16,6 @@ const t = (msg) => msg;
 
 /*eslint-disable camelcase*/
 const QUERY_PARAMETER_SCHEMA = {
-  action: Vat.action(),
   // context is not available when verifying.
   context: Vat.string().min(1),
   country: Vat.string().valid(...AllowedCountries),

--- a/app/scripts/views/index.js
+++ b/app/scripts/views/index.js
@@ -35,8 +35,11 @@ class IndexView extends FormView {
 
   beforeRender () {
     const account = this.getAccount();
+    const relierEmail = this.relier.get('email');
     if (account) {
       this.formPrefill.set(account.pick('email'));
+    } else if (relierEmail) {
+      this.formPrefill.set('email', relierEmail);
     }
   }
 
@@ -68,7 +71,16 @@ class IndexView extends FormView {
       // intentionally empty
       // shows the email-first template, the prefill email was set in beforeRender
     } else if (relierEmail) {
-      return this.checkEmail(relierEmail);
+      // the relier email is in the form already since it was used as the prefillEmail
+      // in beforeRender. Check whether the email is valid, and if so submit. If the
+      // email is not valid then show a validation error to help the user. See #6584
+      if (this.isValid()) {
+        return this.checkEmail(relierEmail);
+      } else {
+        // the email was not valid, show any validation errors.
+        // The relier email set used as the prefill email in beforeRender.
+        this.showValidationErrors();
+      }
     } else if (this.allowSuggestedAccount(suggestedAccount)) {
       this.replaceCurrentPage('signin', {
         account: suggestedAccount

--- a/app/tests/spec/models/reliers/oauth.js
+++ b/app/tests/spec/models/reliers/oauth.js
@@ -230,14 +230,6 @@ describe('models/reliers/oauth', () => {
         testInvalidQueryParams('access_type', invalidValues);
       });
 
-      describe('action', () => {
-        var validValues = [undefined, 'email', 'signin', 'signup', 'force_auth'];
-        testValidQueryParams('action', validValues, 'action', validValues);
-
-        var invalidValues = ['', ' ', 'invalid'];
-        testInvalidQueryParams('action', invalidValues);
-      });
-
       describe('login_hint', () => {
         var validValues = [undefined, 'test@example.com'];
         // login_hint is translated to email if no email is set.

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -126,6 +126,18 @@ describe('models/reliers/relier', function () {
     });
   });
 
+  [undefined, 'email', 'signin', 'signup', 'force_auth'].forEach((action) => {
+    describe(`valid action: ${action}`, () => {
+      testValidQueryParam('action', action, 'action', action);
+    });
+  });
+
+  ['', ' ', 'invalid'].forEach((action) => {
+    describe(`invalid action: ${action}`, () => {
+      testInvalidQueryParam('action', action);
+    });
+  });
+
   describe('email non-verification flow', function () {
     beforeEach(function () {
       relier.set('isVerification', false);
@@ -137,6 +149,16 @@ describe('models/reliers/relier', function () {
 
     ['testuser@testuser.com', 'testuser@testuser.co.uk'].forEach(function (value) {
       testValidQueryParam('email', value, 'email', value);
+    });
+  });
+
+  describe('email first flow', () => {
+    ['', ' '].forEach(function (email) {
+      testInvalidQueryParam('email', email);
+    });
+
+    ['invalid email', 'testuser@testuser.com', 'testuser@testuser.co.uk'].forEach((value) => {
+      testValidQueryParam('email', value, 'email', value.trim(), { action: 'email' });
     });
   });
 
@@ -308,10 +330,8 @@ describe('models/reliers/relier', function () {
     });
   }
 
-  function testValidQueryParam(paramName, paramValue, modelName, expectedValue) {
+  function testValidQueryParam(paramName, paramValue, modelName, expectedValue, params = {}) {
     it('valid query param succeeds (' + paramName + ':' + paramValue + ')', function () {
-      var params = {};
-
       if (! _.isUndefined(paramValue)) {
         params[paramName] = paramValue;
       } else {

--- a/tests/functional/oauth_email_first.js
+++ b/tests/functional/oauth_email_first.js
@@ -27,6 +27,7 @@ const {
   openVerificationLinkInSameTab,
   reOpenWithAdditionalQueryParams,
   testElementExists,
+  testElementTextEquals,
   testElementValueEquals,
   thenify,
   type,
@@ -117,6 +118,17 @@ registerSuite('oauth email first', {
         .then(openVerificationLinkInSameTab(email, 1))
 
         .then(testAtOAuthApp());
+    },
+
+    'email specified by relier, invalid': function () {
+      const invalidEmail = 'invalid@';
+
+      return this.remote
+        .then(openFxaFromRp('email-first', { header: selectors.ENTER_EMAIL.HEADER }))
+        .then(reOpenWithAdditionalQueryParams({ email: invalidEmail }, selectors.ENTER_EMAIL.HEADER ))
+        .then(testElementValueEquals(selectors.ENTER_EMAIL.EMAIL, invalidEmail))
+        .then(testElementExists(selectors.ENTER_EMAIL.TOOLTIP))
+        .then(testElementTextEquals(selectors.ENTER_EMAIL.TOOLTIP, 'Valid email required'));
     },
 
     'email specified by relier, not registered': function () {

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -65,7 +65,7 @@ function signUpWithExistingAccount (context, email, firstPassword, secondPasswor
 registerSuite('signup', {
   beforeEach: function () {
     email = TestHelpers.createEmail();
-    return this.remote.then(clearBrowserState());
+    return this.remote.then(clearBrowserState({ force: true }));
   },
 
   afterEach: function () {

--- a/tests/functional/sync_v3_email_first.js
+++ b/tests/functional/sync_v3_email_first.js
@@ -31,6 +31,7 @@ const {
   openVerificationLinkInNewTab,
   switchToWindow,
   testElementExists,
+  testElementTextEquals,
   testElementTextInclude,
   testElementValueEquals,
   testErrorTextInclude,
@@ -230,6 +231,23 @@ registerSuite('Firefox Desktop Sync v3 email first', {
         .then(closeCurrentWindow())
 
         .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER));
+    },
+
+    'email specified by relier, invalid': function () {
+      const invalidEmail = 'invalid@';
+
+      return this.remote
+        .then(openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
+          query: {
+            email: invalidEmail
+          },
+          webChannelResponses: {
+            'fxaccounts:can_link_account': {ok: true}
+          },
+        }))
+        .then(testElementValueEquals(selectors.ENTER_EMAIL.EMAIL, invalidEmail))
+        .then(testElementExists(selectors.ENTER_EMAIL.TOOLTIP))
+        .then(testElementTextEquals(selectors.ENTER_EMAIL.TOOLTIP, 'Valid email required'));
     },
 
     'email specified by relier, not registered': function () {


### PR DESCRIPTION
This allows reliers to specify an invalid email in the email-first
flow. The user will be shown an error message and given the chance
to modify the email before continuing. Other flows should be unaffected.

As an aside, but I believe a positive side effect, this allows `action=email`
to be used by any integration and is no longer limited to OAuth or Sync flows.

fixes #6584