### PR TITLE
style: make list of TOTP recovery codes clear #6559

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -204,6 +204,7 @@ $close-button-zindex: $fox-logo-zindex + 1;
 
 $recovery-code-color: #666;
 $recovery-code-background-color: #fbfbfb;
+$recovery-code-border-color: #e6e6e6;
 
 $image-url-path: '/images/' !default;
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -203,6 +203,7 @@ $close-button-color: $color-grey-spinner;
 $close-button-zindex: $fox-logo-zindex + 1;
 
 $recovery-code-color: #666;
+$recovery-code-background-color: #fbfbfb;
 
 $image-url-path: '/images/' !default;
 

--- a/app/styles/modules/_settings-totp.scss
+++ b/app/styles/modules/_settings-totp.scss
@@ -80,16 +80,16 @@
     margin-bottom: 20px;
 
     .recovery-code {
-      color: $recovery-code-color;
-      border-width: 2px;
-      border-color:#e6e6e6; 
-      border-style: dotted;
-      display: inline-block;
-      padding: 8px;
-      margin-bottom: 6px;
       background-color: $recovery-code-background-color;
+      border-color: $recovery-code-border-color; 
+      border-style: dotted;
+      border-width: 2px;
+      color: $recovery-code-color;
+      display: inline-block;
       font-family: monospace;
       font-size: 1.2em;
+      margin-bottom: 6px;
+      padding: 8px;
       @include respond-to('small') {
         font-size: 1.5em;
       }

--- a/app/styles/modules/_settings-totp.scss
+++ b/app/styles/modules/_settings-totp.scss
@@ -81,9 +81,15 @@
 
     .recovery-code {
       color: $recovery-code-color;
+      border-width: 2px;
+      border-color:#e6e6e6; 
+      border-style: dotted;
       display: inline-block;
+      padding: 8px;
+      margin-bottom: 6px;
+      background-color: $recovery-code-background-color;
       font-family: monospace;
-      font-size: 2em;
+      font-size: 1.2em;
       @include respond-to('small') {
         font-size: 1.5em;
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.132.1",
+  "version": "1.133.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1641,15 +1641,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -1691,7 +1689,6 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -6418,7 +6415,7 @@
       "integrity": "sha512-1Nq8FtlF0Xb5V/4oKmJuKLKD2nGnM4DuhWCdY5obZEIDtBUHgPb0CUf9FVLY54rHJGzfoItFqrVI+SNpY1GAdw==",
       "requires": {
         "es6-promise": "4.1.1",
-        "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8e",
+        "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8ef32329bc8d7bc28a438372b5acb46616b",
         "xhr2": "0.0.7"
       },
       "dependencies": {
@@ -6934,15 +6931,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -10581,7 +10576,7 @@
       "from": "git://github.com/vladikoff/node-uap.git#9cdd16247",
       "requires": {
         "array.prototype.find": "2.0.0",
-        "uap-core": "git://github.com/ua-parser/uap-core.git",
+        "uap-core": "git://github.com/ua-parser/uap-core.git#b4a50d040ad03b163b675d468d7ee011e9ad5436",
         "uap-ref-impl": "0.2.0",
         "yamlparser": "0.0.2"
       }
@@ -11037,8 +11032,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",


### PR DESCRIPTION
fixes #6559 
The recovery codes of TOTP are now placed within dotted line border to make it clear that how many recovery-codes are in total. @lmorchard @ryanfeeley 