### PR TITLE
fix(test): Fix the OAuth email-first functional test that used a common password.

### DIFF
--- a/tests/functional/oauth_email_first.js
+++ b/tests/functional/oauth_email_first.js
@@ -14,7 +14,7 @@ const selectors = require('./lib/selectors');
 
 const SYNC_SIGNIN_URL = `${config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync&action=email`;
 
-const PASSWORD = 'password123';
+const PASSWORD = 'passwordzxcv';
 let email;
 
 const {


### PR DESCRIPTION
`password123` is common, `passwordzxcv` is not.

fixes #6723

@mozilla/fxa-devs - r?