### PR TITLE
chore(errors): add translated string for redis conflict errors

### DIFF
--- a/app/scripts/lib/auth-errors.js
+++ b/app/scripts/lib/auth-errors.js
@@ -232,6 +232,10 @@ define(function (require, exports, module) {
       errno: 160,
       message: t('This request requires two step authentication enabled on your account.')
     },
+    REDIS_CONFLICT: {
+      errno: 165,
+      message: t('Failed due to a conflicting request, please try again.')
+    },
     // Secondary Email errors end
     SERVER_BUSY: {
       errno: 201,


### PR DESCRIPTION
Adds coverage for the new error I added in mozilla/fxa-auth-server#2967. I wasn't sure what a nice, user-friendly string would be here. How did I do?

@mozilla/fxa-devs r?