### PR TITLE
fix(scripts): make tls-shrink script portable

### DIFF
--- a/scripts/tls-shrink.sh
+++ b/scripts/tls-shrink.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-sed -i '' 's/"resolved": "http:\/\/registry\.npmjs\.org\//"resolved": "https:\/\/registry.npmjs.org\//' npm-shrinkwrap.json
+sed -i.orig 's/"resolved": "http:\/\/registry\.npmjs\.org\//"resolved": "https:\/\/registry.npmjs.org\//' npm-shrinkwrap.json
+rm -f npm-shrinkwrap.json.orig


### PR DESCRIPTION
@shane-tomlinson pointed out that the script I wrote for forcing TLS URLs in shrinkwrap is not portable. This change makes it portable.

@mozilla/fxa-devs r?