### PR TITLE
style(font family): add times instead of fira

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -1,8 +1,8 @@
 @import '../../node_modules/photon-colors/colors.scss';
 
 // Font Variables
-$default-font: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-$header-font: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+$default-font: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Times New Roman', 'Droid Sans', 'Helvetica Neue', sans-serif;
+$header-font: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Times New Roman', 'Droid Sans', 'Helvetica Neue', sans-serif;
 
 $font-size-body-10: 13px;
 $font-weight-body-10: 400;


### PR DESCRIPTION
fixes #5742 
This fixes a part of #5742 which is adding Times as the font family for IOS users.
@shane-tomlinson @lmorchard Pls. review. 