### PR TITLE
chore(clients): Add Fenix to list of clients that can request oldsync scope

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -414,7 +414,8 @@ const conf = module.exports = convict({
           redirectUris: [
             'https://lockbox.firefox.com/fxa/ios-redirect.html',
             'https://lockbox.firefox.com/fxa/android-redirect.html',
-            'https://accounts.firefox.com/oauth/success/3c49430b43dfba77'
+            'https://accounts.firefox.com/oauth/success/a2270f727f45f648', // Fenix
+            'https://accounts.firefox.com/oauth/success/3c49430b43dfba77'  // Reference browser
           ]
         },
         'https://identity.mozilla.com/apps/send': {


### PR DESCRIPTION
bz1528355

@rfk or @vladikoff - r?

Ref https://github.com/mozilla/fxa-auth-server/pull/2924