### PR TITLE
fix(pairing): Expect the channelId to be a base64url string.

### DIFF
--- a/app/scripts/lib/channel-server-client.js
+++ b/app/scripts/lib/channel-server-client.js
@@ -343,9 +343,7 @@ export default class ChannelServerClient extends Model {
     }
 
     const channelKeyBuffer = base64url.toBuffer(channelKey);
-    // The channelId is hex, but the browser uses it as a utf8 string
-    // so we do too so that we end up with the same encryption key.
-    const channelIdBuffer = Buffer.from(channelId, 'utf8');
+    const channelIdBuffer = base64url.toBuffer(channelId);
 
     return Promise.all([
       this._deriveChannelJwk(channelKeyBuffer, channelIdBuffer),

--- a/app/tests/spec/lib/channel-server-client.js
+++ b/app/tests/spec/lib/channel-server-client.js
@@ -89,7 +89,7 @@ describe('lib/channel-server-client', () => {
       let firstJwk;
 
       const channelKeyBase64Url = 'YKR1mHPnuPgKHKjV6k46VtLFTUVU5LLWwSPuqaULNtc';
-      // It's a hex string, but considered UTF8 by the browser
+      // It's a hex string, but considered base64url until the channelserver updates.
       const channelIdUtf8 = '75be751212c4429d9d6f27abcc534d11';
 
       client.set('channelKey', channelKeyBase64Url);
@@ -99,7 +99,7 @@ describe('lib/channel-server-client', () => {
         assert.ok(channelJwk);
 
         const expectedChannelKeyHex = base64url.toBuffer(channelKeyBase64Url).toString('hex');
-        const expectedChannelIdHex = Buffer.from(channelIdUtf8, 'utf8').toString('hex');
+        const expectedChannelIdHex = base64url.toBuffer(channelIdUtf8).toString('hex');
 
         assert.isTrue(client._deriveChannelJwk.calledOnce);
         assert.equal(client._deriveChannelJwk.args[0][0].toString('hex'), expectedChannelKeyHex);


### PR DESCRIPTION
We expected it to be hex, but agreed to use base64url instead.

fixes #6667 

@mozilla/fxa-devs - r?