### PR TITLE
feat(server templates): make aboutMozillaUrl configurable

### DIFF
--- a/grunttasks/l10n-generate-pages.js
+++ b/grunttasks/l10n-generate-pages.js
@@ -24,6 +24,7 @@ module.exports = function (grunt) {
   var templateDest;
 
   var PROPAGATED_ESCAPED_TEMPLATE_FIELDS = [
+    'aboutMozillaUrl',
     'config',
     'flowId',
     'flowBeginTime',

--- a/server/lib/404.js
+++ b/server/lib/404.js
@@ -4,11 +4,15 @@
 
 // It's a 404 not found response.
 
+const config = require('./configuration');
+
+const ABOUT_MOZILLA_URL = config.get('about_mozilla_url');
+
 module.exports = function (req, res, next) {
   res.status(404);
 
   if (req.accepts('html')) {
-    return res.render('404');
+    return res.render('404', { aboutMozillaUrl: ABOUT_MOZILLA_URL });
   }
 
   if (req.accepts('json')) {

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -13,6 +13,12 @@ const versionInfo = require('./version');
 const DEFAULT_SUPPORTED_LANGUAGES = require('fxa-shared').l10n.supportedLanguages;
 
 const conf = module.exports = convict({
+  about_mozilla_url: {
+    default: 'https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral',
+    doc: 'Url for the top right mozilla logo',
+    env: 'ABOUT_MOZILLA_URL',
+    format: String
+  },
   allowed_iframe_contexts: {
     default: ['fx_firstrun_v2', 'iframe'],
     doc: 'context query parameters allowed to embed FxA within an IFRAME',

--- a/server/lib/routes/get-500.js
+++ b/server/lib/routes/get-500.js
@@ -4,13 +4,17 @@
 
 'use strict';
 module.exports = function (config) {
+  const ABOUT_MOZILLA_URL = config.get('about_mozilla_url');
   const STATIC_RESOURCE_URL = config.get('static_resource_url');
 
   return {
     method: 'get',
     path: '/500.html',
     process: (req, res, next) => {
-      res.render('500', { staticResourceUrl: STATIC_RESOURCE_URL });
+      res.render('500', {
+        aboutMozillaUrl: ABOUT_MOZILLA_URL,
+        staticResourceUrl: STATIC_RESOURCE_URL
+      });
     }
   };
 };

--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -8,6 +8,7 @@ const flowMetrics = require('../flow-metrics');
 const logger = require('../logging/log')('routes.index');
 
 module.exports = function (config) {
+  const ABOUT_MOZILLA_URL = config.get('about_mozilla_url');
   const AUTH_SERVER_URL = config.get('fxaccount_url');
   const CLIENT_ID = config.get('oauth_client_id');
   const COPPA_ENABLED = config.get('coppa.enabled');
@@ -48,6 +49,7 @@ module.exports = function (config) {
     const flowEventData = flowMetrics.create(FLOW_ID_KEY, req.headers['user-agent']);
 
     res.render('index', {
+      aboutMozillaUrl: ABOUT_MOZILLA_URL,
       // Note that bundlePath is added to templates as a build step
       bundlePath: '/bundle',
       config: serializedConfig,

--- a/server/lib/routes/get-terms-privacy.js
+++ b/server/lib/routes/get-terms-privacy.js
@@ -27,6 +27,7 @@ const PAGE_TEMPLATE_DIRECTORY = path.join(config.get('page_template_root'), 'dis
 const templates = require('../legal-templates');
 
 module.exports = function verRoute (i18n) {
+  const ABOUT_MOZILLA_URL = config.get('about_mozilla_url');
   const DEFAULT_LANG = config.get('i18n.defaultLang');
   const DEFAULT_LEGAL_LANG = config.get('i18n.defaultLegalLang');
   const STATIC_RESOURCE_URL = config.get('static_resource_url');
@@ -66,6 +67,7 @@ module.exports = function verRoute (i18n) {
         res.format({
           'text/html': function () {
             const context = {
+              aboutMozillaUrl: ABOUT_MOZILLA_URL,
               // Note that staticResourceUrl is added to templates as a
               // build step
               staticResourceUrl: STATIC_RESOURCE_URL

--- a/server/templates/pages/src/404.html
+++ b/server/templates/pages/src/404.html
@@ -31,6 +31,6 @@
             </div>
         </div>
 
-        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
+        <a id="about-mozilla" rel="author" target="_blank" href="{{ aboutMozillaUrl }}"></a>
     </body>
 </html>

--- a/server/templates/pages/src/500.html
+++ b/server/templates/pages/src/500.html
@@ -31,6 +31,6 @@
           </div>
         </div>
 
-        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
+        <a id="about-mozilla" rel="author" target="_blank" href="{{ aboutMozillaUrl }}"></a>
     </body>
 </html>

--- a/server/templates/pages/src/index.html
+++ b/server/templates/pages/src/index.html
@@ -29,7 +29,7 @@
           </div>
         </div>
 
-        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
+        <a id="about-mozilla" rel="author" target="_blank" href="{{ aboutMozillaUrl }}"></a>
 
         <noscript>
           {{#t}}Firefox Accounts requires JavaScript.{{/t}}

--- a/server/templates/pages/src/privacy.html
+++ b/server/templates/pages/src/privacy.html
@@ -27,6 +27,6 @@
             </section>
           </div>
         </div>
-        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
+        <a id="about-mozilla" rel="author" target="_blank" href="{{ aboutMozillaUrl }}"></a>
     </body>
 </html>

--- a/server/templates/pages/src/terms.html
+++ b/server/templates/pages/src/terms.html
@@ -27,6 +27,6 @@
             </section>
           </div>
         </div>
-        <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
+        <a id="about-mozilla" rel="author" target="_blank" href="{{ aboutMozillaUrl }}"></a>
     </body>
 </html>

--- a/tests/server/routes/get-index.js
+++ b/tests/server/routes/get-index.js
@@ -50,9 +50,10 @@ registerSuite('routes/get-index', {
 
               var renderParams = args[1];
               assert.isObject(renderParams);
-              assert.lengthOf(Object.keys(renderParams), 5);
+              assert.lengthOf(Object.keys(renderParams), 6);
               assert.ok(/[0-9a-f]{64}/.exec(renderParams.flowId));
               assert.isAbove(renderParams.flowBeginTime, 0);
+              assert.equal(renderParams.aboutMozillaUrl, config.get('about_mozilla_url'));
               assert.equal(renderParams.bundlePath, '/bundle');
               assert.equal(renderParams.staticResourceUrl, config.get('static_resource_url'));
 


### PR DESCRIPTION
My first attempt to upstream the changes I did for https://accounts.firefox.com.cn/

I'm starting with a simple one, but there's still one problem: this change doesn't work for {502,503}.html which should not be a big deal in reality, but it really feels wrong to just leave them out. Any suggestions?

Thanks.