### PR TITLE
fix(metrics): ensure deviceId falls back to `none` if not set

### DIFF
--- a/app/scripts/lib/metrics.js
+++ b/app/scripts/lib/metrics.js
@@ -350,7 +350,7 @@ define(function (require, exports, module) {
       const allData = _.extend({}, loadData, unloadData, {
         broker: this._brokerType,
         context: this._context,
-        deviceId: flowData.deviceId,
+        deviceId: flowData.deviceId || NOT_REPORTED_VALUE,
         emailDomain: this._emailDomain,
         entrypoint: this._entrypoint,
         experiments: flattenHashIntoArrayOfObjects(this._activeExperiments),

--- a/app/tests/spec/lib/metrics.js
+++ b/app/tests/spec/lib/metrics.js
@@ -98,6 +98,10 @@ define(function (require, exports, module) {
       });
     });
 
+    it('deviceId defaults to NOT_REPORTED_VALUE', () => {
+      assert.equal(metrics.getAllData().deviceId, 'none');
+    });
+
     describe('trigger flow.initialize event', () => {
       beforeEach(() => {
         notifier.trigger('flow.initialize');


### PR DESCRIPTION
Fixes #6867.

I didn't actually manage to reproduce the failing `POST /metrics` request locally, but I'm going to go out on a limb and offer this as a fix to it anyway. As @shane-tomlinson points out in the issue description, when I did #6733 I also clobbered the old `NOT_REPORTED_VALUE` fallback on `deviceId`. This reinstates it in case it wasn't set in the flow model for some reason.

Opened against `train-128` for a point release because it seems pretty low risk and metrics are borked.

@mozilla/fxa-devs r?