### PR TITLE
feat(connect-device): allow showSuccessMessage search param

### DIFF
--- a/app/scripts/views/connect_another_device.js
+++ b/app/scripts/views/connect_another_device.js
@@ -223,7 +223,8 @@ define(function (require, exports, module) {
      * @private
      */
     _showSuccessMessage () {
-      return !! this.model.get('showSuccessMessage');
+      return !! this.model.get('showSuccessMessage') ||
+             !! this.getSearchParam('showSuccessMessage');
     }
 
     /**

--- a/app/tests/spec/views/connect_another_device.js
+++ b/app/tests/spec/views/connect_another_device.js
@@ -360,6 +360,24 @@ define(function (require, exports, module) {
         });
       });
 
+      describe('with showSuccessMessage in the search params', () => {
+        beforeEach(() => {
+          sinon.stub(view, '_isSignedIn').callsFake(() => true);
+
+          windowMock.navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
+          windowMock.location.search = 'showSuccessMessage=true';
+
+          return view.render()
+            .then(() => {
+              view.afterVisible();
+            });
+        });
+
+        it('shows the success message', () => {
+          assert.lengthOf(view.$('.success'), 1);
+        });
+      });
+
       describe('with showSuccessMessage set to false for a user that can send an SMS', () => {
         beforeEach(() => {
           model.set('showSuccessMessage', false);


### PR DESCRIPTION
The reference browser will redirect manually to this page after completing an OAuth login flow.