### PR TITLE
fix(checkbox): adds some margin to checkboxes

### DIFF
--- a/app/styles/modules/_custom-rows.scss
+++ b/app/styles/modules/_custom-rows.scss
@@ -71,7 +71,6 @@
   html[dir='rtl'] & {
     text-align: right;
   }
-
 }
 
 input[type='checkbox'] {
@@ -87,7 +86,15 @@ input[type='checkbox'] {
   cursor: pointer;
   display: inline-block;
   height: 18px;
-  margin-inline-start: 4px;
+
+  html[dir='ltr'] & {
+    margin-right: 4px;
+  }
+
+  html[dir='rtl'] & {
+    margin-left: 4px;
+  }
+
   padding: 0 !important;
   width: 18px;
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-content-server/issues/6626 and hopefully doesn't reintroduce #6574 

<img width="450" alt="screen shot 2018-10-15 at 9 30 59 am" src="https://user-images.githubusercontent.com/1295288/46953935-34bae680-d05d-11e8-9acf-7f4d4b83193a.png">

<img width="486" alt="screen shot 2018-10-15 at 9 27 06 am" src="https://user-images.githubusercontent.com/1295288/46953937-35ec1380-d05d-11e8-9cee-f8555c93162f.png">
