### PR TITLE
feat(totp): Add loading indicator for session status verification

### DIFF
--- a/app/scripts/templates/settings/two_step_authentication.mustache
+++ b/app/scripts/templates/settings/two_step_authentication.mustache
@@ -4,6 +4,10 @@
             <h2 class="settings-unit-title">{{#t}}Two-step authentication{{/t}}</h2>
         </header>
 
+        <button class="settings-button secondary-button settings-unit-loading" disabled>
+            <div class="spinner spinner-settings-fetch"></div>
+        </button>
+
         {{^hasToken}}
             <button class="settings-button primary-button settings-unit-toggle totp-create" data-href="settings/two_step_authentication">
                 {{#t}}Enable…{{/t}}

--- a/app/scripts/views/settings/two_step_authentication.js
+++ b/app/scripts/views/settings/two_step_authentication.js
@@ -21,6 +21,8 @@ const t = msg => msg;
 const CODE_INPUT_SELECTOR = 'input.totp-code';
 const CODE_REFRESH_SELECTOR = 'button.settings-button.totp-refresh';
 const CODE_REFRESH_DELAY_MS = 350;
+const LOADING_INDICATOR_BUTTON = '.settings-button.settings-unit-loading';
+const SETTINGS_UNIT_DETAILS = '.settings-unit-details';
 const TOTP_SUPPORT_URL = 'https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication';
 
 const View = FormView.extend({
@@ -106,8 +108,12 @@ const View = FormView.extend({
 
   createToken() {
     const account = this.getSignedInAccount();
+    this.$el.find(SETTINGS_UNIT_DETAILS).hide();
+    this.$el.find(LOADING_INDICATOR_BUTTON).show();
     return account.createTotpToken()
       .then(result => {
+        this.$el.find(SETTINGS_UNIT_DETAILS).show();
+        this.$el.find(LOADING_INDICATOR_BUTTON).hide();
         this.$('.qr-image').attr('src', result.qrCodeUrl);
 
         const qrImageAltText = t('Use the code %(code)s to set up two-step authentication in supported applications.');


### PR DESCRIPTION
Show a loading indicator when 'Enable' is clicked in Two-step
authentication settings panel and session is being verified.
Remove the earlier used  unverified panel during verification.
Consequently remove the jank caused due to unverified panel
when section is opened.

fixes: #6877

@vbudhram would request your review :smiley: 