### PR TITLE
feat(modals): Keyboard focus capture for modals

### DIFF
--- a/app/scripts/views/mixins/modal-panel-mixin.js
+++ b/app/scripts/views/mixins/modal-panel-mixin.js
@@ -46,6 +46,44 @@ define(function (require, exports, module) {
 
       this._boundBlockerClick = this.onBlockerClick.bind(this);
       $('.blocker').on('click', this._boundBlockerClick);
+
+      /**
+       * Trap keyboard focus when modal opens.
+       */
+      const modal = this.$el[0];
+
+      modal.addEventListener('keydown', tabClick);
+
+      const focusableElementsList = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex="0"], [autofocus]';
+      let focusableElements = modal.querySelectorAll(focusableElementsList);
+
+      focusableElements = Array.prototype.slice.call(focusableElements);
+
+      const firstSelectable = focusableElements[0];
+      const lastSelectable = focusableElements[focusableElements.length - 1];
+
+      firstSelectable.focus();
+
+      function tabClick(event) {
+        //avoid IME composition keydown events
+        //refer: https://developer.mozilla.org/docs/Web/Events/keydown#Notes
+        if (event.isComposing || event.keyCode === 229) {
+          return;
+        }
+        if (event.keyCode  === 9) {
+          if (event.shiftKey) {
+            if (document.activeElement === firstSelectable) {
+              event.preventDefault();
+              lastSelectable.focus();
+            }
+          } else {
+            if (document.activeElement === lastSelectable) {
+              event.preventDefault();
+              firstSelectable.focus();
+            }
+          }
+        }
+      }
     },
 
     /**


### PR DESCRIPTION
Implement keyboard focus capture for modals in
content-server. Whenever a modal is opened,
track tab and shift+tab key combinations to keep
keyboard focus within modals and to cycle through
focusable modal elements until esc is pressed
and modal closes.

fixes: #6594
fixes: #6157

@shane-tomlinson @vbudhram  @lmorchard, would like to have your thoughts on this. So modals needed a keyboard focus trap. Shane [suggested](https://github.com/mozilla/fxa-content-server/issues/6157#issuecomment-476655641) using the [autofocus handler in settings-panel-mixin](https://github.com/mozilla/fxa-content-server/blob/4cfac43f4df7d7006fb7df699b3750375dbf08e9/app/scripts/views/mixins/settings-panel-mixin.js#L45). That works by shifting focus to the first element with the 'autofocus' attribute, on panel open. All modals though need to keep keyboard focus trapped unless the user clicks esc key.

I see two ways we can approach this. Either we [make a list of all possible selectable elements](https://github.com/karansapolia/fxa-content-server/blob/565cda1451c5a0fbe87650c0fb967b5ff1aaa0e4/app/scripts/views/mixins/modal-panel-mixin.js#L57) and cycle through them, or we select only 'autofocus' elements and cycle through them in all modals. By marking autofocus elements in the template, we can avoid cycling through elements not visible to the user. Let me know what approach you think fits best. Also because this could need a few revisions I am keeping it a draft atm.