### PR TITLE
fix(links): Remove `en-US` from any SUMO/MDN links.

### DIFF
--- a/app/scripts/lib/channels/receivers/web-channel.js
+++ b/app/scripts/lib/channels/receivers/web-channel.js
@@ -4,7 +4,7 @@
 
 /**
  * Receive a message from the browser over a WebChannel. See
- * https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
+ * https://developer.mozilla.org/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
  */
 
 

--- a/app/scripts/lib/channels/senders/web-channel.js
+++ b/app/scripts/lib/channels/senders/web-channel.js
@@ -4,7 +4,7 @@
 
 /**
  * Send a message to the browser over a WebChannel. See
- * https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
+ * https://developer.mozilla.org/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
  */
 
 define(function (require, exports, module) {

--- a/app/scripts/lib/channels/web.js
+++ b/app/scripts/lib/channels/web.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // A channel that completes the OAuth flow using Firefox WebChannel events
-// https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
-// https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/FxAccountsOAuthClient.jsm
+// https://developer.mozilla.org/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
+// https://developer.mozilla.org/docs/Mozilla/JavaScript_code_modules/FxAccountsOAuthClient.jsm
 
 define(function (require, exports, module) {
   'use strict';

--- a/app/scripts/lib/user-agent.js
+++ b/app/scripts/lib/user-agent.js
@@ -109,7 +109,7 @@ const UserAgent = function (userAgent) {
      */
     supportsSvgTransformOrigin () {
       // everything except Safari iOS / Edge / IE support TransformOrigin
-      // Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin
+      // Ref: https://developer.mozilla.org/docs/Web/CSS/transform-origin
       return ! (this.isIos() || this.isEdge() || this.isIE());
     },
 

--- a/app/scripts/views/settings/two_step_authentication.js
+++ b/app/scripts/views/settings/two_step_authentication.js
@@ -22,7 +22,7 @@ var t = BaseView.t;
 const CODE_INPUT_SELECTOR = 'input.totp-code';
 const CODE_REFRESH_SELECTOR = 'button.settings-button.totp-refresh';
 const CODE_REFRESH_DELAY_MS = 350;
-const TOTP_SUPPORT_URL = 'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication';
+const TOTP_SUPPORT_URL = 'https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication';
 
 const View = FormView.extend({
   template: Template,

--- a/app/scripts/views/sms_send.js
+++ b/app/scripts/views/sms_send.js
@@ -181,7 +181,7 @@ define(function (require, exports, module) {
     }
 
     static get LEARN_MORE_LINK () {
-      return 'https://www.mozilla.org/en-US/privacy/websites/#campaigns';
+      return 'https://www.mozilla.org/privacy/websites/#campaigns';
     }
   }
 

--- a/app/tests/mocks/broadcast-channel.js
+++ b/app/tests/mocks/broadcast-channel.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // stub out the BroadcastChannel object for testing.
-// See https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API
+// See https://developer.mozilla.org/docs/Web/API/Broadcast_Channel_API
 
 define(function (require, exports, module) {
   'use strict';

--- a/app/tests/spec/views/settings/two_step_authentication.js
+++ b/app/tests/spec/views/settings/two_step_authentication.js
@@ -91,7 +91,7 @@ describe('views/settings/two_step_authentication', () => {
 
   it('should show support link', () => {
     assert.equal(view.$('.totp-support-link').length, 1);
-    assert.equal(view.$('.totp-support-link').attr('href'), 'https://support.mozilla.org/en-US/kb/secure-' +
+    assert.equal(view.$('.totp-support-link').attr('href'), 'https://support.mozilla.org/kb/secure-' +
       'firefox-account-two-step-authentication');
   });
 


### PR DESCRIPTION
`en-US` makes an assumption about the user's language.
SUMO and MDN have the ability to decide the best language
for the user's locale.

fixes [bz1495816](https://bugzilla.mozilla.org/show_bug.cgi?id=1495816)

I opened this against train-121 since we already plan on shipping a point release to re-enable recovery codes.

@mozilla/fxa-devs - r?