### PR TITLE
update recovery length to 32 characters

### DIFF
--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -127,9 +127,10 @@ module.exports = {
 
   UTM_SOURCE_EMAIL: 'email',
 
-  // Recovery keys are base32 encoded, length 28 gives 135 bits of entropy
-  // Ex. (28 char - 1 version char) * 5 bits = 135 bits
-  RECOVERY_KEY_LENGTH: 28,
+  // Recovery keys are base32 encoded, length 32 gives 155 bits of entropy
+  // Ex. (32 char - 1 version char) * 5 bits = 155 bits. This gives us a
+  // 1 in 2^155 chance of clashing recovery keys.
+  RECOVERY_KEY_LENGTH: 32,
 
   DEVICE_PAIRING_CHANNEL_KEY_BYTES: 32,
 

--- a/app/styles/modules/_input-row.scss
+++ b/app/styles/modules/_input-row.scss
@@ -70,7 +70,12 @@
     }
 
     &.recovery-key {
+      font-size: 14px;
       text-transform: uppercase;
+
+      @include respond-to('small') {
+        font-size: 11px;
+      }
 
       &::placeholder {
         text-transform: none;

--- a/app/styles/modules/_settings-account-recovery.scss
+++ b/app/styles/modules/_settings-account-recovery.scss
@@ -111,7 +111,7 @@
     .recovery-key {
       color: $modal-recovery-key-color;
       font-family: monospace;
-      font-size: 1.2em;
+      font-size: 1em;
       padding: 25px 0 25px 0;
 
       @media screen and (max-width: 400px) {


### PR DESCRIPTION
This is just a test PR to see how things might look with a 32 length recovery key.

<img width="442" alt="screen shot 2018-12-12 at 10 40 34 am" src="https://user-images.githubusercontent.com/1295288/49881029-59cc9b00-fdfb-11e8-811f-d05bf6763df8.png">
<img width="462" alt="screen shot 2018-12-12 at 10 31 10 am" src="https://user-images.githubusercontent.com/1295288/49881031-59cc9b00-fdfb-11e8-83ca-cf45b58f9ec3.png">

fixes #6758