### PR TITLE
fix(metrics): update amplitude events to mozlog 2 format

### DIFF
--- a/server/lib/amplitude.js
+++ b/server/lib/amplitude.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const { GROUPS, initialize } = require('fxa-shared/metrics/amplitude');
+const logger = require('./logging/log')();
 const ua = require('./user-agent');
 
 const SERVICES = require('./configuration').get('oauth_client_id_map');
@@ -151,7 +152,7 @@ function receiveEvent (event, request, data) {
   );
 
   if (amplitudeEvent) {
-    process.stderr.write(`${JSON.stringify(amplitudeEvent)}\n`);
+    logger.info('amplitudeEvent', amplitudeEvent);
   }
 }
 


### PR DESCRIPTION
Requested by @jbuck, but I want to make sure that the new output is what he expects before anyone reviews this (I'm not sure what the differences are meant to be).

Before:

```
{"op":"amplitudeEvent","event_type":"fxa_reg - view","time":1548419581016,"device_id":"486260c82c9c46fbba78d7e9bf8162e5","session_id":1548419580557,"app_version":"128","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{},"user_properties":{"flow_id":"1287d6b18c80787eff8410228a111b0e790dc42ef69e6dbeb64436073c4d4cbc","ua_browser":"Firefox","ua_version":"66.0"}}
```

After:

```
fxa-content-server.INFO: amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - view","time":1551118589789,"device_id":"90b8597bad8e4596a0c7523880e815b7","session_id":1551118589306,"app_version":"131","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{},"user_properties":{"flow_id":"6be88f09329fae7d20a9b3a2488c35274d85f79045d96f5a72820fa81660b353","ua_browser":"Firefox","ua_version":"67.0"}}
```

@jbuck is that what you were hoping to see?