### PR TITLE
fix(totp): call proto `afterCompleteSignInWithCode` after entering valid totp code

### DIFF
--- a/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -83,8 +83,16 @@ define(function (require, exports, module) {
       return proto._notifyRelierOfLogin.call(this, account);
     },
 
+    /**
+     * Notify the relier that a sign-in with a code was performed.
+     *
+     * @param {Object} account
+     * @returns {Promise}
+     * @private
+     */
     afterCompleteSignInWithCode (account) {
-      return this._notifyRelierOfLogin(account);
+      return this._notifyRelierOfLogin(account)
+        .then(() => proto.afterCompleteSignInWithCode.call(this, account));
     },
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-content-server/issues/6525
Fixes https://github.com/mozilla/fxa-content-server/issues/6399

Before video:
https://drive.google.com/file/d/1oaB1tjog9-o8zIgV9FkzfblfMhxsehJM/view?usp=sharing

After video:
https://drive.google.com/file/d/1kZ6X39uZ9O4LshPdLs8bULz0UyqS_Nc0/view?usp=sharing