### PR TITLE
fix(forms): attach events for base view and child views

### DIFF
--- a/app/scripts/views/form.js
+++ b/app/scripts/views/form.js
@@ -56,8 +56,7 @@ var FormView = BaseView.extend({
   constructor: function (options) {
     BaseView.call(this, options);
 
-    // attach events of the descendent view and this view.
-    this.delegateEvents(_.extend({}, FormView.prototype.events, this.events));
+    this._attachEvents();
   },
 
   events: {
@@ -87,6 +86,7 @@ var FormView = BaseView.extend({
   },
 
   afterRender () {
+    this._attachEvents();
     // Firefox has a strange issue where if the previous
     // screen was submit using the keyboard, the `enter` key's
     // `keyup` event fires here on the element that receives
@@ -236,6 +236,15 @@ var FormView = BaseView.extend({
         throw err;
       });
   })),
+
+  /**
+   * Attaches events of the descendent view and the newly created view.
+   * It's called on view creation and afterRender for nested views to handle both sources of events.
+   * @private
+   */
+  _attachEvents () {
+    this.delegateEvents(_.extend({}, FormView.prototype.events, this.events));
+  },
 
   /**
      * Checks whether the form is valid. Checks the validitity of each

--- a/app/tests/spec/views/form.js
+++ b/app/tests/spec/views/form.js
@@ -108,6 +108,7 @@ describe('views/form', function () {
       notifier
     });
 
+    sinon.spy(view, '_attachEvents');
     return view.render();
   });
 
@@ -125,7 +126,7 @@ describe('views/form', function () {
         templateWrittenError: 'template written error',
         templateWrittenSuccess: 'template written success'
       });
-
+      assert.isTrue(view._attachEvents.calledOnce, 'events attached for base view');
       return view.render();
     });
 
@@ -134,6 +135,7 @@ describe('views/form', function () {
       assert.isTrue(view.isErrorVisible());
       assert.lengthOf(view.$('.success.visible'), 1);
       assert.isTrue(view.isSuccessVisible());
+      assert.isTrue(view._attachEvents.calledTwice, 'events attached for child views');
     });
   });
 


### PR DESCRIPTION
Extracted from https://github.com/mozilla/fxa-content-server/pull/6876/files#diff-1115514375ece0df300f7c60b8f56426L56

This covers both cases when form renders first (example: secondary email settings) and the new pairing views