### PR TITLE
fix(style): scale down larger customized qr-image for totp

### DIFF
--- a/app/styles/modules/_settings-totp.scss
+++ b/app/styles/modules/_settings-totp.scss
@@ -42,6 +42,12 @@
       height: 228px;
       margin: auto auto 24px auto;
       width: 228px;
+
+      .qr-image {
+        height: 100%;
+        object-fit: scale-down;
+        width: 100%;
+      }
     }
 
     .setup-description,


### PR DESCRIPTION
In FxA China stack, we set `totp.serviceName` to "accounts.firefox.com.cn" in fxa-auth-server, as a result, our QR Code for totp is 276x276px, larger than the hard coded 228x228px.

I considered making fxa-auth-server return the size with the data uri or making this configurable in fxa-content-server, but ended up deciding it's simpler to just scale down the customized QR Code.