### PR TITLE
fix(tests): install node-uuid when running tests/teamcity/run-server.sh

### DIFF
--- a/tests/teamcity/install-npm-deps.sh
+++ b/tests/teamcity/install-npm-deps.sh
@@ -25,6 +25,7 @@ node ./tests/teamcity/install-npm-deps.js \
   morgan                          \
   mozlog                          \
   node-uap                        \
+  node-uuid                       \
   on-headers                      \
   otplib                          \
   proxyquire                      \


### PR DESCRIPTION
Seen in https://tc-test.dev.lcip.org/viewLog.html?buildId=45136&buildTypeId=fxa_LatestServerTests&tab=buildLog#_state=1952

Error: Cannot find module 'node-uuid'