### PR TITLE
feat(signin): add use different account option in security/recovery codes

### DIFF
--- a/app/scripts/templates/sign_in_recovery_code.mustache
+++ b/app/scripts/templates/sign_in_recovery_code.mustache
@@ -28,8 +28,9 @@
 
     </form>
 
-    <div class="links">
-        <a id="use-backup-link" class="center" href="/signin_totp_code">{{#t}}Use security code{{/t}}</a>
+    <div class="links centered">
+      <a id="use-backup-link" href="/signin_totp_code">{{#t}}Use security code{{/t}}</a>
+      <a class="different-account-link" href="/signin">{{#t}}Use a different account{{/t}}</a>
     </div>
   </section>
 </div>

--- a/app/scripts/templates/sign_in_totp_code.mustache
+++ b/app/scripts/templates/sign_in_totp_code.mustache
@@ -28,8 +28,9 @@
 
     </form>
 
-    <div class="links">
-        <a id="use-recovery-code-link" class="center" href="/signin_recovery_code">{{#t}}Use recovery code{{/t}}</a>
+    <div class="links centered">
+      <a id="use-recovery-code-link" href="/signin_recovery_code">{{#t}}Use recovery code{{/t}}</a>
+      <a class="different-account-link" href="/signin">{{#t}}Use a different account{{/t}}</a>
     </div>
   </section>
 </div>

--- a/app/tests/spec/views/sign_in_recovery_code.js
+++ b/app/tests/spec/views/sign_in_recovery_code.js
@@ -84,6 +84,8 @@ describe('views/sign_in_recovery_code', () => {
     it('renders the view', () => {
       assert.lengthOf(view.$('#fxa-recovery-code-header'), 1);
       assert.include(view.$('.verification-recovery-code-message').text(), 'recovery code');
+      assert.equal(view.$('#use-backup-link').attr('href'), '/signin_totp_code');
+      assert.equal(view.$('.different-account-link').attr('href'), '/signin');
     });
 
     describe('without an account', () => {

--- a/app/tests/spec/views/sign_in_totp_code.js
+++ b/app/tests/spec/views/sign_in_totp_code.js
@@ -91,6 +91,8 @@ describe('views/sign_in_totp_code', () => {
     it('renders the view', () => {
       assert.lengthOf(view.$('#fxa-totp-code-header'), 1);
       assert.include(view.$('.verification-totp-message').text(), 'security code');
+      assert.equal(view.$('#use-recovery-code-link').attr('href'), '/signin_recovery_code');
+      assert.equal(view.$('.different-account-link').attr('href'), '/signin');
     });
 
     describe('without an account', () => {


### PR DESCRIPTION
Same PR as https://github.com/mozilla/fxa-content-server/pull/6645, except squashed and merged. I thumbs 👍  it over there.

@mozilla/fxa-devs r?