### PR TITLE
style(avatar): centered avatar in landscape mode

### DIFF
--- a/app/styles/modules/_cropper.scss
+++ b/app/styles/modules/_cropper.scss
@@ -7,6 +7,9 @@
     overflow: hidden;
     position: relative;
     width: $avatar-size + 180px;
+    @include respond-to('compressedLandscape') {
+      margin: 0 auto;
+    }
 
     img {
       position: absolute;


### PR DESCRIPTION
fixes #7019 

It now appears as(for _compressedLandscape_ mode) `(min-width:481px) and (max-height: 480px)`:

![Screenshot from 2019-03-11 15-20-49](https://user-images.githubusercontent.com/32164618/54115442-71271e80-4412-11e9-8a3d-4328889b266c.png)

@shane-tomlinson Please Review!
