### PR TITLE
chore(token-codes): Enroll Reference Browser in the token codes experiment

### DIFF
--- a/app/scripts/lib/experiments/grouping-rules/token-code.js
+++ b/app/scripts/lib/experiments/grouping-rules/token-code.js
@@ -15,6 +15,12 @@ const ROLLOUT_CLIENTS = {
     name: 'Lockbox Extension',
     rolloutRate: 0.0
   },
+  '3c49430b43dfba77': {
+    enableTestEmails: false,
+    groups: GROUPS_DEFAULT,
+    name: 'Android Components Reference Browser',
+    rolloutRate: 1.0
+  },
   '98adfa37698f255b': {
     enableTestEmails: true,
     groups: ['treatment-code'],


### PR DESCRIPTION
IIUC we intend for new mobile apps to use the "token code" flow for signin confirmation (and eventually for signup verification).  Since the current link-based flow can lead to a confusing experience on reference-browser [1] can we please try switching to the token-code flow for that relier.

I've copied the existing config for lockbox, but I think I need to setup rolloutRate to `1.0` for it to work, right?

[1] Ref https://github.com/mozilla-mobile/reference-browser/issues/424