### PR TITLE
fix(test): Fix the Sync v1 tests.

### DIFF
--- a/tests/functional/sync_v1.js
+++ b/tests/functional/sync_v1.js
@@ -27,6 +27,16 @@ registerSuite('Firefox Desktop Sync v1', {
     return this.remote
       .then(clearBrowserState({ force: true }));
   },
+
+  afterEach: function () {
+    return this.remote
+      .execute(() => {
+        // Opening about:blank aborts the Firefox download
+        // and prevents the tests from stalling when run on CentOS
+        window.location.href = 'about:blank';
+      });
+  },
+
   tests: {
     'force_auth': function () {
       return this.remote

--- a/tests/tools/firefox_profile_creator.js
+++ b/tests/tools/firefox_profile_creator.js
@@ -63,6 +63,12 @@ if (profile) {
   myProfile.setPreference('experiments.manifest.uri', '');
   myProfile.setPreference('network.allow-experiments', false);
 
+  // x-iso9600-image for OSX .dmg
+  // application/x-tar for Linux .tgz files
+  // application/octet-stream for Windows .exe files
+  // This prevents the "Save file" dialog for the "Update Firefox" screen.
+  myProfile.setPreference('browser.helperApps.neverAsk.saveToDisk', 'application/x-iso9660-image,application/x-tar,application/octet-stream');
+
 
   myProfile.updatePreferences();
 


### PR DESCRIPTION
Tests stall due to the "Save File" dialog displayed by the browser.

This forces the browser to save w/o asking for permission.

fixes #6946 
