### PR TITLE
fix(deps): Fix the npm audit warning for sync-exec

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12954,12 +12954,6 @@
       "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.3.1.tgz",
       "integrity": "sha1-tvmpANSWpX8CQI8iGYwQndoGMEE="
     },
-    "sync-exec": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.6.2.tgz",
-      "integrity": "sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=",
-      "dev": true
-    },
     "table": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "request": "2.88.0",
     "request-promise": "4.2.0",
     "sinon": "4.5.0",
-    "sync-exec": "0.6.2",
     "webpack-dev-middleware": "3.1.3",
     "xmlhttprequest": "git://github.com/zaach/node-XMLHttpRequest.git#onerror",
     "yargs": "10.0.3"

--- a/tests/tools/firefox_profile.js
+++ b/tests/tools/firefox_profile.js
@@ -1,31 +1,27 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 const path = require('path');
-const exec = require('sync-exec');
+const childProcess = require('child_process');
 
-var createProfile = function (config) {
-  var profileProcess = null;
-  var encodedProfile = '';
+module.exports = function createProfile (config) {
+  console.log('Creating Firefox profile...');
 
-  if (path) {
-    console.log('Creating Firefox profile...');
-    var profileArgs = JSON.stringify(JSON.stringify(config));
-    var profileTool = path.join('tests', 'tools', 'firefox_profile_creator.js');
-    try {
-      profileProcess = exec(['node', profileTool, profileArgs].join(' '));
-    } catch (e) {
-      console.log('Note: execSync failed to run:', e);
-    }
-
-    if (profileProcess && profileProcess.status === 0) {
-      encodedProfile = profileProcess.stdout;
-    } else {
-      console.log('Note: Failed to generate a Firefox profile for this configuration.');
-    }
-
-    return encodedProfile;
+  let encodedProfile = '';
+  const profileArgs = JSON.stringify(JSON.stringify(config));
+  const profileTool = path.join('tests', 'tools', 'firefox_profile_creator.js');
+  try {
+    encodedProfile = childProcess.execSync(['node', profileTool, profileArgs].join(' '));
+  } catch (e) {
+    console.log('Note: execSync failed to run:', e);
   }
-};
 
-module.exports = createProfile;
+  if (encodedProfile) {
+    encodedProfile = encodedProfile.toString('utf8');
+  } else {
+    console.log('Note: Failed to generate a Firefox profile for this configuration.');
+  }
+
+  return encodedProfile;
+};


### PR DESCRIPTION
Remove the package, use node's child_process.syncExec instead.

blocks #6595 

@mozilla/fxa-devs - r? It's a tad easier to review with ?w=1