### PR TITLE
feat(metrics): add deviceId to the resume token

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -53,7 +53,6 @@ import UniqueUserId from '../models/unique-user-id';
 import Url from './url';
 import User from '../models/user';
 import UserAgentMixin from './user-agent-mixin';
-import uuid from 'uuid';
 import WebChannel from './channels/web';
 
 const AUTOMATED_BROWSER_STARTUP_DELAY = 750;
@@ -182,7 +181,6 @@ Start.prototype = {
       clientHeight: screenInfo.clientHeight,
       clientWidth: screenInfo.clientWidth,
       context: relier.get('context'),
-      deviceId: this._getMetricsDeviceId(),
       devicePixelRatio: screenInfo.devicePixelRatio,
       entrypoint: relier.get('entrypoint'),
       isSampledUser: isSampledUser,
@@ -425,17 +423,6 @@ Start.prototype = {
         window: this._window
       });
     }
-  },
-
-  _metricsDeviceId: null,
-  _getMetricsDeviceId () {
-    if (! this._metricsDeviceId) {
-      // Amplitude-specific device id. Transient for now,
-      // but will probably be persistent in the future.
-      this._metricsDeviceId = uuid.v4().replace(/-/g, '');
-    }
-
-    return this._metricsDeviceId;
   },
 
   _uniqueUserId: null,

