### PR TITLE
style(avatar): added space between image and text

### DIFF
--- a/app/styles/modules/_avatar.scss
+++ b/app/styles/modules/_avatar.scss
@@ -191,6 +191,7 @@
 .notice {
   color: $faint-text-color;
   font-size: $base-font;
+  padding-top: 10px;
 }
 
 .main-avatar {


### PR DESCRIPTION
fixes #6979 
@shane-tomlinson @davismtl Please Review!!

It now looks like:
![screenshot from 2019-02-26 12-08-38](https://user-images.githubusercontent.com/32164618/53428088-25d34000-3a10-11e9-881e-ba9b07f051f2.png)
