### PR TITLE
fix(copy):Changed enter code to use code

### DIFF
--- a/app/scripts/templates/sign_in_recovery_code.mustache
+++ b/app/scripts/templates/sign_in_recovery_code.mustache
@@ -29,7 +29,7 @@
     </form>
 
     <div class="links">
-        <a id="use-backup-link" class="center" href="/signin_totp_code">{{#t}}Enter security code{{/t}}</a>
+        <a id="use-backup-link" class="center" href="/signin_totp_code">{{#t}}Use security code{{/t}}</a>
     </div>
   </section>
 </div>


### PR DESCRIPTION
This link title should say use, not enter. You can't enter anything on this page but a recovery code.