### PR TITLE
fix(emails): Make Done button responsive after adding email

### DIFF
--- a/app/scripts/templates/settings/emails.mustache
+++ b/app/scripts/templates/settings/emails.mustache
@@ -72,9 +72,7 @@
                 {{#hasSecondaryEmail}}
                     <button type="submit" class="settings-button email-refresh primary-button enabled" title="{{ lastCheckedTime }}">{{#t}}Refresh Status{{/t}}</button>
 
-                    <button
-                        class="settings-button {{#hasSecondaryVerifiedEmail}}cancel secondary-button enabled{{/hasSecondaryVerifiedEmail}}
-                            {{^hasSecondaryVerifiedEmail}} disabled {{/hasSecondaryVerifiedEmail}}">
+                    <button class="settings-button cancel secondary-button">
                         {{#t}}Done{{/t}}
                     </button>
                 {{/hasSecondaryEmail}}


### PR DESCRIPTION
After adding new email in secondary email section, make
the done button responsive before email verification. Allow
done button to be clicked and panel to be closed. Do not
change the behavior of automatically opening panel if
secondary linked email is unverified.

fixes: #6242

@SorinaFlorean @lmorchard Request you to review please. Thank you.