### PR TITLE
fix(reset): remove confusing password reset messaging

### DIFF
--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -44,6 +44,14 @@ const View = BaseView.extend({
     if (! this.model.has('passwordForgotToken')) {
       this.navigate('reset_password');
     }
+
+    // Check to see if account has a recovery key and store in model.
+    // The password reset success messaging will change depending on if it does
+    const account = this.user.initAccount({email: this.model.get('email')});
+    return account.checkRecoveryKeyExistsByEmail()
+      .then((result) => {
+        this.model.set('hasRecoveryKey', result.exists);
+      });
   },
 
   afterVisible () {
@@ -171,8 +179,14 @@ const View = BaseView.extend({
     // users will be redirected back to the RP, Sync users will be
     // taken to the Sync controlled completion page.
     Session.clear();
+
+    let success = t('Password reset successfully. Sign in to continue.');
+    if (this.model.get('hasRecoveryKey')) {
+      success = t('Sign in to continue.');
+    }
+
     this.navigate('signin', {
-      success: t('Password reset successfully. Sign in to continue.')
+      success
     });
   },
 

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -30,6 +30,7 @@ describe('views/confirm_reset_password', function () {
   let metrics;
   let model;
   let notifier;
+  let recoveryKeyExists = false;
   let relier;
   let user;
   let view;
@@ -61,6 +62,8 @@ describe('views/confirm_reset_password', function () {
     sinon.stub(fxaClient, 'isPasswordResetComplete').callsFake(function () {
       return Promise.resolve(true);
     });
+
+    sinon.stub(fxaClient, 'recoveryKeyExists').callsFake(() => Promise.resolve({exists: recoveryKeyExists}));
 
     model.set({
       email: EMAIL,
@@ -380,14 +383,28 @@ describe('views/confirm_reset_password', function () {
     });
   });
 
-
   describe('_finishPasswordResetDifferentBrowser', function () {
     it('redirects to page specified by broker if user verifies in a second browser', function () {
       sinon.spy(view, 'navigate');
 
       view._finishPasswordResetDifferentBrowser();
 
-      assert(view.navigate.calledOnceWith('signin'));
+      assert(view.navigate.calledOnceWith('signin', {success: 'Password reset successfully. Sign in to continue.'}));
+    });
+  });
+
+  describe('_finishPasswordResetDifferentBrowser with recovery key', () => {
+    beforeEach(() => {
+      recoveryKeyExists = true;
+      return view.render();
+    });
+
+    it('redirects to page specified by broker if user verifies in a second browser', () => {
+      sinon.spy(view, 'navigate');
+
+      view._finishPasswordResetDifferentBrowser();
+
+      assert(view.navigate.calledOnceWith('signin', {success: 'Sign in to continue.'}));
     });
   });
 


### PR DESCRIPTION
Fixes #6495 

Ref https://github.com/mozilla/fxa-content-server/issues/6495#issuecomment-426757088, the `PasswordForgotToken` gets consumed when attempting to use a recovery key (successful or not).

A straight foward solution to this is to only show the `Password reset successfully. Sign in to continue` if doing a non-recovery-key reset in another browser window.