### PR TITLE
fix(test): Fix the openid-config/metrics flow tests on teamcity

### DIFF
--- a/server/lib/configuration.js
+++ b/server/lib/configuration.js
@@ -19,7 +19,7 @@ const conf = module.exports = convict({
     format: Array
   },
   allowed_metrics_flow_cors_origins: {
-    default: [],
+    default: [null],
     doc: 'Origins that are allowed to request the /metrics-flow endpoint',
     env: 'ALLOWED_METRICS_FLOW_ORIGINS',
     format: Array
@@ -415,7 +415,7 @@ const conf = module.exports = convict({
       format: Array,
     },
     server_base_uri: {
-      default: 'wss://channelserver.services.mozilla.com',
+      default: 'wss://dev.channelserver.nonprod.cloudops.mozgcp.net',
       doc: 'The url of the Pairing channel server.',
       env: 'PAIRING_SERVER_BASE_URI'
     },


### PR DESCRIPTION
* Set a default value of `allowed_metrics_flow_cors_origins` to `null`
* Change the default value of `pairing.server_base_uri` to
  `wss://dev.channelserver.nonprod.cloudops.mozgcp.net` which is used
  by all dev boxes. Production config will need to be updated to handle
  this change.

fixes #7066

BREAKING CHANGE - Production config will need to be updated with the prod pairing.server_base_uri

@jrgm, @vladikoff - r?