### PR TITLE
feat(oauth): Added an oauth success screen

### DIFF
--- a/app/scripts/lib/router.js
+++ b/app/scripts/lib/router.js
@@ -117,6 +117,7 @@ const Router = Backbone.Router.extend({
     'oauth/force_auth(/)': createViewHandler(ForceAuthView),
     'oauth/signin(/)': 'onSignIn',
     'oauth/signup(/)': 'onSignUp',
+    'oauth/success(/)': createViewHandler(ReadyView, { type: VerificationReasons.SUCCESSFUL_OAUTH }),
     'pair(/)': createViewHandler('pair/index'),
     'pair/auth/allow(/)': createViewHandler('pair/auth_allow'),
     'pair/auth/complete(/)': createViewHandler('pair/auth_complete'),

--- a/app/scripts/views/ready.js
+++ b/app/scripts/views/ready.js
@@ -63,6 +63,11 @@ const TEMPLATE_INFO = {
     headerId: 'fxa-sign-up-complete-header',
     headerTitle: t('Account verified'),
     readyToSyncText: t('You are now ready to use %(serviceName)s')
+  },
+  SUCCESSFUL_OAUTH: {
+    headerId: 'oauth-successfully-added-header',
+    headerTitle: t('Another device connected'),
+    readyToSyncText: t('You are now ready to use %(serviceName)s')
   }
 };
 

--- a/app/tests/spec/views/ready.js
+++ b/app/tests/spec/views/ready.js
@@ -82,7 +82,7 @@ describe('views/ready', function () {
       FORCE_AUTH: '#fxa-force-auth-complete-header',
       PASSWORD_RESET: '#fxa-reset-password-complete-header',
       SIGN_IN: '#fxa-sign-in-complete-header',
-      SIGN_UP: '#fxa-sign-up-complete-header'
+      SIGN_UP: '#fxa-sign-up-complete-header',
     };
 
     for (var type in expectedHeaders) {


### PR DESCRIPTION
Added an oauth success screen at `/oauth/success/<client_id>`
fixes #6996 
@vladikoff could you please review this. 
