### PR TITLE
fix(reset-password): No more error on /confirm_reset_password w/o initiating flow.

### DIFF
--- a/app/scripts/views/confirm_reset_password.js
+++ b/app/scripts/views/confirm_reset_password.js
@@ -43,6 +43,7 @@ const View = BaseView.extend({
     // user cannot confirm if they have not initiated a reset password
     if (! this.model.has('passwordForgotToken')) {
       this.navigate('reset_password');
+      return;
     }
 
     // Check to see if account has a recovery key and store in model.

--- a/app/tests/spec/views/confirm_reset_password.js
+++ b/app/tests/spec/views/confirm_reset_password.js
@@ -115,12 +115,17 @@ describe('views/confirm_reset_password', function () {
 
     it('redirects to /reset_password if no passwordForgotToken', function () {
       model.unset('passwordForgotToken');
+      const account = {
+        checkRecoveryKeyExistsByEmail: sinon.spy(() => Promise.resolve({}))
+      };
 
       sinon.spy(view, 'navigate');
+      sinon.stub(user, 'initAccount').callsFake(() => account);
 
       return view.render()
         .then(function () {
           assert.isTrue(view.navigate.calledWith('reset_password'));
+          assert.isFalse(account.checkRecoveryKeyExistsByEmail.called);
         });
     });
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -549,11 +549,12 @@ const pollUntilHiddenByQSA = thenify(function (selector, timeout = config.pageLo
  * Ensure no such element exists.
  *
  * @param   {string} selector of element to ensure does not exist.
+ * @param   {number} [timeoutMS] number of ms to wait for the element. Defaults to 0.
  * @returns {promise} resolves when complete, fails if element exists.
  */
-const noSuchElement = thenify(function (selector) {
+const noSuchElement = thenify(function (selector, timeoutMS = 0) {
   return this.parent
-    .setFindTimeout(0)
+    .setFindTimeout(timeoutMS)
 
     .findByCssSelector(selector)
     .then(function () {

--- a/tests/functional/reset_password.js
+++ b/tests/functional/reset_password.js
@@ -122,7 +122,11 @@ registerSuite('reset_password', {
       // sessionToken.
       // Success is showing the screen
       return this.remote
-        .then(openPage(CONFIRM_PAGE_URL, selectors.RESET_PASSWORD.HEADER));
+        .then(openPage(CONFIRM_PAGE_URL, selectors.RESET_PASSWORD.HEADER))
+        // There was an error were users who browsed directly to /confirm_reset_password were
+        // displayed the 400 page. The user should not see the error but should be allowed
+        // to fill out their email address. See #6724
+        .then(noSuchElement(selectors['400'].HEADER, 5000));
     },
 
     'open /reset_password page from /signin': function () {


### PR DESCRIPTION
There was a missing return statement after navigating to `/reset_password` that
caused the `missing email` error to be displayed when looking up whether an account
recovery key exists for a given email address. Since there was no email address
in the test, and the error only appeared after a short delay, our tests didn't
catch the problem. Everything updated.

fixes #6724

@mozilla/fxa-devs - r?