### PR TITLE
chore(server): build extra templates for Mozilla China

### DIFF
--- a/grunttasks/build.js
+++ b/grunttasks/build.js
@@ -70,6 +70,9 @@ module.exports = function (grunt) {
     // Remove whitespace from the HTML
     'htmlmin',
 
+    // make a copy with necessary tweaks for Mozilla Online's deployment
+    'copy:mozillaonline',
+
     // use error pages from en as the static error pages. Comes last
     // to ensure static resources are loaded using cache busting URLs
     'copy:error_pages'

--- a/grunttasks/copy.js
+++ b/grunttasks/copy.js
@@ -31,7 +31,30 @@ module.exports = function (grunt) {
         expand: true,
         flatten: true,
         src: 'en/{500,502,503}.html'
+      }, {
+        cwd: '<%= yeoman.page_template_dist %>',
+        dest: '<%= yeoman.dist %>',
+        dot: true,
+        expand: true,
+        flatten: true,
+        rename: (dest, src) => `${dest}/${src.replace('.html', '.mozillaonline.html')}`,
+        src: 'zh_CN_x_mococn/{500,502,503}.html'
       }]
+    },
+    mozillaonline: {
+      files: [{
+        cwd: '<%= yeoman.page_template_dist %>',
+        dest: '<%= yeoman.page_template_dist %>',
+        expand: true,
+        rename: (dest, src) => `${dest}/${src.replace('/', '_x_mococn/')}`,
+        src: ['{en,zh_CN}/*']
+      }],
+      options: {
+        process: content => {
+          return content.replace('https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral',
+            'https://www.firefox.com.cn/?utm_source=firefox-accounts&amp;utm_medium=Referral');
+        }
+      }
     },
     strings: {
       files: [

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -230,6 +230,15 @@ const conf = module.exports = convict({
         format: Array
       }
     },
+    localeSubdirSuffix: {
+      default: '',
+      doc: 'Enable alternative localized resources for Mozilla Online with private use subtag',
+      env: 'I18N_LOCALE_SUBDIR_SUFFIX',
+      format: [
+        '',
+        '_x_mococn'
+      ]
+    },
     supportedLanguages: {
       default: DEFAULT_SUPPORTED_LANGUAGES,
       doc: 'List of languages this deployment should detect and display localized strings.',

--- a/server/lib/localized-render.js
+++ b/server/lib/localized-render.js
@@ -16,13 +16,14 @@
 'use strict';
 const path = require('path');
 const config = require('./configuration');
+const localeSubdirSuffix = config.get('i18n.localeSubdirSuffix');
 const useLocalizedTemplates = config.get('are_dist_resources');
 
 module.exports = function (config) {
   const i18n = config.i18n;
 
   function getLocalizedTemplatePath(req, templateName) {
-    return path.join(i18n.normalizeLocale(req.locale), templateName);
+    return path.join(i18n.normalizeLocale(req.locale) + localeSubdirSuffix, templateName);
   }
 
   return function (req, res, next) {


### PR DESCRIPTION
This is based on @shane-tomlinson's comment in #6881. but I'm sending it as a separate PR, since this is a completely different approach.

It is no longer a flexible configuration, but more like a hard-coded special handling for https://accounts.firefox.com.cn/ . I'd like to eventually be able to just use your published docker image for deployment w/o running `grunt build` on our own, and that's why I'm building these templates alongside the original ones, instead of replacing them.

What do you think? Is this a good idea or not? Thanks.