### PR TITLE
feat(basket): Make calls directly to basket server rather than the proxy

### DIFF
--- a/app/scripts/lib/marketing-email-client.js
+++ b/app/scripts/lib/marketing-email-client.js
@@ -54,7 +54,7 @@ class MarketingEmailClient {
       // I would prefer to place this into the MarketingEmailPrefs model
       // but doing so required passing around the preferencesUrl to lots of
       // irrelevant classes.
-      if (response.token) {
+      if ('token' in response) {
         response.preferencesUrl = this._preferencesUrl + response.token;
       }
 

--- a/app/tests/spec/lib/marketing-email-client.js
+++ b/app/tests/spec/lib/marketing-email-client.js
@@ -76,14 +76,15 @@ describe('lib/marketing-email-client', () => {
     it('returns a preferences URL for the user', () => {
       sinon.stub(xhrMock, 'ajax').callsFake(() => {
         return Promise.resolve({
-          token: 'users_uuid'
+          // the fake basket server can return a token of the number 0, ensure this is handled.
+          token: 0
         });
       });
 
       return client.fetch('token', 'testuser@testuser.com')
         .then(function (data) {
-          assert.equal(data.token, 'users_uuid');
-          assert.equal(data.preferencesUrl, PREFERENCES_URL + 'users_uuid');
+          assert.strictEqual(data.token, 0);
+          assert.strictEqual(data.preferencesUrl, `${PREFERENCES_URL}0`);
 
           assert.isTrue(xhrMock.ajax.calledOnce);
           const request = xhrMock.ajax.args[0][0];

--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -35,28 +35,6 @@ const conf = module.exports = convict({
     doc: 'Check if the resources are under the /dist directory',
     format: Boolean
   },
-  basket: {
-    api_key: {
-      default: 'test key please change',
-      doc: 'Basket API key',
-      format: String
-    },
-    api_timeout: {
-      default: '5 seconds',
-      doc: 'Timeout for talking to the Basket API server, in ms',
-      format: Number
-    },
-    api_url: {
-      default: 'http://127.0.0.1:10140',
-      doc: 'Url for the Basket API server',
-      format: String
-    },
-    proxy_url: {
-      default: 'http://127.0.0.1:1114',
-      doc: 'Url for the Basket proxy server',
-      format: String
-    }
-  },
   cachify_prefix: {
     default: 'v',
     doc: 'The prefix for cachify hashes in URLs'
@@ -340,8 +318,18 @@ const conf = module.exports = convict({
     }
   },
   marketing_email: {
+    api_key: {
+      default: 'test key please change',
+      doc: 'Basket API key',
+      format: String
+    },
+    api_timeout: {
+      default: '5 seconds',
+      doc: 'Timeout for talking to the Basket API server, in ms',
+      format: 'duration'
+    },
     api_url: {
-      default: 'http://127.0.0.1:1114',
+      default: 'http://127.0.0.1:10140',
       doc: 'User facing URL of the Marketing Email Server',
       env: 'FXA_MARKETING_EMAIL_API_URL',
       format: 'url'

--- a/tests/lib/basket.js
+++ b/tests/lib/basket.js
@@ -4,8 +4,8 @@
 
 const request = require('./request');
 const config = require('../../server/lib/configuration');
-var API_KEY = config.get('basket.api_key');
-var API_URL = config.get('basket.api_url');
+var API_KEY = config.get('marketing_email.api_key');
+var API_URL = config.get('marketing_email.api_url');
 
 var LOOKUP_URL = API_URL + '/lookup-user/?email=';
 


### PR DESCRIPTION
Note: configuration under the basket namespace were merged into the marketing_email namespace,
there doesn't seem to be a good reason for both namespaces to exist.

fixes #7048

BREAKING CHANGE - this may require changes to fxa-dev or cloudops-deployment to migrate any config items under the `basket` namespace.