### PR TITLE
fix(metrics): Fix entrypoint being overwritten for every event.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.128.1",
+  "version": "1.129.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6017,9 +6017,9 @@
       }
     },
     "fxa-shared": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.15.tgz",
-      "integrity": "sha512-9J7ASrgrxZc/xjhqwk6bp/EmqKMVP0igfzHrJ5en/G3xbAqbzm1EzI+5PKz3s5FkiLorb8+p/fpogxcFv/hfLQ==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.16.tgz",
+      "integrity": "sha512-scL68kVRYA5ftx14g0Z+vpvhdbuwRhKvPpqTecqAONCYgvrE0o1VweMJyknrUhGwkvdI3PEnz2WEkUjVpWq25g==",
       "requires": {
         "accept-language": "2.0.17",
         "moment": "2.20.1"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "fxa-geodb": "1.0.4",
     "fxa-js-client": "1.0.7",
     "fxa-mustache-loader": "0.0.2",
-    "fxa-shared": "1.0.15",
+    "fxa-shared": "1.0.16",
     "got": "6.7.1",
     "grunt": "1.0.3",
     "grunt-babel": "6.0.0",


### PR DESCRIPTION
Updates fxa-shared so that it no longer uses the client_id as the entrypoint

issue mozilla/fxa-shared#46

@mozilla/fxa-devs - r?