--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -127,7 +127,6 @@ define(function (require, exports, module) {
     // by default, send the metrics to the content server.
     this._collector = options.collector || '';
     this._context = options.context || Constants.CONTENT_SERVER_CONTEXT;
-    this._deviceId = options.deviceId || NOT_REPORTED_VALUE;
     this._devicePixelRatio = options.devicePixelRatio || NOT_REPORTED_VALUE;
     this._emailDomain = NOT_REPORTED_VALUE;
     this._entrypoint = options.entrypoint || NOT_REPORTED_VALUE;
@@ -351,7 +350,7 @@ define(function (require, exports, module) {
       const allData = _.extend({}, loadData, unloadData, {
         broker: this._brokerType,
         context: this._context,
-        deviceId: this._deviceId,
+        deviceId: flowData.deviceId,
         emailDomain: this._emailDomain,
         entrypoint: this._entrypoint,
         experiments: flattenHashIntoArrayOfObjects(this._activeExperiments),
@@ -657,7 +656,7 @@ define(function (require, exports, module) {
     getFlowEventMetadata () {
       const metadata = (this._flowModel && this._flowModel.attributes) || {};
       return {
-        deviceId: this._deviceId,
+        deviceId: metadata.deviceId,
         flowBeginTime: metadata.flowBegin,
         flowId: metadata.flowId,
         utmCampaign: marshallUtmParam(this._utmCampaign),

--- a/app/scripts/models/flow.js
+++ b/app/scripts/models/flow.js
@@ -21,6 +21,7 @@ const ResumeTokenMixin = require('./mixins/resume-token');
 const UrlMixin = require('./mixins/url');
 const vat = require('../lib/vat');
 const Url = require('../lib/url');
+import uuid from 'uuid';
 
 var Model = Backbone.Model.extend({
   initialize (options) {
@@ -49,9 +50,14 @@ var Model = Backbone.Model.extend({
       this.populateFromDataAttribute('flowId');
       this.populateFromDataAttribute('flowBegin');
     }
+
+    if (! this.has('deviceId')) {
+      this.set('deviceId', uuid.v4().replace(/-/g, ''));
+    }
   },
 
   defaults: {
+    deviceId: null,
     flowBegin: null,
     flowId: null
   },
@@ -74,9 +80,10 @@ var Model = Backbone.Model.extend({
     return ErrorUtils.captureError(error, this.sentryMetrics);
   },
 
-  resumeTokenFields: ['flowId', 'flowBegin'],
+  resumeTokenFields: ['deviceId', 'flowId', 'flowBegin'],
 
   resumeTokenSchema: {
+    deviceId: vat.hex().len(32),
     flowBegin: vat.number().test(function (value) {
       // Integers only
       return value === Math.round(value);

--- a/app/scripts/models/resume-token.js
+++ b/app/scripts/models/resume-token.js
@@ -15,6 +15,7 @@ define(function (require, exports, module) {
 
   var ResumeToken = Backbone.Model.extend({
     defaults: {
+      deviceId: undefined,
       email: undefined,
       entrypoint: undefined,
       flowBegin: undefined,

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -40,7 +40,6 @@ define(function (require, exports, module) {
         clientHeight: 966,
         clientWidth: 1033,
         context: 'fx_desktop_v1',
-        deviceId: 'wibble',
         devicePixelRatio: 2,
         entrypoint: 'menupanel',
         isSampledUser: true,
@@ -88,7 +87,7 @@ define(function (require, exports, module) {
     it('observable flow state is correct', () => {
       assert.isUndefined(metrics.getFlowModel());
       assert.deepEqual(metrics.getFlowEventMetadata(), {
-        deviceId: 'wibble',
+        deviceId: undefined,
         flowBeginTime: undefined,
         flowId: undefined,
         utmCampaign: 'utm_campaign',
@@ -107,16 +106,15 @@ define(function (require, exports, module) {
       it('observable flow state is correct', () => {
         assert.equal(metrics.getFlowModel().get('flowId'), FLOW_ID);
         assert.equal(metrics.getFlowModel().get('flowBegin'), FLOW_BEGIN_TIME);
-        assert.deepEqual(metrics.getFlowEventMetadata(), {
-          deviceId: 'wibble',
-          flowBeginTime: FLOW_BEGIN_TIME,
-          flowId: FLOW_ID,
-          utmCampaign: 'utm_campaign',
-          utmContent: 'utm_content',
-          utmMedium: 'utm_medium',
-          utmSource: undefined,
-          utmTerm: undefined
-        });
+        const metadata = metrics.getFlowEventMetadata();
+        assert.match(metadata.deviceId, /^[0-9a-f]{32}$/);
+        assert.equal(metadata.flowBeginTime, FLOW_BEGIN_TIME);
+        assert.equal(metadata.flowId, FLOW_ID);
+        assert.equal(metadata.utmCampaign, 'utm_campaign');
+        assert.equal(metadata.utmContent, 'utm_content');
+        assert.equal(metadata.utmMedium, 'utm_medium');
+        assert.equal(metadata.utmSource, undefined);
+        assert.equal(metadata.utmTerm, undefined);
       });
 
       it('flow events are triggered correctly', () => {
@@ -154,16 +152,15 @@ define(function (require, exports, module) {
         it('observable flow state is correct', () => {
           assert.equal(metrics.getFlowModel().get('flowId'), FLOW_ID);
           assert.equal(metrics.getFlowModel().get('flowBegin'), FLOW_BEGIN_TIME);
-          assert.deepEqual(metrics.getFlowEventMetadata(), {
-            deviceId: 'wibble',
-            flowBeginTime: FLOW_BEGIN_TIME,
-            flowId: FLOW_ID,
-            utmCampaign: 'utm_campaign',
-            utmContent: 'utm_content',
-            utmMedium: 'utm_medium',
-            utmSource: undefined,
-            utmTerm: undefined
-          });
+          const metadata = metrics.getFlowEventMetadata();
+          assert.match(metadata.deviceId, /^[0-9a-f]{32}$/);
+          assert.equal(metadata.flowBeginTime, FLOW_BEGIN_TIME);
+          assert.equal(metadata.flowId, FLOW_ID);
+          assert.equal(metadata.utmCampaign, 'utm_campaign');
+          assert.equal(metadata.utmContent, 'utm_content');
+          assert.equal(metadata.utmMedium, 'utm_medium');
+          assert.equal(metadata.utmSource, undefined);
+          assert.equal(metadata.utmTerm, undefined);
         });
       });
     });
@@ -277,7 +274,6 @@ define(function (require, exports, module) {
         xhr = { ajax () {} };
         environment = new Environment(windowMock);
         metrics = new Metrics({
-          deviceId: 'mock device id',
           environment: environment,
           inactivityFlushMs: 100,
           notifier,
@@ -335,7 +331,7 @@ define(function (require, exports, module) {
               assert.lengthOf(Object.keys(data), 30);
               assert.equal(data.broker, 'none');
               assert.equal(data.context, Constants.CONTENT_SERVER_CONTEXT);
-              assert.equal(data.deviceId, 'mock device id');
+              assert.match(data.deviceId, /^[0-9a-f]{32}$/);
               assert.isNumber(data.duration);
               assert.equal(data.emailDomain, 'none');
               assert.equal(data.entrypoint, 'none');
@@ -506,7 +502,7 @@ define(function (require, exports, module) {
 
               var data = JSON.parse(settings.data);
               assert.lengthOf(Object.keys(data), 29);
-              assert.equal(data.deviceId, 'mock device id');
+              assert.match(data.deviceId, /^[0-9a-f]{32}$/);
               assert.isArray(data.events);
               assert.lengthOf(data.events, 5);
               assert.equal(data.events[0].type, 'foo');

--- a/app/tests/spec/models/flow.js
+++ b/app/tests/spec/models/flow.js
@@ -14,6 +14,7 @@ define(function (require, exports, module) {
   const Url = require('lib/url');
   const WindowMock = require('../../mocks/window');
 
+  var DEVICE_ID = '0123456789abcdef0123456789abcdef';
   var BODY_FLOW_ID = 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103';
   var RESUME_FLOW_ID = '71031D71031D71031D71031D71031D71031D71031D71031D71031D71031D7103';
 
@@ -49,11 +50,16 @@ define(function (require, exports, module) {
 
     it('fetches from the `resume` search parameter, if available', function () {
       windowMock.location.search = Url.objToSearchString({
-        resume: ResumeToken.stringify({ flowBegin: 42, flowId: RESUME_FLOW_ID })
+        resume: ResumeToken.stringify({
+          deviceId: DEVICE_ID,
+          flowBegin: 42,
+          flowId: RESUME_FLOW_ID
+        })
       });
 
       createFlow();
 
+      assert.equal(flow.get('deviceId'), DEVICE_ID);
       assert.equal(flow.get('flowId'), RESUME_FLOW_ID);
       assert.equal(flow.get('flowBegin'), 42);
     });
@@ -64,19 +70,24 @@ define(function (require, exports, module) {
 
       createFlow();
 
+      assert.match(flow.get('deviceId'), /^[0-9a-f]{32}$/);
       assert.equal(flow.get('flowId'), BODY_FLOW_ID);
       assert.equal(flow.get('flowBegin'), 42);
     });
 
     it('gives preference to values from the `resume` search parameter', function () {
       windowMock.location.search = Url.objToSearchString({
-        resume: ResumeToken.stringify({ flowBegin: 42, flowId: RESUME_FLOW_ID })
+        resume: ResumeToken.stringify({
+          flowBegin: 42,
+          flowId: RESUME_FLOW_ID
+        })
       });
       $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
       $(windowMock.document.body).attr('data-flow-begin', '24');
 
       createFlow();
 
+      assert.match(flow.get('deviceId'), /^[0-9a-f]{32}$/);
       assert.equal(flow.get('flowId'), RESUME_FLOW_ID);
       assert.equal(flow.get('flowBegin'), 42);
     });
@@ -97,6 +108,7 @@ define(function (require, exports, module) {
 
       createFlow();
 
+      assert.match(flow.get('deviceId'), /^[0-9a-f]{32}$/);
       assert.equal(flow.get('flowId'), QUERY_FLOW_ID);
       assert.equal(flow.get('flowBegin'), QUERY_FLOW_BEGIN);
       assert.ok(metricsMock.markEventLogged.calledOnce);
@@ -104,13 +116,14 @@ define(function (require, exports, module) {
 
     it('logs an error when the resume token contains `flowId` but not `flowBegin`', function () {
       windowMock.location.search = Url.objToSearchString({
-        resume: ResumeToken.stringify({ flowId: RESUME_FLOW_ID })
+        resume: ResumeToken.stringify({ deviceId: DEVICE_ID, flowId: RESUME_FLOW_ID })
       });
       $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
       $(windowMock.document.body).attr('data-flow-begin', '24');
 
       createFlow();
 
+      assert.equal(flow.get('deviceId'), DEVICE_ID);
       assert.equal(flow.get('flowId'), RESUME_FLOW_ID);
       assert.notOk(flow.has('flowBegin'));
 
@@ -123,13 +136,14 @@ define(function (require, exports, module) {
 
     it('logs an error when the resume token contains `flowBegin` but not `flowId`', function () {
       windowMock.location.search = Url.objToSearchString({
-        resume: ResumeToken.stringify({ flowBegin: 42 })
+        resume: ResumeToken.stringify({ deviceId: DEVICE_ID, flowBegin: 42 })
       });
       $(windowMock.document.body).attr('data-flow-id', BODY_FLOW_ID);
       $(windowMock.document.body).attr('data-flow-begin', '24');
 
       createFlow();
 
+      assert.equal(flow.get('deviceId'), DEVICE_ID);
       assert.notOk(flow.has('flowId'));
       assert.equal(flow.get('flowBegin'), 42);
 
@@ -173,6 +187,7 @@ define(function (require, exports, module) {
     it('logs two errors when there is no flow data available', function () {
       createFlow();
 
+      assert.match(flow.get('deviceId'), /^[0-9a-f]{32}$/);
       assert.notOk(flow.has('flowId'));
       assert.notOk(flow.has('flowBegin'));
 


### PR DESCRIPTION
Fixes mozilla/fxa-activity-metrics#109.

This ensures that the device id we send to Amplitude will remain consistent when following links in emails, which should fix the linked issue if mozilla/fxa-auth-server#2763 fails to do so.

Opened as `WIP` so I don't forget about it.