### PR TITLE
fix(pw-strength): Use 15px font size in pw-strength meter for Arabic.

### DIFF
--- a/app/styles/modules/_password-row.scss
+++ b/app/styles/modules/_password-row.scss
@@ -183,6 +183,12 @@
     padding: 28px 14px;
     z-index: 5;
 
+    // The characters in Arabic look way too small at 14px and are difficult to read. Bump them up by 1
+    // See #6556
+    html[lang^='ar'] & {
+      font-size: 15px;
+    }
+
     @include respond-to('balloonSmall') {
       left: -3px;
       margin-top: 0;


### PR DESCRIPTION
Reports from users are that the password strength meter is difficult
to read in Arabic, which may be one reason why the conversion rate is so
low in that language. This uses a 15px font size in the pw-strength meter
to try to make it a bit easier to read.

fixes #6556

@mozilla/fxa-devs - r?

### 15px (new)

<img width="320" alt="screenshot 2019-01-22 at 15 09 09" src="https://user-images.githubusercontent.com/848085/51544609-39f7b080-1e58-11e9-84d9-e00daf4d45c6.png">

### 14px

<img width="331" alt="screenshot 2019-01-22 at 15 09 30" src="https://user-images.githubusercontent.com/848085/51544611-39f7b080-1e58-11e9-856b-dfe9fa077081.png">
