### PR TITLE
fix(l10n): Ensure tooltips are translated in local dev

### DIFF
--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -375,7 +375,8 @@ var FormView = BaseView.extend({
     var tooltip = new Tooltip({
       id: tooltipId,
       invalidEl: $invalidEl,
-      message
+      message,
+      translator: this.translator
     });
 
     tooltip.on('destroyed', () => {

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -336,11 +336,15 @@ describe('views/form', function () {
   });
 
   describe('showValidationError', function () {
-    it('creates a tooltip', function () {
-      view.on('validation_error', function (done) {
-        assert.ok(view.$('.tooltip').length);
-        done();
+    it('creates a tooltip, translates the text', function (done) {
+      view.on('validation_error', () => {
+        TestHelpers.wrapAssertion(() => {
+          assert.lengthOf(view.$('.tooltip'), 1);
+          assert.equal(view.$('.tooltip').text(), 'translated this is an error');
+        }, done);
       });
+
+      sinon.stub(view.translator, 'get').callsFake(msg => `translated ${msg}`);
       view.showValidationError('#focusMe', 'this is an error');
     });
 


### PR DESCRIPTION
The translator instance was not passed to the Tooltip. This
affects dev because only the instance created in app-start
fetches translations. The problem does not affect prod
because translations are built into the Translator object.

fixes #6871

@mozilla/fxa-devs - r?

<img width="736" alt="screenshot 2019-01-11 at 20 52 12" src="https://user-images.githubusercontent.com/848085/51059305-a1ee0180-15e3-11e9-96b8-def5768326a2.png">
