### PR TITLE
fix(l10n): Use an inline `t` function to ensure l10n works as expected.

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -12,9 +12,7 @@ define(function (require, exports, module) {
   const Logger = require('./logger');
   var logger = new Logger();
 
-  var t = function (msg) {
-    return msg;
-  };
+  const t = msg => msg;
 
   var UNEXPECTED_ERROR_MESSAGE = t('Unexpected error');
   var EXPIRED_VERIFICATION_ERROR_MESSAGE = t('The link you clicked to verify your email is expired.');

--- a/app/scripts/lib/channel-server-client-errors.js
+++ b/app/scripts/lib/channel-server-client-errors.js
@@ -1,6 +1,5 @@
 import { assign } from 'underscore';
 import Errors from './errors';
-
 const t = msg => msg;
 
 const UNEXPECTED_ERROR_MESSAGE = t('Unexpected error');

--- a/app/scripts/lib/mailcheck.js
+++ b/app/scripts/lib/mailcheck.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
   const KeyCodes = require('./key-codes');
   require('mailcheck');
   const Tooltip = require('../views/tooltip');
-  const t = (msg) => msg;
+  const t = msg => msg;
 
   const DOMAINS = [];
   const SECOND_LEVEL_DOMAINS = [ // domains that get suggested, i.e gnail => gmail

--- a/app/scripts/lib/marketing-email-errors.js
+++ b/app/scripts/lib/marketing-email-errors.js
@@ -9,10 +9,7 @@ define(function (require, exports, module) {
 
   const _ = require('underscore');
   const Errors = require('./errors');
-
-  var t = function (msg) {
-    return msg;
-  };
+  const t = msg => msg;
 
   var UNEXPECTED_ERROR = t('Unexpected error');
 

--- a/app/scripts/lib/oauth-errors.js
+++ b/app/scripts/lib/oauth-errors.js
@@ -12,10 +12,7 @@ define(function (require, exports, module) {
   const Logger = require('./logger');
   var logger = new Logger();
   const Strings = require('./strings');
-
-  var t = function (msg) {
-    return msg;
-  };
+  const t = msg => msg;
 
   var UNEXPECTED_ERROR = t('Unexpected error');
 

--- a/app/scripts/lib/profile-errors.js
+++ b/app/scripts/lib/profile-errors.js
@@ -7,10 +7,7 @@ define(function (require, exports, module) {
 
   const _ = require('underscore');
   const Errors = require('./errors');
-
-  var t = function (msg) {
-    return msg;
-  };
+  const t = msg => msg;
 
   const THROTTLED_ERROR_MESSAGE = t('You\'ve tried too many times. Try again later.');
 

--- a/app/scripts/lib/strings.js
+++ b/app/scripts/lib/strings.js
@@ -5,7 +5,7 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const t = (msg) => msg;
+  const t = msg => msg;
 
   const HTML_CHAR_CODE = /&(\D+|#\d+);/i;
   const HTML_TAG = /<.*>/;

--- a/app/scripts/models/auth_brokers/base.js
+++ b/app/scripts/models/auth_brokers/base.js
@@ -20,8 +20,9 @@ define(function (require, exports, module) {
   const SameBrowserVerificationModel = require('../verification/same-browser');
   const UrlMixin = require('../mixins/url');
   const SettingsIfSignedInBehavior = require('../../views/behaviors/settings');
-  const t = (msg) => msg;
   const Vat = require('../../lib/vat');
+
+  const t = msg => msg;
 
   const QUERY_PARAMETER_SCHEMA = {
     automatedBrowser: Vat.boolean()

--- a/app/scripts/models/auth_brokers/web.js
+++ b/app/scripts/models/auth_brokers/web.js
@@ -14,8 +14,7 @@ define(function (require, exports, module) {
   const { CONTENT_SERVER_CONTEXT } = require('../../lib/constants');
   const NavigateBehavior = require('../../views/behaviors/navigate');
   const SettingsIfSignedInBehavior = require('../../views/behaviors/settings');
-
-  const t = (msg) => msg;
+  const t = msg => msg;
 
   const proto = BaseBroker.prototype;
 

--- a/app/scripts/models/reliers/sync.js
+++ b/app/scripts/models/reliers/sync.js
@@ -12,7 +12,7 @@ const AllowedCountries = Object.keys(require('../../lib/country-telephone-info')
 import Relier from './relier';
 import Vat from '../../lib/vat';
 
-const t = (msg) => msg;
+const t = msg => msg;
 
 /*eslint-disable camelcase*/
 const QUERY_PARAMETER_SCHEMA = {

--- a/app/scripts/views/base.js
+++ b/app/scripts/views/base.js
@@ -1081,21 +1081,6 @@ define(function (require, exports, module) {
     };
   };
 
-  /**
-   * t is a wrapper that is used for string extraction. The extraction
-   * script looks for t(...), and the translator will eventually
-   * translate it. t is put onto BaseView instead of
-   * Translator to reduce the number of dependencies in the views.
-   *
-   * @param {String} str
-   * @returns {String}
-   */
-  function t(str) {
-    return str;
-  }
-
-  BaseView.t = t;
-
   Cocktail.mixin(
     BaseView,
     // Attach the external links mixin in case the

--- a/app/scripts/views/behaviors/settings.js
+++ b/app/scripts/views/behaviors/settings.js
@@ -11,8 +11,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const NavigateBehavior = require('../behaviors/navigate');
-
-  const t = (msg) => msg;
+  const t = msg => msg;
 
   /**
    * Creates navigation behavior that displays a success message

--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -16,7 +16,7 @@ import Session from '../lib/session';
 import Template from 'templates/confirm_reset_password.mustache';
 import { VERIFICATION_POLL_IN_MS } from '../lib/constants';
 
-const t = BaseView.t;
+const t = msg => msg;
 
 const View = BaseView.extend({
   template: Template,

--- a/app/scripts/views/force_auth.js
+++ b/app/scripts/views/force_auth.js
@@ -4,7 +4,7 @@
 
 import _ from 'underscore';
 import AuthErrors from '../lib/auth-errors';
-import { cancelEventThen, t } from './base';
+import { cancelEventThen } from './base';
 import Cocktail from 'cocktail';
 import FormView from './form';
 import NullBehavior from './behaviors/null';
@@ -14,6 +14,8 @@ import ServiceMixin from './mixins/service-mixin';
 import Template from 'templates/force_auth.mustache';
 import Transform from '../lib/transform';
 import Vat from '../lib/vat';
+
+const t = msg => msg;
 
 var RELIER_DATA_SCHEMA = {
   email: Vat.email().required(),

--- a/app/scripts/views/mixins/account-reset-mixin.js
+++ b/app/scripts/views/mixins/account-reset-mixin.js
@@ -13,8 +13,7 @@ define(function (require, exports, module) {
 
   const AuthErrors = require('../../lib/auth-errors');
   const BaseView = require('../base');
-
-  var t = BaseView.t;
+  const t = msg => msg;
 
   var AccountResetMixin = {
     initialize (options) {

--- a/app/scripts/views/mixins/last-checked-time-mixin.js
+++ b/app/scripts/views/mixins/last-checked-time-mixin.js
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const t = msg => msg;
+
 /**
  * Mixin to set the time a panel was refreshed or checked.
  *
  * @mixin LastCheckedTimeMixin
  */
-'use strict';
-
-const {t} = require('../base');
 
 const Mixin = {
 

--- a/app/scripts/views/mixins/open-webmail-mixin.js
+++ b/app/scripts/views/mixins/open-webmail-mixin.js
@@ -11,8 +11,7 @@ define(function (require, exports, module) {
   'use strict';
 
   const _ = require ('underscore');
-  const BaseView = require('../base');
-  const t = BaseView.t;
+  const t = msg => msg;
 
   const WEBMAIL_SERVICES = [
     {

--- a/app/scripts/views/mixins/resend-mixin.js
+++ b/app/scripts/views/mixins/resend-mixin.js
@@ -22,7 +22,8 @@ define(function (require, exports, module) {
   const _ = require('underscore');
   const Duration = require('duration');
   const EmailResend = require('../../models/email-resend');
-  const { preventDefaultThen, t } = require('../base');
+  const { preventDefaultThen } = require('../base');
+  const t = msg => msg;
 
   const SHOW_RESEND_IN_MS = new Duration('5m').milliseconds();
 

--- a/app/scripts/views/mixins/save-options-mixin.js
+++ b/app/scripts/views/mixins/save-options-mixin.js
@@ -10,10 +10,9 @@
 'use strict';
 
 import $ from 'jquery';
-import BaseView from '../base';
-import UserAgentMixin from 'lib/user-agent-mixin';
+import UserAgentMixin from '../../lib/user-agent-mixin';
 
-const {t} = BaseView;
+const t = msg => msg;
 
 const Mixin = {
 

--- a/app/scripts/views/mixins/signin-mixin.js
+++ b/app/scripts/views/mixins/signin-mixin.js
@@ -7,7 +7,6 @@
 define(function (require, exports, module) {
   'use strict';
 
-  const {t} = require('../base');
   const AuthErrors = require('../../lib/auth-errors');
   const OAuthErrors = require('../../lib/oauth-errors');
   const NavigateBehavior = require('../behaviors/navigate');
@@ -16,6 +15,7 @@ define(function (require, exports, module) {
   const VerificationReasons = require('../../lib/verification-reasons');
   const TokenCodeExperimentMixin = require('../mixins/token-code-experiment-mixin');
 
+  const t = msg => msg;
   const TOTP_SUPPORT_URL = 'https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication';
 
   module.exports = {

--- a/app/scripts/views/mixins/upgrade-session-mixin.js
+++ b/app/scripts/views/mixins/upgrade-session-mixin.js
@@ -26,8 +26,8 @@ define(function (require, exports, module) {
   const SessionVerifiedNotificationMixin = require('./session-verified-notification-mixin');
   const SettingsPanelMixin = require('../mixins/settings-panel-mixin');
   const UpgradeSessionTemplate = require('templates/settings/upgrade_session.mustache');
-  const t = BaseView.t;
 
+  const t = msg => msg;
   const showProgressIndicator = require('../decorators/progress_indicator');
   const EMAIL_REFRESH_SELECTOR = 'button.settings-button.refresh-verification-state';
   const EMAIL_REFRESH_DELAYMS = 350;

--- a/app/scripts/views/permissions.js
+++ b/app/scripts/views/permissions.js
@@ -11,9 +11,10 @@ import OAuthErrors from '../lib/oauth-errors';
 import PermissionTemplate from 'templates/partial/permission.mustache';
 import ServiceMixin from './mixins/service-mixin';
 import Strings from '../lib/strings';
-import { t } from './base';
 import Template from 'templates/permissions.mustache';
 import VerificationReasonMixin from './mixins/verification-reason-mixin';
+
+const t = msg => msg;
 
 // Reduce the number of strings to translate by interpolating
 // to create the required variant of a label.
@@ -183,6 +184,9 @@ var View = FormView.extend({
     // convert the permission names to HTML
     return sortedPermissionNames.map((permissionName) => {
       var permission = this._getPermissionConfig(permissionName);
+
+      permission.label = this.translate(permission.label);
+
       if (permission.required !== true) {
         permission.required = false;
       }
@@ -190,7 +194,7 @@ var View = FormView.extend({
       // convert label to the required label
       if (permission.required) {
         permission.label = Strings.interpolate(this.translate(requiredPermissionLabel), {
-          permissionName: this.translate(permission.label)
+          permissionName: permission.label
         });
       }
 

--- a/app/scripts/views/reset_password.js
+++ b/app/scripts/views/reset_password.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
   const Session = require('../lib/session');
   const Template = require('templates/reset_password.mustache');
 
-  const t = (msg) => msg;
+  const t = msg => msg;
 
   const ResetPasswordView = FormView.extend({
     events: {

--- a/app/scripts/views/settings/account_recovery/account_recovery.js
+++ b/app/scripts/views/settings/account_recovery/account_recovery.js
@@ -8,14 +8,15 @@ import SettingsPanelMixin from '../../mixins/settings-panel-mixin';
 import Template from 'templates/settings/account_recovery/account_recovery.mustache';
 import showProgressIndicator from '../../decorators/progress_indicator';
 import LastCheckedTimeMixin from '../../mixins/last-checked-time-mixin';
-import UpgradeSessionMixin from '../../mixins/upgrade-session-mixin';
 import RecoveryKeyExperimentMixin from '../../mixins/recovery-key-experiment-mixin';
+import UpgradeSessionMixin from '../../mixins/upgrade-session-mixin';
+
+const t = msg => msg;
 
 const CODE_REFRESH_SELECTOR = 'button.settings-button.refresh-status';
 const CODE_REFRESH_DELAY_MS = 350;
 const ACCOUNT_RECOVERY_SUPPORT_URL = 'https://support.mozilla.org/kb/reset-your-firefox-account-password-recovery-keys';
 
-var t = BaseView.t;
 
 const View = BaseView.extend({
   template: Template,

--- a/app/scripts/views/settings/account_recovery/recovery_key.js
+++ b/app/scripts/views/settings/account_recovery/recovery_key.js
@@ -5,12 +5,12 @@
 import Cocktail from 'cocktail';
 import BaseView from '../../base';
 import ModalSettingsPanelMixin from '../../mixins/modal-settings-panel-mixin';
+import PrintTemplate from 'templates/settings/account_recovery/recovery_key_print_template.mustache';
 import SaveOptionsMixin from '../../mixins/save-options-mixin';
 import Template from 'templates/settings/account_recovery/recovery_key.mustache';
 import UserAgentMixin from '../../../lib/user-agent-mixin';
-import PrintTemplate from 'templates/settings/account_recovery/recovery_key_print_template.mustache';
 
-const {t} = BaseView;
+const t = msg => msg;
 const ACCOUNT_RECOVERY_ELEMENT = '#account-recovery-key';
 
 const View = BaseView.extend({

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -7,7 +7,6 @@ define(function (require, exports, module) {
 
   const AuthErrors = require('../../lib/auth-errors');
   const BackMixin = require('../mixins/back-mixin');
-  const BaseView = require('../base');
   const Cocktail = require('cocktail');
   const FormView = require('../form');
   const ExperimentMixin = require('../mixins/experiment-mixin');
@@ -16,7 +15,7 @@ define(function (require, exports, module) {
   const SettingsPanelMixin = require('../mixins/settings-panel-mixin');
   const Template = require('templates/settings/change_password.mustache');
 
-  var t = BaseView.t;
+  const t = msg => msg;
 
   var View = FormView.extend({
     template: Template,

--- a/app/scripts/views/settings/client_disconnect.js
+++ b/app/scripts/views/settings/client_disconnect.js
@@ -9,8 +9,9 @@ define(function (require, exports, module) {
   const FormView = require('../form');
   const ModalSettingsPanelMixin = require('../mixins/modal-settings-panel-mixin');
   const SignedOutNotificationMixin = require('../mixins/signed-out-notification-mixin');
-  const t = require('../base').t;
   const Template = require('templates/settings/client_disconnect.mustache');
+
+  const t = msg => msg;
 
   const REASON_HELP = {
     'lost': t('We\'re sorry to hear about this. You should change your Firefox Account password, and look for ' +

--- a/app/scripts/views/settings/clients.js
+++ b/app/scripts/views/settings/clients.js
@@ -15,9 +15,10 @@ define(function (require, exports, module) {
   const SettingsPanelMixin = require('../mixins/settings-panel-mixin');
   const SignedOutNotificationMixin = require('../mixins/signed-out-notification-mixin');
   const Strings = require('../../lib/strings');
-  const { t } = require('../base');
   const Template = require('templates/settings/clients.mustache');
   const UserAgentMixin = require('../../lib/user-agent-mixin');
+
+  const t = msg => msg;
 
   const DEVICE_REMOVED_ANIMATION_MS = 150;
   const LOADING_INDICATOR_BUTTON = '.settings-button.settings-unit-loading';

--- a/app/scripts/views/settings/communication_preferences.js
+++ b/app/scripts/views/settings/communication_preferences.js
@@ -16,8 +16,8 @@ define(function (require, exports, module) {
   const Template = require('templates/settings/communication_preferences.mustache');
   const Xss = require('../../lib/xss');
 
+  const t = msg => msg;
   const NEWSLETTER_ID = Constants.MARKETING_EMAIL_NEWSLETTER_ID;
-  const t = (msg) => msg;
 
   const View = FormView.extend({
     template: Template,

--- a/app/scripts/views/settings/delete_account.js
+++ b/app/scripts/views/settings/delete_account.js
@@ -6,7 +6,6 @@ define(function (require, exports, module) {
   'use strict';
 
   const AuthErrors = require('../../lib/auth-errors');
-  const BaseView = require('../base');
   const Cocktail = require('cocktail');
   const FormView = require('../form');
   const PasswordMixin = require('../mixins/password-mixin');
@@ -15,7 +14,7 @@ define(function (require, exports, module) {
   const SettingsPanelMixin = require('../mixins/service-mixin');
   const Template = require('templates/settings/delete_account.mustache');
 
-  var t = BaseView.t;
+  const t = msg => msg;
 
   var View = FormView.extend({
     template: Template,

--- a/app/scripts/views/settings/display_name.js
+++ b/app/scripts/views/settings/display_name.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
   const SettingsPanelMixin = require('../mixins/settings-panel-mixin');
   const Template = require('templates/settings/display_name.mustache');
 
-  const t = (msg) => msg;
+  const t = msg => msg;
 
   const View = FormView.extend({
     template: Template,

--- a/app/scripts/views/settings/emails.js
+++ b/app/scripts/views/settings/emails.js
@@ -7,7 +7,6 @@ define(function (require, exports, module) {
 
   const $ = require('jquery');
   const AvatarMixin = require('../mixins/avatar-mixin');
-  const BaseView = require('../base');
   const Cocktail = require('cocktail');
   const Email = require('../../models/email');
   const FormView = require('../form');
@@ -19,7 +18,7 @@ define(function (require, exports, module) {
   const showProgressIndicator = require('../decorators/progress_indicator');
   const Template = require('templates/settings/emails.mustache');
 
-  var t = BaseView.t;
+  const t = msg => msg;
 
   const EMAIL_INPUT_SELECTOR = 'input.new-email';
   const EMAIL_REFRESH_SELECTOR = 'button.settings-button.email-refresh';

--- a/app/scripts/views/settings/recovery_codes.js
+++ b/app/scripts/views/settings/recovery_codes.js
@@ -11,7 +11,10 @@ const RecoveryCode = require('../../models/recovery-code');
 const SaveOptionsMixin = require('../mixins/save-options-mixin');
 const UserAgentMixin = require('../../lib/user-agent-mixin');
 
-const {preventDefaultThen, t} = FormView;
+const t = msg => msg;
+
+const { preventDefaultThen } = FormView;
+
 const RECOVERY_CODE_ELEMENT = '#recovery-codes';
 
 const View = FormView.extend({

--- a/app/scripts/views/settings/two_step_authentication.js
+++ b/app/scripts/views/settings/two_step_authentication.js
@@ -7,17 +7,16 @@
 const _ = require('underscore');
 const AvatarMixin = require('../mixins/avatar-mixin');
 const AuthErrors = require('lib/auth-errors');
-const BaseView = require('../base');
 const Cocktail = require('cocktail');
 const FormView = require('../form');
 const LastCheckedTimeMixin = require('../mixins/last-checked-time-mixin');
 const SettingsPanelMixin = require('../mixins/settings-panel-mixin');
 const UpgradeSessionMixin = require('../mixins/upgrade-session-mixin');
 const Template = require('templates/settings/two_step_authentication.mustache');
-const preventDefaultThen = require('../base').preventDefaultThen;
+const { preventDefaultThen } = require('../base');
 const showProgressIndicator = require('../decorators/progress_indicator');
 
-var t = BaseView.t;
+const t = msg => msg;
 
 const CODE_INPUT_SELECTOR = 'input.totp-code';
 const CODE_REFRESH_SELECTOR = 'button.settings-button.totp-refresh';

--- a/app/scripts/views/sign_in.js
+++ b/app/scripts/views/sign_in.js
@@ -19,7 +19,8 @@ import Session from '../lib/session';
 import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SignInMixin from './mixins/signin-mixin';
 import SignInTemplate from 'templates/sign_in.mustache';
-import { t } from './base';
+
+const t = msg => msg;
 
 const EMAIL_SELECTOR = 'input[type=email]';
 const PASSWORD_SELECTOR = 'input[type=password]';

--- a/app/scripts/views/sign_up.js
+++ b/app/scripts/views/sign_up.js
@@ -7,7 +7,6 @@ define(function (require, exports, module) {
 
   const AccountResetMixin = require('./mixins/account-reset-mixin');
   const AuthErrors = require('../lib/auth-errors');
-  const BaseView = require('./base');
   const Cocktail = require('cocktail');
   const CoppaMixin = require('./mixins/coppa-mixin');
   const EmailFirstExperimentMixin = require('./mixins/email-first-experiment-mixin');
@@ -25,7 +24,7 @@ define(function (require, exports, module) {
   const SyncSuggestionMixin = require('./mixins/sync-suggestion-mixin');
   const Template = require('templates/sign_up.mustache');
 
-  var t = BaseView.t;
+  const t = msg => msg;
 
   function selectAutoFocusEl(bouncedEmail, email, password) {
     if (bouncedEmail) {


### PR DESCRIPTION
`t` in `const {t} = BaseView` was being translated by Webpack/babel into
_base.t, which is not recognized by our l10n extraction script.

This changes all `t` declarations to use `const t = msg => msg` which
in local testing, has always kept the same name.

I tried using a module with a simple `module.export = msg => msg` and
import/requiring this using `import t from 'lib/t'`, but Webpack/babel
sometimes changed the `t` to `t_` which also is not recognized by
our extraction script.

issue #6725