### PR TITLE
style(TOTP): add border to the recovery codes in TOTP

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -203,6 +203,8 @@ $close-button-color: $color-grey-spinner;
 $close-button-zindex: $fox-logo-zindex + 1;
 
 $recovery-code-color: #666;
+$recovery-code-background-color: #fbfbfb;
+$recovery-code-border-color: #e6e6e6;
 
 $image-url-path: '/images/' !default;
 

--- a/app/styles/modules/_settings-totp.scss
+++ b/app/styles/modules/_settings-totp.scss
@@ -86,13 +86,16 @@
     margin-bottom: 20px;
 
     .recovery-code {
+      background-color: $recovery-code-background-color;
+      border-color: $recovery-code-border-color;
+      border-style: dotted;
+      border-width: 2px;
       color: $recovery-code-color;
       display: inline-block;
       font-family: monospace;
-      font-size: 2em;
-      @include respond-to('small') {
-        font-size: 1.5em;
-      }
+      font-size: 1.2em;
+      margin-bottom: 6px;
+      padding: 8px;
       text-transform: uppercase;
       width: 49%;
     }


### PR DESCRIPTION
I took @bini11's changes from #7089, have squash the commits and ensured mobile looked good, and am opening the change as a new PR.

### mobile
<img width="309" alt="Screenshot 2019-04-01 at 22 31 46" src="https://user-images.githubusercontent.com/848085/55361115-21e28400-54ce-11e9-893d-e53050402941.png">

### desktop
<img width="425" alt="Screenshot 2019-04-01 at 22 31 51" src="https://user-images.githubusercontent.com/848085/55361116-21e28400-54ce-11e9-8e39-568ba1573fae.png">

@vbudhram - r?