### PR TITLE
feat(coppa): Put COPPA behind a feature flag.

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -474,6 +474,7 @@ Start.prototype = {
       experimentGroupingRules: this._experimentGroupingRules,
       formPrefill: this._formPrefill,
       interTabChannel: this._interTabChannel,
+      isCoppaEnabled: this._config.isCoppaEnabled,
       lang: this._config.lang,
       metrics: this._metrics,
       notifier: this._notifier,

--- a/app/scripts/models/reliers/relier.js
+++ b/app/scripts/models/reliers/relier.js
@@ -32,6 +32,8 @@ const RELIER_FIELDS_IN_RESUME_TOKEN = [
   /*eslint-disable camelcase*/
 const QUERY_PARAMETER_SCHEMA = {
   action: Vat.action(),
+  // Should only be used for testing. If set to false, COPPA is disabled
+  coppa: Vat.boolean().renameTo('isCoppaEnabled'),
   // email is validated within fetch because it's handling depends on the action.
   // FxDesktop declares both `entryPoint` (capital P) and
   // `entrypoint` (lowcase p). Normalize to `entrypoint`.

--- a/app/scripts/views/mixins/coppa-mixin.js
+++ b/app/scripts/views/mixins/coppa-mixin.js
@@ -5,122 +5,144 @@
 /**
  * A mixin for common COPPA functionality
  */
-define(function (require, exports, module) {
-  'use strict';
+import FormPrefillMixin from './form-prefill-mixin';
+import KeyCodes from '../../lib/key-codes';
+import Template from 'templates/partial/coppa-age-input.mustache';
 
-  const FormPrefillMixin = require('./form-prefill-mixin');
-  const KeyCodes = require('../../lib/key-codes');
-  const Template = require('templates/partial/coppa-age-input.mustache');
+const AGE_ELEMENT = '#age';
+const AGE_SIZE_LIMIT = 3;
+const CUTOFF_AGE = 13;
 
-  const AGE_ELEMENT = '#age';
-  const AGE_SIZE_LIMIT = 3;
-  const CUTOFF_AGE = 13;
+const CANNOT_CREATE_ACCOUNT_PATHNAME = 'cannot_create_account';
 
-  const CANNOT_CREATE_ACCOUNT_PATHNAME = 'cannot_create_account';
+/**
+ * Creates the CoppaMixin.
+ *
+ * @param {Object} [config={}]
+ *   @param {Boolean} [config.required=false] Is the input field required on form submit?
+ * @returns {Function}
+ */
+module.exports = function (config = {}) {
+  return {
+    dependsOn: [ FormPrefillMixin ],
 
-  /**
-   * Creates the CoppaMixin.
-   *
-   * @param {Object} [config={}]
-   *   @param {Boolean} [config.required=false] Is the input field required on form submit?
-   * @returns {Function}
-   */
-  module.exports = function (config = {}) {
-    return {
-      dependsOn: [ FormPrefillMixin ],
+    initialize (options) {
+      // COPPA is enabled by default, it has to be flipped off.
+      this._isCoppaEnabled = options.isCoppaEnabled !== false;
+    },
 
-      events: {
-        [`input ${AGE_ELEMENT}`]: 'onCoppaInput',
-        [`keydown ${AGE_ELEMENT}`]: 'onCoppaKeyDown',
-        [`keyup ${AGE_ELEMENT}`]: 'onCoppaInput'
-      },
+    events: {
+      [`input ${AGE_ELEMENT}`]: 'onCoppaInput',
+      [`keydown ${AGE_ELEMENT}`]: 'onCoppaKeyDown',
+      [`keyup ${AGE_ELEMENT}`]: 'onCoppaInput'
+    },
 
-      beforeRender () {
-        if (this.window.document.cookie.indexOf('tooyoung') > -1) {
-          this.navigate(CANNOT_CREATE_ACCOUNT_PATHNAME);
-        }
-      },
+    beforeRender () {
+      if (this.isCoppaEnabled() && this.window.document.cookie.indexOf('tooyoung') > -1) {
+        this.navigate(CANNOT_CREATE_ACCOUNT_PATHNAME);
+      }
+    },
 
-      setInitialContext (context) {
+    setInitialContext (context) {
+      if (this.isCoppaEnabled()) {
+        // only writes the COPPA HTML to the DOM if COPPA is enabled.
         const coppaHTML = this.renderTemplate(Template, { required: config.required });
 
         context.set({
           coppaHTML
         });
-      },
+      }
+    },
 
-      /**
-       * Is the user old enough to sign up?
-       *
-       * @returns {Boolean}
-       */
-      isUserOldEnough () {
-        return this._getAge() >= CUTOFF_AGE;
-      },
+    /**
+     * Is COPPA enabled?
+     *
+     * @returns {Boolean}
+     */
+    isCoppaEnabled () {
+      if (this.relier.has('isCoppaEnabled')) {
+        return this.relier.get('isCoppaEnabled');
+      }
 
-      /**
-       * Mark the user as too young. Navigates to
-       * a page informing the user they are unable
-       * to sign up.
-       */
-      tooYoung () {
-        this.notifier.trigger('signup.tooyoung');
+      return this._isCoppaEnabled;
+    },
 
-        // this is a session cookie. It will go away once:
-        // 1. the user closes the tab
-        // and
-        // 2. the user closes the browser
-        // Both of these have to happen or else the cookie
-        // hangs around like a bad smell.
-        this.window.document.cookie = 'tooyoung=1;';
+    /**
+     * Is the user old enough to sign up?
+     *
+     * @returns {Boolean}
+     */
+    isUserOldEnough () {
+      if (! this.isCoppaEnabled()) {
+        // If COPPA is disabled, user is automatically old enough.
+        return true;
+      }
 
-        this.navigate(CANNOT_CREATE_ACCOUNT_PATHNAME);
-      },
+      return this._getAge() >= CUTOFF_AGE;
+    },
 
-      onCoppaInput () {
-        // limit age to only 3 characters
-        var age = this.$(AGE_ELEMENT);
-        if (age.val().length > AGE_SIZE_LIMIT) {
-          age.val(age.val().substr(0, AGE_SIZE_LIMIT));
-        }
-      },
+    /**
+     * Mark the user as too young. Navigates to
+     * a page informing the user they are unable
+     * to sign up.
+     */
+    tooYoung () {
+      this.notifier.trigger('signup.tooyoung');
 
-      onCoppaKeyDown (event) {
-        // helper function to check for digits and special keys
-        function isKeyADigitOrSpecialCharacter (keyCode) {
-          return (
-            (keyCode === KeyCodes.BACKSPACE) ||
+      // this is a session cookie. It will go away once:
+      // 1. the user closes the tab
+      // and
+      // 2. the user closes the browser
+      // Both of these have to happen or else the cookie
+      // hangs around like a bad smell.
+      this.window.document.cookie = 'tooyoung=1;';
+
+      this.navigate(CANNOT_CREATE_ACCOUNT_PATHNAME);
+    },
+
+    onCoppaInput () {
+      // limit age to only 3 characters
+      var age = this.$(AGE_ELEMENT);
+      if (age.val().length > AGE_SIZE_LIMIT) {
+        age.val(age.val().substr(0, AGE_SIZE_LIMIT));
+      }
+    },
+
+    onCoppaKeyDown (event) {
+      // helper function to check for digits and special keys
+      function isKeyADigitOrSpecialCharacter (keyCode) {
+        return (
+          (keyCode === KeyCodes.BACKSPACE) ||
             (keyCode === KeyCodes.TAB) ||
             (keyCode === KeyCodes.LEFT_ARROW) ||
             (keyCode === KeyCodes.RIGHT_ARROW) ||
             (keyCode === KeyCodes.ENTER) ||
             (keyCode >= KeyCodes.NUM_0 && keyCode <= KeyCodes.NUM_9) ||
             (keyCode >= KeyCodes.NUMPAD_0 && keyCode <= KeyCodes.NUMPAD_9)
-          );
-        }
+        );
+      }
 
-        // force digit input
-        if (! isKeyADigitOrSpecialCharacter(event.which)) {
-          event.preventDefault();
-        }
-      },
+      // force digit input
+      if (! isKeyADigitOrSpecialCharacter(event.which)) {
+        event.preventDefault();
+      }
+    },
 
-      /**
-       * Has the user filled out the COPPA input element?
-       *
-       * @returns {Boolean}
-       */
-      coppaHasValue () {
-        return !! this._getCoppaValue();
-      },
+    /**
+     * Has the user filled out the COPPA input element?
+     *
+     * @returns {Boolean}
+     */
+    coppaHasValue () {
+      return !! this._getCoppaValue();
+    },
 
-      _getCoppaValue () {
-        return this.getElementValue(AGE_ELEMENT);
-      },
+    _getCoppaValue () {
+      return this.getElementValue(AGE_ELEMENT);
+    },
 
-      _getAge () {
-        return parseInt(this._getCoppaValue(), 10);
-      },
-    };
+    _getAge () {
+      return parseInt(this._getCoppaValue(), 10);
+    },
   };
-});
+};

--- a/app/tests/spec/models/reliers/relier.js
+++ b/app/tests/spec/models/reliers/relier.js
@@ -46,6 +46,7 @@ describe('models/reliers/relier', function () {
 
   it('fetch populates expected fields from the search parameters, unexpected search parameters are ignored', function () {
     windowMock.location.search = TestHelpers.toSearchString({
+      coppa: 'false',
       email: EMAIL,
       entrypoint: ENTRYPOINT,
       ignored: 'ignored',
@@ -63,6 +64,7 @@ describe('models/reliers/relier', function () {
         // Next two are not imported from the search parameters, but is set manually.
         assert.equal(relier.get('context'), Constants.CONTENT_SERVER_CONTEXT);
 
+        assert.isFalse(relier.get('isCoppaEnabled'));
         // The rest are imported from search parameters
         assert.equal(relier.get('email'), EMAIL);
 

--- a/app/tests/spec/views/mixins/coppa-mixin.js
+++ b/app/tests/spec/views/mixins/coppa-mixin.js
@@ -2,178 +2,246 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-define(function (require, exports, module) {
-  'use strict';
+import $ from 'jquery';
+import { assert } from 'chai';
+import FormView from 'views/form';
+import Cocktail from 'cocktail';
+import CoppaMixin from 'views/mixins/coppa-mixin';
+import FormPrefill from 'models/form-prefill';
+import KeyCodes from 'lib/key-codes';
+import { Model } from 'backbone';
+import Notifier from 'lib/channels/notifier';
+import sinon from 'sinon';
+import WindowMock from '../../../mocks/window';
 
-  const $ = require('jquery');
-  const { assert } = require('chai');
-  const FormView = require('views/form');
-  const Cocktail = require('cocktail');
-  const CoppaMixin = require('views/mixins/coppa-mixin');
-  const FormPrefill = require('models/form-prefill');
-  const KeyCodes = require('lib/key-codes');
-  const Notifier = require('lib/channels/notifier');
-  const sinon = require('sinon');
-  const WindowMock = require('../../../mocks/window');
+describe('views/mixins/coppa-mixin', () => {
+  let formPrefill;
+  let notifier;
+  let relier;
+  let view;
+  let windowMock;
 
-  describe('views/mixins/coppa-mixin', function () {
-    let formPrefill;
-    let notifier;
-    let view;
-    let windowMock;
+  const CoppaView = FormView.extend({
+    template: (context) => context.coppaHTML
+  });
 
-    const CoppaView = FormView.extend({
-      template: (context) => context.coppaHTML
+  Cocktail.mixin(
+    CoppaView,
+    CoppaMixin({ required: true })
+  );
+
+  beforeEach(() => {
+    formPrefill = new FormPrefill();
+    notifier = new Notifier();
+    relier = new Model();
+    windowMock = new WindowMock();
+
+    view = new CoppaView({
+      formPrefill,
+      notifier,
+      relier,
+      viewName: 'signup',
+      window: windowMock
     });
 
-    Cocktail.mixin(
-      CoppaView,
-      CoppaMixin({ required: true })
-    );
+    return view.render();
+  });
 
-    beforeEach(function () {
-      formPrefill = new FormPrefill();
-      notifier = new Notifier();
-      windowMock = new WindowMock();
+  afterEach(() => {
+    view.remove();
+    view.destroy();
 
-      view = new CoppaView({
+    view = null;
+  });
+
+  describe('render', () => {
+    it('COPPA not rendered if disabled', () => {
+      const coppaNotEnabledView = new CoppaView({
         formPrefill,
+        isCoppaEnabled: false,
         notifier,
+        relier,
         viewName: 'signup',
         window: windowMock
       });
 
-      return view.render();
+      return coppaNotEnabledView.render()
+        .then(() => {
+          assert.lengthOf(coppaNotEnabledView.$('#age'), 0);
+          coppaNotEnabledView.destroy();
+        });
     });
 
-    afterEach(function () {
-      view.remove();
+    it('COPPA not rendered if disabled at relier', () => {
+      const coppaNotEnabledView = new CoppaView({
+        formPrefill,
+        isCoppaEnabled: true,
+        notifier,
+        relier,
+        viewName: 'signup',
+        window: windowMock
+      });
+
+      relier.set('isCoppaEnabled', false);
+
+      return coppaNotEnabledView.render()
+        .then(() => {
+          assert.lengthOf(coppaNotEnabledView.$('#age'), 0);
+          coppaNotEnabledView.destroy();
+        });
+    });
+
+    it('COPPA rendered if disabled in config, enabled by relier', () => {
+      const coppaEnabledView = new CoppaView({
+        formPrefill,
+        isCoppaEnabled: false,
+        notifier,
+        relier,
+        viewName: 'signup',
+        window: windowMock
+      });
+
+      relier.set('isCoppaEnabled', true);
+
+
+      return coppaEnabledView.render()
+        .then(() => {
+          assert.lengthOf(coppaEnabledView.$('#age'), 1);
+        });
+    });
+
+    it('COPPA rendered by default', () => {
+      formPrefill.set('age', 12);
+
+      return view.render()
+        .then(() => {
+          const $ageEl = view.$('#age');
+          assert.lengthOf(view.$('#age'), 1);
+          assert.equal($ageEl.val(), '12');
+          assert.ok($ageEl.prop('required'));
+        });
+    });
+
+    it('redirects to `cannot_create_account` if the user is too young', () => {
+      view.tooYoung();
+
+      sinon.stub(view, 'navigate').callsFake(() => {});
+      return view.render()
+        .then(() => {
+          assert.isTrue(view.navigate.calledOnce);
+          assert.isTrue(view.navigate.calledWith('cannot_create_account'));
+        });
+    });
+  });
+
+  describe('onCoppaInput', () => {
+    it('limits characters', () => {
+      const age = view.$('#age');
+      age.val('13123123123123');
+      view.onCoppaInput();
+      assert.equal(age.val(), '131');
+    });
+  });
+
+  describe('onCoppaKeyDown', () => {
+    it('accept digits', () => {
+      const event = $.Event('keydown', { which: KeyCodes.NUM_1 });
+      sinon.spy(event, 'preventDefault');
+      view.onCoppaKeyDown(event);
+      assert.isFalse(event.preventDefault.called);
+    });
+
+    it('accept ENTER', () => {
+      const event = $.Event('keydown', { which: KeyCodes.ENTER });
+      sinon.spy(event, 'preventDefault');
+      view.onCoppaKeyDown(event);
+      assert.isFalse(event.preventDefault.called);
+    });
+
+    it('does not allow non-digits', () => {
+      const event = $.Event('keydown', {which: KeyCodes.NUM_PERIOD});
+      sinon.spy(event, 'preventDefault');
+      view.onCoppaKeyDown(event);
+      assert.isTrue(event.preventDefault.called);
+    });
+  });
+
+  describe('value is old enough', () => {
+    beforeEach(() => {
+      view.$('#age').val('13');
+    });
+
+    it('isUserOldEnough returns true', () => {
+      assert.isTrue(view.isUserOldEnough());
+    });
+
+    it('coppaHasValue returns true', () => {
+      assert.isTrue(view.coppaHasValue());
+    });
+  });
+
+  describe('value is too young', () => {
+    beforeEach(() => {
+      view.$('#age').val('12');
+    });
+
+    it('isUserOldEnough returns false if COPPA is enabled', () => {
+      sinon.stub(view, 'isCoppaEnabled').callsFake(() => true);
+      assert.isFalse(view.isUserOldEnough());
+    });
+
+    it('isUserOldEnough returns true always if COPPA is disabled', () => {
+      sinon.stub(view, 'isCoppaEnabled').callsFake(() => false);
+      assert.isTrue(view.isUserOldEnough());
+    });
+
+    it('coppaHasValue returns true', () => {
+      assert.isTrue(view.coppaHasValue());
+    });
+  });
+
+  describe('value is empty', () => {
+    beforeEach(() => {
+      view.$('#age').val('');
+    });
+
+    it('isUserOldEnough returns false if COPPA is enabled', () => {
+      sinon.stub(view, 'isCoppaEnabled').callsFake(() => true);
+      assert.isFalse(view.isUserOldEnough());
+    });
+
+    it('isUserOldEnough returns true always if COPPA is disabled', () => {
+      sinon.stub(view, 'isCoppaEnabled').callsFake(() => false);
+      assert.isTrue(view.isUserOldEnough());
+    });
+
+    it('coppaHasValue returns false', () => {
+      assert.isFalse(view.coppaHasValue());
+    });
+  });
+
+  describe('destroy', () => {
+    it('saves the form info to formPrefill', () => {
+      view.$('#age').val('13');
       view.destroy();
-
-      view = null;
+      assert.equal(formPrefill.get('age'), '13');
     });
+  });
 
-    describe('render', function () {
-      it('renders the COPPA row', function () {
-        formPrefill.set('age', 12);
+  describe('tooYoung', () => {
+    it('triggers the `signup.tooyoung` notification, sets a cookie, navigates', () => {
+      sinon.spy(notifier, 'trigger');
+      sinon.stub(view, 'navigate').callsFake(() => {});
 
-        return view.render()
-          .then(function () {
-            const $ageEl = view.$('#age');
-            assert.equal($ageEl.val(), '12');
-            assert.ok($ageEl.prop('required'));
-          });
-      });
+      view.tooYoung();
 
-      it('redirects to `cannot_create_account` if the user is too young', () => {
-        view.tooYoung();
+      assert.isTrue(notifier.trigger.calledOnce);
+      assert.isTrue(notifier.trigger.calledWith('signup.tooyoung'));
 
-        sinon.stub(view, 'navigate').callsFake(() => {});
-        return view.render()
-          .then(() => {
-            assert.isTrue(view.navigate.calledOnce);
-            assert.isTrue(view.navigate.calledWith('cannot_create_account'));
-          });
-      });
-    });
+      assert.equal(windowMock.document.cookie, 'tooyoung=1;');
 
-    describe('onCoppaInput', function () {
-      it('limits characters', function () {
-        const age = view.$('#age');
-        age.val('13123123123123');
-        view.onCoppaInput();
-        assert.equal(age.val(), '131');
-      });
-    });
-
-    describe('onCoppaKeyDown', function () {
-      it('accept digits', function () {
-        const event = $.Event('keydown', { which: KeyCodes.NUM_1 });
-        sinon.spy(event, 'preventDefault');
-        view.onCoppaKeyDown(event);
-        assert.isFalse(event.preventDefault.called);
-      });
-
-      it('accept ENTER', function () {
-        const event = $.Event('keydown', { which: KeyCodes.ENTER });
-        sinon.spy(event, 'preventDefault');
-        view.onCoppaKeyDown(event);
-        assert.isFalse(event.preventDefault.called);
-      });
-
-      it('does not allow non-digits', function () {
-        const event = $.Event('keydown', {which: KeyCodes.NUM_PERIOD});
-        sinon.spy(event, 'preventDefault');
-        view.onCoppaKeyDown(event);
-        assert.isTrue(event.preventDefault.called);
-      });
-    });
-
-    describe('value is old enough', function () {
-      beforeEach(function () {
-        view.$('#age').val('13');
-      });
-
-      it('isUserOldEnough returns true', function () {
-        assert.isTrue(view.isUserOldEnough());
-      });
-
-      it('coppaHasValue returns true', function () {
-        assert.isTrue(view.coppaHasValue());
-      });
-    });
-
-    describe('value is too young', function () {
-      beforeEach(function () {
-        view.$('#age').val('12');
-      });
-
-      it('isUserOldEnough returns false', function () {
-        assert.isFalse(view.isUserOldEnough());
-      });
-
-      it('coppaHasValue returns true', function () {
-        assert.isTrue(view.coppaHasValue());
-      });
-    });
-
-    describe('value is empty', function () {
-      beforeEach(function () {
-        view.$('#age').val('');
-      });
-
-      it('isUserOldEnough returns false', function () {
-        assert.isFalse(view.isUserOldEnough());
-      });
-
-      it('coppaHasValue returns false', function () {
-        assert.isFalse(view.coppaHasValue());
-      });
-    });
-
-    describe('destroy', function () {
-      it('saves the form info to formPrefill', function () {
-        view.$('#age').val('13');
-        view.destroy();
-        assert.equal(formPrefill.get('age'), '13');
-      });
-    });
-
-    describe('tooYoung', () => {
-      it('triggers the `signup.tooyoung` notification, sets a cookie, navigates', () => {
-        sinon.spy(notifier, 'trigger');
-        sinon.stub(view, 'navigate').callsFake(() => {});
-
-        view.tooYoung();
-
-        assert.isTrue(notifier.trigger.calledOnce);
-        assert.isTrue(notifier.trigger.calledWith('signup.tooyoung'));
-
-        assert.equal(windowMock.document.cookie, 'tooyoung=1;');
-
-        assert.isTrue(view.navigate.calledOnce);
-        assert.isTrue(view.navigate.calledWith('cannot_create_account'));
-      });
+      assert.isTrue(view.navigate.calledOnce);
+      assert.isTrue(view.navigate.calledWith('cannot_create_account'));
     });
   });
 });

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -92,6 +92,14 @@ const conf = module.exports = convict({
     },
     secret: 'YOU MUST CHANGE ME'
   },
+  coppa: {
+    enabled: {
+      default: true,
+      doc: 'Is the COPPA age check enabled?',
+      env: 'COPPA_ENABLED',
+      format: Boolean
+    }
+  },
   csp: {
     enabled: {
       default: false,

--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -10,6 +10,7 @@ const logger = require('../logging/log')('routes.index');
 module.exports = function (config) {
   const AUTH_SERVER_URL = config.get('fxaccount_url');
   const CLIENT_ID = config.get('oauth_client_id');
+  const COPPA_ENABLED = config.get('coppa.enabled');
   const ENV = config.get('env');
   const FLOW_ID_KEY = config.get('flow_id_key');
   const MARKETING_EMAIL_API_URL = config.get('marketing_email.api_url');
@@ -26,6 +27,7 @@ module.exports = function (config) {
   const serializedConfig = encodeURIComponent(JSON.stringify({
     authServerUrl: AUTH_SERVER_URL,
     env: ENV,
+    isCoppaEnabled: COPPA_ENABLED,
     marketingEmailPreferencesUrl: MARKETING_EMAIL_PREFERENCES_URL,
     marketingEmailServerUrl: MARKETING_EMAIL_API_URL,
     oAuthClientId: CLIENT_ID,

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -129,7 +129,7 @@ module.exports = {
     HEADER: '#fxa-force-auth-header'
   },
   MOZILLA_ORG_SYNC: {
-    HEADER: '.header-content'
+    HEADER: '.mzp-c-navigation'
   },
   OAUTH_PERMISSIONS: {
     CHECKBOX_DISPLAY_NAME: 'input[name="profile:display_name"]',

--- a/tests/functional/sign_up.js
+++ b/tests/functional/sign_up.js
@@ -86,6 +86,17 @@ registerSuite('signup', {
         .then(testErrorTextInclude('email'));
     },
 
+    'COPPA disabled': function () {
+      return this.remote
+        .then(openPage(PAGE_URL + '?coppa=false', selectors.SIGNUP.HEADER))
+        .then(noSuchElement(selectors.SIGNUP.AGE))
+        .then(type(selectors.SIGNUP.EMAIL, email))
+        .then(type(selectors.SIGNUP.PASSWORD, PASSWORD))
+        .then(type(selectors.SIGNUP.VPASSWORD, PASSWORD))
+        .then(click(selectors.SIGNUP.SUBMIT))
+        .then(testAtConfirmScreen(email));
+    },
+
     'signup, verify same browser': function () {
       return this.remote
         .then(openPage(PAGE_URL, selectors.SIGNUP.HEADER))

--- a/tests/functional/sync_v3_email_first.js
+++ b/tests/functional/sync_v3_email_first.js
@@ -26,6 +26,7 @@ const {
   closeCurrentWindow,
   createUser,
   noPageTransition,
+  noSuchElement,
   openPage,
   openVerificationLinkInDifferentBrowser,
   openVerificationLinkInNewTab,
@@ -145,6 +146,26 @@ registerSuite('Firefox Desktop Sync v3 email first', {
         // will take a few seconds to complete if it erroneously occurs.
         // Add an affordance just in case the poll happens unexpectedly.
         .then(noPageTransition(selectors.CONFIRM_SIGNUP.HEADER));
+    },
+
+    'COPPA disabled': function () {
+      return this.remote
+        .then(openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
+          query: {
+            coppa: 'false'
+          },
+          webChannelResponses: {
+            'fxaccounts:can_link_account': {ok: true}
+          }
+        }))
+        .then(visibleByQSA(selectors.ENTER_EMAIL.SUB_HEADER))
+
+        .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+        .then(click(selectors.ENTER_EMAIL.SUBMIT, selectors.SIGNUP_PASSWORD.HEADER))
+        .then(noSuchElement(selectors.SIGNUP_PASSWORD.AGE))
+        .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, PASSWORD))
+        .then(type(selectors.SIGNUP_PASSWORD.VPASSWORD, PASSWORD))
+        .then(click(selectors.SIGNUP_PASSWORD.SUBMIT, selectors.CHOOSE_WHAT_TO_SYNC.HEADER));
     },
 
     'signin - merge cancelled': function () {


### PR DESCRIPTION
Mozilla China's FxA stack does not need COPPA. So that
they don't have to remove it every time we update our
code, this puts the feature behind a feature flag.

In configuration, coppa.enabled set to `false` will disable COPPA.
COPPA can also be disabled from the URL using `?coppa=false`

fixes #6736
fixes #6740

@mozilla/fxa-devs  - r?

I reformatted a couple of files, best to review this with ?w=1