### PR TITLE
fix(fxa-client): comment margin: 2px

### DIFF
--- a/app/styles/modules/_settings.scss
+++ b/app/styles/modules/_settings.scss
@@ -287,7 +287,6 @@ body.settings #main-content.card {
   .settings-unit-summary {
     display: inline-block;
     margin-bottom: 0;
-    margin-top: 2px;
     overflow: hidden;
 
     html[dir='ltr'] & {


### PR DESCRIPTION
Comment the 'margin-top: 2px' for settings-unit-summary class -> this made the horizontal line to Ymove.

Fixes [#6578](https://github.com/mozilla/fxa-content-server/issues/6578) 

Can you please review this issue? @lmorchard 
Thank you!