### PR TITLE
fix(tests): use stronger password in functional tests

### DIFF
--- a/tests/functional/avatar.js
+++ b/tests/functional/avatar.js
@@ -16,7 +16,7 @@ const ios10UserAgent = uaStrings['ios_firefox_6_1'];
 const ADD_AVATAR_BUTTON_SELECTOR  = '#change-avatar .settings-unit-toggle.primary-button';
 const AVATAR_CHANGE_URL = config.fxaContentRoot + 'settings/avatar/change';
 const AVATAR_CHANGE_URL_AUTOMATED = config.fxaContentRoot + 'settings/avatar/change?automatedBrowser=true';
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 const SETTINGS_URL = config.fxaContentRoot + 'settings';
 const SETTINGS_URL_IOS10 = `${SETTINGS_URL}?forceUA='${encodeURIComponent(ios10UserAgent)}`;
 const SIGNIN_URL = config.fxaContentRoot + 'signin';

--- a/tests/functional/complete_sign_in.js
+++ b/tests/functional/complete_sign_in.js
@@ -13,7 +13,7 @@ const selectors = require('./lib/selectors');
 const config = intern._config;
 const PAGE_COMPLETE_SIGNIN_URL = config.fxaContentRoot + 'complete_signin';
 const PAGE_SIGNIN_URL = config.fxaContentRoot + 'signin?context=fx_desktop_v1&service=sync';
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 
 
 let code;

