### PR TITLE
fix(totp): Remove en-US from the TOTP SUMO link.

### DIFF
--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
   const VerificationReasons = require('../../lib/verification-reasons');
   const TokenCodeExperimentMixin = require('../mixins/token-code-experiment-mixin');
 
-  const TOTP_SUPPORT_URL = 'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication';
+  const TOTP_SUPPORT_URL = 'https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication';
 
   module.exports = {
     dependsOn: [

--- a/app/tests/spec/views/mixins/signin-mixin.js
+++ b/app/tests/spec/views/mixins/signin-mixin.js
@@ -476,7 +476,7 @@ define(function (require, exports, module) {
         it('failed', () => {
           assert.isTrue(AuthErrors.is(err, 'TOTP_REQUIRED'));
           assert.isTrue(view.unsafeDisplayError.calledWith(err));
-          const link = 'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication';
+          const link = 'https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication';
           assert.isTrue(err.forceMessage.indexOf(link) > 0, 'contains setup link');
 
           const args = user.signInAccount.args[0];
@@ -505,7 +505,7 @@ define(function (require, exports, module) {
         it('failed', () => {
           assert.isTrue(OAuthErrors.is(err, 'MISMATCH_ACR_VALUES'));
           assert.isTrue(view.unsafeDisplayError.calledWith(err));
-          const link = 'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication';
+          const link = 'https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication';
           assert.isTrue(err.forceMessage.indexOf(link) > 0, 'contains setup link');
 
           const args = user.signInAccount.args[0];

--- a/grunttasks/ban-word.js
+++ b/grunttasks/ban-word.js
@@ -9,6 +9,12 @@ module.exports = function (grunt) {
         banList: ['unsafeExplicitIV']
       },
       src: ['app/scripts/**/*.js', '!app/scripts/lib/crypto/a256gcm.js', '!app/scripts/lib/crypto/recovery-keys.js']
+    },
+    'en-US': {
+      options: {
+        banList: ['en-us', 'en-US', 'en_us', 'en_US']
+      },
+      src: ['app/scripts/**/*.js']
     }
   });
 };


### PR DESCRIPTION
To avoid this happening again, ban 'en-US' from the app directory.

fixes #6666 

@mozilla/fxa-devs - r?