### PR TITLE
fix(deps): Fix security advisories

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -3,10 +3,12 @@
   "comment_577": "577 is prototype pollution in lodash, used by convict, grunt-usemin, grunt-z-schema.",
   "comment_745": "745 is RegExp denial by grunt-remarkable.",
   "comment_782": "782 is prototype pollution in lodash, used by convict, grunt-usemin, grunt-z-schema.",
+  "comment_786": "786 is RegExp denial of service caused by braces in babel-cli, dev-dep",
   "exceptions": [
     "https://npmjs.com/advisories/532",
     "https://npmjs.com/advisories/577",
     "https://npmjs.com/advisories/745",
-    "https://npmjs.com/advisories/782"
+    "https://npmjs.com/advisories/782",
+    "https://npmjs.com/advisories/786"
    ]
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2619,18 +2619,11 @@
       }
     },
     "clean-css": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.0.13.tgz",
-      "integrity": "sha1-/rKhdgYtcqbD5iTZITysagxIXoA=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
       "requires": {
-        "source-map": "0.5.x"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
+        "source-map": "~0.6.0"
       }
     },
     "cli-cursor": {
@@ -6811,37 +6804,13 @@
       }
     },
     "grunt-contrib-cssmin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-2.1.0.tgz",
-      "integrity": "sha1-FqSZU8sVPDT/+XfAYohq68MLCkE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-3.0.0.tgz",
+      "integrity": "sha512-eXpooYmVGKMs/xV7DzTLgJFPVOfMuawPD3x0JwhlH0mumq2NtH3xsxaHxp1Y3NKxp0j0tRhFS6kSBRsz6TuTGg==",
       "requires": {
-        "chalk": "^1.0.0",
-        "clean-css": "~4.0.12",
+        "chalk": "^2.4.1",
+        "clean-css": "~4.2.1",
         "maxmin": "^2.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "grunt-contrib-htmlmin": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "grunt-contrib-clean": "1.1.0",
     "grunt-contrib-concat": "1.0.1",
     "grunt-contrib-copy": "1.0.0",
-    "grunt-contrib-cssmin": "2.1.0",
+    "grunt-contrib-cssmin": "3.0.0",
     "grunt-contrib-htmlmin": "2.4.0",
     "grunt-file-rev": "1.0.2",
     "grunt-githash": "0.1.3",


### PR DESCRIPTION
* Update grunt-contrib-cssmin to @3.0.0
* Ignore advisory 786, it's a RegExp DOS caused by babel-cli, a dev-dep

@mozilla/fxa-devs - r?