### PR TITLE
style(avatar): oversizing of avatar on small screens

### DIFF
--- a/app/styles/modules/_cropper.scss
+++ b/app/styles/modules/_cropper.scss
@@ -10,6 +10,11 @@
     @include respond-to('compressedLandscape') {
       margin: 0 auto;
     }
+    @include respond-to('small') {
+      margin: 0 auto;
+      text-align: center;
+      width: auto;
+    }
 
     img {
       position: absolute;
@@ -43,6 +48,10 @@
 
     &::after {
       right: -(420 - $avatar-size) / 2;
+    }
+    @include respond-to('small') {
+      display: inline-block;
+      left: 0;
     }
   }
 


### PR DESCRIPTION
fixes #5313 

It now looks like this on mobile view:
![Screenshot from 2019-03-16 15-40-51](https://user-images.githubusercontent.com/32164618/54473799-a06ad080-4802-11e9-8330-aebb8ef5d09c.png)
 
@ryanfeeley Please review.