### PR TITLE
chore(deps): update mailcheck

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9376,8 +9376,9 @@
       }
     },
     "mailcheck": {
-      "version": "git://github.com/mailcheck/mailcheck.git#d995fcc1d02c124a893c2cb0fce2e0ce5f36bce4",
-      "from": "git://github.com/mailcheck/mailcheck.git#d995fcc1d02c124a893c2cb0fce2e0ce5f36bce4"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mailcheck/-/mailcheck-1.1.1.tgz",
+      "integrity": "sha1-2Hz2ugtkulEhmdv5PxSJ9HlZHjQ="
     },
     "make-dir": {
       "version": "1.3.0",
@@ -12743,9 +12744,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
     },
     "speed-trap": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "legal-docs": "git://github.com/mozilla/legal-docs.git#master",
     "load-grunt-tasks": "3.5.2",
     "lodash": "4.17.5",
-    "mailcheck": "git://github.com/mailcheck/mailcheck.git#d995fcc1d02c124a893c2cb0fce2e0ce5f36bce4",
+    "mailcheck": "1.1.1",
     "mkdirp": "0.5.1",
     "mocha": "4.0.1",
     "morgan": "1.9.0",


### PR DESCRIPTION
Originally I tested this out to see if it does better mailchecking than the pinned commit we were depending on. But actually the pinned commit was doing pretty well too, certainly they both handled the `gmal.com` case that was discussed in IRC last night. But I didn't see a reason not to use latest and greatest either, so have PRed this anyway.

<img width="397" alt="Screenshot showing mailcheck at work on the sign-up view with the infamous `gmal.com` email address" src="https://user-images.githubusercontent.com/64367/47775931-0427ad80-dce9-11e8-8093-f33745f33931.png" />

@mozilla/fxa-devs r?