--- a/tests/functional/fx_fennec_v1_force_auth.js
+++ b/tests/functional/fx_fennec_v1_force_auth.js
@@ -25,7 +25,7 @@ const {
   thenify,
 } = FunctionalHelpers;
 
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 let email;
 
 const setupTest = thenify(function (options) {

--- a/tests/functional/oauth_choose_redirect.js
+++ b/tests/functional/oauth_choose_redirect.js
@@ -10,7 +10,7 @@ const FunctionalHelpers = require('./lib/helpers');
 const config = intern._config;
 const CONTENT_SERVER_ROOT = config.fxaContentRoot;
 const TRUSTED_REDIRECT_URI = `${config.fxaOAuthApp}api/oauth`;
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 
 const clearBrowserState = FunctionalHelpers.clearBrowserState;
 const getQueryParamValue = FunctionalHelpers.getQueryParamValue;

--- a/tests/functional/oauth_permissions.js
+++ b/tests/functional/oauth_permissions.js
@@ -16,7 +16,7 @@ const TIMEOUT = 90 * 1000;
 
 const TRUSTED_OAUTH_APP = config.fxaOAuthApp;
 const UNTRUSTED_OAUTH_APP = config.fxaUntrustedOauthApp;
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 
 let email;
 

--- a/tests/functional/oauth_require_totp.js
+++ b/tests/functional/oauth_require_totp.js
@@ -14,7 +14,7 @@ const selectors = require('./lib/selectors');
 
 const SIGNIN_URL = `${config.fxaContentRoot}signin`;
 
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 let email, secret;
 
 const {

--- a/tests/functional/oauth_sign_in.js
+++ b/tests/functional/oauth_sign_in.js
@@ -20,7 +20,7 @@ otplib.authenticator.options = {encoding: 'hex'};
 const SIGNUP_URL = `${config.fxaContentRoot}signup`;
 const SETTINGS_URL = `${config.fxaContentRoot}settings`;
 
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 let authenticator, email, secret, code;
 
 const thenify = FunctionalHelpers.thenify;

--- a/tests/functional/recovery_key.js
+++ b/tests/functional/recovery_key.js
@@ -15,7 +15,7 @@ const SIGNUP_URL = `${config.fxaContentRoot}signup`;
 const SIGNIN_URL = `${config.fxaContentRoot}signin`;
 const SETTINGS_URL = `${config.fxaContentRoot}settings`;
 const RESET_PASSWORD_URL = config.fxaContentRoot + 'reset_password?context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true';
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 const NEW_PASSWORD = '()()():|';
 let email, recoveryKey;
 

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -18,7 +18,7 @@ const RESET_PAGE_URL = config.fxaContentRoot + 'reset_password';
 const CONFIRM_PAGE_URL = config.fxaContentRoot + 'confirm_reset_password';
 const COMPLETE_PAGE_URL_ROOT = config.fxaContentRoot + 'complete_reset_password';
 
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 const TIMEOUT = 90 * 1000;
 
 let client;

--- a/tests/functional/send_sms.js
+++ b/tests/functional/send_sms.js
@@ -28,7 +28,7 @@ const SEND_SMS_NO_QUERY_URL = `${config.fxaContentRoot}sms`;
 
 
 let email;
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 
 let testPhoneNumber;
 let formattedPhoneNumber;

--- a/tests/functional/settings_change_email.js
+++ b/tests/functional/settings_change_email.js
@@ -14,7 +14,7 @@ const config = intern._config;
 const SIGNUP_URL = config.fxaContentRoot + 'signup';
 const SIGNIN_URL = config.fxaContentRoot + 'signin';
 const SETTINGS_URL = config.fxaContentRoot + 'settings';
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 const NEW_PASSWORD = 'password1';
 
 let email;

--- a/tests/functional/settings_secondary_emails.js
+++ b/tests/functional/settings_secondary_emails.js
@@ -13,7 +13,7 @@ const selectors = require('./lib/selectors');
 const config = intern._config;
 const SIGNUP_URL = config.fxaContentRoot + 'signup';
 const SIGNIN_URL = config.fxaContentRoot + 'signin';
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 
 let client;
 let email;

--- a/tests/functional/sign_in_recovery_code.js
+++ b/tests/functional/sign_in_recovery_code.js
@@ -13,7 +13,7 @@ const config = intern._config;
 
 const SIGNUP_URL = `${config.fxaContentRoot}signup`;
 const SETTINGS_URL = `${config.fxaContentRoot}settings`;
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 const SYNC_SIGNIN_URL = `${config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync`;
 
 let email;

--- a/tests/functional/sign_in_token_code.js
+++ b/tests/functional/sign_in_token_code.js
@@ -9,7 +9,7 @@ const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 let email;
 
 const click = FunctionalHelpers.click;

--- a/tests/functional/sign_in_totp.js
+++ b/tests/functional/sign_in_totp.js
@@ -13,7 +13,7 @@ const config = intern._config;
 
 const SIGNUP_URL = `${config.fxaContentRoot}signup`;
 const SETTINGS_URL = `${config.fxaContentRoot}settings`;
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 const SYNC_SIGNIN_URL = `${config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync`;
 const SIGNIN_URL = `${config.fxaContentRoot}signin`;
 const RECOVERY_CODES_URL = `${config.fxaContentRoot}settings/two_step_authentication/recovery_codes`;

--- a/tests/functional/sync_force_auth.js
+++ b/tests/functional/sync_force_auth.js
@@ -31,7 +31,7 @@ const {
   testIsBrowserNotifiedOfMessage: testIsBrowserNotified,
 } = FxDesktopHelpers;
 
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 let email;
 
 const setupTest = thenify(function (options = {}) {

--- a/tests/functional/sync_v3_reset_password.js
+++ b/tests/functional/sync_v3_reset_password.js
@@ -12,7 +12,7 @@ const uaStrings = require('./lib/ua-strings');
 
 const config = intern._config;
 
-const PASSWORD = 'password';
+const PASSWORD = 'passwordzxcv';
 const RESET_PASSWORD_URL = `${config.fxaContentRoot}reset_password?context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true`;
 
 let email;


### PR DESCRIPTION
Fixes #6713 

This updates passwords used in functional tests to meet new password requirements. Not all the tests needed the updated since updated requirements only appear with email-first, but figured it was ok to make the change since we would have to do it at some point.

`s/const PASSWORD = 'password'/const PASSWORD = 'passwordzxcv/`