### PR TITLE
feat(settings): put communication prefs behind a feature flag

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -463,6 +463,7 @@ Start.prototype = {
       interTabChannel: this._interTabChannel,
       isCoppaEnabled: this._config.isCoppaEnabled,
       lang: this._config.lang,
+      marketingEmailEnabled: this._config.marketingEmailEnabled,
       metrics: this._metrics,
       notifier: this._notifier,
       relier: this._relier,

--- a/app/scripts/views/mixins/email-opt-in-mixin.js
+++ b/app/scripts/views/mixins/email-opt-in-mixin.js
@@ -15,6 +15,7 @@ define(function (require, exports, module) {
   module.exports = {
     initialize (options = {}) {
       this._experimentGroupingRules = options.experimentGroupingRules;
+      this._marketingEmailEnabled = options.marketingEmailEnabled !== false;
     },
 
     setInitialContext (context) {
@@ -26,6 +27,10 @@ define(function (require, exports, module) {
     },
 
     _isEmailOptInEnabled () {
+      if (! this._marketingEmailEnabled) {
+        return false;
+      }
+
       return !! this._experimentGroupingRules.choose('communicationPrefsVisible', {
         lang: this.navigator.language
       });

--- a/app/scripts/views/settings.js
+++ b/app/scripts/views/settings.js
@@ -71,6 +71,7 @@ define(function (require, exports, module) {
       this._childView = options.childView;
       this._createView = options.createView;
       this._experimentGroupingRules = options.experimentGroupingRules;
+      this._marketingEmailEnabled = options.marketingEmailEnabled !== false;
 
       const uid = this.relier.get('uid');
       this.notifier.trigger('set-uid', uid);
@@ -232,6 +233,10 @@ define(function (require, exports, module) {
      * @private
      */
     _areCommunicationPrefsVisible () {
+      if (! this._marketingEmailEnabled) {
+        return false;
+      }
+
       if (! this._experimentGroupingRules.choose('communicationPrefsVisible', {
         lang: this.navigator.language
       })) {

--- a/app/tests/spec/views/mixins/email-opt-in-mixin.js
+++ b/app/tests/spec/views/mixins/email-opt-in-mixin.js
@@ -24,15 +24,18 @@ define(function (require, exports, module) {
 
   describe('views/mixins/email-opt-in-mixin', function () {
     let experimentGroupingRules;
+    let marketingEmailEnabled;
     let view;
 
     beforeEach(() => {
       experimentGroupingRules = {
         choose: () => {}
       };
+      marketingEmailEnabled = true;
 
       view = new View({
-        experimentGroupingRules
+        experimentGroupingRules,
+        marketingEmailEnabled
       });
     });
 

--- a/app/tests/spec/views/settings.js
+++ b/app/tests/spec/views/settings.js
@@ -43,6 +43,7 @@ define(function (require, exports, module) {
     var experimentGroupingRules;
     var formPrefill;
     var initialChildView;
+    var marketingEmailEnabled;
     var metrics;
     var notifier;
     var profileClient;
@@ -65,6 +66,7 @@ define(function (require, exports, module) {
         createView,
         experimentGroupingRules,
         formPrefill,
+        marketingEmailEnabled,
         metrics,
         notifier,
         relier,
@@ -85,6 +87,7 @@ define(function (require, exports, module) {
       experimentGroupingRules = new ExperimentGroupingRules();
       formPrefill = new FormPrefill();
       notifier = new Notifier();
+      marketingEmailEnabled = true;
       metrics = new Metrics({ notifier });
       profileClient = new ProfileClient();
       relier = new Relier();

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -279,6 +279,12 @@ const conf = module.exports = convict({
       env: 'FXA_MARKETING_EMAIL_API_URL',
       format: 'url'
     },
+    enabled: {
+      default: true,
+      doc: 'Feature flag for communication preferences in settings',
+      env: 'FXA_MARKETING_EMAIL_ENABLED',
+      format: Boolean
+    },
     preferences_url: {
       default: 'https://www-dev.allizom.org/newsletter/existing/',
       doc: 'User facing URL where a user can manage their email preferences',

--- a/server/lib/routes/get-index.js
+++ b/server/lib/routes/get-index.js
@@ -14,6 +14,7 @@ module.exports = function (config) {
   const ENV = config.get('env');
   const FLOW_ID_KEY = config.get('flow_id_key');
   const MARKETING_EMAIL_API_URL = config.get('marketing_email.api_url');
+  const MARKETING_EMAIL_ENABLED = config.get('marketing_email.enabled');
   const MARKETING_EMAIL_PREFERENCES_URL = config.get('marketing_email.preferences_url');
   const OAUTH_SERVER_URL = config.get('oauth_url');
   const PROFILE_SERVER_URL = config.get('profile_url');
@@ -28,6 +29,7 @@ module.exports = function (config) {
     authServerUrl: AUTH_SERVER_URL,
     env: ENV,
     isCoppaEnabled: COPPA_ENABLED,
+    marketingEmailEnabled: MARKETING_EMAIL_ENABLED,
     marketingEmailPreferencesUrl: MARKETING_EMAIL_PREFERENCES_URL,
     marketingEmailServerUrl: MARKETING_EMAIL_API_URL,
     oAuthClientId: CLIENT_ID,


### PR DESCRIPTION
Beijing office distributes our own newsletter w/o using basket, so we disabled this section of the settings page.

I guess it's possible to expose a basket like api on our newsletter server, but that would surely take more efforts.

Alternatively, maybe it's better to make the available languages configuable and disable it there?