### PR TITLE
feat(pw-strength): Add pw-strength balloon to password change. 

### DIFF
--- a/app/scripts/templates/partial/password-strength-balloon.mustache
+++ b/app/scripts/templates/partial/password-strength-balloon.mustache
@@ -2,18 +2,18 @@
   <h3 class="big-only">{{#t}}Your Firefox Account password{{/t}}</h3>
   <ul>
     <li id="password-too-short"
-      {{^hasEnteredPassword}}class="min-length unmet"{{/hasEnteredPassword}}
+      {{^hasUserTakenAction}}class="min-length unmet"{{/hasUserTakenAction}}
       {{#isTooShort}}class="min-length fail"{{/isTooShort}}
       {{^isTooShort}}class="min-length met"{{/isTooShort}}
     >{{#t}}Must be at least 8 characters{{/t}}</li>
     <li id="password-same-as-email"
-      {{^hasEnteredPassword}}class="not-email unmet"{{/hasEnteredPassword}}
+      {{^hasUserTakenAction}}class="not-email unmet"{{/hasUserTakenAction}}
       {{#isTooShort}}class="not-email unmet"{{/isTooShort}}
       {{#isSameAsEmail}}class="not-email fail"{{/isSameAsEmail}}
       {{^isSameAsEmail}}class="not-email met"{{/isSameAsEmail}}
     >{{#t}}Must not be your email address{{/t}}</li>
     <li id="password-too-common"
-      {{^hasEnteredPassword}}class="not-common unmet"{{/hasEnteredPassword}}
+      {{^hasUserTakenAction}}class="not-common unmet"{{/hasUserTakenAction}}
       {{#isTooShort}}class="not-common unmet"{{/isTooShort}}
       {{#isSameAsEmail}}class="not-common unmet"{{/isSameAsEmail}}
       {{#isCommon}}class="not-common fail"{{/isCommon}}

--- a/app/scripts/templates/settings/change_password.mustache
+++ b/app/scripts/templates/settings/change_password.mustache
@@ -27,7 +27,7 @@
 
       <div class="input-row password-row">
         <input type="password" class="password check-password tooltip-below" id="new_password" placeholder="{{#t}}New password{{/t}}" required pattern=".{8,}"  data-synchronize-show="true"/>
-        <div class="input-help">{{#t}}Must be at least 8 characters{{/t}}</div>
+        <div class="helper-balloon"></div>
       </div>
 
       <div class="input-row password-row">

--- a/app/scripts/views/elements/jquery-plugin.js
+++ b/app/scripts/views/elements/jquery-plugin.js
@@ -47,7 +47,14 @@ define(function (require, exports, module) {
   }
 
   $.fn.validate = function () {
-    return getHelper(this).validate.call(this);
+    if (this.data('validate')) {
+      // the element has a custom validator attached to it,
+      // probably from a view. Depend on the validator instead
+      // of the standard validation functions.
+      return this.data('validate')();
+    } else {
+      return getHelper(this).validate.call(this);
+    }
   };
 
   $.fn.__val = $.fn.val;

--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -368,33 +368,39 @@ var FormView = BaseView.extend({
     const $invalidEl = this.$(el);
     const message = AuthErrors.toMessage(err);
 
-    // tooltipId is used to bind the invalid element
-    // with the tooltip using `aria-described-by`
-    const tooltipId = `error-tooltip-${err.errno}`;
-
-    var tooltip = new Tooltip({
-      id: tooltipId,
-      invalidEl: $invalidEl,
-      message,
-      translator: this.translator
-    });
-
-    tooltip.on('destroyed', () => {
-      this.markElementValid($invalidEl);
-      this.trigger('validation_error_removed', el);
-    }).render().then(() => {
-      this.markElementInvalid($invalidEl, tooltipId);
+    const markElementInvalidAndFocus = (describedById) => {
+      this.markElementInvalid($invalidEl, describedById);
       try {
         $invalidEl.get(0).focus();
       } catch (e) {
-        // IE can blow up if the element is not visible.
+      // IE can blow up if the element is not visible.
       }
 
       // used for testing
       this.trigger('validation_error', el, message);
-    });
+    };
 
-    this.trackChildView(tooltip);
+    if (err.describedById) {
+      markElementInvalidAndFocus(err.describedById);
+    } else {
+      // tooltipId is used to bind the invalid element
+      // with the tooltip using `aria-described-by`
+      const tooltipId = `error-tooltip-${err.errno}`;
+
+      var tooltip = new Tooltip({
+        id: tooltipId,
+        invalidEl: $invalidEl,
+        message,
+        translator: this.translator
+      });
+
+      tooltip.on('destroyed', () => {
+        this.markElementValid($invalidEl);
+        this.trigger('validation_error_removed', el);
+      }).render().then(() => markElementInvalidAndFocus(tooltipId));
+
+      this.trackChildView(tooltip);
+    }
 
     return message;
   },

--- a/app/scripts/views/mixins/password-strength-mixin.js
+++ b/app/scripts/views/mixins/password-strength-mixin.js
@@ -33,26 +33,23 @@ export default function (config = {}) {
         }
 
         const passwordModel = this.passwordModel = this._createPasswordStrengthBalloonModel();
-        // wait a short time after the last change to log the invalid reason.
+        // wait a short time after the last invalid event to log the invalid reason.
         // The additional delay over when the UI updates is to minimize the
         // chances of spurious warnings being logged as us helping the user.
-        this.listenTo(passwordModel, 'change', debounce(() => this._logErrorIfInvalid(), delayBeforeLogReasonMS));
+        this.listenTo(passwordModel, 'invalid', debounce(() => this._logErrorIfInvalid(), delayBeforeLogReasonMS));
 
-        this.on('submitStart', () => passwordModel.set('isSubmitting', true));
-        this.on('submitEnd', () => passwordModel.set('isSubmitting', false));
-
-        const passwordView = this._createPasswordWithStrengthBalloonView(passwordModel);
-        this.trackChildView(passwordView);
-
-        // the password element is already rendered,
-        // call it's afterRender function to
-        // create the balloon.
-        return passwordView.afterRender();
+        return passwordModel.fetch()
+          .then(() => {
+            const passwordView = this._createPasswordWithStrengthBalloonView(this.passwordModel);
+            this.trackChildView(passwordView);
+          });
       });
     },
 
     _createPasswordStrengthBalloonModel () {
-      return new PasswordStrengthBalloonModel(this.getAccount().pick('email'));
+      return new PasswordStrengthBalloonModel({
+        email: this.getAccount().get('email'),
+      });
     },
 
     _createPasswordWithStrengthBalloonView (passwordModel) {
@@ -65,43 +62,8 @@ export default function (config = {}) {
       });
     },
 
-    isValidStart () {
-      if (this.passwordModel.validate()) {
-        // does not allow the form to be submit if the model says there are any problems.
-        return false;
-      }
-      // If fall through occurs, the mixin target's isValidStart will be called.
-    },
-
-    showValidationErrorsStart () {
-      if (this.passwordModel.validate()) {
-        this.focus(passwordEl);
-        // do not show any additional tooltips if the model says there are any errors
-        // under the assumption our PasswordStrengthBalloonView will display errors.
-        return true;
-      }
-      // If fall through occurs, the mixin target's showValidationErrorsStart will be called.
-    },
-
-    logError (error) {
-      // propagate errors to the notifier, the password-strength experiment
-      // will decide whether any of them are worth saving state about.
-      // This also handles password validation errors for the control group
-      // since there is no model saying the field is invalid.
-      this.notifier.trigger('password.error', error);
-    },
-
     _logErrorIfInvalid () {
-      // The model's `change` event occurs when any of the attributes are
-      // updated. Because the model's `updateForPassword` method is
-      // asynchronous, it's possible for a `change` event to be triggered
-      // and the model be considered invalid before the password has
-      // been checked. Only log errors after the password has been checked.
-      if (! this.passwordModel.get('hasCheckedPassword')) {
-        return;
-      }
-
-      const error = this.passwordModel.validate();
+      const error = this.passwordModel.validationError;
       if (error) {
         this.logError(error);
       }

--- a/app/scripts/views/password_strength/password_strength_balloon.js
+++ b/app/scripts/views/password_strength/password_strength_balloon.js
@@ -11,16 +11,16 @@
  * @extends {BaseView}
  */
 
+import AuthErrors from '../../lib/auth-errors';
 import BaseView from '../base';
 import Cocktail from 'cocktail';
 import OneVisibleOfTypeMixin from '../mixins/one-visible-of-type-mixin';
 import Template from '../../templates/partial/password-strength-balloon.mustache';
 import XSS from '../../lib/xss';
 
-const DELAY_BEFORE_UPDATE_MS = 1000;
 // Allow the balloon to stay visible for a bit so that
 // the user can see all the criteria were met.
-const DELAY_BEFORE_HIDE_MS = DELAY_BEFORE_UPDATE_MS + 750;
+const DELAY_BEFORE_HIDE_MS = 750;
 
 const DELAY_BEFORE_HIDE_BALLOON_EL_MS = 500;
 
@@ -31,69 +31,51 @@ class PasswordStrengthBalloonView extends BaseView {
   template = Template;
 
   initialize (config = {}) {
-    this.delayBeforeUpdateMS = config.delayBeforeUpdateMS || DELAY_BEFORE_UPDATE_MS;
     this.delayBeforeHideMS = config.delayBeforeHideMS || DELAY_BEFORE_HIDE_MS;
 
-    this.listenTo(this.model, 'change:hasEnteredPassword', () => this.update());
-    this.listenTo(this.model, 'change:isCommon', () => this.update());
-    this.listenTo(this.model, 'change:isSameAsEmail', () => this.update());
-    this.listenTo(this.model, 'change:isTooShort', () => this.update());
-
-    this.listenTo(this.model, 'change:isValid', () => this.hideIfValid());
+    this.listenTo(this.model, 'change:password', this.update);
   }
 
   setInitialContext (context) {
+    const validationError = this.model.validationError;
+
     context.set({
-      escapedCommonPasswordLinkAttrs: `href="${ESCAPED_SUMO_ARTICLE_HREF}" target="_blank"`
+      escapedCommonPasswordLinkAttrs: `href="${ESCAPED_SUMO_ARTICLE_HREF}" target="_blank"`,
+      isCommon: validationError && AuthErrors.is(validationError, 'PASSWORD_TOO_COMMON'),
+      isSameAsEmail: validationError && AuthErrors.is(validationError, 'PASSWORD_SAME_AS_EMAIL'),
+      isTooShort: validationError && (AuthErrors.is(validationError, 'PASSWORD_REQUIRED') || AuthErrors.is(validationError, 'PASSWORD_TOO_SHORT')),
     });
   }
 
   afterRender () {
-    // Show the balloon if the model is already invalid.
-    if (this.model.validate()) {
+    if (this.model.validationError) {
+      // OneVisibleOfTypeMixin uses 'show' to destroy any other
+      // tooltip-like views.
       this.show();
     }
   }
 
-  hideIfValid () {
-    if (this.model.get('isValid')) {
-      this.clearTimeouts();
-      return this.hideAfterDelay();
-    }
-  }
-
   update () {
-    // Render immediately if submitting so the user sees immediate
-    // feedback, otherwise introduce a short delay to reduce jank.
-    if (this.model.get('isSubmitting')) {
-      return this.render();
-    } else {
-      return this.renderAfterDelay();
-    }
+    this.clearTimeouts();
+    return this.render()
+      .then(() => {
+        if (! this.model.validationError) {
+          return this.hideAfterDelay();
+        }
+      });
   }
 
   clearTimeouts () {
     this.clearTimeout(this._hideTimeout);
     this.clearTimeout(this._hideBalloonElTimeout);
-    this.clearTimeout(this._renderTimeout);
-  }
-
-  renderAfterDelay () {
-    this.clearTimeouts();
-
-    this._renderTimeout = this.setTimeout(() => {
-      this.render();
-    }, this.delayBeforeUpdateMS);
   }
 
   show () {
-    this.model.set('isVisible', true);
     this.$(PASSWORD_STRENGTH_BALLOON_SELECTOR).show().css('opacity', '1');
   }
 
   hide () {
     const $balloonEl = this.$(PASSWORD_STRENGTH_BALLOON_SELECTOR);
-    this.model.set('isVisible', false);
     $balloonEl.css('opacity', '0');
     this._hideBalloonElTimeout = this.setTimeout(() => {
       // In addition to the opacity, the element must be hidden
@@ -105,20 +87,9 @@ class PasswordStrengthBalloonView extends BaseView {
   }
 
   hideAfterDelay () {
-    // Only hide if already visible. This helps to prevent
-    // jank if the bubble goes away, the user removes
-    // one character to make the password invalid, then
-    // they immediately type a character again making the
-    // password valid again.
-    if (this.model.get('isVisible')) {
-      // force a re-render so that the list-item icons
-      // update just before hiding
-      this.renderAfterDelay();
-
-      this._hideTimeout = this.setTimeout(() => {
-        this.hide();
-      }, this.delayBeforeHideMS);
-    }
+    this._hideTimeout = this.setTimeout(() => {
+      this.hide();
+    }, this.delayBeforeHideMS);
   }
 }
 

--- a/app/scripts/views/password_strength/password_with_strength_balloon.js
+++ b/app/scripts/views/password_strength/password_with_strength_balloon.js
@@ -13,71 +13,130 @@
  * @extends {FormView}
  */
 
+import AuthErrors from '../../lib/auth-errors';
+import { debounce } from 'underscore';
 import FormView from '../form';
 import PasswordStrengthBalloonView from './password_strength_balloon';
 
+const DELAY_BEFORE_UPDATE_MODEL_MS = 1000;
+
 const PasswordWithStrengthBalloonView = FormView.extend({
   events: {
-    change: 'updateModelForPassword',
-    keyup: 'updateModelForPassword',
+    change: 'updateModelAfterDelay',
+    focus: 'createBalloonIfNeeded',
+    keypress: 'updateModelAfterDelay',
   },
 
   initialize (options = {}) {
-    this.passwordHelperBalloon = options.passwordHelperBalloon || new PasswordStrengthBalloonView({
-      el: options.balloonEl,
+    this.passwordHelperBalloon = options.passwordHelperBalloon;
+    this.balloonEl = options.balloonEl;
+
+    // setting the validator causes the jquery-plugin to delegate
+    // validation to this.validate() rather than the standard
+    // validation logic.
+    this.$el.data('validate', () => this.validate());
+
+    this.listenTo(this.model, 'invalid', () => this.createBalloonIfNeeded());
+
+    // Controlling UI updates is easier by debouncing on input than trying
+    // to introduce a delay after the model has been updated.
+    const delayBeforeUpdateModelMS = options.delayBeforeUpdateModelMS || DELAY_BEFORE_UPDATE_MODEL_MS;
+    this.updateModelAfterDelay = debounce(() => this.updateModel(), delayBeforeUpdateModelMS);
+  },
+
+  createBalloonIfNeeded () {
+    // The balloon is created as soon as the user focuses the input element
+    // and the password is missing or invalid, or as soon as the model
+    // becomes invalid.
+    if (this.shouldCreateBalloon()) {
+      this.createBalloon();
+    }
+  },
+
+  shouldCreateBalloon () {
+    if (this.passwordHelperBalloon) {
+      return false;
+    }
+
+    // If a password was pre-filled into the input element, only
+    // show the balloon if the password is invalid.
+    const password = this.$el.val();
+    if (password) {
+      // use validate directly to avoid triggering an `invalid` event,
+      // which causes the check to occur a 2nd time.
+      return !! this.model.validate({ password });
+    }
+
+    // There is no prefilled password, yes, show the balloon.
+    return true;
+  },
+
+  createBalloon () {
+    const passwordHelperBalloon = this.passwordHelperBalloon = new PasswordStrengthBalloonView({
+      el: this.balloonEl,
       lang: this.lang,
       model: this.model,
       translator: this.translator
     });
-    this.trackChildView(this.passwordHelperBalloon);
+
+    this.trackChildView(passwordHelperBalloon);
+    // update our own styles whenever the balloon does to avoid any jank.
+    this.listenTo(passwordHelperBalloon, 'rendered', () => this.updateStyles());
+
+    return passwordHelperBalloon.render()
+      .then(() => {
+        // update our own styles whenever the balloon does to avoid any jank. This only
+        // updates after the first render
+        this.$el.attr('aria-described-by', 'password-strength-balloon');
+
+        // The password field was pre-filled, update
+        // the model with it.
+        if (this.$el.val()) {
+          this.updateModel();
+        }
+      });
   },
 
-  afterRender () {
-    return Promise.resolve().then(() => {
-      // If a password is pre-filled, update the model values
-      // before rendering so that the tooltip is not displayed if
-      // not necessary.
-      if (this.$el.val().length) {
-        return this.updateModelForPassword();
-      }
-    }).then(() => {
-      // update our own styles whenever the balloon does to avoid any jank.
-      this.listenTo(this.passwordHelperBalloon, 'rendered', () => this.updateStyles());
-
-      return this.passwordHelperBalloon.render();
-    }).then(() => {
-      this.$el.attr('aria-described-by', 'password-strength-balloon');
-    });
-  },
-
-  updateModelForPassword () {
+  /**
+   * Updates the model after some sort of user action.
+   */
+  updateModel () {
     this.model.set('password', this.$el.val());
   },
 
   updateStyles () {
-    const { hasEnteredPassword, isValid } = this.model.toJSON();
-
-    if (hasEnteredPassword && ! isValid) {
-      const describedById = this._getDescribedById();
+    // The input element should only be marked invalid if the user has
+    // taken some sort of action.
+    const validationError = this.model.validationError;
+    if (validationError) {
+      const describedById = this._getDescribedById(validationError);
       this.markElementInvalid(this.$el, describedById);
     } else {
       this.markElementValid(this.$el);
     }
   },
 
-  _getDescribedById () {
-    const {
-      isCommon,
-      isSameAsEmail,
-      isTooShort,
-    } = this.model.toJSON();
-
-    if (isTooShort) {
+  _getDescribedById (validationError) {
+    if (AuthErrors.is(validationError, 'PASSWORD_REQUIRED')) {
       return 'password-too-short';
-    } else if (isSameAsEmail) {
+    } else if (AuthErrors.is(validationError, 'PASSWORD_TOO_SHORT')) {
+      return 'password-too-short';
+    } else if (AuthErrors.is(validationError, 'PASSWORD_SAME_AS_EMAIL')) {
       return 'password-same-as-email';
-    } else if (isCommon) {
+    } else if (AuthErrors.is(validationError, 'PASSWORD_TOO_COMMON')) {
       return 'password-too-common';
+    }
+  },
+
+  validate () {
+    // validate is called by jquery-plugin to validate the password element.
+    // Since this is part of normal validation, update the model immediately
+    // then check for validity.
+    this.updateModel();
+    const validationError = this.model.validationError;
+    if (validationError) {
+      validationError.describedById = this._getDescribedById(validationError);
+      throw validationError;
     }
   }
 });

--- a/app/scripts/views/settings/change_password.js
+++ b/app/scripts/views/settings/change_password.js
@@ -8,6 +8,7 @@ import Cocktail from 'cocktail';
 import FormView from '../form';
 import ExperimentMixin from '../mixins/experiment-mixin';
 import PasswordMixin from '../mixins/password-mixin';
+import PasswordStrengthMixin from '../mixins/password-strength-mixin';
 import ServiceMixin from '../mixins/service-mixin';
 import SettingsPanelMixin from '../mixins/settings-panel-mixin';
 import Template from 'templates/settings/change_password.mustache';
@@ -86,6 +87,10 @@ Cocktail.mixin(
   View,
   ExperimentMixin,
   PasswordMixin,
+  PasswordStrengthMixin({
+    balloonEl: '.helper-balloon',
+    passwordEl: '#new_password'
+  }),
   SettingsPanelMixin,
   ServiceMixin,
   BackMixin

--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -192,7 +192,7 @@
     }
 
     @include respond-to('balloonBig') {
-      left: 360px;
+      left: calc(100% + 18px);
       top: -22px;
       width: 272px;
     }

--- a/app/tests/spec/models/password_strength/password_strength_balloon.js
+++ b/app/tests/spec/models/password_strength/password_strength_balloon.js
@@ -5,6 +5,7 @@
 import { assert } from 'chai';
 import AuthErrors from 'lib/auth-errors';
 import PasswordModel from 'models/password_strength/password_strength_balloon';
+import sinon from 'sinon';
 
 let model;
 
@@ -13,40 +14,44 @@ describe('models/password_strength/password_strength_balloon', () => {
     model = new PasswordModel({
       email: 'testuser@testuser.com'
     });
+
+    sinon.spy(model, '_getCommonPasswordList');
+    sinon.spy(model, 'isValid');
+
+    return model.fetch();
+  });
+
+  it('`fetch` fetches the password list', () => {
+    assert.isTrue(model._getCommonPasswordList.calledOnce);
   });
 
   it('has the expected defaults', () => {
     assert.deepEqual(model.toJSON(), {
       email: 'testuser@testuser.com',
-      hasCheckedPassword: false,
-      hasEnteredPassword: false,
-      hasSubmit: false,
-      isCommon: false,
-      isSameAsEmail: false,
-      isSubmitting: false,
-      isTooShort: false,
-      isValid: false,
-      password: ''
+      hasUserTakenAction: false,
+      isVisible: false,
+      password: null
     });
   });
 
-  describe('updateForPassword', () => {
+  describe('validate', () => {
+    function testPasswordCausesValidationError(password, expectedError) {
+      const err = model.validate({ password });
+      assert.isTrue(AuthErrors.is(err, expectedError));
+    }
+
+    it('no error if no password entered and user has taken no action', () => {
+      const err = model.validate({ password: '' });
+      assert.isUndefined(err);
+    });
+
+    it('catches if no password entered but user has taken some action', () => {
+      const err = model.validate({ hasUserTakenAction: true, password: '' });
+      assert.isTrue(AuthErrors.is(err, 'PASSWORD_REQUIRED'));
+    });
+
     it('catches if password is too short', () => {
-      model.set('password', 'passwor', { silent: true });
-      return model.updateForPassword().then(() => {
-        assert.deepEqual(model.toJSON(), {
-          email: 'testuser@testuser.com',
-          hasCheckedPassword: true,
-          hasEnteredPassword: true,
-          hasSubmit: false,
-          isCommon: false,
-          isSameAsEmail: false,
-          isSubmitting: false,
-          isTooShort: true,
-          isValid: false,
-          password: 'passwor',
-        });
-      });
+      testPasswordCausesValidationError('passwor', 'PASSWORD_TOO_SHORT');
     });
 
     [
@@ -58,22 +63,7 @@ describe('models/password_strength/password_strength_balloon', () => {
       '12345678TESTUSER',              // local part is 50% of password
     ].forEach((password) => {
       it(`catches ${password} as too similar to email`, () => {
-        model.set('password', password, { silent: true });
-        return model.updateForPassword()
-          .then(() => {
-            assert.deepEqual(model.toJSON(), {
-              email: 'testuser@testuser.com',
-              hasCheckedPassword: true,
-              hasEnteredPassword: true,
-              hasSubmit: false,
-              isCommon: false,
-              isSameAsEmail: true,
-              isSubmitting: false,
-              isTooShort: false,
-              isValid: false,
-              password,
-            });
-          });
+        testPasswordCausesValidationError(password, 'PASSWORD_SAME_AS_EMAIL');
       });
     });
 
@@ -81,23 +71,8 @@ describe('models/password_strength/password_strength_balloon', () => {
       'tes12345',             // local part < 50%, at the beginning
       '123456789TESTUSER',    // local part < 50%, not at the beginning
     ].forEach((password) => {
-      it(`catches ${password} as too similar to email`, () => {
-        model.set('password', password, { silent: true });
-        return model.updateForPassword()
-          .then(() => {
-            assert.deepEqual(model.toJSON(), {
-              email: 'testuser@testuser.com',
-              hasCheckedPassword: true,
-              hasEnteredPassword: true,
-              hasSubmit: false,
-              isCommon: false,
-              isSameAsEmail: false,
-              isSubmitting: false,
-              isTooShort: false,
-              isValid: true,
-              password,
-            });
-          });
+      it(`allows ${password}, not similar enough to email`, () => {
+        assert.isUndefined(model.validate({ password }));
       });
     });
 
@@ -120,121 +95,24 @@ describe('models/password_strength/password_strength_balloon', () => {
       'SUMOFirefox'
     ].forEach((password) => {
       it(`considers '${password}' common`, () => {
-        model.set('password', password, { silent: true });
-        return model.updateForPassword()
-          .then(() => {
-            assert.deepEqual(model.toJSON(), {
-              email: 'testuser@testuser.com',
-              hasCheckedPassword: true,
-              hasEnteredPassword: true,
-              hasSubmit: false,
-              isCommon: true,
-              isSameAsEmail: false,
-              isSubmitting: false,
-              isTooShort: false,
-              isValid: false,
-              password,
-            });
-          });
+        testPasswordCausesValidationError(password, 'PASSWORD_TOO_COMMON');
       });
     });
 
-    it('`hasEnteredPassword` remains true after entering then deleting password', () => {
-      model.set({
-        hasEnteredPassword: true,
-        password: ''
-      }, { silent: false });
-      return model.updateForPassword()
-        .then(() => {
-          assert.deepEqual(model.toJSON(), {
-            email: 'testuser@testuser.com',
-            hasCheckedPassword: true,
-            hasEnteredPassword: true,
-            hasSubmit: false,
-            isCommon: false,
-            isSameAsEmail: false,
-            isSubmitting: false,
-            isTooShort: true,
-            isValid: false,
-            password: '',
-          });
-        });
+    it('sets `hasUserTakenAction` to true when `password` set to ``', () => {
+      model.set('password', '');
+      assert.isTrue(model.get('hasUserTakenAction'));
     });
 
-    it('sets `isValid: true` if all criteria are met', () => {
-      const password = '15asdgljk325sadglkasdgklasdjlg';
-      model.set('password', password, { silent: true });
-      return model.updateForPassword()
-        .then(() => {
-          assert.deepEqual(model.toJSON(), {
-            email: 'testuser@testuser.com',
-            hasCheckedPassword: true,
-            hasEnteredPassword: true,
-            hasSubmit: false,
-            isCommon: false,
-            isSameAsEmail: false,
-            isSubmitting: false,
-            isTooShort: false,
-            isValid: true,
-            password
-          });
-        });
-    });
-  });
-
-  describe('validate', () => {
-    it('returns PASSWORD_REQUIRED if no password entered', () => {
-      model.set('hasEnteredPassword', false);
-      assert.isTrue(AuthErrors.is(model.validate(), 'PASSWORD_REQUIRED'));
+    it('sets `hasUserTakenAction` to true when `password` changes', () => {
+      model.set('password', 'p');
+      assert.isTrue(model.get('hasUserTakenAction'));
     });
 
-    it('returns PASSWORD_TOO_SHORT for isTooShort', () => {
-      model.set({
-        hasEnteredPassword: true,
-        isCommon: false,
-        isSameAsEmail: false,
-        isTooShort: true,
-        password: 'pass',
-      });
-      assert.isTrue(AuthErrors.is(model.validate(), 'PASSWORD_TOO_SHORT'));
+    it('calls `isValid` whenever the password changes', () => {
+      assert.isFalse(model.isValid.called);
+      model.set('password', 'p');
+      assert.isTrue(model.isValid.calledOnce);
     });
-
-    it('returns PASSWORD_SAME_AS_EMAIL for isSameAsEmail', () => {
-      model.set({
-        hasEnteredPassword: true,
-        isCommon: false,
-        isSameAsEmail: true,
-        isTooShort: false,
-        password: 'testuser',
-      });
-      assert.isTrue(AuthErrors.is(model.validate(), 'PASSWORD_SAME_AS_EMAIL'));
-    });
-
-    it('returns PASSWORD_TOO_COMMON for isCommon', () => {
-      model.set({
-        hasEnteredPassword: true,
-        isCommon: true,
-        isSameAsEmail: false,
-        isTooShort: false,
-        password: 'password',
-      });
-      assert.isTrue(AuthErrors.is(model.validate(), 'PASSWORD_TOO_COMMON'));
-    });
-
-    it('returns undefined if no problem', () => {
-      model.set({
-        hasEnteredPassword: true,
-        isCommon: false,
-        isSameAsEmail: false,
-        isTooShort: false,
-        password: 'password123123',
-      });
-      assert.isUndefined(model.validate());
-    });
-  });
-
-  it('updating isSubmitting changes `hasSubmit` to true', () => {
-    model.set('isSubmitting', true);
-    assert.isTrue(model.get('hasSubmit'));
   });
 });

--- a/app/tests/spec/views/mixins/password-strength-mixin.js
+++ b/app/tests/spec/views/mixins/password-strength-mixin.js
@@ -90,106 +90,42 @@ describe('views/mixins/password-strength-mixin', () => {
   });
 
   it('render sets up the password model and view', () => {
-    const passwordModel = {};
-    const passwordView = {
-      afterRender: sinon.spy(() => Promise.resolve('heyo'))
+    const passwordModel = {
+      fetch: sinon.spy(() => Promise.resolve())
     };
+    const passwordView = {};
 
     sinon.stub(view, '_createPasswordStrengthBalloonModel').callsFake(() => passwordModel);
     sinon.stub(view, '_createPasswordWithStrengthBalloonView').callsFake(() => passwordView);
     sinon.stub(view, 'trackChildView');
     sinon.stub(view, 'listenTo');
-    sinon.stub(view, 'on');
 
     return view.render()
       .then(() => {
         assert.isTrue(view._createPasswordStrengthBalloonModel.calledOnce);
-        assert.isTrue(view.listenTo.calledOnceWith(passwordModel, 'change'));
-        assert.isTrue(view.on.calledTwice);
+        assert.isTrue(view.listenTo.calledOnceWith(passwordModel, 'invalid'));
 
         assert.isTrue(view._createPasswordWithStrengthBalloonView.calledOnce);
         assert.isTrue(view.trackChildView.calledOnceWith(passwordView));
-        assert.isTrue(passwordView.afterRender.calledOnce);
+
+        assert.isTrue(passwordModel.fetch.calledOnce);
       });
-  });
-
-  it('submitStart and submitEnd update the passwordModel', () => {
-    const passwordModel = new Model({});
-    const passwordView = {
-      afterRender: sinon.spy(() => Promise.resolve('heyo')),
-      on: sinon.spy()
-    };
-
-    sinon.stub(view, '_createPasswordStrengthBalloonModel').callsFake(() => passwordModel);
-    sinon.stub(view, '_createPasswordWithStrengthBalloonView').callsFake(() => passwordView);
-
-    return view.render()
-      .then(() => {
-        view.trigger('submitStart');
-        assert.isTrue(passwordModel.get('isSubmitting'));
-        view.trigger('submitEnd');
-        assert.isFalse(passwordModel.get('isSubmitting'));
-      });
-  });
-
-  describe('isValidStart', () => {
-    it('returns false if the validate function returns an error', () => {
-      let validationError = undefined;
-      view.passwordModel = {
-        validate: sinon.spy(() => validationError)
-      };
-      assert.isTrue(view.isValidStart());
-      assert.isTrue(view.passwordModel.validate.calledOnce);
-
-      validationError = new Error('uh oh');
-      assert.isFalse(view.isValidStart());
-      assert.isTrue(view.passwordModel.validate.calledTwice);
-    });
-  });
-
-  describe('showValidationErrorsStart', () => {
-    it('shows expected validation errors', () => {
-      sinon.stub(view, 'focus');
-      let validationError = undefined;
-      view.passwordModel = {
-        validate: sinon.spy(() => validationError)
-      };
-      assert.isUndefined(view.showValidationErrorsStart());
-      assert.isTrue(view.passwordModel.validate.calledOnce);
-
-      validationError = new Error('uh oh');
-      assert.isTrue(view.showValidationErrorsStart());
-      assert.isTrue(view.passwordModel.validate.calledTwice);
-
-      assert.isTrue(view.focus.calledOnceWith('#password'));
-    });
   });
 
   it('_logErrorIfInvalid only logs validation errors if the password has been checked', () => {
-    const error = new Error('uh oh');
-    let hasCheckedPassword = false;
     view.passwordModel = {
-      get: () => hasCheckedPassword,
-      validate: sinon.spy(() => error)
+      get: () => true
     };
+
     sinon.stub(view, 'logError');
 
     view._logErrorIfInvalid();
     assert.isFalse(view.logError.called);
 
-    hasCheckedPassword = true;
+    const error = new Error('uh oh');
+    view.passwordModel.validationError = error;
+
     view._logErrorIfInvalid();
     assert.isTrue(view.logError.calledOnceWith(error));
-  });
-
-  it('logError triggers a `password.error` on the notifier', () => {
-    view.notifier = {
-      trigger: sinon.spy()
-    };
-
-    const error = new Error('uh oh');
-    view.logError(error);
-
-    assert.isTrue(view.notifier.trigger.calledOnceWith('password.error', error));
   });
 });

--- a/app/tests/spec/views/password_strength/password_with_strength_balloon.js
+++ b/app/tests/spec/views/password_strength/password_with_strength_balloon.js
@@ -4,10 +4,10 @@
 
 import $ from 'jquery';
 import { assert } from 'chai';
-import { assign } from 'underscore';
-import { Events } from 'backbone';
+import AuthErrors from 'lib/auth-errors';
 import Model from 'models/password_strength/password_strength_balloon';
 import PasswordWithStrengthBalloon from 'views/password_strength/password_with_strength_balloon';
+import { requiresFocus } from '../../../lib/helpers';
 import sinon from 'sinon';
 
 const template = `
@@ -27,92 +27,143 @@ describe('views/password_strength/password_with_strength_ballon', () => {
 
     model = new Model({});
 
-    passwordHelperBalloon = assign({
-      render: sinon.spy()
-    }, Events);
-
     view = new PasswordWithStrengthBalloon({
       balloonEl: '#balloon',
       el: '#password',
       model,
       passwordHelperBalloon
     });
-
-    return view.afterRender();
   });
 
-  it('renders the pw balloon in afterRender, sets the aria field', () => {
-    assert.isTrue(view.passwordHelperBalloon.render.calledOnce);
-    assert.equal(view.$el.attr('aria-described-by'), 'password-strength-balloon');
+  it('sets data.validate on the element', () => {
+    assert.isFunction(view.$el.data('validate'));
   });
 
-  it('updates the model for the password element value', () => {
-    $('#password').val('password');
-    sinon.spy(view, 'updateModelForPassword');
+  it('creates the balloon on element focus', () => {
+    requiresFocus(() => {
+      sinon.stub(view, 'createBalloonIfNeeded');
+      view.$el.trigger('focus');
 
-    return view.afterRender()
+      assert.isTrue(view.createBalloonIfNeeded.calledOnce);
+    });
+  });
+
+  it('creates the balloon on validation error', () => {
+    sinon.stub(view, 'createBalloonIfNeeded');
+    model.trigger('invalid');
+
+    assert.isTrue(view.createBalloonIfNeeded.calledOnce);
+  });
+
+  describe('createBalloonIfNeeded', () => {
+    it('creates the balloon if `shouldCreateBalloon` says to', () => {
+      sinon.stub(view, 'shouldCreateBalloon').callsFake(() => true);
+      sinon.stub(view, 'createBalloon');
+
+      view.createBalloonIfNeeded();
+      assert.isTrue(view.createBalloon.calledOnce);
+    });
+
+    it('does not create the balloon if `shouldCreateBalloon` says no', () => {
+      sinon.stub(view, 'shouldCreateBalloon').callsFake(() => false);
+      sinon.stub(view, 'createBalloon');
+
+      view.createBalloonIfNeeded();
+      assert.isFalse(view.createBalloon.called);
+    });
+  });
+
+  it('createBalloon creates the balloon', () => {
+    sinon.stub(view, 'shouldCreateBalloon').callsFake(() => true);
+    sinon.stub(view, 'updateStyles');
+    return view.createBalloon()
       .then(() => {
-        assert.isTrue(view.updateModelForPassword.calledOnce);
+        assert.isTrue(view.updateStyles.calledOnce);
+        assert.equal(view.$el.attr('aria-described-by'), 'password-strength-balloon');
       });
   });
 
-  it('updateModelForPassword updates delegates to the model', () => {
+  it('passwordHelperBalloon and element update styles at the same time', () => {
+    sinon.stub(view, 'updateStyles');
+    return view.createBalloon()
+      .then(() => {
+        assert.isTrue(view.updateStyles.calledOnce);
+        view.passwordHelperBalloon.trigger('rendered');
+        assert.isTrue(view.updateStyles.calledTwice);
+      });
+  });
+
+  it('updateModel updates delegates to the model', () => {
     $('#password').val('password');
-    sinon.spy(model, 'set');
-    view.updateModelForPassword();
-    assert.isTrue(model.set.calledOnceWith('password', 'password'));
+    view.updateModel();
+
+    assert.equal(model.get('password'), 'password');
   });
 
   it('the element is marked as invalid if password has been entered and is invalid', () => {
     sinon.stub(view, 'markElementValid');
     sinon.stub(view, 'markElementInvalid');
-    model.set({
-      hasEnteredPassword: false,
-      isValid: false
-    }, { silent: true });
 
     view.updateStyles();
     assert.isFalse(view.markElementInvalid.called);
     assert.isTrue(view.markElementValid.calledOnceWith(view.$el));
 
-    model.set('hasEnteredPassword', true, { silent: true });
-    sinon.stub(view, '_getDescribedById').callsFake(() => 'password-too-short');
+    model.validationError = AuthErrors.toError('PASSWORD_TOO_SHORT');
     view.updateStyles();
     assert.isTrue(view.markElementInvalid.calledOnceWith(view.$el, 'password-too-short'));
 
-    model.set('isValid', true, { silent: true });
+    delete model.validationError;
     view.updateStyles();
     assert.isTrue(view.markElementValid.calledTwice);
     assert.equal(view.markElementValid.args[1][0], view.$el);
   });
 
-  it('passwordHelperBalloon updates cause updateStyles', (done) => {
-    sinon.stub(view, 'updateStyles').callsFake(() => done());
-    passwordHelperBalloon.trigger('rendered');
-  });
-
   describe('_getDescribedById', () => {
-    beforeEach(() => {
-      model.set({
-        isCommon: false,
-        isSameAsEmail: false,
-        isTooShort: false,
-      });
+    it('returns `password-too-short` if no password', () => {
+      assert.equal(
+        view._getDescribedById(AuthErrors.toError('PASSWORD_REQUIRED')), 'password-too-short');
     });
 
     it('returns `password-too-short` if password is too short', () => {
-      model.set('isTooShort', true);
-      assert.equal(view._getDescribedById(), 'password-too-short');
+      assert.equal(
+        view._getDescribedById(AuthErrors.toError('PASSWORD_TOO_SHORT')), 'password-too-short');
     });
 
     it('returns `password-same-as-email` if same as email', () => {
-      model.set('isSameAsEmail', true);
-      assert.equal(view._getDescribedById(), 'password-same-as-email');
+      assert.equal(
+        view._getDescribedById(AuthErrors.toError('PASSWORD_SAME_AS_EMAIL')), 'password-same-as-email');
     });
 
     it('returns `password-too-common` when too common', () => {
-      model.set('isCommon', true);
-      assert.equal(view._getDescribedById(), 'password-too-common');
+      assert.equal(
+        view._getDescribedById(AuthErrors.toError('PASSWORD_TOO_COMMON')), 'password-too-common');
+    });
+  });
+
+  describe('validate', () => {
+    beforeEach(() => {
+      sinon.stub(view, 'updateModel');
+    });
+
+    it('updates the model, does not throw if valid', () => {
+      sinon.stub(model, 'isValid').callsFake(() => true);
+      view.validate();
+
+      assert.isTrue(view.updateModel.calledOnce);
+    });
+
+    it('updates the model, throws if invalid', () => {
+      sinon.stub(model, 'isValid').callsFake(() => false);
+
+      const err = AuthErrors.toError('PASSWORD_SAME_AS_EMAIL');
+      model.validationError = err;
+
+      assert.throws(() => {
+        view.validate();
+      }, err);
+
+      assert.isTrue(view.updateModel.calledOnce);
+      assert.equal(err.describedById, 'password-same-as-email');
     });
   });
 });

--- a/app/tests/spec/views/settings/change_password.js
+++ b/app/tests/spec/views/settings/change_password.js
@@ -78,10 +78,11 @@ describe('views/settings/change_password', function () {
 
     describe('render', function () {
       it('renders properly', function () {
-        assert.ok($('#old_password').length);
-        assert.ok($('.reset-password').length);
-        assert.ok($('#new_password').length);
-        assert.isTrue($('.input-help').length === 2);
+        assert.lengthOf($('#old_password'), 1);
+        assert.lengthOf($('.reset-password'), 1);
+        assert.lengthOf($('#new_password'), 1);
+        assert.lengthOf($('#new_vpassword'), 1);
+        assert.lengthOf($('.input-help'), 1);
         assert.isTrue($('.input-help-forgot-pw').length === 1);
         assert.equal(view.$('input[type=email]').val(), EMAIL);
       });

--- a/app/tests/spec/views/sign_up_password.js
+++ b/app/tests/spec/views/sign_up_password.js
@@ -54,6 +54,10 @@ define(function (require, exports, module) {
         window: windowMock
       });
 
+      // Stub in he password strength balloon to avoid unexpected validation
+      // errors during tests.
+      sinon.stub(view, '_createPasswordWithStrengthBalloonView').callsFake(() => ({ on: sinon.spy() }));
+
       return view.render();
     });
 
@@ -105,8 +109,6 @@ define(function (require, exports, module) {
 
     describe('validateAndSubmit', () => {
       beforeEach(() => {
-        sinon.stub(view, 'isValidStart').callsFake(() => true);
-        sinon.stub(view, 'showValidationErrorsStart').callsFake(() => false);
         sinon.stub(view, 'signUp').callsFake(() => Promise.resolve());
         sinon.stub(view, 'tooYoung');
         sinon.spy(view, 'displayError');
@@ -130,8 +132,8 @@ define(function (require, exports, module) {
 
       describe('user is too young', () => {
         it('delegates to `tooYoung`', () => {
-          view.$('#password').val('password');
-          view.$('#vpassword').val('password');
+          view.$('#password').val('password123123');
+          view.$('#vpassword').val('password123123');
           view.$('#age').val('11');
 
           return Promise.resolve(view.validateAndSubmit())
@@ -145,16 +147,15 @@ define(function (require, exports, module) {
 
       describe('user is old enough', () => {
         it('signs up the user', () => {
-          view.$('#password').val('password');
-          view.$('#vpassword').val('password');
+          view.$('#password').val('password123123');
+          view.$('#vpassword').val('password123123');
           view.$('#age').val('21');
 
           sinon.stub(view, 'hasOptedInToMarketingEmail').callsFake(() => true);
 
           return Promise.resolve(view.validateAndSubmit())
             .then(() => {
-              assert.isTrue(view.signUp.calledOnce);
-              assert.isTrue(view.signUp.calledWith(account, 'password'));
+              assert.isTrue(view.signUp.calledOnceWith(account, 'password123123'));
               assert.isTrue(account.get('needsOptedInToMarketingEmail', true));
 
               assert.isFalse(view.displayError.called);

--- a/tests/functional/change_password.js
+++ b/tests/functional/change_password.js
@@ -101,7 +101,32 @@ registerSuite('change_password', {
         .then(noSuchElement(selectors.CHANGE_PASSWORD.TOOLTIP));
     },
 
-    'vpassword validation, tooltip shows': function () {
+    'new_password validation, balloon': function () {
+      return this.remote
+        .then(setupTest())
+
+        .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
+        // new_password empty
+        .then(fillOutChangePassword(FIRST_PASSWORD, '', { expectSuccess: false, vpassword: SECOND_PASSWORD }))
+        .then(testElementExists(selectors.CHANGE_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_FAIL))
+
+        // new_password too short
+        .then(fillOutChangePassword(FIRST_PASSWORD, 'pass', { expectSuccess: false, vpassword: SECOND_PASSWORD }))
+        .then(testElementExists(selectors.CHANGE_PASSWORD.PASSWORD_BALLOON.MIN_LENGTH_FAIL))
+
+        // new_password too close to the email address
+        .then(fillOutChangePassword(FIRST_PASSWORD, email, { expectSuccess: false, vpassword: SECOND_PASSWORD }))
+        .then(testElementExists(selectors.CHANGE_PASSWORD.PASSWORD_BALLOON.NOT_EMAIL_FAIL))
+
+        // new_password too common
+        .then(fillOutChangePassword(FIRST_PASSWORD, 'password', { expectSuccess: false, vpassword: SECOND_PASSWORD }))
+        .then(testElementExists(selectors.CHANGE_PASSWORD.PASSWORD_BALLOON.NOT_COMMON_FAIL))
+
+        // all good
+        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
+    },
+
+    'new_vpassword validation, tooltip shows': function () {
       return this.remote
         .then(setupTest())
 

--- a/tests/functional/lib/helpers.js
+++ b/tests/functional/lib/helpers.js
@@ -1518,10 +1518,10 @@ const fillOutChangePassword = thenify(function (oldPassword, newPassword, option
   return this.parent
     .setFindTimeout(intern._config.pageLoadTimeout)
 
-    .then(type('#old_password', oldPassword))
-    .then(type('#new_password', newPassword))
-    .then(type('#new_vpassword', 'vpassword' in options ? options.vpassword : newPassword))
-    .then(click('#change-password button[type="submit"]'))
+    .then(type(selectors.CHANGE_PASSWORD.OLD_PASSWORD, oldPassword))
+    .then(type(selectors.CHANGE_PASSWORD.NEW_PASSWORD, newPassword))
+    .then(type(selectors.CHANGE_PASSWORD.NEW_VPASSWORD, 'vpassword' in options ? options.vpassword : newPassword))
+    .then(click(selectors.CHANGE_PASSWORD.SUBMIT))
     .then(function () {
       if (options.expectSuccess !== false) {
         return this.parent

--- a/tests/functional/lib/selectors.js
+++ b/tests/functional/lib/selectors.js
@@ -33,8 +33,12 @@ module.exports = {
     ERROR: '#change-password .error',
     LINK_RESET_PASSWORD: '.reset-password',
     MENU_BUTTON: '#change-password .settings-unit-toggle',
+    NEW_PASSWORD: '#new_password',
+    NEW_VPASSWORD: '#new_vpassword',
     OLD_PASSWORD: '#old_password',
     OLD_PASSWORD_SHOW: '[for=show-old_password]',
+    PASSWORD_BALLOON,
+    SUBMIT: '#change-password button[type="submit"]',
     TOOLTIP: '.tooltip',
   },
   CHOOSE_WHAT_TO_SYNC: {


### PR DESCRIPTION
This was a real pain.

The difficulty started with assuming that the password input
element would be the first input element in the form. This
doesn't hold for change password where the old password comes
first. A way was needed to trigger element validation
in the correct order. This is done by storing a validator
function on the element that overrides the default
processing for that element, and is called in the
correct order..

Using the `validate` method this way the password-strength-mixin
a ton easier because `isValidStart` and `showValidationErrorsStart`
no longer need to be overridden.

Next, the password_strength_balloon model was way too complex
because the model's validate function was not being used in
the way Backbone instends. We now are, and we no longer need
the two methods 'updateForPassword' and 'validate', just the
2nd is needed. When model.isValid is called, and when the
model's password is updated, `model.validate()` is called,
and if the element is invalid, an `invalid` event is triggered
on the model.

fixes #6573 

