### PR TITLE
fix(secondary-emails): Handle long emails in the secondary email panel

### DIFF
--- a/app/scripts/templates/settings/emails.mustache
+++ b/app/scripts/templates/settings/emails.mustache
@@ -19,13 +19,13 @@
                     {{#emails}}
                         {{^isPrimary}}
                             <li class="email-address">
-                                <div class="address">{{email}}</div>
-                                <div class="details">
+                                <div class="address {{#verified}}verified{{/verified}}">{{email}}</div>
+                                <div class="details {{#verified}}verified{{/verified}}{{^verified}}not-verified{{/verified}}">
                                     {{#verified}}
-                                        <div class="verified">{{#t}}verified{{/t}}</div>
+                                        <div>{{#t}}verified{{/t}}</div>
                                     {{/verified}}
                                     {{^verified}}
-                                        <div class="not-verified">{{#t}}verification required{{/t}}</div>
+                                        <div>{{#t}}verification required{{/t}}</div>
                                     {{/verified}}
                                 </div>
                                 <div class="settings-button-group">

--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -604,6 +604,16 @@ section.modal-panel {
       @media screen and (max-width: 400px) {
         width: 100%;
       }
+
+      &.verified {
+        @media screen and (min-width: 400px) {
+          // There are two buttons when the email
+          // is verified, the extra button width
+          // needs to be taken into account.
+          // See #6751
+          width: calc(95% - 195px);
+        }
+      }
     }
 
     .settings-button-group {
@@ -688,19 +698,24 @@ section.modal-panel {
   white-space: nowrap;
   width: calc(95% - 95px);
 
-  & .not-verified {
+  &.not-verified {
     color: $color-red;
   }
 
-  & .verified {
+  &.verified {
     color: $color-green;
+    // There are two buttons when the email
+    // is verified, the extra button width
+    // needs to be taken into account.
+    // See #6751
+    width: calc(95% - 195px);
   }
 
-  & .disabled {
+  > .disabled {
     color: $color-red;
   }
 
-  & .enabled {
+  > .enabled {
     color: $color-green;
   }
 }

--- a/app/tests/spec/views/settings/emails.js
+++ b/app/tests/spec/views/settings/emails.js
@@ -183,7 +183,7 @@ define(function (require, exports, module) {
           assert.equal(view.$('.email-address').length, 1);
           assert.lengthOf(view.$('.email-address .address'), 1);
           assert.equal(view.$('.email-address .address').html(), 'another@one.com');
-          assert.equal(view.$('.email-address .details .not-verified').length, 1);
+          assert.equal(view.$('.email-address .details.not-verified').length, 1);
           assert.equal(view.$('.email-address .settings-button.warning-button.email-disconnect').length, 1);
           assert.equal(view.$('.email-address .settings-button.warning-button.email-disconnect').attr('data-id'), 'another@one.com');
           assert.equal(view.$('.email-address .settings-button.secondary-button.set-primary').length, 0);
@@ -256,7 +256,7 @@ define(function (require, exports, module) {
           assert.equal(view.$('.email-address').length, 1);
           assert.lengthOf(view.$('.email-address .address'), 1);
           assert.equal(view.$('.email-address .address').html(), 'another@one.com');
-          assert.equal(view.$('.email-address .details .verified').length, 1);
+          assert.equal(view.$('.email-address .details.verified').length, 1);
           assert.equal(view.$('.email-address .settings-button.warning-button.email-disconnect').length, 1);
           assert.equal(view.$('.email-address .settings-button.warning-button.email-disconnect').attr('data-id'), 'another@one.com');
         });
@@ -303,7 +303,7 @@ define(function (require, exports, module) {
           assert.equal(view.$('.email-address').length, 1);
           assert.lengthOf(view.$('.email-address .address'), 1);
           assert.equal(view.$('.email-address .address').html(), 'secondary@email.com');
-          assert.equal(view.$('.email-address .details .verified').length, 1);
+          assert.equal(view.$('.email-address .details.verified').length, 1);
           assert.equal(view.$('.email-address .settings-button.warning-button.email-disconnect').length, 1);
           assert.equal(view.$('.email-address .settings-button.warning-button.email-disconnect').attr('data-id'), 'secondary@email.com');
           assert.equal(view.$('.email-address .settings-button.secondary-button.set-primary').length, 1);

--- a/tests/functional/settings_change_email.js
+++ b/tests/functional/settings_change_email.js
@@ -66,9 +66,9 @@ registerSuite('settings change email', {
       // set new primary email
       .then(openPage(SETTINGS_URL, selectors.SETTINGS.HEADER))
       .then(click(selectors.EMAIL.MENU_BUTTON))
-      .sleep(5000)
       .then(testElementTextEquals(selectors.EMAIL.ADDRESS_LABEL, secondaryEmail))
       .then(testElementExists(selectors.EMAIL.VERIFIED_LABEL))
+      .then(click(selectors.EMAIL.SET_PRIMARY_EMAIL_BUTTON))
       .then(click(selectors.EMAIL.SET_PRIMARY_EMAIL_BUTTON))
       .then(visibleByQSA(selectors.EMAIL.SUCCESS));
   },

--- a/tests/functional/settings_change_email.js
+++ b/tests/functional/settings_change_email.js
@@ -69,7 +69,6 @@ registerSuite('settings change email', {
       .then(testElementTextEquals(selectors.EMAIL.ADDRESS_LABEL, secondaryEmail))
       .then(testElementExists(selectors.EMAIL.VERIFIED_LABEL))
       .then(click(selectors.EMAIL.SET_PRIMARY_EMAIL_BUTTON))
-      .then(click(selectors.EMAIL.SET_PRIMARY_EMAIL_BUTTON))
       .then(visibleByQSA(selectors.EMAIL.SUCCESS));
   },
 

--- a/tests/functional/settings_change_email.js
+++ b/tests/functional/settings_change_email.js
@@ -66,6 +66,7 @@ registerSuite('settings change email', {
       // set new primary email
       .then(openPage(SETTINGS_URL, selectors.SETTINGS.HEADER))
       .then(click(selectors.EMAIL.MENU_BUTTON))
+      .sleep(5000)
       .then(testElementTextEquals(selectors.EMAIL.ADDRESS_LABEL, secondaryEmail))
       .then(testElementExists(selectors.EMAIL.VERIFIED_LABEL))
       .then(click(selectors.EMAIL.SET_PRIMARY_EMAIL_BUTTON))


### PR DESCRIPTION
The .address CSS only took one button into account when the width
was calculated. If an email is verified, there are two buttons.

This makes affordances for the 2nd button, but only when the
email is verified.

fixes #6751

@vbudhram - r?

### unverified
<img width="496" alt="screenshot 2018-12-20 at 16 32 15" src="https://user-images.githubusercontent.com/848085/50297719-5e392980-0475-11e9-9dd1-06835b303698.png">

### verified
<img width="487" alt="screenshot 2018-12-20 at 16 32 28" src="https://user-images.githubusercontent.com/848085/50297725-609b8380-0475-11e9-81c5-20df93bb698c.png">
