### PR TITLE
fix(recovery): remove recovery key control group

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/recovery-key.js
+++ b/app/scripts/lib/experiments/grouping-rules/recovery-key.js
@@ -5,7 +5,7 @@
 
 const BaseGroupingRule = require('./base');
 
-const GROUPS = ['control', 'treatment'];
+const GROUPS = ['treatment'];
 
 module.exports = class RecoveryKeyGroupingRule extends BaseGroupingRule {
   constructor() {

--- a/app/tests/spec/lib/experiments/grouping-rules/recovery-key.js
+++ b/app/tests/spec/lib/experiments/grouping-rules/recovery-key.js
@@ -41,7 +41,7 @@ describe('lib/experiments/grouping-rules/recovery-key', () => {
       sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
       experiment.choose(subject);
       assert.isTrue(experiment.uniformChoice.calledOnce);
-      assert.isTrue(experiment.uniformChoice.calledWith(['control', 'treatment'], 'user-id'));
+      assert.isTrue(experiment.uniformChoice.calledWith(['treatment'], 'user-id'));
     });
 
     it('returns false if not in rollout', () => {


### PR DESCRIPTION
@davismtl noticed his account page did not have the `Account recovery` option. This was because the 100% rollout was split between control and treatment groups which made the real rollout 50%. This removes the control so all users are put in the treatment group.