### PR TITLE
fix(ci): update travis to use oauth server in auth server repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ group: deprecated-2017Q3
 cache:
   directories:
     - node_modules
-    - deps/node_modules/fxa-auth-server/node_modules
+    - deps/fxa-auth-server/node_modules
     - deps/node_modules/fxa-profile-server/node_modules
-    - deps/node_modules/fxa-oauth-server/node_modules
+    - deps/fxa-auth-server/fxa-oauth-server/node_modules
 
 notifications:
   irc:

--- a/tests/ci/deps.sh
+++ b/tests/ci/deps.sh
@@ -5,19 +5,28 @@ mkdir -p deps/node_modules
 cd deps
 
 # Auth
-git clone https://github.com/mozilla/fxa-auth-server.git --depth=1
-cd fxa-auth-server
+if [ -d fxa-auth-server ]
+then
+  # node_modules is cached and we can't clone into a non-empty directory
+  cd fxa-auth-server
+  git init
+  git remote add origin https://github.com/mozilla/fxa-auth-server.git
+  git fetch origin master
+  git checkout -f -b master origin/master
+else
+  git clone https://github.com/mozilla/fxa-auth-server.git --depth=1
+  cd fxa-auth-server
+fi
 # Install devDeps for the Auth Server to get memory db
 npm i &> /dev/null
 LOG_LEVEL=error node ./node_modules/fxa-auth-db-mysql/bin/mem.js &
 node ./scripts/gen_keys.js
 SIGNIN_UNBLOCK_ALLOWED_EMAILS="^block.*@restmail\\.net$" SIGNIN_UNBLOCK_FORCED_EMAILS="^block.*@restmail\\.net$" npm start &> /dev/null &
-cd ..
 
 # OAuth
 
-npm i mozilla/fxa-oauth-server &> /dev/null
-cd node_modules/fxa-oauth-server
+cd fxa-oauth-server
+npm i > /dev/null
 LOG_LEVEL=error NODE_ENV=dev node ./bin/server.js &
 cd ../..
 


### PR DESCRIPTION
Noticed travis failing on @irrationalagent's PR (https://github.com/mozilla/fxa-content-server/pull/6662), looks like it's OAuth related.

I've taken a wild stab in the dark here and assumed its related to the recent repo merge. This updates Travis to use the OAuth server code that's now already in the auth server repo. While doing that, I noticed the path for the auth server cached directory didn't match where it gets cloned to in the deps script. So I fixed that too.

Let's see if it fixes the build...

@mozilla/fxa-devs r?