### PR TITLE
refactor(mixin): cleaned up usage of uap.supportsSvgTransformOrigin()…

### DIFF
--- a/app/scripts/views/connect_another_device.js
+++ b/app/scripts/views/connect_another_device.js
@@ -16,6 +16,7 @@ define(function (require, exports, module) {
   const ExperimentMixin = require('./mixins/experiment-mixin');
   const FlowEventsMixin = require('./mixins/flow-events-mixin');
   const FormView = require('./form');
+  const PairingGraphicsMixin = require('./mixins/pairing-graphics-mixin');
   const {
     MARKETING_ID_AUTUMN_2016,
     SYNC_SERVICE,
@@ -150,7 +151,7 @@ define(function (require, exports, module) {
       const escapedSignInUrl = this._getEscapedSignInUrl(email);
 
       const uap = this.getUserAgent();
-      const graphicId = uap.supportsSvgTransformOrigin() ? 'graphic-connect-another-device-hearts' : 'graphic-connect-another-device';
+      const graphicId = this.getGraphicsId();
       const isAndroid = uap.isAndroid();
       const isFirefoxAndroid = uap.isFirefoxAndroid();
       const isFirefoxDesktop = uap.isFirefoxDesktop();
@@ -261,6 +262,7 @@ define(function (require, exports, module) {
     ConnectAnotherDeviceMixin,
     ExperimentMixin,
     FlowEventsMixin,
+    PairingGraphicsMixin,
     MarketingMixin({
       // The marketing area is manually created to which badges are displayed.
       autocreate: false,

--- a/app/scripts/views/mixins/pairing-graphics-mixin.js
+++ b/app/scripts/views/mixins/pairing-graphics-mixin.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Returns graphicId depending on whether the browser will supports
+ * SVG Transform Origin or not.
+ *
+ * @mixin PairingGraphicsMixin
+ */
+
+define(function (require, exports, module) {
+  'use strict';
+
+  const UserAgentMixin = require('../../lib/user-agent-mixin');
+
+  module.exports = {
+    dependsOn: [ UserAgentMixin ],
+
+    /**
+     * Returns graphicId 'graphic-connect-another-device-hearts' if the
+     * browser supports SVG Transform Origin, and 'graphic-connect-another-device'
+     * if it does not.
+     *
+     * @returns {String}
+     */
+
+    getGraphicsId () {
+      const uap = this.getUserAgent();
+      if (uap.supportsSvgTransformOrigin()) {
+        return 'graphic-connect-another-device-hearts';
+      }
+      return 'graphic-connect-another-device';
+    }
+  };
+});

--- a/app/scripts/views/pair/auth_complete.js
+++ b/app/scripts/views/pair/auth_complete.js
@@ -5,8 +5,8 @@
 import BaseView from '../base';
 import Cocktail from 'cocktail';
 import DeviceBeingPairedMixin from './device-being-paired-mixin';
+import PairingGraphicsMixin from '../mixins/pairing-graphics-mixin';
 import Template from '../../templates/pair/auth_complete.mustache';
-import UserAgentMixin from '../../lib/user-agent-mixin';
 
 class PairAuthCompleteView extends BaseView {
   template = Template;
@@ -16,8 +16,7 @@ class PairAuthCompleteView extends BaseView {
   }
 
   setInitialContext (context) {
-    const uap = this.getUserAgent();
-    const graphicId = uap.supportsSvgTransformOrigin() ? 'graphic-connect-another-device-hearts' : 'graphic-connect-another-device';
+    const graphicId = this.getGraphicsId();
 
     context.set({ graphicId });
   }
@@ -26,7 +25,7 @@ class PairAuthCompleteView extends BaseView {
 Cocktail.mixin(
   PairAuthCompleteView,
   DeviceBeingPairedMixin(),
-  UserAgentMixin,
+  PairingGraphicsMixin
 );
 
 export default PairAuthCompleteView;

--- a/app/scripts/views/pair/index.js
+++ b/app/scripts/views/pair/index.js
@@ -6,6 +6,7 @@ import FormView from '../form';
 import Cocktail from 'cocktail';
 import Template from '../../templates/pair/index.mustache';
 import UserAgentMixin from '../../lib/user-agent-mixin';
+import PairingGraphicsMixin from '../mixins/pairing-graphics-mixin';
 import { DOWNLOAD_LINK_PAIRING_APP } from '../../lib/constants';
 
 class PairIndexView extends FormView {
@@ -36,8 +37,7 @@ class PairIndexView extends FormView {
   }
 
   setInitialContext (context) {
-    const uap = this.getUserAgent();
-    const graphicId = uap.supportsSvgTransformOrigin() ? 'graphic-connect-another-device-hearts' : 'graphic-connect-another-device';
+    const graphicId = this.getGraphicsId();
 
     context.set({
       downloadAppLink: DOWNLOAD_LINK_PAIRING_APP,
@@ -49,7 +49,8 @@ class PairIndexView extends FormView {
 
 Cocktail.mixin(
   PairIndexView,
-  UserAgentMixin,
+  PairingGraphicsMixin,
+  UserAgentMixin
 );
 
 export default PairIndexView;

--- a/app/scripts/views/pair/success.js
+++ b/app/scripts/views/pair/success.js
@@ -7,15 +7,14 @@
 
 import BaseView from '../base';
 import Cocktail from 'cocktail';
+import PairingGraphicsMixin from '../mixins/pairing-graphics-mixin';
 import Template from '../../templates/pair/success.mustache';
-import UserAgentMixin from '../../lib/user-agent-mixin';
 
 class PairAuthCompleteView extends BaseView {
   template = Template;
 
   setInitialContext (context) {
-    const uap = this.getUserAgent();
-    const graphicId = uap.supportsSvgTransformOrigin() ? 'graphic-connect-another-device-hearts' : 'graphic-connect-another-device';
+    const graphicId = this.getGraphicsId();
 
     context.set({ graphicId });
   }
@@ -23,7 +22,7 @@ class PairAuthCompleteView extends BaseView {
 
 Cocktail.mixin(
   PairAuthCompleteView,
-  UserAgentMixin,
+  PairingGraphicsMixin
 );
 
 export default PairAuthCompleteView;

--- a/app/scripts/views/sms_send.js
+++ b/app/scripts/views/sms_send.js
@@ -17,13 +17,13 @@ define(function (require, exports, module) {
   const FlowEventsMixin = require('./mixins/flow-events-mixin');
   const FormPrefillMixin = require('./mixins/form-prefill-mixin');
   const FormView = require('./form');
+  const PairingGraphicsMixin = require('./mixins/pairing-graphics-mixin');
   const { MARKETING_ID_AUTUMN_2016, SYNC_SERVICE } = require('../lib/constants');
   const MarketingMixin = require('./mixins/marketing-mixin');
   const PulseGraphicMixin = require('./mixins/pulse-graphic-mixin');
   const SELECTOR_PHONE_NUMBER = 'input[type=tel]';
   const SmsMixin = require('./mixins/sms-mixin');
   const Template = require('templates/sms_send.mustache');
-  const UserAgentMixin = require('../lib/user-agent-mixin');
   const VerificationReasonMixin = require('views/mixins/verification-reason-mixin');
 
   class SmsSendView extends FormView {
@@ -63,8 +63,7 @@ define(function (require, exports, module) {
       }
 
       const isSignIn = this.isSignIn();
-      const uap = this.getUserAgent();
-      const graphicId = uap.supportsSvgTransformOrigin() ? 'graphic-connect-another-device-hearts' : 'graphic-connect-another-device';
+      const graphicId = this.getGraphicsId();
 
       context.set({
         country,
@@ -189,6 +188,7 @@ define(function (require, exports, module) {
     SmsSendView,
     FlowEventsMixin,
     FormPrefillMixin,
+    PairingGraphicsMixin,
     MarketingMixin({
       marketingId: MARKETING_ID_AUTUMN_2016,
       // This screen is only shown to Sync users. The service is always Sync,
@@ -198,7 +198,6 @@ define(function (require, exports, module) {
     }),
     PulseGraphicMixin,
     SmsMixin,
-    UserAgentMixin,
     VerificationReasonMixin
   );
 

--- a/app/scripts/views/sms_sent.js
+++ b/app/scripts/views/sms_sent.js
@@ -15,11 +15,11 @@ define(function (require, exports, module) {
   const { FIREFOX_MOBILE_INSTALL } = require('../lib/sms-message-ids');
   const FlowEventsMixin = require('./mixins/flow-events-mixin');
   const { MARKETING_ID_AUTUMN_2016 } = require('../lib/constants');
+  const PairingGraphicsMixin = require('./mixins/pairing-graphics-mixin');
   const MarketingMixin = require('./mixins/marketing-mixin')({ marketingId: MARKETING_ID_AUTUMN_2016 });
   const ResendMixin = require('./mixins/resend-mixin')({ successMessage: false });
   const SmsMixin = require('./mixins/sms-mixin');
   const Template = require('templates/sms_sent.mustache');
-  const UserAgentMixin = require('../lib/user-agent-mixin');
 
   function arePrereqsMet (model) {
     return model.has('normalizedPhoneNumber') &&
@@ -37,8 +37,7 @@ define(function (require, exports, module) {
     },
 
     setInitialContext (context) {
-      const uap = this.getUserAgent();
-      const graphicId = uap.supportsSvgTransformOrigin() ? 'graphic-connect-another-device-hearts' : 'graphic-connect-another-device';
+      const graphicId = this.getGraphicsId();
 
       context.set({
         // The attributes are not surrounded by quotes because _.escape would
@@ -67,9 +66,9 @@ define(function (require, exports, module) {
     View,
     BackMixin,
     FlowEventsMixin,
+    PairingGraphicsMixin,
     MarketingMixin,
     ResendMixin,
-    UserAgentMixin,
     SmsMixin
   );
 

--- a/app/tests/spec/views/mixins/pairing-graphics-mixin.js
+++ b/app/tests/spec/views/mixins/pairing-graphics-mixin.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const BaseView = require('views/base');
+const Cocktail = require('cocktail');
+const PairingGraphicsMixin = require('views/mixins/pairing-graphics-mixin');
+const sinon = require('sinon');
+
+const View = BaseView.extend({});
+
+Cocktail.mixin(
+  View,
+  PairingGraphicsMixin
+);
+
+describe('views/mixins/pairing-graphics-mixin', function () {
+  let view;
+
+  beforeEach(() => {
+    view = new View({});
+  });
+
+  describe('getGraphicsId', () => {
+    it('returns `graphic-connect-another-device` if SvgTransformOrigin not supported', () => {
+      sinon.stub(view, 'getUserAgent').callsFake(() => {
+        return {
+          supportsSvgTransformOrigin: () => false
+        };
+      });
+      assert.equal(view.getGraphicsId(), 'graphic-connect-another-device');
+    });
+
+    it('returns `graphic-connect-another-device-hearts` if SvgTransformOrigin supported', () => {
+      sinon.stub(view, 'getUserAgent').callsFake(() => {
+        return {
+          supportsSvgTransformOrigin: () => true
+        };
+      });
+      assert.equal(view.getGraphicsId(), 'graphic-connect-another-device-hearts');
+    });
+  });
+});

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -174,6 +174,7 @@ require('./spec/views/mixins/cached-credentials-mixin');
 require('./spec/views/mixins/connect-another-device-mixin');
 require('./spec/views/mixins/coppa-mixin');
 require('./spec/views/mixins/disable-form-mixin');
+require('./spec/views/mixins/pairing-graphics-mixin');
 require('./spec/views/mixins/email-first-experiment-mixin');
 require('./spec/views/mixins/email-opt-in-mixin');
 require('./spec/views/mixins/experiment-mixin');


### PR DESCRIPTION
… in views

Added a mixin to implement the functionality of returning graphicId based on if the browser supports Svg Transform Origin or not.
Fixes #6988 

@lmorchard, @shane-tomlinson Could you please review?