### PR TITLE
chore(config): Add scoped-keys configuration for Firefox Send.

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -434,6 +434,11 @@ const conf = module.exports = convict({
           redirectUris: [
             'https://lockbox.firefox.com/fxa/ios-redirect.html'
           ]
+        },
+        'https://identity.mozilla.com/apps/send': {
+          redirectUris: [
+            'https://send2.dev.lcip.org/oauth'
+          ]
         }
       },
       doc: 'Validates redirect uris for requested scopes',


### PR DESCRIPTION
In support of https://bugzilla.mozilla.org/show_bug.cgi?id=1483369#c5

Longer-term, we should have a chat about whether we want to keep doing this validation in content-server, or whether the costs of maintaining it outweigh the benefits.  I could see us (for example) reducing it down so that only the "oldsync" scope gets this special extra level of checking, while new key-bearing scopes like "apps/send" do not.