### PR TITLE
chore(config): Add reference-browser to allowlist for oldsync scope.

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -428,7 +428,8 @@ const conf = module.exports = convict({
         'https://identity.mozilla.com/apps/oldsync': {
           redirectUris: [
             'https://lockbox.firefox.com/fxa/ios-redirect.html',
-            'https://lockbox.firefox.com/fxa/android-redirect.html'
+            'https://lockbox.firefox.com/fxa/android-redirect.html',
+            'https://accounts.firefox.com/oauth/success/3c49430b43dfba77'
           ]
         },
         'https://identity.mozilla.com/apps/send': {


### PR DESCRIPTION
To accompany https://bugzilla.mozilla.org/show_bug.cgi?id=1503456

The page doesn't exist yet, but https://github.com/mozilla-mobile/reference-browser/pull/172 seems to be using it successfully even though it's a 404, so we may as well let them fetch keys via that flow.